### PR TITLE
Establish migration-backed foundation storage (#72)

### DIFF
--- a/src/lib/event-game-record.test.ts
+++ b/src/lib/event-game-record.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, test } from "bun:test";
+import {
+  canonicalizeEventGameRecordRoot,
+  type EventGameRecordRoot,
+} from "@/lib/foundation-record-types";
+import { createEventGameRecord, type ExternalScopeResolver } from "@/lib/event-game-record";
+import { createInMemoryFoundationStorage } from "@/lib/foundation-storage-memory";
+
+function createRoot(overrides: Partial<EventGameRecordRoot> = {}): EventGameRecordRoot {
+  return {
+    recordId: "record-1",
+    eventId: "event-1",
+    eventGameId: "event-game-1",
+    ownership: {
+      eventId: "event-1",
+      eventGameId: "event-game-1",
+    },
+    externalScope: {
+      eventId: "event-1",
+      gameDayId: "game-day-1",
+      pitchId: "pitch-1",
+      pitchSlotId: "pitch-slot-1",
+    },
+    gameSides: [
+      {
+        id: "side-1",
+        eventTeamId: "team-1",
+        teamInterpretationRef: "team-interpretation-1",
+      },
+      {
+        id: "side-2",
+        eventTeamId: "team-2",
+        teamInterpretationRef: "team-interpretation-2",
+      },
+    ],
+    lifecycle: {
+      phase: "scheduled",
+      commencedAtMs: null,
+      finishedAtMs: null,
+      lockedAtMs: null,
+      lockReason: null,
+    },
+    compatibility: {
+      recordVersion: "record-v1",
+      schemaVersion: "schema-v1",
+      interpreterVersion: "rules-v1",
+    },
+    creationEvidence: {
+      operationId: "register-1",
+      actorReference: "event-admin-session-1",
+      source: "event-game-registration",
+      createdAtMs: 1_000,
+    },
+    ...overrides,
+  };
+}
+
+describe("Event Game Record contract", () => {
+  test("registers one root, makes identical registration idempotent, and rejects conflicting scope", async () => {
+    const root = createRoot();
+    const record = createEventGameRecord(createInMemoryFoundationStorage(), {
+      externalScopeResolver: createScopeResolver(root),
+    });
+
+    expect(await record.registerRoot(root)).toMatchObject({ status: "registered" });
+    expect(await record.registerRoot(structuredClone(root))).toMatchObject({
+      status: "idempotent",
+    });
+
+    const conflict = createRoot({
+      externalScope: {
+        ...root.externalScope,
+        pitchSlotId: "pitch-slot-2",
+      },
+    });
+    expect(await record.registerRoot(conflict)).toMatchObject({
+      status: "rejected",
+      reason: "external-scope-conflict",
+    });
+  });
+
+  test("stores canonical content rather than object insertion order", async () => {
+    const root = createRoot();
+    const record = createEventGameRecord(createInMemoryFoundationStorage(), {
+      externalScopeResolver: createScopeResolver(root),
+    });
+    const reordered = JSON.parse(
+      JSON.stringify({
+        creationEvidence: root.creationEvidence,
+        compatibility: root.compatibility,
+        lifecycle: root.lifecycle,
+        gameSides: root.gameSides,
+        externalScope: root.externalScope,
+        ownership: root.ownership,
+        eventGameId: root.eventGameId,
+        eventId: root.eventId,
+        recordId: root.recordId,
+      }),
+    ) as EventGameRecordRoot;
+
+    expect(canonicalizeEventGameRecordRoot(root)).toBe(canonicalizeEventGameRecordRoot(reordered));
+    expect(await record.registerRoot(root)).toMatchObject({ status: "registered" });
+    expect(await record.registerRoot(reordered)).toMatchObject({ status: "idempotent" });
+  });
+
+  test("rolls back a storage transaction when its work fails", async () => {
+    const storage = createInMemoryFoundationStorage();
+    const root = createRoot();
+
+    let failure: unknown;
+    try {
+      await storage.transaction((transaction) => {
+        transaction.insertRoot({
+          root,
+          canonicalContent: canonicalizeEventGameRecordRoot(root),
+        });
+        throw new Error("simulated failure");
+      });
+    } catch (error) {
+      failure = error;
+    }
+    expect(failure).toBeInstanceOf(Error);
+    if (failure instanceof Error) {
+      expect(failure.message).toContain("simulated failure");
+    }
+
+    expect(await storage.readRoot(root.recordId)).toBeNull();
+  });
+});
+
+function createScopeResolver(root: EventGameRecordRoot): ExternalScopeResolver {
+  return {
+    resolve(scope) {
+      return JSON.stringify(scope) === JSON.stringify(root.externalScope)
+        ? { status: "resolved", scope: structuredClone(scope) }
+        : { status: "mismatch", detail: "The external scope does not match the root." };
+    },
+  };
+}

--- a/src/lib/event-game-record.ts
+++ b/src/lib/event-game-record.ts
@@ -1,0 +1,222 @@
+import {
+  canonicalizeEventGameRecordRoot,
+  cloneEventGameRecordRoot,
+  validateEventGameRecordRoot,
+  type EventGameRecordRoot,
+} from "@/lib/foundation-record-types";
+import {
+  FoundationStorageConstraintError,
+  FoundationStorageNotReadyError,
+  type FoundationStorage,
+  type FoundationStorageSnapshot,
+} from "@/lib/foundation-storage";
+
+export type ExternalScopeResolution =
+  | {
+      status: "resolved";
+      scope: EventGameRecordRoot["externalScope"];
+    }
+  | {
+      status: "missing" | "mismatch";
+      detail: string;
+    };
+
+/**
+ * Resolves the external Event hierarchy without exposing external storage rows.
+ * The transaction capability is the same synchronous snapshot used to accept the owned root.
+ */
+export type ExternalScopeResolver = {
+  resolve(
+    scope: EventGameRecordRoot["externalScope"],
+    snapshot: FoundationStorageSnapshot,
+  ): ExternalScopeResolution;
+};
+
+export type EventGameRecordOptions = {
+  externalScopeResolver: ExternalScopeResolver;
+};
+
+export type RootRegistrationOutcome =
+  | {
+      status: "registered" | "idempotent";
+      root: EventGameRecordRoot;
+    }
+  | {
+      status: "rejected";
+      reason:
+        | "invalid-root"
+        | "content-conflict"
+        | "ownership-conflict"
+        | "external-scope-conflict"
+        | "stable-side-conflict"
+        | "storage-not-ready";
+      detail: string;
+    };
+
+export type EventGameRecord = {
+  registerRoot(root: unknown): Promise<RootRegistrationOutcome>;
+  readRoot(recordId: string): Promise<EventGameRecordRoot | null>;
+};
+
+export function createEventGameRecord(
+  storage: FoundationStorage,
+  options: EventGameRecordOptions,
+): EventGameRecord {
+  return {
+    async registerRoot(input) {
+      const validated = validateEventGameRecordRoot(input);
+      if (!validated.ok) {
+        return {
+          status: "rejected",
+          reason: "invalid-root",
+          detail: validated.error,
+        };
+      }
+
+      const root = validated.value;
+      const canonicalContent = canonicalizeEventGameRecordRoot(root);
+
+      try {
+        return await storage.transaction((transaction) => {
+          const existing = transaction.findRootByRecordId(root.recordId);
+          if (existing !== null) {
+            const existingCanonicalContent = canonicalizeEventGameRecordRoot(existing);
+            if (existingCanonicalContent === canonicalContent) {
+              return {
+                status: "idempotent",
+                root: cloneEventGameRecordRoot(existing),
+              } satisfies RootRegistrationOutcome;
+            }
+          }
+
+          const scopeResolution = options.externalScopeResolver.resolve(
+            root.externalScope,
+            transaction,
+          );
+          if (scopeResolution.status !== "resolved") {
+            return {
+              status: "rejected",
+              reason: "external-scope-conflict",
+              detail: scopeResolution.detail,
+            } satisfies RootRegistrationOutcome;
+          }
+          if (!sameExternalScope(scopeResolution.scope, root.externalScope)) {
+            return {
+              status: "rejected",
+              reason: "external-scope-conflict",
+              detail: "The external scope resolver returned a mismatched hierarchy.",
+            } satisfies RootRegistrationOutcome;
+          }
+
+          if (existing !== null) {
+            return {
+              status: "rejected",
+              reason: classifyRootConflict(existing, root),
+              detail: "The root identity is already registered with different content.",
+            } satisfies RootRegistrationOutcome;
+          }
+
+          if (transaction.findRootByEventGameId(root.eventGameId) !== null) {
+            return {
+              status: "rejected",
+              reason: "ownership-conflict",
+              detail: "The Event Game identity belongs to another root.",
+            } satisfies RootRegistrationOutcome;
+          }
+          if (transaction.findRootByPitchSlotId(root.externalScope.pitchSlotId) !== null) {
+            return {
+              status: "rejected",
+              reason: "external-scope-conflict",
+              detail: "The external Pitch Slot reference belongs to another root.",
+            } satisfies RootRegistrationOutcome;
+          }
+          for (const side of root.gameSides) {
+            if (transaction.findRootByGameSideId(side.id) !== null) {
+              return {
+                status: "rejected",
+                reason: "stable-side-conflict",
+                detail: "A stable Game Side identity belongs to another root.",
+              } satisfies RootRegistrationOutcome;
+            }
+          }
+
+          transaction.insertRoot({ root, canonicalContent });
+          return {
+            status: "registered",
+            root: cloneEventGameRecordRoot(root),
+          } satisfies RootRegistrationOutcome;
+        });
+      } catch (error) {
+        if (error instanceof FoundationStorageNotReadyError) {
+          return {
+            status: "rejected",
+            reason: "storage-not-ready",
+            detail: error.readiness.ok
+              ? "Foundation storage is not ready for authoritative writes."
+              : error.readiness.detail,
+          };
+        }
+        if (error instanceof FoundationStorageConstraintError) {
+          return {
+            status: "rejected",
+            reason: constraintToConflict(error),
+            detail: "The root conflicts with a concurrently committed identity.",
+          };
+        }
+        throw error;
+      }
+    },
+
+    readRoot(recordId) {
+      return storage.readRoot(recordId);
+    },
+  };
+}
+
+function sameExternalScope(
+  left: EventGameRecordRoot["externalScope"],
+  right: EventGameRecordRoot["externalScope"],
+): boolean {
+  return (
+    left.eventId === right.eventId &&
+    left.gameDayId === right.gameDayId &&
+    left.pitchId === right.pitchId &&
+    left.pitchSlotId === right.pitchSlotId
+  );
+}
+
+function classifyRootConflict(
+  existing: EventGameRecordRoot,
+  incoming: EventGameRecordRoot,
+): Extract<RootRegistrationOutcome, { status: "rejected" }>["reason"] {
+  if (
+    existing.ownership.eventId !== incoming.ownership.eventId ||
+    existing.ownership.eventGameId !== incoming.ownership.eventGameId
+  ) {
+    return "ownership-conflict";
+  }
+  if (
+    existing.externalScope.eventId !== incoming.externalScope.eventId ||
+    existing.externalScope.gameDayId !== incoming.externalScope.gameDayId ||
+    existing.externalScope.pitchId !== incoming.externalScope.pitchId ||
+    existing.externalScope.pitchSlotId !== incoming.externalScope.pitchSlotId
+  ) {
+    return "external-scope-conflict";
+  }
+  return "content-conflict";
+}
+
+function constraintToConflict(
+  error: FoundationStorageConstraintError,
+): Extract<RootRegistrationOutcome, { status: "rejected" }>["reason"] {
+  switch (error.constraint) {
+    case "event-game-id":
+      return "ownership-conflict";
+    case "pitch-slot-id":
+      return "external-scope-conflict";
+    case "game-side-id":
+      return "stable-side-conflict";
+    case "record-id":
+      return "content-conflict";
+  }
+}

--- a/src/lib/foundation-migrations.test.ts
+++ b/src/lib/foundation-migrations.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "bun:test";
+import {
+  assessMigrationReadiness,
+  checksumMigrationSql,
+  type FoundationMigration,
+  type MigrationLedgerEntry,
+} from "@/lib/foundation-migrations";
+
+const migrations: readonly FoundationMigration[] = [
+  createMigration("001-first", 1, 1, "CREATE TABLE first (id TEXT) STRICT;"),
+  createMigration("002-second", 2, 2, "CREATE TABLE second (id TEXT) STRICT;"),
+];
+
+describe("foundation migration ledger compatibility", () => {
+  test("distinguishes pending and missing migrations", () => {
+    expect(assessMigrationReadiness(false, [], migrations)).toMatchObject({ status: "pending" });
+    expect(assessMigrationReadiness(true, [], migrations)).toMatchObject({ status: "pending" });
+  });
+
+  test("rejects reordered, changed, incomplete, and future entries", () => {
+    const second = migrations[1];
+    if (second === undefined) throw new Error("Expected the second migration.");
+
+    expect(assessMigrationReadiness(true, [ledgerEntry(second)], migrations)).toMatchObject({
+      status: "reordered",
+    });
+
+    expect(
+      assessMigrationReadiness(
+        true,
+        [{ ...ledgerEntry(migrations[0]), checksum: "changed" }],
+        migrations,
+      ),
+    ).toMatchObject({ status: "changed-checksum" });
+
+    expect(
+      assessMigrationReadiness(
+        true,
+        [{ ...ledgerEntry(migrations[0]), status: "applying" }],
+        migrations,
+      ),
+    ).toMatchObject({ status: "incomplete" });
+
+    expect(
+      assessMigrationReadiness(
+        true,
+        [
+          ledgerEntry(migrations[0]),
+          {
+            id: "003-future",
+            ordinal: 3,
+            schemaVersion: 3,
+            checksum: "future",
+            status: "complete",
+          },
+        ],
+        migrations,
+      ),
+    ).toMatchObject({ status: "future" });
+  });
+
+  test("accepts only a complete ordered prefix followed by the current release", () => {
+    expect(assessMigrationReadiness(true, [ledgerEntry(migrations[0])], migrations)).toMatchObject({
+      status: "missing",
+    });
+    expect(
+      assessMigrationReadiness(
+        true,
+        [ledgerEntry(migrations[0]), ledgerEntry(migrations[1])],
+        migrations,
+      ),
+    ).toMatchObject({ status: "ready", schemaVersion: 2 });
+  });
+});
+
+function createMigration(
+  id: string,
+  ordinal: number,
+  schemaVersion: number,
+  sql: string,
+): FoundationMigration {
+  return { id, ordinal, schemaVersion, sql, checksum: checksumMigrationSql(sql) };
+}
+
+function ledgerEntry(migration: FoundationMigration | undefined): MigrationLedgerEntry {
+  if (migration === undefined) throw new Error("Expected a migration.");
+  return {
+    id: migration.id,
+    ordinal: migration.ordinal,
+    schemaVersion: migration.schemaVersion,
+    checksum: migration.checksum,
+    status: "complete",
+  };
+}

