### PR TITLE
Persist immutable Event Game actions (#73)

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build:executable": "bun run build.ts --compile --compile-target=bun-linux-x64-modern --outfile=dist/quadball-timer",
     "check:sqlite-runtime": "bun scripts/check-sqlite-runtime.ts",
     "test": "bun test --isolate",
+    "test:focused:sqlite": "bun test --isolate ./src/lib/event-game-actions-sqlite.focused.ts",
     "test:changed": "bun test --changed",
     "format": "bunx --bun oxfmt \"**/*.{js,jsx,ts,tsx,mjs,cjs}\" \"!docs/**\"",
     "format:check": "bunx --bun oxfmt \"**/*.{js,jsx,ts,tsx,mjs,cjs}\" \"!docs/**\" --check",

--- a/src/lib/event-game-action-codecs.ts
+++ b/src/lib/event-game-action-codecs.ts
@@ -1,0 +1,547 @@
+import {
+  SHARED_LIMITS,
+  validateIntegerInRange,
+  validateOnlineOccurrenceMs,
+  validateOpaqueIdentifier,
+  type ValidationResult,
+} from "@/lib/validation-policy";
+import { canonicalizeJson, sha256 } from "@/lib/event-game-action-json";
+import type {
+  ActionJsonValue,
+  ControlActionCodec,
+  ControlActionCodecRegistry,
+  ControlActionGrantProvenance,
+  ControlActionInput,
+  ControlActionInterpretation,
+  ControlActionKind,
+  ControlActionLifecycleContext,
+  ControlActionOccurrence,
+  ControlActionRecoveryProvenance,
+  IqaGameRulesInterpreter,
+  OfficialOverrideMetadata,
+} from "@/lib/event-game-actions";
+import type { EventGameRecordRoot } from "@/lib/foundation-record-types";
+
+const MAX_TIMESTAMP_MS = Number.MAX_SAFE_INTEGER;
+
+export function createControlActionCodecRegistry(
+  codecs: readonly ControlActionCodec[] = createDefaultControlActionCodecs(),
+): ControlActionCodecRegistry {
+  const byKey = new Map<string, ControlActionCodec>();
+  for (const codec of codecs) {
+    registerCodec(byKey, codec);
+  }
+
+  return {
+    register(codec) {
+      registerCodec(byKey, codec);
+    },
+    resolve(kind, version) {
+      return byKey.get(codecKey(kind, version));
+    },
+    entries() {
+      return [...byKey.values()];
+    },
+  };
+}
+
+export function createDefaultControlActionCodecs(): readonly ControlActionCodec[] {
+  return [createGameFactCodec(), createCorrectionCodec()];
+}
+
+export function createDeterministicTestIqaInterpreter(version: string): IqaGameRulesInterpreter {
+  return {
+    version,
+    rebuild({ canonicalActions, effectiveFacts }) {
+      return {
+        interpreterVersion: version,
+        canonicalActionIds: canonicalActions.map((action) => action.operationId),
+        effectiveFactIds: effectiveFacts.map((fact) => fact.factId),
+      };
+    },
+  };
+}
+
+type GameFactPayload = {
+  factId: string;
+  factType: string;
+  gameSideId: string | null;
+  gameTimeMs: number | null;
+  data: ActionJsonValue;
+};
+
+type CorrectionPayload = {
+  correctionId: string;
+  targetFactId: string;
+  effective: boolean;
+};
+
+function createGameFactCodec(): ControlActionCodec<GameFactPayload> {
+  return {
+    kind: "game-fact",
+    version: "1",
+    decode(payload) {
+      if (!isRecord(payload)) return invalid("Game Fact payload must be an object.");
+      const factId = validateId(payload.factId, "payload.factId");
+      const factType = validateId(payload.factType, "payload.factType");
+      if (!factId.ok) return factId;
+      if (!factType.ok) return factType;
+      const gameSideId =
+        payload.gameSideId === null
+          ? valid(null)
+          : validateId(payload.gameSideId, "payload.gameSideId");
+      if (!gameSideId.ok) return gameSideId;
+      const gameTimeMs =
+        payload.gameTimeMs === undefined
+          ? valid(null)
+          : validateIntegerInRange(
+              payload.gameTimeMs,
+              0,
+              SHARED_LIMITS.clock.maxMs,
+              "payload.gameTimeMs",
+            );
+      if (!gameTimeMs.ok) return gameTimeMs;
+      let data: ActionJsonValue = null;
+      if (payload.data !== undefined) {
+        const dataResult = parseJsonValue(payload.data, "payload.data");
+        if (!dataResult.ok) return dataResult;
+        data = dataResult.value;
+      }
+      return valid({
+        factId: factId.value,
+        factType: factType.value,
+        gameSideId: gameSideId.value,
+        gameTimeMs: gameTimeMs.value,
+        data,
+      });
+    },
+    canonicalize(payload) {
+      return canonicalizeJson(payload);
+    },
+    fingerprint(payload) {
+      return sha256(canonicalizeJson(payload));
+    },
+    interpret(payload) {
+      return {
+        type: "fact",
+        factId: payload.factId,
+        factType: payload.factType,
+        gameSideId: payload.gameSideId,
+        payload: payload as ActionJsonValue,
+      };
+    },
+  };
+}
+
+function createCorrectionCodec(): ControlActionCodec<CorrectionPayload> {
+  return {
+    kind: "correction",
+    version: "1",
+    decode(payload) {
+      if (!isRecord(payload)) return invalid("Correction payload must be an object.");
+      const correctionId = validateId(payload.correctionId, "payload.correctionId");
+      const targetFactId = validateId(payload.targetFactId, "payload.targetFactId");
+      if (!correctionId.ok) return correctionId;
+      if (!targetFactId.ok) return targetFactId;
+      if (typeof payload.effective !== "boolean") {
+        return invalid("payload.effective must be a boolean.");
+      }
+      return valid({
+        correctionId: correctionId.value,
+        targetFactId: targetFactId.value,
+        effective: payload.effective,
+      });
+    },
+    canonicalize(payload) {
+      return canonicalizeJson(payload);
+    },
+    fingerprint(payload) {
+      return sha256(canonicalizeJson(payload));
+    },
+    interpret(payload) {
+      return {
+        type: "correction",
+        correctionId: payload.correctionId,
+        targetFactId: payload.targetFactId,
+        effective: payload.effective,
+      };
+    },
+  };
+}
+
+export function validateKind(value: unknown): ValidationResult<ControlActionKind> {
+  if (!isRecord(value)) return invalid("Control Action kind must be an object.");
+  const id = validateId(value.id, "kind.id");
+  const version = validateId(value.version, "kind.version");
+  if (!id.ok) return id;
+  if (!version.ok) return version;
+  return valid({ id: id.value, version: version.value });
+}
+
+export function validatePredecessors(value: unknown): ValidationResult<string[]> {
+  if (!Array.isArray(value)) return invalid("causalPredecessorIds must be an array.");
+  if (value.length > SHARED_LIMITS.replay.maxControlActions) {
+    return invalid("causalPredecessorIds exceeds the replay action limit.");
+  }
+  const ids: string[] = [];
+  const seen = new Set<string>();
+  for (const [index, item] of value.entries()) {
+    const id = validateId(item, `causalPredecessorIds[${index}]`);
+    if (!id.ok) return id;
+    if (!seen.add(id.value)) return invalid("causalPredecessorIds must be unique.");
+    ids.push(id.value);
+  }
+  ids.sort();
+  return valid(ids);
+}
+
+export function validateOccurrence(
+  value: unknown,
+  serverNowMs: number,
+): ValidationResult<ControlActionOccurrence> {
+  const occurrence = validateOccurrenceWithoutClock(value);
+  if (!occurrence.ok) return occurrence;
+  if (occurrence.value.source === "online") {
+    const trusted = validateOnlineOccurrenceMs(occurrence.value.trustedAtMs, serverNowMs);
+    if (!trusted.ok) return trusted;
+  }
+  return occurrence;
+}
+
+export function validateOccurrenceWithoutClock(
+  value: unknown,
+): ValidationResult<ControlActionOccurrence> {
+  if (!isRecord(value)) return invalid("occurrence must be an object.");
+  const trustedAtMs = validateTimestamp(value.trustedAtMs, "occurrence.trustedAtMs");
+  const clientOriginAtMs =
+    value.clientOriginAtMs === null
+      ? valid(null)
+      : validateTimestamp(value.clientOriginAtMs, "occurrence.clientOriginAtMs");
+  if (!trustedAtMs.ok) return trustedAtMs;
+  if (!clientOriginAtMs.ok) return clientOriginAtMs;
+  if (value.source !== "online" && value.source !== "offline") {
+    return invalid("occurrence.source is unsupported.");
+  }
+  return valid({
+    trustedAtMs: trustedAtMs.value,
+    clientOriginAtMs: clientOriginAtMs.value,
+    source: value.source,
+  });
+}
+
+export function validateGrant(value: unknown): ValidationResult<ControlActionGrantProvenance> {
+  if (!isRecord(value)) return invalid("grant must be an object.");
+  const sessionId = validateId(value.sessionId, "grant.sessionId");
+  const versionId = validateId(value.versionId, "grant.versionId");
+  const authorityReference =
+    value.authorityReference === undefined
+      ? valid(undefined)
+      : validateId(value.authorityReference, "grant.authorityReference");
+  if (!sessionId.ok) return sessionId;
+  if (!versionId.ok) return versionId;
+  if (!authorityReference.ok) return authorityReference;
+  return valid({
+    sessionId: sessionId.value,
+    versionId: versionId.value,
+    ...(authorityReference.value === undefined
+      ? {}
+      : { authorityReference: authorityReference.value }),
+  });
+}
+
+export function validateLifecycle(value: unknown): ValidationResult<ControlActionLifecycleContext> {
+  if (!isRecord(value)) return invalid("lifecycle must be an object.");
+  if (
+    value.phase !== "scheduled" &&
+    value.phase !== "in-progress" &&
+    value.phase !== "suspended" &&
+    value.phase !== "finished"
+  ) {
+    return invalid("lifecycle.phase is unsupported.");
+  }
+  const commencedAtMs = validateNullableTimestamp(value.commencedAtMs, "lifecycle.commencedAtMs");
+  const finishedAtMs = validateNullableTimestamp(value.finishedAtMs, "lifecycle.finishedAtMs");
+  const lockedAtMs = validateNullableTimestamp(value.lockedAtMs, "lifecycle.lockedAtMs");
+  if (!commencedAtMs.ok) return commencedAtMs;
+  if (!finishedAtMs.ok) return finishedAtMs;
+  if (!lockedAtMs.ok) return lockedAtMs;
+  if (
+    value.lockReason !== null &&
+    value.lockReason !== "finished-inactivity" &&
+    value.lockReason !== "administrative"
+  ) {
+    return invalid("lifecycle.lockReason is unsupported.");
+  }
+  return valid({
+    phase: value.phase,
+    commencedAtMs: commencedAtMs.value,
+    finishedAtMs: finishedAtMs.value,
+    lockedAtMs: lockedAtMs.value,
+    lockReason: value.lockReason,
+  });
+}
+
+export function validateOverride(
+  value: unknown,
+): ValidationResult<OfficialOverrideMetadata | undefined> {
+  if (value === undefined) return valid(undefined);
+  if (!isRecord(value)) return invalid("override must be an object.");
+  const guardrail = validateId(value.guardrail, "override.guardrail");
+  const direction = validateId(value.direction, "override.direction");
+  const confirmation = validateId(value.confirmation, "override.confirmation");
+  const authorityReference = validateId(value.authorityReference, "override.authorityReference");
+  const gameTimeMs = validateIntegerInRange(
+    value.gameTimeMs,
+    0,
+    SHARED_LIMITS.clock.maxMs,
+    "override.gameTimeMs",
+  );
+  const reason = validateOptionalBoundedText(value.reason, "override.reason");
+  const note = validateOptionalBoundedText(value.note, "override.note");
+  if (!guardrail.ok) return guardrail;
+  if (!direction.ok) return direction;
+  if (!confirmation.ok) return confirmation;
+  if (!authorityReference.ok) return authorityReference;
+  if (!gameTimeMs.ok) return gameTimeMs;
+  if (!reason.ok) return reason;
+  if (!note.ok) return note;
+  return valid({
+    guardrail: guardrail.value,
+    direction: direction.value,
+    confirmation: confirmation.value,
+    authorityReference: authorityReference.value,
+    gameTimeMs: gameTimeMs.value,
+    ...(reason.value === undefined ? {} : { reason: reason.value }),
+    ...(note.value === undefined ? {} : { note: note.value }),
+  });
+}
+
+export function validateRecoveryProvenance(
+  value: unknown,
+  root: EventGameRecordRoot,
+  operationId: string,
+): ValidationResult<ControlActionRecoveryProvenance | undefined> {
+  const shape = validateRecoveryProvenanceShape(value);
+  if (!shape.ok) return shape;
+  if (shape.value === undefined) return shape;
+  const provenance = shape.value;
+  if (
+    provenance.sourceRecordId !== root.recordId ||
+    provenance.sourceEventGameId !== root.eventGameId
+  ) {
+    return invalid("recoveryProvenance references another Event Game Record.");
+  }
+  if (provenance.sourceOperationId !== operationId) {
+    return invalid("recoveryProvenance.sourceOperationId must match operationId.");
+  }
+  return shape;
+}
+
+function validateRecoveryProvenanceShape(
+  value: unknown,
+): ValidationResult<ControlActionRecoveryProvenance | undefined> {
+  if (value === undefined) return valid(undefined);
+  if (!isRecord(value)) return invalid("recoveryProvenance must be an object.");
+  const importId = validateId(value.importId, "recoveryProvenance.importId");
+  const sourceRecordId = validateId(value.sourceRecordId, "recoveryProvenance.sourceRecordId");
+  const sourceEventGameId = validateId(
+    value.sourceEventGameId,
+    "recoveryProvenance.sourceEventGameId",
+  );
+  const sourceOperationId = validateId(
+    value.sourceOperationId,
+    "recoveryProvenance.sourceOperationId",
+  );
+  const sourceReference = validateId(value.sourceReference, "recoveryProvenance.sourceReference");
+  const sourceAcceptedAtMs = validateNullableTimestamp(
+    value.sourceAcceptedAtMs,
+    "recoveryProvenance.sourceAcceptedAtMs",
+  );
+  if (!importId.ok) return importId;
+  if (!sourceRecordId.ok) return sourceRecordId;
+  if (!sourceEventGameId.ok) return sourceEventGameId;
+  if (!sourceOperationId.ok) return sourceOperationId;
+  if (!sourceReference.ok) return sourceReference;
+  if (!sourceAcceptedAtMs.ok) return sourceAcceptedAtMs;
+  return valid({
+    importId: importId.value,
+    sourceRecordId: sourceRecordId.value,
+    sourceEventGameId: sourceEventGameId.value,
+    sourceOperationId: sourceOperationId.value,
+    sourceReference: sourceReference.value,
+    sourceAcceptedAtMs: sourceAcceptedAtMs.value,
+  });
+}
+
+function validateOptionalBoundedText(
+  value: unknown,
+  field: string,
+): ValidationResult<string | undefined> {
+  if (value === undefined) return valid(undefined);
+  if (typeof value !== "string") return invalid(`${field} must be a string.`);
+  const normalized = value.trim().normalize("NFC");
+  if (Array.from(normalized).length > SHARED_LIMITS.names.operatorNoteMaxCodePoints) {
+    return invalid(
+      `${field} exceeds ${SHARED_LIMITS.names.operatorNoteMaxCodePoints} Unicode code points.`,
+    );
+  }
+  return valid(normalized);
+}
+
+export function validateInterpretation(
+  value: unknown,
+): ValidationResult<ControlActionInterpretation> {
+  if (!isRecord(value)) return invalid("Action interpreter output must be an object.");
+  if (value.type === "fact") {
+    const factId = validateId(value.factId, "interpretation.factId");
+    const factType = validateId(value.factType, "interpretation.factType");
+    const gameSideId =
+      value.gameSideId === null
+        ? valid(null)
+        : validateId(value.gameSideId, "interpretation.gameSideId");
+    const payload = parseJsonValue(value.payload, "interpretation.payload");
+    if (!factId.ok) return factId;
+    if (!factType.ok) return factType;
+    if (!gameSideId.ok) return gameSideId;
+    if (!payload.ok) return payload;
+    return valid({
+      type: "fact",
+      factId: factId.value,
+      factType: factType.value,
+      gameSideId: gameSideId.value,
+      payload: payload.value,
+    });
+  }
+  if (value.type === "correction") {
+    const correctionId = validateId(value.correctionId, "interpretation.correctionId");
+    const targetFactId = validateId(value.targetFactId, "interpretation.targetFactId");
+    if (!correctionId.ok) return correctionId;
+    if (!targetFactId.ok) return targetFactId;
+    if (typeof value.effective !== "boolean") {
+      return invalid("interpretation.effective must be boolean.");
+    }
+    return valid({
+      type: "correction",
+      correctionId: correctionId.value,
+      targetFactId: targetFactId.value,
+      effective: value.effective,
+    });
+  }
+  if (value.type === "non-fact") {
+    const stableId = validateId(value.stableId, "interpretation.stableId");
+    return stableId.ok ? valid({ type: "non-fact", stableId: stableId.value }) : stableId;
+  }
+  return invalid("Action interpreter output type is unsupported.");
+}
+
+function registerCodec(byKey: Map<string, ControlActionCodec>, codec: ControlActionCodec): void {
+  if (!codec || typeof codec !== "object") throw new TypeError("Control Action codec is invalid.");
+  const kind = validateId(codec.kind, "codec.kind");
+  const version = validateId(codec.version, "codec.version");
+  if (!kind.ok || !version.ok) throw new TypeError("Control Action codec identity is invalid.");
+  if (
+    typeof codec.decode !== "function" ||
+    typeof codec.canonicalize !== "function" ||
+    typeof codec.fingerprint !== "function" ||
+    typeof codec.interpret !== "function"
+  ) {
+    throw new TypeError(
+      "Control Action codec must provide decode, canonicalize, fingerprint, and interpret.",
+    );
+  }
+  const key = codecKey(kind.value, version.value);
+  if (byKey.has(key)) throw new TypeError("Control Action codec identity is already registered.");
+  byKey.set(key, codec);
+}
+
+function codecKey(kind: string, version: string): string {
+  return `${kind}\u0000${version}`;
+}
+
+export function sameLifecycle(
+  left: ControlActionLifecycleContext,
+  right: EventGameRecordRoot["lifecycle"],
+): boolean {
+  return (
+    left.phase === right.phase &&
+    left.commencedAtMs === right.commencedAtMs &&
+    left.finishedAtMs === right.finishedAtMs &&
+    left.lockedAtMs === right.lockedAtMs &&
+    left.lockReason === right.lockReason
+  );
+}
+
+export function parseJsonValue(value: unknown, field: string): ValidationResult<ActionJsonValue> {
+  try {
+    const canonical = canonicalizeJson(value);
+    return valid(JSON.parse(canonical) as ActionJsonValue);
+  } catch {
+    return invalid(`${field} must contain only canonical JSON values.`);
+  }
+}
+
+export function validateStoredInput(
+  value: Record<string, unknown>,
+): ValidationResult<ControlActionInput> {
+  const recordId = validateId(value.recordId, "recordId");
+  const eventGameId = validateId(value.eventGameId, "eventGameId");
+  const operationId = validateId(value.operationId, "operationId");
+  const kind = validateKind(value.kind);
+  const predecessors = validatePredecessors(value.causalPredecessorIds);
+  const occurrence = validateOccurrenceWithoutClock(value.occurrence);
+  const grant = validateGrant(value.grant);
+  const lifecycle = validateLifecycle(value.lifecycle);
+  const payload = parseJsonValue(value.payload, "payload");
+  const override = validateOverride(value.override);
+  const recoveryProvenance = validateRecoveryProvenanceShape(value.recoveryProvenance);
+  if (!recordId.ok) return recordId;
+  if (!eventGameId.ok) return eventGameId;
+  if (!operationId.ok) return operationId;
+  if (!kind.ok) return kind;
+  if (!predecessors.ok) return predecessors;
+  if (!occurrence.ok) return occurrence;
+  if (!grant.ok) return grant;
+  if (!lifecycle.ok) return lifecycle;
+  if (!payload.ok) return payload;
+  if (!override.ok) return override;
+  if (!recoveryProvenance.ok) return recoveryProvenance;
+  return valid({
+    recordId: recordId.value,
+    eventGameId: eventGameId.value,
+    operationId: operationId.value,
+    kind: kind.value,
+    payload: payload.value,
+    causalPredecessorIds: predecessors.value,
+    occurrence: occurrence.value,
+    grant: grant.value,
+    lifecycle: lifecycle.value,
+    ...(override.value === undefined ? {} : { override: override.value }),
+    ...(recoveryProvenance.value === undefined
+      ? {}
+      : { recoveryProvenance: recoveryProvenance.value }),
+  });
+}
+
+export function validateId(value: unknown, field: string): ValidationResult<string> {
+  return validateOpaqueIdentifier(value, field);
+}
+
+export function validateTimestamp(value: unknown, field: string): ValidationResult<number> {
+  return validateIntegerInRange(value, 0, MAX_TIMESTAMP_MS, field);
+}
+
+function validateNullableTimestamp(value: unknown, field: string): ValidationResult<number | null> {
+  return value === null ? valid(null) : validateTimestamp(value, field);
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function valid<T>(value: T): ValidationResult<T> {
+  return { ok: true, value };
+}
+
+export function invalid<T>(error: string): ValidationResult<T> {
+  return { ok: false, error };
+}

--- a/src/lib/event-game-action-json.ts
+++ b/src/lib/event-game-action-json.ts
@@ -1,0 +1,36 @@
+import { createHash } from "node:crypto";
+import type { ActionJsonValue } from "@/lib/event-game-actions";
+
+export function canonicalizeJson(value: unknown): string {
+  return JSON.stringify(sortJsonValue(value, "value"));
+}
+
+export function sha256(value: string): string {
+  return createHash("sha256").update(value, "utf8").digest("hex");
+}
+
+export function sortJsonValue(value: unknown, field: string): ActionJsonValue {
+  if (value === null || typeof value === "boolean" || typeof value === "string") return value;
+  if (typeof value === "number") {
+    if (!Number.isFinite(value) || !Number.isSafeInteger(value)) {
+      throw new TypeError(`${field} contains a non-safe number.`);
+    }
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item, index) => sortJsonValue(item, `${field}[${index}]`));
+  }
+  if (typeof value === "object") {
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) {
+      throw new TypeError(`${field} contains a non-plain object.`);
+    }
+    const record = value as Record<string, unknown>;
+    return Object.fromEntries(
+      Object.keys(record)
+        .sort()
+        .map((key) => [key, sortJsonValue(record[key], `${field}.${key}`)]),
+    );
+  }
+  throw new TypeError(`${field} contains an unsupported JSON value.`);
+}