--- a/src/lib/foundation-migrations.ts
+++ b/src/lib/foundation-migrations.ts
@@ -1,0 +1,369 @@
+import { createHash } from "node:crypto";
+
+export const FOUNDATION_MIGRATION_LEDGER_TABLE = "foundation_migration_ledger";
+
+export type FoundationMigration = {
+  id: string;
+  ordinal: number;
+  schemaVersion: number;
+  sql: string;
+  checksum: string;
+};
+
+export type MigrationLedgerEntry = {
+  id: string;
+  ordinal: number;
+  schemaVersion: number;
+  checksum: string;
+  status: "complete" | "applying";
+};
+
+export type MigrationReadiness =
+  | {
+      status: "ready";
+      schemaVersion: number;
+      appliedMigrationIds: string[];
+    }
+  | {
+      status: "pending" | "missing" | "reordered" | "changed-checksum" | "incomplete" | "future";
+      detail: string;
+      schemaVersion: number;
+      appliedMigrationIds: string[];
+    };
+
+export const FOUNDATION_LEDGER_TABLE_SQL = `
+  CREATE TABLE foundation_migration_ledger (
+    migration_id TEXT PRIMARY KEY,
+    ordinal INTEGER NOT NULL UNIQUE,
+    schema_version INTEGER NOT NULL,
+    checksum TEXT NOT NULL,
+    status TEXT NOT NULL CHECK (status IN ('complete', 'applying')),
+    applied_at_ms INTEGER
+  ) STRICT
+`;
+
+export const FOUNDATION_ROOT_TABLE_SQL = `
+  CREATE TABLE foundation_event_game_record_roots (
+    record_id TEXT PRIMARY KEY,
+    event_id TEXT NOT NULL,
+    event_game_id TEXT NOT NULL UNIQUE,
+    owner_event_id TEXT NOT NULL,
+    owner_event_game_id TEXT NOT NULL,
+    scope_event_id TEXT NOT NULL,
+    game_day_id TEXT NOT NULL,
+    pitch_id TEXT NOT NULL,
+    pitch_slot_id TEXT NOT NULL UNIQUE,
+    lifecycle_phase TEXT NOT NULL CHECK (lifecycle_phase IN ('scheduled', 'in-progress', 'suspended', 'finished')),
+    commenced_at_ms INTEGER,
+    finished_at_ms INTEGER,
+    locked_at_ms INTEGER,
+    lock_reason TEXT CHECK (lock_reason IS NULL OR lock_reason IN ('finished-inactivity', 'administrative')),
+    record_version TEXT NOT NULL,
+    schema_version TEXT NOT NULL,
+    interpreter_version TEXT NOT NULL,
+    creation_operation_id TEXT NOT NULL,
+    creation_actor_reference TEXT NOT NULL,
+    creation_source TEXT NOT NULL CHECK (creation_source = 'event-game-registration'),
+    creation_created_at_ms INTEGER NOT NULL,
+    canonical_content TEXT NOT NULL,
+    root_json TEXT NOT NULL CHECK (json_valid(root_json)),
+    CHECK (owner_event_id = event_id),
+    CHECK (owner_event_game_id = event_game_id),
+    CHECK (scope_event_id = event_id),
+    CHECK (finished_at_ms IS NULL OR commenced_at_ms IS NOT NULL),
+    CHECK (locked_at_ms IS NULL OR finished_at_ms IS NOT NULL),
+    CHECK ((locked_at_ms IS NULL) = (lock_reason IS NULL))
+  ) STRICT
+`;
+
+export const FOUNDATION_SIDE_TABLE_SQL = `
+  CREATE TABLE foundation_event_game_record_sides (
+    side_id TEXT PRIMARY KEY,
+    record_id TEXT NOT NULL REFERENCES foundation_event_game_record_roots(record_id) ON DELETE CASCADE,
+    side_position TEXT NOT NULL CHECK (side_position IN ('a', 'b')),
+    event_team_id TEXT NOT NULL,
+    team_interpretation_ref TEXT NOT NULL,
+    UNIQUE (record_id, side_position),
+    UNIQUE (record_id, event_team_id)
+  ) STRICT
+`;
+
+export const FOUNDATION_ROOT_EVENT_INDEX_SQL = `
+  CREATE INDEX foundation_event_game_record_roots_event_id
+    ON foundation_event_game_record_roots (event_id)
+`;
+
+export const FOUNDATION_ROOT_GAME_DAY_INDEX_SQL = `
+  CREATE INDEX foundation_event_game_record_roots_game_day_id
+    ON foundation_event_game_record_roots (scope_event_id, game_day_id)
+`;
+
+export const FOUNDATION_SIDE_RECORD_INDEX_SQL = `
+  CREATE INDEX foundation_event_game_record_sides_record_id
+    ON foundation_event_game_record_sides (record_id)
+`;
+
+const FOUNDATION_INITIAL_ROOT_MIGRATION_SQL = `
+      CREATE TABLE foundation_event_game_record_roots (
+        record_id TEXT PRIMARY KEY,
+        event_id TEXT NOT NULL,
+        event_game_id TEXT NOT NULL UNIQUE,
+        owner_event_id TEXT NOT NULL,
+        owner_event_game_id TEXT NOT NULL,
+        scope_event_id TEXT NOT NULL,
+        game_day_id TEXT NOT NULL,
+        pitch_id TEXT NOT NULL,
+        pitch_slot_id TEXT NOT NULL UNIQUE,
+        side_a_id TEXT NOT NULL UNIQUE,
+        side_a_event_team_id TEXT NOT NULL,
+        side_a_team_interpretation_ref TEXT NOT NULL,
+        side_b_id TEXT NOT NULL UNIQUE,
+        side_b_event_team_id TEXT NOT NULL,
+        side_b_team_interpretation_ref TEXT NOT NULL,
+        lifecycle_phase TEXT NOT NULL CHECK (lifecycle_phase IN ('scheduled', 'in-progress', 'suspended', 'finished')),
+        commenced_at_ms INTEGER,
+        finished_at_ms INTEGER,
+        locked_at_ms INTEGER,
+        lock_reason TEXT CHECK (lock_reason IS NULL OR lock_reason IN ('finished-inactivity', 'administrative')),
+        record_version TEXT NOT NULL,
+        schema_version TEXT NOT NULL,
+        interpreter_version TEXT NOT NULL,
+        creation_operation_id TEXT NOT NULL,
+        creation_actor_reference TEXT NOT NULL,
+        creation_source TEXT NOT NULL CHECK (creation_source = 'event-game-registration'),
+        creation_created_at_ms INTEGER NOT NULL,
+        canonical_content TEXT NOT NULL,
+        root_json TEXT NOT NULL CHECK (json_valid(root_json)),
+        CHECK (owner_event_id = event_id),
+        CHECK (owner_event_game_id = event_game_id),
+        CHECK (scope_event_id = event_id),
+        CHECK (finished_at_ms IS NULL OR commenced_at_ms IS NOT NULL),
+        CHECK (locked_at_ms IS NULL OR finished_at_ms IS NOT NULL),
+        CHECK (locked_at_ms IS NULL OR lock_reason IS NOT NULL)
+      ) STRICT;
+
+      CREATE INDEX foundation_event_game_record_roots_event_id
+        ON foundation_event_game_record_roots (event_id);
+      CREATE INDEX foundation_event_game_record_roots_game_day_id
+        ON foundation_event_game_record_roots (scope_event_id, game_day_id);
+    `;
+
+const FOUNDATION_NORMALIZE_ROOTS_MIGRATION_SQL = `
+  CREATE TABLE foundation_event_game_record_roots_v2 (
+    record_id TEXT PRIMARY KEY,
+    event_id TEXT NOT NULL,
+    event_game_id TEXT NOT NULL UNIQUE,
+    owner_event_id TEXT NOT NULL,
+    owner_event_game_id TEXT NOT NULL,
+    scope_event_id TEXT NOT NULL,
+    game_day_id TEXT NOT NULL,
+    pitch_id TEXT NOT NULL,
+    pitch_slot_id TEXT NOT NULL UNIQUE,
+    lifecycle_phase TEXT NOT NULL CHECK (lifecycle_phase IN ('scheduled', 'in-progress', 'suspended', 'finished')),
+    commenced_at_ms INTEGER,
+    finished_at_ms INTEGER,
+    locked_at_ms INTEGER,
+    lock_reason TEXT CHECK (lock_reason IS NULL OR lock_reason IN ('finished-inactivity', 'administrative')),
+    record_version TEXT NOT NULL,
+    schema_version TEXT NOT NULL,
+    interpreter_version TEXT NOT NULL,
+    creation_operation_id TEXT NOT NULL,
+    creation_actor_reference TEXT NOT NULL,
+    creation_source TEXT NOT NULL CHECK (creation_source = 'event-game-registration'),
+    creation_created_at_ms INTEGER NOT NULL,
+    canonical_content TEXT NOT NULL,
+    root_json TEXT NOT NULL CHECK (json_valid(root_json)),
+    CHECK (owner_event_id = event_id),
+    CHECK (owner_event_game_id = event_game_id),
+    CHECK (scope_event_id = event_id),
+    CHECK (finished_at_ms IS NULL OR commenced_at_ms IS NOT NULL),
+    CHECK (locked_at_ms IS NULL OR finished_at_ms IS NOT NULL),
+    CHECK ((locked_at_ms IS NULL) = (lock_reason IS NULL))
+  ) STRICT;
+
+  INSERT INTO foundation_event_game_record_roots_v2 (
+    record_id, event_id, event_game_id, owner_event_id, owner_event_game_id,
+    scope_event_id, game_day_id, pitch_id, pitch_slot_id,
+    lifecycle_phase, commenced_at_ms, finished_at_ms, locked_at_ms, lock_reason,
+    record_version, schema_version, interpreter_version,
+    creation_operation_id, creation_actor_reference, creation_source,
+    creation_created_at_ms, canonical_content, root_json
+  )
+  SELECT
+    record_id, event_id, event_game_id, owner_event_id, owner_event_game_id,
+    scope_event_id, game_day_id, pitch_id, pitch_slot_id,
+    lifecycle_phase, commenced_at_ms, finished_at_ms, locked_at_ms, lock_reason,
+    record_version, schema_version, interpreter_version,
+    creation_operation_id, creation_actor_reference, creation_source,
+    creation_created_at_ms, canonical_content, root_json
+  FROM foundation_event_game_record_roots;
+
+  CREATE TABLE foundation_event_game_record_sides_v2 (
+    side_id TEXT PRIMARY KEY,
+    record_id TEXT NOT NULL REFERENCES foundation_event_game_record_roots_v2(record_id) ON DELETE CASCADE,
+    side_position TEXT NOT NULL CHECK (side_position IN ('a', 'b')),
+    event_team_id TEXT NOT NULL,
+    team_interpretation_ref TEXT NOT NULL,
+    UNIQUE (record_id, side_position),
+    UNIQUE (record_id, event_team_id)
+  ) STRICT;
+
+  INSERT INTO foundation_event_game_record_sides_v2 (
+    side_id, record_id, side_position, event_team_id, team_interpretation_ref
+  )
+  SELECT side_a_id, record_id, 'a', side_a_event_team_id, side_a_team_interpretation_ref
+  FROM foundation_event_game_record_roots
+  UNION ALL
+  SELECT side_b_id, record_id, 'b', side_b_event_team_id, side_b_team_interpretation_ref
+  FROM foundation_event_game_record_roots;
+
+  DROP TABLE foundation_event_game_record_roots;
+  ALTER TABLE foundation_event_game_record_roots_v2 RENAME TO foundation_event_game_record_roots;
+  ALTER TABLE foundation_event_game_record_sides_v2 RENAME TO foundation_event_game_record_sides;
+
+  CREATE INDEX foundation_event_game_record_roots_event_id
+    ON foundation_event_game_record_roots (event_id);
+  CREATE INDEX foundation_event_game_record_roots_game_day_id
+    ON foundation_event_game_record_roots (scope_event_id, game_day_id);
+  CREATE INDEX foundation_event_game_record_sides_record_id
+    ON foundation_event_game_record_sides (record_id);
+`;
+
+export const FOUNDATION_MIGRATIONS: readonly FoundationMigration[] = Object.freeze([
+  createMigration({
+    id: "001-foundation-event-game-record-roots",
+    ordinal: 1,
+    schemaVersion: 1,
+    sql: FOUNDATION_INITIAL_ROOT_MIGRATION_SQL,
+  }),
+  createMigration({
+    id: "002-normalize-event-game-record-sides",
+    ordinal: 2,
+    schemaVersion: 2,
+    sql: FOUNDATION_NORMALIZE_ROOTS_MIGRATION_SQL,
+  }),
+]);
+
+export const FOUNDATION_MIGRATION_LEDGER_SQL = `
+  CREATE TABLE IF NOT EXISTS ${FOUNDATION_MIGRATION_LEDGER_TABLE} (
+    migration_id TEXT PRIMARY KEY,
+    ordinal INTEGER NOT NULL UNIQUE,
+    schema_version INTEGER NOT NULL,
+    checksum TEXT NOT NULL,
+    status TEXT NOT NULL CHECK (status IN ('complete', 'applying')),
+    applied_at_ms INTEGER
+  ) STRICT;
+`;
+
+export function checksumMigrationSql(sql: string): string {
+  return createHash("sha256").update(sql, "utf8").digest("hex");
+}
+
+export function assessMigrationReadiness(
+  ledgerExists: boolean,
+  entries: readonly MigrationLedgerEntry[],
+  migrations: readonly FoundationMigration[] = FOUNDATION_MIGRATIONS,
+): MigrationReadiness {
+  const expectedIds = migrations.map((migration) => migration.id);
+  const appliedMigrationIds = entries.map((entry) => entry.id);
+  const latestSchemaVersion = migrations.at(-1)?.schemaVersion ?? 0;
+  const currentSchemaVersion = entries.reduce(
+    (version, entry) => Math.max(version, entry.schemaVersion),
+    0,
+  );
+
+  if (!ledgerExists) {
+    return {
+      status: "pending",
+      detail: "The application-owned migration ledger has not been created.",
+      schemaVersion: currentSchemaVersion,
+      appliedMigrationIds,
+    };
+  }
+
+  const expectedById = new Map(migrations.map((migration) => [migration.id, migration]));
+  for (const entry of entries) {
+    const expected = expectedById.get(entry.id);
+    if (expected === undefined || entry.ordinal > migrations.length) {
+      return {
+        status: "future",
+        detail: `Migration ${entry.id} is newer than this executable supports.`,
+        schemaVersion: currentSchemaVersion,
+        appliedMigrationIds,
+      };
+    }
+    if (entry.status !== "complete") {
+      return {
+        status: "incomplete",
+        detail: `Migration ${entry.id} is incomplete.`,
+        schemaVersion: currentSchemaVersion,
+        appliedMigrationIds,
+      };
+    }
+    if (entry.checksum !== expected.checksum) {
+      return {
+        status: "changed-checksum",
+        detail: `Migration ${entry.id} has a changed checksum.`,
+        schemaVersion: currentSchemaVersion,
+        appliedMigrationIds,
+      };
+    }
+    if (entry.schemaVersion !== expected.schemaVersion || entry.ordinal !== expected.ordinal) {
+      return {
+        status: "reordered",
+        detail: `Migration ${entry.id} has an incompatible order or schema version.`,
+        schemaVersion: currentSchemaVersion,
+        appliedMigrationIds,
+      };
+    }
+  }
+
+  for (let index = 0; index < entries.length; index += 1) {
+    const entry = entries[index];
+    const expectedId = expectedIds[index];
+    if (entry === undefined || expectedId === undefined) break;
+    if (entry.id !== expectedId) {
+      return {
+        status: "reordered",
+        detail: "Applied migrations are not an ordered prefix of the release migrations.",
+        schemaVersion: currentSchemaVersion,
+        appliedMigrationIds,
+      };
+    }
+  }
+
+  if (entries.length < migrations.length) {
+    const missingMigration = migrations[entries.length];
+    return {
+      status: entries.length === 0 ? "pending" : "missing",
+      detail:
+        missingMigration === undefined
+          ? "The migration ledger is missing a required migration."
+          : `Migration ${missingMigration.id} has not been applied.`,
+      schemaVersion: currentSchemaVersion,
+      appliedMigrationIds,
+    };
+  }
+
+  if (currentSchemaVersion > latestSchemaVersion) {
+    return {
+      status: "future",
+      detail: "The database schema is newer than this executable supports.",
+      schemaVersion: currentSchemaVersion,
+      appliedMigrationIds,
+    };
+  }
+
+  return {
+    status: "ready",
+    schemaVersion: currentSchemaVersion,
+    appliedMigrationIds,
+  };
+}
+
+function createMigration(migration: Omit<FoundationMigration, "checksum">): FoundationMigration {
+  return {
+    ...migration,
+    checksum: checksumMigrationSql(migration.sql),
+  };
+}

--- a/src/lib/foundation-record-types.ts
+++ b/src/lib/foundation-record-types.ts
@@ -1,0 +1,335 @@
+import {
+  validateIntegerInRange,
+  validateOpaqueIdentifier,
+  type ValidationResult,
+} from "@/lib/validation-policy";
+
+export type EventGameLifecyclePhase = "scheduled" | "in-progress" | "suspended" | "finished";
+
+export type EventGameRecordSide = {
+  id: string;
+  eventTeamId: string;
+  teamInterpretationRef: string;
+};
+
+export type EventGameRecordRoot = {
+  recordId: string;
+  eventId: string;
+  eventGameId: string;
+  ownership: {
+    eventId: string;
+    eventGameId: string;
+  };
+  externalScope: {
+    eventId: string;
+    gameDayId: string;
+    pitchId: string;
+    pitchSlotId: string;
+  };
+  gameSides: readonly [EventGameRecordSide, EventGameRecordSide];
+  lifecycle: {
+    phase: EventGameLifecyclePhase;
+    commencedAtMs: number | null;
+    finishedAtMs: number | null;
+    lockedAtMs: number | null;
+    lockReason: "finished-inactivity" | "administrative" | null;
+  };
+  compatibility: {
+    recordVersion: string;
+    schemaVersion: string;
+    interpreterVersion: string;
+  };
+  creationEvidence: {
+    operationId: string;
+    actorReference: string;
+    source: "event-game-registration";
+    createdAtMs: number;
+  };
+};
+
+export type RootValidationResult = ValidationResult<EventGameRecordRoot>;
+
+const MAX_TIMESTAMP_MS = Number.MAX_SAFE_INTEGER;
+
+export function validateEventGameRecordRoot(value: unknown): RootValidationResult {
+  if (!isRecord(value)) {
+    return invalid("Event Game Record root must be an object.");
+  }
+
+  const recordId = validateId(value.recordId, "recordId");
+  const eventId = validateId(value.eventId, "eventId");
+  const eventGameId = validateId(value.eventGameId, "eventGameId");
+  if (!recordId.ok) return recordId;
+  if (!eventId.ok) return eventId;
+  if (!eventGameId.ok) return eventGameId;
+
+  const ownership = validateOwnership(value.ownership);
+  if (!ownership.ok) return ownership;
+  if (ownership.value.eventId !== eventId.value) {
+    return invalid("ownership.eventId must match eventId.");
+  }
+  if (ownership.value.eventGameId !== eventGameId.value) {
+    return invalid("ownership.eventGameId must match eventGameId.");
+  }
+
+  const externalScope = validateExternalScope(value.externalScope);
+  if (!externalScope.ok) return externalScope;
+  if (externalScope.value.eventId !== eventId.value) {
+    return invalid("externalScope.eventId must match eventId.");
+  }
+
+  const gameSides = validateGameSides(value.gameSides);
+  if (!gameSides.ok) return gameSides;
+
+  const lifecycle = validateLifecycle(value.lifecycle);
+  if (!lifecycle.ok) return lifecycle;
+
+  const compatibility = validateCompatibility(value.compatibility);
+  if (!compatibility.ok) return compatibility;
+
+  const creationEvidence = validateCreationEvidence(value.creationEvidence);
+  if (!creationEvidence.ok) return creationEvidence;
+
+  return valid({
+    recordId: recordId.value,
+    eventId: eventId.value,
+    eventGameId: eventGameId.value,
+    ownership: ownership.value,
+    externalScope: externalScope.value,
+    gameSides: gameSides.value,
+    lifecycle: lifecycle.value,
+    compatibility: compatibility.value,
+    creationEvidence: creationEvidence.value,
+  });
+}
+
+export function canonicalizeEventGameRecordRoot(root: EventGameRecordRoot): string {
+  return JSON.stringify(sortJsonValue(root));
+}
+
+export function cloneEventGameRecordRoot(root: EventGameRecordRoot): EventGameRecordRoot {
+  return structuredClone(root);
+}
+
+function validateOwnership(value: unknown): ValidationResult<EventGameRecordRoot["ownership"]> {
+  if (!isRecord(value)) return invalid("ownership must be an object.");
+
+  const eventId = validateId(value.eventId, "ownership.eventId");
+  const eventGameId = validateId(value.eventGameId, "ownership.eventGameId");
+  if (!eventId.ok) return eventId;
+  if (!eventGameId.ok) return eventGameId;
+
+  return valid({ eventId: eventId.value, eventGameId: eventGameId.value });
+}
+
+function validateExternalScope(
+  value: unknown,
+): ValidationResult<EventGameRecordRoot["externalScope"]> {
+  if (!isRecord(value)) return invalid("externalScope must be an object.");
+
+  const eventId = validateId(value.eventId, "externalScope.eventId");
+  const gameDayId = validateId(value.gameDayId, "externalScope.gameDayId");
+  const pitchId = validateId(value.pitchId, "externalScope.pitchId");
+  const pitchSlotId = validateId(value.pitchSlotId, "externalScope.pitchSlotId");
+  if (!eventId.ok) return eventId;
+  if (!gameDayId.ok) return gameDayId;
+  if (!pitchId.ok) return pitchId;
+  if (!pitchSlotId.ok) return pitchSlotId;
+
+  return valid({
+    eventId: eventId.value,
+    gameDayId: gameDayId.value,
+    pitchId: pitchId.value,
+    pitchSlotId: pitchSlotId.value,
+  });
+}
+
+function validateGameSides(value: unknown): ValidationResult<EventGameRecordRoot["gameSides"]> {
+  if (!Array.isArray(value) || value.length !== 2) {
+    return invalid("gameSides must contain exactly two stable sides.");
+  }
+
+  const sides: EventGameRecordSide[] = [];
+  const sideIds = new Set<string>();
+  const eventTeamIds = new Set<string>();
+  for (const [index, sideValue] of value.entries()) {
+    if (!isRecord(sideValue)) return invalid(`gameSides[${index}] must be an object.`);
+
+    const id = validateId(sideValue.id, `gameSides[${index}].id`);
+    const eventTeamId = validateId(sideValue.eventTeamId, `gameSides[${index}].eventTeamId`);
+    const teamInterpretationRef = validateId(
+      sideValue.teamInterpretationRef,
+      `gameSides[${index}].teamInterpretationRef`,
+    );
+    if (!id.ok) return id;
+    if (!eventTeamId.ok) return eventTeamId;
+    if (!teamInterpretationRef.ok) return teamInterpretationRef;
+
+    if (!sideIds.add(id.value)) {
+      return invalid("gameSides must have distinct stable side identities.");
+    }
+    if (!eventTeamIds.add(eventTeamId.value)) {
+      return invalid("gameSides must reference distinct Event Teams.");
+    }
+
+    sides.push({
+      id: id.value,
+      eventTeamId: eventTeamId.value,
+      teamInterpretationRef: teamInterpretationRef.value,
+    });
+  }
+
+  const first = sides[0];
+  const second = sides[1];
+  if (first === undefined || second === undefined) {
+    return invalid("gameSides must contain exactly two stable sides.");
+  }
+
+  return valid([first, second]);
+}
+
+function validateLifecycle(value: unknown): ValidationResult<EventGameRecordRoot["lifecycle"]> {
+  if (!isRecord(value)) return invalid("lifecycle must be an object.");
+  if (
+    value.phase !== "scheduled" &&
+    value.phase !== "in-progress" &&
+    value.phase !== "suspended" &&
+    value.phase !== "finished"
+  ) {
+    return invalid("lifecycle.phase is unsupported.");
+  }
+
+  const commencedAtMs = validateNullableTimestamp(value.commencedAtMs, "lifecycle.commencedAtMs");
+  const finishedAtMs = validateNullableTimestamp(value.finishedAtMs, "lifecycle.finishedAtMs");
+  const lockedAtMs = validateNullableTimestamp(value.lockedAtMs, "lifecycle.lockedAtMs");
+  if (!commencedAtMs.ok) return commencedAtMs;
+  if (!finishedAtMs.ok) return finishedAtMs;
+  if (!lockedAtMs.ok) return lockedAtMs;
+
+  if (
+    value.lockReason !== null &&
+    value.lockReason !== "finished-inactivity" &&
+    value.lockReason !== "administrative"
+  ) {
+    return invalid("lifecycle.lockReason is unsupported.");
+  }
+  if (lockedAtMs.value !== null && finishedAtMs.value === null) {
+    return invalid("lifecycle.lockedAtMs requires lifecycle.finishedAtMs.");
+  }
+  if (finishedAtMs.value !== null && commencedAtMs.value === null) {
+    return invalid("lifecycle.finishedAtMs requires lifecycle.commencedAtMs.");
+  }
+  if (
+    commencedAtMs.value !== null &&
+    finishedAtMs.value !== null &&
+    finishedAtMs.value < commencedAtMs.value
+  ) {
+    return invalid("lifecycle.finishedAtMs cannot precede lifecycle.commencedAtMs.");
+  }
+  if (
+    finishedAtMs.value !== null &&
+    lockedAtMs.value !== null &&
+    lockedAtMs.value < finishedAtMs.value
+  ) {
+    return invalid("lifecycle.lockedAtMs cannot precede lifecycle.finishedAtMs.");
+  }
+  if (lockedAtMs.value === null && value.lockReason !== null) {
+    return invalid("lifecycle.lockReason requires lifecycle.lockedAtMs.");
+  }
+  if (lockedAtMs.value !== null && value.lockReason === null) {
+    return invalid("lifecycle.lockedAtMs requires lifecycle.lockReason.");
+  }
+
+  return valid({
+    phase: value.phase,
+    commencedAtMs: commencedAtMs.value,
+    finishedAtMs: finishedAtMs.value,
+    lockedAtMs: lockedAtMs.value,
+    lockReason: value.lockReason,
+  });
+}
+
+function validateCompatibility(
+  value: unknown,
+): ValidationResult<EventGameRecordRoot["compatibility"]> {
+  if (!isRecord(value)) return invalid("compatibility must be an object.");
+
+  const recordVersion = validateId(value.recordVersion, "compatibility.recordVersion");
+  const schemaVersion = validateId(value.schemaVersion, "compatibility.schemaVersion");
+  const interpreterVersion = validateId(
+    value.interpreterVersion,
+    "compatibility.interpreterVersion",
+  );
+  if (!recordVersion.ok) return recordVersion;
+  if (!schemaVersion.ok) return schemaVersion;
+  if (!interpreterVersion.ok) return interpreterVersion;
+
+  return valid({
+    recordVersion: recordVersion.value,
+    schemaVersion: schemaVersion.value,
+    interpreterVersion: interpreterVersion.value,
+  });
+}
+
+function validateCreationEvidence(
+  value: unknown,
+): ValidationResult<EventGameRecordRoot["creationEvidence"]> {
+  if (!isRecord(value)) return invalid("creationEvidence must be an object.");
+  const operationId = validateId(value.operationId, "creationEvidence.operationId");
+  const actorReference = validateId(value.actorReference, "creationEvidence.actorReference");
+  const createdAtMs = validateTimestamp(value.createdAtMs, "creationEvidence.createdAtMs");
+  if (!operationId.ok) return operationId;
+  if (!actorReference.ok) return actorReference;
+  if (!createdAtMs.ok) return createdAtMs;
+  if (value.source !== "event-game-registration") {
+    return invalid("creationEvidence.source is unsupported.");
+  }
+
+  return valid({
+    operationId: operationId.value,
+    actorReference: actorReference.value,
+    source: value.source,
+    createdAtMs: createdAtMs.value,
+  });
+}
+
+function validateId(value: unknown, field: string): ValidationResult<string> {
+  return validateOpaqueIdentifier(value, field);
+}
+
+function validateTimestamp(value: unknown, field: string): ValidationResult<number> {
+  return validateIntegerInRange(value, 0, MAX_TIMESTAMP_MS, field);
+}
+
+function validateNullableTimestamp(value: unknown, field: string): ValidationResult<number | null> {
+  if (value === null) return valid(null);
+  return validateTimestamp(value, field);
+}
+
+function sortJsonValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => sortJsonValue(item));
+  }
+
+  if (isRecord(value)) {
+    return Object.fromEntries(
+      Object.keys(value)
+        .sort()
+        .map((key) => [key, sortJsonValue(value[key])]),
+    );
+  }
+
+  return value;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function valid<T>(value: T): ValidationResult<T> {
+  return { ok: true, value };
+}
+
+function invalid<T>(error: string): ValidationResult<T> {
+  return { ok: false, error };
+}