--- a/src/lib/event-game-actions-sqlite.focused.ts
+++ b/src/lib/event-game-actions-sqlite.focused.ts
@@ -1,0 +1,466 @@
+import { describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  createDeterministicTestIqaInterpreter,
+  type ControlActionInput,
+} from "@/lib/event-game-actions";
+import { createEventGameRecord, type ExternalScopeResolver } from "@/lib/event-game-record";
+import { ACCEPTED_AUDIT_DETAIL, createAuditEntry } from "@/lib/event-game-record-helpers";
+import { openSqliteFoundationStorage } from "@/lib/foundation-storage-sqlite";
+import type { EventGameRecordRoot } from "@/lib/foundation-record-types";
+
+describe("SQLite immutable Event Game actions", () => {
+  test("persists the action, idempotency, metadata, and audit across restart", async () => {
+    await withDatabase(async (databasePath) => {
+      const root = createRoot("record-sqlite-restart");
+      const firstStorage = openSqliteFoundationStorage(databasePath);
+      await firstStorage.applyMigrations();
+      const firstRecord = createRecord(firstStorage, root);
+      expect(await firstRecord.registerRoot(root)).toMatchObject({ status: "registered" });
+      const action = createFact(root, "operation-restart", 1_000);
+      expect(await firstRecord.acceptAction(action)).toMatchObject({ status: "accepted" });
+      firstStorage.close();
+
+      const reopenedStorage = openSqliteFoundationStorage(databasePath);
+      const reopenedRecord = createRecord(reopenedStorage, root);
+      expect(await reopenedRecord.registerRoot(root)).toMatchObject({ status: "idempotent" });
+      expect(await reopenedRecord.acceptAction(action)).toMatchObject({
+        status: "duplicate-accepted",
+      });
+      expect(await reopenedRecord.readMetadata()).toMatchObject({ actionCount: 1 });
+      expect((await reopenedRecord.readAudit(createAuditAuthority())).length).toBe(1);
+      expect(await reopenedRecord.rebuild()).toMatchObject({ status: "ready" });
+      expect(await reopenedRecord.readiness()).toMatchObject({ ok: true, actionCount: 1 });
+      reopenedStorage.close();
+    });
+  });
+
+  test("rejects changed content under a permanent operation identity without mutating action state", async () => {
+    await withDatabase(async (databasePath) => {
+      const root = createRoot("record-sqlite-conflict");
+      const storage = openSqliteFoundationStorage(databasePath);
+      await storage.applyMigrations();
+      const record = createRecord(storage, root);
+      await record.registerRoot(root);
+      const action = createFact(root, "operation-conflict", 1_000);
+      expect(await record.acceptAction(action)).toMatchObject({ status: "accepted" });
+      expect(
+        await record.acceptAction({
+          ...action,
+          payload: {
+            ...(action.payload as Record<string, unknown>),
+            data: { changed: true },
+          },
+        }),
+      ).toMatchObject({ status: "rejected", reason: "operation-conflict" });
+      expect((await record.readActions()).length).toBe(1);
+      expect(await record.readMetadata()).toMatchObject({ actionCount: 1 });
+      expect((await record.readAudit(createAuditAuthority())).length).toBe(2);
+      storage.close();
+    });
+  });
+
+  test("rolls back action, idempotency, metadata, and audit when the commit fails", async () => {
+    await withDatabase(async (databasePath) => {
+      const root = createRoot("record-sqlite-rollback");
+      const storage = openSqliteFoundationStorage(databasePath);
+      await storage.applyMigrations();
+      const record = createRecord(storage, root);
+      await record.registerRoot(root);
+      const database = new Database(databasePath);
+      database.exec(`
+        CREATE TRIGGER fail_action_audit
+        BEFORE INSERT ON foundation_event_game_record_audit
+        WHEN NEW.audit_kind = 'action-accepted'
+        BEGIN
+          SELECT RAISE(ABORT, 'simulated audit failure');
+        END;
+      `);
+      database.close();
+
+      expect(
+        await record.acceptAction(createFact(root, "operation-rollback", 1_000)),
+      ).toMatchObject({
+        status: "rejected",
+        reason: "storage-not-ready",
+      });
+      const repaired = new Database(databasePath);
+      repaired.exec("DROP TRIGGER fail_action_audit;");
+      repaired.close();
+      expect((await record.readActions()).length).toBe(0);
+      expect(await record.readMetadata()).toMatchObject({ actionCount: 0 });
+      expect((await record.readAudit(createAuditAuthority())).length).toBe(0);
+      storage.close();
+    });
+  });
+
+  test("fails readiness when durable action versions are unknown", async () => {
+    await withDatabase(async (databasePath) => {
+      const root = createRoot("record-sqlite-unknown-version");
+      const storage = openSqliteFoundationStorage(databasePath);
+      await storage.applyMigrations();
+      const record = createRecord(storage, root);
+      await record.registerRoot(root);
+      await record.acceptAction(createFact(root, "operation-unknown-version", 1_000));
+      storage.close();
+
+      const database = new Database(databasePath);
+      const row = database
+        .query(
+          "SELECT action_json FROM foundation_event_game_record_actions WHERE operation_id = ?",
+        )
+        .get("operation-unknown-version") as { action_json: string } | null;
+      if (row === null) throw new Error("Expected the durable action row.");
+      const action = JSON.parse(row.action_json) as Record<string, unknown>;
+      action.kind = { id: "game-fact", version: "99" };
+      database
+        .query(
+          "UPDATE foundation_event_game_record_actions SET action_json = ?, action_version = ? WHERE operation_id = ?",
+        )
+        .run(JSON.stringify(action), "99", "operation-unknown-version");
+      database.close();
+
+      const reopened = openSqliteFoundationStorage(databasePath);
+      const reopenedRecord = createRecord(reopened, root);
+      expect(await reopenedRecord.registerRoot(root)).toMatchObject({ status: "idempotent" });
+      expect(await reopenedRecord.readiness()).toMatchObject({
+        ok: false,
+        status: "rebuild-failure",
+      });
+      expect(
+        await reopenedRecord.acceptAction(
+          createFact(root, "operation-after-unknown-version", 2_000),
+        ),
+      ).toMatchObject({ status: "rejected", reason: "storage-not-ready" });
+      expect(
+        (await reopenedRecord.readAudit(createAuditAuthority())).filter(
+          (entry) => entry.operationId === "operation-after-unknown-version",
+        ),
+      ).toHaveLength(0);
+      reopened.close();
+    });
+  });
+
+  test("fails closed on idempotency ledger parity corruption before a new write", async () => {
+    await withDatabase(async (databasePath) => {
+      const root = createRoot("record-sqlite-idempotency-corrupt");
+      const storage = openSqliteFoundationStorage(databasePath);
+      await storage.applyMigrations();
+      const record = createRecord(storage, root);
+      await record.registerRoot(root);
+      await record.acceptAction(createFact(root, "operation-idempotency-corrupt", 1_000));
+      storage.close();
+
+      const database = new Database(databasePath);
+      database
+        .query(
+          "UPDATE foundation_event_game_record_idempotency SET content_fingerprint = ? WHERE operation_id = ?",
+        )
+        .run("f".repeat(64), "operation-idempotency-corrupt");
+      database.close();
+
+      const reopened = openSqliteFoundationStorage(databasePath);
+      const reopenedRecord = createRecord(reopened, root);
+      expect(await reopenedRecord.registerRoot(root)).toMatchObject({
+        status: "rejected",
+        reason: "storage-not-ready",
+      });
+      expect(await reopened.readiness()).toMatchObject({
+        ok: false,
+        status: "integrity-failure",
+      });
+      expect(
+        await reopenedRecord.acceptAction(
+          createFact(root, "operation-after-idempotency-corrupt", 2_000),
+        ),
+      ).toMatchObject({ status: "rejected", reason: "storage-not-ready" });
+      const unchanged = new Database(databasePath);
+      const actionCount = unchanged
+        .query("SELECT COUNT(*) AS count FROM foundation_event_game_record_actions")
+        .get() as { count: number };
+      expect(actionCount.count).toBe(1);
+      unchanged.close();
+      reopened.close();
+    });
+  });
+
+  test("fails closed on missing and extra idempotency rows", async () => {
+    const mutations: readonly [string, (database: Database, root: EventGameRecordRoot) => void][] =
+      [
+        [
+          "missing",
+          (database, root) => {
+            database
+              .query("DELETE FROM foundation_event_game_record_idempotency WHERE record_id = ?")
+              .run(root.recordId);
+          },
+        ],
+        [
+          "extra",
+          (database, root) => {
+            database.exec("PRAGMA foreign_keys = OFF;");
+            database
+              .query(
+                "INSERT INTO foundation_event_game_record_idempotency (action_id, record_id, operation_id, content_fingerprint, accepted_at_ms) VALUES (?, ?, ?, ?, ?)",
+              )
+              .run("extra-action", root.recordId, "extra-operation", "e".repeat(64), 2_000);
+          },
+        ],
+      ];
+
+    for (const [label, mutate] of mutations) {
+      await withDatabase(async (databasePath) => {
+        const root = createRoot(`record-sqlite-idempotency-${label}`);
+        const storage = openSqliteFoundationStorage(databasePath);
+        await storage.applyMigrations();
+        const record = createRecord(storage, root);
+        await record.registerRoot(root);
+        await record.acceptAction(createFact(root, "operation-retained", 1_000));
+        storage.close();
+
+        const database = new Database(databasePath);
+        mutate(database, root);
+        database.close();
+
+        const reopened = openSqliteFoundationStorage(databasePath);
+        const reopenedRecord = createRecord(reopened, root);
+        expect(await reopened.readiness()).toMatchObject({
+          ok: false,
+          status: "integrity-failure",
+        });
+        expect(
+          await reopenedRecord.acceptAction(createFact(root, `operation-after-${label}`, 2_000)),
+        ).toMatchObject({ status: "rejected", reason: "storage-not-ready" });
+        reopened.close();
+      });
+    }
+  });
+
+  test("does not acknowledge an accepted action when its audit identity is already occupied", async () => {
+    await withDatabase(async (databasePath) => {
+      const root = createRoot("record-sqlite-strict-audit");
+      const storage = openSqliteFoundationStorage(databasePath);
+      await storage.applyMigrations();
+      const record = createRecord(storage, root);
+      await record.registerRoot(root);
+      const action = createFact(root, "operation-strict-audit", 1_000);
+      await storage.transaction((transaction) => {
+        const acceptedAuditId = createAuditEntry(
+          action,
+          "action-accepted",
+          ACCEPTED_AUDIT_DETAIL,
+          10_000,
+        ).auditId;
+        transaction.appendAuditEntry({
+          ...createAuditEntry(action, "action-rejected", "occupied audit identity", 10_000),
+          auditId: acceptedAuditId,
+        });
+      });
+      expect(await record.acceptAction(action)).toMatchObject({
+        status: "rejected",
+        reason: "storage-not-ready",
+      });
+      expect(await record.readActions()).toHaveLength(0);
+      expect(await record.readMetadata()).toMatchObject({ actionCount: 0 });
+      storage.close();
+    });
+  });
+
+  test("blocks a new SQLite action when the injected interpreter is nondeterministic", async () => {
+    await withDatabase(async (databasePath) => {
+      const root = createRoot("record-sqlite-nondeterministic");
+      const storage = openSqliteFoundationStorage(databasePath);
+      await storage.applyMigrations();
+      const seeded = createRecord(storage, root);
+      await seeded.registerRoot(root);
+      await seeded.acceptAction(createFact(root, "operation-seeded", 1_000));
+
+      let rebuildCount = 0;
+      const nondeterministic = createEventGameRecord(storage, {
+        externalScopeResolver: createScopeResolver(root),
+        clock: () => 10_000,
+        interpreter: {
+          version: "rules-v1",
+          rebuild() {
+            rebuildCount += 1;
+            return { rebuildCount };
+          },
+        },
+        auditAuthorityVerifier: testAuditAuthorityVerifier,
+      });
+      expect(await nondeterministic.registerRoot(root)).toMatchObject({ status: "idempotent" });
+      expect(
+        await nondeterministic.acceptAction(
+          createFact(root, "operation-after-nondeterministic", 2_000),
+        ),
+      ).toMatchObject({ status: "rejected", reason: "storage-not-ready" });
+      expect(await seeded.readActions()).toHaveLength(1);
+      expect(await nondeterministic.readAudit(createAuditAuthority())).toHaveLength(1);
+      storage.close();
+    });
+  });
+
+  test("rechecks semantic history after an independent commit before the write lock", async () => {
+    await withDatabase(async (databasePath) => {
+      const root = createRoot("record-sqlite-cache-race");
+      let arm = false;
+      let injected = false;
+      const storage = openSqliteFoundationStorage(databasePath, {
+        beforeWriteTransactionLock() {
+          if (!arm || injected) return;
+          injected = true;
+          const external = new Database(databasePath);
+          const row = external
+            .query(
+              "SELECT action_json FROM foundation_event_game_record_actions WHERE operation_id = ?",
+            )
+            .get("operation-cache-seed") as { action_json: string } | null;
+          if (row === null) throw new Error("Expected the seeded durable action.");
+          const action = JSON.parse(row.action_json) as Record<string, unknown>;
+          action.kind = { id: "game-fact", version: "99" };
+          external
+            .query(
+              "UPDATE foundation_event_game_record_actions SET action_json = ?, action_version = ? WHERE operation_id = ?",
+            )
+            .run(JSON.stringify(action), "99", "operation-cache-seed");
+          external.close();
+        },
+      });
+      await storage.applyMigrations();
+      const record = createRecord(storage, root);
+      await record.registerRoot(root);
+      expect(
+        await record.acceptAction(createFact(root, "operation-cache-seed", 1_000)),
+      ).toMatchObject({
+        status: "accepted",
+      });
+      arm = true;
+
+      expect(
+        await record.acceptAction(createFact(root, "operation-after-cache-race", 2_000)),
+      ).toMatchObject({ status: "rejected", reason: "storage-not-ready" });
+      expect(await record.readActions()).toHaveLength(1);
+      expect(await record.readAudit(createAuditAuthority())).toHaveLength(1);
+      storage.close();
+    });
+  });
+});
+
+async function withDatabase(work: (databasePath: string) => Promise<void>): Promise<void> {
+  const directory = await mkdtemp(join(tmpdir(), "quadball-timer-action-sqlite-"));
+  try {
+    await work(join(directory, "foundation.sqlite"));
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+}
+
+function createRecord(
+  storage: ReturnType<typeof openSqliteFoundationStorage>,
+  root: EventGameRecordRoot,
+) {
+  return createEventGameRecord(storage, {
+    externalScopeResolver: createScopeResolver(root),
+    clock: () => 10_000,
+    interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
+    auditAuthorityVerifier: testAuditAuthorityVerifier,
+  });
+}
+
+function createFact(
+  root: EventGameRecordRoot,
+  operationId: string,
+  trustedAtMs: number,
+): ControlActionInput {
+  return {
+    recordId: root.recordId,
+    eventGameId: root.eventGameId,
+    operationId,
+    kind: { id: "game-fact", version: "1" },
+    payload: {
+      factId: `fact-${operationId}`,
+      factType: "deterministic-test-fact",
+      gameSideId: "side-a",
+      gameTimeMs: trustedAtMs,
+      data: { operationId },
+    },
+    causalPredecessorIds: [],
+    occurrence: { trustedAtMs, clientOriginAtMs: trustedAtMs, source: "online" },
+    grant: { sessionId: "session-1", versionId: "grant-version-1" },
+    lifecycle: structuredClone(root.lifecycle),
+  };
+}
+
+function createRoot(recordId: string): EventGameRecordRoot {
+  return {
+    recordId,
+    eventId: `event-${recordId}`,
+    eventGameId: `event-game-${recordId}`,
+    ownership: { eventId: `event-${recordId}`, eventGameId: `event-game-${recordId}` },
+    externalScope: {
+      eventId: `event-${recordId}`,
+      gameDayId: `day-${recordId}`,
+      pitchId: `pitch-${recordId}`,
+      pitchSlotId: `slot-${recordId}`,
+    },
+    gameSides: [
+      { id: "side-a", eventTeamId: "team-a", teamInterpretationRef: "interpretation-a" },
+      { id: "side-b", eventTeamId: "team-b", teamInterpretationRef: "interpretation-b" },
+    ],
+    lifecycle: {
+      phase: "scheduled",
+      commencedAtMs: null,
+      finishedAtMs: null,
+      lockedAtMs: null,
+      lockReason: null,
+    },
+    compatibility: {
+      recordVersion: "record-v1",
+      schemaVersion: "schema-v1",
+      interpreterVersion: "rules-v1",
+    },
+    creationEvidence: {
+      operationId: `register-${recordId}`,
+      actorReference: "event-admin-session-1",
+      source: "event-game-registration",
+      createdAtMs: 500,
+    },
+  };
+}
+
+function createScopeResolver(root: EventGameRecordRoot): ExternalScopeResolver {
+  return {
+    resolve(scope) {
+      return JSON.stringify(scope) === JSON.stringify(root.externalScope)
+        ? { status: "resolved", scope: structuredClone(scope) }
+        : { status: "mismatch", detail: "The external scope does not match the root." };
+    },
+  };
+}
+
+function createAuditAuthority(): object {
+  return testAuditAuthority.credential;
+}
+
+function createTestAuditAuthority(role: "event-admin" | "technical-admin"): {
+  credential: object;
+  verifier: { verify(candidate: unknown): boolean };
+} {
+  const credentials = new WeakSet<object>();
+  const credential = Object.freeze({ role });
+  credentials.add(credential);
+  return {
+    credential,
+    verifier: {
+      verify(candidate: unknown) {
+        return typeof candidate === "object" && candidate !== null && credentials.has(candidate);
+      },
+    },
+  };
+}
+
+const testAuditAuthority = createTestAuditAuthority("technical-admin");
+const testAuditAuthorityVerifier = testAuditAuthority.verifier;

--- a/src/lib/event-game-actions.test.ts
+++ b/src/lib/event-game-actions.test.ts
@@ -1,0 +1,551 @@
+import { describe, expect, test } from "bun:test";
+import {
+  createControlActionCodecRegistry,
+  createDeterministicTestIqaInterpreter,
+  prepareControlAction,
+  type ControlActionInput,
+} from "@/lib/event-game-actions";
+import {
+  createEventGameRecord,
+  type ControlAuditAuthorityVerifier,
+  type ExternalScopeResolver,
+} from "@/lib/event-game-record";
+import type {
+  FoundationStorage,
+  FoundationStorageSnapshot,
+  FoundationStorageTransaction,
+  StoredControlAction,
+} from "@/lib/foundation-storage";
+import { createInMemoryFoundationStorage } from "@/lib/foundation-storage-memory";
+import type { EventGameRecordRoot } from "@/lib/foundation-record-types";
+
+describe("immutable Event Game actions", () => {
+  test("retains an operation identity beyond 10,000 later actions and rebuilds through IQA", async () => {
+    const root = createRoot("record-permanent");
+    const storage = createInMemoryFoundationStorage();
+    const record = createEventGameRecord(storage, {
+      externalScopeResolver: createScopeResolver(root),
+      clock: () => 10_000,
+      interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
+      auditAuthorityVerifier: testAuditAuthorityVerifier,
+    });
+
+    expect(await record.registerRoot(root)).toMatchObject({ status: "registered" });
+    const first = createFact(root, "operation-first", 1_000);
+    expect(await record.acceptAction(first)).toMatchObject({ status: "accepted" });
+
+    for (let index = 0; index < 10_001; index += 1) {
+      const operationId = `operation-later-${index}`;
+      expect(
+        await record.acceptAction(createFact(root, operationId, 2_000 + index, `fact-${index}`)),
+      ).toMatchObject({ status: "accepted" });
+    }
+
+    expect(await record.acceptAction(first)).toMatchObject({
+      status: "duplicate-accepted",
+      action: { operationId: "operation-first" },
+    });
+
+    const rebuild = await record.rebuild();
+    expect(rebuild).toMatchObject({ status: "ready" });
+    if (rebuild.status !== "ready") throw new Error("Expected a ready rebuild.");
+    expect(rebuild.canonicalActions[0]?.operationId).toBe("operation-first");
+    expect(rebuild.effectiveFacts[0]?.factId).toBe("fact-operation-first");
+    expect(rebuild.derivedGameState).toMatchObject({ interpreterVersion: "rules-v1" });
+    expect((await record.readAudit(createAuditAuthority())).length).toBe(10_002);
+  }, 30_000);
+
+  test("orders independent actions canonically and applies a correction without mutable history", async () => {
+    const firstRoot = createRoot("record-order-a");
+    const secondRoot = createRoot("record-order-b");
+    const first = await createRecord(firstRoot);
+    const second = await createRecord(secondRoot);
+    const early = createFact(firstRoot, "operation-early", 1_000, "fact-early");
+    const late = createFact(firstRoot, "operation-late", 2_000, "fact-late");
+    const earlyOther = createFact(secondRoot, "operation-early", 1_000, "fact-early");
+    const lateOther = createFact(secondRoot, "operation-late", 2_000, "fact-late");
+
+    await first.acceptAction(late);
+    await first.acceptAction(early);
+    await second.acceptAction(earlyOther);
+    await second.acceptAction(lateOther);
+    const firstRebuild = await first.rebuild();
+    const secondRebuild = await second.rebuild();
+    expect(firstRebuild).toMatchObject({ status: "ready" });
+    expect(secondRebuild).toMatchObject({ status: "ready" });
+    if (firstRebuild.status !== "ready" || secondRebuild.status !== "ready") {
+      throw new Error("Expected ready rebuilds.");
+    }
+    expect(firstRebuild.canonicalActions.map((action) => action.operationId)).toEqual(
+      secondRebuild.canonicalActions.map((action) => action.operationId),
+    );
+
+    const correction: ControlActionInput = {
+      ...createFact(firstRoot, "operation-correction", 3_000, "fact-late"),
+      kind: { id: "correction", version: "1" },
+      payload: {
+        correctionId: "correction-1",
+        targetFactId: "fact-late",
+        effective: false,
+      },
+    };
+    expect(await first.acceptAction(correction)).toMatchObject({ status: "accepted" });
+    const correctedRebuild = await first.rebuild();
+    expect(correctedRebuild.status).toBe("ready");
+    if (correctedRebuild.status !== "ready") {
+      throw new Error("Expected corrected action history to be ready");
+    }
+    expect(correctedRebuild.effectiveFacts.map((fact) => fact.factId)).toEqual(["fact-early"]);
+    expect((await first.readActions()).map((stored) => stored.action.operationId)).toEqual([
+      "operation-late",
+      "operation-early",
+      "operation-correction",
+    ]);
+  });
+
+  test("rejects unsupported versions, invalid occurrence evidence, and broken references", async () => {
+    const root = createRoot("record-validation");
+    const record = await createRecord(root);
+    const validAction = createFact(root, "operation-validation", 1_000);
+
+    expect(
+      await record.acceptAction({
+        ...validAction,
+        kind: { id: "game-fact", version: "2" },
+      }),
+    ).toMatchObject({ status: "rejected", reason: "unsupported-action" });
+    expect(
+      await record.acceptAction({
+        ...validAction,
+        occurrence: {
+          trustedAtMs: 130_001,
+          clientOriginAtMs: 130_001,
+          source: "online",
+        },
+      }),
+    ).toMatchObject({ status: "rejected", reason: "invalid-action" });
+    expect(
+      await record.acceptAction({
+        ...validAction,
+        operationId: "operation-missing-dependency",
+        causalPredecessorIds: ["operation-not-retained"],
+      }),
+    ).toMatchObject({ status: "rejected", reason: "missing-dependency" });
+    expect(
+      await record.acceptAction({
+        ...validAction,
+        operationId: "operation-self-cycle",
+        causalPredecessorIds: ["operation-self-cycle"],
+      }),
+    ).toMatchObject({ status: "rejected", reason: "cyclic-dependency" });
+    expect(
+      await record.acceptAction({
+        ...validAction,
+        eventGameId: "another-event-game",
+      }),
+    ).toMatchObject({ status: "rejected", reason: "invalid-action" });
+    expect((await record.readActions()).length).toBe(0);
+  });
+
+  test("fails rebuild and readiness for incompatible or nondeterministic interpreters", async () => {
+    const versionRoot = createRoot("record-interpreter-version");
+    const versionRecord = createEventGameRecord(createInMemoryFoundationStorage(), {
+      externalScopeResolver: createScopeResolver(versionRoot),
+      interpreter: createDeterministicTestIqaInterpreter("rules-v2"),
+    });
+    expect(await versionRecord.registerRoot(versionRoot)).toMatchObject({ status: "registered" });
+    expect(await versionRecord.rebuild()).toMatchObject({
+      status: "failed",
+      reason: "unknown-interpreter-version",
+    });
+    expect(await versionRecord.readiness()).toMatchObject({
+      ok: false,
+      status: "rebuild-failure",
+    });
+    expect(
+      await versionRecord.acceptAction(
+        createFact(versionRoot, "operation-after-version-failure", 2_000),
+      ),
+    ).toMatchObject({ status: "rejected", reason: "storage-not-ready" });
+
+    const nondeterministicRoot = createRoot("record-interpreter-nondeterministic");
+    let rebuildCount = 0;
+    const nondeterministicRecord = createEventGameRecord(createInMemoryFoundationStorage(), {
+      externalScopeResolver: createScopeResolver(nondeterministicRoot),
+      interpreter: {
+        version: "rules-v1",
+        rebuild() {
+          rebuildCount += 1;
+          return { rebuildCount };
+        },
+      },
+    });
+    expect(await nondeterministicRecord.registerRoot(nondeterministicRoot)).toMatchObject({
+      status: "registered",
+    });
+    expect(
+      await nondeterministicRecord.acceptAction(
+        createFact(nondeterministicRoot, "operation-nondeterministic", 1_000),
+      ),
+    ).toMatchObject({ status: "rejected", reason: "storage-not-ready" });
+    expect(await nondeterministicRecord.readActions()).toHaveLength(0);
+    expect(await nondeterministicRecord.rebuild()).toMatchObject({
+      status: "failed",
+      reason: "nondeterministic-interpreter",
+    });
+    expect(await nondeterministicRecord.readiness()).toMatchObject({
+      ok: false,
+      status: "rebuild-failure",
+    });
+  });
+
+  test("requires an explicitly injected interpreter and rejects forgeable audit credentials", async () => {
+    const root = createRoot("record-explicit-interpreter");
+    const storage = createInMemoryFoundationStorage();
+    const record = createEventGameRecord(storage, {
+      externalScopeResolver: createScopeResolver(root),
+    });
+    expect(await record.registerRoot(root)).toMatchObject({ status: "registered" });
+    expect(
+      await record.acceptAction(createFact(root, "operation-no-interpreter", 1_000)),
+    ).toMatchObject({
+      status: "rejected",
+      reason: "storage-not-ready",
+    });
+    expect(await record.readActions()).toHaveLength(0);
+    expect(record.readAudit(createTestAuditAuthority("event-admin").credential)).rejects.toThrow(
+      "trusted",
+    );
+    expect(record.readAudit({ verify: () => true })).rejects.toThrow("trusted");
+    expect(record.readAudit(Object.freeze({ role: "event-admin" }))).rejects.toThrow("trusted");
+
+    const trusted = createTestAuditAuthority("event-admin");
+    const authorizedRecord = createEventGameRecord(storage, {
+      externalScopeResolver: createScopeResolver(root),
+      auditAuthorityVerifier: trusted.verifier,
+      interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
+    });
+    expect(await authorizedRecord.registerRoot(root)).toMatchObject({ status: "idempotent" });
+    expect(await authorizedRecord.readAudit(trusted.credential)).toHaveLength(0);
+    expect(
+      authorizedRecord.readAudit(createTestAuditAuthority("technical-admin").credential),
+    ).rejects.toThrow("trusted");
+    storage.close();
+  });
+
+  test("blocks authoritative writes when retained memory history is semantically corrupt", async () => {
+    const corruptions: readonly [
+      string,
+      (snapshot: FoundationStorageSnapshot) => FoundationStorageSnapshot,
+    ][] = [
+      [
+        "missing audit evidence",
+        (snapshot) => ({
+          ...snapshot,
+          listAuditEntries: () => [],
+        }),
+      ],
+      [
+        "inconsistent metadata",
+        (snapshot) => ({
+          ...snapshot,
+          readRecordMetadata: () => ({
+            recordId: "record-corrupt",
+            actionCount: 0,
+            orderingVersion: "causal-occurrence-operation-v1",
+            lastAcceptedAtMs: null,
+            updatedAtMs: 500,
+          }),
+        }),
+      ],
+      [
+        "unknown action version",
+        (snapshot) => ({
+          ...snapshot,
+          listActions: (recordId) =>
+            snapshot.listActions(recordId).map((stored) => ({
+              ...stored,
+              action: { ...stored.action, kind: { id: "game-fact", version: "99" } },
+            })),
+        }),
+      ],
+      [
+        "missing dependency",
+        (snapshot) => ({
+          ...snapshot,
+          listActions: (recordId) =>
+            patchStoredActions(snapshot.listActions(recordId), {
+              causalPredecessorIds: ["operation-not-retained"],
+            }),
+        }),
+      ],
+      [
+        "causal cycle",
+        (snapshot) => ({
+          ...snapshot,
+          listActions: (recordId) =>
+            patchStoredActions(snapshot.listActions(recordId), {
+              causalPredecessorIds: ["operation-corrupt"],
+            }),
+        }),
+      ],
+      [
+        "idempotency mismatch",
+        (snapshot) => ({
+          ...snapshot,
+          listIdempotencyEntries: () => [],
+        }),
+      ],
+    ];
+
+    for (const [label, corruption] of corruptions) {
+      const root = createRoot(`record-corrupt-${label.replaceAll(" ", "-")}`);
+      const baseStorage = createInMemoryFoundationStorage();
+      const writer = createEventGameRecord(baseStorage, {
+        externalScopeResolver: createScopeResolver(root),
+        clock: () => 10_000,
+        interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
+      });
+      expect(await writer.registerRoot(root)).toMatchObject({ status: "registered" });
+      expect(await writer.acceptAction(createFact(root, "operation-corrupt", 1_000))).toMatchObject(
+        {
+          status: "accepted",
+        },
+      );
+
+      const corruptStorage = createCorruptingStorage(baseStorage, corruption);
+      const record = createEventGameRecord(corruptStorage, {
+        externalScopeResolver: createScopeResolver(root),
+        clock: () => 10_000,
+        interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
+      });
+      expect(await record.registerRoot(root)).toMatchObject({ status: "idempotent" });
+      expect(
+        await record.acceptAction(
+          createFact(root, `operation-after-${label.replaceAll(" ", "-")}`, 2_000),
+        ),
+      ).toMatchObject({ status: "rejected", reason: "storage-not-ready" });
+      expect(await baseStorage.readActions(root.recordId)).toHaveLength(1);
+      expect(await baseStorage.readAuditEntries(root.recordId)).toHaveLength(1);
+      baseStorage.close();
+    }
+  });
+
+  test("retains explicit recovery provenance with the immutable action", async () => {
+    const root = createRoot("record-recovery-provenance");
+    const record = await createRecord(root);
+    const action = {
+      ...createFact(root, "operation-recovered", 1_000),
+      recoveryProvenance: {
+        importId: "recovery-import-1",
+        sourceRecordId: root.recordId,
+        sourceEventGameId: root.eventGameId,
+        sourceOperationId: "operation-recovered",
+        sourceReference: "controller-queue-1",
+        sourceAcceptedAtMs: null,
+      },
+    };
+    expect(await record.acceptAction(action)).toMatchObject({ status: "accepted" });
+    expect(await record.readRecoveryProvenance()).toEqual([action.recoveryProvenance]);
+    expect(await record.rebuild()).toMatchObject({ status: "ready" });
+  });
+});
+
+async function createRecord(root: EventGameRecordRoot) {
+  const storage = createInMemoryFoundationStorage();
+  const record = createEventGameRecord(storage, {
+    externalScopeResolver: createScopeResolver(root),
+    clock: () => 10_000,
+    interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
+    auditAuthorityVerifier: testAuditAuthorityVerifier,
+  });
+  expect(await record.registerRoot(root)).toMatchObject({ status: "registered" });
+  return record;
+}
+
+function createAuditAuthority(): object {
+  return testAuditAuthority.credential;
+}
+
+function createTestAuditAuthority(role: "event-admin" | "technical-admin"): {
+  credential: object;
+  verifier: ControlAuditAuthorityVerifier;
+} {
+  const credentials = new WeakSet<object>();
+  const credential = Object.freeze({ role });
+  credentials.add(credential);
+  return {
+    credential,
+    verifier: {
+      verify(candidate) {
+        return typeof candidate === "object" && candidate !== null && credentials.has(candidate);
+      },
+    },
+  };
+}
+
+const testAuditAuthority = createTestAuditAuthority("event-admin");
+const testAuditAuthorityVerifier = testAuditAuthority.verifier;
+
+function createCorruptingStorage(
+  storage: FoundationStorage,
+  corruption: (snapshot: FoundationStorageSnapshot) => FoundationStorageSnapshot,
+): FoundationStorage {
+  const snapshot = (base: FoundationStorageSnapshot): FoundationStorageSnapshot => corruption(base);
+  return {
+    transaction(work) {
+      return storage.transaction((transaction) =>
+        work(snapshot(transaction) as FoundationStorageTransaction),
+      );
+    },
+    readRoot: (recordId) => storage.readRoot(recordId),
+    readActions: async (recordId) =>
+      snapshot(await readSnapshot(storage, recordId)).listActions(recordId),
+    readIdempotencyEntries: async (recordId) =>
+      snapshot(await readSnapshot(storage, recordId)).listIdempotencyEntries(recordId),
+    readRecordMetadata: async (recordId) =>
+      snapshot(await readSnapshot(storage, recordId)).readRecordMetadata(recordId),
+    readAuditEntries: async (recordId) =>
+      snapshot(await readSnapshot(storage, recordId)).listAuditEntries(recordId),
+    readiness: () => storage.readiness(),
+    close: () => storage.close(),
+  };
+}
+
+async function readSnapshot(
+  storage: FoundationStorage,
+  recordId: string,
+): Promise<FoundationStorageSnapshot> {
+  const [root, actions, idempotency, metadata, audits] = await Promise.all([
+    storage.readRoot(recordId),
+    storage.readActions(recordId),
+    storage.readIdempotencyEntries(recordId),
+    storage.readRecordMetadata(recordId),
+    storage.readAuditEntries(recordId),
+  ]);
+  return {
+    revision: 0,
+    findRootByRecordId: () => root,
+    findRootByEventGameId: () => root,
+    findRootByPitchSlotId: () => root,
+    findRootByGameSideId: () => root,
+    findActionByOperationId: (_recordId, operationId) =>
+      actions.find((stored) => stored.action.operationId === operationId) ?? null,
+    listActions: () => actions,
+    listIdempotencyEntries: () => idempotency,
+    readRecordMetadata: () => metadata,
+    listAuditEntries: () => audits,
+  };
+}
+
+function patchStoredActions(
+  storedActions: readonly StoredControlAction[],
+  patch: Partial<ControlActionInput>,
+): StoredControlAction[] {
+  const registry = createControlActionCodecRegistry();
+  return storedActions.map((stored) => {
+    const action = { ...stored.action, ...patch };
+    const prepared = prepareControlAction(
+      action,
+      createRoot(action.recordId),
+      registry,
+      action.acceptedAtMs,
+    );
+    if (!prepared.ok) throw new Error(`Could not prepare corrupt action: ${prepared.error}`);
+    return {
+      action,
+      canonicalContent: prepared.value.canonicalContent,
+      contentFingerprint: prepared.value.contentFingerprint,
+    };
+  });
+}
+
+function createFact(
+  root: EventGameRecordRoot,
+  operationId: string,
+  trustedAtMs: number,
+  factId = `fact-${operationId}`,
+): ControlActionInput {
+  return {
+    recordId: root.recordId,
+    eventGameId: root.eventGameId,
+    operationId,
+    kind: { id: "game-fact", version: "1" },
+    payload: {
+      factId,
+      factType: "deterministic-test-fact",
+      gameSideId: "side-a",
+      gameTimeMs: trustedAtMs,
+      data: { operationId },
+    },
+    causalPredecessorIds: [],
+    occurrence: {
+      trustedAtMs,
+      clientOriginAtMs: trustedAtMs,
+      source: "online",
+    },
+    grant: {
+      sessionId: "session-1",
+      versionId: "grant-version-1",
+    },
+    lifecycle: structuredClone(root.lifecycle),
+  };
+}
+
+function createRoot(recordId: string): EventGameRecordRoot {
+  return {
+    recordId,
+    eventId: `event-${recordId}`,
+    eventGameId: `event-game-${recordId}`,
+    ownership: {
+      eventId: `event-${recordId}`,
+      eventGameId: `event-game-${recordId}`,
+    },
+    externalScope: {
+      eventId: `event-${recordId}`,
+      gameDayId: `day-${recordId}`,
+      pitchId: `pitch-${recordId}`,
+      pitchSlotId: `slot-${recordId}`,
+    },
+    gameSides: [
+      {
+        id: "side-a",
+        eventTeamId: "team-a",
+        teamInterpretationRef: "interpretation-a",
+      },
+      {
+        id: "side-b",
+        eventTeamId: "team-b",
+        teamInterpretationRef: "interpretation-b",
+      },
+    ],
+    lifecycle: {
+      phase: "scheduled",
+      commencedAtMs: null,
+      finishedAtMs: null,
+      lockedAtMs: null,
+      lockReason: null,
+    },
+    compatibility: {
+      recordVersion: "record-v1",
+      schemaVersion: "schema-v1",
+      interpreterVersion: "rules-v1",
+    },
+    creationEvidence: {
+      operationId: `register-${recordId}`,
+      actorReference: "event-admin-session-1",
+      source: "event-game-registration",
+      createdAtMs: 500,
+    },
+  };
+}
+
+function createScopeResolver(root: EventGameRecordRoot): ExternalScopeResolver {
+  return {
+    resolve(scope) {
+      return JSON.stringify(scope) === JSON.stringify(root.externalScope)
+        ? { status: "resolved", scope: structuredClone(scope) }
+        : { status: "mismatch", detail: "The external scope does not match the root." };
+    },
+  };
+}

--- a/src/lib/event-game-actions.ts
+++ b/src/lib/event-game-actions.ts
@@ -1,0 +1,575 @@
+import type { ValidationResult } from "@/lib/validation-policy";
+import type { EventGameLifecyclePhase, EventGameRecordRoot } from "@/lib/foundation-record-types";
+import { canonicalizeJson, sha256 } from "@/lib/event-game-action-json";
+import {
+  invalid,
+  isRecord,
+  sameLifecycle,
+  validateGrant,
+  validateInterpretation,
+  validateId,
+  validateKind,
+  validateLifecycle,
+  validateOccurrence,
+  validateOverride,
+  validatePredecessors,
+  validateRecoveryProvenance,
+  validateStoredInput,
+  validateTimestamp,
+  valid,
+} from "@/lib/event-game-action-codecs";
+
+export { canonicalizeJson, sha256 } from "@/lib/event-game-action-json";
+export {
+  createControlActionCodecRegistry,
+  createDefaultControlActionCodecs,
+  createDeterministicTestIqaInterpreter,
+} from "@/lib/event-game-action-codecs";
+
+export type ActionJsonValue =
+  | null
+  | boolean
+  | number
+  | string
+  | ActionJsonValue[]
+  | { [key: string]: ActionJsonValue };
+
+export type ControlActionKind = {
+  id: string;
+  version: string;
+};
+
+export type ControlActionOccurrence = {
+  trustedAtMs: number;
+  clientOriginAtMs: number | null;
+  source: "online" | "offline";
+};
+
+export type ControlActionGrantProvenance = {
+  sessionId: string;
+  versionId: string;
+  authorityReference?: string;
+};
+
+export type ControlActionLifecycleContext = {
+  phase: EventGameLifecyclePhase;
+  commencedAtMs: number | null;
+  finishedAtMs: number | null;
+  lockedAtMs: number | null;
+  lockReason: "finished-inactivity" | "administrative" | null;
+};
+
+export type ControlActionRecoveryProvenance = {
+  importId: string;
+  sourceRecordId: string;
+  sourceEventGameId: string;
+  sourceOperationId: string;
+  sourceReference: string;
+  sourceAcceptedAtMs: number | null;
+};
+
+export type OfficialOverrideMetadata = {
+  guardrail: string;
+  direction: string;
+  confirmation: string;
+  authorityReference: string;
+  gameTimeMs: number;
+  reason?: string;
+  note?: string;
+};
+
+export type ControlActionInput = {
+  recordId: string;
+  eventGameId: string;
+  operationId: string;
+  kind: ControlActionKind;
+  payload: unknown;
+  causalPredecessorIds: readonly string[];
+  occurrence: ControlActionOccurrence;
+  grant: ControlActionGrantProvenance;
+  lifecycle: ControlActionLifecycleContext;
+  override?: OfficialOverrideMetadata;
+  recoveryProvenance?: ControlActionRecoveryProvenance;
+};
+
+export type FactInterpretation = {
+  type: "fact";
+  factId: string;
+  factType: string;
+  gameSideId: string | null;
+  payload: ActionJsonValue;
+};
+
+export type CorrectionInterpretation = {
+  type: "correction";
+  correctionId: string;
+  targetFactId: string;
+  effective: boolean;
+};
+
+export type NonFactInterpretation = {
+  type: "non-fact";
+  stableId: string;
+};
+
+export type ControlActionInterpretation =
+  | FactInterpretation
+  | CorrectionInterpretation
+  | NonFactInterpretation;
+
+export type ControlAction = ControlActionInput & {
+  acceptedAtMs: number;
+  interpretation: ControlActionInterpretation;
+};
+
+export type ControlAuditEntry = {
+  auditId: string;
+  recordId: string;
+  eventGameId: string;
+  operationId: string | null;
+  kind: "action-accepted" | "action-conflict" | "action-rejected" | "action-duplicate";
+  outcome: string;
+  createdAtMs: number;
+  redactedDetail: string;
+};
+
+export type EventGameRecordMetadata = {
+  recordId: string;
+  actionCount: number;
+  orderingVersion: string;
+  lastAcceptedAtMs: number | null;
+  updatedAtMs: number;
+};
+
+export const CONTROL_ACTION_ORDERING_VERSION = "causal-occurrence-operation-v1";
+
+export type EffectiveGameFact = {
+  factId: string;
+  action: ControlAction;
+  interpretation: FactInterpretation;
+};
+
+export type IqaGameRulesRebuildInput = {
+  root: EventGameRecordRoot;
+  canonicalActions: readonly ControlAction[];
+  effectiveFacts: readonly EffectiveGameFact[];
+};
+
+export type IqaGameRulesInterpreter = {
+  version: string;
+  rebuild(input: IqaGameRulesRebuildInput): unknown;
+};
+
+export type ControlActionCodec<TPayload = unknown> = {
+  kind: string;
+  version: string;
+  decode(payload: unknown): ValidationResult<TPayload>;
+  canonicalize(payload: TPayload): string;
+  fingerprint(payload: TPayload): string;
+  interpret(payload: TPayload): ControlActionInterpretation;
+};
+
+export type ControlActionCodecRegistry = {
+  register(codec: ControlActionCodec): void;
+  resolve(kind: string, version: string): ControlActionCodec | undefined;
+  entries(): readonly ControlActionCodec[];
+};
+
+export type PreparedControlAction = {
+  input: ControlActionInput;
+  canonicalContent: string;
+  contentFingerprint: string;
+  interpretation: ControlActionInterpretation;
+};
+
+export type ActionHistoryReadiness = { ok: true } | { ok: false; detail: string };
+
+export type ActionRebuildResult =
+  | {
+      status: "ready";
+      canonicalActions: readonly ControlAction[];
+      effectiveFacts: readonly EffectiveGameFact[];
+      derivedGameState: unknown;
+    }
+  | {
+      status: "failed";
+      reason:
+        | "invalid-history"
+        | "missing-dependency"
+        | "cyclic-dependency"
+        | "unknown-action-version"
+        | "unknown-interpreter-version"
+        | "missing-interpreter"
+        | "nondeterministic-interpreter";
+      detail: string;
+    };
+
+export function prepareControlAction(
+  input: unknown,
+  root: EventGameRecordRoot,
+  registry: ControlActionCodecRegistry,
+  serverNowMs: number,
+): ValidationResult<PreparedControlAction> {
+  if (!isRecord(input)) return invalid("Control Action must be an object.");
+
+  const recordId = validateId(input.recordId, "recordId");
+  const eventGameId = validateId(input.eventGameId, "eventGameId");
+  const operationId = validateId(input.operationId, "operationId");
+  if (!recordId.ok) return recordId;
+  if (!eventGameId.ok) return eventGameId;
+  if (!operationId.ok) return operationId;
+  if (recordId.value !== root.recordId) return invalid("Control Action references another record.");
+  if (eventGameId.value !== root.eventGameId) {
+    return invalid("Control Action references another Event Game.");
+  }
+
+  const kindResult = validateKind(input.kind);
+  if (!kindResult.ok) return kindResult;
+  const codec = registry.resolve(kindResult.value.id, kindResult.value.version);
+  if (codec === undefined) {
+    return invalid("The Control Action kind or version is unsupported.");
+  }
+
+  const payloadResult = codec.decode(input.payload);
+  if (!payloadResult.ok) return payloadResult;
+  let canonicalPayloadValue: ActionJsonValue;
+  let canonicalPayload: string;
+  let codecFingerprint: string;
+  let interpretation: ControlActionInterpretation;
+  try {
+    canonicalPayload = codec.canonicalize(payloadResult.value);
+    codecFingerprint = codec.fingerprint(payloadResult.value);
+    interpretation = codec.interpret(payloadResult.value);
+    if (typeof canonicalPayload !== "string" || typeof codecFingerprint !== "string") {
+      throw new TypeError("The Control Action codec returned a non-string canonical value.");
+    }
+    canonicalPayloadValue = JSON.parse(canonicalPayload) as ActionJsonValue;
+    if (canonicalizeJson(canonicalPayloadValue) !== canonicalPayload) {
+      throw new TypeError("The Control Action codec returned a non-canonical payload.");
+    }
+  } catch {
+    return invalid("The Control Action payload could not be canonicalized.");
+  }
+  const interpretationResult = validateInterpretation(interpretation);
+  if (!interpretationResult.ok) return interpretationResult;
+  if (interpretationResult.value.type === "fact") {
+    const { gameSideId } = interpretationResult.value;
+    if (gameSideId !== null && !root.gameSides.some((side) => side.id === gameSideId)) {
+      return invalid("Game Fact references an unknown stable Game Side.");
+    }
+  }
+
+  const predecessorResult = validatePredecessors(input.causalPredecessorIds);
+  if (!predecessorResult.ok) return predecessorResult;
+  const occurrenceResult = validateOccurrence(input.occurrence, serverNowMs);
+  if (!occurrenceResult.ok) return occurrenceResult;
+  const grantResult = validateGrant(input.grant);
+  if (!grantResult.ok) return grantResult;
+  const lifecycleResult = validateLifecycle(input.lifecycle);
+  if (!lifecycleResult.ok) return lifecycleResult;
+  if (!sameLifecycle(lifecycleResult.value, root.lifecycle)) {
+    return invalid("Control Action lifecycle context is stale.");
+  }
+  const overrideResult = validateOverride(input.override);
+  if (!overrideResult.ok) return overrideResult;
+  const recoveryResult = validateRecoveryProvenance(
+    input.recoveryProvenance,
+    root,
+    operationId.value,
+  );
+  if (!recoveryResult.ok) return recoveryResult;
+
+  const normalizedInput: ControlActionInput = {
+    recordId: recordId.value,
+    eventGameId: eventGameId.value,
+    operationId: operationId.value,
+    kind: kindResult.value,
+    payload: structuredClone(payloadResult.value),
+    causalPredecessorIds: predecessorResult.value,
+    occurrence: occurrenceResult.value,
+    grant: grantResult.value,
+    lifecycle: lifecycleResult.value,
+    ...(overrideResult.value === undefined ? {} : { override: overrideResult.value }),
+    ...(recoveryResult.value === undefined ? {} : { recoveryProvenance: recoveryResult.value }),
+  };
+  const canonicalContent = canonicalizeJson({
+    ...normalizedInput,
+    payload: canonicalPayloadValue,
+  });
+  const contentFingerprint = sha256(`${codecFingerprint}:${canonicalContent}`);
+  return valid({
+    input: normalizedInput,
+    canonicalContent,
+    contentFingerprint,
+    interpretation: interpretationResult.value,
+  });
+}
+
+export function materializeControlAction(
+  prepared: PreparedControlAction,
+  acceptedAtMs: number,
+): ControlAction {
+  return {
+    ...structuredClone(prepared.input),
+    acceptedAtMs,
+    interpretation: structuredClone(prepared.interpretation),
+  };
+}
+
+export function actionIdentity(recordId: string, operationId: string): string {
+  return `action-${sha256(`${recordId}:${operationId}`)}`;
+}
+
+export function parseStoredControlAction(value: unknown): ValidationResult<ControlAction> {
+  if (!isRecord(value)) return invalid("Stored Control Action must be an object.");
+  const acceptedAtMs = validateTimestamp(value.acceptedAtMs, "acceptedAtMs");
+  const inputResult = validateStoredInput(value);
+  if (!acceptedAtMs.ok) return acceptedAtMs;
+  if (!inputResult.ok) return inputResult;
+  const interpretationResult = validateInterpretation(value.interpretation);
+  if (!interpretationResult.ok) return interpretationResult;
+  return valid({
+    ...inputResult.value,
+    acceptedAtMs: acceptedAtMs.value,
+    interpretation: interpretationResult.value,
+  });
+}
+
+export function validateStoredControlAction(
+  action: ControlAction,
+  canonicalContent: string,
+  contentFingerprint: string,
+  root: EventGameRecordRoot,
+  registry: ControlActionCodecRegistry,
+): ActionHistoryReadiness {
+  const prepared = prepareControlAction(action, root, registry, action.occurrence.trustedAtMs);
+  if (!prepared.ok) return { ok: false, detail: prepared.error };
+  if (prepared.value.canonicalContent !== canonicalContent) {
+    return { ok: false, detail: "Stored Control Action canonical content is inconsistent." };
+  }
+  if (prepared.value.contentFingerprint !== contentFingerprint) {
+    return { ok: false, detail: "Stored Control Action fingerprint is inconsistent." };
+  }
+  if (canonicalizeJson(prepared.value.interpretation) !== canonicalizeJson(action.interpretation)) {
+    return { ok: false, detail: "Stored Control Action interpreter hook output is inconsistent." };
+  }
+  return { ok: true };
+}
+
+export function rebuildControlActionHistory(
+  root: EventGameRecordRoot,
+  storedActions: readonly {
+    action: ControlAction;
+    canonicalContent: string;
+    contentFingerprint: string;
+  }[],
+  registry: ControlActionCodecRegistry,
+  interpreter: IqaGameRulesInterpreter,
+): ActionRebuildResult {
+  if (interpreter.version !== root.compatibility.interpreterVersion) {
+    return {
+      status: "failed",
+      reason: "unknown-interpreter-version",
+      detail: "The registered IQA interpreter does not match the record version.",
+    };
+  }
+
+  const actions: ControlAction[] = [];
+  for (const stored of storedActions) {
+    const validity = validateStoredControlAction(
+      stored.action,
+      stored.canonicalContent,
+      stored.contentFingerprint,
+      root,
+      registry,
+    );
+    if (!validity.ok) {
+      const reason = validity.detail.includes("unsupported")
+        ? "unknown-action-version"
+        : "invalid-history";
+      return { status: "failed", reason, detail: validity.detail };
+    }
+    actions.push(structuredClone(stored.action));
+  }
+
+  const ordered = canonicalizeActionHistory(actions);
+  if (!ordered.ok) {
+    return {
+      status: "failed",
+      reason: ordered.reason,
+      detail: ordered.detail,
+    };
+  }
+
+  const factsById = new Map<string, EffectiveGameFact>();
+  for (const action of ordered.actions) {
+    if (action.interpretation.type !== "fact") continue;
+    if (factsById.has(action.interpretation.factId)) {
+      return {
+        status: "failed",
+        reason: "invalid-history",
+        detail: "The retained history contains duplicate stable Game Fact identities.",
+      };
+    }
+    factsById.set(action.interpretation.factId, {
+      factId: action.interpretation.factId,
+      action,
+      interpretation: action.interpretation,
+    });
+  }
+
+  const effectiveByFactId = new Map([...factsById.keys()].map((factId) => [factId, true]));
+  for (const action of ordered.actions) {
+    if (action.interpretation.type !== "correction") continue;
+    if (!factsById.has(action.interpretation.targetFactId)) {
+      return {
+        status: "failed",
+        reason: "invalid-history",
+        detail: "A Correction targets a missing stable Game Fact.",
+      };
+    }
+    effectiveByFactId.set(action.interpretation.targetFactId, action.interpretation.effective);
+  }
+
+  const effectiveFacts: EffectiveGameFact[] = [];
+  for (const action of ordered.actions) {
+    if (
+      action.interpretation.type !== "fact" ||
+      effectiveByFactId.get(action.interpretation.factId) !== true
+    ) {
+      continue;
+    }
+    const fact = factsById.get(action.interpretation.factId);
+    if (fact !== undefined) effectiveFacts.push(fact);
+  }
+
+  let firstState: unknown;
+  let secondState: unknown;
+  try {
+    firstState = interpreter.rebuild({
+      root: structuredClone(root),
+      canonicalActions: structuredClone(ordered.actions),
+      effectiveFacts: structuredClone(effectiveFacts),
+    });
+    secondState = interpreter.rebuild({
+      root: structuredClone(root),
+      canonicalActions: structuredClone(ordered.actions),
+      effectiveFacts: structuredClone(effectiveFacts),
+    });
+  } catch {
+    return {
+      status: "failed",
+      reason: "invalid-history",
+      detail: "The IQA interpreter could not rebuild the retained history.",
+    };
+  }
+  let firstCanonical: string;
+  let secondCanonical: string;
+  try {
+    firstCanonical = canonicalizeJson(firstState);
+    secondCanonical = canonicalizeJson(secondState);
+  } catch {
+    return {
+      status: "failed",
+      reason: "nondeterministic-interpreter",
+      detail: "The IQA interpreter returned a non-canonical state.",
+    };
+  }
+  if (firstCanonical !== secondCanonical) {
+    return {
+      status: "failed",
+      reason: "nondeterministic-interpreter",
+      detail: "The IQA interpreter produced different rebuild results.",
+    };
+  }
+
+  return {
+    status: "ready",
+    canonicalActions: ordered.actions,
+    effectiveFacts,
+    derivedGameState: firstState,
+  };
+}
+
+function canonicalizeActionHistory(actions: readonly ControlAction[]):
+  | { ok: true; actions: ControlAction[] }
+  | {
+      ok: false;
+      reason: Extract<ActionRebuildResult, { status: "failed" }>["reason"];
+      detail: string;
+    } {
+  const byOperationId = new Map<string, ControlAction>();
+  const dependents = new Map<string, string[]>();
+  const remaining = new Map<string, number>();
+  for (const action of actions) {
+    if (byOperationId.has(action.operationId)) {
+      return {
+        ok: false,
+        reason: "invalid-history",
+        detail: "The retained history contains duplicate operation identities.",
+      };
+    }
+    byOperationId.set(action.operationId, action);
+    remaining.set(action.operationId, action.causalPredecessorIds.length);
+    for (const predecessorId of action.causalPredecessorIds) {
+      if (!byOperationId.has(predecessorId)) {
+        // The complete map is populated after this loop; defer this check.
+        continue;
+      }
+      const dependentIds = dependents.get(predecessorId) ?? [];
+      dependentIds.push(action.operationId);
+      dependents.set(predecessorId, dependentIds);
+    }
+  }
+
+  for (const action of actions) {
+    for (const predecessorId of action.causalPredecessorIds) {
+      if (!byOperationId.has(predecessorId)) {
+        return {
+          ok: false,
+          reason: "missing-dependency",
+          detail: "A retained Control Action references a missing predecessor.",
+        };
+      }
+      const dependentIds = dependents.get(predecessorId) ?? [];
+      if (!dependentIds.includes(action.operationId)) dependentIds.push(action.operationId);
+      dependents.set(predecessorId, dependentIds);
+    }
+  }
+
+  const ready = actions
+    .filter((action) => remaining.get(action.operationId) === 0)
+    .sort(compareCanonicalActions);
+  const ordered: ControlAction[] = [];
+  while (ready.length > 0) {
+    const next = ready.shift();
+    if (next === undefined) break;
+    ordered.push(next);
+    for (const dependentId of dependents.get(next.operationId) ?? []) {
+      const count = (remaining.get(dependentId) ?? 0) - 1;
+      remaining.set(dependentId, count);
+      if (count === 0) {
+        const dependent = byOperationId.get(dependentId);
+        if (dependent !== undefined) {
+          ready.push(dependent);
+          ready.sort(compareCanonicalActions);
+        }
+      }
+    }
+  }
+  if (ordered.length !== actions.length) {
+    return {
+      ok: false,
+      reason: "cyclic-dependency",
+      detail: "The retained Control Action history contains a causal cycle.",
+    };
+  }
+  return { ok: true, actions: ordered };
+}
+
+function compareCanonicalActions(left: ControlAction, right: ControlAction): number {
+  return (
+    left.occurrence.trustedAtMs - right.occurrence.trustedAtMs ||
+    left.operationId.localeCompare(right.operationId)
+  );
+}

--- a/src/lib/event-game-record-helpers.ts
+++ b/src/lib/event-game-record-helpers.ts
@@ -1,0 +1,236 @@
+import {
+  CONTROL_ACTION_ORDERING_VERSION,
+  actionIdentity,
+  sha256,
+  type ControlAction,
+  type ControlActionInput,
+  type ControlAuditEntry,
+} from "@/lib/event-game-actions";
+import { canonicalizeJson } from "@/lib/event-game-action-json";
+import type { EventGameRecordRoot } from "@/lib/foundation-record-types";
+import {
+  FoundationStorageConstraintError,
+  type FoundationStorageSnapshot,
+  type FoundationStorageTransaction,
+  type StoredControlAction,
+  type StoredControlIdempotencyEntry,
+} from "@/lib/foundation-storage";
+import type {
+  ControlActionAcceptanceOutcome,
+  RootRegistrationOutcome,
+} from "@/lib/event-game-record";
+
+export const ACCEPTED_AUDIT_DETAIL =
+  "accepted after atomic action, idempotency, metadata, and audit commit";
+
+export function ensureRecordMetadata(
+  transaction: FoundationStorageTransaction,
+  root: EventGameRecordRoot,
+): void {
+  if (transaction.readRecordMetadata(root.recordId) !== null) return;
+  transaction.upsertRecordMetadata({
+    recordId: root.recordId,
+    actionCount: 0,
+    orderingVersion: CONTROL_ACTION_ORDERING_VERSION,
+    lastAcceptedAtMs: null,
+    updatedAtMs: root.creationEvidence.createdAtMs,
+  });
+}
+
+export function validateAuditHistory(
+  root: EventGameRecordRoot,
+  actions: readonly StoredControlAction[],
+  entries: readonly ControlAuditEntry[],
+): string | null {
+  const actionsByOperationId = new Map(
+    actions.map((stored) => [stored.action.operationId, stored.action]),
+  );
+  const actionOperationIds = new Set(actionsByOperationId.keys());
+  const acceptedOperationIds = new Set<string>();
+  for (const entry of entries) {
+    if (entry.recordId !== root.recordId || entry.eventGameId !== root.eventGameId) {
+      return "Control Audit Trail entry references another Event Game Record.";
+    }
+    const expectedOutcome =
+      entry.kind === "action-accepted" || entry.kind === "action-duplicate"
+        ? "accepted"
+        : "rejected";
+    if (entry.outcome !== expectedOutcome) {
+      return "Control Audit Trail entry outcome is inconsistent.";
+    }
+    if (entry.kind === "action-accepted") {
+      const action =
+        entry.operationId === null ? undefined : actionsByOperationId.get(entry.operationId);
+      if (
+        entry.operationId === null ||
+        !actionOperationIds.has(entry.operationId) ||
+        action === undefined ||
+        entry.auditId !== acceptedAuditId(action) ||
+        entry.redactedDetail !== ACCEPTED_AUDIT_DETAIL ||
+        !acceptedOperationIds.add(entry.operationId)
+      ) {
+        return "Control Audit Trail accepted-action evidence is inconsistent.";
+      }
+    }
+  }
+  if (acceptedOperationIds.size !== actions.length) {
+    return "Control Audit Trail is missing accepted-action evidence.";
+  }
+  return null;
+}
+
+export function validateIdempotencyHistory(
+  root: EventGameRecordRoot,
+  actions: readonly StoredControlAction[],
+  entries: readonly StoredControlIdempotencyEntry[],
+): string | null {
+  if (entries.length !== actions.length) {
+    return "Control Action and idempotency histories have different lengths.";
+  }
+  const actionFingerprints = new Set<string>();
+  const entriesByActionId = new Map<string, StoredControlIdempotencyEntry>();
+  for (const entry of entries) {
+    if (
+      entry.recordId !== root.recordId ||
+      entry.actionId !== actionIdentity(entry.recordId, entry.operationId) ||
+      entriesByActionId.has(entry.actionId)
+    ) {
+      return "Control Action idempotency evidence is inconsistent.";
+    }
+    entriesByActionId.set(entry.actionId, entry);
+  }
+  for (const stored of actions) {
+    const { action } = stored;
+    if (!actionFingerprints.add(stored.contentFingerprint)) {
+      return "Control Action content fingerprints are not unique.";
+    }
+    const expectedActionId = actionIdentity(action.recordId, action.operationId);
+    const entry = entriesByActionId.get(expectedActionId);
+    if (
+      entry === undefined ||
+      entry.recordId !== action.recordId ||
+      entry.operationId !== action.operationId ||
+      entry.contentFingerprint !== stored.contentFingerprint ||
+      entry.acceptedAtMs !== action.acceptedAtMs
+    ) {
+      return "Control Action idempotency evidence is inconsistent.";
+    }
+  }
+  return null;
+}
+
+export function readRecordId(input: unknown): string {
+  if (typeof input === "object" && input !== null && !Array.isArray(input)) {
+    const value = (input as Record<string, unknown>).recordId;
+    if (typeof value === "string") return value;
+  }
+  return "invalid-record-id";
+}
+
+export function validateDependencies(
+  transaction: FoundationStorageSnapshot,
+  input: ControlActionInput,
+): Extract<ControlActionAcceptanceOutcome, { status: "rejected" }> | null {
+  if (input.causalPredecessorIds.includes(input.operationId)) {
+    return {
+      status: "rejected",
+      reason: "cyclic-dependency",
+      detail: "A Control Action cannot depend on itself.",
+    };
+  }
+  for (const predecessorId of input.causalPredecessorIds) {
+    if (transaction.findActionByOperationId(input.recordId, predecessorId) === null) {
+      return {
+        status: "rejected",
+        reason: "missing-dependency",
+        detail: "A causal predecessor is not retained for this Event Game Record.",
+      };
+    }
+  }
+  return null;
+}
+
+export function findFactById(
+  actions: readonly StoredControlAction[],
+  factId: string,
+): StoredControlAction | null {
+  return (
+    actions.find(
+      (stored) =>
+        stored.action.interpretation.type === "fact" &&
+        stored.action.interpretation.factId === factId,
+    ) ?? null
+  );
+}
+
+export function createAuditEntry(
+  input: ControlActionInput,
+  kind: ControlAuditEntry["kind"],
+  redactedDetail: string,
+  createdAtMs: number,
+): ControlAuditEntry {
+  return {
+    auditId: `audit-${sha256(`${input.recordId}:${input.operationId}:${kind}:${redactedDetail}:${canonicalizeJson(input.payload)}`)}`,
+    recordId: input.recordId,
+    eventGameId: input.eventGameId,
+    operationId: input.operationId,
+    kind,
+    outcome: kind === "action-accepted" ? "accepted" : "rejected",
+    createdAtMs,
+    redactedDetail,
+  };
+}
+
+export function acceptedAuditId(action: ControlAction): string {
+  return `audit-${sha256(`${action.recordId}:${action.operationId}:action-accepted:${ACCEPTED_AUDIT_DETAIL}:${canonicalizeJson(action.payload)}`)}`;
+}
+
+export function sameExternalScope(
+  left: EventGameRecordRoot["externalScope"],
+  right: EventGameRecordRoot["externalScope"],
+): boolean {
+  return (
+    left.eventId === right.eventId &&
+    left.gameDayId === right.gameDayId &&
+    left.pitchId === right.pitchId &&
+    left.pitchSlotId === right.pitchSlotId
+  );
+}
+
+export function classifyRootConflict(
+  existing: EventGameRecordRoot,
+  incoming: EventGameRecordRoot,
+): Extract<RootRegistrationOutcome, { status: "rejected" }>["reason"] {
+  if (
+    existing.ownership.eventId !== incoming.ownership.eventId ||
+    existing.ownership.eventGameId !== incoming.ownership.eventGameId
+  ) {
+    return "ownership-conflict";
+  }
+  if (
+    existing.externalScope.eventId !== incoming.externalScope.eventId ||
+    existing.externalScope.gameDayId !== incoming.externalScope.gameDayId ||
+    existing.externalScope.pitchId !== incoming.externalScope.pitchId ||
+    existing.externalScope.pitchSlotId !== incoming.externalScope.pitchSlotId
+  ) {
+    return "external-scope-conflict";
+  }
+  return "content-conflict";
+}
+
+export function constraintToConflict(
+  error: FoundationStorageConstraintError,
+): Extract<RootRegistrationOutcome, { status: "rejected" }>["reason"] {
+  switch (error.constraint) {
+    case "event-game-id":
+      return "ownership-conflict";
+    case "pitch-slot-id":
+      return "external-scope-conflict";
+    case "game-side-id":
+      return "stable-side-conflict";
+    case "record-id":
+    case "operation-id":
+    case "audit-id":
+      return "content-conflict";
+  }
+}

--- a/src/lib/event-game-record.ts
+++ b/src/lib/event-game-record.ts
@@ -9,7 +9,49 @@ import {
   FoundationStorageNotReadyError,
   type FoundationStorage,
   type FoundationStorageSnapshot,
+  type StoredControlAction,
 } from "@/lib/foundation-storage";
+import {
+  ACCEPTED_AUDIT_DETAIL,
+  acceptedAuditId,
+  classifyRootConflict,
+  constraintToConflict,
+  createAuditEntry,
+  ensureRecordMetadata,
+  findFactById,
+  readRecordId,
+  sameExternalScope,
+  validateAuditHistory,
+  validateDependencies,
+  validateIdempotencyHistory,
+} from "@/lib/event-game-record-helpers";
+import {
+  CONTROL_ACTION_ORDERING_VERSION,
+  createControlActionCodecRegistry,
+  materializeControlAction,
+  prepareControlAction,
+  rebuildControlActionHistory,
+  type ActionRebuildResult,
+  type ControlAction,
+  type ControlActionCodec,
+  type ControlActionCodecRegistry,
+  type ControlActionRecoveryProvenance,
+  type ControlAuditEntry,
+  type EventGameRecordMetadata,
+  type IqaGameRulesInterpreter,
+} from "@/lib/event-game-actions";
+
+/**
+ * Trusted composition boundary for Control Audit Trail access.
+ *
+ * Runtime credentials remain opaque to this deep module. The adapter is
+ * responsible for validating Event Admin or Technical Admin authority; the
+ * record only asks that trusted adapter whether a supplied credential is
+ * valid. No credential-minting helper is exported here.
+ */
+export type ControlAuditAuthorityVerifier = {
+  verify(credential: unknown): boolean;
+};
 
 export type ExternalScopeResolution =
   | {
@@ -34,6 +76,11 @@ export type ExternalScopeResolver = {
 
 export type EventGameRecordOptions = {
   externalScopeResolver: ExternalScopeResolver;
+  clock?: () => number;
+  actionCodecs?: readonly ControlActionCodec[];
+  actionCodecRegistry?: ControlActionCodecRegistry;
+  interpreter?: IqaGameRulesInterpreter;
+  auditAuthorityVerifier?: ControlAuditAuthorityVerifier;
 };
 
 export type RootRegistrationOutcome =
@@ -56,12 +103,178 @@ export type RootRegistrationOutcome =
 export type EventGameRecord = {
   registerRoot(root: unknown): Promise<RootRegistrationOutcome>;
   readRoot(recordId: string): Promise<EventGameRecordRoot | null>;
+  acceptAction(input: unknown): Promise<ControlActionAcceptanceOutcome>;
+  readActions(): Promise<StoredControlAction[]>;
+  readRecoveryProvenance(): Promise<ControlActionRecoveryProvenance[]>;
+  readAudit(credential: unknown): Promise<ControlAuditEntry[]>;
+  readMetadata(): Promise<EventGameRecordMetadata | null>;
+  rebuild(): Promise<ActionRebuildResult>;
+  readiness(): Promise<EventGameRecordReadiness>;
 };
+
+export type ControlActionAcceptanceOutcome =
+  | {
+      status: "accepted" | "duplicate-accepted";
+      action: ControlAction;
+      auditId: string;
+    }
+  | {
+      status: "rejected";
+      reason:
+        | "invalid-action"
+        | "unsupported-action"
+        | "record-not-found"
+        | "operation-conflict"
+        | "missing-dependency"
+        | "cyclic-dependency"
+        | "fact-target-missing"
+        | "storage-not-ready";
+      detail: string;
+    };
+
+export type EventGameRecordReadiness =
+  | {
+      ok: true;
+      recordId: string;
+      actionCount: number;
+      storage: Awaited<ReturnType<FoundationStorage["readiness"]>>;
+    }
+  | {
+      ok: false;
+      status: "storage-not-ready" | "record-missing" | "rebuild-failure";
+      detail: string;
+      storage: Awaited<ReturnType<FoundationStorage["readiness"]>>;
+    };
+
+function rebuildRecordSnapshot(
+  root: EventGameRecordRoot,
+  snapshot: FoundationStorageSnapshot,
+  registry: ControlActionCodecRegistry,
+  interpreter: IqaGameRulesInterpreter | undefined,
+): ActionRebuildResult {
+  const storedActions = snapshot.listActions(root.recordId);
+  const idempotencyEntries = snapshot.listIdempotencyEntries(root.recordId);
+  const auditEntries = snapshot.listAuditEntries(root.recordId);
+  const metadata = snapshot.readRecordMetadata(root.recordId);
+  if (metadata === null) {
+    return {
+      status: "failed",
+      reason: "invalid-history",
+      detail: "Event Game Record action metadata is missing.",
+    };
+  }
+  if (
+    metadata.actionCount !== storedActions.length ||
+    metadata.orderingVersion !== CONTROL_ACTION_ORDERING_VERSION
+  ) {
+    return {
+      status: "failed",
+      reason: "invalid-history",
+      detail: "Event Game Record action metadata is inconsistent.",
+    };
+  }
+  let lastAcceptedAtMs: number | null = null;
+  for (const stored of storedActions) {
+    if (lastAcceptedAtMs === null || stored.action.acceptedAtMs > lastAcceptedAtMs) {
+      lastAcceptedAtMs = stored.action.acceptedAtMs;
+    }
+  }
+  if (metadata.lastAcceptedAtMs !== lastAcceptedAtMs) {
+    return {
+      status: "failed",
+      reason: "invalid-history",
+      detail: "Event Game Record acceptance metadata is inconsistent.",
+    };
+  }
+  const expectedUpdatedAtMs = lastAcceptedAtMs ?? root.creationEvidence.createdAtMs;
+  if (metadata.updatedAtMs !== expectedUpdatedAtMs) {
+    return {
+      status: "failed",
+      reason: "invalid-history",
+      detail: "Event Game Record metadata update time is inconsistent.",
+    };
+  }
+  const idempotencyFailure = validateIdempotencyHistory(root, storedActions, idempotencyEntries);
+  if (idempotencyFailure !== null) {
+    return { status: "failed", reason: "invalid-history", detail: idempotencyFailure };
+  }
+  const auditFailure = validateAuditHistory(root, storedActions, auditEntries);
+  if (auditFailure !== null) {
+    return { status: "failed", reason: "invalid-history", detail: auditFailure };
+  }
+  if (interpreter === undefined) {
+    return {
+      status: "failed",
+      reason: "missing-interpreter",
+      detail: "An explicit IQA interpreter is required for Event Game Record replay.",
+    };
+  }
+  return rebuildControlActionHistory(root, storedActions, registry, interpreter);
+}
 
 export function createEventGameRecord(
   storage: FoundationStorage,
   options: EventGameRecordOptions,
 ): EventGameRecord {
+  const clock = options.clock ?? (() => Date.now());
+  const codecRegistry =
+    options.actionCodecRegistry ?? createControlActionCodecRegistry(options.actionCodecs);
+  let activeRecordId: string | undefined;
+  let verifiedRevision: number | undefined;
+
+  function currentRecordId(): string {
+    if (activeRecordId === undefined) {
+      throw new Error("Event Game Record has not been registered.");
+    }
+    return activeRecordId;
+  }
+
+  async function rebuildActiveRecord(): Promise<ActionRebuildResult> {
+    try {
+      const root = await storage.readRoot(currentRecordId());
+      if (root === null) {
+        return {
+          status: "failed",
+          reason: "invalid-history",
+          detail: "The Event Game Record is not registered.",
+        };
+      }
+      const [storedActions, idempotencyEntries, auditEntries, metadata] = await Promise.all([
+        storage.readActions(root.recordId),
+        storage.readIdempotencyEntries(root.recordId),
+        storage.readAuditEntries(root.recordId),
+        storage.readRecordMetadata(root.recordId),
+      ]);
+      const snapshot: FoundationStorageSnapshot = {
+        revision: 0,
+        findRootByRecordId: () => root,
+        findRootByEventGameId: () => root,
+        findRootByPitchSlotId: () => root,
+        findRootByGameSideId: () => root,
+        findActionByOperationId: (_recordId, operationId) =>
+          storedActions.find((stored) => stored.action.operationId === operationId) ?? null,
+        listActions: () => storedActions,
+        listIdempotencyEntries: () => idempotencyEntries,
+        readRecordMetadata: () => metadata,
+        listAuditEntries: () => auditEntries,
+      };
+      return rebuildRecordSnapshot(root, snapshot, codecRegistry, options.interpreter);
+    } catch (error) {
+      if (error instanceof FoundationStorageNotReadyError) {
+        return {
+          status: "failed",
+          reason: "invalid-history",
+          detail: "Event Game Record storage is not ready for rebuild.",
+        };
+      }
+      return {
+        status: "failed",
+        reason: "invalid-history",
+        detail: "Event Game Record durable history could not be read.",
+      };
+    }
+  }
+
   return {
     async registerRoot(input) {
       const validated = validateEventGameRecordRoot(input);
@@ -77,11 +290,12 @@ export function createEventGameRecord(
       const canonicalContent = canonicalizeEventGameRecordRoot(root);
 
       try {
-        return await storage.transaction((transaction) => {
+        const outcome = await storage.transaction((transaction) => {
           const existing = transaction.findRootByRecordId(root.recordId);
           if (existing !== null) {
             const existingCanonicalContent = canonicalizeEventGameRecordRoot(existing);
             if (existingCanonicalContent === canonicalContent) {
+              ensureRecordMetadata(transaction, existing);
               return {
                 status: "idempotent",
                 root: cloneEventGameRecordRoot(existing),
@@ -141,11 +355,17 @@ export function createEventGameRecord(
           }
 
           transaction.insertRoot({ root, canonicalContent });
+          ensureRecordMetadata(transaction, root);
           return {
             status: "registered",
             root: cloneEventGameRecordRoot(root),
           } satisfies RootRegistrationOutcome;
         });
+        if (outcome.status === "registered" || outcome.status === "idempotent") {
+          activeRecordId = root.recordId;
+          verifiedRevision = undefined;
+        }
+        return outcome;
       } catch (error) {
         if (error instanceof FoundationStorageNotReadyError) {
           return {
@@ -163,60 +383,279 @@ export function createEventGameRecord(
             detail: "The root conflicts with a concurrently committed identity.",
           };
         }
-        throw error;
+        return {
+          status: "rejected",
+          reason: "storage-not-ready",
+          detail: "The Event Game Record could not be durably registered.",
+        };
       }
     },
 
     readRoot(recordId) {
       return storage.readRoot(recordId);
     },
+
+    async acceptAction(input) {
+      const nowMs = clock();
+      if (!Number.isSafeInteger(nowMs) || nowMs < 0) {
+        return {
+          status: "rejected",
+          reason: "invalid-action",
+          detail: "The authoritative server time is invalid.",
+        };
+      }
+
+      try {
+        let nextVerifiedRevision: number | undefined;
+        const outcome = await storage.transaction((transaction) => {
+          const root = transaction.findRootByRecordId(readRecordId(input));
+          if (root === null) {
+            return {
+              status: "rejected",
+              reason: "record-not-found",
+              detail: "The Event Game Record is not registered.",
+            } satisfies ControlActionAcceptanceOutcome;
+          }
+
+          const historyReady =
+            verifiedRevision === transaction.revision ||
+            rebuildRecordSnapshot(root, transaction, codecRegistry, options.interpreter).status ===
+              "ready";
+          if (!historyReady) {
+            return {
+              status: "rejected",
+              reason: "storage-not-ready",
+              detail: "The Event Game Record history is not ready for authoritative writes.",
+            } satisfies ControlActionAcceptanceOutcome;
+          }
+
+          const prepared = prepareControlAction(input, root, codecRegistry, nowMs);
+          if (!prepared.ok) {
+            return {
+              status: "rejected",
+              reason: prepared.error.includes("unsupported")
+                ? "unsupported-action"
+                : "invalid-action",
+              detail: prepared.error,
+            } satisfies ControlActionAcceptanceOutcome;
+          }
+
+          const existing = transaction.findActionByOperationId(
+            root.recordId,
+            prepared.value.input.operationId,
+          );
+          if (existing !== null) {
+            if (existing.contentFingerprint === prepared.value.contentFingerprint) {
+              return {
+                status: "duplicate-accepted",
+                action: structuredClone(existing.action),
+                auditId: acceptedAuditId(existing.action),
+              } satisfies ControlActionAcceptanceOutcome;
+            }
+            const audit = createAuditEntry(
+              prepared.value.input,
+              "action-conflict",
+              "operation identity is already bound to different content",
+              nowMs,
+            );
+            transaction.appendAuditEntry(audit);
+            return {
+              status: "rejected",
+              reason: "operation-conflict",
+              detail: "The operation identity is already bound to different content.",
+            } satisfies ControlActionAcceptanceOutcome;
+          }
+
+          const dependencyReason = validateDependencies(transaction, prepared.value.input);
+          if (dependencyReason !== null) {
+            const audit = createAuditEntry(
+              prepared.value.input,
+              "action-rejected",
+              dependencyReason.detail,
+              nowMs,
+            );
+            transaction.appendAuditEntry(audit);
+            return {
+              status: "rejected",
+              reason: dependencyReason.reason,
+              detail: dependencyReason.detail,
+            } satisfies ControlActionAcceptanceOutcome;
+          }
+
+          if (prepared.value.interpretation.type === "correction") {
+            const target = findFactById(
+              transaction.listActions(root.recordId),
+              prepared.value.interpretation.targetFactId,
+            );
+            if (target === null) {
+              const audit = createAuditEntry(
+                prepared.value.input,
+                "action-rejected",
+                "correction target is not a retained Game Fact",
+                nowMs,
+              );
+              transaction.appendAuditEntry(audit);
+              return {
+                status: "rejected",
+                reason: "fact-target-missing",
+                detail: "The Correction target is not a retained Game Fact.",
+              } satisfies ControlActionAcceptanceOutcome;
+            }
+          }
+
+          const action = materializeControlAction(prepared.value, nowMs);
+          transaction.insertAction({
+            action,
+            canonicalContent: prepared.value.canonicalContent,
+            contentFingerprint: prepared.value.contentFingerprint,
+          });
+          const previousMetadata = transaction.readRecordMetadata(root.recordId);
+          const lastAcceptedAtMs =
+            previousMetadata?.lastAcceptedAtMs === null ||
+            previousMetadata?.lastAcceptedAtMs === undefined
+              ? nowMs
+              : Math.max(previousMetadata.lastAcceptedAtMs, nowMs);
+          transaction.upsertRecordMetadata({
+            recordId: root.recordId,
+            actionCount: (previousMetadata?.actionCount ?? 0) + 1,
+            orderingVersion: CONTROL_ACTION_ORDERING_VERSION,
+            lastAcceptedAtMs,
+            updatedAtMs: lastAcceptedAtMs,
+          });
+          const audit = createAuditEntry(
+            prepared.value.input,
+            "action-accepted",
+            ACCEPTED_AUDIT_DETAIL,
+            nowMs,
+          );
+          transaction.appendAuditEntry(audit);
+          nextVerifiedRevision = transaction.revision + 1;
+          return {
+            status: "accepted",
+            action,
+            auditId: audit.auditId,
+          } satisfies ControlActionAcceptanceOutcome;
+        });
+        if (outcome.status === "accepted" && nextVerifiedRevision !== undefined) {
+          verifiedRevision = nextVerifiedRevision;
+        } else if (outcome.status !== "duplicate-accepted") {
+          verifiedRevision = undefined;
+        }
+        return outcome;
+      } catch (error) {
+        verifiedRevision = undefined;
+        if (error instanceof FoundationStorageNotReadyError) {
+          return {
+            status: "rejected",
+            reason: "storage-not-ready",
+            detail: "Foundation storage is not ready for authoritative writes.",
+          };
+        }
+        if (error instanceof FoundationStorageConstraintError) {
+          if (error.constraint === "audit-id") {
+            return {
+              status: "rejected",
+              reason: "storage-not-ready",
+              detail: "The Control Audit Trail could not be durably committed.",
+            };
+          }
+          return {
+            status: "rejected",
+            reason: "operation-conflict",
+            detail: "The operation identity conflicts with committed content.",
+          };
+        }
+        return {
+          status: "rejected",
+          reason: "storage-not-ready",
+          detail: "The Control Action could not be durably committed.",
+        };
+      }
+    },
+
+    readActions() {
+      return storage.readActions(currentRecordId());
+    },
+
+    async readRecoveryProvenance() {
+      const actions = await storage.readActions(currentRecordId());
+      return actions.flatMap((stored) => {
+        const provenance = stored.action.recoveryProvenance;
+        return provenance === undefined ? [] : [structuredClone(provenance)];
+      });
+    },
+
+    async readAudit(credential) {
+      let verified = false;
+      try {
+        verified = options.auditAuthorityVerifier?.verify(credential) === true;
+      } catch {
+        verified = false;
+      }
+      if (!verified) {
+        throw new Error("A trusted Event Admin or Technical Admin audit authority is required.");
+      }
+      return storage.readAuditEntries(currentRecordId());
+    },
+
+    readMetadata() {
+      return storage.readRecordMetadata(currentRecordId());
+    },
+
+    rebuild: rebuildActiveRecord,
+
+    async readiness() {
+      const storageReadiness = await storage.readiness();
+      if (!storageReadiness.ok) {
+        return {
+          ok: false,
+          status: "storage-not-ready",
+          detail: storageReadiness.detail,
+          storage: storageReadiness,
+        } satisfies EventGameRecordReadiness;
+      }
+      if (activeRecordId === undefined) {
+        return {
+          ok: false,
+          status: "record-missing",
+          detail: "The Event Game Record is not registered.",
+          storage: storageReadiness,
+        } satisfies EventGameRecordReadiness;
+      }
+      let root: EventGameRecordRoot | null;
+      try {
+        root = await storage.readRoot(activeRecordId);
+      } catch {
+        return {
+          ok: false,
+          status: "storage-not-ready",
+          detail: "The Event Game Record root could not be read.",
+          storage: storageReadiness,
+        } satisfies EventGameRecordReadiness;
+      }
+      if (root === null) {
+        return {
+          ok: false,
+          status: "record-missing",
+          detail: "The Event Game Record is not registered.",
+          storage: storageReadiness,
+        } satisfies EventGameRecordReadiness;
+      }
+      const rebuild = await rebuildActiveRecord();
+      if (rebuild.status !== "ready") {
+        return {
+          ok: false,
+          status: "rebuild-failure",
+          detail: rebuild.detail,
+          storage: storageReadiness,
+        } satisfies EventGameRecordReadiness;
+      }
+      return {
+        ok: true,
+        recordId: root.recordId,
+        actionCount: rebuild.canonicalActions.length,
+        storage: storageReadiness,
+      } satisfies EventGameRecordReadiness;
+    },
   };
-}
-
-function sameExternalScope(
-  left: EventGameRecordRoot["externalScope"],
-  right: EventGameRecordRoot["externalScope"],
-): boolean {
-  return (
-    left.eventId === right.eventId &&
-    left.gameDayId === right.gameDayId &&
-    left.pitchId === right.pitchId &&
-    left.pitchSlotId === right.pitchSlotId
-  );
-}
-
-function classifyRootConflict(
-  existing: EventGameRecordRoot,
-  incoming: EventGameRecordRoot,
-): Extract<RootRegistrationOutcome, { status: "rejected" }>["reason"] {
-  if (
-    existing.ownership.eventId !== incoming.ownership.eventId ||
-    existing.ownership.eventGameId !== incoming.ownership.eventGameId
-  ) {
-    return "ownership-conflict";
-  }
-  if (
-    existing.externalScope.eventId !== incoming.externalScope.eventId ||
-    existing.externalScope.gameDayId !== incoming.externalScope.gameDayId ||
-    existing.externalScope.pitchId !== incoming.externalScope.pitchId ||
-    existing.externalScope.pitchSlotId !== incoming.externalScope.pitchSlotId
-  ) {
-    return "external-scope-conflict";
-  }
-  return "content-conflict";
-}
-
-function constraintToConflict(
-  error: FoundationStorageConstraintError,
-): Extract<RootRegistrationOutcome, { status: "rejected" }>["reason"] {
-  switch (error.constraint) {
-    case "event-game-id":
-      return "ownership-conflict";
-    case "pitch-slot-id":
-      return "external-scope-conflict";
-    case "game-side-id":
-      return "stable-side-conflict";
-    case "record-id":
-      return "content-conflict";
-  }
 }

--- a/src/lib/foundation-migrations.ts
+++ b/src/lib/foundation-migrations.ts
@@ -88,6 +88,65 @@ export const FOUNDATION_SIDE_TABLE_SQL = `
   ) STRICT
 `;
 
+export const FOUNDATION_ACTION_TABLE_SQL = `
+  CREATE TABLE foundation_event_game_record_actions (
+    action_id TEXT PRIMARY KEY,
+    record_id TEXT NOT NULL REFERENCES foundation_event_game_record_roots(record_id) ON DELETE CASCADE,
+    event_game_id TEXT NOT NULL,
+    operation_id TEXT NOT NULL,
+    action_kind TEXT NOT NULL,
+    action_version TEXT NOT NULL,
+    accepted_at_ms INTEGER NOT NULL,
+    content_fingerprint TEXT NOT NULL,
+    canonical_content TEXT NOT NULL,
+    action_json TEXT NOT NULL CHECK (json_valid(action_json)),
+    UNIQUE (record_id, operation_id),
+    UNIQUE (record_id, content_fingerprint),
+    CHECK (length(content_fingerprint) = 64),
+    CHECK (event_game_id <> '')
+  ) STRICT
+`;
+
+export const FOUNDATION_IDEMPOTENCY_TABLE_SQL = `
+  CREATE TABLE foundation_event_game_record_idempotency (
+    action_id TEXT PRIMARY KEY REFERENCES foundation_event_game_record_actions(action_id) ON DELETE CASCADE,
+    record_id TEXT NOT NULL,
+    operation_id TEXT NOT NULL,
+    content_fingerprint TEXT NOT NULL,
+    accepted_at_ms INTEGER NOT NULL,
+    UNIQUE (record_id, operation_id),
+    UNIQUE (record_id, content_fingerprint),
+    FOREIGN KEY (record_id, operation_id)
+      REFERENCES foundation_event_game_record_actions(record_id, operation_id)
+      ON DELETE CASCADE
+  ) STRICT
+`;
+
+export const FOUNDATION_METADATA_TABLE_SQL = `
+  CREATE TABLE foundation_event_game_record_metadata (
+    record_id TEXT PRIMARY KEY REFERENCES foundation_event_game_record_roots(record_id) ON DELETE CASCADE,
+    action_count INTEGER NOT NULL CHECK (action_count >= 0),
+    ordering_version TEXT NOT NULL,
+    last_accepted_at_ms INTEGER,
+    updated_at_ms INTEGER NOT NULL
+  ) STRICT
+`;
+
+export const FOUNDATION_AUDIT_TABLE_SQL = `
+  CREATE TABLE foundation_event_game_record_audit (
+    audit_id TEXT PRIMARY KEY,
+    record_id TEXT NOT NULL REFERENCES foundation_event_game_record_roots(record_id) ON DELETE CASCADE,
+    event_game_id TEXT NOT NULL,
+    operation_id TEXT,
+    audit_kind TEXT NOT NULL CHECK (audit_kind IN ('action-accepted', 'action-conflict', 'action-rejected', 'action-duplicate')),
+    outcome TEXT NOT NULL,
+    created_at_ms INTEGER NOT NULL,
+    redacted_detail TEXT NOT NULL,
+    audit_json TEXT NOT NULL CHECK (json_valid(audit_json)),
+    CHECK (event_game_id <> '')
+  ) STRICT
+`;
+
 export const FOUNDATION_ROOT_EVENT_INDEX_SQL = `
   CREATE INDEX foundation_event_game_record_roots_event_id
     ON foundation_event_game_record_roots (event_id)
@@ -101,6 +160,21 @@ export const FOUNDATION_ROOT_GAME_DAY_INDEX_SQL = `
 export const FOUNDATION_SIDE_RECORD_INDEX_SQL = `
   CREATE INDEX foundation_event_game_record_sides_record_id
     ON foundation_event_game_record_sides (record_id)
+`;
+
+export const FOUNDATION_ACTION_RECORD_INDEX_SQL = `
+  CREATE INDEX foundation_event_game_record_actions_record_id
+    ON foundation_event_game_record_actions (record_id, accepted_at_ms)
+`;
+
+export const FOUNDATION_IDEMPOTENCY_RECORD_INDEX_SQL = `
+  CREATE INDEX foundation_event_game_record_idempotency_record_id
+    ON foundation_event_game_record_idempotency (record_id)
+`;
+
+export const FOUNDATION_AUDIT_RECORD_INDEX_SQL = `
+  CREATE INDEX foundation_event_game_record_audit_record_id
+    ON foundation_event_game_record_audit (record_id, created_at_ms)
 `;
 
 const FOUNDATION_INITIAL_ROOT_MIGRATION_SQL = `
@@ -229,6 +303,21 @@ const FOUNDATION_NORMALIZE_ROOTS_MIGRATION_SQL = `
     ON foundation_event_game_record_sides (record_id);
 `;
 
+const FOUNDATION_ACTIONS_MIGRATION_SQL = `
+  ${FOUNDATION_ACTION_TABLE_SQL};
+  ${FOUNDATION_IDEMPOTENCY_TABLE_SQL};
+  ${FOUNDATION_METADATA_TABLE_SQL};
+  ${FOUNDATION_AUDIT_TABLE_SQL};
+  INSERT INTO foundation_event_game_record_metadata (
+    record_id, action_count, ordering_version, last_accepted_at_ms, updated_at_ms
+  )
+  SELECT record_id, 0, 'causal-occurrence-operation-v1', NULL, creation_created_at_ms
+  FROM foundation_event_game_record_roots;
+  ${FOUNDATION_ACTION_RECORD_INDEX_SQL};
+  ${FOUNDATION_IDEMPOTENCY_RECORD_INDEX_SQL};
+  ${FOUNDATION_AUDIT_RECORD_INDEX_SQL};
+`;
+
 export const FOUNDATION_MIGRATIONS: readonly FoundationMigration[] = Object.freeze([
   createMigration({
     id: "001-foundation-event-game-record-roots",
@@ -241,6 +330,12 @@ export const FOUNDATION_MIGRATIONS: readonly FoundationMigration[] = Object.free
     ordinal: 2,
     schemaVersion: 2,
     sql: FOUNDATION_NORMALIZE_ROOTS_MIGRATION_SQL,
+  }),
+  createMigration({
+    id: "003-persist-event-game-actions",
+    ordinal: 3,
+    schemaVersion: 3,
+    sql: FOUNDATION_ACTIONS_MIGRATION_SQL,
   }),
 ]);
 

--- a/src/lib/foundation-schema.ts
+++ b/src/lib/foundation-schema.ts
@@ -1,7 +1,14 @@
 import { createHash } from "node:crypto";
 import { Database } from "bun:sqlite";
 import {
+  FOUNDATION_ACTION_RECORD_INDEX_SQL,
+  FOUNDATION_ACTION_TABLE_SQL,
+  FOUNDATION_AUDIT_RECORD_INDEX_SQL,
+  FOUNDATION_AUDIT_TABLE_SQL,
   FOUNDATION_LEDGER_TABLE_SQL,
+  FOUNDATION_IDEMPOTENCY_RECORD_INDEX_SQL,
+  FOUNDATION_IDEMPOTENCY_TABLE_SQL,
+  FOUNDATION_METADATA_TABLE_SQL,
   FOUNDATION_ROOT_EVENT_INDEX_SQL,
   FOUNDATION_ROOT_GAME_DAY_INDEX_SQL,
   FOUNDATION_ROOT_TABLE_SQL,
@@ -60,12 +67,20 @@ type FoundationSchemaManifest = {
 const ROOT_TABLE = "foundation_event_game_record_roots";
 const SIDE_TABLE = "foundation_event_game_record_sides";
 const LEDGER_TABLE = "foundation_migration_ledger";
+const ACTION_TABLE = "foundation_event_game_record_actions";
+const IDEMPOTENCY_TABLE = "foundation_event_game_record_idempotency";
+const METADATA_TABLE = "foundation_event_game_record_metadata";
+const AUDIT_TABLE = "foundation_event_game_record_audit";
 
 const expectedManifest: FoundationSchemaManifest = {
   objects: [
     object("table", LEDGER_TABLE, LEDGER_TABLE, FOUNDATION_LEDGER_TABLE_SQL),
     object("table", ROOT_TABLE, ROOT_TABLE, FOUNDATION_ROOT_TABLE_SQL),
     object("table", SIDE_TABLE, SIDE_TABLE, FOUNDATION_SIDE_TABLE_SQL),
+    object("table", ACTION_TABLE, ACTION_TABLE, FOUNDATION_ACTION_TABLE_SQL),
+    object("table", IDEMPOTENCY_TABLE, IDEMPOTENCY_TABLE, FOUNDATION_IDEMPOTENCY_TABLE_SQL),
+    object("table", METADATA_TABLE, METADATA_TABLE, FOUNDATION_METADATA_TABLE_SQL),
+    object("table", AUDIT_TABLE, AUDIT_TABLE, FOUNDATION_AUDIT_TABLE_SQL),
     object(
       "index",
       "foundation_event_game_record_roots_event_id",
@@ -83,6 +98,24 @@ const expectedManifest: FoundationSchemaManifest = {
       "foundation_event_game_record_sides_record_id",
       SIDE_TABLE,
       FOUNDATION_SIDE_RECORD_INDEX_SQL,
+    ),
+    object(
+      "index",
+      "foundation_event_game_record_actions_record_id",
+      ACTION_TABLE,
+      FOUNDATION_ACTION_RECORD_INDEX_SQL,
+    ),
+    object(
+      "index",
+      "foundation_event_game_record_idempotency_record_id",
+      IDEMPOTENCY_TABLE,
+      FOUNDATION_IDEMPOTENCY_RECORD_INDEX_SQL,
+    ),
+    object(
+      "index",
+      "foundation_event_game_record_audit_record_id",
+      AUDIT_TABLE,
+      FOUNDATION_AUDIT_RECORD_INDEX_SQL,
     ),
   ].sort(compareNamed),
   tables: [
@@ -149,11 +182,131 @@ const expectedManifest: FoundationSchemaManifest = {
         },
       ],
     },
+    {
+      name: ACTION_TABLE,
+      columns: [
+        column("action_id", "TEXT", 1, 1),
+        column("record_id", "TEXT", 1, 0),
+        column("event_game_id", "TEXT", 1, 0),
+        column("operation_id", "TEXT", 1, 0),
+        column("action_kind", "TEXT", 1, 0),
+        column("action_version", "TEXT", 1, 0),
+        column("accepted_at_ms", "INTEGER", 1, 0),
+        column("content_fingerprint", "TEXT", 1, 0),
+        column("canonical_content", "TEXT", 1, 0),
+        column("action_json", "TEXT", 1, 0),
+      ],
+      foreignKeys: [
+        {
+          id: 0,
+          sequence: 0,
+          table: ROOT_TABLE,
+          from: "record_id",
+          to: "record_id",
+          onUpdate: "NO ACTION",
+          onDelete: "CASCADE",
+          match: "NONE",
+        },
+      ],
+    },
+    {
+      name: IDEMPOTENCY_TABLE,
+      columns: [
+        column("action_id", "TEXT", 1, 1),
+        column("record_id", "TEXT", 1, 0),
+        column("operation_id", "TEXT", 1, 0),
+        column("content_fingerprint", "TEXT", 1, 0),
+        column("accepted_at_ms", "INTEGER", 1, 0),
+      ],
+      foreignKeys: [
+        {
+          id: 0,
+          sequence: 0,
+          table: "foundation_event_game_record_actions",
+          from: "record_id",
+          to: "record_id",
+          onUpdate: "NO ACTION",
+          onDelete: "CASCADE",
+          match: "NONE",
+        },
+        {
+          id: 0,
+          sequence: 1,
+          table: "foundation_event_game_record_actions",
+          from: "operation_id",
+          to: "operation_id",
+          onUpdate: "NO ACTION",
+          onDelete: "CASCADE",
+          match: "NONE",
+        },
+        {
+          id: 1,
+          sequence: 0,
+          table: ACTION_TABLE,
+          from: "action_id",
+          to: "action_id",
+          onUpdate: "NO ACTION",
+          onDelete: "CASCADE",
+          match: "NONE",
+        },
+      ],
+    },
+    {
+      name: METADATA_TABLE,
+      columns: [
+        column("record_id", "TEXT", 1, 1),
+        column("action_count", "INTEGER", 1, 0),
+        column("ordering_version", "TEXT", 1, 0),
+        column("last_accepted_at_ms", "INTEGER", 0, 0),
+        column("updated_at_ms", "INTEGER", 1, 0),
+      ],
+      foreignKeys: [
+        {
+          id: 0,
+          sequence: 0,
+          table: ROOT_TABLE,
+          from: "record_id",
+          to: "record_id",
+          onUpdate: "NO ACTION",
+          onDelete: "CASCADE",
+          match: "NONE",
+        },
+      ],
+    },
+    {
+      name: AUDIT_TABLE,
+      columns: [
+        column("audit_id", "TEXT", 1, 1),
+        column("record_id", "TEXT", 1, 0),
+        column("event_game_id", "TEXT", 1, 0),
+        column("operation_id", "TEXT", 0, 0),
+        column("audit_kind", "TEXT", 1, 0),
+        column("outcome", "TEXT", 1, 0),
+        column("created_at_ms", "INTEGER", 1, 0),
+        column("redacted_detail", "TEXT", 1, 0),
+        column("audit_json", "TEXT", 1, 0),
+      ],
+      foreignKeys: [
+        {
+          id: 0,
+          sequence: 0,
+          table: ROOT_TABLE,
+          from: "record_id",
+          to: "record_id",
+          onUpdate: "NO ACTION",
+          onDelete: "CASCADE",
+          match: "NONE",
+        },
+      ],
+    },
   ].sort(compareNamed),
   indexes: [
     index("foundation_event_game_record_roots_event_id", 0, ["event_id"]),
     index("foundation_event_game_record_roots_game_day_id", 0, ["scope_event_id", "game_day_id"]),
     index("foundation_event_game_record_sides_record_id", 0, ["record_id"]),
+    index("foundation_event_game_record_actions_record_id", 0, ["record_id", "accepted_at_ms"]),
+    index("foundation_event_game_record_idempotency_record_id", 0, ["record_id"]),
+    index("foundation_event_game_record_audit_record_id", 0, ["record_id", "created_at_ms"]),
   ].sort(compareNamed),
 };
 
@@ -350,7 +503,15 @@ function readSchemaManifest(database: Database): FoundationSchemaManifest {
     );
   });
 
-  const tables = [LEDGER_TABLE, ROOT_TABLE, SIDE_TABLE].map((name) => ({
+  const tables = [
+    LEDGER_TABLE,
+    ROOT_TABLE,
+    SIDE_TABLE,
+    ACTION_TABLE,
+    IDEMPOTENCY_TABLE,
+    METADATA_TABLE,
+    AUDIT_TABLE,
+  ].map((name) => ({
     name,
     columns: readColumns(database, name),
     foreignKeys: readForeignKeys(database, name),
@@ -359,6 +520,9 @@ function readSchemaManifest(database: Database): FoundationSchemaManifest {
     "foundation_event_game_record_roots_event_id",
     "foundation_event_game_record_roots_game_day_id",
     "foundation_event_game_record_sides_record_id",
+    "foundation_event_game_record_actions_record_id",
+    "foundation_event_game_record_idempotency_record_id",
+    "foundation_event_game_record_audit_record_id",
   ].map((name) => readIndex(database, name));
 
   return {
@@ -377,6 +541,7 @@ function tableExists(database: Database, name: string): boolean {
 }
 
 function canBeginWrite(database: Database): boolean {
+  if (database.inTransaction) return true;
   try {
     database.exec("BEGIN IMMEDIATE; ROLLBACK;");
     return true;
@@ -454,7 +619,11 @@ function readIndex(database: Database, name: string): SchemaIndex {
 }
 
 function indexTable(name: string): string {
-  return name.includes("sides") ? SIDE_TABLE : ROOT_TABLE;
+  if (name.includes("sides")) return SIDE_TABLE;
+  if (name.includes("actions")) return ACTION_TABLE;
+  if (name.includes("idempotency")) return IDEMPOTENCY_TABLE;
+  if (name.includes("audit")) return AUDIT_TABLE;
+  return ROOT_TABLE;
 }
 
 function object(

--- a/src/lib/foundation-storage-memory.ts
+++ b/src/lib/foundation-storage-memory.ts
@@ -11,33 +11,55 @@ import {
   type FoundationStorageReadiness,
   type FoundationStorageTransaction,
   type FoundationStorageTransactionWork,
+  type StoredControlAction,
+  type StoredControlAuditEntry,
+  type StoredControlIdempotencyEntry,
+  type StoredEventGameRecordMetadata,
   type StoredEventGameRecordRoot,
   isThenable,
 } from "@/lib/foundation-storage";
+import { actionIdentity, parseStoredControlAction } from "@/lib/event-game-actions";
 
-type MemoryState = Map<string, StoredEventGameRecordRoot>;
+type MemoryState = {
+  roots: Map<string, StoredEventGameRecordRoot>;
+  actions: Map<string, Map<string, StoredControlAction>>;
+  idempotency: Map<string, Map<string, StoredControlIdempotencyEntry>>;
+  metadata: Map<string, StoredEventGameRecordMetadata>;
+  audits: Map<string, Map<string, StoredControlAuditEntry>>;
+};
 
 export function createInMemoryFoundationStorage(): FoundationStorage {
   return new InMemoryFoundationStorage();
 }
 
 class InMemoryFoundationStorage implements FoundationStorage {
-  private state: MemoryState = new Map();
+  private readonly state: MemoryState = {
+    roots: new Map(),
+    actions: new Map(),
+    idempotency: new Map(),
+    metadata: new Map(),
+    audits: new Map(),
+  };
+
   private writerTail: Promise<void> = Promise.resolve();
   private closed = false;
+  private revision = 0;
 
   transaction<T>(work: FoundationStorageTransactionWork<T>): Promise<T> {
     const operation = this.writerTail.then(() => {
       this.assertOpen();
-      const workingState = cloneState(this.state);
-      const transaction = createTransaction(workingState);
-      const result = work(transaction);
-      if (isThenable(result)) {
-        throw new TypeError("Foundation storage transactions must complete synchronously.");
+      const undo: (() => void)[] = [];
+      try {
+        const result = work(createTransaction(this.state, undo, this.revision));
+        if (isThenable(result)) {
+          throw new TypeError("Foundation storage transactions must complete synchronously.");
+        }
+        this.revision += 1;
+        return result;
+      } catch (error) {
+        for (const revert of undo.reverse()) revert();
+        throw error;
       }
-
-      this.state = workingState;
-      return result;
     });
     this.writerTail = operation.then(
       () => undefined,
@@ -46,11 +68,44 @@ class InMemoryFoundationStorage implements FoundationStorage {
     return operation;
   }
 
-  async readRoot(recordId: string): Promise<EventGameRecordRoot | null> {
+  readRoot(recordId: string): Promise<EventGameRecordRoot | null> {
     return this.writerTail.then(() => {
       this.assertOpen();
-      const stored = this.state.get(recordId);
+      const stored = this.state.roots.get(recordId);
       return stored === undefined ? null : cloneEventGameRecordRoot(stored.root);
+    });
+  }
+
+  readActions(recordId: string): Promise<StoredControlAction[]> {
+    return this.writerTail.then(() => {
+      this.assertOpen();
+      return cloneActions(this.state.actions.get(recordId));
+    });
+  }
+
+  readRecordMetadata(recordId: string): Promise<StoredEventGameRecordMetadata | null> {
+    return this.writerTail.then(() => {
+      this.assertOpen();
+      const metadata = this.state.metadata.get(recordId);
+      return metadata === undefined ? null : structuredClone(metadata);
+    });
+  }
+
+  readIdempotencyEntries(recordId: string): Promise<StoredControlIdempotencyEntry[]> {
+    return this.writerTail.then(() => {
+      this.assertOpen();
+      return [...(this.state.idempotency.get(recordId)?.values() ?? [])].map((entry) =>
+        structuredClone(entry),
+      );
+    });
+  }
+
+  readAuditEntries(recordId: string): Promise<StoredControlAuditEntry[]> {
+    return this.writerTail.then(() => {
+      this.assertOpen();
+      return [...(this.state.audits.get(recordId)?.values() ?? [])].map((entry) =>
+        structuredClone(entry),
+      );
     });
   }
 
@@ -64,7 +119,7 @@ class InMemoryFoundationStorage implements FoundationStorage {
           storage: "memory",
         } satisfies FoundationStorageReadiness;
       }
-      for (const stored of this.state.values()) {
+      for (const stored of this.state.roots.values()) {
         const validated = validateEventGameRecordRoot(stored.root);
         if (
           !validated.ok ||
@@ -74,6 +129,58 @@ class InMemoryFoundationStorage implements FoundationStorage {
             ok: false,
             status: "integrity-failure",
             detail: "An in-memory Event Game Record root failed semantic validation.",
+            storage: "memory",
+          } satisfies FoundationStorageReadiness;
+        }
+      }
+      for (const actions of this.state.actions.values()) {
+        for (const stored of actions.values()) {
+          if (!parseStoredControlAction(stored.action).ok) {
+            return {
+              ok: false,
+              status: "integrity-failure",
+              detail: "An in-memory Control Action failed structural validation.",
+              storage: "memory",
+            } satisfies FoundationStorageReadiness;
+          }
+        }
+      }
+      for (const [recordId, actions] of this.state.actions) {
+        const idempotency = this.state.idempotency.get(recordId);
+        if (idempotency === undefined || idempotency.size !== actions.size) {
+          return {
+            ok: false,
+            status: "integrity-failure",
+            detail: "In-memory action and idempotency state is inconsistent.",
+            storage: "memory",
+          } satisfies FoundationStorageReadiness;
+        }
+        for (const stored of actions.values()) {
+          const expectedId = actionIdentity(stored.action.recordId, stored.action.operationId);
+          const entry = idempotency.get(expectedId);
+          if (
+            entry === undefined ||
+            entry.actionId !== expectedId ||
+            entry.recordId !== stored.action.recordId ||
+            entry.operationId !== stored.action.operationId ||
+            entry.contentFingerprint !== stored.contentFingerprint ||
+            entry.acceptedAtMs !== stored.action.acceptedAtMs
+          ) {
+            return {
+              ok: false,
+              status: "integrity-failure",
+              detail: "In-memory action and idempotency state is inconsistent.",
+              storage: "memory",
+            } satisfies FoundationStorageReadiness;
+          }
+        }
+      }
+      for (const [recordId, entries] of this.state.idempotency) {
+        if (!this.state.actions.has(recordId) && entries.size > 0) {
+          return {
+            ok: false,
+            status: "integrity-failure",
+            detail: "In-memory idempotency state has entries without actions.",
             storage: "memory",
           } satisfies FoundationStorageReadiness;
         }
@@ -91,92 +198,166 @@ class InMemoryFoundationStorage implements FoundationStorage {
   }
 
   private assertOpen(): void {
-    if (this.closed) {
-      throw new FoundationStorageClosedError();
-    }
+    if (this.closed) throw new FoundationStorageClosedError();
   }
 }
 
-function createTransaction(state: MemoryState): FoundationStorageTransaction {
+function createTransaction(
+  state: MemoryState,
+  undo: (() => void)[],
+  revision: number,
+): FoundationStorageTransaction {
   return {
+    revision,
     findRootByRecordId(recordId) {
-      return cloneStoredRoot(state.get(recordId));
+      return cloneRoot(state.roots.get(recordId));
     },
     findRootByEventGameId(eventGameId) {
-      return findRoot(state, (stored) => stored.root.eventGameId === eventGameId);
+      return findRoot(state.roots, (stored) => stored.root.eventGameId === eventGameId);
     },
     findRootByPitchSlotId(pitchSlotId) {
-      return findRoot(state, (stored) => stored.root.externalScope.pitchSlotId === pitchSlotId);
+      return findRoot(
+        state.roots,
+        (stored) => stored.root.externalScope.pitchSlotId === pitchSlotId,
+      );
     },
     findRootByGameSideId(gameSideId) {
-      return findRoot(state, (stored) =>
+      return findRoot(state.roots, (stored) =>
         stored.root.gameSides.some((side) => side.id === gameSideId),
       );
     },
+    findActionByOperationId(recordId, operationId) {
+      return cloneAction(state.actions.get(recordId)?.get(operationId));
+    },
+    listActions(recordId) {
+      return cloneActions(state.actions.get(recordId));
+    },
+    listIdempotencyEntries(recordId) {
+      return [...(state.idempotency.get(recordId)?.values() ?? [])].map((entry) =>
+        structuredClone(entry),
+      );
+    },
+    readRecordMetadata(recordId) {
+      const metadata = state.metadata.get(recordId);
+      return metadata === undefined ? null : structuredClone(metadata);
+    },
+    listAuditEntries(recordId) {
+      return [...(state.audits.get(recordId)?.values() ?? [])].map((entry) =>
+        structuredClone(entry),
+      );
+    },
     insertRoot(storedRoot) {
-      if (state.has(storedRoot.root.recordId)) {
+      if (state.roots.has(storedRoot.root.recordId)) {
         throw new FoundationStorageConstraintError("record-id");
       }
       if (
-        findRoot(state, (stored) => stored.root.eventGameId === storedRoot.root.eventGameId) !==
-        null
+        findRoot(state.roots, (stored) => stored.root.eventGameId === storedRoot.root.eventGameId)
       ) {
         throw new FoundationStorageConstraintError("event-game-id");
       }
       if (
         findRoot(
-          state,
+          state.roots,
           (stored) =>
             stored.root.externalScope.pitchSlotId === storedRoot.root.externalScope.pitchSlotId,
-        ) !== null
+        )
       ) {
         throw new FoundationStorageConstraintError("pitch-slot-id");
       }
       for (const side of storedRoot.root.gameSides) {
         if (
-          findRoot(state, (stored) =>
+          findRoot(state.roots, (stored) =>
             stored.root.gameSides.some((candidate) => candidate.id === side.id),
-          ) !== null
+          )
         ) {
           throw new FoundationStorageConstraintError("game-side-id");
         }
       }
-
-      state.set(storedRoot.root.recordId, {
+      state.roots.set(storedRoot.root.recordId, {
         root: cloneEventGameRecordRoot(storedRoot.root),
         canonicalContent: storedRoot.canonicalContent,
       });
+      undo.push(() => state.roots.delete(storedRoot.root.recordId));
+    },
+    insertAction(storedAction) {
+      const { action } = storedAction;
+      if (!state.roots.has(action.recordId)) {
+        throw new FoundationStorageConstraintError("record-id");
+      }
+      let actions = state.actions.get(action.recordId);
+      if (actions === undefined) {
+        actions = new Map();
+        state.actions.set(action.recordId, actions);
+        undo.push(() => state.actions.delete(action.recordId));
+      }
+      if (actions.has(action.operationId)) {
+        throw new FoundationStorageConstraintError("operation-id");
+      }
+      actions.set(action.operationId, structuredClone(storedAction));
+      undo.push(() => actions?.delete(action.operationId));
+      const actionId = actionIdentity(action.recordId, action.operationId);
+      let idempotency = state.idempotency.get(action.recordId);
+      if (idempotency === undefined) {
+        idempotency = new Map();
+        state.idempotency.set(action.recordId, idempotency);
+        undo.push(() => state.idempotency.delete(action.recordId));
+      }
+      if (idempotency.has(actionId)) {
+        throw new FoundationStorageConstraintError("operation-id");
+      }
+      idempotency.set(actionId, {
+        actionId,
+        recordId: action.recordId,
+        operationId: action.operationId,
+        contentFingerprint: storedAction.contentFingerprint,
+        acceptedAtMs: action.acceptedAtMs,
+      });
+      undo.push(() => idempotency?.delete(actionId));
+    },
+    upsertRecordMetadata(metadata) {
+      const previous = state.metadata.get(metadata.recordId);
+      state.metadata.set(metadata.recordId, structuredClone(metadata));
+      undo.push(() => {
+        if (previous === undefined) state.metadata.delete(metadata.recordId);
+        else state.metadata.set(metadata.recordId, previous);
+      });
+    },
+    appendAuditEntry(entry) {
+      let audits = state.audits.get(entry.recordId);
+      if (audits === undefined) {
+        audits = new Map();
+        state.audits.set(entry.recordId, audits);
+        undo.push(() => state.audits.delete(entry.recordId));
+      }
+      if (audits.has(entry.auditId)) {
+        throw new FoundationStorageConstraintError("audit-id");
+      }
+      audits.set(entry.auditId, structuredClone(entry));
+      undo.push(() => audits?.delete(entry.auditId));
     },
   };
 }
 
 function findRoot(
-  state: MemoryState,
+  roots: Map<string, StoredEventGameRecordRoot>,
   predicate: (stored: StoredEventGameRecordRoot) => boolean,
 ): EventGameRecordRoot | null {
-  for (const stored of state.values()) {
-    if (predicate(stored)) {
-      return cloneEventGameRecordRoot(stored.root);
-    }
+  for (const stored of roots.values()) {
+    if (predicate(stored)) return cloneEventGameRecordRoot(stored.root);
   }
-
   return null;
 }
 
-function cloneStoredRoot(
-  stored: StoredEventGameRecordRoot | undefined,
-): EventGameRecordRoot | null {
+function cloneRoot(stored: StoredEventGameRecordRoot | undefined): EventGameRecordRoot | null {
   return stored === undefined ? null : cloneEventGameRecordRoot(stored.root);
 }
 
-function cloneState(state: MemoryState): MemoryState {
-  return new Map(
-    [...state.entries()].map(([recordId, stored]) => [
-      recordId,
-      {
-        root: cloneEventGameRecordRoot(stored.root),
-        canonicalContent: stored.canonicalContent,
-      },
-    ]),
-  );
+function cloneAction(stored: StoredControlAction | undefined): StoredControlAction | null {
+  return stored === undefined ? null : structuredClone(stored);
+}
+
+function cloneActions(
+  actions: Map<string, StoredControlAction> | undefined,
+): StoredControlAction[] {
+  return [...(actions?.values() ?? [])].map((stored) => structuredClone(stored));
 }

--- a/src/lib/foundation-storage-sqlite-helpers.ts
+++ b/src/lib/foundation-storage-sqlite-helpers.ts
@@ -1,0 +1,182 @@
+import { parseStoredControlAction, sha256 } from "@/lib/event-game-actions";
+import {
+  FoundationStorageConstraintError,
+  type StoredControlAction,
+  type StoredControlAuditEntry,
+  type StoredControlIdempotencyEntry,
+  type StoredEventGameRecordMetadata,
+} from "@/lib/foundation-storage";
+
+export type RootRow = Record<string, unknown>;
+
+export function translateSqliteConstraint(error: unknown): unknown {
+  if (!(error instanceof Error)) return error;
+  const message = error.message.toLowerCase();
+  if (message.includes("record_id")) {
+    return new FoundationStorageConstraintError("record-id");
+  }
+  if (message.includes("event_game_id")) {
+    return new FoundationStorageConstraintError("event-game-id");
+  }
+  if (message.includes("pitch_slot_id")) {
+    return new FoundationStorageConstraintError("pitch-slot-id");
+  }
+  if (message.includes("side_id")) {
+    return new FoundationStorageConstraintError("game-side-id");
+  }
+  if (message.includes("operation_id")) {
+    return new FoundationStorageConstraintError("operation-id");
+  }
+  if (message.includes("audit_id")) {
+    return new FoundationStorageConstraintError("audit-id");
+  }
+  return error;
+}
+
+export function readStoredAction(row: RootRow): StoredControlAction {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readText(row.action_json)) as unknown;
+  } catch {
+    throw new Error("Stored Control Action JSON is invalid.");
+  }
+  const action = parseStoredControlAction(parsed);
+  if (!action.ok) throw new Error("Stored Control Action failed structural validation.");
+  if (action.value.kind.id !== readText(row.action_kind)) {
+    throw new Error("Stored Control Action kind projection is inconsistent.");
+  }
+  if (action.value.kind.version !== readText(row.action_version)) {
+    throw new Error("Stored Control Action version projection is inconsistent.");
+  }
+  if (action.value.acceptedAtMs !== readInteger(row.accepted_at_ms)) {
+    throw new Error("Stored Control Action acceptance time is inconsistent.");
+  }
+  return {
+    action: action.value,
+    canonicalContent: readText(row.canonical_content),
+    contentFingerprint: readText(row.content_fingerprint),
+  };
+}
+
+export function readMetadata(row: RootRow): StoredEventGameRecordMetadata {
+  return {
+    recordId: readText(row.record_id),
+    actionCount: readInteger(row.action_count),
+    orderingVersion: readText(row.ordering_version),
+    lastAcceptedAtMs: readNullableInteger(row.last_accepted_at_ms),
+    updatedAtMs: readInteger(row.updated_at_ms),
+  };
+}
+
+export function readAudit(row: RootRow): StoredControlAuditEntry {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readText(row.audit_json)) as unknown;
+  } catch {
+    throw new Error("Stored Control Audit entry JSON is invalid.");
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error("Stored Control Audit entry is invalid.");
+  }
+  const entry = parsed as Record<string, unknown>;
+  const kind = entry.kind;
+  if (
+    kind !== "action-accepted" &&
+    kind !== "action-conflict" &&
+    kind !== "action-rejected" &&
+    kind !== "action-duplicate"
+  ) {
+    throw new Error("Stored Control Audit entry kind is invalid.");
+  }
+  const result: StoredControlAuditEntry = {
+    auditId: readText(entry.auditId),
+    recordId: readText(entry.recordId),
+    eventGameId: readText(entry.eventGameId),
+    operationId: entry.operationId === null ? null : readText(entry.operationId),
+    kind,
+    outcome: readText(entry.outcome),
+    createdAtMs: readInteger(entry.createdAtMs),
+    redactedDetail: readText(entry.redactedDetail),
+  };
+  if (
+    result.auditId !== readText(row.audit_id) ||
+    result.recordId !== readText(row.record_id) ||
+    result.eventGameId !== readText(row.event_game_id) ||
+    result.operationId !== (row.operation_id === null ? null : readText(row.operation_id)) ||
+    result.kind !== readText(row.audit_kind) ||
+    result.outcome !== readText(row.outcome) ||
+    result.createdAtMs !== readInteger(row.created_at_ms) ||
+    result.redactedDetail !== readText(row.redacted_detail)
+  ) {
+    throw new Error("Stored Control Audit entry projection is inconsistent.");
+  }
+  return result;
+}
+
+export function readIdempotency(row: RootRow): StoredControlIdempotencyEntry {
+  return {
+    actionId: readText(row.action_id),
+    recordId: readText(row.record_id),
+    operationId: readText(row.operation_id),
+    contentFingerprint: readText(row.content_fingerprint),
+    acceptedAtMs: readInteger(row.accepted_at_ms),
+  };
+}
+
+export function actionIdentity(recordId: string, operationId: string): string {
+  return `action-${sha256(`${recordId}:${operationId}`)}`;
+}
+
+export function quoteSqliteString(value: string): string {
+  return `'${value.replaceAll("'", "''")}'`;
+}
+
+export function asRecord(value: unknown): RootRow {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error("SQLite returned an invalid row.");
+  }
+  return value as RootRow;
+}
+
+export function readText(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (typeof value === "object" && value !== null && "journal_mode" in value) {
+    return readText(value.journal_mode);
+  }
+  if (typeof value === "object" && value !== null && "synchronous" in value) {
+    return readText(value.synchronous);
+  }
+  if (typeof value === "object" && value !== null && "foreign_keys" in value) {
+    return readText(value.foreign_keys);
+  }
+  if (typeof value === "object" && value !== null && "busy_timeout" in value) {
+    return readText(value.busy_timeout);
+  }
+  if (typeof value === "object" && value !== null && "timeout" in value) {
+    return readText(value.timeout);
+  }
+  if (typeof value === "object" && value !== null && "count" in value) {
+    return readText(value.count);
+  }
+  if (typeof value === "object" && value !== null && "data_version" in value) {
+    return readText(value.data_version);
+  }
+  if (typeof value === "object" && value !== null && "quick_check" in value) {
+    return readText(value.quick_check);
+  }
+  if (typeof value === "object" && value !== null && "integrity_check" in value) {
+    return readText(value.integrity_check);
+  }
+  if (typeof value === "number" || typeof value === "bigint") return String(value);
+  throw new Error("SQLite returned an invalid value.");
+}
+
+export function readInteger(value: unknown): number {
+  const parsed = Number(readText(value));
+  if (!Number.isSafeInteger(parsed)) throw new Error("SQLite returned an invalid integer.");
+  return parsed;
+}
+
+export function readNullableInteger(value: unknown): number | null {
+  return value === null ? null : readInteger(value);
+}

--- a/src/lib/foundation-storage-sqlite.test.ts
+++ b/src/lib/foundation-storage-sqlite.test.ts
@@ -56,7 +56,7 @@ describe("SQLite foundation storage", () => {
       first.close();
 
       const reopened = openSqliteFoundationStorage(databasePath);
-      expect(await reopened.readiness()).toMatchObject({ ok: true, schemaVersion: "2" });
+      expect(await reopened.readiness()).toMatchObject({ ok: true, schemaVersion: "3" });
       const reopenedRecord = createEventGameRecord(reopened, {
         externalScopeResolver: createScopeResolver(root),
       });
@@ -74,12 +74,12 @@ describe("SQLite foundation storage", () => {
       const storage = openSqliteFoundationStorage(databasePath);
       const candidate = await storage.validateCandidate();
       expect(candidate.ready).toBe(true);
-      expect(candidate.readiness).toMatchObject({ ok: true, schemaVersion: "2" });
+      expect(candidate.readiness).toMatchObject({ ok: true, schemaVersion: "3" });
       expect(existsSync(candidate.candidatePath)).toBe(false);
       expect(await storage.readiness()).toMatchObject({ ok: false, status: "pending" });
 
       const migration = await storage.applyMigrations({ requireCandidate: true });
-      expect(migration.schemaVersion).toBe(2);
+      expect(migration.schemaVersion).toBe(3);
       expect(await storage.readiness()).toMatchObject({ ok: true });
       storage.close();
     });
@@ -89,7 +89,12 @@ describe("SQLite foundation storage", () => {
     await withDatabase(async (databasePath) => {
       const initialMigration = FOUNDATION_MIGRATIONS[0];
       const repairMigration = FOUNDATION_MIGRATIONS[1];
-      if (initialMigration === undefined || repairMigration === undefined) {
+      const actionMigration = FOUNDATION_MIGRATIONS[2];
+      if (
+        initialMigration === undefined ||
+        repairMigration === undefined ||
+        actionMigration === undefined
+      ) {
         throw new Error("Expected the foundation migrations.");
       }
       const legacy = openSqliteFoundationStorage(databasePath, {
@@ -101,8 +106,8 @@ describe("SQLite foundation storage", () => {
       const current = openSqliteFoundationStorage(databasePath);
       expect(await current.readiness()).toMatchObject({ ok: false, status: "missing" });
       const migration = await current.applyMigrations();
-      expect(migration.appliedMigrationIds).toEqual([repairMigration.id]);
-      expect(await current.readiness()).toMatchObject({ ok: true, schemaVersion: "2" });
+      expect(migration.appliedMigrationIds).toEqual([repairMigration.id, actionMigration.id]);
+      expect(await current.readiness()).toMatchObject({ ok: true, schemaVersion: "3" });
       current.close();
     });
   });
@@ -133,7 +138,7 @@ describe("SQLite foundation storage", () => {
       });
       expect(await priorBinary.readiness()).toMatchObject({
         ok: true,
-        schemaVersion: "2",
+        schemaVersion: "3",
       });
       priorBinary.close();
 
@@ -205,7 +210,7 @@ describe("SQLite foundation storage", () => {
         .query(
           "INSERT INTO foundation_migration_ledger (migration_id, ordinal, schema_version, checksum, status, applied_at_ms) VALUES (?, ?, ?, ?, ?, ?)",
         )
-        .run("future-999", 3, 3, "future-checksum", "complete", 2_000);
+        .run("future-999", 4, 4, "future-checksum", "complete", 2_000);
       futureDatabase.close();
       const future = openSqliteFoundationStorage(databasePath);
       expect(await future.readiness()).toMatchObject({ ok: false });

--- a/src/lib/foundation-storage-sqlite.ts
+++ b/src/lib/foundation-storage-sqlite.ts
@@ -14,19 +14,37 @@ import {
 import { verifyFoundationSchema, readValidatedFoundationRoot } from "@/lib/foundation-schema";
 import {
   FoundationStorageClosedError,
-  FoundationStorageConstraintError,
   FoundationStorageNotReadyError,
   isThenable,
   type FoundationStorage,
   type FoundationStorageReadiness,
   type FoundationStorageTransaction,
   type FoundationStorageTransactionWork,
+  type StoredControlAction,
+  type StoredControlAuditEntry,
+  type StoredControlIdempotencyEntry,
+  type StoredEventGameRecordMetadata,
   type StoredEventGameRecordRoot,
 } from "@/lib/foundation-storage";
+import {
+  actionIdentity,
+  asRecord,
+  quoteSqliteString,
+  readAudit,
+  readIdempotency,
+  readInteger,
+  readMetadata,
+  readStoredAction,
+  readText,
+  translateSqliteConstraint,
+  type RootRow,
+} from "@/lib/foundation-storage-sqlite-helpers";
 
 export type SqliteFoundationStorageOptions = {
   migrations?: readonly FoundationMigration[];
   busyTimeoutMs?: number;
+  /** Test-only synchronization seam immediately before acquiring the writer lock. */
+  beforeWriteTransactionLock?: () => void;
 };
 
 export type SqliteFoundationSettings = {
@@ -60,8 +78,6 @@ export class FoundationMigrationError extends Error {
 
 type SqlStatement = ReturnType<Database["query"]>;
 
-type RootRow = Record<string, unknown>;
-
 type RootStatements = {
   byRecordId: SqlStatement;
   byEventGameId: SqlStatement;
@@ -69,6 +85,15 @@ type RootStatements = {
   byGameSideId: SqlStatement;
   insertRoot: SqlStatement;
   insertSide: SqlStatement;
+  actionByOperationId: SqlStatement;
+  actionsByRecordId: SqlStatement;
+  insertAction: SqlStatement;
+  insertIdempotency: SqlStatement;
+  metadataByRecordId: SqlStatement;
+  upsertMetadata: SqlStatement;
+  auditByRecordId: SqlStatement;
+  idempotencyByRecordId: SqlStatement;
+  insertAudit: SqlStatement;
 };
 
 const ROOT_SELECT_COLUMNS = `
@@ -92,32 +117,44 @@ export class SqliteFoundationStorage implements FoundationStorage {
   private readonly database: Database;
   private readonly migrations: readonly FoundationMigration[];
   private readonly busyTimeoutMs: number;
+  private readonly beforeWriteTransactionLock: (() => void) | undefined;
   private writerTail: Promise<void> = Promise.resolve();
   private statements: RootStatements | undefined;
   private closed = false;
+  private revision = 0;
+  private dataVersion: number;
 
   constructor(databasePath: string, options: SqliteFoundationStorageOptions = {}) {
     this.databasePath = databasePath;
     this.migrations = options.migrations ?? FOUNDATION_MIGRATIONS;
     this.busyTimeoutMs = options.busyTimeoutMs ?? 5_000;
+    this.beforeWriteTransactionLock = options.beforeWriteTransactionLock;
     this.database = new Database(databasePath);
     this.configureDatabase();
+    this.dataVersion = this.readDataVersion();
   }
 
   transaction<T>(work: FoundationStorageTransactionWork<T>): Promise<T> {
     return this.enqueue(() => {
-      const readiness = this.readinessSync();
-      if (!readiness.ok) {
-        throw new FoundationStorageNotReadyError(readiness);
-      }
-
+      this.beforeWriteTransactionLock?.();
       this.database.exec("BEGIN IMMEDIATE;");
       try {
+        // The write lock fixes the snapshot before both the external revision
+        // token and semantic readiness are derived. A commit from another
+        // connection cannot land between these operations and be hidden by
+        // the verified-revision cache.
+        this.refreshExternalRevision();
+        const readiness = this.readinessSync();
+        if (!readiness.ok) {
+          throw new FoundationStorageNotReadyError(readiness);
+        }
         const result = work(this.createTransaction());
         if (isThenable(result)) {
           throw new TypeError("Foundation storage transactions must complete synchronously.");
         }
         this.database.exec("COMMIT;");
+        this.revision += 1;
+        this.dataVersion = this.readDataVersion();
         return result;
       } catch (error) {
         this.rollbackQuietly();
@@ -133,6 +170,39 @@ export class SqliteFoundationStorage implements FoundationStorage {
         throw new FoundationStorageNotReadyError(readiness);
       }
       return this.readRootByStatement(this.getStatements().byRecordId, recordId);
+    });
+  }
+
+  readActions(recordId: string): Promise<StoredControlAction[]> {
+    return this.enqueue(() => {
+      const readiness = this.readinessSync();
+      if (!readiness.ok) throw new FoundationStorageNotReadyError(readiness);
+      return this.readActionsByRecordId(this.getStatements().actionsByRecordId, recordId);
+    });
+  }
+
+  readRecordMetadata(recordId: string): Promise<StoredEventGameRecordMetadata | null> {
+    return this.enqueue(() => {
+      const readiness = this.readinessSync();
+      if (!readiness.ok) throw new FoundationStorageNotReadyError(readiness);
+      const row = this.getStatements().metadataByRecordId.get(recordId) as RootRow | null;
+      return row === null ? null : readMetadata(row);
+    });
+  }
+
+  readIdempotencyEntries(recordId: string): Promise<StoredControlIdempotencyEntry[]> {
+    return this.enqueue(() => {
+      const readiness = this.readinessSync();
+      if (!readiness.ok) throw new FoundationStorageNotReadyError(readiness);
+      return this.readIdempotencyByRecordId(this.getStatements().idempotencyByRecordId, recordId);
+    });
+  }
+
+  readAuditEntries(recordId: string): Promise<StoredControlAuditEntry[]> {
+    return this.enqueue(() => {
+      const readiness = this.readinessSync();
+      if (!readiness.ok) throw new FoundationStorageNotReadyError(readiness);
+      return this.readAuditByRecordId(this.getStatements().auditByRecordId, recordId);
     });
   }
 
@@ -274,6 +344,7 @@ export class SqliteFoundationStorage implements FoundationStorage {
   private createTransaction(): FoundationStorageTransaction {
     const statements = this.getStatements();
     return {
+      revision: this.revision,
       findRootByRecordId: (recordId) => this.readRootByStatement(statements.byRecordId, recordId),
       findRootByEventGameId: (eventGameId) =>
         this.readRootByStatement(statements.byEventGameId, eventGameId),
@@ -282,6 +353,20 @@ export class SqliteFoundationStorage implements FoundationStorage {
       findRootByGameSideId: (gameSideId) =>
         this.readRootByStatement(statements.byGameSideId, gameSideId),
       insertRoot: (storedRoot) => this.insertRoot(statements, storedRoot),
+      findActionByOperationId: (recordId, operationId) =>
+        this.readActionByStatement(statements.actionByOperationId, recordId, operationId),
+      listActions: (recordId) => this.readActionsByRecordId(statements.actionsByRecordId, recordId),
+      listIdempotencyEntries: (recordId) =>
+        this.readIdempotencyByRecordId(statements.idempotencyByRecordId, recordId),
+      readRecordMetadata: (recordId) => {
+        const row = statements.metadataByRecordId.get(recordId) as RootRow | null;
+        return row === null ? null : readMetadata(row);
+      },
+      listAuditEntries: (recordId) =>
+        this.readAuditByRecordId(statements.auditByRecordId, recordId),
+      insertAction: (storedAction) => this.insertAction(statements, storedAction),
+      upsertRecordMetadata: (metadata) => this.upsertRecordMetadata(statements, metadata),
+      appendAuditEntry: (entry) => this.appendAuditEntry(statements, entry),
     };
   }
 
@@ -329,6 +414,57 @@ export class SqliteFoundationStorage implements FoundationStorage {
     );
   }
 
+  private insertAction(statements: RootStatements, storedAction: StoredControlAction): void {
+    const { action } = storedAction;
+    const actionId = actionIdentity(action.recordId, action.operationId);
+    statements.insertAction.run(
+      actionId,
+      action.recordId,
+      action.eventGameId,
+      action.operationId,
+      action.kind.id,
+      action.kind.version,
+      action.acceptedAtMs,
+      storedAction.contentFingerprint,
+      storedAction.canonicalContent,
+      JSON.stringify(action),
+    );
+    statements.insertIdempotency.run(
+      actionId,
+      action.recordId,
+      action.operationId,
+      storedAction.contentFingerprint,
+      action.acceptedAtMs,
+    );
+  }
+
+  private upsertRecordMetadata(
+    statements: RootStatements,
+    metadata: StoredEventGameRecordMetadata,
+  ): void {
+    statements.upsertMetadata.run(
+      metadata.recordId,
+      metadata.actionCount,
+      metadata.orderingVersion,
+      metadata.lastAcceptedAtMs,
+      metadata.updatedAtMs,
+    );
+  }
+
+  private appendAuditEntry(statements: RootStatements, entry: StoredControlAuditEntry): void {
+    statements.insertAudit.run(
+      entry.auditId,
+      entry.recordId,
+      entry.eventGameId,
+      entry.operationId,
+      entry.kind,
+      entry.outcome,
+      entry.createdAtMs,
+      entry.redactedDetail,
+      JSON.stringify(entry),
+    );
+  }
+
   private readRootByStatement(
     statement: SqlStatement,
     ...parameters: string[]
@@ -336,6 +472,36 @@ export class SqliteFoundationStorage implements FoundationStorage {
     const row = statement.get(...parameters) as RootRow | null;
     if (row === null) return null;
     return readValidatedFoundationRoot(this.database, row);
+  }
+
+  private readActionByStatement(
+    statement: SqlStatement,
+    recordId: string,
+    operationId: string,
+  ): StoredControlAction | null {
+    const row = statement.get(recordId, operationId) as RootRow | null;
+    return row === null ? null : readStoredAction(row);
+  }
+
+  private readActionsByRecordId(statement: SqlStatement, recordId: string): StoredControlAction[] {
+    const rows = statement.all(recordId) as unknown[];
+    return rows.map((value) => readStoredAction(asRecord(value)));
+  }
+
+  private readIdempotencyByRecordId(
+    statement: SqlStatement,
+    recordId: string,
+  ): StoredControlIdempotencyEntry[] {
+    const rows = statement.all(recordId) as unknown[];
+    return rows.map((value) => readIdempotency(asRecord(value)));
+  }
+
+  private readAuditByRecordId(
+    statement: SqlStatement,
+    recordId: string,
+  ): StoredControlAuditEntry[] {
+    const rows = statement.all(recordId) as unknown[];
+    return rows.map((value) => readAudit(asRecord(value)));
   }
 
   private getStatements(): RootStatements {
@@ -371,6 +537,64 @@ export class SqliteFoundationStorage implements FoundationStorage {
         INSERT INTO foundation_event_game_record_sides (
           side_id, record_id, side_position, event_team_id, team_interpretation_ref
         ) VALUES (?, ?, ?, ?, ?)
+      `),
+      actionByOperationId: this.database.query(`
+        SELECT action_json, action_kind, action_version, accepted_at_ms,
+               canonical_content, content_fingerprint
+        FROM foundation_event_game_record_actions
+        WHERE record_id = ? AND operation_id = ?
+      `),
+      actionsByRecordId: this.database.query(`
+        SELECT action_json, action_kind, action_version, accepted_at_ms,
+               canonical_content, content_fingerprint
+        FROM foundation_event_game_record_actions
+        WHERE record_id = ?
+        ORDER BY rowid
+      `),
+      insertAction: this.database.query(`
+        INSERT INTO foundation_event_game_record_actions (
+          action_id, record_id, event_game_id, operation_id, action_kind, action_version,
+          accepted_at_ms, content_fingerprint, canonical_content, action_json
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `),
+      insertIdempotency: this.database.query(`
+        INSERT INTO foundation_event_game_record_idempotency (
+          action_id, record_id, operation_id, content_fingerprint, accepted_at_ms
+        ) VALUES (?, ?, ?, ?, ?)
+      `),
+      metadataByRecordId: this.database.query(`
+        SELECT record_id, action_count, ordering_version, last_accepted_at_ms, updated_at_ms
+        FROM foundation_event_game_record_metadata
+        WHERE record_id = ?
+      `),
+      upsertMetadata: this.database.query(`
+        INSERT INTO foundation_event_game_record_metadata (
+          record_id, action_count, ordering_version, last_accepted_at_ms, updated_at_ms
+        ) VALUES (?, ?, ?, ?, ?)
+        ON CONFLICT(record_id) DO UPDATE SET
+          action_count = excluded.action_count,
+          ordering_version = excluded.ordering_version,
+          last_accepted_at_ms = excluded.last_accepted_at_ms,
+          updated_at_ms = excluded.updated_at_ms
+      `),
+      auditByRecordId: this.database.query(`
+        SELECT audit_id, record_id, event_game_id, operation_id, audit_kind, outcome,
+               created_at_ms, redacted_detail, audit_json
+        FROM foundation_event_game_record_audit
+        WHERE record_id = ?
+        ORDER BY rowid
+      `),
+      idempotencyByRecordId: this.database.query(`
+        SELECT action_id, record_id, operation_id, content_fingerprint, accepted_at_ms
+        FROM foundation_event_game_record_idempotency
+        WHERE record_id = ?
+        ORDER BY rowid
+      `),
+      insertAudit: this.database.query(`
+        INSERT INTO foundation_event_game_record_audit (
+          audit_id, record_id, event_game_id, operation_id, audit_kind, outcome,
+          created_at_ms, redacted_detail, audit_json
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
       `),
     };
     return this.statements;
@@ -435,6 +659,15 @@ export class SqliteFoundationStorage implements FoundationStorage {
       if (!schemaVerification.ok) {
         return { ...schemaVerification, storage: "sqlite" };
       }
+      const idempotencyFailure = this.verifyIdempotencyParity();
+      if (idempotencyFailure !== null) {
+        return {
+          ok: false,
+          status: "integrity-failure",
+          detail: idempotencyFailure,
+          storage: "sqlite",
+        };
+      }
 
       return {
         ok: true,
@@ -468,11 +701,84 @@ export class SqliteFoundationStorage implements FoundationStorage {
     };
   }
 
+  private readDataVersion(): number {
+    return readInteger(this.database.query("PRAGMA data_version").get());
+  }
+
+  private refreshExternalRevision(): void {
+    const currentDataVersion = this.readDataVersion();
+    if (currentDataVersion !== this.dataVersion) {
+      this.revision += 1;
+      this.dataVersion = currentDataVersion;
+    }
+  }
+
   private tableExists(name: string): boolean {
     const row = this.database
       .query("SELECT 1 AS present FROM sqlite_master WHERE type = 'table' AND name = ?")
       .get(name) as RootRow | null;
     return row !== null;
+  }
+
+  private verifyIdempotencyParity(): string | null {
+    const actionCount = readInteger(
+      this.database
+        .query("SELECT COUNT(*) AS count FROM foundation_event_game_record_actions")
+        .get(),
+    );
+    const idempotencyCount = readInteger(
+      this.database
+        .query("SELECT COUNT(*) AS count FROM foundation_event_game_record_idempotency")
+        .get(),
+    );
+    if (actionCount !== idempotencyCount) {
+      return "SQLite action and idempotency row counts are inconsistent.";
+    }
+    const rows = this.database
+      .query(`
+        SELECT
+          actions.action_id AS action_action_id,
+          actions.record_id AS action_record_id,
+          actions.operation_id AS action_operation_id,
+          actions.content_fingerprint AS action_content_fingerprint,
+          actions.accepted_at_ms AS action_accepted_at_ms,
+          idempotency.action_id AS idempotency_action_id,
+          idempotency.record_id AS idempotency_record_id,
+          idempotency.operation_id AS idempotency_operation_id,
+          idempotency.content_fingerprint AS idempotency_content_fingerprint,
+          idempotency.accepted_at_ms AS idempotency_accepted_at_ms
+        FROM foundation_event_game_record_actions AS actions
+        LEFT JOIN foundation_event_game_record_idempotency AS idempotency
+          ON idempotency.action_id = actions.action_id
+      `)
+      .all() as unknown[];
+    for (const value of rows) {
+      const row = asRecord(value);
+      if (row.idempotency_action_id === null) {
+        return "SQLite action and idempotency state is missing a paired row.";
+      }
+      if (
+        readText(row.action_action_id) !== readText(row.idempotency_action_id) ||
+        readText(row.action_record_id) !== readText(row.idempotency_record_id) ||
+        readText(row.action_operation_id) !== readText(row.idempotency_operation_id) ||
+        readText(row.action_content_fingerprint) !==
+          readText(row.idempotency_content_fingerprint) ||
+        readInteger(row.action_accepted_at_ms) !== readInteger(row.idempotency_accepted_at_ms)
+      ) {
+        return "SQLite action and idempotency columns are inconsistent.";
+      }
+    }
+    const extra = this.database
+      .query(`
+        SELECT idempotency.action_id
+        FROM foundation_event_game_record_idempotency AS idempotency
+        LEFT JOIN foundation_event_game_record_actions AS actions
+          ON actions.action_id = idempotency.action_id
+        WHERE actions.action_id IS NULL
+        LIMIT 1
+      `)
+      .get() as RootRow | null;
+    return extra === null ? null : "SQLite idempotency state has an extra row.";
   }
 
   private configureDatabase(): void {
@@ -521,66 +827,4 @@ export async function validateFoundationMigrationCandidate(
   options: { retainCandidate?: boolean } = {},
 ): Promise<FoundationMigrationCandidateReport> {
   return storage.validateCandidate(options);
-}
-
-function translateSqliteConstraint(error: unknown): unknown {
-  if (!(error instanceof Error)) return error;
-  const message = error.message.toLowerCase();
-  if (message.includes("record_id")) {
-    return new FoundationStorageConstraintError("record-id");
-  }
-  if (message.includes("event_game_id")) {
-    return new FoundationStorageConstraintError("event-game-id");
-  }
-  if (message.includes("pitch_slot_id")) {
-    return new FoundationStorageConstraintError("pitch-slot-id");
-  }
-  if (message.includes("side_id")) {
-    return new FoundationStorageConstraintError("game-side-id");
-  }
-  return error;
-}
-
-function quoteSqliteString(value: string): string {
-  return `'${value.replaceAll("'", "''")}'`;
-}
-
-function asRecord(value: unknown): RootRow {
-  if (typeof value !== "object" || value === null || Array.isArray(value)) {
-    throw new Error("SQLite returned an invalid row.");
-  }
-  return value as RootRow;
-}
-
-function readText(value: unknown): string {
-  if (typeof value === "string") return value;
-  if (typeof value === "object" && value !== null && "journal_mode" in value) {
-    return readText(value.journal_mode);
-  }
-  if (typeof value === "object" && value !== null && "synchronous" in value) {
-    return readText(value.synchronous);
-  }
-  if (typeof value === "object" && value !== null && "foreign_keys" in value) {
-    return readText(value.foreign_keys);
-  }
-  if (typeof value === "object" && value !== null && "busy_timeout" in value) {
-    return readText(value.busy_timeout);
-  }
-  if (typeof value === "object" && value !== null && "timeout" in value) {
-    return readText(value.timeout);
-  }
-  if (typeof value === "object" && value !== null && "quick_check" in value) {
-    return readText(value.quick_check);
-  }
-  if (typeof value === "object" && value !== null && "integrity_check" in value) {
-    return readText(value.integrity_check);
-  }
-  if (typeof value === "number" || typeof value === "bigint") return String(value);
-  throw new Error("SQLite returned an invalid value.");
-}
-
-function readInteger(value: unknown): number {
-  const parsed = Number(readText(value));
-  if (!Number.isSafeInteger(parsed)) throw new Error("SQLite returned an invalid integer.");
-  return parsed;
 }

--- a/src/lib/foundation-storage.ts
+++ b/src/lib/foundation-storage.ts
@@ -1,9 +1,32 @@
 import type { EventGameRecordRoot } from "@/lib/foundation-record-types";
+import type {
+  ControlAction,
+  ControlAuditEntry,
+  EventGameRecordMetadata,
+} from "@/lib/event-game-actions";
 
 export type StoredEventGameRecordRoot = {
   root: EventGameRecordRoot;
   canonicalContent: string;
 };
+
+export type StoredControlAction = {
+  action: ControlAction;
+  canonicalContent: string;
+  contentFingerprint: string;
+};
+
+export type StoredControlIdempotencyEntry = {
+  actionId: string;
+  recordId: string;
+  operationId: string;
+  contentFingerprint: string;
+  acceptedAtMs: number;
+};
+
+export type StoredControlAuditEntry = ControlAuditEntry;
+
+export type StoredEventGameRecordMetadata = EventGameRecordMetadata;
 
 export type FoundationStorageReadiness =
   | {
@@ -29,14 +52,23 @@ export type FoundationStorageReadiness =
     };
 
 export type FoundationStorageSnapshot = {
+  revision: number;
   findRootByRecordId(recordId: string): EventGameRecordRoot | null;
   findRootByEventGameId(eventGameId: string): EventGameRecordRoot | null;
   findRootByPitchSlotId(pitchSlotId: string): EventGameRecordRoot | null;
   findRootByGameSideId(gameSideId: string): EventGameRecordRoot | null;
+  findActionByOperationId(recordId: string, operationId: string): StoredControlAction | null;
+  listActions(recordId: string): StoredControlAction[];
+  listIdempotencyEntries(recordId: string): StoredControlIdempotencyEntry[];
+  readRecordMetadata(recordId: string): StoredEventGameRecordMetadata | null;
+  listAuditEntries(recordId: string): StoredControlAuditEntry[];
 };
 
 export type FoundationStorageTransaction = FoundationStorageSnapshot & {
   insertRoot(root: StoredEventGameRecordRoot): void;
+  insertAction(action: StoredControlAction): void;
+  upsertRecordMetadata(metadata: StoredEventGameRecordMetadata): void;
+  appendAuditEntry(entry: StoredControlAuditEntry): void;
 };
 
 export type FoundationStorageTransactionWork<T> = (transaction: FoundationStorageTransaction) => T;
@@ -44,6 +76,10 @@ export type FoundationStorageTransactionWork<T> = (transaction: FoundationStorag
 export interface FoundationStorage {
   transaction<T>(work: FoundationStorageTransactionWork<T>): Promise<T>;
   readRoot(recordId: string): Promise<EventGameRecordRoot | null>;
+  readActions(recordId: string): Promise<StoredControlAction[]>;
+  readIdempotencyEntries(recordId: string): Promise<StoredControlIdempotencyEntry[]>;
+  readRecordMetadata(recordId: string): Promise<StoredEventGameRecordMetadata | null>;
+  readAuditEntries(recordId: string): Promise<StoredControlAuditEntry[]>;
   readiness(): Promise<FoundationStorageReadiness>;
   close(): void;
 }
@@ -52,7 +88,9 @@ export type FoundationStorageConstraint =
   | "record-id"
   | "event-game-id"
   | "pitch-slot-id"
-  | "game-side-id";
+  | "game-side-id"
+  | "operation-id"
+  | "audit-id";
 
 export class FoundationStorageConstraintError extends Error {
   readonly constraint: FoundationStorageConstraint;


### PR DESCRIPTION
## Summary

- Add versioned, canonical Control Action codecs with permanent operation identity and content fingerprints.
- Persist immutable actions, idempotency, lifecycle/order metadata, audit evidence, and recovery provenance atomically.
- Rebuild effective state through an injected deterministic IQA interpreter and fail readiness on broken, unknown, or nondeterministic history.

## Why

Event Game work must survive retries and restarts without mutable-history rewrites or derived-state checkpoints. This layer establishes the semantic action boundary that later correction, synchronization, and authority work can safely compose with.

## Impact

Identical retries return the original accepted outcome, conflicting reuse is rejected, and idempotency is retained for the lifetime of the record. Both adapters freeze authoritative writes when retained history or audit evidence is unsafe, while ordinary domain tests remain database-free.

## Validation

- `bun install --frozen-lockfile`
- `bun audit` — no vulnerabilities
- `bun run check`
- `bun run test` — 155 Fast Tests passed
- `bun run test:changed` — 34 passed; focused SQLite test remained undiscovered
- `bun run test:focused:sqlite` — 9 passed
- `bun run build`
- `bun run build:executable`

No Qualification Test or `bun run check:sqlite-runtime` workload was run.

## Stack

Third layer of stack #103. Depends on #100 and is followed by #102.

Closes #73.