--- a/src/lib/foundation-schema.ts
+++ b/src/lib/foundation-schema.ts
@@ -1,0 +1,533 @@
+import { createHash } from "node:crypto";
+import { Database } from "bun:sqlite";
+import {
+  FOUNDATION_LEDGER_TABLE_SQL,
+  FOUNDATION_ROOT_EVENT_INDEX_SQL,
+  FOUNDATION_ROOT_GAME_DAY_INDEX_SQL,
+  FOUNDATION_ROOT_TABLE_SQL,
+  FOUNDATION_SIDE_RECORD_INDEX_SQL,
+  FOUNDATION_SIDE_TABLE_SQL,
+} from "@/lib/foundation-migrations";
+import {
+  canonicalizeEventGameRecordRoot,
+  cloneEventGameRecordRoot,
+  validateEventGameRecordRoot,
+  type EventGameRecordRoot,
+} from "@/lib/foundation-record-types";
+
+type SchemaColumn = {
+  name: string;
+  type: string;
+  notNull: number;
+  defaultValue: string | null;
+  primaryKeyPosition: number;
+};
+
+type SchemaForeignKey = {
+  id: number;
+  sequence: number;
+  table: string;
+  from: string;
+  to: string;
+  onUpdate: string;
+  onDelete: string;
+  match: string;
+};
+
+type SchemaIndex = {
+  name: string;
+  unique: number;
+  origin: string;
+  partial: number;
+  columns: string[];
+};
+
+type FoundationSchemaManifest = {
+  objects: readonly {
+    type: string;
+    name: string;
+    tableName: string;
+    sql: string;
+  }[];
+  tables: readonly {
+    name: string;
+    columns: readonly SchemaColumn[];
+    foreignKeys: readonly SchemaForeignKey[];
+  }[];
+  indexes: readonly SchemaIndex[];
+};
+
+const ROOT_TABLE = "foundation_event_game_record_roots";
+const SIDE_TABLE = "foundation_event_game_record_sides";
+const LEDGER_TABLE = "foundation_migration_ledger";
+
+const expectedManifest: FoundationSchemaManifest = {
+  objects: [
+    object("table", LEDGER_TABLE, LEDGER_TABLE, FOUNDATION_LEDGER_TABLE_SQL),
+    object("table", ROOT_TABLE, ROOT_TABLE, FOUNDATION_ROOT_TABLE_SQL),
+    object("table", SIDE_TABLE, SIDE_TABLE, FOUNDATION_SIDE_TABLE_SQL),
+    object(
+      "index",
+      "foundation_event_game_record_roots_event_id",
+      ROOT_TABLE,
+      FOUNDATION_ROOT_EVENT_INDEX_SQL,
+    ),
+    object(
+      "index",
+      "foundation_event_game_record_roots_game_day_id",
+      ROOT_TABLE,
+      FOUNDATION_ROOT_GAME_DAY_INDEX_SQL,
+    ),
+    object(
+      "index",
+      "foundation_event_game_record_sides_record_id",
+      SIDE_TABLE,
+      FOUNDATION_SIDE_RECORD_INDEX_SQL,
+    ),
+  ].sort(compareNamed),
+  tables: [
+    {
+      name: LEDGER_TABLE,
+      columns: [
+        column("migration_id", "TEXT", 1, 1),
+        column("ordinal", "INTEGER", 1, 0),
+        column("schema_version", "INTEGER", 1, 0),
+        column("checksum", "TEXT", 1, 0),
+        column("status", "TEXT", 1, 0),
+        column("applied_at_ms", "INTEGER", 0, 0),
+      ],
+      foreignKeys: [],
+    },
+    {
+      name: ROOT_TABLE,
+      columns: [
+        column("record_id", "TEXT", 1, 1),
+        column("event_id", "TEXT", 1, 0),
+        column("event_game_id", "TEXT", 1, 0),
+        column("owner_event_id", "TEXT", 1, 0),
+        column("owner_event_game_id", "TEXT", 1, 0),
+        column("scope_event_id", "TEXT", 1, 0),
+        column("game_day_id", "TEXT", 1, 0),
+        column("pitch_id", "TEXT", 1, 0),
+        column("pitch_slot_id", "TEXT", 1, 0),
+        column("lifecycle_phase", "TEXT", 1, 0),
+        column("commenced_at_ms", "INTEGER", 0, 0),
+        column("finished_at_ms", "INTEGER", 0, 0),
+        column("locked_at_ms", "INTEGER", 0, 0),
+        column("lock_reason", "TEXT", 0, 0),
+        column("record_version", "TEXT", 1, 0),
+        column("schema_version", "TEXT", 1, 0),
+        column("interpreter_version", "TEXT", 1, 0),
+        column("creation_operation_id", "TEXT", 1, 0),
+        column("creation_actor_reference", "TEXT", 1, 0),
+        column("creation_source", "TEXT", 1, 0),
+        column("creation_created_at_ms", "INTEGER", 1, 0),
+        column("canonical_content", "TEXT", 1, 0),
+        column("root_json", "TEXT", 1, 0),
+      ],
+      foreignKeys: [],
+    },
+    {
+      name: SIDE_TABLE,
+      columns: [
+        column("side_id", "TEXT", 1, 1),
+        column("record_id", "TEXT", 1, 0),
+        column("side_position", "TEXT", 1, 0),
+        column("event_team_id", "TEXT", 1, 0),
+        column("team_interpretation_ref", "TEXT", 1, 0),
+      ],
+      foreignKeys: [
+        {
+          id: 0,
+          sequence: 0,
+          table: ROOT_TABLE,
+          from: "record_id",
+          to: "record_id",
+          onUpdate: "NO ACTION",
+          onDelete: "CASCADE",
+          match: "NONE",
+        },
+      ],
+    },
+  ].sort(compareNamed),
+  indexes: [
+    index("foundation_event_game_record_roots_event_id", 0, ["event_id"]),
+    index("foundation_event_game_record_roots_game_day_id", 0, ["scope_event_id", "game_day_id"]),
+    index("foundation_event_game_record_sides_record_id", 0, ["record_id"]),
+  ].sort(compareNamed),
+};
+
+export const FOUNDATION_SCHEMA_FINGERPRINT = fingerprint(expectedManifest);
+
+export type FoundationSchemaVerification =
+  | { ok: true }
+  | {
+      ok: false;
+      status: "missing" | "integrity-failure" | "not-writeable";
+      detail: string;
+    };
+
+export function hasExpectedFoundationSchema(database: Database): boolean {
+  return foundationSchemaFingerprint(database) === FOUNDATION_SCHEMA_FINGERPRINT;
+}
+
+export function foundationSchemaFingerprint(database: Database): string {
+  return fingerprint(readSchemaManifest(database));
+}
+
+export function verifyFoundationSchema(database: Database): FoundationSchemaVerification {
+  try {
+    if (!tableExists(database, ROOT_TABLE)) {
+      return {
+        ok: false,
+        status: "missing",
+        detail: "The supported root table is missing.",
+      };
+    }
+    if (!hasExpectedFoundationSchema(database)) {
+      return {
+        ok: false,
+        status: "integrity-failure",
+        detail: "SQLite does not contain the supported foundation schema definition.",
+      };
+    }
+    if (
+      readPragmaText(database, "quick_check") !== "ok" ||
+      readPragmaText(database, "integrity_check") !== "ok"
+    ) {
+      return {
+        ok: false,
+        status: "integrity-failure",
+        detail: "SQLite integrity checks did not pass.",
+      };
+    }
+    const foreignKeyViolations = database.query("PRAGMA foreign_key_check").all() as unknown[];
+    if (foreignKeyViolations.length !== 0) {
+      return {
+        ok: false,
+        status: "integrity-failure",
+        detail: "SQLite reported foreign-key violations.",
+      };
+    }
+    if (!canBeginWrite(database)) {
+      return {
+        ok: false,
+        status: "not-writeable",
+        detail: "SQLite did not permit a writeability check.",
+      };
+    }
+    scanFoundationRoots(database);
+    return { ok: true };
+  } catch {
+    return {
+      ok: false,
+      status: "integrity-failure",
+      detail: "SQLite foundation schema verification failed.",
+    };
+  }
+}
+
+export function readValidatedFoundationRoot(
+  database: Database,
+  row: Record<string, unknown>,
+): EventGameRecordRoot {
+  const parsed = JSON.parse(readText(row.root_json)) as unknown;
+  const validated = validateEventGameRecordRoot(parsed);
+  if (!validated.ok) {
+    throw new Error("Stored Event Game Record root failed validation.");
+  }
+  if (canonicalizeEventGameRecordRoot(validated.value) !== readText(row.canonical_content)) {
+    throw new Error("Stored Event Game Record root checksum does not match its content.");
+  }
+  assertRootProjection(row, validated.value);
+  assertStoredSides(database, validated.value);
+  return cloneEventGameRecordRoot(validated.value);
+}
+
+export function scanFoundationRoots(database: Database): void {
+  const rows = database
+    .query("SELECT * FROM foundation_event_game_record_roots ORDER BY record_id")
+    .all() as unknown[];
+  for (const value of rows) {
+    readValidatedFoundationRoot(database, asRecord(value));
+  }
+}
+
+function assertStoredSides(database: Database, root: EventGameRecordRoot): void {
+  const rows = database
+    .query(
+      `SELECT side_id, side_position, event_team_id, team_interpretation_ref
+       FROM foundation_event_game_record_sides
+       WHERE record_id = ?
+       ORDER BY side_position`,
+    )
+    .all(root.recordId) as unknown[];
+  if (rows.length !== 2) {
+    throw new Error("Stored Event Game Record sides are incomplete.");
+  }
+  const sides = rows.map((value) => {
+    const row = asRecord(value);
+    return {
+      id: readText(row.side_id),
+      position: readText(row.side_position),
+      eventTeamId: readText(row.event_team_id),
+      teamInterpretationRef: readText(row.team_interpretation_ref),
+    };
+  });
+  const [sideA, sideB] = root.gameSides;
+  const storedA = sides.find((side) => side.position === "a");
+  const storedB = sides.find((side) => side.position === "b");
+  if (
+    storedA === undefined ||
+    storedB === undefined ||
+    storedA.id !== sideA.id ||
+    storedA.eventTeamId !== sideA.eventTeamId ||
+    storedA.teamInterpretationRef !== sideA.teamInterpretationRef ||
+    storedB.id !== sideB.id ||
+    storedB.eventTeamId !== sideB.eventTeamId ||
+    storedB.teamInterpretationRef !== sideB.teamInterpretationRef
+  ) {
+    throw new Error("Stored Event Game Record sides do not match the semantic root.");
+  }
+}
+
+function assertRootProjection(row: Record<string, unknown>, root: EventGameRecordRoot): void {
+  const expectedText: readonly [string, string][] = [
+    ["record_id", root.recordId],
+    ["event_id", root.eventId],
+    ["event_game_id", root.eventGameId],
+    ["owner_event_id", root.ownership.eventId],
+    ["owner_event_game_id", root.ownership.eventGameId],
+    ["scope_event_id", root.externalScope.eventId],
+    ["game_day_id", root.externalScope.gameDayId],
+    ["pitch_id", root.externalScope.pitchId],
+    ["pitch_slot_id", root.externalScope.pitchSlotId],
+    ["lifecycle_phase", root.lifecycle.phase],
+    ["record_version", root.compatibility.recordVersion],
+    ["schema_version", root.compatibility.schemaVersion],
+    ["interpreter_version", root.compatibility.interpreterVersion],
+    ["creation_operation_id", root.creationEvidence.operationId],
+    ["creation_actor_reference", root.creationEvidence.actorReference],
+    ["creation_source", root.creationEvidence.source],
+  ];
+  for (const [field, expected] of expectedText) {
+    if (readText(row[field]) !== expected) {
+      throw new Error("Stored Event Game Record projection does not match its semantic root.");
+    }
+  }
+  const expectedNullableNumbers: readonly [string, number | null][] = [
+    ["commenced_at_ms", root.lifecycle.commencedAtMs],
+    ["finished_at_ms", root.lifecycle.finishedAtMs],
+    ["locked_at_ms", root.lifecycle.lockedAtMs],
+  ];
+  for (const [field, expected] of expectedNullableNumbers) {
+    if (readNullableInteger(row[field]) !== expected) {
+      throw new Error("Stored Event Game Record timestamps do not match their semantic root.");
+    }
+  }
+  if (readNullableText(row.lock_reason) !== root.lifecycle.lockReason) {
+    throw new Error("Stored Event Game Record lock state does not match its semantic root.");
+  }
+  if (readInteger(row.creation_created_at_ms) !== root.creationEvidence.createdAtMs) {
+    throw new Error("Stored Event Game Record creation evidence does not match its semantic root.");
+  }
+}
+
+function readSchemaManifest(database: Database): FoundationSchemaManifest {
+  const objects = (
+    database
+      .query(
+        "SELECT type, name, tbl_name, sql FROM sqlite_master WHERE name NOT LIKE 'sqlite_%' ORDER BY type, name",
+      )
+      .all() as unknown[]
+  ).map((value) => {
+    const row = asRecord(value);
+    return object(
+      readText(row.type),
+      readText(row.name),
+      readText(row.tbl_name),
+      readText(row.sql),
+    );
+  });
+
+  const tables = [LEDGER_TABLE, ROOT_TABLE, SIDE_TABLE].map((name) => ({
+    name,
+    columns: readColumns(database, name),
+    foreignKeys: readForeignKeys(database, name),
+  }));
+  const indexes = [
+    "foundation_event_game_record_roots_event_id",
+    "foundation_event_game_record_roots_game_day_id",
+    "foundation_event_game_record_sides_record_id",
+  ].map((name) => readIndex(database, name));
+
+  return {
+    objects: objects.sort(compareNamed),
+    tables: tables.sort(compareNamed),
+    indexes: indexes.sort(compareNamed),
+  };
+}
+
+function tableExists(database: Database, name: string): boolean {
+  return (
+    database
+      .query("SELECT 1 AS present FROM sqlite_master WHERE type = 'table' AND name = ?")
+      .get(name) !== null
+  );
+}
+
+function canBeginWrite(database: Database): boolean {
+  try {
+    database.exec("BEGIN IMMEDIATE; ROLLBACK;");
+    return true;
+  } catch {
+    try {
+      database.exec("ROLLBACK;");
+    } catch {
+      // The verification result is the useful boundary for callers.
+    }
+    return false;
+  }
+}
+
+function readPragmaText(database: Database, name: "quick_check" | "integrity_check"): string {
+  const value = database.query(`PRAGMA ${name}`).get();
+  if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+    const row = value as Record<string, unknown>;
+    if (name in row) return readText(row[name]);
+  }
+  return readText(value);
+}
+
+function readColumns(database: Database, tableName: string): SchemaColumn[] {
+  return (
+    database.query(`PRAGMA table_info(${quoteIdentifier(tableName)})`).all() as unknown[]
+  ).map((value) => {
+    const row = asRecord(value);
+    return {
+      name: readText(row.name),
+      type: readText(row.type),
+      notNull: readInteger(row.notnull),
+      defaultValue: row.dflt_value === null ? null : readText(row.dflt_value),
+      primaryKeyPosition: readInteger(row.pk),
+    };
+  });
+}
+
+function readForeignKeys(database: Database, tableName: string): SchemaForeignKey[] {
+  return (
+    database.query(`PRAGMA foreign_key_list(${quoteIdentifier(tableName)})`).all() as unknown[]
+  ).map((value) => {
+    const row = asRecord(value);
+    return {
+      id: readInteger(row.id),
+      sequence: readInteger(row.seq),
+      table: readText(row.table),
+      from: readText(row.from),
+      to: readText(row.to),
+      onUpdate: readText(row.on_update),
+      onDelete: readText(row.on_delete),
+      match: readText(row.match),
+    };
+  });
+}
+
+function readIndex(database: Database, name: string): SchemaIndex {
+  const indexRows = database
+    .query(`PRAGMA index_list(${quoteIdentifier(indexTable(name))})`)
+    .all() as unknown[];
+  const indexRow = indexRows.map(asRecord).find((row) => readText(row.name) === name);
+  if (indexRow === undefined) {
+    throw new Error(`Expected SQLite index ${name} is missing.`);
+  }
+  const columns = (database.query(`PRAGMA index_info(${quoteIdentifier(name)})`).all() as unknown[])
+    .map(asRecord)
+    .sort((left, right) => readInteger(left.seqno) - readInteger(right.seqno))
+    .map((row) => readText(row.name));
+  return {
+    name,
+    unique: readInteger(indexRow.unique),
+    origin: readText(indexRow.origin),
+    partial: readInteger(indexRow.partial),
+    columns,
+  };
+}
+
+function indexTable(name: string): string {
+  return name.includes("sides") ? SIDE_TABLE : ROOT_TABLE;
+}
+
+function object(
+  type: string,
+  name: string,
+  tableName: string,
+  sql: string,
+): FoundationSchemaManifest["objects"][number] {
+  return { type, name, tableName, sql: normalizeSql(sql) };
+}
+
+function column(
+  name: string,
+  type: string,
+  notNull: number,
+  primaryKeyPosition: number,
+): SchemaColumn {
+  return {
+    name,
+    type,
+    notNull,
+    defaultValue: null,
+    primaryKeyPosition,
+  };
+}
+
+function index(name: string, unique: number, columns: string[]): SchemaIndex {
+  return { name, unique, origin: "c", partial: 0, columns };
+}
+
+function fingerprint(manifest: FoundationSchemaManifest): string {
+  return createHash("sha256").update(JSON.stringify(manifest), "utf8").digest("hex");
+}
+
+function normalizeSql(sql: string): string {
+  return sql
+    .replaceAll(/"([A-Za-z_][A-Za-z0-9_]*)"/g, "$1")
+    .replaceAll(/\s+/g, " ")
+    .trim()
+    .toLowerCase();
+}
+
+function compareNamed(left: { name: string }, right: { name: string }): number {
+  return left.name.localeCompare(right.name);
+}
+
+function quoteIdentifier(value: string): string {
+  return `"${value.replaceAll('"', '""')}"`;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error("SQLite returned an invalid schema row.");
+  }
+  return value as Record<string, unknown>;
+}
+
+function readText(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "bigint") return String(value);
+  throw new Error("SQLite returned an invalid schema value.");
+}
+
+function readInteger(value: unknown): number {
+  const parsed = Number(readText(value));
+  if (!Number.isSafeInteger(parsed)) throw new Error("SQLite returned an invalid schema integer.");
+  return parsed;
+}
+
+function readNullableInteger(value: unknown): number | null {
+  return value === null ? null : readInteger(value);
+}
+
+function readNullableText(value: unknown): string | null {
+  return value === null ? null : readText(value);
+}

--- a/src/lib/foundation-storage-contract.test.ts
+++ b/src/lib/foundation-storage-contract.test.ts
@@ -1,0 +1,431 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createEventGameRecord, type ExternalScopeResolver } from "@/lib/event-game-record";
+import {
+  canonicalizeEventGameRecordRoot,
+  type EventGameRecordRoot,
+} from "@/lib/foundation-record-types";
+import { createInMemoryFoundationStorage } from "@/lib/foundation-storage-memory";
+import { openSqliteFoundationStorage } from "@/lib/foundation-storage-sqlite";
+import { FoundationStorageConstraintError, type FoundationStorage } from "@/lib/foundation-storage";
+
+type StorageHarness = {
+  storage: FoundationStorage;
+  cleanup(): Promise<void>;
+};
+
+type StorageFactory = () => Promise<StorageHarness>;
+
+function createRoot(overrides: Partial<EventGameRecordRoot> = {}): EventGameRecordRoot {
+  return {
+    recordId: "record-1",
+    eventId: "event-1",
+    eventGameId: "event-game-1",
+    ownership: {
+      eventId: "event-1",
+      eventGameId: "event-game-1",
+    },
+    externalScope: {
+      eventId: "event-1",
+      gameDayId: "game-day-1",
+      pitchId: "pitch-1",
+      pitchSlotId: "pitch-slot-1",
+    },
+    gameSides: [
+      {
+        id: "side-1",
+        eventTeamId: "team-1",
+        teamInterpretationRef: "team-interpretation-1",
+      },
+      {
+        id: "side-2",
+        eventTeamId: "team-2",
+        teamInterpretationRef: "team-interpretation-2",
+      },
+    ],
+    lifecycle: {
+      phase: "scheduled",
+      commencedAtMs: null,
+      finishedAtMs: null,
+      lockedAtMs: null,
+      lockReason: null,
+    },
+    compatibility: {
+      recordVersion: "record-v1",
+      schemaVersion: "schema-v1",
+      interpreterVersion: "rules-v1",
+    },
+    creationEvidence: {
+      operationId: "register-1",
+      actorReference: "event-admin-session-1",
+      source: "event-game-registration",
+      createdAtMs: 1_000,
+    },
+    ...overrides,
+  };
+}
+
+const memoryFactory: StorageFactory = async () => {
+  const storage = createInMemoryFoundationStorage();
+  return {
+    storage,
+    cleanup: async () => storage.close(),
+  };
+};
+
+const sqliteFactory: StorageFactory = async () => {
+  const directory = await mkdtemp(join(tmpdir(), "quadball-timer-storage-contract-"));
+  const databasePath = join(directory, "foundation.sqlite");
+  const storage = openSqliteFoundationStorage(databasePath);
+  await storage.applyMigrations();
+  return {
+    storage,
+    cleanup: async () => {
+      storage.close();
+      await rm(directory, { recursive: true, force: true });
+    },
+  };
+};
+
+function runStorageContract(name: string, factory: StorageFactory): void {
+  describe(`${name} foundation storage contract`, () => {
+    test("registers and reads a semantic Event Game Record root", async () => {
+      const harness = await factory();
+      try {
+        const root = createRoot();
+        const record = createEventGameRecord(harness.storage, {
+          externalScopeResolver: createScopeResolver(root),
+        });
+        expect(await record.registerRoot(root)).toMatchObject({ status: "registered" });
+        expect(await record.readRoot(root.recordId)).toEqual(root);
+      } finally {
+        await harness.cleanup();
+      }
+    });
+
+    test("exposes duplicate identity and external scope conflicts without rows", async () => {
+      const harness = await factory();
+      try {
+        const root = createRoot();
+        const record = createEventGameRecord(harness.storage, {
+          externalScopeResolver: createScopeResolver(root),
+        });
+        expect(await record.registerRoot(root)).toMatchObject({ status: "registered" });
+        expect(await record.registerRoot(structuredClone(root))).toMatchObject({
+          status: "idempotent",
+        });
+
+        expect(
+          await record.registerRoot({
+            ...createRoot({
+              recordId: "record-2",
+              eventGameId: "event-game-2",
+              ownership: { eventId: "event-1", eventGameId: "event-game-2" },
+              gameSides: [
+                { ...root.gameSides[0], id: "side-3", eventTeamId: "team-3" },
+                { ...root.gameSides[1], id: "side-4", eventTeamId: "team-4" },
+              ],
+            }),
+            externalScope: {
+              ...root.externalScope,
+              pitchSlotId: root.externalScope.pitchSlotId,
+            },
+          }),
+        ).toMatchObject({
+          status: "rejected",
+          reason: "external-scope-conflict",
+        });
+      } finally {
+        await harness.cleanup();
+      }
+    });
+
+    test("keeps an identical retry idempotent when external scope resolution later fails", async () => {
+      const harness = await factory();
+      try {
+        const root = createRoot();
+        let resolutionCount = 0;
+        const resolver: ExternalScopeResolver = {
+          resolve(scope) {
+            resolutionCount += 1;
+            return resolutionCount === 1
+              ? { status: "resolved", scope: structuredClone(scope) }
+              : {
+                  status: "missing",
+                  detail: "missing: the external scope catalog is temporarily unavailable.",
+                };
+          },
+        };
+        const record = createEventGameRecord(harness.storage, {
+          externalScopeResolver: resolver,
+        });
+
+        expect(await record.registerRoot(root)).toMatchObject({ status: "registered" });
+        expect(await record.registerRoot(structuredClone(root))).toMatchObject({
+          status: "idempotent",
+        });
+        expect(resolutionCount).toBe(1);
+        expect(await record.readRoot(root.recordId)).toEqual(root);
+        expect(await record.readRoot("record-2")).toBeNull();
+      } finally {
+        await harness.cleanup();
+      }
+    });
+
+    test("serializes concurrent identical registrations into one commit", async () => {
+      const harness = await factory();
+      try {
+        const root = createRoot();
+        const record = createEventGameRecord(harness.storage, {
+          externalScopeResolver: createScopeResolver(root),
+        });
+        const outcomes = await Promise.all([record.registerRoot(root), record.registerRoot(root)]);
+        expect(outcomes.filter((outcome) => outcome.status === "registered")).toHaveLength(1);
+        expect(outcomes.filter((outcome) => outcome.status === "idempotent")).toHaveLength(1);
+        expect(await record.readRoot(root.recordId)).toEqual(root);
+      } finally {
+        await harness.cleanup();
+      }
+    });
+
+    test("resolves every external scope relationship inside the storage transaction", async () => {
+      const root = createRoot();
+      const knownValues = new Set([
+        "event-1",
+        "event-2",
+        "game-day-1",
+        "game-day-2",
+        "pitch-1",
+        "pitch-2",
+        "pitch-slot-1",
+        "pitch-slot-2",
+      ]);
+      const resolver: ExternalScopeResolver = {
+        resolve(scope, transaction) {
+          expect(transaction.findRootByRecordId("not-yet-committed")).toBeNull();
+          if (
+            ![scope.eventId, scope.gameDayId, scope.pitchId, scope.pitchSlotId].every((value) =>
+              knownValues.has(value),
+            )
+          ) {
+            return {
+              status: "missing",
+              detail: "missing: the external scope reference does not exist.",
+            };
+          }
+          if (JSON.stringify(scope) !== JSON.stringify(root.externalScope)) {
+            return {
+              status: "mismatch",
+              detail: "mismatch: the external scope references do not belong to one hierarchy.",
+            };
+          }
+          return { status: "resolved", scope: structuredClone(scope) };
+        },
+      };
+      const cases: readonly [string, Partial<EventGameRecordRoot["externalScope"]>, string][] = [
+        ["missing Event", { eventId: "missing-event" }, "missing"],
+        ["missing Game Day", { gameDayId: "missing-game-day" }, "missing"],
+        ["missing Pitch", { pitchId: "missing-pitch" }, "missing"],
+        ["missing Pitch Slot", { pitchSlotId: "missing-pitch-slot" }, "missing"],
+        ["mismatched Event", { eventId: "event-2" }, "mismatch"],
+        ["mismatched Game Day", { gameDayId: "game-day-2" }, "mismatch"],
+        ["mismatched Pitch", { pitchId: "pitch-2" }, "mismatch"],
+        ["mismatched Pitch Slot", { pitchSlotId: "pitch-slot-2" }, "mismatch"],
+      ];
+
+      for (const [label, patch, expectedStatus] of cases) {
+        const harness = await factory();
+        try {
+          const externalScope = { ...root.externalScope, ...patch };
+          const caseEventId = externalScope.eventId;
+          const caseEventGameId = `event-game-${label.replaceAll(" ", "-").toLowerCase()}`;
+          const record = createEventGameRecord(harness.storage, {
+            externalScopeResolver: resolver,
+          });
+          const outcome = await record.registerRoot(
+            createRoot({
+              recordId: `record-${label.replaceAll(" ", "-").toLowerCase()}`,
+              eventId: caseEventId,
+              eventGameId: caseEventGameId,
+              ownership: { eventId: caseEventId, eventGameId: caseEventGameId },
+              externalScope,
+            }),
+          );
+          expect(outcome).toMatchObject({
+            status: "rejected",
+            reason: "external-scope-conflict",
+          });
+          if (outcome.status === "rejected") {
+            expect(outcome.detail).toContain(expectedStatus);
+          }
+        } finally {
+          await harness.cleanup();
+        }
+      }
+
+      const harness = await factory();
+      try {
+        const record = createEventGameRecord(harness.storage, {
+          externalScopeResolver: resolver,
+        });
+        expect(await record.registerRoot(root)).toMatchObject({ status: "registered" });
+      } finally {
+        await harness.cleanup();
+      }
+    });
+
+    test("rejects unpaired lock timestamp and reason before reaching either adapter", async () => {
+      const invalidLifecycles: readonly EventGameRecordRoot["lifecycle"][] = [
+        {
+          phase: "finished",
+          commencedAtMs: 100,
+          finishedAtMs: 200,
+          lockedAtMs: 300,
+          lockReason: null,
+        },
+        {
+          phase: "finished",
+          commencedAtMs: 100,
+          finishedAtMs: 200,
+          lockedAtMs: null,
+          lockReason: "administrative",
+        },
+      ];
+
+      for (const [index, lifecycle] of invalidLifecycles.entries()) {
+        const harness = await factory();
+        try {
+          const root = createRoot({
+            recordId: `invalid-lock-record-${index}`,
+            eventGameId: `invalid-lock-game-${index}`,
+            ownership: {
+              eventId: "event-1",
+              eventGameId: `invalid-lock-game-${index}`,
+            },
+            externalScope: {
+              ...createRoot().externalScope,
+              pitchSlotId: `invalid-lock-slot-${index}`,
+            },
+            lifecycle,
+          });
+          const record = createEventGameRecord(harness.storage, {
+            externalScopeResolver: createScopeResolver(root),
+          });
+          const outcome = await record.registerRoot(root);
+          expect(outcome).toMatchObject({ status: "rejected", reason: "invalid-root" });
+          if (outcome.status === "rejected") {
+            expect(outcome.detail).not.toContain("CHECK");
+            expect(outcome.detail).not.toContain("constraint");
+          }
+          expect(await record.readRoot(root.recordId)).toBeNull();
+        } finally {
+          await harness.cleanup();
+        }
+      }
+    });
+
+    test("enforces global Game Side identity uniqueness in both positions", async () => {
+      const orientations: readonly [string, 0 | 1][] = [
+        ["incoming-side-a-reuses-existing-side-b", 0],
+        ["incoming-side-b-reuses-existing-side-a", 1],
+      ];
+      for (const [label, incomingPosition] of orientations) {
+        const harness = await factory();
+        try {
+          const first = createRoot();
+          const firstSideId = first.gameSides[incomingPosition === 0 ? 1 : 0]?.id;
+          if (firstSideId === undefined) throw new Error("Expected a first Game Side.");
+          const secondGameId = `game-${label}`;
+          const secondSides = [
+            {
+              id: `new-side-a-${label}`,
+              eventTeamId: `new-team-a-${label}`,
+              teamInterpretationRef: "interpretation-a",
+            },
+            {
+              id: `new-side-b-${label}`,
+              eventTeamId: `new-team-b-${label}`,
+              teamInterpretationRef: "interpretation-b",
+            },
+          ] as [EventGameRecordRoot["gameSides"][0], EventGameRecordRoot["gameSides"][1]];
+          secondSides[incomingPosition].id = firstSideId;
+          const second = createRoot({
+            recordId: `record-${label}`,
+            eventGameId: secondGameId,
+            ownership: { eventId: "event-1", eventGameId: secondGameId },
+            externalScope: { ...first.externalScope, pitchSlotId: `slot-${label}` },
+            gameSides: secondSides,
+          });
+
+          let failure: unknown;
+          try {
+            await harness.storage.transaction((transaction) => {
+              transaction.insertRoot({
+                root: first,
+                canonicalContent: canonicalizeEventGameRecordRoot(first),
+              });
+              transaction.insertRoot({
+                root: second,
+                canonicalContent: canonicalizeEventGameRecordRoot(second),
+              });
+            });
+          } catch (error) {
+            failure = error;
+          }
+          expect(failure).toBeInstanceOf(FoundationStorageConstraintError);
+          if (failure instanceof FoundationStorageConstraintError) {
+            expect(failure.constraint).toBe("game-side-id");
+          }
+          expect(await harness.storage.readRoot(first.recordId)).toBeNull();
+          expect(await harness.storage.readRoot(second.recordId)).toBeNull();
+        } finally {
+          await harness.cleanup();
+        }
+      }
+    });
+
+    test("rolls back a failed transaction and leaves no root behind", async () => {
+      const harness = await factory();
+      try {
+        const root = createRoot();
+        let failure: unknown;
+        try {
+          await harness.storage.transaction((transaction) => {
+            transaction.insertRoot({
+              root,
+              canonicalContent: JSON.stringify(root),
+            });
+            throw new Error("contract rollback");
+          });
+        } catch (error) {
+          failure = error;
+        }
+        expect(failure).toBeInstanceOf(Error);
+        if (failure instanceof Error) {
+          expect(failure.message).toContain("contract rollback");
+        }
+        expect(await harness.storage.readRoot(root.recordId)).toBeNull();
+      } finally {
+        await harness.cleanup();
+      }
+    });
+  });
+}
+
+function createScopeResolver(root: EventGameRecordRoot): ExternalScopeResolver {
+  return {
+    resolve(scope) {
+      return JSON.stringify(scope) === JSON.stringify(root.externalScope)
+        ? { status: "resolved", scope: structuredClone(scope) }
+        : {
+            status: "mismatch",
+            detail: "The external scope does not match the registered hierarchy.",
+          };
+    },
+  };
+}
+
+runStorageContract("in-memory", memoryFactory);
+runStorageContract("SQLite", sqliteFactory);

--- a/src/lib/foundation-storage-memory.ts
+++ b/src/lib/foundation-storage-memory.ts
@@ -1,0 +1,182 @@
+import {
+  canonicalizeEventGameRecordRoot,
+  cloneEventGameRecordRoot,
+  validateEventGameRecordRoot,
+  type EventGameRecordRoot,
+} from "@/lib/foundation-record-types";
+import {
+  FoundationStorageClosedError,
+  FoundationStorageConstraintError,
+  type FoundationStorage,
+  type FoundationStorageReadiness,
+  type FoundationStorageTransaction,
+  type FoundationStorageTransactionWork,
+  type StoredEventGameRecordRoot,
+  isThenable,
+} from "@/lib/foundation-storage";
+
+type MemoryState = Map<string, StoredEventGameRecordRoot>;
+
+export function createInMemoryFoundationStorage(): FoundationStorage {
+  return new InMemoryFoundationStorage();
+}
+
+class InMemoryFoundationStorage implements FoundationStorage {
+  private state: MemoryState = new Map();
+  private writerTail: Promise<void> = Promise.resolve();
+  private closed = false;
+
+  transaction<T>(work: FoundationStorageTransactionWork<T>): Promise<T> {
+    const operation = this.writerTail.then(() => {
+      this.assertOpen();
+      const workingState = cloneState(this.state);
+      const transaction = createTransaction(workingState);
+      const result = work(transaction);
+      if (isThenable(result)) {
+        throw new TypeError("Foundation storage transactions must complete synchronously.");
+      }
+
+      this.state = workingState;
+      return result;
+    });
+    this.writerTail = operation.then(
+      () => undefined,
+      () => undefined,
+    );
+    return operation;
+  }
+
+  async readRoot(recordId: string): Promise<EventGameRecordRoot | null> {
+    return this.writerTail.then(() => {
+      this.assertOpen();
+      const stored = this.state.get(recordId);
+      return stored === undefined ? null : cloneEventGameRecordRoot(stored.root);
+    });
+  }
+
+  readiness(): Promise<FoundationStorageReadiness> {
+    return this.writerTail.then(() => {
+      if (this.closed) {
+        return {
+          ok: false,
+          status: "closed",
+          detail: "In-memory foundation storage is closed.",
+          storage: "memory",
+        } satisfies FoundationStorageReadiness;
+      }
+      for (const stored of this.state.values()) {
+        const validated = validateEventGameRecordRoot(stored.root);
+        if (
+          !validated.ok ||
+          canonicalizeEventGameRecordRoot(validated.value) !== stored.canonicalContent
+        ) {
+          return {
+            ok: false,
+            status: "integrity-failure",
+            detail: "An in-memory Event Game Record root failed semantic validation.",
+            storage: "memory",
+          } satisfies FoundationStorageReadiness;
+        }
+      }
+      return {
+        ok: true,
+        schemaVersion: "memory",
+        storage: "memory",
+      } satisfies FoundationStorageReadiness;
+    });
+  }
+
+  close(): void {
+    this.closed = true;
+  }
+
+  private assertOpen(): void {
+    if (this.closed) {
+      throw new FoundationStorageClosedError();
+    }
+  }
+}
+
+function createTransaction(state: MemoryState): FoundationStorageTransaction {
+  return {
+    findRootByRecordId(recordId) {
+      return cloneStoredRoot(state.get(recordId));
+    },
+    findRootByEventGameId(eventGameId) {
+      return findRoot(state, (stored) => stored.root.eventGameId === eventGameId);
+    },
+    findRootByPitchSlotId(pitchSlotId) {
+      return findRoot(state, (stored) => stored.root.externalScope.pitchSlotId === pitchSlotId);
+    },
+    findRootByGameSideId(gameSideId) {
+      return findRoot(state, (stored) =>
+        stored.root.gameSides.some((side) => side.id === gameSideId),
+      );
+    },
+    insertRoot(storedRoot) {
+      if (state.has(storedRoot.root.recordId)) {
+        throw new FoundationStorageConstraintError("record-id");
+      }
+      if (
+        findRoot(state, (stored) => stored.root.eventGameId === storedRoot.root.eventGameId) !==
+        null
+      ) {
+        throw new FoundationStorageConstraintError("event-game-id");
+      }
+      if (
+        findRoot(
+          state,
+          (stored) =>
+            stored.root.externalScope.pitchSlotId === storedRoot.root.externalScope.pitchSlotId,
+        ) !== null
+      ) {
+        throw new FoundationStorageConstraintError("pitch-slot-id");
+      }
+      for (const side of storedRoot.root.gameSides) {
+        if (
+          findRoot(state, (stored) =>
+            stored.root.gameSides.some((candidate) => candidate.id === side.id),
+          ) !== null
+        ) {
+          throw new FoundationStorageConstraintError("game-side-id");
+        }
+      }
+
+      state.set(storedRoot.root.recordId, {
+        root: cloneEventGameRecordRoot(storedRoot.root),
+        canonicalContent: storedRoot.canonicalContent,
+      });
+    },
+  };
+}
+
+function findRoot(
+  state: MemoryState,
+  predicate: (stored: StoredEventGameRecordRoot) => boolean,
+): EventGameRecordRoot | null {
+  for (const stored of state.values()) {
+    if (predicate(stored)) {
+      return cloneEventGameRecordRoot(stored.root);
+    }
+  }
+
+  return null;
+}
+
+function cloneStoredRoot(
+  stored: StoredEventGameRecordRoot | undefined,
+): EventGameRecordRoot | null {
+  return stored === undefined ? null : cloneEventGameRecordRoot(stored.root);
+}
+
+function cloneState(state: MemoryState): MemoryState {
+  return new Map(
+    [...state.entries()].map(([recordId, stored]) => [
+      recordId,
+      {
+        root: cloneEventGameRecordRoot(stored.root),
+        canonicalContent: stored.canonicalContent,
+      },
+    ]),
+  );
+}

--- a/src/lib/foundation-storage-sqlite.test.ts
+++ b/src/lib/foundation-storage-sqlite.test.ts
@@ -1,0 +1,361 @@
+import { describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { existsSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  checksumMigrationSql,
+  FOUNDATION_MIGRATIONS,
+  type FoundationMigration,
+} from "@/lib/foundation-migrations";
+import type { EventGameRecordRoot } from "@/lib/foundation-record-types";
+import { createEventGameRecord, type ExternalScopeResolver } from "@/lib/event-game-record";
+import {
+  FoundationMigrationError,
+  openSqliteFoundationStorage,
+} from "@/lib/foundation-storage-sqlite";
+
+async function withDatabase<T>(work: (databasePath: string) => Promise<T>): Promise<T> {
+  const directory = await mkdtemp(join(tmpdir(), "quadball-timer-sqlite-"));
+  try {
+    return await work(join(directory, "foundation.sqlite"));
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+}
+
+describe("SQLite foundation storage", () => {
+  test("configures production settings without migrating on open", async () => {
+    await withDatabase(async (databasePath) => {
+      const storage = openSqliteFoundationStorage(databasePath);
+      expect(storage.getSettings()).toEqual({
+        journalMode: "wal",
+        synchronous: 2,
+        foreignKeys: 1,
+        busyTimeoutMs: 5_000,
+      });
+      expect(await storage.readiness()).toMatchObject({
+        ok: false,
+        status: "pending",
+      });
+      storage.close();
+    });
+  });
+
+  test("applies explicit migrations, persists a root, and reopens it", async () => {
+    await withDatabase(async (databasePath) => {
+      const first = openSqliteFoundationStorage(databasePath);
+      await first.applyMigrations();
+      const recordId = "record-reopen";
+      const root = createRoot(recordId);
+      const firstRecord = createEventGameRecord(first, {
+        externalScopeResolver: createScopeResolver(root),
+      });
+      expect(await firstRecord.registerRoot(root)).toMatchObject({ status: "registered" });
+      first.close();
+
+      const reopened = openSqliteFoundationStorage(databasePath);
+      expect(await reopened.readiness()).toMatchObject({ ok: true, schemaVersion: "2" });
+      const reopenedRecord = createEventGameRecord(reopened, {
+        externalScopeResolver: createScopeResolver(root),
+      });
+      expect(await reopenedRecord.readRoot(recordId)).toMatchObject({
+        recordId,
+        eventGameId: "event-game-reopen",
+      });
+      expect(await reopenedRecord.registerRoot(root)).toMatchObject({ status: "idempotent" });
+      reopened.close();
+    });
+  });
+
+  test("validates a disposable candidate before production migration", async () => {
+    await withDatabase(async (databasePath) => {
+      const storage = openSqliteFoundationStorage(databasePath);
+      const candidate = await storage.validateCandidate();
+      expect(candidate.ready).toBe(true);
+      expect(candidate.readiness).toMatchObject({ ok: true, schemaVersion: "2" });
+      expect(existsSync(candidate.candidatePath)).toBe(false);
+      expect(await storage.readiness()).toMatchObject({ ok: false, status: "pending" });
+
+      const migration = await storage.applyMigrations({ requireCandidate: true });
+      expect(migration.schemaVersion).toBe(2);
+      expect(await storage.readiness()).toMatchObject({ ok: true });
+      storage.close();
+    });
+  });
+
+  test("upgrades an already-ledgered initial schema through the explicit repair migration", async () => {
+    await withDatabase(async (databasePath) => {
+      const initialMigration = FOUNDATION_MIGRATIONS[0];
+      const repairMigration = FOUNDATION_MIGRATIONS[1];
+      if (initialMigration === undefined || repairMigration === undefined) {
+        throw new Error("Expected the foundation migrations.");
+      }
+      const legacy = openSqliteFoundationStorage(databasePath, {
+        migrations: [initialMigration],
+      });
+      await legacy.applyMigrations({ requireCandidate: false });
+      legacy.close();
+
+      const current = openSqliteFoundationStorage(databasePath);
+      expect(await current.readiness()).toMatchObject({ ok: false, status: "missing" });
+      const migration = await current.applyMigrations();
+      expect(migration.appliedMigrationIds).toEqual([repairMigration.id]);
+      expect(await current.readiness()).toMatchObject({ ok: true, schemaVersion: "2" });
+      current.close();
+    });
+  });
+
+  test("leaves the prior schema usable when a later migration fails", async () => {
+    await withDatabase(async (databasePath) => {
+      const baseMigrations = FOUNDATION_MIGRATIONS;
+      const failingMigration = createMigration(
+        "003-failing-test-migration",
+        3,
+        3,
+        "CREATE TABLE migration_failure_probe (id TEXT) STRICT; THIS IS NOT SQL;",
+      );
+      const store = openSqliteFoundationStorage(databasePath, {
+        migrations: [...baseMigrations, failingMigration],
+      });
+      let failure: unknown;
+      try {
+        await store.applyMigrations({ requireCandidate: false });
+      } catch (error) {
+        failure = error;
+      }
+      expect(failure).toBeInstanceOf(Error);
+      store.close();
+
+      const priorBinary = openSqliteFoundationStorage(databasePath, {
+        migrations: baseMigrations,
+      });
+      expect(await priorBinary.readiness()).toMatchObject({
+        ok: true,
+        schemaVersion: "2",
+      });
+      priorBinary.close();
+
+      const database = new Database(databasePath);
+      expect(
+        database
+          .query("SELECT 1 AS present FROM sqlite_master WHERE name = 'migration_failure_probe'")
+          .get(),
+      ).toBeNull();
+      database.close();
+    });
+  });
+
+  test("fails readiness for changed, incomplete, and future ledger state", async () => {
+    await withDatabase(async (databasePath) => {
+      const initial = openSqliteFoundationStorage(databasePath);
+      await initial.applyMigrations();
+      initial.close();
+
+      const firstMigration = FOUNDATION_MIGRATIONS[0];
+      const secondMigration = FOUNDATION_MIGRATIONS[1];
+      if (firstMigration === undefined || secondMigration === undefined) {
+        throw new Error("Expected the foundation migrations.");
+      }
+
+      const database = new Database(databasePath);
+      database
+        .query("UPDATE foundation_migration_ledger SET checksum = ? WHERE migration_id = ?")
+        .run("changed", firstMigration.id);
+      database.close();
+      const changed = openSqliteFoundationStorage(databasePath);
+      expect(await changed.readiness()).toMatchObject({
+        ok: false,
+        status: "changed-checksum",
+      });
+      changed.close();
+
+      const incompleteDatabase = new Database(databasePath);
+      incompleteDatabase
+        .query(
+          "UPDATE foundation_migration_ledger SET checksum = ?, status = ? WHERE migration_id = ?",
+        )
+        .run(firstMigration.checksum, "complete", firstMigration.id);
+      incompleteDatabase
+        .query(
+          "UPDATE foundation_migration_ledger SET checksum = ?, status = ? WHERE migration_id = ?",
+        )
+        .run(secondMigration.checksum, "applying", secondMigration.id);
+      incompleteDatabase.close();
+      const incomplete = openSqliteFoundationStorage(databasePath);
+      expect(await incomplete.readiness()).toMatchObject({
+        ok: false,
+        status: "incomplete",
+      });
+      incomplete.close();
+
+      const futureDatabase = new Database(databasePath);
+      futureDatabase
+        .query(
+          "UPDATE foundation_migration_ledger SET checksum = ?, status = ? WHERE migration_id = ?",
+        )
+        .run(firstMigration.checksum, "complete", firstMigration.id);
+      futureDatabase
+        .query(
+          "UPDATE foundation_migration_ledger SET checksum = ?, status = ? WHERE migration_id = ?",
+        )
+        .run(secondMigration.checksum, "complete", secondMigration.id);
+      futureDatabase
+        .query(
+          "INSERT INTO foundation_migration_ledger (migration_id, ordinal, schema_version, checksum, status, applied_at_ms) VALUES (?, ?, ?, ?, ?, ?)",
+        )
+        .run("future-999", 3, 3, "future-checksum", "complete", 2_000);
+      futureDatabase.close();
+      const future = openSqliteFoundationStorage(databasePath);
+      expect(await future.readiness()).toMatchObject({ ok: false });
+      future.close();
+    });
+  });
+
+  test("scans every owned root and refuses production migration for canonical corruption", async () => {
+    await withDatabase(async (databasePath) => {
+      const initial = openSqliteFoundationStorage(databasePath);
+      await initial.applyMigrations();
+      const root = createRoot("corrupt-root");
+      const record = createEventGameRecord(initial, {
+        externalScopeResolver: createScopeResolver(root),
+      });
+      expect(await record.registerRoot(root)).toMatchObject({ status: "registered" });
+      initial.close();
+
+      const database = new Database(databasePath);
+      database
+        .query("UPDATE foundation_event_game_record_roots SET canonical_content = ?")
+        .run("tampered-canonical-content");
+      database.close();
+
+      const reopened = openSqliteFoundationStorage(databasePath);
+      expect(await reopened.readiness()).toMatchObject({
+        ok: false,
+        status: "integrity-failure",
+      });
+      const candidate = await reopened.validateCandidate();
+      expect(candidate.ready).toBe(false);
+      expect(candidate.readiness).toMatchObject({
+        ok: false,
+        status: "integrity-failure",
+      });
+      let migrationFailure: unknown;
+      try {
+        await reopened.applyMigrations();
+      } catch (error) {
+        migrationFailure = error;
+      }
+      expect(migrationFailure).toBeInstanceOf(FoundationMigrationError);
+      reopened.close();
+    });
+  });
+
+  test("fails closed when a valid ledger has a tampered installed schema", async () => {
+    await withDatabase(async (databasePath) => {
+      const initial = openSqliteFoundationStorage(databasePath);
+      await initial.applyMigrations();
+      initial.close();
+
+      const database = new Database(databasePath);
+      database.exec(
+        "DROP TABLE foundation_event_game_record_sides; CREATE TABLE foundation_event_game_record_sides (side_id TEXT PRIMARY KEY) STRICT;",
+      );
+      database.close();
+
+      const reopened = openSqliteFoundationStorage(databasePath);
+      expect(await reopened.readiness()).toMatchObject({
+        ok: false,
+        status: "integrity-failure",
+      });
+      const candidate = await reopened.validateCandidate();
+      expect(candidate.ready).toBe(false);
+      expect(candidate.readiness).toMatchObject({
+        ok: false,
+        status: "integrity-failure",
+      });
+      let migrationFailure: unknown;
+      try {
+        await reopened.applyMigrations();
+      } catch (error) {
+        migrationFailure = error;
+      }
+      expect(migrationFailure).toBeInstanceOf(FoundationMigrationError);
+      reopened.close();
+    });
+  });
+});
+
+function createMigration(
+  id: string,
+  ordinal: number,
+  schemaVersion: number,
+  sql: string,
+): FoundationMigration {
+  return {
+    id,
+    ordinal,
+    schemaVersion,
+    sql,
+    checksum: checksumMigrationSql(sql),
+  };
+}
+
+function createRoot(recordId: string): EventGameRecordRoot {
+  return {
+    recordId,
+    eventId: "event-reopen",
+    eventGameId: "event-game-reopen",
+    ownership: {
+      eventId: "event-reopen",
+      eventGameId: "event-game-reopen",
+    },
+    externalScope: {
+      eventId: "event-reopen",
+      gameDayId: "day-reopen",
+      pitchId: "pitch-reopen",
+      pitchSlotId: `slot-${recordId}`,
+    },
+    gameSides: [
+      {
+        id: `side-a-${recordId}`,
+        eventTeamId: "team-a",
+        teamInterpretationRef: "interpretation-a",
+      },
+      {
+        id: `side-b-${recordId}`,
+        eventTeamId: "team-b",
+        teamInterpretationRef: "interpretation-b",
+      },
+    ],
+    lifecycle: {
+      phase: "scheduled" as const,
+      commencedAtMs: null,
+      finishedAtMs: null,
+      lockedAtMs: null,
+      lockReason: null,
+    },
+    compatibility: {
+      recordVersion: "record-v1",
+      schemaVersion: "schema-v1",
+      interpreterVersion: "rules-v1",
+    },
+    creationEvidence: {
+      operationId: `operation-${recordId}`,
+      actorReference: "test-actor",
+      source: "event-game-registration" as const,
+      createdAtMs: 1_000,
+    },
+  };
+}
+
+function createScopeResolver(root: EventGameRecordRoot): ExternalScopeResolver {
+  return {
+    resolve(scope) {
+      return JSON.stringify(scope) === JSON.stringify(root.externalScope)
+        ? { status: "resolved", scope: structuredClone(scope) }
+        : { status: "mismatch", detail: "The external scope does not match the root." };
+    },
+  };
+}

--- a/src/lib/foundation-storage-sqlite.ts
+++ b/src/lib/foundation-storage-sqlite.ts
@@ -1,0 +1,586 @@
+import { Database } from "bun:sqlite";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { EventGameRecordRoot } from "@/lib/foundation-record-types";
+import {
+  assessMigrationReadiness,
+  FOUNDATION_MIGRATION_LEDGER_SQL,
+  FOUNDATION_MIGRATIONS,
+  type FoundationMigration,
+  type MigrationLedgerEntry,
+  type MigrationReadiness,
+} from "@/lib/foundation-migrations";
+import { verifyFoundationSchema, readValidatedFoundationRoot } from "@/lib/foundation-schema";
+import {
+  FoundationStorageClosedError,
+  FoundationStorageConstraintError,
+  FoundationStorageNotReadyError,
+  isThenable,
+  type FoundationStorage,
+  type FoundationStorageReadiness,
+  type FoundationStorageTransaction,
+  type FoundationStorageTransactionWork,
+  type StoredEventGameRecordRoot,
+} from "@/lib/foundation-storage";
+
+export type SqliteFoundationStorageOptions = {
+  migrations?: readonly FoundationMigration[];
+  busyTimeoutMs?: number;
+};
+
+export type SqliteFoundationSettings = {
+  journalMode: string;
+  synchronous: number;
+  foreignKeys: number;
+  busyTimeoutMs: number;
+};
+
+export type FoundationMigrationReport = {
+  appliedMigrationIds: string[];
+  schemaVersion: number;
+};
+
+export type FoundationMigrationCandidateReport = {
+  ready: boolean;
+  candidatePath: string;
+  migration: FoundationMigrationReport;
+  readiness: FoundationStorageReadiness;
+};
+
+export class FoundationMigrationError extends Error {
+  readonly readiness?: MigrationReadiness;
+
+  constructor(message: string, readiness?: MigrationReadiness) {
+    super(message);
+    this.name = "FoundationMigrationError";
+    this.readiness = readiness;
+  }
+}
+
+type SqlStatement = ReturnType<Database["query"]>;
+
+type RootRow = Record<string, unknown>;
+
+type RootStatements = {
+  byRecordId: SqlStatement;
+  byEventGameId: SqlStatement;
+  byPitchSlotId: SqlStatement;
+  byGameSideId: SqlStatement;
+  insertRoot: SqlStatement;
+  insertSide: SqlStatement;
+};
+
+const ROOT_SELECT_COLUMNS = `
+  roots.record_id AS record_id, roots.event_id AS event_id, roots.event_game_id AS event_game_id,
+  roots.owner_event_id AS owner_event_id, roots.owner_event_game_id AS owner_event_game_id,
+  roots.scope_event_id AS scope_event_id, roots.game_day_id AS game_day_id,
+  roots.pitch_id AS pitch_id, roots.pitch_slot_id AS pitch_slot_id,
+  roots.lifecycle_phase AS lifecycle_phase, roots.commenced_at_ms AS commenced_at_ms,
+  roots.finished_at_ms AS finished_at_ms, roots.locked_at_ms AS locked_at_ms,
+  roots.lock_reason AS lock_reason, roots.record_version AS record_version,
+  roots.schema_version AS schema_version, roots.interpreter_version AS interpreter_version,
+  roots.creation_operation_id AS creation_operation_id,
+  roots.creation_actor_reference AS creation_actor_reference,
+  roots.creation_source AS creation_source, roots.creation_created_at_ms AS creation_created_at_ms,
+  roots.canonical_content AS canonical_content, roots.root_json AS root_json
+`;
+
+export class SqliteFoundationStorage implements FoundationStorage {
+  readonly databasePath: string;
+
+  private readonly database: Database;
+  private readonly migrations: readonly FoundationMigration[];
+  private readonly busyTimeoutMs: number;
+  private writerTail: Promise<void> = Promise.resolve();
+  private statements: RootStatements | undefined;
+  private closed = false;
+
+  constructor(databasePath: string, options: SqliteFoundationStorageOptions = {}) {
+    this.databasePath = databasePath;
+    this.migrations = options.migrations ?? FOUNDATION_MIGRATIONS;
+    this.busyTimeoutMs = options.busyTimeoutMs ?? 5_000;
+    this.database = new Database(databasePath);
+    this.configureDatabase();
+  }
+
+  transaction<T>(work: FoundationStorageTransactionWork<T>): Promise<T> {
+    return this.enqueue(() => {
+      const readiness = this.readinessSync();
+      if (!readiness.ok) {
+        throw new FoundationStorageNotReadyError(readiness);
+      }
+
+      this.database.exec("BEGIN IMMEDIATE;");
+      try {
+        const result = work(this.createTransaction());
+        if (isThenable(result)) {
+          throw new TypeError("Foundation storage transactions must complete synchronously.");
+        }
+        this.database.exec("COMMIT;");
+        return result;
+      } catch (error) {
+        this.rollbackQuietly();
+        throw translateSqliteConstraint(error);
+      }
+    });
+  }
+
+  readRoot(recordId: string): Promise<EventGameRecordRoot | null> {
+    return this.enqueue(() => {
+      const readiness = this.readinessSync();
+      if (!readiness.ok) {
+        throw new FoundationStorageNotReadyError(readiness);
+      }
+      return this.readRootByStatement(this.getStatements().byRecordId, recordId);
+    });
+  }
+
+  readiness(): Promise<FoundationStorageReadiness> {
+    return this.enqueue(() => this.readinessSync());
+  }
+
+  getSettings(): SqliteFoundationSettings {
+    this.assertOpen();
+    return this.readSettings();
+  }
+
+  async applyMigrations(
+    options: { requireCandidate?: boolean } = {},
+  ): Promise<FoundationMigrationReport> {
+    if (options.requireCandidate !== false) {
+      const candidate = await this.validateCandidate();
+      if (!candidate.ready) {
+        throw new FoundationMigrationError(
+          "The disposable migration candidate did not reach readiness.",
+        );
+      }
+    }
+
+    return this.enqueue(() => this.applyMigrationsSync());
+  }
+
+  async validateCandidate(
+    options: { retainCandidate?: boolean } = {},
+  ): Promise<FoundationMigrationCandidateReport> {
+    this.assertOpen();
+    if (this.databasePath === ":memory:") {
+      throw new FoundationMigrationError(
+        "A file-backed database is required for candidate validation.",
+      );
+    }
+
+    const temporaryDirectory = await mkdtemp(join(tmpdir(), "quadball-timer-foundation-"));
+    const candidatePath = join(temporaryDirectory, "candidate.sqlite");
+    let candidate: SqliteFoundationStorage | undefined;
+    let retainCandidate = options.retainCandidate === true;
+    try {
+      await this.enqueue(() => {
+        this.database.exec(`VACUUM INTO ${quoteSqliteString(candidatePath)};`);
+      });
+
+      candidate = new SqliteFoundationStorage(candidatePath, {
+        migrations: this.migrations,
+        busyTimeoutMs: this.busyTimeoutMs,
+      });
+      const migration = await candidate.applyMigrations({ requireCandidate: false });
+      const readiness = await candidate.readiness();
+      retainCandidate = options.retainCandidate === true;
+      return {
+        ready: readiness.ok,
+        candidatePath,
+        migration,
+        readiness,
+      };
+    } finally {
+      candidate?.close();
+      if (!retainCandidate) {
+        await rm(temporaryDirectory, { recursive: true, force: true });
+      }
+    }
+  }
+
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.database.close();
+  }
+
+  private applyMigrationsSync(): FoundationMigrationReport {
+    this.assertOpen();
+    const appliedMigrationIds: string[] = [];
+
+    while (true) {
+      this.database.exec("BEGIN IMMEDIATE;");
+      try {
+        this.database.exec(FOUNDATION_MIGRATION_LEDGER_SQL);
+        const state = this.readMigrationState();
+        const readiness = assessMigrationReadiness(true, state.entries, this.migrations);
+        if (readiness.status === "ready") {
+          this.database.exec("COMMIT;");
+          return {
+            appliedMigrationIds,
+            schemaVersion: readiness.schemaVersion,
+          };
+        }
+
+        if (readiness.status !== "missing" && readiness.status !== "pending") {
+          throw new FoundationMigrationError(
+            "The migration ledger is incompatible with this executable.",
+            readiness,
+          );
+        }
+
+        const nextMigration = this.migrations[state.entries.length];
+        if (nextMigration === undefined) {
+          throw new FoundationMigrationError(
+            "The migration ledger is missing a required migration.",
+            readiness,
+          );
+        }
+
+        this.database
+          .query(
+            `INSERT INTO foundation_migration_ledger
+              (migration_id, ordinal, schema_version, checksum, status, applied_at_ms)
+             VALUES (?, ?, ?, ?, 'applying', NULL)`,
+          )
+          .run(
+            nextMigration.id,
+            nextMigration.ordinal,
+            nextMigration.schemaVersion,
+            nextMigration.checksum,
+          );
+        this.database.exec(nextMigration.sql);
+        this.database
+          .query(
+            `UPDATE foundation_migration_ledger
+             SET status = 'complete', applied_at_ms = ?
+             WHERE migration_id = ?`,
+          )
+          .run(Date.now(), nextMigration.id);
+        this.database.exec("COMMIT;");
+        appliedMigrationIds.push(nextMigration.id);
+      } catch (error) {
+        this.rollbackQuietly();
+        if (error instanceof FoundationMigrationError) {
+          throw error;
+        }
+        throw new FoundationMigrationError("The transactional foundation migration failed.");
+      }
+    }
+  }
+
+  private createTransaction(): FoundationStorageTransaction {
+    const statements = this.getStatements();
+    return {
+      findRootByRecordId: (recordId) => this.readRootByStatement(statements.byRecordId, recordId),
+      findRootByEventGameId: (eventGameId) =>
+        this.readRootByStatement(statements.byEventGameId, eventGameId),
+      findRootByPitchSlotId: (pitchSlotId) =>
+        this.readRootByStatement(statements.byPitchSlotId, pitchSlotId),
+      findRootByGameSideId: (gameSideId) =>
+        this.readRootByStatement(statements.byGameSideId, gameSideId),
+      insertRoot: (storedRoot) => this.insertRoot(statements, storedRoot),
+    };
+  }
+
+  private insertRoot(statements: RootStatements, storedRoot: StoredEventGameRecordRoot): void {
+    const { root } = storedRoot;
+    statements.insertRoot.run(
+      root.recordId,
+      root.eventId,
+      root.eventGameId,
+      root.ownership.eventId,
+      root.ownership.eventGameId,
+      root.externalScope.eventId,
+      root.externalScope.gameDayId,
+      root.externalScope.pitchId,
+      root.externalScope.pitchSlotId,
+      root.lifecycle.phase,
+      root.lifecycle.commencedAtMs,
+      root.lifecycle.finishedAtMs,
+      root.lifecycle.lockedAtMs,
+      root.lifecycle.lockReason,
+      root.compatibility.recordVersion,
+      root.compatibility.schemaVersion,
+      root.compatibility.interpreterVersion,
+      root.creationEvidence.operationId,
+      root.creationEvidence.actorReference,
+      root.creationEvidence.source,
+      root.creationEvidence.createdAtMs,
+      storedRoot.canonicalContent,
+      JSON.stringify(root),
+    );
+    const [sideA, sideB] = root.gameSides;
+    statements.insertSide.run(
+      sideA.id,
+      root.recordId,
+      "a",
+      sideA.eventTeamId,
+      sideA.teamInterpretationRef,
+    );
+    statements.insertSide.run(
+      sideB.id,
+      root.recordId,
+      "b",
+      sideB.eventTeamId,
+      sideB.teamInterpretationRef,
+    );
+  }
+
+  private readRootByStatement(
+    statement: SqlStatement,
+    ...parameters: string[]
+  ): EventGameRecordRoot | null {
+    const row = statement.get(...parameters) as RootRow | null;
+    if (row === null) return null;
+    return readValidatedFoundationRoot(this.database, row);
+  }
+
+  private getStatements(): RootStatements {
+    if (this.statements !== undefined) return this.statements;
+    this.statements = {
+      byRecordId: this.database.query(
+        `SELECT ${ROOT_SELECT_COLUMNS} FROM foundation_event_game_record_roots AS roots WHERE roots.record_id = ?`,
+      ),
+      byEventGameId: this.database.query(
+        `SELECT ${ROOT_SELECT_COLUMNS} FROM foundation_event_game_record_roots AS roots WHERE roots.event_game_id = ?`,
+      ),
+      byPitchSlotId: this.database.query(
+        `SELECT ${ROOT_SELECT_COLUMNS} FROM foundation_event_game_record_roots AS roots WHERE roots.pitch_slot_id = ?`,
+      ),
+      byGameSideId: this.database.query(
+        `SELECT ${ROOT_SELECT_COLUMNS}
+         FROM foundation_event_game_record_roots AS roots
+         INNER JOIN foundation_event_game_record_sides AS sides
+           ON sides.record_id = roots.record_id
+         WHERE sides.side_id = ?`,
+      ),
+      insertRoot: this.database.query(`
+        INSERT INTO foundation_event_game_record_roots (
+          record_id, event_id, event_game_id, owner_event_id, owner_event_game_id,
+          scope_event_id, game_day_id, pitch_id, pitch_slot_id,
+          lifecycle_phase, commenced_at_ms, finished_at_ms, locked_at_ms, lock_reason,
+          record_version, schema_version, interpreter_version,
+          creation_operation_id, creation_actor_reference, creation_source,
+          creation_created_at_ms, canonical_content, root_json
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `),
+      insertSide: this.database.query(`
+        INSERT INTO foundation_event_game_record_sides (
+          side_id, record_id, side_position, event_team_id, team_interpretation_ref
+        ) VALUES (?, ?, ?, ?, ?)
+      `),
+    };
+    return this.statements;
+  }
+
+  private readMigrationState(): { ledgerExists: boolean; entries: MigrationLedgerEntry[] } {
+    const ledgerExists = this.tableExists("foundation_migration_ledger");
+    if (!ledgerExists) return { ledgerExists: false, entries: [] };
+
+    const entries = this.database
+      .query(
+        "SELECT migration_id, ordinal, schema_version, checksum, status FROM foundation_migration_ledger ORDER BY ordinal",
+      )
+      .all() as unknown[];
+    return {
+      ledgerExists: true,
+      entries: entries.map((entry) => {
+        const row = asRecord(entry);
+        return {
+          id: readText(row.migration_id),
+          ordinal: readInteger(row.ordinal),
+          schemaVersion: readInteger(row.schema_version),
+          checksum: readText(row.checksum),
+          status: readText(row.status) === "complete" ? "complete" : "applying",
+        };
+      }),
+    };
+  }
+
+  private readinessSync(): FoundationStorageReadiness {
+    try {
+      this.assertOpen();
+      const settings = this.readSettings();
+      if (
+        settings.journalMode.toLowerCase() !== "wal" ||
+        settings.synchronous !== 2 ||
+        settings.foreignKeys !== 1
+      ) {
+        return {
+          ok: false,
+          status: "unsafe-settings",
+          detail: "SQLite did not report the required WAL, FULL, and foreign-key settings.",
+          storage: "sqlite",
+        };
+      }
+
+      const migrationState = this.readMigrationState();
+      const migrationReadiness = assessMigrationReadiness(
+        migrationState.ledgerExists,
+        migrationState.entries,
+        this.migrations,
+      );
+      if (migrationReadiness.status !== "ready") {
+        return {
+          ok: false,
+          status: migrationReadiness.status,
+          detail: migrationReadiness.detail,
+          storage: "sqlite",
+        };
+      }
+      const schemaVerification = verifyFoundationSchema(this.database);
+      if (!schemaVerification.ok) {
+        return { ...schemaVerification, storage: "sqlite" };
+      }
+
+      return {
+        ok: true,
+        schemaVersion: String(migrationReadiness.schemaVersion),
+        storage: "sqlite",
+      };
+    } catch (error) {
+      if (error instanceof FoundationStorageClosedError) {
+        return {
+          ok: false,
+          status: "closed",
+          detail: "SQLite foundation storage is closed.",
+          storage: "sqlite",
+        };
+      }
+      return {
+        ok: false,
+        status: "integrity-failure",
+        detail: "SQLite readiness verification failed.",
+        storage: "sqlite",
+      };
+    }
+  }
+
+  private readSettings(): SqliteFoundationSettings {
+    return {
+      journalMode: readText(this.database.query("PRAGMA journal_mode").get()),
+      synchronous: readInteger(this.database.query("PRAGMA synchronous").get()),
+      foreignKeys: readInteger(this.database.query("PRAGMA foreign_keys").get()),
+      busyTimeoutMs: readInteger(this.database.query("PRAGMA busy_timeout").get()),
+    };
+  }
+
+  private tableExists(name: string): boolean {
+    const row = this.database
+      .query("SELECT 1 AS present FROM sqlite_master WHERE type = 'table' AND name = ?")
+      .get(name) as RootRow | null;
+    return row !== null;
+  }
+
+  private configureDatabase(): void {
+    this.database.exec(
+      `PRAGMA busy_timeout = ${this.busyTimeoutMs};
+       PRAGMA journal_mode = WAL;
+       PRAGMA synchronous = FULL;
+       PRAGMA foreign_keys = ON;`,
+    );
+  }
+
+  private rollbackQuietly(): void {
+    try {
+      this.database.exec("ROLLBACK;");
+    } catch {
+      // The original transaction error is the useful one for callers.
+    }
+  }
+
+  private enqueue<T>(operation: () => T): Promise<T> {
+    const queued = this.writerTail.then(() => {
+      this.assertOpen();
+      return operation();
+    });
+    this.writerTail = queued.then(
+      () => undefined,
+      () => undefined,
+    );
+    return queued;
+  }
+
+  private assertOpen(): void {
+    if (this.closed) throw new FoundationStorageClosedError();
+  }
+}
+
+export function openSqliteFoundationStorage(
+  databasePath: string,
+  options: SqliteFoundationStorageOptions = {},
+): SqliteFoundationStorage {
+  return new SqliteFoundationStorage(databasePath, options);
+}
+
+export async function validateFoundationMigrationCandidate(
+  storage: SqliteFoundationStorage,
+  options: { retainCandidate?: boolean } = {},
+): Promise<FoundationMigrationCandidateReport> {
+  return storage.validateCandidate(options);
+}
+
+function translateSqliteConstraint(error: unknown): unknown {
+  if (!(error instanceof Error)) return error;
+  const message = error.message.toLowerCase();
+  if (message.includes("record_id")) {
+    return new FoundationStorageConstraintError("record-id");
+  }
+  if (message.includes("event_game_id")) {
+    return new FoundationStorageConstraintError("event-game-id");
+  }
+  if (message.includes("pitch_slot_id")) {
+    return new FoundationStorageConstraintError("pitch-slot-id");
+  }
+  if (message.includes("side_id")) {
+    return new FoundationStorageConstraintError("game-side-id");
+  }
+  return error;
+}
+
+function quoteSqliteString(value: string): string {
+  return `'${value.replaceAll("'", "''")}'`;
+}
+
+function asRecord(value: unknown): RootRow {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error("SQLite returned an invalid row.");
+  }
+  return value as RootRow;
+}
+
+function readText(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (typeof value === "object" && value !== null && "journal_mode" in value) {
+    return readText(value.journal_mode);
+  }
+  if (typeof value === "object" && value !== null && "synchronous" in value) {
+    return readText(value.synchronous);
+  }
+  if (typeof value === "object" && value !== null && "foreign_keys" in value) {
+    return readText(value.foreign_keys);
+  }
+  if (typeof value === "object" && value !== null && "busy_timeout" in value) {
+    return readText(value.busy_timeout);
+  }
+  if (typeof value === "object" && value !== null && "timeout" in value) {
+    return readText(value.timeout);
+  }
+  if (typeof value === "object" && value !== null && "quick_check" in value) {
+    return readText(value.quick_check);
+  }
+  if (typeof value === "object" && value !== null && "integrity_check" in value) {
+    return readText(value.integrity_check);
+  }
+  if (typeof value === "number" || typeof value === "bigint") return String(value);
+  throw new Error("SQLite returned an invalid value.");
+}
+
+function readInteger(value: unknown): number {
+  const parsed = Number(readText(value));
+  if (!Number.isSafeInteger(parsed)) throw new Error("SQLite returned an invalid integer.");
+  return parsed;
+}

--- a/src/lib/foundation-storage.ts
+++ b/src/lib/foundation-storage.ts
@@ -1,0 +1,91 @@
+import type { EventGameRecordRoot } from "@/lib/foundation-record-types";
+
+export type StoredEventGameRecordRoot = {
+  root: EventGameRecordRoot;
+  canonicalContent: string;
+};
+
+export type FoundationStorageReadiness =
+  | {
+      ok: true;
+      schemaVersion: string;
+      storage: "memory" | "sqlite";
+    }
+  | {
+      ok: false;
+      status:
+        | "closed"
+        | "pending"
+        | "missing"
+        | "reordered"
+        | "changed-checksum"
+        | "incomplete"
+        | "future"
+        | "unsafe-settings"
+        | "integrity-failure"
+        | "not-writeable";
+      detail: string;
+      storage: "memory" | "sqlite";
+    };
+
+export type FoundationStorageSnapshot = {
+  findRootByRecordId(recordId: string): EventGameRecordRoot | null;
+  findRootByEventGameId(eventGameId: string): EventGameRecordRoot | null;
+  findRootByPitchSlotId(pitchSlotId: string): EventGameRecordRoot | null;
+  findRootByGameSideId(gameSideId: string): EventGameRecordRoot | null;
+};
+
+export type FoundationStorageTransaction = FoundationStorageSnapshot & {
+  insertRoot(root: StoredEventGameRecordRoot): void;
+};
+
+export type FoundationStorageTransactionWork<T> = (transaction: FoundationStorageTransaction) => T;
+
+export interface FoundationStorage {
+  transaction<T>(work: FoundationStorageTransactionWork<T>): Promise<T>;
+  readRoot(recordId: string): Promise<EventGameRecordRoot | null>;
+  readiness(): Promise<FoundationStorageReadiness>;
+  close(): void;
+}
+
+export type FoundationStorageConstraint =
+  | "record-id"
+  | "event-game-id"
+  | "pitch-slot-id"
+  | "game-side-id";
+
+export class FoundationStorageConstraintError extends Error {
+  readonly constraint: FoundationStorageConstraint;
+
+  constructor(constraint: FoundationStorageConstraint) {
+    super(`Foundation storage rejected a duplicate ${constraint}.`);
+    this.name = "FoundationStorageConstraintError";
+    this.constraint = constraint;
+  }
+}
+
+export class FoundationStorageNotReadyError extends Error {
+  readonly readiness: FoundationStorageReadiness;
+
+  constructor(readiness: FoundationStorageReadiness) {
+    super("Foundation storage is not ready for authoritative writes.");
+    this.name = "FoundationStorageNotReadyError";
+    this.readiness = readiness;
+  }
+}
+
+export class FoundationStorageClosedError extends Error {
+  constructor() {
+    super("Foundation storage is closed.");
+    this.name = "FoundationStorageClosedError";
+  }
+}
+
+export function isThenable(value: unknown): value is PromiseLike<unknown> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "then" in value &&
+    typeof value.then === "function"
+  );
+}


### PR DESCRIPTION
## Summary

- Add the Event Game Record root deep module and its canonical, idempotent registration contract.
- Provide deterministic in-memory and `bun:sqlite` adapters with serialized transactions, WAL/FULL/foreign-key settings, and shared behavioral tests.
- Add ordered checksum-bearing migrations, candidate-copy validation, exact schema/readiness checks, and semantic corruption scanning.

## Why

Durable Event Game and Grant work needs a storage boundary that preserves domain invariants without exposing database rows. The repository previously had neither an application-owned migration ledger nor a production-shaped adapter that could fail closed on incompatible or corrupted state.

## Impact

Agents can implement higher-level domain behavior against the fast in-memory seam while SQLite provides equivalent commit, rollback, uniqueness, upgrade, restart, and readiness behavior. Startup does not migrate automatically; incompatible state remains unavailable until an explicit validated migration.

## Validation

- `bun install --frozen-lockfile`
- `bun audit` — no vulnerabilities
- `bun run check`
- `bun run test` — 148 passed
- shared memory/SQLite storage contract — 30 passed
- `bun run build`
- `bun run build:executable`

No Qualification Test or `bun run check:sqlite-runtime` workload was run.

## Stack

Second layer of stack #103. Depends on #99 and is followed by #101.

Closes #72.
