### PR TITLE
Admit scoped Control Grant sessions by QR (#74)

### DIFF
--- a/docs/agents/grant-authority.md
+++ b/docs/agents/grant-authority.md
@@ -1,0 +1,89 @@
+# Scoped Control Grant lifecycle
+
+The Control Grant authority creates a QR-bound capability for one validated
+event, game day, pitch, and pitch slot. The public lifecycle is:
+
+1. `createControlGrant` validates the scope and a structured fixture authority,
+   then returns the QR credential once. The durable Grant stores only its
+   encrypted credential envelope and keyed lookup material.
+2. `revealControlGrant` decrypts the credential for an authorized authority and
+   returns it without exposing stored plaintext.
+3. `rotateControlGrantCredentialKeys` decrypts a retained credential with its
+   recorded old encryption key, verifies its complete binding and lookup
+   digest, then re-encrypts and re-indexes it with the current keys. The Grant
+   update and permanent `credential-rotated` audit evidence commit atomically;
+   any cryptographic, collision, audit, or storage failure leaves the old
+   credential and versions usable.
+4. `admitControlGrant` validates the QR credential, resolves the current event
+   game, and creates a separately random session bearer. A second admission in
+   the same browser context revokes that context's active session and records a
+   replacement; other contexts remain active.
+5. `authorizeControlGrant` accepts only the session bearer and rechecks the
+   Grant version, lifecycle, scope resolution, and session state.
+6. `disableControlGrant` and `revokeControlGrant` are administrative lifecycle
+   transitions. A Grant reaching its expiry time transitions every non-expired
+   Grant (including disabled and revoked Grants) and all sessions to `expired`,
+   appends exactly one `grant-expired` audit entry, and never revives. This is
+   one storage transaction: encrypted credential material, lookup digests, and
+   session bearer verifiers are erased while only non-secret metadata and a
+   domain-separated retained fingerprint remain.
+
+## Privacy and authority boundary
+
+Authority callers provide `{ kind: "fixture", id }`, not a free-form audit
+actor string. The ID is validated for the narrow boundary and immediately
+included only as input to a keyed HMAC derivation. Durable audit reads expose a
+pseudonymous `actor-*` reference; QR credentials, session bearers, browser
+contexts, human identities, and caller-selected actor text are not persisted in
+Grant rows or audit evidence. Grant reveal material uses AES-256-GCM, while
+credential lookup and session bearer verification use separately keyed HMAC
+material. Injected randomness must provide at least 256 bits for credentials
+and independently random session bearers.
+
+Invalid external credentials, unavailable scope state, disabled/revoked/expired
+Grants, and invalid sessions return generic failures. Every public authority
+operation contains storage failures at the module boundary; list operations
+return a typed unavailable result and mutations return redacted failure
+details. Storage writes for a Grant and its mandatory audit evidence are
+transactional in both adapters, including expiry erasure and audit evidence.
+Expired Grants have no credential key versions, ciphertext, IV, authentication
+tag, lookup digest, or session verifier material and cannot rotate. Migration
+006 upgrades legacy active, disabled, revoked, due, and expired rows in one
+transaction. It preserves all prior audit evidence, creates missing expiry
+evidence exactly once, erases due or terminal capability material, and replaces
+legacy digest-equal values with tagged opaque 256-bit migration references. These
+references are not credential fingerprints and are therefore never copied into
+Grant Audit Trail fingerprint fields. Runtime audit creation likewise omits them;
+only newly derived keyed credential fingerprints may occupy those fields. A
+non-expired migrated Grant replaces the compatibility reference with a keyed
+fingerprint when its retained credential keys are rotated.
+
+## Test routing
+
+The reusable semantic contract runs against in-memory storage in the ordinary
+Fast Test boundary and against disposable SQLite storage in the focused
+integration boundary. The SQLite contract covers replacement, generic failure,
+atomic credential key rotation, expiry erasure, migration upgrade and rollback,
+redaction, restart, and real independent-worker admission contention. The
+contention harness uses an allowlisted child environment, a private owner-only
+credential file, capped streaming diagnostics, and one bounded deadline for
+barrier, work, TERM/KILL escalation, reap, and artifact cleanup. The focused
+command is intentionally outside
+ordinary Fast Test discovery, while remaining deterministic and isolated.
+
+Run the fast unit contract with:
+
+```text
+bun test src/lib/grant-authority.test.ts
+```
+
+Run the focused SQLite contract with:
+
+```text
+bun run test:focused:grant
+```
+
+The focused file is intentionally outside ordinary test discovery. This slice
+does not implement QR URL or fragment handling, cookies, React UI, Technical
+Admin authentication, Grant Codes, or the complete three-type lifecycle
+matrix.

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "check:sqlite-runtime": "bun scripts/check-sqlite-runtime.ts",
     "test": "bun test --isolate",
     "test:focused:sqlite": "bun test --isolate ./src/lib/event-game-actions-sqlite.focused.ts",
+    "test:focused:grant": "bun test ./src/lib/grant-authority.focused.ts",
     "test:changed": "bun test --changed",
     "format": "bunx --bun oxfmt \"**/*.{js,jsx,ts,tsx,mjs,cjs}\" \"!docs/**\"",
     "format:check": "bunx --bun oxfmt \"**/*.{js,jsx,ts,tsx,mjs,cjs}\" \"!docs/**\" --check",

--- a/src/lib/event-game-actions.test.ts
+++ b/src/lib/event-game-actions.test.ts
@@ -435,6 +435,12 @@ async function readSnapshot(
     listIdempotencyEntries: () => idempotency,
     readRecordMetadata: () => metadata,
     listAuditEntries: () => audits,
+    findGrantById: () => null,
+    findGrantByCredentialLookupDigest: () => null,
+    findActiveSessionByGrantAndContext: () => null,
+    findSessionByBearerVerifier: () => null,
+    listGrantSessions: () => [],
+    listGrantAudit: () => [],
   };
 }
 

--- a/src/lib/event-game-record-helpers.ts
+++ b/src/lib/event-game-record-helpers.ts
@@ -231,6 +231,14 @@ export function constraintToConflict(
     case "record-id":
     case "operation-id":
     case "audit-id":
+    case "grant-id":
+    case "grant-version":
+    case "grant-pitch-slot-id":
+    case "grant-credential-digest":
+    case "grant-session-id":
+    case "grant-session-verifier":
+    case "grant-session-context":
+    case "grant-audit-id":
       return "content-conflict";
   }
 }

--- a/src/lib/event-game-record.ts
+++ b/src/lib/event-game-record.ts
@@ -257,6 +257,12 @@ export function createEventGameRecord(
         listIdempotencyEntries: () => idempotencyEntries,
         readRecordMetadata: () => metadata,
         listAuditEntries: () => auditEntries,
+        findGrantById: () => null,
+        findGrantByCredentialLookupDigest: () => null,
+        findActiveSessionByGrantAndContext: () => null,
+        findSessionByBearerVerifier: () => null,
+        listGrantSessions: () => [],
+        listGrantAudit: () => [],
       };
       return rebuildRecordSnapshot(root, snapshot, codecRegistry, options.interpreter);
     } catch (error) {

--- a/src/lib/foundation-grant-erasure-migration.test.ts
+++ b/src/lib/foundation-grant-erasure-migration.test.ts
@@ -1,0 +1,496 @@
+import { describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  checksumMigrationSql,
+  FOUNDATION_MIGRATIONS,
+  type FoundationMigration,
+} from "@/lib/foundation-migrations";
+import {
+  FoundationMigrationError,
+  openSqliteFoundationStorage,
+} from "@/lib/foundation-storage-sqlite";
+
+async function withDatabase<T>(work: (databasePath: string) => Promise<T>): Promise<T> {
+  const directory = await mkdtemp(join(tmpdir(), "quadball-timer-grant-migration-"));
+  try {
+    return await work(join(directory, "foundation.sqlite"));
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+}
+
+describe("Grant cryptographic erasure migration", () => {
+  test("upgrades the accepted Grant schema while preserving legacy rows safely", async () => {
+    await withDatabase(async (databasePath) => {
+      const legacy = openSqliteFoundationStorage(databasePath, {
+        migrations: FOUNDATION_MIGRATIONS.slice(0, 5),
+      });
+      await legacy.applyMigrations({ requireCandidate: false });
+      legacy.close();
+
+      const database = new Database(databasePath);
+      database
+        .query(
+          `INSERT INTO foundation_grant_roots (
+             grant_id, grant_type, grant_version, event_id, game_day_id, pitch_id, pitch_slot_id,
+             status, created_at_ms, expires_at_ms, credential_format_version, credential_kind,
+             encryption_key_version, lookup_key_version, credential_iv, credential_ciphertext,
+             credential_tag, credential_lookup_digest, credential_fingerprint
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          "grant-legacy",
+          "control",
+          "grant-version-legacy",
+          "event-1",
+          "day-1",
+          "pitch-1",
+          "slot-legacy",
+          "active",
+          1_000,
+          null,
+          1,
+          "qr",
+          "encryption-v1",
+          "lookup-v1",
+          "iv-legacy",
+          "ciphertext-legacy",
+          "tag-legacy",
+          "lookup-legacy",
+          "lookup-legacy",
+        );
+      database
+        .query(
+          `INSERT INTO foundation_grant_sessions (
+             session_id, grant_id, grant_version, event_game_id, browser_context_digest,
+             browser_context_key_version, bearer_lookup_verifier, bearer_lookup_key_version,
+             status, created_at_ms, last_active_at_ms, revoked_at_ms
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          "session-legacy",
+          "grant-legacy",
+          "grant-version-legacy",
+          "game-1",
+          "browser-legacy",
+          "lookup-v1",
+          "bearer-legacy",
+          "lookup-v1",
+          "active",
+          1_000,
+          1_000,
+          null,
+        );
+      database
+        .query(
+          `INSERT INTO foundation_grant_audit (
+             audit_id, action, outcome, actor_reference, grant_id, grant_type, grant_version,
+             event_id, game_day_id, pitch_id, pitch_slot_id, session_id, replaced_session_id,
+             event_game_id, credential_kind, credential_fingerprint, before_status, after_status,
+             created_at_ms
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          "audit-legacy-created",
+          "grant-created",
+          "accepted",
+          "actor-legacy",
+          "grant-legacy",
+          "control",
+          "grant-version-legacy",
+          "event-1",
+          "day-1",
+          "pitch-1",
+          "slot-legacy",
+          null,
+          null,
+          null,
+          "qr",
+          "lookup-legacy",
+          null,
+          "active",
+          1_000,
+        );
+      database.close();
+
+      const current = openSqliteFoundationStorage(databasePath);
+      await current.applyMigrations({ requireCandidate: false });
+      const state = await current.transaction((transaction) => ({
+        grant: transaction.findGrantById("grant-legacy"),
+        sessions: transaction.listGrantSessions("grant-legacy"),
+        audit: transaction.listGrantAudit("grant-legacy"),
+      }));
+      expect(state.grant?.credential.materialState).toBe("present");
+      expect(state.grant?.credential.fingerprint).toMatch(
+        /^opaque-migration-reference-v1:[a-f0-9]{64}$/,
+      );
+      expect(state.grant?.credential.fingerprint).not.toBe(state.grant?.credential.lookupDigest);
+      expect(state.grant?.credential.fingerprint).not.toContain("lookup-legacy");
+      expect(state.sessions[0]?.bearerMaterialState).toBe("present");
+      expect(state.audit).toEqual([
+        expect.objectContaining({
+          auditId: "audit-legacy-created",
+          action: "grant-created",
+          actorReference: "actor-legacy",
+          credentialFingerprint: null,
+        }),
+      ]);
+      current.close();
+    });
+  });
+
+  test("erases due legacy Grants without losing or duplicating audit evidence", async () => {
+    await withDatabase(async (databasePath) => {
+      const legacy = openSqliteFoundationStorage(databasePath, {
+        migrations: FOUNDATION_MIGRATIONS.slice(0, 5),
+      });
+      await legacy.applyMigrations({ requireCandidate: false });
+      legacy.close();
+
+      const database = new Database(databasePath);
+      const seeds: LegacyGrantSeed[] = [
+        { suffix: "active", status: "active", expiresAtMs: null },
+        {
+          suffix: "active-keyed",
+          status: "active",
+          expiresAtMs: null,
+          credentialFingerprint: "keyed-fingerprint-active",
+        },
+        {
+          suffix: "disabled-due-keyed",
+          status: "disabled",
+          expiresAtMs: 2_000,
+          credentialFingerprint: "keyed-fingerprint-disabled-due",
+        },
+        { suffix: "disabled-due", status: "disabled", expiresAtMs: 2_000 },
+        { suffix: "revoked-due", status: "revoked", expiresAtMs: 2_000 },
+        { suffix: "expired", status: "expired", expiresAtMs: 2_000 },
+      ];
+      for (const seed of seeds) seedLegacyGrant(database, seed);
+      database.close();
+
+      const current = openSqliteFoundationStorage(databasePath);
+      await current.applyMigrations({ requireCandidate: false });
+      expect(await current.readiness()).toMatchObject({ ok: true, schemaVersion: "6" });
+      current.close();
+
+      const raw = new Database(databasePath);
+      const grants = raw
+        .query("SELECT * FROM foundation_grant_roots ORDER BY grant_id")
+        .all() as Record<string, unknown>[];
+      const sessions = raw
+        .query("SELECT * FROM foundation_grant_sessions ORDER BY session_id")
+        .all() as Record<string, unknown>[];
+      const audit = raw
+        .query("SELECT * FROM foundation_grant_audit ORDER BY grant_id, audit_id")
+        .all() as Record<string, unknown>[];
+
+      const active = grants.find((row) => row.grant_id === "grant-active");
+      expect(active).toMatchObject({
+        status: "active",
+        credential_material_state: "present",
+        credential_lookup_digest: "digest-active",
+      });
+      for (const suffix of ["disabled-due", "revoked-due", "expired"]) {
+        const grant = grants.find((row) => row.grant_id === `grant-${suffix}`);
+        expect(grant).toMatchObject({
+          status: "expired",
+          credential_material_state: "erased",
+          encryption_key_version: null,
+          lookup_key_version: null,
+          credential_iv: null,
+          credential_ciphertext: null,
+          credential_tag: null,
+          credential_lookup_digest: null,
+        });
+        const session = sessions.find((row) => row.grant_id === `grant-${suffix}`);
+        expect(session).toMatchObject({
+          status: "expired",
+          bearer_material_state: "erased",
+          bearer_lookup_verifier: null,
+          bearer_lookup_key_version: null,
+        });
+        expect(JSON.stringify({ grant, session })).not.toContain(`digest-${suffix}`);
+      }
+
+      for (const seed of seeds) {
+        const grant = grants.find((row) => row.grant_id === `grant-${seed.suffix}`);
+        const grantAudit = audit.filter((row) => row.grant_id === `grant-${seed.suffix}`);
+        expect(grantAudit.filter((row) => row.action === "grant-created")).toHaveLength(1);
+        if (seed.credentialFingerprint === undefined) {
+          const fingerprint = grant?.credential_fingerprint;
+          expect(fingerprint).toMatch(/^opaque-migration-reference-v1:[a-f0-9]{64}$/);
+          expect(String(fingerprint)).not.toContain(`digest-${seed.suffix}`);
+          expect(grantAudit.every((row) => row.credential_fingerprint === null)).toBe(true);
+        } else {
+          expect(grant?.credential_fingerprint).toBe(seed.credentialFingerprint);
+          expect(
+            grantAudit.every((row) => row.credential_fingerprint === seed.credentialFingerprint),
+          ).toBe(true);
+          if (seed.expiresAtMs !== null) {
+            expect(grantAudit.find((row) => row.action === "grant-expired")).toMatchObject({
+              session_id: null,
+              replaced_session_id: null,
+              event_game_id: null,
+              credential_fingerprint: seed.credentialFingerprint,
+            });
+          }
+        }
+        expect(JSON.stringify(grantAudit)).not.toContain(`digest-${seed.suffix}`);
+        expect(grantAudit.filter((row) => row.action === "grant-expired")).toHaveLength(
+          seed.status === "active" && seed.expiresAtMs === null ? 0 : 1,
+        );
+      }
+      expect(audit).toHaveLength(15);
+      expect(() =>
+        raw
+          .query(
+            `UPDATE foundation_grant_roots SET
+               credential_material_state = 'present', encryption_key_version = 'old',
+               lookup_key_version = 'old', credential_iv = 'old',
+               credential_ciphertext = 'old', credential_tag = 'old',
+               credential_lookup_digest = 'old'
+             WHERE grant_id = 'grant-expired'`,
+          )
+          .run(),
+      ).toThrow();
+      expect(() =>
+        raw
+          .query(
+            `UPDATE foundation_grant_sessions SET
+               bearer_material_state = 'present', bearer_lookup_verifier = 'old',
+               bearer_lookup_key_version = 'old'
+             WHERE session_id = 'session-expired'`,
+          )
+          .run(),
+      ).toThrow();
+      raw.close();
+
+      const reopened = openSqliteFoundationStorage(databasePath);
+      expect(await reopened.readiness()).toMatchObject({ ok: true, schemaVersion: "6" });
+      const restartedAudit = await reopened.transaction((transaction) =>
+        transaction.listGrantAudit("grant-expired"),
+      );
+      expect(restartedAudit.filter((entry) => entry.action === "grant-expired")).toHaveLength(1);
+      reopened.close();
+    });
+  });
+
+  test("rolls back migration 006 without losing legacy Grant evidence", async () => {
+    await withDatabase(async (databasePath) => {
+      const accepted = FOUNDATION_MIGRATIONS.slice(0, 5);
+      const legacy = openSqliteFoundationStorage(databasePath, { migrations: accepted });
+      await legacy.applyMigrations({ requireCandidate: false });
+      legacy.close();
+
+      const database = new Database(databasePath);
+      for (const seed of legacyLifecycleSeeds()) seedLegacyGrant(database, seed);
+      database.close();
+
+      const migration006 = FOUNDATION_MIGRATIONS[5];
+      if (migration006 === undefined) throw new Error("Expected migration 006.");
+      const failing006 = createMigration(
+        migration006.id,
+        migration006.ordinal,
+        migration006.schemaVersion,
+        `${migration006.sql}; THIS IS NOT SQL;`,
+      );
+      const failing = openSqliteFoundationStorage(databasePath, {
+        migrations: [...accepted, failing006],
+      });
+      const migrationFailure = await captureFailure(
+        failing.applyMigrations({ requireCandidate: false }),
+      );
+      expect(migrationFailure).toBeInstanceOf(FoundationMigrationError);
+      failing.close();
+
+      const preserved = new Database(databasePath);
+      expect(
+        preserved.query("SELECT COUNT(*) AS count FROM foundation_migration_ledger").get(),
+      ).toEqual({ count: 5 });
+      expect(
+        preserved
+          .query(
+            "SELECT COUNT(*) AS count FROM foundation_migration_ledger WHERE migration_id = '006-grant-cryptographic-erasure'",
+          )
+          .get(),
+      ).toEqual({ count: 0 });
+      expect(
+        preserved
+          .query(
+            "SELECT COUNT(*) AS count FROM pragma_table_info('foundation_grant_roots') WHERE name = 'credential_material_state'",
+          )
+          .get(),
+      ).toEqual({ count: 0 });
+      expect(preserved.query("SELECT COUNT(*) AS count FROM foundation_grant_roots").get()).toEqual(
+        { count: 4 },
+      );
+      expect(
+        preserved.query("SELECT COUNT(*) AS count FROM foundation_grant_sessions").get(),
+      ).toEqual({ count: 4 });
+      expect(preserved.query("SELECT COUNT(*) AS count FROM foundation_grant_audit").get()).toEqual(
+        { count: 8 },
+      );
+      expect(
+        preserved
+          .query(
+            "SELECT COUNT(*) AS count FROM sqlite_master WHERE name LIKE 'foundation_grant_%_copy' OR name = 'foundation_grant_erasure_mapping'",
+          )
+          .get(),
+      ).toEqual({ count: 0 });
+      preserved.close();
+    });
+  });
+});
+
+function createMigration(
+  id: string,
+  ordinal: number,
+  schemaVersion: number,
+  sql: string,
+): FoundationMigration {
+  return { id, ordinal, schemaVersion, sql, checksum: checksumMigrationSql(sql) };
+}
+
+async function captureFailure(operation: Promise<unknown>): Promise<unknown> {
+  try {
+    await operation;
+    return null;
+  } catch (error) {
+    return error;
+  }
+}
+
+type LegacyGrantSeed = {
+  suffix: string;
+  status: "active" | "disabled" | "revoked" | "expired";
+  expiresAtMs: number | null;
+  credentialFingerprint?: string;
+};
+
+function legacyLifecycleSeeds(): LegacyGrantSeed[] {
+  return [
+    { suffix: "active", status: "active", expiresAtMs: null },
+    { suffix: "disabled-due", status: "disabled", expiresAtMs: 2_000 },
+    { suffix: "revoked-due", status: "revoked", expiresAtMs: 2_000 },
+    { suffix: "expired", status: "expired", expiresAtMs: 2_000 },
+  ];
+}
+
+function seedLegacyGrant(database: Database, seed: LegacyGrantSeed): void {
+  const grantId = `grant-${seed.suffix}`;
+  const grantVersion = `grant-version-${seed.suffix}`;
+  const fingerprint = `digest-${seed.suffix}`;
+  database
+    .query(
+      `INSERT INTO foundation_grant_roots (
+         grant_id, grant_type, grant_version, event_id, game_day_id, pitch_id, pitch_slot_id,
+         status, created_at_ms, expires_at_ms, credential_format_version, credential_kind,
+         encryption_key_version, lookup_key_version, credential_iv, credential_ciphertext,
+         credential_tag, credential_lookup_digest, credential_fingerprint
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      grantId,
+      "control",
+      grantVersion,
+      "event-legacy",
+      "day-legacy",
+      `pitch-${seed.suffix}`,
+      `slot-${seed.suffix}`,
+      seed.status,
+      1_000,
+      seed.expiresAtMs,
+      1,
+      "qr",
+      "encryption-v1",
+      "lookup-v1",
+      `iv-${seed.suffix}`,
+      `ciphertext-${seed.suffix}`,
+      `tag-${seed.suffix}`,
+      fingerprint,
+      seed.credentialFingerprint ?? fingerprint,
+    );
+  database
+    .query(
+      `INSERT INTO foundation_grant_sessions (
+         session_id, grant_id, grant_version, event_game_id, browser_context_digest,
+         browser_context_key_version, bearer_lookup_verifier, bearer_lookup_key_version,
+         status, created_at_ms, last_active_at_ms, revoked_at_ms
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      `session-${seed.suffix}`,
+      grantId,
+      grantVersion,
+      `game-${seed.suffix}`,
+      `browser-${seed.suffix}`,
+      "lookup-v1",
+      `bearer-${seed.suffix}`,
+      "lookup-v1",
+      seed.status === "active" ? "active" : "revoked",
+      1_000,
+      1_000,
+      seed.status === "active" ? null : 1_500,
+    );
+  seedLegacyAudit(
+    database,
+    seed,
+    "grant-created",
+    `audit-${seed.suffix}-created`,
+    null,
+    seed.status,
+  );
+  seedLegacyAudit(
+    database,
+    seed,
+    seed.status === "expired" ? "grant-expired" : "credential-revealed",
+    `audit-${seed.suffix}-second`,
+    seed.status === "expired" ? "active" : seed.status,
+    seed.status,
+  );
+}
+
+function seedLegacyAudit(
+  database: Database,
+  seed: LegacyGrantSeed,
+  action: "grant-created" | "credential-revealed" | "grant-expired",
+  auditId: string,
+  beforeStatus: LegacyGrantSeed["status"] | null,
+  afterStatus: LegacyGrantSeed["status"],
+): void {
+  database
+    .query(
+      `INSERT INTO foundation_grant_audit (
+         audit_id, action, outcome, actor_reference, grant_id, grant_type, grant_version,
+         event_id, game_day_id, pitch_id, pitch_slot_id, session_id, replaced_session_id,
+         event_game_id, credential_kind, credential_fingerprint, before_status, after_status,
+         created_at_ms
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      auditId,
+      action,
+      "accepted",
+      `actor-${seed.suffix}`,
+      `grant-${seed.suffix}`,
+      "control",
+      `grant-version-${seed.suffix}`,
+      "event-legacy",
+      "day-legacy",
+      `pitch-${seed.suffix}`,
+      `slot-${seed.suffix}`,
+      null,
+      null,
+      null,
+      "qr",
+      seed.credentialFingerprint ??
+        (action === "grant-created" ? `digest-${seed.suffix}` : `alternate-${seed.suffix}`),
+      beforeStatus,
+      afterStatus,
+      1_000,
+    );
+}

--- a/src/lib/foundation-grant-erasure-migration.ts
+++ b/src/lib/foundation-grant-erasure-migration.ts
@@ -1,0 +1,159 @@
+type GrantErasureMigrationTables = {
+  grantTableSql: string;
+  sessionTableSql: string;
+  auditTableSql: string;
+  sessionGrantIndexSql: string;
+  sessionContextIndexSql: string;
+  auditGrantIndexSql: string;
+};
+
+export function createFoundationGrantErasureMigrationSql(
+  tables: GrantErasureMigrationTables,
+): string {
+  return `
+  CREATE TABLE foundation_grant_erasure_mapping (
+    grant_id TEXT PRIMARY KEY,
+    original_status TEXT NOT NULL,
+    should_expire INTEGER NOT NULL CHECK (should_expire IN (0, 1)),
+    old_lookup_digest TEXT NOT NULL,
+    retained_opaque_reference TEXT NOT NULL
+  ) STRICT;
+  INSERT INTO foundation_grant_erasure_mapping (
+    grant_id, original_status, should_expire, old_lookup_digest, retained_opaque_reference
+  )
+  SELECT
+    grant_id,
+    status,
+    CASE
+      WHEN status = 'expired' THEN 1
+      WHEN expires_at_ms IS NOT NULL AND expires_at_ms <= CAST(unixepoch('subsec') * 1000 AS INTEGER) THEN 1
+      ELSE 0
+    END,
+    credential_lookup_digest,
+    CASE
+      WHEN credential_fingerprint = credential_lookup_digest
+      THEN 'opaque-migration-reference-v1:' || lower(hex(randomblob(32)))
+      ELSE credential_fingerprint
+    END
+  FROM foundation_grant_roots;
+
+  CREATE TABLE foundation_grant_sessions_erasure_copy AS SELECT
+    session_id, grant_id, grant_version, event_game_id, browser_context_digest,
+    browser_context_key_version,
+    CASE WHEN mapping.should_expire = 1 THEN 'erased' ELSE 'present' END AS bearer_material_state,
+    CASE WHEN mapping.should_expire = 1 THEN NULL ELSE bearer_lookup_verifier END AS bearer_lookup_verifier,
+    CASE WHEN mapping.should_expire = 1 THEN NULL ELSE bearer_lookup_key_version END AS bearer_lookup_key_version,
+    CASE WHEN mapping.should_expire = 1 THEN 'expired' ELSE sessions.status END AS status,
+    created_at_ms,
+    last_active_at_ms, revoked_at_ms
+  FROM foundation_grant_sessions AS sessions
+  JOIN foundation_grant_erasure_mapping AS mapping USING (grant_id);
+  DROP TABLE foundation_grant_sessions;
+
+  CREATE TABLE foundation_grant_audit_erasure_copy AS SELECT *
+  FROM foundation_grant_audit;
+  DROP TABLE foundation_grant_audit;
+
+  ${tables.grantTableSql.replace(
+    "CREATE TABLE foundation_grant_roots",
+    "CREATE TABLE foundation_grant_roots_v5",
+  )};
+  INSERT INTO foundation_grant_roots_v5 (
+    grant_id, grant_type, grant_version, event_id, game_day_id, pitch_id, pitch_slot_id,
+    status, created_at_ms, expires_at_ms, credential_format_version, credential_kind,
+    credential_material_state, encryption_key_version, lookup_key_version, credential_iv,
+    credential_ciphertext, credential_tag, credential_lookup_digest, credential_fingerprint
+  )
+  SELECT
+    roots.grant_id, grant_type, grant_version, event_id, game_day_id, pitch_id, pitch_slot_id,
+    CASE WHEN mapping.should_expire = 1 THEN 'expired' ELSE roots.status END,
+    created_at_ms, expires_at_ms, credential_format_version, credential_kind,
+    CASE WHEN mapping.should_expire = 1 THEN 'erased' ELSE 'present' END,
+    CASE WHEN mapping.should_expire = 1 THEN NULL ELSE encryption_key_version END,
+    CASE WHEN mapping.should_expire = 1 THEN NULL ELSE lookup_key_version END,
+    CASE WHEN mapping.should_expire = 1 THEN NULL ELSE credential_iv END,
+    CASE WHEN mapping.should_expire = 1 THEN NULL ELSE credential_ciphertext END,
+    CASE WHEN mapping.should_expire = 1 THEN NULL ELSE credential_tag END,
+    CASE WHEN mapping.should_expire = 1 THEN NULL ELSE credential_lookup_digest END,
+    mapping.retained_opaque_reference
+  FROM foundation_grant_roots AS roots
+  JOIN foundation_grant_erasure_mapping AS mapping USING (grant_id);
+  DROP TABLE foundation_grant_roots;
+  ALTER TABLE foundation_grant_roots_v5 RENAME TO foundation_grant_roots;
+
+  ${tables.sessionTableSql};
+  INSERT INTO foundation_grant_sessions (
+    session_id, grant_id, grant_version, event_game_id, browser_context_digest,
+    browser_context_key_version, bearer_material_state, bearer_lookup_verifier,
+    bearer_lookup_key_version, status, created_at_ms, last_active_at_ms, revoked_at_ms
+  )
+  SELECT
+    session_id, grant_id, grant_version, event_game_id, browser_context_digest,
+    browser_context_key_version, bearer_material_state, bearer_lookup_verifier,
+    bearer_lookup_key_version, status, created_at_ms, last_active_at_ms, revoked_at_ms
+  FROM foundation_grant_sessions_erasure_copy;
+  DROP TABLE foundation_grant_sessions_erasure_copy;
+  ${tables.sessionGrantIndexSql};
+  ${tables.sessionContextIndexSql};
+
+  ${tables.auditTableSql};
+  INSERT INTO foundation_grant_audit (
+    audit_id, action, outcome, actor_reference, grant_id, grant_type, grant_version,
+    event_id, game_day_id, pitch_id, pitch_slot_id, session_id, replaced_session_id,
+    event_game_id, credential_kind, credential_fingerprint, before_status, after_status,
+    created_at_ms
+  )
+  SELECT
+    audit_id, action, outcome, actor_reference, audit.grant_id, grant_type, grant_version,
+    event_id, game_day_id, pitch_id, pitch_slot_id, session_id, replaced_session_id,
+    event_game_id, credential_kind,
+    CASE
+      WHEN mapping.retained_opaque_reference LIKE 'opaque-migration-reference-v1:%' THEN NULL
+      ELSE audit.credential_fingerprint
+    END,
+    before_status, after_status, created_at_ms
+  FROM foundation_grant_audit_erasure_copy AS audit
+  JOIN foundation_grant_erasure_mapping AS mapping USING (grant_id);
+
+  INSERT INTO foundation_grant_audit (
+    audit_id, action, outcome, actor_reference, grant_id, grant_type, grant_version,
+    event_id, game_day_id, pitch_id, pitch_slot_id, session_id, replaced_session_id,
+    event_game_id, credential_kind, credential_fingerprint, before_status, after_status,
+    created_at_ms
+  )
+  SELECT
+    'grant-audit-migration-' || lower(hex(randomblob(16))),
+    'grant-expired',
+    'accepted',
+    'actor-migration-' || lower(hex(randomblob(32))),
+    roots.grant_id,
+    roots.grant_type,
+    roots.grant_version,
+    roots.event_id,
+    roots.game_day_id,
+    roots.pitch_id,
+    roots.pitch_slot_id,
+    NULL,
+    NULL,
+    NULL,
+    roots.credential_kind,
+    CASE
+      WHEN mapping.retained_opaque_reference LIKE 'opaque-migration-reference-v1:%' THEN NULL
+      ELSE mapping.retained_opaque_reference
+    END,
+    mapping.original_status,
+    'expired',
+    COALESCE(roots.expires_at_ms, roots.created_at_ms)
+  FROM foundation_grant_roots AS roots
+  JOIN foundation_grant_erasure_mapping AS mapping USING (grant_id)
+  WHERE mapping.should_expire = 1
+    AND NOT EXISTS (
+      SELECT 1 FROM foundation_grant_audit AS audit
+      WHERE audit.grant_id = roots.grant_id AND audit.action = 'grant-expired'
+    );
+  ${tables.auditGrantIndexSql};
+
+  DROP TABLE foundation_grant_audit_erasure_copy;
+  DROP TABLE foundation_grant_erasure_mapping;
+`;
+}

--- a/src/lib/foundation-migrations.test.ts
+++ b/src/lib/foundation-migrations.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   assessMigrationReadiness,
   checksumMigrationSql,
+  FOUNDATION_MIGRATIONS,
   type FoundationMigration,
   type MigrationLedgerEntry,
 } from "@/lib/foundation-migrations";
@@ -12,6 +13,33 @@ const migrations: readonly FoundationMigration[] = [
 ];
 
 describe("foundation migration ledger compatibility", () => {
+  test("keeps accepted migrations 001 through 005 byte-for-byte immutable", () => {
+    expect(FOUNDATION_MIGRATIONS.slice(0, 5).map(({ id, checksum }) => ({ id, checksum }))).toEqual(
+      [
+        {
+          id: "001-foundation-event-game-record-roots",
+          checksum: "915727680c9142dc2bd5e6482b13879df1bcbfa779d6b5ad67160f7e6c3d0510",
+        },
+        {
+          id: "002-normalize-event-game-record-sides",
+          checksum: "c7f15ac99143c0968d6140cda6a1d0a7800c70754800d571a49cf487d89b62a3",
+        },
+        {
+          id: "003-persist-event-game-actions",
+          checksum: "0d7d827884408cbe8fc591b02c39d79b0eb9bbfd24e1e96eeef318073e2609a2",
+        },
+        {
+          id: "004-foundation-control-grants",
+          checksum: "ba3f4a44c36086e3f31f15da707e14e7ab9167ab85a76874566bc7ef5493210f",
+        },
+        {
+          id: "005-grant-expiry-lifecycle",
+          checksum: "8580876d7d4a490f6cf252cafc7be81cf3cc5a8769821b3bd82f760c0115b3d1",
+        },
+      ],
+    );
+  });
+
   test("distinguishes pending and missing migrations", () => {
     expect(assessMigrationReadiness(false, [], migrations)).toMatchObject({ status: "pending" });
     expect(assessMigrationReadiness(true, [], migrations)).toMatchObject({ status: "pending" });

--- a/src/lib/foundation-migrations.ts
+++ b/src/lib/foundation-migrations.ts
@@ -1,5 +1,7 @@
 import { createHash } from "node:crypto";
 
+import { createFoundationGrantErasureMigrationSql } from "./foundation-grant-erasure-migration";
+
 export const FOUNDATION_MIGRATION_LEDGER_TABLE = "foundation_migration_ledger";
 
 export type FoundationMigration = {
@@ -177,6 +179,202 @@ export const FOUNDATION_AUDIT_RECORD_INDEX_SQL = `
     ON foundation_event_game_record_audit (record_id, created_at_ms)
 `;
 
+const FOUNDATION_GRANT_TABLE_V4_SQL = `
+  CREATE TABLE foundation_grant_roots (
+    grant_id TEXT PRIMARY KEY,
+    grant_type TEXT NOT NULL CHECK (grant_type = 'control'),
+    grant_version TEXT NOT NULL UNIQUE,
+    event_id TEXT NOT NULL,
+    game_day_id TEXT NOT NULL,
+    pitch_id TEXT NOT NULL,
+    pitch_slot_id TEXT NOT NULL UNIQUE,
+    status TEXT NOT NULL CHECK (status IN ('active', 'disabled', 'revoked', 'expired')),
+    created_at_ms INTEGER NOT NULL,
+    expires_at_ms INTEGER,
+    credential_format_version INTEGER NOT NULL CHECK (credential_format_version = 1),
+    credential_kind TEXT NOT NULL CHECK (credential_kind = 'qr'),
+    encryption_key_version TEXT NOT NULL,
+    lookup_key_version TEXT NOT NULL,
+    credential_iv TEXT NOT NULL,
+    credential_ciphertext TEXT NOT NULL,
+    credential_tag TEXT NOT NULL,
+    credential_lookup_digest TEXT NOT NULL UNIQUE,
+    credential_fingerprint TEXT NOT NULL,
+    CHECK (expires_at_ms IS NULL OR expires_at_ms > created_at_ms)
+  ) STRICT
+`;
+
+const FOUNDATION_GRANT_SESSION_TABLE_V4_SQL = `
+  CREATE TABLE foundation_grant_sessions (
+    session_id TEXT PRIMARY KEY,
+    grant_id TEXT NOT NULL REFERENCES foundation_grant_roots(grant_id) ON DELETE CASCADE,
+    grant_version TEXT NOT NULL,
+    event_game_id TEXT NOT NULL,
+    browser_context_digest TEXT NOT NULL,
+    browser_context_key_version TEXT NOT NULL,
+    bearer_lookup_verifier TEXT NOT NULL UNIQUE,
+    bearer_lookup_key_version TEXT NOT NULL,
+    status TEXT NOT NULL CHECK (status IN ('active', 'revoked', 'expired')),
+    created_at_ms INTEGER NOT NULL,
+    last_active_at_ms INTEGER NOT NULL,
+    revoked_at_ms INTEGER,
+    CHECK ((status = 'active' AND revoked_at_ms IS NULL) OR (status <> 'active'))
+  ) STRICT
+`;
+
+export const FOUNDATION_GRANT_TABLE_SQL = `
+  CREATE TABLE foundation_grant_roots (
+    grant_id TEXT PRIMARY KEY,
+    grant_type TEXT NOT NULL CHECK (grant_type = 'control'),
+    grant_version TEXT NOT NULL UNIQUE,
+    event_id TEXT NOT NULL,
+    game_day_id TEXT NOT NULL,
+    pitch_id TEXT NOT NULL,
+    pitch_slot_id TEXT NOT NULL UNIQUE,
+    status TEXT NOT NULL CHECK (status IN ('active', 'disabled', 'revoked', 'expired')),
+    created_at_ms INTEGER NOT NULL,
+    expires_at_ms INTEGER,
+    credential_format_version INTEGER NOT NULL CHECK (credential_format_version = 1),
+    credential_kind TEXT NOT NULL CHECK (credential_kind = 'qr'),
+    credential_material_state TEXT NOT NULL CHECK (credential_material_state IN ('present', 'erased')),
+    encryption_key_version TEXT,
+    lookup_key_version TEXT,
+    credential_iv TEXT,
+    credential_ciphertext TEXT,
+    credential_tag TEXT,
+    credential_lookup_digest TEXT UNIQUE,
+    credential_fingerprint TEXT NOT NULL,
+    CHECK (expires_at_ms IS NULL OR expires_at_ms > created_at_ms),
+    CHECK (
+      (credential_material_state = 'present' AND encryption_key_version IS NOT NULL AND lookup_key_version IS NOT NULL AND credential_iv IS NOT NULL AND credential_ciphertext IS NOT NULL AND credential_tag IS NOT NULL AND credential_lookup_digest IS NOT NULL)
+      OR
+      (credential_material_state = 'erased' AND encryption_key_version IS NULL AND lookup_key_version IS NULL AND credential_iv IS NULL AND credential_ciphertext IS NULL AND credential_tag IS NULL AND credential_lookup_digest IS NULL)
+    ),
+    CHECK (
+      (status = 'expired' AND credential_material_state = 'erased')
+      OR
+      (status <> 'expired' AND credential_material_state = 'present')
+    )
+  ) STRICT
+`;
+
+export const FOUNDATION_GRANT_SESSION_TABLE_SQL = `
+  CREATE TABLE foundation_grant_sessions (
+    session_id TEXT PRIMARY KEY,
+    grant_id TEXT NOT NULL REFERENCES foundation_grant_roots(grant_id) ON DELETE CASCADE,
+    grant_version TEXT NOT NULL,
+    event_game_id TEXT NOT NULL,
+    browser_context_digest TEXT NOT NULL,
+    browser_context_key_version TEXT NOT NULL,
+    bearer_material_state TEXT NOT NULL CHECK (bearer_material_state IN ('present', 'erased')),
+    bearer_lookup_verifier TEXT UNIQUE,
+    bearer_lookup_key_version TEXT,
+    status TEXT NOT NULL CHECK (status IN ('active', 'revoked', 'expired')),
+    created_at_ms INTEGER NOT NULL,
+    last_active_at_ms INTEGER NOT NULL,
+    revoked_at_ms INTEGER,
+    CHECK ((status = 'active' AND revoked_at_ms IS NULL) OR (status <> 'active')),
+    CHECK (
+      (bearer_material_state = 'present' AND bearer_lookup_verifier IS NOT NULL AND bearer_lookup_key_version IS NOT NULL)
+      OR
+      (bearer_material_state = 'erased' AND bearer_lookup_verifier IS NULL AND bearer_lookup_key_version IS NULL)
+    ),
+    CHECK (
+      (status = 'expired' AND bearer_material_state = 'erased')
+      OR
+      (status <> 'expired' AND bearer_material_state = 'present')
+    )
+  ) STRICT
+`;
+
+const FOUNDATION_GRANT_AUDIT_TABLE_V4_SQL = `
+  CREATE TABLE foundation_grant_audit (
+    audit_id TEXT PRIMARY KEY,
+    action TEXT NOT NULL CHECK (action IN ('grant-created', 'credential-revealed', 'grant-disabled', 'grant-revoked', 'session-admitted', 'session-replaced')),
+    outcome TEXT NOT NULL CHECK (outcome = 'accepted'),
+    actor_reference TEXT NOT NULL,
+    grant_id TEXT NOT NULL REFERENCES foundation_grant_roots(grant_id) ON DELETE CASCADE,
+    grant_type TEXT NOT NULL CHECK (grant_type = 'control'),
+    grant_version TEXT NOT NULL,
+    event_id TEXT NOT NULL,
+    game_day_id TEXT NOT NULL,
+    pitch_id TEXT NOT NULL,
+    pitch_slot_id TEXT NOT NULL,
+    session_id TEXT,
+    replaced_session_id TEXT,
+    event_game_id TEXT,
+    credential_kind TEXT CHECK (credential_kind IS NULL OR credential_kind = 'qr'),
+    credential_fingerprint TEXT,
+    before_status TEXT CHECK (before_status IS NULL OR before_status IN ('active', 'disabled', 'revoked', 'expired')),
+    after_status TEXT CHECK (after_status IS NULL OR after_status IN ('active', 'disabled', 'revoked', 'expired')),
+    created_at_ms INTEGER NOT NULL
+  ) STRICT
+`;
+
+const FOUNDATION_GRANT_AUDIT_TABLE_V5_SQL = `
+  CREATE TABLE foundation_grant_audit (
+    audit_id TEXT PRIMARY KEY,
+    action TEXT NOT NULL CHECK (action IN ('grant-created', 'credential-revealed', 'grant-expired', 'grant-disabled', 'grant-revoked', 'session-admitted', 'session-replaced')),
+    outcome TEXT NOT NULL CHECK (outcome = 'accepted'),
+    actor_reference TEXT NOT NULL,
+    grant_id TEXT NOT NULL REFERENCES foundation_grant_roots(grant_id) ON DELETE CASCADE,
+    grant_type TEXT NOT NULL CHECK (grant_type = 'control'),
+    grant_version TEXT NOT NULL,
+    event_id TEXT NOT NULL,
+    game_day_id TEXT NOT NULL,
+    pitch_id TEXT NOT NULL,
+    pitch_slot_id TEXT NOT NULL,
+    session_id TEXT,
+    replaced_session_id TEXT,
+    event_game_id TEXT,
+    credential_kind TEXT CHECK (credential_kind IS NULL OR credential_kind = 'qr'),
+    credential_fingerprint TEXT,
+    before_status TEXT CHECK (before_status IS NULL OR before_status IN ('active', 'disabled', 'revoked', 'expired')),
+    after_status TEXT CHECK (after_status IS NULL OR after_status IN ('active', 'disabled', 'revoked', 'expired')),
+    created_at_ms INTEGER NOT NULL
+  ) STRICT
+`;
+
+export const FOUNDATION_GRANT_AUDIT_TABLE_SQL = `
+  CREATE TABLE foundation_grant_audit (
+    audit_id TEXT PRIMARY KEY,
+    action TEXT NOT NULL CHECK (action IN ('grant-created', 'credential-revealed', 'credential-rotated', 'grant-expired', 'grant-disabled', 'grant-revoked', 'session-admitted', 'session-replaced')),
+    outcome TEXT NOT NULL CHECK (outcome = 'accepted'),
+    actor_reference TEXT NOT NULL,
+    grant_id TEXT NOT NULL REFERENCES foundation_grant_roots(grant_id) ON DELETE CASCADE,
+    grant_type TEXT NOT NULL CHECK (grant_type = 'control'),
+    grant_version TEXT NOT NULL,
+    event_id TEXT NOT NULL,
+    game_day_id TEXT NOT NULL,
+    pitch_id TEXT NOT NULL,
+    pitch_slot_id TEXT NOT NULL,
+    session_id TEXT,
+    replaced_session_id TEXT,
+    event_game_id TEXT,
+    credential_kind TEXT CHECK (credential_kind IS NULL OR credential_kind = 'qr'),
+    credential_fingerprint TEXT,
+    before_status TEXT CHECK (before_status IS NULL OR before_status IN ('active', 'disabled', 'revoked', 'expired')),
+    after_status TEXT CHECK (after_status IS NULL OR after_status IN ('active', 'disabled', 'revoked', 'expired')),
+    created_at_ms INTEGER NOT NULL
+  ) STRICT
+`;
+
+export const FOUNDATION_GRANT_SESSION_GRANT_INDEX_SQL = `
+  CREATE INDEX foundation_grant_sessions_grant_id
+    ON foundation_grant_sessions (grant_id)
+`;
+
+export const FOUNDATION_GRANT_SESSION_CONTEXT_INDEX_SQL = `
+  CREATE UNIQUE INDEX foundation_grant_sessions_active_context
+    ON foundation_grant_sessions (grant_id, browser_context_digest)
+    WHERE status = 'active'
+`;
+
+export const FOUNDATION_GRANT_AUDIT_GRANT_INDEX_SQL = `
+  CREATE INDEX foundation_grant_audit_grant_id
+    ON foundation_grant_audit (grant_id, audit_id)
+`;
+
 const FOUNDATION_INITIAL_ROOT_MIGRATION_SQL = `
       CREATE TABLE foundation_event_game_record_roots (
         record_id TEXT PRIMARY KEY,
@@ -318,6 +516,46 @@ const FOUNDATION_ACTIONS_MIGRATION_SQL = `
   ${FOUNDATION_AUDIT_RECORD_INDEX_SQL};
 `;
 
+const FOUNDATION_GRANT_MIGRATION_SQL = `
+  ${FOUNDATION_GRANT_TABLE_V4_SQL};
+  ${FOUNDATION_GRANT_SESSION_TABLE_V4_SQL};
+  ${FOUNDATION_GRANT_AUDIT_TABLE_V4_SQL};
+  ${FOUNDATION_GRANT_SESSION_GRANT_INDEX_SQL};
+  ${FOUNDATION_GRANT_SESSION_CONTEXT_INDEX_SQL};
+  ${FOUNDATION_GRANT_AUDIT_GRANT_INDEX_SQL};
+`;
+
+const FOUNDATION_GRANT_EXPIRY_MIGRATION_SQL = `
+  ${FOUNDATION_GRANT_AUDIT_TABLE_V5_SQL.replace(
+    "CREATE TABLE foundation_grant_audit",
+    "CREATE TABLE foundation_grant_audit_v4",
+  )};
+  INSERT INTO foundation_grant_audit_v4 (
+    audit_id, action, outcome, actor_reference, grant_id, grant_type, grant_version,
+    event_id, game_day_id, pitch_id, pitch_slot_id, session_id, replaced_session_id,
+    event_game_id, credential_kind, credential_fingerprint, before_status, after_status,
+    created_at_ms
+  )
+  SELECT
+    audit_id, action, outcome, actor_reference, grant_id, grant_type, grant_version,
+    event_id, game_day_id, pitch_id, pitch_slot_id, session_id, replaced_session_id,
+    event_game_id, credential_kind, credential_fingerprint, before_status, after_status,
+    created_at_ms
+  FROM foundation_grant_audit;
+  DROP TABLE foundation_grant_audit;
+  ALTER TABLE foundation_grant_audit_v4 RENAME TO foundation_grant_audit;
+  ${FOUNDATION_GRANT_AUDIT_GRANT_INDEX_SQL};
+`;
+
+const FOUNDATION_GRANT_ERASURE_MIGRATION_SQL = createFoundationGrantErasureMigrationSql({
+  grantTableSql: FOUNDATION_GRANT_TABLE_SQL,
+  sessionTableSql: FOUNDATION_GRANT_SESSION_TABLE_SQL,
+  auditTableSql: FOUNDATION_GRANT_AUDIT_TABLE_SQL,
+  sessionGrantIndexSql: FOUNDATION_GRANT_SESSION_GRANT_INDEX_SQL,
+  sessionContextIndexSql: FOUNDATION_GRANT_SESSION_CONTEXT_INDEX_SQL,
+  auditGrantIndexSql: FOUNDATION_GRANT_AUDIT_GRANT_INDEX_SQL,
+});
+
 export const FOUNDATION_MIGRATIONS: readonly FoundationMigration[] = Object.freeze([
   createMigration({
     id: "001-foundation-event-game-record-roots",
@@ -336,6 +574,24 @@ export const FOUNDATION_MIGRATIONS: readonly FoundationMigration[] = Object.free
     ordinal: 3,
     schemaVersion: 3,
     sql: FOUNDATION_ACTIONS_MIGRATION_SQL,
+  }),
+  createMigration({
+    id: "004-foundation-control-grants",
+    ordinal: 4,
+    schemaVersion: 4,
+    sql: FOUNDATION_GRANT_MIGRATION_SQL,
+  }),
+  createMigration({
+    id: "005-grant-expiry-lifecycle",
+    ordinal: 5,
+    schemaVersion: 5,
+    sql: FOUNDATION_GRANT_EXPIRY_MIGRATION_SQL,
+  }),
+  createMigration({
+    id: "006-grant-cryptographic-erasure",
+    ordinal: 6,
+    schemaVersion: 6,
+    sql: FOUNDATION_GRANT_ERASURE_MIGRATION_SQL,
   }),
 ]);
 

--- a/src/lib/foundation-schema.ts
+++ b/src/lib/foundation-schema.ts
@@ -14,6 +14,12 @@ import {
   FOUNDATION_ROOT_TABLE_SQL,
   FOUNDATION_SIDE_RECORD_INDEX_SQL,
   FOUNDATION_SIDE_TABLE_SQL,
+  FOUNDATION_GRANT_AUDIT_GRANT_INDEX_SQL,
+  FOUNDATION_GRANT_AUDIT_TABLE_SQL,
+  FOUNDATION_GRANT_SESSION_CONTEXT_INDEX_SQL,
+  FOUNDATION_GRANT_SESSION_GRANT_INDEX_SQL,
+  FOUNDATION_GRANT_SESSION_TABLE_SQL,
+  FOUNDATION_GRANT_TABLE_SQL,
 } from "@/lib/foundation-migrations";
 import {
   canonicalizeEventGameRecordRoot,
@@ -71,6 +77,9 @@ const ACTION_TABLE = "foundation_event_game_record_actions";
 const IDEMPOTENCY_TABLE = "foundation_event_game_record_idempotency";
 const METADATA_TABLE = "foundation_event_game_record_metadata";
 const AUDIT_TABLE = "foundation_event_game_record_audit";
+const GRANT_TABLE = "foundation_grant_roots";
+const GRANT_SESSION_TABLE = "foundation_grant_sessions";
+const GRANT_AUDIT_TABLE = "foundation_grant_audit";
 
 const expectedManifest: FoundationSchemaManifest = {
   objects: [
@@ -81,6 +90,9 @@ const expectedManifest: FoundationSchemaManifest = {
     object("table", IDEMPOTENCY_TABLE, IDEMPOTENCY_TABLE, FOUNDATION_IDEMPOTENCY_TABLE_SQL),
     object("table", METADATA_TABLE, METADATA_TABLE, FOUNDATION_METADATA_TABLE_SQL),
     object("table", AUDIT_TABLE, AUDIT_TABLE, FOUNDATION_AUDIT_TABLE_SQL),
+    object("table", GRANT_TABLE, GRANT_TABLE, FOUNDATION_GRANT_TABLE_SQL),
+    object("table", GRANT_SESSION_TABLE, GRANT_SESSION_TABLE, FOUNDATION_GRANT_SESSION_TABLE_SQL),
+    object("table", GRANT_AUDIT_TABLE, GRANT_AUDIT_TABLE, FOUNDATION_GRANT_AUDIT_TABLE_SQL),
     object(
       "index",
       "foundation_event_game_record_roots_event_id",
@@ -116,6 +128,24 @@ const expectedManifest: FoundationSchemaManifest = {
       "foundation_event_game_record_audit_record_id",
       AUDIT_TABLE,
       FOUNDATION_AUDIT_RECORD_INDEX_SQL,
+    ),
+    object(
+      "index",
+      "foundation_grant_sessions_grant_id",
+      GRANT_SESSION_TABLE,
+      FOUNDATION_GRANT_SESSION_GRANT_INDEX_SQL,
+    ),
+    object(
+      "index",
+      "foundation_grant_sessions_active_context",
+      GRANT_SESSION_TABLE,
+      FOUNDATION_GRANT_SESSION_CONTEXT_INDEX_SQL,
+    ),
+    object(
+      "index",
+      "foundation_grant_audit_grant_id",
+      GRANT_AUDIT_TABLE,
+      FOUNDATION_GRANT_AUDIT_GRANT_INDEX_SQL,
     ),
   ].sort(compareNamed),
   tables: [
@@ -203,6 +233,62 @@ const expectedManifest: FoundationSchemaManifest = {
           table: ROOT_TABLE,
           from: "record_id",
           to: "record_id",
+          onUpdate: "NO ACTION",
+          onDelete: "CASCADE",
+          match: "NONE",
+        },
+      ],
+    },
+    {
+      name: GRANT_TABLE,
+      columns: [
+        column("grant_id", "TEXT", 1, 1),
+        column("grant_type", "TEXT", 1, 0),
+        column("grant_version", "TEXT", 1, 0),
+        column("event_id", "TEXT", 1, 0),
+        column("game_day_id", "TEXT", 1, 0),
+        column("pitch_id", "TEXT", 1, 0),
+        column("pitch_slot_id", "TEXT", 1, 0),
+        column("status", "TEXT", 1, 0),
+        column("created_at_ms", "INTEGER", 1, 0),
+        column("expires_at_ms", "INTEGER", 0, 0),
+        column("credential_format_version", "INTEGER", 1, 0),
+        column("credential_kind", "TEXT", 1, 0),
+        column("credential_material_state", "TEXT", 1, 0),
+        column("encryption_key_version", "TEXT", 0, 0),
+        column("lookup_key_version", "TEXT", 0, 0),
+        column("credential_iv", "TEXT", 0, 0),
+        column("credential_ciphertext", "TEXT", 0, 0),
+        column("credential_tag", "TEXT", 0, 0),
+        column("credential_lookup_digest", "TEXT", 0, 0),
+        column("credential_fingerprint", "TEXT", 1, 0),
+      ],
+      foreignKeys: [],
+    },
+    {
+      name: GRANT_SESSION_TABLE,
+      columns: [
+        column("session_id", "TEXT", 1, 1),
+        column("grant_id", "TEXT", 1, 0),
+        column("grant_version", "TEXT", 1, 0),
+        column("event_game_id", "TEXT", 1, 0),
+        column("browser_context_digest", "TEXT", 1, 0),
+        column("browser_context_key_version", "TEXT", 1, 0),
+        column("bearer_material_state", "TEXT", 1, 0),
+        column("bearer_lookup_verifier", "TEXT", 0, 0),
+        column("bearer_lookup_key_version", "TEXT", 0, 0),
+        column("status", "TEXT", 1, 0),
+        column("created_at_ms", "INTEGER", 1, 0),
+        column("last_active_at_ms", "INTEGER", 1, 0),
+        column("revoked_at_ms", "INTEGER", 0, 0),
+      ],
+      foreignKeys: [
+        {
+          id: 0,
+          sequence: 0,
+          table: GRANT_TABLE,
+          from: "grant_id",
+          to: "grant_id",
           onUpdate: "NO ACTION",
           onDelete: "CASCADE",
           match: "NONE",
@@ -299,6 +385,42 @@ const expectedManifest: FoundationSchemaManifest = {
         },
       ],
     },
+    {
+      name: GRANT_AUDIT_TABLE,
+      columns: [
+        column("audit_id", "TEXT", 1, 1),
+        column("action", "TEXT", 1, 0),
+        column("outcome", "TEXT", 1, 0),
+        column("actor_reference", "TEXT", 1, 0),
+        column("grant_id", "TEXT", 1, 0),
+        column("grant_type", "TEXT", 1, 0),
+        column("grant_version", "TEXT", 1, 0),
+        column("event_id", "TEXT", 1, 0),
+        column("game_day_id", "TEXT", 1, 0),
+        column("pitch_id", "TEXT", 1, 0),
+        column("pitch_slot_id", "TEXT", 1, 0),
+        column("session_id", "TEXT", 0, 0),
+        column("replaced_session_id", "TEXT", 0, 0),
+        column("event_game_id", "TEXT", 0, 0),
+        column("credential_kind", "TEXT", 0, 0),
+        column("credential_fingerprint", "TEXT", 0, 0),
+        column("before_status", "TEXT", 0, 0),
+        column("after_status", "TEXT", 0, 0),
+        column("created_at_ms", "INTEGER", 1, 0),
+      ],
+      foreignKeys: [
+        {
+          id: 0,
+          sequence: 0,
+          table: GRANT_TABLE,
+          from: "grant_id",
+          to: "grant_id",
+          onUpdate: "NO ACTION",
+          onDelete: "CASCADE",
+          match: "NONE",
+        },
+      ],
+    },
   ].sort(compareNamed),
   indexes: [
     index("foundation_event_game_record_roots_event_id", 0, ["event_id"]),
@@ -307,6 +429,9 @@ const expectedManifest: FoundationSchemaManifest = {
     index("foundation_event_game_record_actions_record_id", 0, ["record_id", "accepted_at_ms"]),
     index("foundation_event_game_record_idempotency_record_id", 0, ["record_id"]),
     index("foundation_event_game_record_audit_record_id", 0, ["record_id", "created_at_ms"]),
+    index("foundation_grant_sessions_grant_id", 0, ["grant_id"]),
+    index("foundation_grant_sessions_active_context", 1, ["grant_id", "browser_context_digest"], 1),
+    index("foundation_grant_audit_grant_id", 0, ["grant_id", "audit_id"]),
   ].sort(compareNamed),
 };
 
@@ -370,6 +495,7 @@ export function verifyFoundationSchema(database: Database): FoundationSchemaVeri
       };
     }
     scanFoundationRoots(database);
+    scanFoundationGrantState(database);
     return { ok: true };
   } catch {
     return {
@@ -403,6 +529,29 @@ export function scanFoundationRoots(database: Database): void {
     .all() as unknown[];
   for (const value of rows) {
     readValidatedFoundationRoot(database, asRecord(value));
+  }
+}
+
+function scanFoundationGrantState(database: Database): void {
+  const invalidGrant = database
+    .query(
+      `SELECT grant_id FROM foundation_grant_roots
+       WHERE (status = 'expired') <> (credential_material_state = 'erased')
+       LIMIT 1`,
+    )
+    .get();
+  if (invalidGrant !== null) {
+    throw new Error("Stored Grant lifecycle and credential material state do not match.");
+  }
+  const invalidSession = database
+    .query(
+      `SELECT session_id FROM foundation_grant_sessions
+       WHERE (status = 'expired') <> (bearer_material_state = 'erased')
+       LIMIT 1`,
+    )
+    .get();
+  if (invalidSession !== null) {
+    throw new Error("Stored Grant Session lifecycle and bearer material state do not match.");
   }
 }
 
@@ -511,6 +660,9 @@ function readSchemaManifest(database: Database): FoundationSchemaManifest {
     IDEMPOTENCY_TABLE,
     METADATA_TABLE,
     AUDIT_TABLE,
+    GRANT_TABLE,
+    GRANT_SESSION_TABLE,
+    GRANT_AUDIT_TABLE,
   ].map((name) => ({
     name,
     columns: readColumns(database, name),
@@ -523,6 +675,9 @@ function readSchemaManifest(database: Database): FoundationSchemaManifest {
     "foundation_event_game_record_actions_record_id",
     "foundation_event_game_record_idempotency_record_id",
     "foundation_event_game_record_audit_record_id",
+    "foundation_grant_sessions_grant_id",
+    "foundation_grant_sessions_active_context",
+    "foundation_grant_audit_grant_id",
   ].map((name) => readIndex(database, name));
 
   return {
@@ -619,6 +774,8 @@ function readIndex(database: Database, name: string): SchemaIndex {
 }
 
 function indexTable(name: string): string {
+  if (name.startsWith("foundation_grant_sessions")) return GRANT_SESSION_TABLE;
+  if (name.startsWith("foundation_grant_audit")) return GRANT_AUDIT_TABLE;
   if (name.includes("sides")) return SIDE_TABLE;
   if (name.includes("actions")) return ACTION_TABLE;
   if (name.includes("idempotency")) return IDEMPOTENCY_TABLE;
@@ -650,8 +807,8 @@ function column(
   };
 }
 
-function index(name: string, unique: number, columns: string[]): SchemaIndex {
-  return { name, unique, origin: "c", partial: 0, columns };
+function index(name: string, unique: number, columns: string[], partial = 0): SchemaIndex {
+  return { name, unique, origin: "c", partial, columns };
 }
 
 function fingerprint(manifest: FoundationSchemaManifest): string {

--- a/src/lib/foundation-storage-memory.ts
+++ b/src/lib/foundation-storage-memory.ts
@@ -5,6 +5,14 @@ import {
   type EventGameRecordRoot,
 } from "@/lib/foundation-record-types";
 import {
+  cloneStoredControlGrant,
+  cloneStoredGrantAuditEntry,
+  cloneStoredGrantSession,
+  type StoredControlGrant,
+  type StoredGrantAuditEntry,
+  type StoredGrantSession,
+} from "@/lib/grant-types";
+import {
   FoundationStorageClosedError,
   FoundationStorageConstraintError,
   type FoundationStorage,
@@ -25,7 +33,10 @@ type MemoryState = {
   actions: Map<string, Map<string, StoredControlAction>>;
   idempotency: Map<string, Map<string, StoredControlIdempotencyEntry>>;
   metadata: Map<string, StoredEventGameRecordMetadata>;
-  audits: Map<string, Map<string, StoredControlAuditEntry>>;
+  controlAudits: Map<string, Map<string, StoredControlAuditEntry>>;
+  grants: Map<string, StoredControlGrant>;
+  sessions: Map<string, StoredGrantSession>;
+  grantAudits: Map<string, StoredGrantAuditEntry>;
 };
 
 export function createInMemoryFoundationStorage(): FoundationStorage {
@@ -38,9 +49,11 @@ class InMemoryFoundationStorage implements FoundationStorage {
     actions: new Map(),
     idempotency: new Map(),
     metadata: new Map(),
-    audits: new Map(),
+    controlAudits: new Map(),
+    grants: new Map(),
+    sessions: new Map(),
+    grantAudits: new Map(),
   };
-
   private writerTail: Promise<void> = Promise.resolve();
   private closed = false;
   private revision = 0;
@@ -103,7 +116,7 @@ class InMemoryFoundationStorage implements FoundationStorage {
   readAuditEntries(recordId: string): Promise<StoredControlAuditEntry[]> {
     return this.writerTail.then(() => {
       this.assertOpen();
-      return [...(this.state.audits.get(recordId)?.values() ?? [])].map((entry) =>
+      return [...(this.state.controlAudits.get(recordId)?.values() ?? [])].map((entry) =>
         structuredClone(entry),
       );
     });
@@ -242,7 +255,7 @@ function createTransaction(
       return metadata === undefined ? null : structuredClone(metadata);
     },
     listAuditEntries(recordId) {
-      return [...(state.audits.get(recordId)?.values() ?? [])].map((entry) =>
+      return [...(state.controlAudits.get(recordId)?.values() ?? [])].map((entry) =>
         structuredClone(entry),
       );
     },
@@ -323,17 +336,200 @@ function createTransaction(
       });
     },
     appendAuditEntry(entry) {
-      let audits = state.audits.get(entry.recordId);
+      let audits = state.controlAudits.get(entry.recordId);
       if (audits === undefined) {
         audits = new Map();
-        state.audits.set(entry.recordId, audits);
-        undo.push(() => state.audits.delete(entry.recordId));
+        state.controlAudits.set(entry.recordId, audits);
+        undo.push(() => state.controlAudits.delete(entry.recordId));
       }
       if (audits.has(entry.auditId)) {
         throw new FoundationStorageConstraintError("audit-id");
       }
       audits.set(entry.auditId, structuredClone(entry));
       undo.push(() => audits?.delete(entry.auditId));
+    },
+    findGrantById(grantId) {
+      const grant = state.grants.get(grantId);
+      return grant === undefined ? null : cloneStoredControlGrant(grant);
+    },
+    findGrantByCredentialLookupDigest(lookupDigest) {
+      return findGrant(state.grants, (grant) => grant.credential.lookupDigest === lookupDigest);
+    },
+    findActiveSessionByGrantAndContext(grantId, browserContextDigest) {
+      return findSession(
+        state.sessions,
+        (session) =>
+          session.grantId === grantId &&
+          session.browserContextDigest === browserContextDigest &&
+          session.status === "active",
+      );
+    },
+    findSessionByBearerVerifier(bearerLookupVerifier, bearerLookupKeyVersion) {
+      return findSession(
+        state.sessions,
+        (session) =>
+          session.bearerLookupVerifier === bearerLookupVerifier &&
+          session.bearerLookupKeyVersion === bearerLookupKeyVersion,
+      );
+    },
+    listGrantSessions(grantId) {
+      return [...state.sessions.values()]
+        .filter((session) => session.grantId === grantId)
+        .sort((left, right) => left.sessionId.localeCompare(right.sessionId))
+        .map(cloneStoredGrantSession);
+    },
+    listGrantAudit(grantId) {
+      return [...state.grantAudits.values()]
+        .filter((entry) => entry.grantId === grantId)
+        .sort((left, right) => left.auditId.localeCompare(right.auditId))
+        .map(cloneStoredGrantAuditEntry);
+    },
+    insertGrant(grant) {
+      if (state.grants.has(grant.grantId)) {
+        throw new FoundationStorageConstraintError("grant-id");
+      }
+      if (findGrant(state.grants, (candidate) => candidate.grantVersion === grant.grantVersion)) {
+        throw new FoundationStorageConstraintError("grant-version");
+      }
+      if (
+        findGrant(
+          state.grants,
+          (candidate) =>
+            grant.credential.lookupDigest !== null &&
+            candidate.credential.lookupDigest === grant.credential.lookupDigest,
+        )
+      ) {
+        throw new FoundationStorageConstraintError("grant-credential-digest");
+      }
+      if (
+        findGrant(
+          state.grants,
+          (candidate) => candidate.scope.pitchSlotId === grant.scope.pitchSlotId,
+        )
+      ) {
+        throw new FoundationStorageConstraintError("grant-pitch-slot-id");
+      }
+      state.grants.set(grant.grantId, cloneStoredControlGrant(grant));
+      undo.push(() => state.grants.delete(grant.grantId));
+    },
+    updateGrant(grant) {
+      if (!state.grants.has(grant.grantId)) {
+        throw new FoundationStorageConstraintError("grant-id");
+      }
+      if (
+        findGrant(
+          state.grants,
+          (candidate) =>
+            candidate.grantId !== grant.grantId && candidate.grantVersion === grant.grantVersion,
+        )
+      ) {
+        throw new FoundationStorageConstraintError("grant-version");
+      }
+      if (
+        findGrant(
+          state.grants,
+          (candidate) =>
+            candidate.grantId !== grant.grantId &&
+            candidate.scope.pitchSlotId === grant.scope.pitchSlotId,
+        )
+      ) {
+        throw new FoundationStorageConstraintError("grant-pitch-slot-id");
+      }
+      if (
+        findGrant(
+          state.grants,
+          (candidate) =>
+            candidate.grantId !== grant.grantId &&
+            grant.credential.lookupDigest !== null &&
+            candidate.credential.lookupDigest === grant.credential.lookupDigest,
+        )
+      ) {
+        throw new FoundationStorageConstraintError("grant-credential-digest");
+      }
+      const previous = state.grants.get(grant.grantId);
+      state.grants.set(grant.grantId, cloneStoredControlGrant(grant));
+      undo.push(() => {
+        if (previous !== undefined) state.grants.set(grant.grantId, previous);
+      });
+    },
+    insertGrantSession(session) {
+      if (state.sessions.has(session.sessionId)) {
+        throw new FoundationStorageConstraintError("grant-session-id");
+      }
+      if (
+        findSession(
+          state.sessions,
+          (candidate) =>
+            session.bearerLookupVerifier !== null &&
+            candidate.bearerLookupVerifier === session.bearerLookupVerifier,
+        )
+      ) {
+        throw new FoundationStorageConstraintError("grant-session-verifier");
+      }
+      if (
+        session.status === "active" &&
+        findSession(
+          state.sessions,
+          (candidate) =>
+            candidate.grantId === session.grantId &&
+            candidate.browserContextDigest === session.browserContextDigest &&
+            candidate.status === "active",
+        )
+      ) {
+        throw new FoundationStorageConstraintError("grant-session-context");
+      }
+      if (!state.grants.has(session.grantId)) {
+        throw new FoundationStorageConstraintError("grant-id");
+      }
+      state.sessions.set(session.sessionId, cloneStoredGrantSession(session));
+      undo.push(() => state.sessions.delete(session.sessionId));
+    },
+    updateGrantSession(session) {
+      if (!state.sessions.has(session.sessionId)) {
+        throw new FoundationStorageConstraintError("grant-session-id");
+      }
+      if (!state.grants.has(session.grantId)) {
+        throw new FoundationStorageConstraintError("grant-id");
+      }
+      if (
+        findSession(
+          state.sessions,
+          (candidate) =>
+            candidate.sessionId !== session.sessionId &&
+            session.bearerLookupVerifier !== null &&
+            candidate.bearerLookupVerifier === session.bearerLookupVerifier,
+        )
+      ) {
+        throw new FoundationStorageConstraintError("grant-session-verifier");
+      }
+      if (
+        session.status === "active" &&
+        findSession(
+          state.sessions,
+          (candidate) =>
+            candidate.sessionId !== session.sessionId &&
+            candidate.grantId === session.grantId &&
+            candidate.browserContextDigest === session.browserContextDigest &&
+            candidate.status === "active",
+        )
+      ) {
+        throw new FoundationStorageConstraintError("grant-session-context");
+      }
+      const previous = state.sessions.get(session.sessionId);
+      state.sessions.set(session.sessionId, cloneStoredGrantSession(session));
+      undo.push(() => {
+        if (previous !== undefined) state.sessions.set(session.sessionId, previous);
+      });
+    },
+    appendGrantAudit(entry) {
+      if (state.grantAudits.has(entry.auditId)) {
+        throw new FoundationStorageConstraintError("grant-audit-id");
+      }
+      if (!state.grants.has(entry.grantId)) {
+        throw new FoundationStorageConstraintError("grant-id");
+      }
+      state.grantAudits.set(entry.auditId, cloneStoredGrantAuditEntry(entry));
+      undo.push(() => state.grantAudits.delete(entry.auditId));
     },
   };
 }
@@ -360,4 +556,24 @@ function cloneActions(
   actions: Map<string, StoredControlAction> | undefined,
 ): StoredControlAction[] {
   return [...(actions?.values() ?? [])].map((stored) => structuredClone(stored));
+}
+
+function findGrant(
+  state: Map<string, StoredControlGrant>,
+  predicate: (grant: StoredControlGrant) => boolean,
+): StoredControlGrant | null {
+  for (const grant of state.values()) {
+    if (predicate(grant)) return cloneStoredControlGrant(grant);
+  }
+  return null;
+}
+
+function findSession(
+  state: Map<string, StoredGrantSession>,
+  predicate: (session: StoredGrantSession) => boolean,
+): StoredGrantSession | null {
+  for (const session of state.values()) {
+    if (predicate(session)) return cloneStoredGrantSession(session);
+  }
+  return null;
 }

--- a/src/lib/foundation-storage-sqlite.test.ts
+++ b/src/lib/foundation-storage-sqlite.test.ts
@@ -56,7 +56,7 @@ describe("SQLite foundation storage", () => {
       first.close();
 
       const reopened = openSqliteFoundationStorage(databasePath);
-      expect(await reopened.readiness()).toMatchObject({ ok: true, schemaVersion: "3" });
+      expect(await reopened.readiness()).toMatchObject({ ok: true, schemaVersion: "6" });
       const reopenedRecord = createEventGameRecord(reopened, {
         externalScopeResolver: createScopeResolver(root),
       });
@@ -74,12 +74,12 @@ describe("SQLite foundation storage", () => {
       const storage = openSqliteFoundationStorage(databasePath);
       const candidate = await storage.validateCandidate();
       expect(candidate.ready).toBe(true);
-      expect(candidate.readiness).toMatchObject({ ok: true, schemaVersion: "3" });
+      expect(candidate.readiness).toMatchObject({ ok: true, schemaVersion: "6" });
       expect(existsSync(candidate.candidatePath)).toBe(false);
       expect(await storage.readiness()).toMatchObject({ ok: false, status: "pending" });
 
       const migration = await storage.applyMigrations({ requireCandidate: true });
-      expect(migration.schemaVersion).toBe(3);
+      expect(migration.schemaVersion).toBe(6);
       expect(await storage.readiness()).toMatchObject({ ok: true });
       storage.close();
     });
@@ -90,10 +90,16 @@ describe("SQLite foundation storage", () => {
       const initialMigration = FOUNDATION_MIGRATIONS[0];
       const repairMigration = FOUNDATION_MIGRATIONS[1];
       const actionMigration = FOUNDATION_MIGRATIONS[2];
+      const grantMigration = FOUNDATION_MIGRATIONS[3];
+      const expiryMigration = FOUNDATION_MIGRATIONS[4];
+      const erasureMigration = FOUNDATION_MIGRATIONS[5];
       if (
         initialMigration === undefined ||
         repairMigration === undefined ||
-        actionMigration === undefined
+        actionMigration === undefined ||
+        grantMigration === undefined ||
+        expiryMigration === undefined ||
+        erasureMigration === undefined
       ) {
         throw new Error("Expected the foundation migrations.");
       }
@@ -106,8 +112,14 @@ describe("SQLite foundation storage", () => {
       const current = openSqliteFoundationStorage(databasePath);
       expect(await current.readiness()).toMatchObject({ ok: false, status: "missing" });
       const migration = await current.applyMigrations();
-      expect(migration.appliedMigrationIds).toEqual([repairMigration.id, actionMigration.id]);
-      expect(await current.readiness()).toMatchObject({ ok: true, schemaVersion: "3" });
+      expect(migration.appliedMigrationIds).toEqual([
+        repairMigration.id,
+        actionMigration.id,
+        grantMigration.id,
+        expiryMigration.id,
+        erasureMigration.id,
+      ]);
+      expect(await current.readiness()).toMatchObject({ ok: true, schemaVersion: "6" });
       current.close();
     });
   });
@@ -116,9 +128,9 @@ describe("SQLite foundation storage", () => {
     await withDatabase(async (databasePath) => {
       const baseMigrations = FOUNDATION_MIGRATIONS;
       const failingMigration = createMigration(
-        "003-failing-test-migration",
-        3,
-        3,
+        "007-failing-test-migration",
+        7,
+        7,
         "CREATE TABLE migration_failure_probe (id TEXT) STRICT; THIS IS NOT SQL;",
       );
       const store = openSqliteFoundationStorage(databasePath, {
@@ -138,7 +150,7 @@ describe("SQLite foundation storage", () => {
       });
       expect(await priorBinary.readiness()).toMatchObject({
         ok: true,
-        schemaVersion: "3",
+        schemaVersion: "6",
       });
       priorBinary.close();
 
@@ -210,7 +222,7 @@ describe("SQLite foundation storage", () => {
         .query(
           "INSERT INTO foundation_migration_ledger (migration_id, ordinal, schema_version, checksum, status, applied_at_ms) VALUES (?, ?, ?, ?, ?, ?)",
         )
-        .run("future-999", 4, 4, "future-checksum", "complete", 2_000);
+        .run("future-999", 7, 7, "future-checksum", "complete", 2_000);
       futureDatabase.close();
       const future = openSqliteFoundationStorage(databasePath);
       expect(await future.readiness()).toMatchObject({ ok: false });

--- a/src/lib/foundation-storage-sqlite.ts
+++ b/src/lib/foundation-storage-sqlite.ts
@@ -4,6 +4,19 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { EventGameRecordRoot } from "@/lib/foundation-record-types";
 import {
+  appendGrantAudit,
+  createGrantSqliteStatements,
+  insertGrant,
+  insertGrantSession,
+  listGrantAudit,
+  listGrantSessions,
+  readGrantByStatement,
+  readSessionByStatement,
+  updateGrant,
+  updateGrantSession,
+  type GrantSqliteStatements,
+} from "@/lib/grant-storage-sqlite";
+import {
   assessMigrationReadiness,
   FOUNDATION_MIGRATION_LEDGER_SQL,
   FOUNDATION_MIGRATIONS,
@@ -14,6 +27,7 @@ import {
 import { verifyFoundationSchema, readValidatedFoundationRoot } from "@/lib/foundation-schema";
 import {
   FoundationStorageClosedError,
+  FoundationStorageConstraintError,
   FoundationStorageNotReadyError,
   isThenable,
   type FoundationStorage,
@@ -36,7 +50,7 @@ import {
   readMetadata,
   readStoredAction,
   readText,
-  translateSqliteConstraint,
+  translateSqliteConstraint as translateControlSqliteConstraint,
   type RootRow,
 } from "@/lib/foundation-storage-sqlite-helpers";
 
@@ -120,6 +134,7 @@ export class SqliteFoundationStorage implements FoundationStorage {
   private readonly beforeWriteTransactionLock: (() => void) | undefined;
   private writerTail: Promise<void> = Promise.resolve();
   private statements: RootStatements | undefined;
+  private grantStatements: GrantSqliteStatements | undefined;
   private closed = false;
   private revision = 0;
   private dataVersion: number;
@@ -367,6 +382,30 @@ export class SqliteFoundationStorage implements FoundationStorage {
       insertAction: (storedAction) => this.insertAction(statements, storedAction),
       upsertRecordMetadata: (metadata) => this.upsertRecordMetadata(statements, metadata),
       appendAuditEntry: (entry) => this.appendAuditEntry(statements, entry),
+      findGrantById: (grantId) =>
+        readGrantByStatement(this.getGrantStatements().byGrantId, grantId),
+      findGrantByCredentialLookupDigest: (lookupDigest) =>
+        readGrantByStatement(this.getGrantStatements().byCredentialDigest, lookupDigest),
+      findActiveSessionByGrantAndContext: (grantId, browserContextDigest) =>
+        readSessionByStatement(
+          this.getGrantStatements().activeSessionByContext,
+          grantId,
+          browserContextDigest,
+        ),
+      findSessionByBearerVerifier: (bearerLookupVerifier, bearerLookupKeyVersion) =>
+        readSessionByStatement(
+          this.getGrantStatements().sessionByBearer,
+          bearerLookupVerifier,
+          bearerLookupKeyVersion,
+        ),
+      listGrantSessions: (grantId) =>
+        listGrantSessions(this.getGrantStatements().sessionsByGrant, grantId),
+      listGrantAudit: (grantId) => listGrantAudit(this.getGrantStatements().auditByGrant, grantId),
+      insertGrant: (grant) => insertGrant(this.getGrantStatements(), grant),
+      updateGrant: (grant) => updateGrant(this.getGrantStatements(), grant),
+      insertGrantSession: (session) => insertGrantSession(this.getGrantStatements(), session),
+      updateGrantSession: (session) => updateGrantSession(this.getGrantStatements(), session),
+      appendGrantAudit: (entry) => appendGrantAudit(this.getGrantStatements(), entry),
     };
   }
 
@@ -600,6 +639,12 @@ export class SqliteFoundationStorage implements FoundationStorage {
     return this.statements;
   }
 
+  private getGrantStatements(): GrantSqliteStatements {
+    if (this.grantStatements !== undefined) return this.grantStatements;
+    this.grantStatements = createGrantSqliteStatements(this.database);
+    return this.grantStatements;
+  }
+
   private readMigrationState(): { ledgerExists: boolean; entries: MigrationLedgerEntry[] } {
     const ledgerExists = this.tableExists("foundation_migration_ledger");
     if (!ledgerExists) return { ledgerExists: false, entries: [] };
@@ -827,4 +872,38 @@ export async function validateFoundationMigrationCandidate(
   options: { retainCandidate?: boolean } = {},
 ): Promise<FoundationMigrationCandidateReport> {
   return storage.validateCandidate(options);
+}
+
+function translateSqliteConstraint(error: unknown): unknown {
+  if (!(error instanceof Error)) return error;
+  const message = error.message.toLowerCase();
+  if (message.includes("foundation_grant_roots.grant_id")) {
+    return new FoundationStorageConstraintError("grant-id");
+  }
+  if (message.includes("foundation_grant_roots.grant_version")) {
+    return new FoundationStorageConstraintError("grant-version");
+  }
+  if (message.includes("foundation_grant_roots.pitch_slot_id")) {
+    return new FoundationStorageConstraintError("grant-pitch-slot-id");
+  }
+  if (message.includes("foundation_grant_roots.credential_lookup_digest")) {
+    return new FoundationStorageConstraintError("grant-credential-digest");
+  }
+  if (
+    message.includes("foundation_grant_sessions_active_context") ||
+    (message.includes("foundation_grant_sessions.grant_id") &&
+      message.includes("browser_context_digest"))
+  ) {
+    return new FoundationStorageConstraintError("grant-session-context");
+  }
+  if (message.includes("foundation_grant_sessions.session_id")) {
+    return new FoundationStorageConstraintError("grant-session-id");
+  }
+  if (message.includes("foundation_grant_sessions.bearer_lookup_verifier")) {
+    return new FoundationStorageConstraintError("grant-session-verifier");
+  }
+  if (message.includes("foundation_grant_audit.audit_id")) {
+    return new FoundationStorageConstraintError("grant-audit-id");
+  }
+  return translateControlSqliteConstraint(error);
 }

--- a/src/lib/foundation-storage.ts
+++ b/src/lib/foundation-storage.ts
@@ -4,6 +4,11 @@ import type {
   ControlAuditEntry,
   EventGameRecordMetadata,
 } from "@/lib/event-game-actions";
+import type {
+  StoredControlGrant,
+  StoredGrantAuditEntry,
+  StoredGrantSession,
+} from "@/lib/grant-types";
 
 export type StoredEventGameRecordRoot = {
   root: EventGameRecordRoot;
@@ -62,6 +67,18 @@ export type FoundationStorageSnapshot = {
   listIdempotencyEntries(recordId: string): StoredControlIdempotencyEntry[];
   readRecordMetadata(recordId: string): StoredEventGameRecordMetadata | null;
   listAuditEntries(recordId: string): StoredControlAuditEntry[];
+  findGrantById(grantId: string): StoredControlGrant | null;
+  findGrantByCredentialLookupDigest(lookupDigest: string): StoredControlGrant | null;
+  findActiveSessionByGrantAndContext(
+    grantId: string,
+    browserContextDigest: string,
+  ): StoredGrantSession | null;
+  findSessionByBearerVerifier(
+    bearerLookupVerifier: string,
+    bearerLookupKeyVersion: string,
+  ): StoredGrantSession | null;
+  listGrantSessions(grantId: string): StoredGrantSession[];
+  listGrantAudit(grantId: string): StoredGrantAuditEntry[];
 };
 
 export type FoundationStorageTransaction = FoundationStorageSnapshot & {
@@ -69,6 +86,11 @@ export type FoundationStorageTransaction = FoundationStorageSnapshot & {
   insertAction(action: StoredControlAction): void;
   upsertRecordMetadata(metadata: StoredEventGameRecordMetadata): void;
   appendAuditEntry(entry: StoredControlAuditEntry): void;
+  insertGrant(grant: StoredControlGrant): void;
+  updateGrant(grant: StoredControlGrant): void;
+  insertGrantSession(session: StoredGrantSession): void;
+  updateGrantSession(session: StoredGrantSession): void;
+  appendGrantAudit(entry: StoredGrantAuditEntry): void;
 };
 
 export type FoundationStorageTransactionWork<T> = (transaction: FoundationStorageTransaction) => T;
@@ -90,7 +112,15 @@ export type FoundationStorageConstraint =
   | "pitch-slot-id"
   | "game-side-id"
   | "operation-id"
-  | "audit-id";
+  | "audit-id"
+  | "grant-id"
+  | "grant-version"
+  | "grant-pitch-slot-id"
+  | "grant-credential-digest"
+  | "grant-session-id"
+  | "grant-session-verifier"
+  | "grant-session-context"
+  | "grant-audit-id";
 
 export class FoundationStorageConstraintError extends Error {
   readonly constraint: FoundationStorageConstraint;

--- a/src/lib/grant-authority-concurrent-worker.ts
+++ b/src/lib/grant-authority-concurrent-worker.ts
@@ -1,0 +1,61 @@
+import { existsSync } from "node:fs";
+import { createGrantAuthority } from "@/lib/grant-authority";
+import { createGrantTestKeyRing, createGrantTestRandomness } from "@/lib/grant-authority-contract";
+import { readPrivateGrantCredential } from "@/lib/grant-concurrency-process";
+import { openSqliteFoundationStorage } from "@/lib/foundation-storage-sqlite";
+
+const [databasePath, readyPath, startPath, credentialPath, seedValue] = Bun.argv.slice(2);
+if (
+  databasePath === undefined ||
+  readyPath === undefined ||
+  startPath === undefined ||
+  credentialPath === undefined ||
+  seedValue === undefined
+) {
+  process.exit(2);
+}
+
+const storage = openSqliteFoundationStorage(databasePath);
+const authority = createGrantAuthority(storage, {
+  environmentId: "test-environment",
+  clock: { nowMs: () => 1_000 },
+  randomness: createGrantTestRandomness(Number(seedValue)),
+  keyRing: createGrantTestKeyRing(),
+  controlScopeResolver: {
+    resolve() {
+      return { status: "eligible", eventGameId: "game-1" };
+    },
+  },
+});
+
+try {
+  await Bun.write(readyPath, "ready");
+  const deadline = Date.now() + 5_000;
+  while (!existsSync(startPath)) {
+    if (Date.now() >= deadline) {
+      process.stdout.write(JSON.stringify({ status: "worker-timeout" }));
+      process.exitCode = 1;
+      break;
+    }
+    await Bun.sleep(2);
+  }
+  if (process.exitCode !== 1) {
+    const qrCredential = await readPrivateGrantCredential(credentialPath);
+    const result = await authority.admitControlGrant({
+      qrCredential,
+      browserContext: "browser-process-barrier",
+    });
+    process.stdout.write(
+      JSON.stringify(
+        result.status === "admitted"
+          ? { status: result.status, grantSessionId: result.grantSessionId }
+          : { status: result.status },
+      ),
+    );
+  }
+} catch {
+  process.stdout.write(JSON.stringify({ status: "worker-failed" }));
+  process.exitCode = 1;
+} finally {
+  storage.close();
+}

--- a/src/lib/grant-authority-contract.ts
+++ b/src/lib/grant-authority-contract.ts
@@ -1,0 +1,608 @@
+import { expect } from "bun:test";
+import { parseCredentialToken } from "@/lib/grant-crypto";
+import { registerGrantRotationContract } from "@/lib/grant-rotation-contract";
+import {
+  GENERIC_GRANT_ADMISSION_FAILURE,
+  createGrantAuthority,
+  type ControlGrantScope,
+  type ControlGrantScopeResolution,
+  type GrantAuthority,
+  type GrantAuthorityActor,
+  type GrantKeyRing,
+  type GrantRandomness,
+} from "@/lib/grant-authority";
+import type { FoundationStorage } from "@/lib/foundation-storage";
+import { FoundationStorageConstraintError } from "@/lib/foundation-storage";
+
+export type GrantAuthorityContractStorage = {
+  storage: FoundationStorage;
+  cleanup(): Promise<void> | void;
+};
+
+export type GrantAuthorityContractFactory = () =>
+  | GrantAuthorityContractStorage
+  | Promise<GrantAuthorityContractStorage>;
+
+export type GrantAuthorityContractRegistrar = (
+  name: string,
+  callback: () => void | Promise<void>,
+) => unknown;
+
+export function registerGrantAuthorityContract(
+  register: GrantAuthorityContractRegistrar,
+  createStorage: GrantAuthorityContractFactory,
+): void {
+  register(
+    "creates a scoped Control Grant, admits a device, and authorizes its session",
+    async () => {
+      await withStorage(createStorage, async (storage) => {
+        await runGrantScenario(storage);
+      });
+    },
+  );
+
+  register("derives pseudonymous audit actors from structured authority input", async () => {
+    await withStorage(createStorage, async (storage) => {
+      const authority = createAuthority(storage);
+      const bearerShapedActor = `session-${"a".repeat(43)}`;
+      const created = await authority.createControlGrant({
+        scope: createScope(),
+        actor: { kind: "fixture", id: bearerShapedActor },
+      });
+      expect(created.status).toBe("created");
+      if (created.status !== "created") throw new Error("Expected a created Control Grant.");
+
+      const audit = await readGrantAudit(authority, created.grantId);
+      const serialized = JSON.stringify(audit);
+      expect(serialized).not.toContain(bearerShapedActor);
+      expect(serialized).not.toContain("fixture-authority");
+      expect(audit[0]?.actorReference).toMatch(/^actor-[A-Za-z0-9_-]+$/);
+    });
+  });
+
+  register("replaces only the same browser context and redacts session evidence", async () => {
+    await withStorage(createStorage, async (storage) => {
+      const authority = createAuthority(storage);
+      const created = await createGrant(authority);
+      const stored = await storage.transaction((transaction) =>
+        transaction.findGrantById(created.grantId),
+      );
+      expect(stored?.credential.fingerprint).not.toBe(stored?.credential.lookupDigest);
+      const first = await admit(authority, created.qrCredential, "browser-a");
+      const otherContext = await admit(authority, created.qrCredential, "browser-b");
+      const replacement = await admit(authority, created.qrCredential, "browser-a");
+
+      expect(await authority.authorizeControlGrant({ sessionBearer: first.sessionBearer })).toEqual(
+        {
+          status: "rejected",
+          code: "grant-authorization-failed",
+          message: "Unable to authorize this Grant Session.",
+        },
+      );
+      expect(
+        await authority.authorizeControlGrant({ sessionBearer: otherContext.sessionBearer }),
+      ).toMatchObject({ status: "authorized", grantSessionId: otherContext.grantSessionId });
+      expect(
+        await authority.authorizeControlGrant({ sessionBearer: replacement.sessionBearer }),
+      ).toMatchObject({ status: "authorized", grantSessionId: replacement.grantSessionId });
+
+      const sessions = await readGrantSessions(authority, created.grantId);
+      expect(sessions).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ sessionId: first.grantSessionId, status: "revoked" }),
+          expect.objectContaining({ sessionId: otherContext.grantSessionId, status: "active" }),
+          expect.objectContaining({ sessionId: replacement.grantSessionId, status: "active" }),
+        ]),
+      );
+      const audit = await readGrantAudit(authority, created.grantId);
+      expect(audit).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            action: "session-replaced",
+            replacedSessionId: first.grantSessionId,
+          }),
+        ]),
+      );
+      const redacted = JSON.stringify({ audit, sessions });
+      expect(redacted).not.toContain(created.qrCredential);
+      expect(redacted).not.toContain(first.sessionBearer);
+      expect(redacted).not.toContain(otherContext.sessionBearer);
+      expect(redacted).not.toContain(replacement.sessionBearer);
+      await expectAtomicAuditRollback(storage, created.grantId);
+    });
+  });
+
+  register("uses generic failures and atomically expires the Grant lifecycle", async () => {
+    await withStorage(createStorage, async (storage) => {
+      const authority = createAuthority(storage);
+      const created = await createGrant(authority);
+      const wrongEnvironment = createAuthority(storage, { environmentId: "other-environment" });
+      const wrongScope = createAuthority(storage, {
+        resolve: () => ({ status: "mismatch", detail: "wrong scope" }),
+      });
+      const failures = await Promise.all([
+        authority.admitControlGrant({ qrCredential: "malformed", browserContext: "browser-a" }),
+        wrongEnvironment.admitControlGrant({
+          qrCredential: created.qrCredential,
+          browserContext: "browser-a",
+        }),
+        wrongScope.admitControlGrant({
+          qrCredential: created.qrCredential,
+          browserContext: "browser-a",
+        }),
+      ]);
+      for (const failure of failures) expect(failure).toEqual(GENERIC_GRANT_ADMISSION_FAILURE);
+
+      expect(await authority.disableControlGrant(created.grantId, createActor())).toMatchObject({
+        status: "updated",
+      });
+      expect(
+        await authority.admitControlGrant({
+          qrCredential: created.qrCredential,
+          browserContext: "browser-a",
+        }),
+      ).toEqual(GENERIC_GRANT_ADMISSION_FAILURE);
+      expect(await authority.revokeControlGrant(created.grantId, createActor())).toMatchObject({
+        status: "updated",
+      });
+    });
+
+    await withStorage(createStorage, async (storage) => {
+      let nowMs = 1_000;
+      const authority = createAuthority(storage, { nowMs: () => nowMs });
+      const expired = await authority.createControlGrant({
+        scope: createScope(),
+        actor: createActor(),
+        expiresAtMs: 1_100,
+      });
+      expect(expired.status).toBe("created");
+      if (expired.status !== "created") throw new Error("Expected an expiring Control Grant.");
+      const admitted = await admit(authority, expired.qrCredential, "browser-a");
+      nowMs = 1_100;
+      expect(
+        await authority.admitControlGrant({
+          qrCredential: expired.qrCredential,
+          browserContext: "browser-a",
+        }),
+      ).toEqual(GENERIC_GRANT_ADMISSION_FAILURE);
+      expect(
+        await authority.authorizeControlGrant({ sessionBearer: admitted.sessionBearer }),
+      ).toMatchObject({ status: "rejected" });
+
+      const lifecycle = await storage.transaction((transaction) => ({
+        grant: transaction.findGrantById(expired.grantId),
+        sessions: transaction.listGrantSessions(expired.grantId),
+        audit: transaction.listGrantAudit(expired.grantId),
+      }));
+      expect(lifecycle.grant?.status).toBe("expired");
+      expect(lifecycle.sessions).toEqual([
+        expect.objectContaining({ sessionId: admitted.grantSessionId, status: "expired" }),
+      ]);
+      expect(lifecycle.audit).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ action: "grant-expired", afterStatus: "expired" }),
+        ]),
+      );
+    });
+  });
+
+  register(
+    "erases every capability secret across terminal expiry states exactly once",
+    async () => {
+      await withStorage(createStorage, async (storage) => {
+        let nowMs = 1_000;
+        const authority = createAuthority(storage, { nowMs: () => nowMs });
+        const created = await authority.createControlGrant({
+          scope: createScope(),
+          actor: createActor(),
+          expiresAtMs: 1_100,
+        });
+        expect(created.status).toBe("created");
+        if (created.status !== "created") throw new Error("Expected an expiring Control Grant.");
+        const admitted = await admit(authority, created.qrCredential, "browser-a");
+        expect(await authority.disableControlGrant(created.grantId, createActor())).toMatchObject({
+          status: "updated",
+        });
+        nowMs = 1_100;
+
+        const firstAudit = await readGrantAudit(authority, created.grantId);
+        const secondAudit = await readGrantAudit(authority, created.grantId);
+        expect(secondAudit.filter((entry) => entry.action === "grant-expired")).toHaveLength(1);
+        expect(firstAudit.filter((entry) => entry.action === "grant-expired")).toHaveLength(1);
+        const stored = await storage.transaction((transaction) => ({
+          grant: transaction.findGrantById(created.grantId),
+          sessions: transaction.listGrantSessions(created.grantId),
+        }));
+        expect(stored.grant?.status).toBe("expired");
+        expect(stored.grant?.credential).toMatchObject({
+          materialState: "erased",
+          encryptionKeyVersion: null,
+          lookupKeyVersion: null,
+          iv: null,
+          ciphertext: null,
+          tag: null,
+          lookupDigest: null,
+        });
+        expect(stored.grant?.credential.fingerprint).toEqual(
+          expect.stringMatching(/^[A-Za-z0-9_-]+$/),
+        );
+        expect(stored.sessions).toEqual([
+          expect.objectContaining({
+            sessionId: admitted.grantSessionId,
+            status: "expired",
+            bearerMaterialState: "erased",
+            bearerLookupVerifier: null,
+            bearerLookupKeyVersion: null,
+          }),
+        ]);
+        expect(
+          await authority.rotateControlGrantCredentialKeys(created.grantId, createActor()),
+        ).toEqual({
+          status: "rejected",
+          reason: "unavailable",
+          detail: "The Grant credential cannot be rotated.",
+        });
+      });
+
+      await withStorage(createStorage, async (storage) => {
+        let nowMs = 1_000;
+        const authority = createAuthority(storage, { nowMs: () => nowMs });
+        const revoked = await authority.createControlGrant({
+          scope: createScope(),
+          actor: createActor(),
+          expiresAtMs: 1_100,
+        });
+        expect(revoked.status).toBe("created");
+        if (revoked.status !== "created") throw new Error("Expected an expiring Control Grant.");
+        expect(await authority.revokeControlGrant(revoked.grantId, createActor())).toMatchObject({
+          status: "updated",
+        });
+        nowMs = 1_100;
+        const audit = await readGrantAudit(authority, revoked.grantId);
+        const stored = await storage.transaction((transaction) =>
+          transaction.findGrantById(revoked.grantId),
+        );
+        expect(stored?.status).toBe("expired");
+        expect(audit.filter((entry) => entry.action === "grant-expired")).toHaveLength(1);
+      });
+    },
+  );
+
+  register("returns the typed session-context constraint from both adapter paths", async () => {
+    await withStorage(createStorage, async (storage) => {
+      const authority = createAuthority(storage);
+      const created = await createGrant(authority);
+      const admitted = await admit(authority, created.qrCredential, "browser-a");
+      const first = await storage.transaction((transaction) => {
+        const session = transaction.findSessionByBearerVerifier("unused", "unused");
+        return transaction.listGrantSessions(created.grantId)[0] ?? session;
+      });
+      if (first === null || first === undefined) throw new Error("Expected a stored session.");
+
+      let insertFailure: unknown;
+      try {
+        await storage.transaction((transaction) => {
+          transaction.insertGrantSession({
+            ...first,
+            sessionId: `${admitted.grantSessionId}-insert-conflict`,
+            bearerLookupVerifier: "different-verifier",
+            status: "active",
+            revokedAtMs: null,
+          });
+        });
+      } catch (error) {
+        insertFailure = error;
+      }
+      expect(insertFailure).toBeInstanceOf(FoundationStorageConstraintError);
+      expect((insertFailure as FoundationStorageConstraintError).constraint).toBe(
+        "grant-session-context",
+      );
+
+      let updateFailure: unknown;
+      try {
+        await storage.transaction((transaction) => {
+          transaction.insertGrantSession({
+            ...first,
+            sessionId: `${admitted.grantSessionId}-update-conflict`,
+            browserContextDigest: "different-context",
+            bearerLookupVerifier: "another-verifier",
+            status: "active",
+            revokedAtMs: null,
+          });
+          transaction.updateGrantSession({
+            ...first,
+            sessionId: `${admitted.grantSessionId}-update-conflict`,
+            bearerLookupVerifier: "another-verifier",
+            status: "active",
+            revokedAtMs: null,
+          });
+        });
+      } catch (error) {
+        updateFailure = error;
+      }
+      expect(updateFailure).toBeInstanceOf(FoundationStorageConstraintError);
+      expect((updateFailure as FoundationStorageConstraintError).constraint).toBe(
+        "grant-session-context",
+      );
+    });
+  });
+
+  register("contains storage failures behind typed redacted authority outcomes", async () => {
+    await withStorage(createStorage, async (storage) => {
+      const authority = createAuthority(createFailingStorage(storage));
+      const input = { scope: createScope(), actor: createActor() };
+      expect(await authority.createControlGrant(input)).toEqual({
+        status: "rejected",
+        reason: "unavailable",
+        detail: "Grant authority storage is temporarily unavailable.",
+      });
+      expect(await authority.revealControlGrant("grant-failure", createActor())).toEqual({
+        status: "rejected",
+        reason: "unavailable",
+        detail: "The Grant cannot be revealed.",
+      });
+      expect(await authority.disableControlGrant("grant-failure", createActor())).toEqual({
+        status: "rejected",
+        reason: "unavailable",
+        detail: "Grant authority storage is temporarily unavailable.",
+      });
+      expect(await authority.revokeControlGrant("grant-failure", createActor())).toEqual({
+        status: "rejected",
+        reason: "unavailable",
+        detail: "Grant authority storage is temporarily unavailable.",
+      });
+      expect(
+        await authority.rotateControlGrantCredentialKeys("grant-failure", createActor()),
+      ).toEqual({
+        status: "rejected",
+        reason: "unavailable",
+        detail: "The Grant credential cannot be rotated.",
+      });
+      expect(await authority.listGrantSessions("grant-failure")).toEqual({
+        status: "unavailable",
+        code: "grant-storage-unavailable",
+        message: "Grant authority storage is temporarily unavailable.",
+      });
+      expect(await authority.listGrantAudit("grant-failure")).toEqual({
+        status: "unavailable",
+        code: "grant-storage-unavailable",
+        message: "Grant authority storage is temporarily unavailable.",
+      });
+    });
+  });
+
+  registerGrantRotationContract(register, createStorage);
+}
+
+async function withStorage(
+  createStorage: GrantAuthorityContractFactory,
+  work: (storage: FoundationStorage) => Promise<void>,
+): Promise<void> {
+  const handle = await createStorage();
+  try {
+    await work(handle.storage);
+  } finally {
+    await handle.cleanup();
+  }
+}
+
+function createFailingStorage(storage: FoundationStorage): FoundationStorage {
+  return {
+    transaction<T>(): Promise<T> {
+      return Promise.reject(new Error("sqlite secret failure must not escape"));
+    },
+    readRoot(): Promise<null> {
+      return Promise.reject(new Error("sqlite secret failure must not escape"));
+    },
+    readActions(): Promise<never> {
+      return Promise.reject(new Error("sqlite secret failure must not escape"));
+    },
+    readIdempotencyEntries(): Promise<never> {
+      return Promise.reject(new Error("sqlite secret failure must not escape"));
+    },
+    readRecordMetadata(): Promise<never> {
+      return Promise.reject(new Error("sqlite secret failure must not escape"));
+    },
+    readAuditEntries(): Promise<never> {
+      return Promise.reject(new Error("sqlite secret failure must not escape"));
+    },
+    readiness() {
+      return storage.readiness();
+    },
+    close() {
+      storage.close();
+    },
+  };
+}
+
+async function runGrantScenario(storage: FoundationStorage): Promise<void> {
+  const authority = createAuthority(storage);
+  const created = await createGrant(authority);
+  const parsedCredential = parseCredentialToken(created.qrCredential);
+  expect(parsedCredential).not.toBeNull();
+  if (parsedCredential === null) throw new Error("Expected a parseable QR credential.");
+  expect(Buffer.from(parsedCredential.entropy, "base64url").byteLength).toBe(32);
+
+  const admitted = await admit(authority, created.qrCredential, "browser-a");
+  expect(admitted.grantId).toBe(created.grantId);
+  expect(admitted.eventGameId).toBe("game-1");
+  expect(admitted.sessionBearer).toEqual(expect.any(String));
+  expect(
+    await authority.authorizeControlGrant({ sessionBearer: admitted.sessionBearer }),
+  ).toMatchObject({
+    status: "authorized",
+    grantId: created.grantId,
+    eventGameId: "game-1",
+    scope: createScope(),
+  });
+}
+
+async function createGrant(authority: GrantAuthority) {
+  const result = await authority.createControlGrant({ scope: createScope(), actor: createActor() });
+  expect(result.status).toBe("created");
+  if (result.status !== "created") throw new Error("Expected a created Control Grant.");
+  return result;
+}
+
+async function admit(authority: GrantAuthority, qrCredential: string, browserContext: string) {
+  const result = await authority.admitControlGrant({ qrCredential, browserContext });
+  expect(result.status).toBe("admitted");
+  if (result.status !== "admitted") throw new Error("Expected an admitted Grant Session.");
+  return result;
+}
+
+async function readGrantSessions(authority: GrantAuthority, grantId: string) {
+  const result = await authority.listGrantSessions(grantId);
+  expect(result.status).toBe("ok");
+  if (result.status !== "ok") throw new Error("Expected Grant Session read evidence.");
+  return result.value;
+}
+
+async function readGrantAudit(authority: GrantAuthority, grantId: string) {
+  const result = await authority.listGrantAudit(grantId);
+  expect(result.status).toBe("ok");
+  if (result.status !== "ok") throw new Error("Expected Grant Audit read evidence.");
+  return result.value;
+}
+
+function createAuthority(
+  storage: FoundationStorage,
+  configuration: {
+    environmentId?: string;
+    keyRing?: GrantKeyRing;
+    randomness?: GrantRandomness;
+    nowMs?: () => number;
+    resolve?: (scope: ControlGrantScope) => ControlGrantScopeResolution;
+  } = {},
+): GrantAuthority {
+  return createGrantAuthority(storage, {
+    environmentId: configuration.environmentId ?? "test-environment",
+    clock: { nowMs: configuration.nowMs ?? (() => 1_000) },
+    randomness: configuration.randomness ?? createDeterministicRandomness(),
+    keyRing: configuration.keyRing ?? createKeyRing(),
+    controlScopeResolver: {
+      resolve(scope) {
+        if (configuration.resolve !== undefined) return configuration.resolve(scope);
+        expect(scope).toEqual(createScope());
+        return { status: "eligible", eventGameId: "game-1" };
+      },
+    },
+  });
+}
+
+export function createGrantTestScope(): ControlGrantScope {
+  return createScope();
+}
+
+export function createGrantTestKeyRing(): GrantKeyRing {
+  return createKeyRing();
+}
+
+export function createGrantTestRotatedKeyRing(original: GrantKeyRing): GrantKeyRing {
+  return createRotatedKeyRing(original);
+}
+
+export function createGrantTestCurrentOnlyKeyRing(keyRing: GrantKeyRing): GrantKeyRing {
+  return keepOnlyCurrentKeys(keyRing);
+}
+
+export function createGrantTestRandomness(seed = 0): GrantRandomness {
+  return createDeterministicRandomness(seed);
+}
+
+function createScope(): ControlGrantScope {
+  return {
+    eventId: "event-1",
+    gameDayId: "day-1",
+    pitchId: "pitch-1",
+    pitchSlotId: "slot-1",
+  };
+}
+
+function createActor(): GrantAuthorityActor {
+  return { kind: "fixture", id: "fixture-authority" };
+}
+
+function createDeterministicRandomness(seed = 0): GrantRandomness {
+  let randomCall = 0;
+  return {
+    bytes(length) {
+      randomCall += 1;
+      return Uint8Array.from({ length }, (_, index) => (index + length + randomCall + seed) % 256);
+    },
+  };
+}
+
+function createKeyRing(): GrantKeyRing {
+  return {
+    encryption: {
+      currentVersion: "encryption-v1",
+      keys: new Map([["encryption-v1", Uint8Array.from({ length: 32 }, (_, index) => index + 1)]]),
+    },
+    lookup: {
+      currentVersion: "lookup-v1",
+      keys: new Map([["lookup-v1", Uint8Array.from({ length: 32 }, (_, index) => index + 33)]]),
+    },
+  };
+}
+
+function createRotatedKeyRing(original: GrantKeyRing): GrantKeyRing {
+  return {
+    encryption: {
+      currentVersion: "encryption-v2",
+      keys: new Map([
+        ...original.encryption.keys,
+        ["encryption-v2", Uint8Array.from({ length: 32 }, (_, index) => index + 97)],
+      ]),
+    },
+    lookup: {
+      currentVersion: "lookup-v2",
+      keys: new Map([
+        ...original.lookup.keys,
+        ["lookup-v2", Uint8Array.from({ length: 32 }, (_, index) => index + 65)],
+      ]),
+    },
+  };
+}
+
+function keepOnlyCurrentKeys(keyRing: GrantKeyRing): GrantKeyRing {
+  const encryptionKey = keyRing.encryption.keys.get(keyRing.encryption.currentVersion);
+  const lookupKey = keyRing.lookup.keys.get(keyRing.lookup.currentVersion);
+  if (encryptionKey === undefined || lookupKey === undefined) {
+    throw new Error("Expected current Grant test keys.");
+  }
+  return {
+    encryption: {
+      currentVersion: keyRing.encryption.currentVersion,
+      keys: new Map([[keyRing.encryption.currentVersion, encryptionKey]]),
+    },
+    lookup: {
+      currentVersion: keyRing.lookup.currentVersion,
+      keys: new Map([[keyRing.lookup.currentVersion, lookupKey]]),
+    },
+  };
+}
+
+async function expectAtomicAuditRollback(storage: FoundationStorage, grantId: string) {
+  const audit = await storage.transaction((transaction) => transaction.listGrantAudit(grantId));
+  const firstAudit = audit[0];
+  if (firstAudit === undefined) throw new Error("Expected Grant audit evidence.");
+  let failure: unknown;
+  try {
+    await storage.transaction((transaction) => {
+      const grant = transaction.findGrantById(grantId);
+      if (grant === null) throw new Error("Expected the Grant.");
+      transaction.updateGrant({ ...grant, status: "disabled" });
+      transaction.appendGrantAudit(firstAudit);
+    });
+  } catch (error) {
+    failure = error;
+  }
+  expect(failure).toBeInstanceOf(Error);
+  expect(
+    (await storage.transaction((transaction) => transaction.findGrantById(grantId)))?.status,
+  ).toBe("active");
+  expect(
+    (await storage.transaction((transaction) => transaction.listGrantAudit(grantId))).length,
+  ).toBe(audit.length);
+}

--- a/src/lib/grant-authority-types.ts
+++ b/src/lib/grant-authority-types.ts
@@ -1,0 +1,130 @@
+import { GRANT_CREDENTIAL_FORMAT_VERSION, GRANT_TYPE } from "@/lib/grant-types";
+import type {
+  ControlGrantScope,
+  GrantAuthorityActor,
+  GrantSessionSummary,
+  StoredGrantAuditEntry,
+} from "@/lib/grant-types";
+
+export const GENERIC_GRANT_ADMISSION_FAILURE = Object.freeze({
+  status: "rejected",
+  code: "grant-admission-failed",
+  message: "Unable to admit this Grant.",
+} as const);
+
+export const GENERIC_GRANT_AUTHORIZATION_FAILURE = Object.freeze({
+  status: "rejected",
+  code: "grant-authorization-failed",
+  message: "Unable to authorize this Grant Session.",
+} as const);
+
+export const GENERIC_GRANT_STORAGE_FAILURE = Object.freeze({
+  status: "unavailable",
+  code: "grant-storage-unavailable",
+  message: "Grant authority storage is temporarily unavailable.",
+} as const);
+
+export type CreateControlGrantInput = {
+  scope: ControlGrantScope;
+  actor: GrantAuthorityActor;
+  expiresAtMs?: number | null;
+};
+
+export type CreateControlGrantResult =
+  | {
+      status: "created";
+      grantId: string;
+      grantVersion: string;
+      grantType: typeof GRANT_TYPE;
+      scope: ControlGrantScope;
+      qrCredential: string;
+      credentialFormatVersion: typeof GRANT_CREDENTIAL_FORMAT_VERSION;
+    }
+  | { status: "rejected"; reason: "invalid-input" | "unavailable"; detail: string };
+
+export type AdmitControlGrantInput = {
+  qrCredential: string;
+  browserContext: string;
+};
+
+export type AdmitControlGrantResult =
+  | {
+      status: "admitted";
+      grantId: string;
+      grantVersion: string;
+      grantType: typeof GRANT_TYPE;
+      scope: ControlGrantScope;
+      eventGameId: string;
+      grantSessionId: string;
+      sessionBearer: string;
+    }
+  | typeof GENERIC_GRANT_ADMISSION_FAILURE;
+
+export type AuthorizeControlGrantInput = {
+  sessionBearer: string;
+};
+
+export type AuthorizeControlGrantResult =
+  | {
+      status: "authorized";
+      grantId: string;
+      grantVersion: string;
+      grantType: typeof GRANT_TYPE;
+      scope: ControlGrantScope;
+      eventGameId: string;
+      grantSessionId: string;
+    }
+  | typeof GENERIC_GRANT_AUTHORIZATION_FAILURE;
+
+export type GrantMutationResult =
+  | { status: "updated"; grantId: string }
+  | {
+      status: "rejected";
+      reason: "not-found" | "invalid-input" | "unavailable";
+      detail?: string;
+    };
+
+export type RevealControlGrantResult =
+  | {
+      status: "revealed";
+      grantId: string;
+      grantVersion: string;
+      qrCredential: string;
+      credentialFormatVersion: typeof GRANT_CREDENTIAL_FORMAT_VERSION;
+    }
+  | { status: "rejected"; reason: "not-found" | "unavailable"; detail: string };
+
+export type RotateControlGrantCredentialKeysResult =
+  | {
+      status: "rotated";
+      grantId: string;
+      encryptionKeyVersion: string;
+      lookupKeyVersion: string;
+    }
+  | { status: "rejected"; reason: "not-found" | "unavailable"; detail: string };
+
+export type GrantSessionListResult =
+  | { status: "ok"; value: GrantSessionSummary[] }
+  | typeof GENERIC_GRANT_STORAGE_FAILURE;
+
+export type GrantAuditListResult =
+  | { status: "ok"; value: StoredGrantAuditEntry[] }
+  | typeof GENERIC_GRANT_STORAGE_FAILURE;
+
+export type GrantAuthority = {
+  createControlGrant(input: CreateControlGrantInput): Promise<CreateControlGrantResult>;
+  revealControlGrant(
+    grantId: string,
+    actor: GrantAuthorityActor,
+  ): Promise<RevealControlGrantResult>;
+  rotateControlGrantCredentialKeys(
+    grantId: string,
+    actor: GrantAuthorityActor,
+  ): Promise<RotateControlGrantCredentialKeysResult>;
+  admitControlGrant(input: AdmitControlGrantInput): Promise<AdmitControlGrantResult>;
+  authorizeControlGrant(input: AuthorizeControlGrantInput): Promise<AuthorizeControlGrantResult>;
+  disableControlGrant(grantId: string, actor: GrantAuthorityActor): Promise<GrantMutationResult>;
+  revokeControlGrant(grantId: string, actor: GrantAuthorityActor): Promise<GrantMutationResult>;
+  listGrantSessions(grantId: string): Promise<GrantSessionListResult>;
+  listGrantAudit(grantId: string): Promise<GrantAuditListResult>;
+};

--- a/src/lib/grant-authority.focused.ts
+++ b/src/lib/grant-authority.focused.ts
@@ -1,0 +1,402 @@
+import { describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { existsSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  createGrantAuthority,
+  type ControlGrantScope,
+  type GrantAuthority,
+  type GrantKeyRing,
+} from "@/lib/grant-authority";
+import {
+  createGrantTestKeyRing,
+  createGrantTestCurrentOnlyKeyRing,
+  createGrantTestRandomness,
+  createGrantTestRotatedKeyRing,
+  createGrantTestScope,
+  registerGrantAuthorityContract,
+  type GrantAuthorityContractStorage,
+} from "@/lib/grant-authority-contract";
+import { openSqliteFoundationStorage } from "@/lib/foundation-storage-sqlite";
+import {
+  buildGrantAdmissionWorkerCommand,
+  createGrantAdmissionWorkerEnvironment,
+  superviseGrantAdmissionWorkers,
+  writePrivateGrantCredential,
+} from "@/lib/grant-concurrency-process";
+import {
+  installProbeSignalHandlers,
+  spawnProbeCommand,
+} from "@/lib/sqlite-foundation-probe-process";
+
+describe("focused SQLite Grant authority boundary", () => {
+  registerGrantAuthorityContract(test, createStorage);
+
+  test("redacts credentials from SQLite and preserves lifecycle across restart", async () => {
+    const handle = await createStorage();
+    const databasePath = handle.databasePath;
+    const first = handle.storage;
+    try {
+      const authority = createAuthority(first, createGrantTestRandomness());
+      const created = await createGrant(authority);
+      const admitted = await admit(authority, created.qrCredential, "browser-a");
+      assertSQLiteSecretsAreRedacted(databasePath, created.qrCredential, admitted.sessionBearer);
+      first.close();
+
+      const reopened = openSqliteFoundationStorage(databasePath);
+      try {
+        const reopenedAuthority = createAuthority(reopened, createGrantTestRandomness());
+        expect(
+          await reopenedAuthority.revealControlGrant(created.grantId, createActor()),
+        ).toMatchObject({ status: "revealed", grantId: created.grantId });
+        const readmitted = await admit(reopenedAuthority, created.qrCredential, "browser-b");
+        expect(
+          await reopenedAuthority.authorizeControlGrant({
+            sessionBearer: readmitted.sessionBearer,
+          }),
+        ).toMatchObject({ status: "authorized", grantId: created.grantId });
+      } finally {
+        reopened.close();
+      }
+    } finally {
+      await handle.cleanup();
+    }
+  });
+
+  test("persists cryptographic erasure through raw SQLite rows and restart", async () => {
+    let nowMs = 1_000;
+    const handle = await createStorage();
+    const authority = createAuthority(
+      handle.storage,
+      createGrantTestRandomness(),
+      createGrantTestKeyRing(),
+      () => nowMs,
+    );
+    try {
+      const created = await createGrant(authority, 1_100);
+      const admitted = await admit(authority, created.qrCredential, "browser-erasure");
+      nowMs = 1_100;
+      const auditResult = await authority.listGrantAudit(created.grantId);
+      expect(auditResult.status).toBe("ok");
+      if (auditResult.status !== "ok") throw new Error("Expected audit read evidence.");
+      expect(auditResult.value.filter((entry) => entry.action === "grant-expired")).toHaveLength(1);
+      assertSQLiteGrantSecretsAreErased(
+        handle.databasePath,
+        created.grantId,
+        admitted.grantSessionId,
+      );
+      handle.storage.close();
+
+      const reopened = openSqliteFoundationStorage(handle.databasePath);
+      try {
+        const reopenedAuthority = createAuthority(
+          reopened,
+          createGrantTestRandomness(),
+          createGrantTestKeyRing(),
+          () => nowMs,
+        );
+        const reopenedAudit = await reopenedAuthority.listGrantAudit(created.grantId);
+        expect(reopenedAudit.status).toBe("ok");
+        if (reopenedAudit.status !== "ok") throw new Error("Expected restarted audit evidence.");
+        expect(
+          reopenedAudit.value.filter((entry) => entry.action === "grant-expired"),
+        ).toHaveLength(1);
+        assertSQLiteGrantSecretsAreErased(
+          handle.databasePath,
+          created.grantId,
+          admitted.grantSessionId,
+        );
+      } finally {
+        reopened.close();
+      }
+    } finally {
+      await handle.cleanup();
+    }
+  });
+
+  test("persists atomic credential key rotation across restart", async () => {
+    const handle = await createStorage();
+    const originalKeyRing = createGrantTestKeyRing();
+    const rotatedKeyRing = createGrantTestRotatedKeyRing(originalKeyRing);
+    try {
+      const original = createAuthority(
+        handle.storage,
+        createGrantTestRandomness(),
+        originalKeyRing,
+      );
+      const created = await createGrant(original);
+      handle.storage.close();
+
+      const rotatingStorage = openSqliteFoundationStorage(handle.databasePath);
+      const rotating = createAuthority(
+        rotatingStorage,
+        createGrantTestRandomness(20),
+        rotatedKeyRing,
+      );
+      expect(
+        await rotating.rotateControlGrantCredentialKeys(created.grantId, createActor()),
+      ).toMatchObject({
+        status: "rotated",
+        encryptionKeyVersion: "encryption-v2",
+        lookupKeyVersion: "lookup-v2",
+      });
+      rotatingStorage.close();
+
+      const reopened = openSqliteFoundationStorage(handle.databasePath);
+      try {
+        const currentOnly = createAuthority(
+          reopened,
+          createGrantTestRandomness(40),
+          createGrantTestCurrentOnlyKeyRing(rotatedKeyRing),
+        );
+        expect(
+          await admit(currentOnly, created.qrCredential, "browser-after-rotation"),
+        ).toMatchObject({ grantId: created.grantId });
+        const audit = await currentOnly.listGrantAudit(created.grantId);
+        expect(audit.status).toBe("ok");
+        if (audit.status !== "ok") throw new Error("Expected rotation audit evidence.");
+        expect(audit.value.filter((entry) => entry.action === "credential-rotated")).toHaveLength(
+          1,
+        );
+        expect(JSON.stringify(audit)).not.toContain(created.qrCredential);
+        const database = new Database(handle.databasePath);
+        try {
+          expect(
+            database
+              .query(
+                `SELECT encryption_key_version, lookup_key_version
+                 FROM foundation_grant_roots WHERE grant_id = ?`,
+              )
+              .get(created.grantId),
+          ).toEqual({ encryption_key_version: "encryption-v2", lookup_key_version: "lookup-v2" });
+        } finally {
+          database.close();
+        }
+      } finally {
+        reopened.close();
+      }
+    } finally {
+      await handle.cleanup();
+    }
+  });
+
+  test("serializes concurrent same-context admission across independent SQLite instances", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "quadball-timer-grant-concurrent-"));
+    const databasePath = join(directory, "foundation.sqlite");
+    const creator = openSqliteFoundationStorage(databasePath);
+    try {
+      await creator.applyMigrations();
+      const created = await createGrant(createAuthority(creator, createGrantTestRandomness(1)));
+      creator.close();
+      const readyPaths = [join(directory, "worker-a.ready"), join(directory, "worker-b.ready")];
+      const startPath = join(directory, "workers.start");
+      const credentialPath = join(directory, "credential.private");
+      const workerPath = join(import.meta.dir, "grant-authority-concurrent-worker.ts");
+      await writePrivateGrantCredential(credentialPath, created.qrCredential);
+      const environment = createGrantAdmissionWorkerEnvironment(directory);
+      const commands = [10, 20].map((seed, index) =>
+        buildGrantAdmissionWorkerCommand({
+          executablePath: process.execPath,
+          workerPath,
+          databasePath,
+          readyPath: readyPaths[index] ?? join(directory, `worker-${index}.ready`),
+          startPath,
+          credentialPath,
+          seed,
+        }),
+      );
+      expect(JSON.stringify({ commands, environment })).not.toContain(created.qrCredential);
+      const workers = commands.map((command) =>
+        spawnProbeCommand(command, { env: environment, detached: true }),
+      );
+      const signals = installProbeSignalHandlers();
+      try {
+        const workerResults = await superviseGrantAdmissionWorkers({
+          workers,
+          readyPaths,
+          startPath,
+          artifactPaths: [...readyPaths, startPath, credentialPath],
+          signal: signals.signal,
+        });
+        expect(workers.every((worker) => worker.process.exitCode !== null)).toBe(true);
+        const results = workerResults.map(
+          (result) => JSON.parse(result.stdout) as WorkerAdmissionResult,
+        );
+        expect(await Bun.file(credentialPath).exists()).toBe(false);
+        const leftResult = results[0];
+        const rightResult = results[1];
+        expect(leftResult?.status).toBe("admitted");
+        expect(rightResult?.status).toBe("admitted");
+        if (leftResult?.status !== "admitted" || rightResult?.status !== "admitted") {
+          throw new Error("Expected both concurrent admissions to commit.");
+        }
+
+        const reader = openSqliteFoundationStorage(databasePath);
+        try {
+          const readerAuthority = createAuthority(reader, createGrantTestRandomness(30));
+          const sessionsResult = await readerAuthority.listGrantSessions(created.grantId);
+          expect(sessionsResult.status).toBe("ok");
+          if (sessionsResult.status !== "ok") throw new Error("Expected session read evidence.");
+          const sessions = sessionsResult.value;
+          const active = sessions.filter((session) => session.status === "active");
+          expect(active).toHaveLength(1);
+          const admittedIds = new Set([leftResult.grantSessionId, rightResult.grantSessionId]);
+          expect(admittedIds).toHaveLength(2);
+          expect(admittedIds.has(active[0]?.sessionId ?? "")).toBe(true);
+          const revoked = sessions.find((session) => session.status === "revoked");
+          expect(revoked).toBeDefined();
+          const auditResult = await readerAuthority.listGrantAudit(created.grantId);
+          expect(auditResult.status).toBe("ok");
+          if (auditResult.status !== "ok") throw new Error("Expected audit read evidence.");
+          const audit = auditResult.value;
+          expect(audit).toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({ action: "session-admitted" }),
+              expect.objectContaining({
+                action: "session-replaced",
+                replacedSessionId: revoked?.sessionId,
+              }),
+            ]),
+          );
+        } finally {
+          reader.close();
+        }
+      } finally {
+        signals.cleanup();
+      }
+    } finally {
+      creator.close();
+      await rm(directory, { recursive: true, force: true });
+      expect(existsSync(directory)).toBe(false);
+    }
+  });
+});
+
+type WorkerAdmissionResult = { status: string; grantSessionId?: string };
+
+type SqliteGrantStorage = GrantAuthorityContractStorage & { databasePath: string };
+
+async function createStorage(): Promise<SqliteGrantStorage> {
+  const directory = await mkdtemp(join(tmpdir(), "quadball-timer-grant-focused-"));
+  const databasePath = join(directory, "foundation.sqlite");
+  const storage = openSqliteFoundationStorage(databasePath);
+  try {
+    await storage.applyMigrations();
+  } catch (error) {
+    storage.close();
+    await rm(directory, { recursive: true, force: true });
+    throw error;
+  }
+  return {
+    storage,
+    databasePath,
+    cleanup: async () => {
+      storage.close();
+      await rm(directory, { recursive: true, force: true });
+    },
+  };
+}
+
+function createAuthority(
+  storage: SqliteGrantStorage["storage"],
+  randomness: ReturnType<typeof createGrantTestRandomness>,
+  keyRing: GrantKeyRing = createGrantTestKeyRing(),
+  nowMs: () => number = () => 1_000,
+): GrantAuthority {
+  return createGrantAuthority(storage, {
+    environmentId: "test-environment",
+    clock: { nowMs },
+    randomness,
+    keyRing,
+    controlScopeResolver: {
+      resolve(scope: ControlGrantScope) {
+        expect(scope).toEqual(createGrantTestScope());
+        return { status: "eligible", eventGameId: "game-1" };
+      },
+    },
+  });
+}
+
+async function createGrant(authority: GrantAuthority, expiresAtMs?: number) {
+  const result = await authority.createControlGrant({
+    scope: createGrantTestScope(),
+    actor: createActor(),
+    expiresAtMs,
+  });
+  expect(result.status).toBe("created");
+  if (result.status !== "created") throw new Error("Expected a created Control Grant.");
+  return result;
+}
+
+function assertSQLiteGrantSecretsAreErased(
+  databasePath: string,
+  grantId: string,
+  sessionId: string,
+): void {
+  const database = new Database(databasePath);
+  try {
+    const grant = database
+      .query(
+        `SELECT credential_material_state, encryption_key_version, lookup_key_version,
+                credential_iv, credential_ciphertext, credential_tag,
+                credential_lookup_digest, credential_fingerprint
+         FROM foundation_grant_roots WHERE grant_id = ?`,
+      )
+      .get(grantId) as Record<string, unknown> | null;
+    expect(grant).toMatchObject({
+      credential_material_state: "erased",
+      encryption_key_version: null,
+      lookup_key_version: null,
+      credential_iv: null,
+      credential_ciphertext: null,
+      credential_tag: null,
+      credential_lookup_digest: null,
+    });
+    expect(typeof grant?.credential_fingerprint).toBe("string");
+    const session = database
+      .query(
+        `SELECT bearer_material_state, bearer_lookup_verifier, bearer_lookup_key_version
+         FROM foundation_grant_sessions WHERE session_id = ?`,
+      )
+      .get(sessionId) as Record<string, unknown> | null;
+    expect(session).toEqual({
+      bearer_material_state: "erased",
+      bearer_lookup_verifier: null,
+      bearer_lookup_key_version: null,
+    });
+  } finally {
+    database.close();
+  }
+}
+
+async function admit(authority: GrantAuthority, qrCredential: string, browserContext: string) {
+  const result = await authority.admitControlGrant({ qrCredential, browserContext });
+  expect(result.status).toBe("admitted");
+  if (result.status !== "admitted") throw new Error("Expected an admitted Grant Session.");
+  return result;
+}
+
+function createActor() {
+  return { kind: "fixture" as const, id: "fixture-authority" };
+}
+
+function assertSQLiteSecretsAreRedacted(
+  databasePath: string,
+  qrCredential: string,
+  sessionBearer: string,
+): void {
+  const database = new Database(databasePath);
+  try {
+    const serialized = JSON.stringify({
+      grants: database.query("SELECT * FROM foundation_grant_roots").all(),
+      sessions: database.query("SELECT * FROM foundation_grant_sessions").all(),
+      audit: database.query("SELECT * FROM foundation_grant_audit").all(),
+    });
+    expect(serialized).not.toContain(qrCredential);
+    expect(serialized).not.toContain(sessionBearer);
+  } finally {
+    database.close();
+  }
+}

--- a/src/lib/grant-authority.test.ts
+++ b/src/lib/grant-authority.test.ts
@@ -1,0 +1,13 @@
+import { describe, test } from "bun:test";
+import {
+  registerGrantAuthorityContract,
+  type GrantAuthorityContractStorage,
+} from "@/lib/grant-authority-contract";
+import { createInMemoryFoundationStorage } from "@/lib/foundation-storage-memory";
+
+describe("grant authority (memory)", () => {
+  registerGrantAuthorityContract(test, (): GrantAuthorityContractStorage => {
+    const storage = createInMemoryFoundationStorage();
+    return { storage, cleanup: () => storage.close() };
+  });
+});

--- a/src/lib/grant-authority.ts
+++ b/src/lib/grant-authority.ts
@@ -1,0 +1,644 @@
+import {
+  computeBrowserContextDigest,
+  computeLookupDigest,
+  computeSessionVerifier,
+  createCredentialToken,
+  createRandomIdentifier,
+  decryptCredential,
+  encryptCredential,
+  listLookupKeyVersions,
+  parseCredentialToken,
+  sameSecret,
+} from "@/lib/grant-crypto";
+import {
+  FoundationStorageConstraintError,
+  type FoundationStorage,
+  type FoundationStorageConstraint,
+} from "@/lib/foundation-storage";
+import {
+  GRANT_CREDENTIAL_FORMAT_VERSION,
+  GRANT_TYPE,
+  validateControlGrantScope,
+  type ControlGrantScope,
+  type ControlGrantScopeResolver,
+  type GrantClock,
+  type GrantAuthorityActor,
+  type GrantKeyRing,
+  type GrantRandomness,
+  type GrantSessionSummary,
+  type StoredControlGrant,
+  type StoredGrantSession,
+  type StoredGrantStatus,
+} from "@/lib/grant-types";
+import {
+  GENERIC_GRANT_ADMISSION_FAILURE,
+  GENERIC_GRANT_AUTHORIZATION_FAILURE,
+  GENERIC_GRANT_STORAGE_FAILURE,
+  type AdmitControlGrantInput,
+  type AdmitControlGrantResult,
+  type AuthorizeControlGrantInput,
+  type AuthorizeControlGrantResult,
+  type CreateControlGrantInput,
+  type CreateControlGrantResult,
+  type GrantAuditListResult,
+  type GrantAuthority,
+  type GrantMutationResult,
+  type GrantSessionListResult,
+  type RevealControlGrantResult,
+} from "@/lib/grant-authority-types";
+import { createAuditEntry, expireGrantIfDue, validateActor } from "@/lib/grant-lifecycle";
+import { rotateControlGrantCredentialKeys } from "@/lib/grant-rotation";
+import { validateOpaqueIdentifier } from "@/lib/validation-policy";
+
+export type {
+  ControlGrantScope,
+  ControlGrantScopeResolution,
+  ControlGrantScopeResolver,
+  GrantClock,
+  GrantAuthorityActor,
+  GrantKeyRing,
+  GrantRandomness,
+} from "@/lib/grant-types";
+
+export type GrantAuthorityOptions = {
+  environmentId: string;
+  clock: GrantClock;
+  randomness: GrantRandomness;
+  keyRing: GrantKeyRing;
+  controlScopeResolver: ControlGrantScopeResolver;
+};
+
+export type {
+  AdmitControlGrantInput,
+  AdmitControlGrantResult,
+  AuthorizeControlGrantInput,
+  AuthorizeControlGrantResult,
+  CreateControlGrantInput,
+  CreateControlGrantResult,
+  GrantAuditListResult,
+  GrantAuthority,
+  GrantMutationResult,
+  GrantSessionListResult,
+  RevealControlGrantResult,
+  RotateControlGrantCredentialKeysResult,
+} from "@/lib/grant-authority-types";
+export {
+  GENERIC_GRANT_ADMISSION_FAILURE,
+  GENERIC_GRANT_STORAGE_FAILURE,
+} from "@/lib/grant-authority-types";
+
+export function createGrantAuthority(
+  storage: FoundationStorage,
+  options: GrantAuthorityOptions,
+): GrantAuthority {
+  const environmentId = validateIdentifier(options.environmentId, "environmentId");
+  validateKeyConfiguration(options.keyRing);
+
+  return {
+    createControlGrant(input) {
+      return createControlGrant(storage, options, environmentId, input);
+    },
+    revealControlGrant(grantId, actor) {
+      return revealControlGrant(storage, options, environmentId, grantId, actor);
+    },
+    rotateControlGrantCredentialKeys(grantId, actor) {
+      return rotateControlGrantCredentialKeys(storage, options, environmentId, grantId, actor);
+    },
+    admitControlGrant(input) {
+      return admitControlGrant(storage, options, environmentId, input);
+    },
+    authorizeControlGrant(input) {
+      return authorizeControlGrant(storage, options, input);
+    },
+    disableControlGrant(grantId, actor) {
+      return updateGrantStatus(storage, options, grantId, "disabled", "grant-disabled", actor);
+    },
+    revokeControlGrant(grantId, actor) {
+      return updateGrantStatus(storage, options, grantId, "revoked", "grant-revoked", actor);
+    },
+    listGrantSessions(grantId) {
+      return storage
+        .transaction((transaction) => {
+          const grant = transaction.findGrantById(grantId);
+          if (grant !== null) expireGrantIfDue(transaction, options, grant);
+          return transaction.listGrantSessions(grantId).map(toSessionSummary);
+        })
+        .then((value) => ({ status: "ok", value }) satisfies GrantSessionListResult)
+        .catch(() => GENERIC_GRANT_STORAGE_FAILURE);
+    },
+    listGrantAudit(grantId) {
+      return storage
+        .transaction((transaction) => {
+          const grant = transaction.findGrantById(grantId);
+          if (grant !== null) expireGrantIfDue(transaction, options, grant);
+          return transaction.listGrantAudit(grantId);
+        })
+        .then((value) => ({ status: "ok", value }) satisfies GrantAuditListResult)
+        .catch(() => GENERIC_GRANT_STORAGE_FAILURE);
+    },
+  };
+}
+
+async function createControlGrant(
+  storage: FoundationStorage,
+  options: GrantAuthorityOptions,
+  environmentId: string,
+  input: CreateControlGrantInput,
+): Promise<CreateControlGrantResult> {
+  if (!isRecord(input)) {
+    return {
+      status: "rejected",
+      reason: "invalid-input",
+      detail: "Control Grant input must be an object.",
+    };
+  }
+  const scope = validateControlGrantScope(input.scope);
+  if (!scope.ok) return { status: "rejected", reason: "invalid-input", detail: scope.error };
+  const actor = validateActor(input.actor);
+  if (!actor.ok) {
+    return { status: "rejected", reason: "invalid-input", detail: actor.error };
+  }
+  const nowMs = readNow(options.clock);
+  const expiresAtMs = input.expiresAtMs ?? null;
+  if (expiresAtMs !== null && (!Number.isSafeInteger(expiresAtMs) || expiresAtMs <= nowMs)) {
+    return {
+      status: "rejected",
+      reason: "invalid-input",
+      detail: "expiresAtMs must be a safe timestamp after the current time.",
+    };
+  }
+
+  const grantId = createRandomIdentifier("grant", options.randomness);
+  const grantVersion = createRandomIdentifier("grant-version", options.randomness);
+  const binding = {
+    environmentId,
+    grantId,
+    grantType: GRANT_TYPE,
+    grantVersion,
+    scope: scope.value,
+  } as const;
+  const qrCredential = createCredentialToken(binding, options.randomness);
+  const credential = encryptCredential(qrCredential, binding, options.randomness, options.keyRing);
+  const grant: StoredControlGrant = {
+    grantId,
+    grantType: GRANT_TYPE,
+    grantVersion,
+    scope: scope.value,
+    status: "active",
+    createdAtMs: nowMs,
+    expiresAtMs,
+    credential,
+  };
+  const audit = createAuditEntry(options, {
+    action: "grant-created",
+    actor: { kind: "authority", value: actor.value },
+    grant,
+    sessionId: null,
+    replacedSessionId: null,
+    eventGameId: null,
+    beforeStatus: null,
+    afterStatus: "active",
+  });
+
+  try {
+    await storage.transaction((transaction) => {
+      transaction.insertGrant(grant);
+      transaction.appendGrantAudit(audit);
+    });
+  } catch (error) {
+    if (isGrantIdentityConstraint(error)) {
+      return {
+        status: "rejected",
+        reason: "invalid-input",
+        detail: "The Control Grant identity conflicts with existing authority.",
+      };
+    }
+    return {
+      status: "rejected",
+      reason: "unavailable",
+      detail: "Grant authority storage is temporarily unavailable.",
+    };
+  }
+
+  return {
+    status: "created",
+    grantId,
+    grantVersion,
+    grantType: GRANT_TYPE,
+    scope: structuredClone(scope.value),
+    qrCredential,
+    credentialFormatVersion: GRANT_CREDENTIAL_FORMAT_VERSION,
+  };
+}
+
+async function revealControlGrant(
+  storage: FoundationStorage,
+  options: GrantAuthorityOptions,
+  environmentId: string,
+  grantId: string,
+  actorInput: GrantAuthorityActor,
+): Promise<RevealControlGrantResult> {
+  const actor = validateActor(actorInput);
+  if (!actor.ok) {
+    return { status: "rejected", reason: "unavailable", detail: "The Grant cannot be revealed." };
+  }
+
+  return storage
+    .transaction<RevealControlGrantResult>((transaction) => {
+      const storedGrant = transaction.findGrantById(grantId);
+      if (storedGrant === null) {
+        return { status: "rejected", reason: "not-found", detail: "The Grant was not found." };
+      }
+      const grant = expireGrantIfDue(transaction, options, storedGrant);
+      if (grant.status !== "active") {
+        return {
+          status: "rejected",
+          reason: "unavailable",
+          detail: "The Grant cannot be revealed.",
+        };
+      }
+      const token = decryptCredential(
+        grant.credential,
+        bindingForGrant(environmentId, grant),
+        options.keyRing,
+      );
+      if (token === null || !credentialMatches(token, environmentId, grant)) {
+        return {
+          status: "rejected",
+          reason: "unavailable",
+          detail: "The Grant cannot be revealed.",
+        };
+      }
+      transaction.appendGrantAudit(
+        createAuditEntry(options, {
+          action: "credential-revealed",
+          actor: { kind: "authority", value: actor.value },
+          grant,
+          sessionId: null,
+          replacedSessionId: null,
+          eventGameId: null,
+          beforeStatus: grant.status,
+          afterStatus: grant.status,
+        }),
+      );
+      return {
+        status: "revealed",
+        grantId: grant.grantId,
+        grantVersion: grant.grantVersion,
+        qrCredential: token,
+        credentialFormatVersion: GRANT_CREDENTIAL_FORMAT_VERSION,
+      };
+    })
+    .catch((): RevealControlGrantResult => ({
+      status: "rejected",
+      reason: "unavailable",
+      detail: "The Grant cannot be revealed.",
+    }));
+}
+
+async function admitControlGrant(
+  storage: FoundationStorage,
+  options: GrantAuthorityOptions,
+  environmentId: string,
+  input: AdmitControlGrantInput,
+): Promise<AdmitControlGrantResult> {
+  if (
+    !isRecord(input) ||
+    !isValidBrowserContext(input.browserContext) ||
+    !isValidCredential(input.qrCredential)
+  ) {
+    return GENERIC_GRANT_ADMISSION_FAILURE;
+  }
+
+  try {
+    return await storage.transaction((transaction) => {
+      let grant: StoredControlGrant | null = null;
+      for (const keyVersion of listLookupKeyVersions(options.keyRing)) {
+        const lookupDigest = computeLookupDigest(input.qrCredential, options.keyRing, keyVersion);
+        grant = transaction.findGrantByCredentialLookupDigest(lookupDigest);
+        if (grant !== null) break;
+      }
+      if (grant === null) return GENERIC_GRANT_ADMISSION_FAILURE;
+      grant = expireGrantIfDue(transaction, options, grant);
+      if (grant.status !== "active") {
+        return GENERIC_GRANT_ADMISSION_FAILURE;
+      }
+      if (
+        grant.credential.materialState !== "present" ||
+        grant.credential.lookupDigest === null ||
+        grant.credential.lookupKeyVersion === null
+      ) {
+        return GENERIC_GRANT_ADMISSION_FAILURE;
+      }
+
+      const decrypted = decryptCredential(
+        grant.credential,
+        bindingForGrant(environmentId, grant),
+        options.keyRing,
+      );
+      if (
+        decrypted === null ||
+        !sameSecret(decrypted, input.qrCredential) ||
+        !credentialMatches(decrypted, environmentId, grant) ||
+        !sameSecret(
+          grant.credential.lookupDigest,
+          computeLookupDigest(decrypted, options.keyRing, grant.credential.lookupKeyVersion),
+        )
+      ) {
+        return GENERIC_GRANT_ADMISSION_FAILURE;
+      }
+
+      const resolved = options.controlScopeResolver.resolve(grant.scope);
+      if (resolved.status !== "eligible" || !isValidEventGameId(resolved.eventGameId)) {
+        return GENERIC_GRANT_ADMISSION_FAILURE;
+      }
+
+      const nowMs = readNow(options.clock);
+      const lookupKeyVersion = options.keyRing.lookup.currentVersion;
+      let previousSession: StoredGrantSession | null = null;
+      for (const keyVersion of listLookupKeyVersions(options.keyRing)) {
+        previousSession = transaction.findActiveSessionByGrantAndContext(
+          grant.grantId,
+          computeBrowserContextDigest(input.browserContext, options.keyRing, keyVersion),
+        );
+        if (previousSession !== null) break;
+      }
+      const browserContextDigest = computeBrowserContextDigest(
+        input.browserContext,
+        options.keyRing,
+        lookupKeyVersion,
+      );
+      if (previousSession !== null) {
+        transaction.updateGrantSession({
+          ...previousSession,
+          status: "revoked",
+          revokedAtMs: nowMs,
+        });
+      }
+
+      const sessionBearerBytes = options.randomness.bytes(32);
+      if (sessionBearerBytes.byteLength !== 32) {
+        throw new Error("Injected session randomness has an invalid size.");
+      }
+      const sessionBearer = Buffer.from(sessionBearerBytes).toString("base64url");
+      const session: StoredGrantSession = {
+        sessionId: createRandomIdentifier("grant-session", options.randomness),
+        grantId: grant.grantId,
+        grantVersion: grant.grantVersion,
+        eventGameId: resolved.eventGameId,
+        browserContextDigest,
+        browserContextKeyVersion: lookupKeyVersion,
+        bearerMaterialState: "present",
+        bearerLookupVerifier: computeSessionVerifier(
+          sessionBearer,
+          options.keyRing,
+          lookupKeyVersion,
+        ),
+        bearerLookupKeyVersion: lookupKeyVersion,
+        status: "active",
+        createdAtMs: nowMs,
+        lastActiveAtMs: nowMs,
+        revokedAtMs: null,
+      };
+      transaction.insertGrantSession(session);
+      transaction.appendGrantAudit(
+        createAuditEntry(options, {
+          action: previousSession === null ? "session-admitted" : "session-replaced",
+          actor: { kind: "session", sessionId: session.sessionId },
+          grant,
+          sessionId: session.sessionId,
+          replacedSessionId: previousSession?.sessionId ?? null,
+          eventGameId: session.eventGameId,
+          beforeStatus: previousSession?.status === "active" ? "active" : null,
+          afterStatus: "active",
+        }),
+      );
+
+      return {
+        status: "admitted",
+        grantId: grant.grantId,
+        grantVersion: grant.grantVersion,
+        grantType: GRANT_TYPE,
+        scope: structuredClone(grant.scope),
+        eventGameId: session.eventGameId,
+        grantSessionId: session.sessionId,
+        sessionBearer,
+      };
+    });
+  } catch {
+    return GENERIC_GRANT_ADMISSION_FAILURE;
+  }
+}
+
+async function authorizeControlGrant(
+  storage: FoundationStorage,
+  options: GrantAuthorityOptions,
+  input: AuthorizeControlGrantInput,
+): Promise<AuthorizeControlGrantResult> {
+  if (!isRecord(input) || !isValidBearer(input.sessionBearer)) {
+    return GENERIC_GRANT_AUTHORIZATION_FAILURE;
+  }
+
+  try {
+    return await storage.transaction((transaction) => {
+      let session: StoredGrantSession | null = null;
+      for (const keyVersion of listLookupKeyVersions(options.keyRing)) {
+        const verifier = computeSessionVerifier(input.sessionBearer, options.keyRing, keyVersion);
+        session = transaction.findSessionByBearerVerifier(verifier, keyVersion);
+        if (session !== null) break;
+      }
+      if (session === null) {
+        return GENERIC_GRANT_AUTHORIZATION_FAILURE;
+      }
+
+      const storedGrant = transaction.findGrantById(session.grantId);
+      if (storedGrant === null) return GENERIC_GRANT_AUTHORIZATION_FAILURE;
+      const grant = expireGrantIfDue(transaction, options, storedGrant);
+      if (
+        session.status !== "active" ||
+        grant.status !== "active" ||
+        grant.grantVersion !== session.grantVersion
+      ) {
+        return GENERIC_GRANT_AUTHORIZATION_FAILURE;
+      }
+      const resolved = options.controlScopeResolver.resolve(grant.scope);
+      if (
+        resolved.status !== "eligible" ||
+        !isValidEventGameId(resolved.eventGameId) ||
+        resolved.eventGameId !== session.eventGameId
+      ) {
+        return GENERIC_GRANT_AUTHORIZATION_FAILURE;
+      }
+
+      const nowMs = readNow(options.clock);
+      transaction.updateGrantSession({ ...session, lastActiveAtMs: nowMs });
+      return {
+        status: "authorized",
+        grantId: grant.grantId,
+        grantVersion: grant.grantVersion,
+        grantType: GRANT_TYPE,
+        scope: structuredClone(grant.scope),
+        eventGameId: session.eventGameId,
+        grantSessionId: session.sessionId,
+      };
+    });
+  } catch {
+    return GENERIC_GRANT_AUTHORIZATION_FAILURE;
+  }
+}
+
+async function updateGrantStatus(
+  storage: FoundationStorage,
+  options: GrantAuthorityOptions,
+  grantId: string,
+  status: Extract<StoredGrantStatus, "disabled" | "revoked">,
+  action: "grant-disabled" | "grant-revoked",
+  actorInput: GrantAuthorityActor,
+): Promise<GrantMutationResult> {
+  const actor = validateActor(actorInput);
+  if (!actor.ok) return { status: "rejected", reason: "invalid-input" };
+  return storage
+    .transaction<GrantMutationResult>((transaction) => {
+      const storedGrant = transaction.findGrantById(grantId);
+      if (storedGrant === null) return { status: "rejected", reason: "not-found" };
+      const grant = expireGrantIfDue(transaction, options, storedGrant);
+      if (grant.status === "expired") return { status: "updated", grantId };
+      if (grant.status === status) return { status: "updated", grantId };
+      transaction.updateGrant({ ...grant, status });
+      transaction.appendGrantAudit(
+        createAuditEntry(options, {
+          action,
+          actor: { kind: "authority", value: actor.value },
+          grant,
+          sessionId: null,
+          replacedSessionId: null,
+          eventGameId: null,
+          beforeStatus: grant.status,
+          afterStatus: status,
+        }),
+      );
+      return { status: "updated", grantId };
+    })
+    .catch((): GrantMutationResult => ({
+      status: "rejected",
+      reason: "unavailable",
+      detail: "Grant authority storage is temporarily unavailable.",
+    }));
+}
+
+function bindingForGrant(environmentId: string, grant: StoredControlGrant) {
+  return {
+    environmentId,
+    grantId: grant.grantId,
+    grantType: grant.grantType,
+    grantVersion: grant.grantVersion,
+    scope: grant.scope,
+  } as const;
+}
+
+function credentialMatches(
+  token: string,
+  environmentId: string,
+  grant: StoredControlGrant,
+): boolean {
+  const parsed = parseCredentialForComparison(token);
+  return (
+    parsed !== null &&
+    parsed.environmentId === environmentId &&
+    parsed.grantId === grant.grantId &&
+    parsed.grantType === grant.grantType &&
+    parsed.grantVersion === grant.grantVersion &&
+    parsed.credentialKind === grant.credential.kind &&
+    parsed.formatVersion === grant.credential.formatVersion &&
+    sameScope(parsed.scope, grant.scope)
+  );
+}
+
+function parseCredentialForComparison(token: string) {
+  return parseCredentialToken(token);
+}
+
+function validateIdentifier(value: unknown, field: string): string {
+  const result = validateOpaqueIdentifier(value, field);
+  if (!result.ok) throw new Error(`Invalid Grant configuration: ${result.error}`);
+  return result.value;
+}
+
+function isGrantIdentityConstraint(error: unknown): boolean {
+  return (
+    error instanceof FoundationStorageConstraintError &&
+    GRANT_IDENTITY_CONSTRAINTS.has(error.constraint)
+  );
+}
+
+const GRANT_IDENTITY_CONSTRAINTS = new Set<FoundationStorageConstraint>([
+  "grant-id",
+  "grant-version",
+  "grant-pitch-slot-id",
+  "grant-credential-digest",
+]);
+
+function isValidBrowserContext(value: unknown): value is string {
+  return validateOpaqueIdentifier(value, "browserContext").ok;
+}
+
+function isValidCredential(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0 && value.length <= 4096;
+}
+
+function isValidEventGameId(value: unknown): value is string {
+  return validateOpaqueIdentifier(value, "eventGameId").ok;
+}
+
+function isValidBearer(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0 && value.length <= 4096;
+}
+
+function readNow(clock: GrantClock): number {
+  const nowMs = clock.nowMs();
+  if (!Number.isSafeInteger(nowMs) || nowMs < 0) {
+    throw new Error("Grant clock returned an invalid timestamp.");
+  }
+  return nowMs;
+}
+
+function validateKeyConfiguration(keyRing: GrantKeyRing): void {
+  if (
+    keyRing.encryption.currentVersion.length === 0 ||
+    keyRing.lookup.currentVersion.length === 0
+  ) {
+    throw new Error("Grant key-ring versions must not be empty.");
+  }
+  if (!keyRing.encryption.keys.has(keyRing.encryption.currentVersion)) {
+    throw new Error("The current Grant encryption key is unavailable.");
+  }
+  if (!keyRing.lookup.keys.has(keyRing.lookup.currentVersion)) {
+    throw new Error("The current Grant lookup key is unavailable.");
+  }
+}
+
+function sameScope(left: ControlGrantScope, right: ControlGrantScope): boolean {
+  return (
+    left.eventId === right.eventId &&
+    left.gameDayId === right.gameDayId &&
+    left.pitchId === right.pitchId &&
+    left.pitchSlotId === right.pitchSlotId
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function toSessionSummary(session: StoredGrantSession): GrantSessionSummary {
+  return {
+    sessionId: session.sessionId,
+    grantId: session.grantId,
+    grantVersion: session.grantVersion,
+    eventGameId: session.eventGameId,
+    status: session.status,
+    createdAtMs: session.createdAtMs,
+    lastActiveAtMs: session.lastActiveAtMs,
+    revokedAtMs: session.revokedAtMs,
+  };
+}

--- a/src/lib/grant-concurrency-process.test.ts
+++ b/src/lib/grant-concurrency-process.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, test } from "bun:test";
+import { chmod, mkdtemp, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  buildGrantAdmissionWorkerCommand,
+  createGrantAdmissionWorkerEnvironment,
+  readPrivateGrantCredential,
+  superviseGrantAdmissionWorkers,
+  writePrivateGrantCredential,
+  type GrantAdmissionWorkerDependencies,
+} from "@/lib/grant-concurrency-process";
+import type { ProbeWorkerHandle, ProbeWorkerResult } from "@/lib/sqlite-foundation-probe-process";
+
+describe("Grant admission concurrency process safety", () => {
+  test("uses an allowlisted environment and keeps the credential out of argv", () => {
+    const environment = createGrantAdmissionWorkerEnvironment("/private/owned-grant-temp");
+    expect(environment).toEqual({
+      LANG: "C",
+      NO_COLOR: "1",
+      TMPDIR: "/private/owned-grant-temp",
+      TZ: "UTC",
+    });
+    expect(JSON.stringify(environment)).not.toContain("HOST_CI_TOKEN");
+
+    const command = buildGrantAdmissionWorkerCommand({
+      executablePath: "/absolute/bun",
+      workerPath: "/absolute/worker.ts",
+      databasePath: "/private/owned-grant-temp/foundation.sqlite",
+      readyPath: "/private/owned-grant-temp/worker.ready",
+      startPath: "/private/owned-grant-temp/workers.start",
+      credentialPath: "/private/owned-grant-temp/credential.private",
+      seed: 10,
+    });
+    expect(command).toContain("--no-env-file");
+    expect(command).not.toContain("qr-secret-must-not-be-an-argument");
+  });
+
+  test("writes and validates a bounded owner-only credential channel", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "quadball-grant-private-channel-"));
+    const credentialPath = join(directory, "credential.private");
+    try {
+      await writePrivateGrantCredential(credentialPath, "qr-secret");
+      expect((await stat(credentialPath)).mode & 0o777).toBe(0o600);
+      expect(await readPrivateGrantCredential(credentialPath)).toBe("qr-secret");
+      await chmod(credentialPath, 0o644);
+      expect(await captureFailure(readPrivateGrantCredential(credentialPath))).toEqual(
+        expect.objectContaining({ message: "Grant credential channel permissions are unsafe." }),
+      );
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("reserves one deadline for TERM, KILL, reap, and artifact cleanup", async () => {
+    const observed: { timeoutMs?: number; aborted?: boolean; cleaned?: boolean } = {};
+    let nowMs = 0;
+    const dependencies: GrantAdmissionWorkerDependencies = {
+      nowMs: () => nowMs,
+      sleep: async (milliseconds) => {
+        nowMs += milliseconds;
+      },
+      fileExists: async () => false,
+      writeStart: async () => undefined,
+      cleanupArtifacts: async () => {
+        observed.cleaned = true;
+      },
+      superviseWorkers: async (_workers, options) => {
+        observed.timeoutMs = options.timeoutMs;
+        await new Promise<void>((_resolve, reject) => {
+          options.signal?.addEventListener(
+            "abort",
+            () => {
+              observed.aborted = true;
+              reject(new Error("aborted"));
+            },
+            { once: true },
+          );
+        });
+        return [];
+      },
+    };
+
+    expect(
+      await captureFailure(
+        superviseGrantAdmissionWorkers({
+          workers: [fakeWorker()],
+          readyPaths: ["worker.ready"],
+          startPath: "workers.start",
+          overallTimeoutMs: 1_000,
+          terminationGraceMs: 100,
+          reapTimeoutMs: 200,
+          artifactCleanupMs: 100,
+          dependencies,
+        }),
+      ),
+    ).toEqual(expect.objectContaining({ message: expect.stringContaining("did not reach") }));
+    expect(observed).toEqual({ timeoutMs: 400, aborted: true, cleaned: true });
+  });
+
+  test("propagates interruption through the same cleanup path", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    let cleaned = false;
+    const dependencies: GrantAdmissionWorkerDependencies = {
+      nowMs: () => 0,
+      sleep: async () => undefined,
+      fileExists: async () => false,
+      writeStart: async () => undefined,
+      cleanupArtifacts: async () => {
+        cleaned = true;
+      },
+      superviseWorkers: async () => {
+        throw new Error("interrupted");
+      },
+    };
+    expect(
+      await captureFailure(
+        superviseGrantAdmissionWorkers({
+          workers: [fakeWorker()],
+          readyPaths: ["worker.ready"],
+          startPath: "workers.start",
+          signal: controller.signal,
+          dependencies,
+        }),
+      ),
+    ).toBeInstanceOf(Error);
+    expect(cleaned).toBe(true);
+  });
+});
+
+function fakeWorker(): ProbeWorkerHandle {
+  const result: ProbeWorkerResult = {
+    exitCode: 0,
+    stdout: "{}",
+    stderr: "",
+    outputExceeded: false,
+  };
+  return {
+    process: {
+      pid: 123,
+      exitCode: 0,
+      killed: false,
+      exited: Promise.resolve(0),
+      kill() {},
+    },
+    result: Promise.resolve(result),
+  };
+}
+
+async function captureFailure(operation: Promise<unknown>): Promise<unknown> {
+  try {
+    await operation;
+    return null;
+  } catch (error) {
+    return error;
+  }
+}

--- a/src/lib/grant-concurrency-process.ts
+++ b/src/lib/grant-concurrency-process.ts
@@ -1,0 +1,232 @@
+import { open, readFile, rm, stat } from "node:fs/promises";
+import {
+  superviseProbeWorkers,
+  type ProbeSupervisionOptions,
+  type ProbeWorkerHandle,
+  type ProbeWorkerResult,
+} from "@/lib/sqlite-foundation-probe-process";
+
+export const GRANT_ADMISSION_OVERALL_TIMEOUT_MS = 5_000;
+export const GRANT_ADMISSION_TERMINATION_GRACE_MS = 100;
+export const GRANT_ADMISSION_REAP_TIMEOUT_MS = 300;
+export const GRANT_ADMISSION_ARTIFACT_CLEANUP_MS = 100;
+export const GRANT_ADMISSION_CREDENTIAL_MAX_BYTES = 4_096;
+
+type WorkerCommandInput = {
+  executablePath: string;
+  workerPath: string;
+  databasePath: string;
+  readyPath: string;
+  startPath: string;
+  credentialPath: string;
+  seed: number;
+};
+
+export type GrantAdmissionWorkerDependencies = {
+  nowMs(): number;
+  sleep(milliseconds: number): Promise<void>;
+  fileExists(path: string): Promise<boolean>;
+  writeStart(path: string): Promise<unknown>;
+  cleanupArtifacts(paths: readonly string[]): Promise<void>;
+  superviseWorkers(
+    workers: readonly ProbeWorkerHandle[],
+    options: ProbeSupervisionOptions,
+  ): Promise<ProbeWorkerResult[]>;
+};
+
+type SuperviseGrantAdmissionWorkersInput = {
+  workers: readonly ProbeWorkerHandle[];
+  readyPaths: readonly string[];
+  startPath: string;
+  artifactPaths?: readonly string[];
+  signal?: AbortSignal;
+  overallTimeoutMs?: number;
+  terminationGraceMs?: number;
+  reapTimeoutMs?: number;
+  artifactCleanupMs?: number;
+  dependencies?: GrantAdmissionWorkerDependencies;
+};
+
+export function createGrantAdmissionWorkerEnvironment(
+  temporaryDirectory: string,
+): Record<string, string> {
+  return {
+    LANG: "C",
+    NO_COLOR: "1",
+    TMPDIR: temporaryDirectory,
+    TZ: "UTC",
+  };
+}
+
+export function buildGrantAdmissionWorkerCommand(input: WorkerCommandInput): string[] {
+  return [
+    input.executablePath,
+    "--no-env-file",
+    input.workerPath,
+    input.databasePath,
+    input.readyPath,
+    input.startPath,
+    input.credentialPath,
+    String(input.seed),
+  ];
+}
+
+export async function writePrivateGrantCredential(path: string, credential: string): Promise<void> {
+  const byteLength = Buffer.byteLength(credential, "utf8");
+  if (byteLength === 0 || byteLength > GRANT_ADMISSION_CREDENTIAL_MAX_BYTES) {
+    throw new Error("Grant credential channel content is invalid.");
+  }
+  const handle = await open(path, "wx", 0o600);
+  try {
+    await handle.writeFile(credential, "utf8");
+    await handle.sync();
+  } catch (error) {
+    await rm(path, { force: true });
+    throw error;
+  } finally {
+    await handle.close();
+  }
+  await assertPrivateCredentialFile(path);
+}
+
+export async function readPrivateGrantCredential(path: string): Promise<string> {
+  const metadata = await assertPrivateCredentialFile(path);
+  if (metadata.size === 0 || metadata.size > GRANT_ADMISSION_CREDENTIAL_MAX_BYTES) {
+    throw new Error("Grant credential channel content is invalid.");
+  }
+  const credential = await readFile(path, "utf8");
+  if (Buffer.byteLength(credential, "utf8") !== metadata.size) {
+    throw new Error("Grant credential channel changed while being read.");
+  }
+  return credential;
+}
+
+export async function superviseGrantAdmissionWorkers(
+  input: SuperviseGrantAdmissionWorkersInput,
+): Promise<ProbeWorkerResult[]> {
+  const dependencies = input.dependencies ?? defaultDependencies;
+  const overallTimeoutMs = input.overallTimeoutMs ?? GRANT_ADMISSION_OVERALL_TIMEOUT_MS;
+  const terminationGraceMs = input.terminationGraceMs ?? GRANT_ADMISSION_TERMINATION_GRACE_MS;
+  const reapTimeoutMs = input.reapTimeoutMs ?? GRANT_ADMISSION_REAP_TIMEOUT_MS;
+  const artifactCleanupMs = input.artifactCleanupMs ?? GRANT_ADMISSION_ARTIFACT_CLEANUP_MS;
+  const operationBudgetMs =
+    overallTimeoutMs - terminationGraceMs - 2 * reapTimeoutMs - artifactCleanupMs;
+  if (input.workers.length === 0 || operationBudgetMs <= 0) {
+    throw new Error("Grant admission worker supervision limits are invalid.");
+  }
+
+  const startedAtMs = dependencies.nowMs();
+  const operationDeadlineMs = startedAtMs + operationBudgetMs;
+  const overallDeadlineMs = startedAtMs + overallTimeoutMs;
+  const controller = new AbortController();
+  const abort = () => controller.abort();
+  if (input.signal?.aborted) abort();
+  input.signal?.addEventListener("abort", abort, { once: true });
+  const supervision = dependencies.superviseWorkers(input.workers, {
+    signal: controller.signal,
+    timeoutMs: operationBudgetMs,
+    terminationGraceMs,
+    reapTimeoutMs,
+    sleep: (milliseconds) => dependencies.sleep(milliseconds),
+  });
+  let operationError: unknown;
+  let results: ProbeWorkerResult[] | undefined;
+  try {
+    await racePhaseAgainstWorkers(
+      waitForBarrier(input.readyPaths, operationDeadlineMs, controller.signal, dependencies),
+      supervision,
+      "Concurrent Grant workers exited before reaching the barrier.",
+    );
+    await racePhaseAgainstWorkers(
+      dependencies.writeStart(input.startPath),
+      supervision,
+      "Concurrent Grant workers exited before the start barrier was released.",
+    );
+    results = await supervision;
+  } catch (error) {
+    operationError = error;
+    controller.abort();
+    try {
+      await supervision;
+    } catch {
+      // The operation error remains the primary failure after bounded worker cleanup.
+    }
+  } finally {
+    input.signal?.removeEventListener("abort", abort);
+  }
+
+  const cleanupPaths = input.artifactPaths ?? [...input.readyPaths, input.startPath];
+  const cleanupBudgetMs = Math.max(0, overallDeadlineMs - dependencies.nowMs());
+  const cleaned = await waitWithin(
+    dependencies.cleanupArtifacts(cleanupPaths),
+    cleanupBudgetMs,
+    (milliseconds) => dependencies.sleep(milliseconds),
+  );
+  if (!cleaned) {
+    throw new Error("Concurrent Grant worker artifact cleanup exceeded the overall deadline.");
+  }
+  if (operationError !== undefined) throw operationError;
+  if (results === undefined) throw new Error("Concurrent Grant workers produced no result.");
+  return results;
+}
+
+async function assertPrivateCredentialFile(path: string) {
+  const metadata = await stat(path);
+  if (!metadata.isFile() || (metadata.mode & 0o777) !== 0o600) {
+    throw new Error("Grant credential channel permissions are unsafe.");
+  }
+  const getuid = process.getuid;
+  if (getuid !== undefined && metadata.uid !== getuid.call(process)) {
+    throw new Error("Grant credential channel ownership is unsafe.");
+  }
+  return metadata;
+}
+
+async function waitForBarrier(
+  paths: readonly string[],
+  deadlineMs: number,
+  signal: AbortSignal,
+  dependencies: GrantAdmissionWorkerDependencies,
+): Promise<void> {
+  while (!signal.aborted) {
+    const ready = await Promise.all(paths.map((path) => dependencies.fileExists(path)));
+    if (ready.every(Boolean)) return;
+    const remainingMs = deadlineMs - dependencies.nowMs();
+    if (remainingMs <= 0) break;
+    await dependencies.sleep(Math.min(2, remainingMs));
+  }
+  throw new Error(
+    "Concurrent Grant workers did not reach the barrier within the overall deadline.",
+  );
+}
+
+async function racePhaseAgainstWorkers(
+  phase: Promise<unknown>,
+  supervision: Promise<ProbeWorkerResult[]>,
+  earlyExitMessage: string,
+): Promise<void> {
+  const outcome = await Promise.race([
+    phase.then(() => "phase" as const),
+    supervision.then(() => "workers" as const),
+  ]);
+  if (outcome === "workers") throw new Error(earlyExitMessage);
+}
+
+async function waitWithin(
+  promise: Promise<unknown>,
+  timeoutMs: number,
+  sleep: (milliseconds: number) => Promise<void>,
+): Promise<boolean> {
+  return Promise.race([promise.then(() => true), sleep(timeoutMs).then(() => false)]);
+}
+
+const defaultDependencies: GrantAdmissionWorkerDependencies = {
+  nowMs: Date.now,
+  sleep: Bun.sleep,
+  fileExists: (path) => Bun.file(path).exists(),
+  writeStart: (path) => Bun.write(path, "start"),
+  async cleanupArtifacts(paths) {
+    await Promise.all(paths.map((path) => rm(path, { force: true })));
+  },
+  superviseWorkers: superviseProbeWorkers,
+};

--- a/src/lib/grant-crypto.ts
+++ b/src/lib/grant-crypto.ts
@@ -1,0 +1,309 @@
+import { createCipheriv, createDecipheriv, createHmac, timingSafeEqual } from "node:crypto";
+import {
+  GRANT_CREDENTIAL_FORMAT_VERSION,
+  GRANT_CREDENTIAL_KIND,
+  GRANT_TYPE,
+  validateControlGrantScope,
+  type ControlGrantScope,
+  type GrantKeyRing,
+  type GrantRandomness,
+  type StoredControlGrant,
+  type StoredGrantCredential,
+} from "@/lib/grant-types";
+
+const CREDENTIAL_ENTROPY_BYTES = 32;
+const AES_KEY_BYTES = 32;
+const HMAC_KEY_MIN_BYTES = 32;
+const AES_IV_BYTES = 12;
+const AES_TAG_BYTES = 16;
+
+export type CredentialEnvelope = {
+  formatVersion: typeof GRANT_CREDENTIAL_FORMAT_VERSION;
+  environmentId: string;
+  grantId: string;
+  grantType: typeof GRANT_TYPE;
+  scope: ControlGrantScope;
+  grantVersion: string;
+  credentialKind: typeof GRANT_CREDENTIAL_KIND;
+  entropy: string;
+};
+
+type CredentialBinding = Pick<
+  StoredControlGrant,
+  "grantId" | "grantType" | "grantVersion" | "scope"
+> & {
+  environmentId: string;
+};
+
+export class GrantCryptoConfigurationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "GrantCryptoConfigurationError";
+  }
+}
+
+export function createCredentialToken(
+  binding: CredentialBinding,
+  randomness: GrantRandomness,
+): string {
+  const entropy = randomness.bytes(CREDENTIAL_ENTROPY_BYTES);
+  if (entropy.byteLength !== CREDENTIAL_ENTROPY_BYTES) {
+    throw new GrantCryptoConfigurationError("Injected credential randomness has an invalid size.");
+  }
+
+  return encodeBase64Url(
+    new TextEncoder().encode(
+      canonicalize({
+        formatVersion: GRANT_CREDENTIAL_FORMAT_VERSION,
+        environmentId: binding.environmentId,
+        grantId: binding.grantId,
+        grantType: binding.grantType,
+        scope: binding.scope,
+        grantVersion: binding.grantVersion,
+        credentialKind: GRANT_CREDENTIAL_KIND,
+        entropy: encodeBase64Url(entropy),
+      } satisfies CredentialEnvelope),
+    ),
+  );
+}
+
+export function parseCredentialToken(value: unknown): CredentialEnvelope | null {
+  if (typeof value !== "string") return null;
+  const bytes = decodeBase64Url(value);
+  if (bytes === null) return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(new TextDecoder().decode(bytes)) as unknown;
+  } catch {
+    return null;
+  }
+  if (!isRecord(parsed)) return null;
+  if (
+    parsed.formatVersion !== GRANT_CREDENTIAL_FORMAT_VERSION ||
+    typeof parsed.environmentId !== "string" ||
+    typeof parsed.grantId !== "string" ||
+    parsed.grantType !== GRANT_TYPE ||
+    typeof parsed.grantVersion !== "string" ||
+    parsed.credentialKind !== GRANT_CREDENTIAL_KIND ||
+    typeof parsed.entropy !== "string"
+  ) {
+    return null;
+  }
+
+  const scope = validateControlGrantScope(parsed.scope);
+  if (!scope.ok) return null;
+  const entropy = decodeBase64Url(parsed.entropy);
+  if (entropy === null || entropy.byteLength !== CREDENTIAL_ENTROPY_BYTES) return null;
+
+  return {
+    formatVersion: GRANT_CREDENTIAL_FORMAT_VERSION,
+    environmentId: parsed.environmentId,
+    grantId: parsed.grantId,
+    grantType: GRANT_TYPE,
+    scope: scope.value,
+    grantVersion: parsed.grantVersion,
+    credentialKind: GRANT_CREDENTIAL_KIND,
+    entropy: parsed.entropy,
+  };
+}
+
+export function encryptCredential(
+  token: string,
+  binding: CredentialBinding,
+  randomness: GrantRandomness,
+  keyRing: GrantKeyRing,
+): StoredGrantCredential {
+  const encryptionKeyVersion = keyRing.encryption.currentVersion;
+  const encryptionKey = getAesKey(keyRing.encryption.keys, encryptionKeyVersion);
+  const lookupKeyVersion = keyRing.lookup.currentVersion;
+  const lookupKey = getKey(keyRing.lookup.keys, lookupKeyVersion, HMAC_KEY_MIN_BYTES);
+  const iv = randomness.bytes(AES_IV_BYTES);
+  if (iv.byteLength !== AES_IV_BYTES) {
+    throw new GrantCryptoConfigurationError("Injected encryption randomness has an invalid size.");
+  }
+
+  const cipher = createCipheriv("aes-256-gcm", encryptionKey, iv);
+  cipher.setAAD(new TextEncoder().encode(canonicalizeBinding(binding)));
+  const ciphertext = new Uint8Array(
+    Buffer.concat([cipher.update(Buffer.from(token, "utf8")), cipher.final()]),
+  );
+  const tag = new Uint8Array(cipher.getAuthTag());
+  if (tag.byteLength !== AES_TAG_BYTES) {
+    throw new GrantCryptoConfigurationError("AES-GCM returned an invalid authentication tag.");
+  }
+  const lookupDigest = hmac(lookupKey, token);
+
+  return {
+    materialState: "present",
+    formatVersion: GRANT_CREDENTIAL_FORMAT_VERSION,
+    kind: GRANT_CREDENTIAL_KIND,
+    encryptionKeyVersion,
+    lookupKeyVersion,
+    iv: encodeBase64Url(iv),
+    ciphertext: encodeBase64Url(ciphertext),
+    tag: encodeBase64Url(tag),
+    lookupDigest: encodeBase64Url(lookupDigest),
+    fingerprint: encodeBase64Url(hmac(lookupKey, `grant-fingerprint:${token}`)),
+  };
+}
+
+export function decryptCredential(
+  stored: StoredGrantCredential,
+  binding: CredentialBinding,
+  keyRing: GrantKeyRing,
+): string | null {
+  if (
+    stored.materialState !== "present" ||
+    stored.formatVersion !== GRANT_CREDENTIAL_FORMAT_VERSION ||
+    stored.kind !== GRANT_CREDENTIAL_KIND ||
+    typeof stored.encryptionKeyVersion !== "string" ||
+    typeof stored.lookupKeyVersion !== "string" ||
+    typeof stored.iv !== "string" ||
+    typeof stored.ciphertext !== "string" ||
+    typeof stored.tag !== "string" ||
+    typeof stored.lookupDigest !== "string"
+  ) {
+    return null;
+  }
+
+  let iv: Uint8Array;
+  let ciphertext: Uint8Array;
+  let tag: Uint8Array;
+  try {
+    iv = requireBase64Url(stored.iv);
+    ciphertext = requireBase64Url(stored.ciphertext);
+    tag = requireBase64Url(stored.tag);
+  } catch {
+    return null;
+  }
+  if (iv.byteLength !== AES_IV_BYTES || tag.byteLength !== AES_TAG_BYTES) return null;
+
+  let encryptionKey: Uint8Array;
+  try {
+    encryptionKey = getAesKey(keyRing.encryption.keys, stored.encryptionKeyVersion);
+  } catch {
+    return null;
+  }
+
+  try {
+    const decipher = createDecipheriv("aes-256-gcm", encryptionKey, iv);
+    decipher.setAAD(new TextEncoder().encode(canonicalizeBinding(binding)));
+    decipher.setAuthTag(tag);
+    const token = Buffer.concat([
+      decipher.update(Buffer.from(ciphertext)),
+      decipher.final(),
+    ]).toString("utf8");
+    return token;
+  } catch {
+    return null;
+  }
+}
+
+export function computeLookupDigest(
+  token: string,
+  keyRing: GrantKeyRing,
+  keyVersion = keyRing.lookup.currentVersion,
+): string {
+  const key = getKey(keyRing.lookup.keys, keyVersion, HMAC_KEY_MIN_BYTES);
+  return encodeBase64Url(hmac(key, token));
+}
+
+export function computeSessionVerifier(
+  bearer: string,
+  keyRing: GrantKeyRing,
+  keyVersion = keyRing.lookup.currentVersion,
+): string {
+  return computeLookupDigest(bearer, keyRing, keyVersion);
+}
+
+export function computeBrowserContextDigest(
+  browserContext: string,
+  keyRing: GrantKeyRing,
+  keyVersion = keyRing.lookup.currentVersion,
+): string {
+  return computeLookupDigest(`browser-context:${browserContext}`, keyRing, keyVersion);
+}
+
+export function listLookupKeyVersions(keyRing: GrantKeyRing): string[] {
+  return [...keyRing.lookup.keys.keys()];
+}
+
+export function createRandomIdentifier(prefix: string, randomness: GrantRandomness): string {
+  const bytes = randomness.bytes(16);
+  if (bytes.byteLength !== 16) {
+    throw new GrantCryptoConfigurationError("Injected identifier randomness has an invalid size.");
+  }
+  return `${prefix}-${encodeBase64Url(bytes)}`;
+}
+
+export function sameSecret(left: string, right: string): boolean {
+  const leftBytes = new TextEncoder().encode(left);
+  const rightBytes = new TextEncoder().encode(right);
+  return leftBytes.byteLength === rightBytes.byteLength && timingSafeEqual(leftBytes, rightBytes);
+}
+
+function canonicalize(value: unknown): string {
+  return JSON.stringify(value);
+}
+
+function canonicalizeBinding(binding: CredentialBinding): string {
+  return canonicalize({
+    formatVersion: GRANT_CREDENTIAL_FORMAT_VERSION,
+    environmentId: binding.environmentId,
+    grantId: binding.grantId,
+    grantType: binding.grantType,
+    scope: binding.scope,
+    grantVersion: binding.grantVersion,
+    credentialKind: GRANT_CREDENTIAL_KIND,
+  });
+}
+
+function hmac(key: Uint8Array, value: string): Uint8Array {
+  return new Uint8Array(createHmac("sha256", key).update(value, "utf8").digest());
+}
+
+function getKey(
+  keys: ReadonlyMap<string, Uint8Array>,
+  version: string,
+  minimumBytes: number,
+): Uint8Array {
+  const key = keys.get(version);
+  if (key === undefined || key.byteLength < minimumBytes) {
+    throw new GrantCryptoConfigurationError("The required Grant key version is unavailable.");
+  }
+  return key;
+}
+
+function getAesKey(keys: ReadonlyMap<string, Uint8Array>, version: string): Uint8Array {
+  const key = keys.get(version);
+  if (key === undefined || key.byteLength !== AES_KEY_BYTES) {
+    throw new GrantCryptoConfigurationError("The required Grant encryption key is unavailable.");
+  }
+  return key;
+}
+
+function encodeBase64Url(bytes: Uint8Array): string {
+  return Buffer.from(bytes).toString("base64url");
+}
+
+function decodeBase64Url(value: string): Uint8Array | null {
+  if (!/^[A-Za-z0-9_-]+$/.test(value)) return null;
+  try {
+    const bytes = new Uint8Array(Buffer.from(value, "base64url"));
+    return encodeBase64Url(bytes) === value ? bytes : null;
+  } catch {
+    return null;
+  }
+}
+
+function requireBase64Url(value: string): Uint8Array {
+  const decoded = decodeBase64Url(value);
+  if (decoded === null)
+    throw new GrantCryptoConfigurationError("Stored Grant material is invalid.");
+  return decoded;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/lib/grant-lifecycle.ts
+++ b/src/lib/grant-lifecycle.ts
@@ -1,0 +1,157 @@
+import { computeLookupDigest, createRandomIdentifier } from "@/lib/grant-crypto";
+import type { FoundationStorageTransaction } from "@/lib/foundation-storage";
+import type { GrantAuthorityOptions } from "@/lib/grant-authority";
+import {
+  GRANT_CREDENTIAL_KIND,
+  GRANT_TYPE,
+  OPAQUE_MIGRATION_CREDENTIAL_REFERENCE_PREFIX,
+  type GrantAuthorityActor,
+  type StoredControlGrant,
+  type StoredGrantAuditEntry,
+  type StoredGrantStatus,
+} from "@/lib/grant-types";
+import { validateOpaqueIdentifier } from "@/lib/validation-policy";
+
+export function validateActor(
+  value: unknown,
+): { ok: true; value: GrantAuthorityActor } | { ok: false; error: string } {
+  if (!isRecord(value) || value.kind !== "fixture") {
+    return { ok: false, error: "actor must be a structured fixture authority." };
+  }
+  const id = validateOpaqueIdentifier(value.id, "actor.id");
+  if (!id.ok) return id;
+  return { ok: true, value: { kind: "fixture", id: id.value } };
+}
+
+export function createAuditEntry(
+  options: GrantAuthorityOptions,
+  input: {
+    action: StoredGrantAuditEntry["action"];
+    actor:
+      | { kind: "authority"; value: GrantAuthorityActor }
+      | { kind: "session"; sessionId: string }
+      | { kind: "system"; value: "grant-expiry" };
+    grant: StoredControlGrant;
+    sessionId: string | null;
+    replacedSessionId: string | null;
+    eventGameId: string | null;
+    beforeStatus: StoredGrantStatus | null;
+    afterStatus: StoredGrantStatus | null;
+  },
+): StoredGrantAuditEntry {
+  const auditId = createRandomIdentifier("grant-audit", options.randomness);
+  return {
+    auditId,
+    action: input.action,
+    outcome: "accepted",
+    actorReference: deriveAuditActorReference(options, input.grant.grantId, input.actor),
+    grantId: input.grant.grantId,
+    grantType: GRANT_TYPE,
+    grantVersion: input.grant.grantVersion,
+    scope: structuredClone(input.grant.scope),
+    sessionId: input.sessionId,
+    replacedSessionId: input.replacedSessionId,
+    eventGameId: input.eventGameId,
+    credentialKind: GRANT_CREDENTIAL_KIND,
+    credentialFingerprint: input.grant.credential.fingerprint.startsWith(
+      OPAQUE_MIGRATION_CREDENTIAL_REFERENCE_PREFIX,
+    )
+      ? null
+      : input.grant.credential.fingerprint,
+    beforeStatus: input.beforeStatus,
+    afterStatus: input.afterStatus,
+    createdAtMs: readNow(options),
+  };
+}
+
+export function expireGrantIfDue(
+  transaction: FoundationStorageTransaction,
+  options: GrantAuthorityOptions,
+  grant: StoredControlGrant,
+): StoredControlGrant {
+  if (grant.status === "expired" || grant.expiresAtMs === null) return grant;
+  const nowMs = readNow(options);
+  if (nowMs < grant.expiresAtMs) return grant;
+
+  const expiredGrant: StoredControlGrant = {
+    ...grant,
+    status: "expired",
+    credential: eraseGrantCredential(grant.credential),
+  };
+  transaction.updateGrant(expiredGrant);
+  for (const session of transaction.listGrantSessions(grant.grantId)) {
+    if (
+      session.status !== "expired" ||
+      session.bearerMaterialState !== "erased" ||
+      session.bearerLookupVerifier !== null ||
+      session.bearerLookupKeyVersion !== null
+    ) {
+      transaction.updateGrantSession({
+        ...session,
+        status: "expired",
+        bearerMaterialState: "erased",
+        bearerLookupVerifier: null,
+        bearerLookupKeyVersion: null,
+      });
+    }
+  }
+  transaction.appendGrantAudit(
+    createAuditEntry(options, {
+      action: "grant-expired",
+      actor: { kind: "system", value: "grant-expiry" },
+      grant,
+      sessionId: null,
+      replacedSessionId: null,
+      eventGameId: null,
+      beforeStatus: grant.status,
+      afterStatus: "expired",
+    }),
+  );
+  return expiredGrant;
+}
+
+function eraseGrantCredential(
+  credential: StoredControlGrant["credential"],
+): StoredControlGrant["credential"] {
+  return {
+    materialState: "erased",
+    formatVersion: credential.formatVersion,
+    kind: credential.kind,
+    encryptionKeyVersion: null,
+    lookupKeyVersion: null,
+    iv: null,
+    ciphertext: null,
+    tag: null,
+    lookupDigest: null,
+    fingerprint: credential.fingerprint,
+  };
+}
+
+function deriveAuditActorReference(
+  options: GrantAuthorityOptions,
+  grantId: string,
+  actor:
+    | { kind: "authority"; value: GrantAuthorityActor }
+    | { kind: "session"; sessionId: string }
+    | { kind: "system"; value: "grant-expiry" },
+): string {
+  const source =
+    actor.kind === "authority"
+      ? { source: actor.kind, authorityKind: actor.value.kind, authorityId: actor.value.id }
+      : actor.kind === "session"
+        ? { source: actor.kind, sessionId: actor.sessionId }
+        : { source: actor.kind, operation: actor.value };
+  return `actor-${computeLookupDigest(JSON.stringify({ domain: "grant-audit", grantId, source }), options.keyRing)}`;
+}
+
+function readNow(options: GrantAuthorityOptions): number {
+  const nowMs = options.clock.nowMs();
+  if (!Number.isSafeInteger(nowMs) || nowMs < 0) {
+    throw new Error("Grant clock returned an invalid timestamp.");
+  }
+  return nowMs;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/lib/grant-rotation-contract.ts
+++ b/src/lib/grant-rotation-contract.ts
@@ -1,0 +1,401 @@
+import { expect } from "bun:test";
+
+import { computeLookupDigest } from "@/lib/grant-crypto";
+import {
+  createGrantAuthority,
+  type ControlGrantScope,
+  type GrantAuthority,
+  type GrantKeyRing,
+  type GrantRandomness,
+} from "@/lib/grant-authority";
+import type {
+  GrantAuthorityContractFactory,
+  GrantAuthorityContractRegistrar,
+} from "@/lib/grant-authority-contract";
+import type { FoundationStorage } from "@/lib/foundation-storage";
+
+export function registerGrantRotationContract(
+  register: GrantAuthorityContractRegistrar,
+  createStorage: GrantAuthorityContractFactory,
+): void {
+  register("atomically rotates retained credential key material and audit evidence", async () => {
+    await withStorage(createStorage, async (storage) => {
+      const randomness = createDeterministicRandomness();
+      const originalKeyRing = createKeyRing();
+      const original = createAuthority(storage, { randomness, keyRing: originalKeyRing });
+      const created = await createGrant(original);
+      const before = await findGrant(storage, created.grantId);
+      const rotatedKeyRing = createRotatedKeyRing(originalKeyRing);
+      const rotated = createAuthority(storage, { randomness, keyRing: rotatedKeyRing });
+
+      expect(
+        await rotated.rotateControlGrantCredentialKeys(created.grantId, createActor()),
+      ).toMatchObject({
+        status: "rotated",
+        grantId: created.grantId,
+        encryptionKeyVersion: "encryption-v2",
+        lookupKeyVersion: "lookup-v2",
+      });
+
+      const after = await findGrant(storage, created.grantId);
+      expect(after?.credential).toMatchObject({
+        materialState: "present",
+        encryptionKeyVersion: "encryption-v2",
+        lookupKeyVersion: "lookup-v2",
+      });
+      expect(after?.credential.ciphertext).not.toBe(before?.credential.ciphertext);
+      expect(after?.credential.lookupDigest).not.toBe(before?.credential.lookupDigest);
+      expect(after?.credential.fingerprint).not.toBe(after?.credential.lookupDigest);
+      const audit = await readAudit(storage, created.grantId);
+      expect(audit.filter((entry) => entry.action === "credential-rotated")).toEqual([
+        expect.objectContaining({
+          credentialFingerprint: after?.credential.fingerprint,
+          beforeStatus: "active",
+          afterStatus: "active",
+        }),
+      ]);
+      expect(JSON.stringify({ after, audit })).not.toContain(created.qrCredential);
+
+      const currentOnly = createAuthority(storage, {
+        randomness,
+        keyRing: keepOnlyCurrentKeys(rotatedKeyRing),
+      });
+      const admitted = await admit(currentOnly, created.qrCredential, "browser-a");
+      expect(
+        await currentOnly.authorizeControlGrant({ sessionBearer: admitted.sessionBearer }),
+      ).toMatchObject({ status: "authorized" });
+    });
+  });
+
+  register("rolls back credential rotation on index collision or audit failure", async () => {
+    await verifyCollisionRollback(createStorage);
+    await verifyAuditRollback(createStorage);
+    await verifyCryptographicRollback(createStorage);
+  });
+
+  register("rotates retained credentials without changing disabled or revoked status", async () => {
+    for (const status of ["disabled", "revoked"] as const) {
+      await withStorage(createStorage, async (storage) => {
+        const randomness = createDeterministicRandomness();
+        const originalKeyRing = createKeyRing();
+        const original = createAuthority(storage, { randomness, keyRing: originalKeyRing });
+        const created = await createGrant(original);
+        await original[status === "disabled" ? "disableControlGrant" : "revokeControlGrant"](
+          created.grantId,
+          createActor(),
+        );
+        const before = await findGrant(storage, created.grantId);
+        const rotated = createAuthority(storage, {
+          randomness,
+          keyRing: createRotatedKeyRing(originalKeyRing),
+        });
+
+        expect(
+          await rotated.rotateControlGrantCredentialKeys(created.grantId, createActor()),
+        ).toMatchObject({ status: "rotated", grantId: created.grantId });
+        const after = await findGrant(storage, created.grantId);
+        expect(after).toMatchObject({
+          status,
+          credential: { materialState: "present", lookupKeyVersion: "lookup-v2" },
+        });
+        expect(after?.credential.lookupDigest).not.toBe(before?.credential.lookupDigest);
+        expect((await readAudit(storage, created.grantId)).filter(isRotationAudit)).toEqual([
+          expect.objectContaining({ beforeStatus: status, afterStatus: status }),
+        ]);
+      });
+    }
+  });
+
+  register("refuses rotation after atomic expiry erases the credential", async () => {
+    await withStorage(createStorage, async (storage) => {
+      let nowMs = 1_000;
+      const originalKeyRing = createKeyRing();
+      const original = createAuthority(storage, {
+        keyRing: originalKeyRing,
+        nowMs: () => nowMs,
+      });
+      const created = await createGrant(original, 1_100);
+      nowMs = 1_100;
+      const rotated = createAuthority(storage, {
+        keyRing: createRotatedKeyRing(originalKeyRing),
+        nowMs: () => nowMs,
+      });
+
+      expect(
+        await rotated.rotateControlGrantCredentialKeys(created.grantId, createActor()),
+      ).toEqual(rotationFailure);
+      expect(await findGrant(storage, created.grantId)).toMatchObject({
+        status: "expired",
+        credential: {
+          materialState: "erased",
+          encryptionKeyVersion: null,
+          lookupKeyVersion: null,
+          lookupDigest: null,
+        },
+      });
+      expect((await readAudit(storage, created.grantId)).filter(isExpiryAudit)).toHaveLength(1);
+      expect(
+        await rotated.rotateControlGrantCredentialKeys(created.grantId, createActor()),
+      ).toEqual(rotationFailure);
+      expect((await readAudit(storage, created.grantId)).filter(isExpiryAudit)).toHaveLength(1);
+    });
+  });
+}
+
+async function verifyCollisionRollback(
+  createStorage: GrantAuthorityContractFactory,
+): Promise<void> {
+  await withStorage(createStorage, async (storage) => {
+    const originalKeyRing = createKeyRing();
+    const rotatedKeyRing = createRotatedKeyRing(originalKeyRing);
+    const randomness = createDeterministicRandomness();
+    const original = createAuthority(storage, { randomness, keyRing: originalKeyRing });
+    const created = await createGrant(original);
+    const before = await storage.transaction((transaction) => {
+      const grant = transaction.findGrantById(created.grantId);
+      if (grant === null) throw new Error("Expected the stored Grant.");
+      transaction.insertGrant({
+        ...grant,
+        grantId: "grant-rotation-collision",
+        grantVersion: "grant-version-rotation-collision",
+        scope: { ...grant.scope, pitchSlotId: "slot-rotation-collision" },
+        credential: {
+          ...grant.credential,
+          lookupKeyVersion: rotatedKeyRing.lookup.currentVersion,
+          lookupDigest: computeLookupDigest(created.qrCredential, rotatedKeyRing),
+          fingerprint: "fingerprint-rotation-collision",
+        },
+      });
+      return grant;
+    });
+    const rotated = createAuthority(storage, { randomness, keyRing: rotatedKeyRing });
+    expect(await rotated.rotateControlGrantCredentialKeys(created.grantId, createActor())).toEqual(
+      rotationFailure,
+    );
+    expect(await findGrant(storage, created.grantId)).toEqual(before);
+    expect(await admit(original, created.qrCredential, "browser-collision")).toMatchObject({
+      grantId: created.grantId,
+    });
+  });
+}
+
+async function verifyAuditRollback(createStorage: GrantAuthorityContractFactory): Promise<void> {
+  await withStorage(createStorage, async (storage) => {
+    const originalKeyRing = createKeyRing();
+    const randomness = createDeterministicRandomness();
+    const original = createAuthority(storage, { randomness, keyRing: originalKeyRing });
+    const created = await createGrant(original);
+    const before = await findGrant(storage, created.grantId);
+    const rotated = createAuthority(createRotationAuditFailingStorage(storage), {
+      randomness,
+      keyRing: createRotatedKeyRing(originalKeyRing),
+    });
+    expect(await rotated.rotateControlGrantCredentialKeys(created.grantId, createActor())).toEqual(
+      rotationFailure,
+    );
+    expect(await findGrant(storage, created.grantId)).toEqual(before);
+    expect((await readAudit(storage, created.grantId)).some(isRotationAudit)).toBe(false);
+    expect(await admit(original, created.qrCredential, "browser-audit-failure")).toMatchObject({
+      grantId: created.grantId,
+    });
+  });
+}
+
+async function verifyCryptographicRollback(
+  createStorage: GrantAuthorityContractFactory,
+): Promise<void> {
+  await withStorage(createStorage, async (storage) => {
+    const originalKeyRing = createKeyRing();
+    const original = createAuthority(storage, { keyRing: originalKeyRing });
+    const created = await createGrant(original);
+    const before = await findGrant(storage, created.grantId);
+    const rotatedKeyRing = createRotatedKeyRing(originalKeyRing);
+    const withoutOldKey = createAuthority(storage, {
+      keyRing: keepOnlyCurrentKeys(rotatedKeyRing),
+    });
+    expect(
+      await withoutOldKey.rotateControlGrantCredentialKeys(created.grantId, createActor()),
+    ).toEqual(rotationFailure);
+
+    const invalidRandomness = createAuthority(storage, {
+      keyRing: rotatedKeyRing,
+      randomness: { bytes: (length) => new Uint8Array(length === 12 ? 11 : length) },
+    });
+    expect(
+      await invalidRandomness.rotateControlGrantCredentialKeys(created.grantId, createActor()),
+    ).toEqual(rotationFailure);
+    expect(await findGrant(storage, created.grantId)).toEqual(before);
+    expect(await admit(original, created.qrCredential, "browser-crypto-failure")).toMatchObject({
+      grantId: created.grantId,
+    });
+  });
+}
+
+const rotationFailure = {
+  status: "rejected",
+  reason: "unavailable",
+  detail: "The Grant credential cannot be rotated.",
+} as const;
+
+async function withStorage(
+  createStorage: GrantAuthorityContractFactory,
+  work: (storage: FoundationStorage) => Promise<void>,
+): Promise<void> {
+  const handle = await createStorage();
+  try {
+    await work(handle.storage);
+  } finally {
+    await handle.cleanup();
+  }
+}
+
+function createRotationAuditFailingStorage(storage: FoundationStorage): FoundationStorage {
+  return {
+    transaction(work) {
+      return storage.transaction((transaction) => {
+        const wrapped = Object.create(transaction) as typeof transaction;
+        wrapped.appendGrantAudit = (entry) => {
+          if (entry.action === "credential-rotated") {
+            throw new Error("sqlite rotation audit failure must not escape");
+          }
+          transaction.appendGrantAudit(entry);
+        };
+        return work(wrapped);
+      });
+    },
+    readRoot: (recordId) => storage.readRoot(recordId),
+    readActions: (recordId) => storage.readActions(recordId),
+    readIdempotencyEntries: (recordId) => storage.readIdempotencyEntries(recordId),
+    readRecordMetadata: (recordId) => storage.readRecordMetadata(recordId),
+    readAuditEntries: (recordId) => storage.readAuditEntries(recordId),
+    readiness: () => storage.readiness(),
+    close: () => storage.close(),
+  };
+}
+
+function createAuthority(
+  storage: FoundationStorage,
+  configuration: {
+    keyRing?: GrantKeyRing;
+    randomness?: GrantRandomness;
+    nowMs?: () => number;
+  } = {},
+): GrantAuthority {
+  return createGrantAuthority(storage, {
+    environmentId: "test-environment",
+    clock: { nowMs: configuration.nowMs ?? (() => 1_000) },
+    randomness: configuration.randomness ?? createDeterministicRandomness(),
+    keyRing: configuration.keyRing ?? createKeyRing(),
+    controlScopeResolver: {
+      resolve(scope) {
+        expect(scope).toEqual(createScope());
+        return { status: "eligible", eventGameId: "game-1" };
+      },
+    },
+  });
+}
+
+async function createGrant(authority: GrantAuthority, expiresAtMs?: number) {
+  const result = await authority.createControlGrant({
+    scope: createScope(),
+    actor: createActor(),
+    expiresAtMs,
+  });
+  if (result.status !== "created") throw new Error("Expected a created Control Grant.");
+  return result;
+}
+
+async function admit(authority: GrantAuthority, qrCredential: string, browserContext: string) {
+  const result = await authority.admitControlGrant({ qrCredential, browserContext });
+  if (result.status !== "admitted") throw new Error("Expected an admitted Grant Session.");
+  return result;
+}
+
+function findGrant(storage: FoundationStorage, grantId: string) {
+  return storage.transaction((transaction) => transaction.findGrantById(grantId));
+}
+
+function readAudit(storage: FoundationStorage, grantId: string) {
+  return storage.transaction((transaction) => transaction.listGrantAudit(grantId));
+}
+
+function isRotationAudit(entry: { action: string }): boolean {
+  return entry.action === "credential-rotated";
+}
+
+function isExpiryAudit(entry: { action: string }): boolean {
+  return entry.action === "grant-expired";
+}
+
+function createScope(): ControlGrantScope {
+  return {
+    eventId: "event-1",
+    gameDayId: "day-1",
+    pitchId: "pitch-1",
+    pitchSlotId: "slot-1",
+  };
+}
+
+function createActor() {
+  return { kind: "fixture", id: "fixture-authority" } as const;
+}
+
+function createDeterministicRandomness(): GrantRandomness {
+  let randomCall = 0;
+  return {
+    bytes(length) {
+      randomCall += 1;
+      return Uint8Array.from({ length }, (_, index) => (index + length + randomCall) % 256);
+    },
+  };
+}
+
+function createKeyRing(): GrantKeyRing {
+  return {
+    encryption: {
+      currentVersion: "encryption-v1",
+      keys: new Map([["encryption-v1", Uint8Array.from({ length: 32 }, (_, index) => index + 1)]]),
+    },
+    lookup: {
+      currentVersion: "lookup-v1",
+      keys: new Map([["lookup-v1", Uint8Array.from({ length: 32 }, (_, index) => index + 33)]]),
+    },
+  };
+}
+
+function createRotatedKeyRing(original: GrantKeyRing): GrantKeyRing {
+  return {
+    encryption: {
+      currentVersion: "encryption-v2",
+      keys: new Map([
+        ...original.encryption.keys,
+        ["encryption-v2", Uint8Array.from({ length: 32 }, (_, index) => index + 97)],
+      ]),
+    },
+    lookup: {
+      currentVersion: "lookup-v2",
+      keys: new Map([
+        ...original.lookup.keys,
+        ["lookup-v2", Uint8Array.from({ length: 32 }, (_, index) => index + 65)],
+      ]),
+    },
+  };
+}
+
+function keepOnlyCurrentKeys(keyRing: GrantKeyRing): GrantKeyRing {
+  const encryptionKey = keyRing.encryption.keys.get(keyRing.encryption.currentVersion);
+  const lookupKey = keyRing.lookup.keys.get(keyRing.lookup.currentVersion);
+  if (encryptionKey === undefined || lookupKey === undefined) {
+    throw new Error("Expected current Grant test keys.");
+  }
+  return {
+    encryption: {
+      currentVersion: keyRing.encryption.currentVersion,
+      keys: new Map([[keyRing.encryption.currentVersion, encryptionKey]]),
+    },
+    lookup: {
+      currentVersion: keyRing.lookup.currentVersion,
+      keys: new Map([[keyRing.lookup.currentVersion, lookupKey]]),
+    },
+  };
+}

--- a/src/lib/grant-rotation.ts
+++ b/src/lib/grant-rotation.ts
@@ -1,0 +1,120 @@
+import {
+  computeLookupDigest,
+  decryptCredential,
+  encryptCredential,
+  parseCredentialToken,
+  sameSecret,
+} from "@/lib/grant-crypto";
+import type { FoundationStorage } from "@/lib/foundation-storage";
+import type { GrantAuthorityOptions } from "@/lib/grant-authority";
+import type { RotateControlGrantCredentialKeysResult } from "@/lib/grant-authority-types";
+import { createAuditEntry, expireGrantIfDue, validateActor } from "@/lib/grant-lifecycle";
+import type { ControlGrantScope, GrantAuthorityActor, StoredControlGrant } from "@/lib/grant-types";
+
+export async function rotateControlGrantCredentialKeys(
+  storage: FoundationStorage,
+  options: GrantAuthorityOptions,
+  environmentId: string,
+  grantId: string,
+  actorInput: GrantAuthorityActor,
+): Promise<RotateControlGrantCredentialKeysResult> {
+  const actor = validateActor(actorInput);
+  if (!actor.ok) return rotationFailure();
+
+  return storage
+    .transaction<RotateControlGrantCredentialKeysResult>((transaction) => {
+      const storedGrant = transaction.findGrantById(grantId);
+      if (storedGrant === null) {
+        return { status: "rejected", reason: "not-found", detail: "The Grant was not found." };
+      }
+      const grant = expireGrantIfDue(transaction, options, storedGrant);
+      if (grant.status === "expired" || grant.credential.materialState !== "present") {
+        return rotationFailure();
+      }
+      const binding = bindingForGrant(environmentId, grant);
+      const token = decryptCredential(grant.credential, binding, options.keyRing);
+      if (!credentialCanRotate(token, environmentId, grant, options)) return rotationFailure();
+
+      const rotatedGrant: StoredControlGrant = {
+        ...grant,
+        credential: encryptCredential(token, binding, options.randomness, options.keyRing),
+      };
+      transaction.updateGrant(rotatedGrant);
+      transaction.appendGrantAudit(
+        createAuditEntry(options, {
+          action: "credential-rotated",
+          actor: { kind: "authority", value: actor.value },
+          grant: rotatedGrant,
+          sessionId: null,
+          replacedSessionId: null,
+          eventGameId: null,
+          beforeStatus: grant.status,
+          afterStatus: rotatedGrant.status,
+        }),
+      );
+      return {
+        status: "rotated",
+        grantId: rotatedGrant.grantId,
+        encryptionKeyVersion: options.keyRing.encryption.currentVersion,
+        lookupKeyVersion: options.keyRing.lookup.currentVersion,
+      };
+    })
+    .catch(rotationFailure);
+}
+
+function credentialCanRotate(
+  token: string | null,
+  environmentId: string,
+  grant: StoredControlGrant,
+  options: GrantAuthorityOptions,
+): token is string {
+  if (
+    token === null ||
+    grant.credential.lookupDigest === null ||
+    grant.credential.lookupKeyVersion === null
+  ) {
+    return false;
+  }
+  const parsed = parseCredentialToken(token);
+  return (
+    parsed !== null &&
+    parsed.environmentId === environmentId &&
+    parsed.grantId === grant.grantId &&
+    parsed.grantType === grant.grantType &&
+    parsed.grantVersion === grant.grantVersion &&
+    parsed.credentialKind === grant.credential.kind &&
+    parsed.formatVersion === grant.credential.formatVersion &&
+    sameScope(parsed.scope, grant.scope) &&
+    sameSecret(
+      grant.credential.lookupDigest,
+      computeLookupDigest(token, options.keyRing, grant.credential.lookupKeyVersion),
+    )
+  );
+}
+
+function bindingForGrant(environmentId: string, grant: StoredControlGrant) {
+  return {
+    environmentId,
+    grantId: grant.grantId,
+    grantType: grant.grantType,
+    grantVersion: grant.grantVersion,
+    scope: grant.scope,
+  } as const;
+}
+
+function sameScope(left: ControlGrantScope, right: ControlGrantScope): boolean {
+  return (
+    left.eventId === right.eventId &&
+    left.gameDayId === right.gameDayId &&
+    left.pitchId === right.pitchId &&
+    left.pitchSlotId === right.pitchSlotId
+  );
+}
+
+function rotationFailure(): RotateControlGrantCredentialKeysResult {
+  return {
+    status: "rejected",
+    reason: "unavailable",
+    detail: "The Grant credential cannot be rotated.",
+  };
+}

--- a/src/lib/grant-storage-sqlite.ts
+++ b/src/lib/grant-storage-sqlite.ts
@@ -1,0 +1,475 @@
+import { Database } from "bun:sqlite";
+import {
+  GRANT_CREDENTIAL_FORMAT_VERSION,
+  GRANT_CREDENTIAL_KIND,
+  GRANT_TYPE,
+  isStoredGrantSessionStatus,
+  isStoredGrantStatus,
+  type StoredControlGrant,
+  type StoredGrantAuditEntry,
+  type StoredGrantSession,
+} from "@/lib/grant-types";
+
+type SqlStatement = ReturnType<Database["query"]>;
+type GrantRow = Record<string, unknown>;
+
+export type GrantSqliteStatements = {
+  byGrantId: SqlStatement;
+  byCredentialDigest: SqlStatement;
+  activeSessionByContext: SqlStatement;
+  sessionByBearer: SqlStatement;
+  sessionsByGrant: SqlStatement;
+  auditByGrant: SqlStatement;
+  insertGrant: SqlStatement;
+  updateGrant: SqlStatement;
+  insertSession: SqlStatement;
+  updateSession: SqlStatement;
+  insertAudit: SqlStatement;
+};
+
+const GRANT_SELECT_COLUMNS = `
+  grants.grant_id AS grant_id, grants.grant_type AS grant_type,
+  grants.grant_version AS grant_version, grants.event_id AS event_id,
+  grants.game_day_id AS game_day_id, grants.pitch_id AS pitch_id,
+  grants.pitch_slot_id AS pitch_slot_id, grants.status AS status,
+  grants.created_at_ms AS created_at_ms, grants.expires_at_ms AS expires_at_ms,
+  grants.credential_format_version AS credential_format_version,
+  grants.credential_kind AS credential_kind,
+  grants.credential_material_state AS credential_material_state,
+  grants.encryption_key_version AS encryption_key_version,
+  grants.lookup_key_version AS lookup_key_version,
+  grants.credential_iv AS credential_iv,
+  grants.credential_ciphertext AS credential_ciphertext,
+  grants.credential_tag AS credential_tag,
+  grants.credential_lookup_digest AS credential_lookup_digest,
+  grants.credential_fingerprint AS credential_fingerprint
+`;
+
+const SESSION_SELECT_COLUMNS = `
+  sessions.session_id AS session_id, sessions.grant_id AS grant_id,
+  sessions.grant_version AS grant_version, sessions.event_game_id AS event_game_id,
+  sessions.browser_context_digest AS browser_context_digest,
+  sessions.browser_context_key_version AS browser_context_key_version,
+  sessions.bearer_material_state AS bearer_material_state,
+  sessions.bearer_lookup_verifier AS bearer_lookup_verifier,
+  sessions.bearer_lookup_key_version AS bearer_lookup_key_version,
+  sessions.status AS status, sessions.created_at_ms AS created_at_ms,
+  sessions.last_active_at_ms AS last_active_at_ms, sessions.revoked_at_ms AS revoked_at_ms
+`;
+
+const AUDIT_SELECT_COLUMNS = `
+  audit.audit_id AS audit_id, audit.action AS action, audit.outcome AS outcome,
+  audit.actor_reference AS actor_reference, audit.grant_id AS grant_id,
+  audit.grant_type AS grant_type, audit.grant_version AS grant_version,
+  audit.event_id AS event_id, audit.game_day_id AS game_day_id,
+  audit.pitch_id AS pitch_id, audit.pitch_slot_id AS pitch_slot_id,
+  audit.session_id AS session_id, audit.replaced_session_id AS replaced_session_id,
+  audit.event_game_id AS event_game_id, audit.credential_kind AS credential_kind,
+  audit.credential_fingerprint AS credential_fingerprint,
+  audit.before_status AS before_status, audit.after_status AS after_status,
+  audit.created_at_ms AS created_at_ms
+`;
+
+export function createGrantSqliteStatements(database: Database): GrantSqliteStatements {
+  return {
+    byGrantId: database.query(
+      `SELECT ${GRANT_SELECT_COLUMNS} FROM foundation_grant_roots AS grants WHERE grants.grant_id = ?`,
+    ),
+    byCredentialDigest: database.query(
+      `SELECT ${GRANT_SELECT_COLUMNS} FROM foundation_grant_roots AS grants WHERE grants.credential_lookup_digest = ?`,
+    ),
+    activeSessionByContext: database.query(
+      `SELECT ${SESSION_SELECT_COLUMNS}
+       FROM foundation_grant_sessions AS sessions
+       WHERE sessions.grant_id = ? AND sessions.browser_context_digest = ? AND sessions.status = 'active'`,
+    ),
+    sessionByBearer: database.query(
+      `SELECT ${SESSION_SELECT_COLUMNS}
+       FROM foundation_grant_sessions AS sessions
+       WHERE sessions.bearer_lookup_verifier = ? AND sessions.bearer_lookup_key_version = ?`,
+    ),
+    sessionsByGrant: database.query(
+      `SELECT ${SESSION_SELECT_COLUMNS}
+       FROM foundation_grant_sessions AS sessions
+       WHERE sessions.grant_id = ? ORDER BY sessions.session_id`,
+    ),
+    auditByGrant: database.query(
+      `SELECT ${AUDIT_SELECT_COLUMNS}
+       FROM foundation_grant_audit AS audit
+       WHERE audit.grant_id = ? ORDER BY audit.audit_id`,
+    ),
+    insertGrant: database.query(`
+      INSERT INTO foundation_grant_roots (
+        grant_id, grant_type, grant_version, event_id, game_day_id, pitch_id, pitch_slot_id,
+        status, created_at_ms, expires_at_ms, credential_format_version, credential_kind,
+        credential_material_state, encryption_key_version, lookup_key_version, credential_iv, credential_ciphertext,
+        credential_tag, credential_lookup_digest, credential_fingerprint
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `),
+    updateGrant: database.query(`
+      UPDATE foundation_grant_roots SET
+        grant_type = ?, grant_version = ?, event_id = ?, game_day_id = ?, pitch_id = ?,
+        pitch_slot_id = ?, status = ?, created_at_ms = ?, expires_at_ms = ?,
+        credential_format_version = ?, credential_kind = ?, credential_material_state = ?, encryption_key_version = ?,
+        lookup_key_version = ?, credential_iv = ?, credential_ciphertext = ?,
+        credential_tag = ?, credential_lookup_digest = ?, credential_fingerprint = ?
+      WHERE grant_id = ?
+    `),
+    insertSession: database.query(`
+      INSERT INTO foundation_grant_sessions (
+        session_id, grant_id, grant_version, event_game_id, browser_context_digest,
+        browser_context_key_version, bearer_material_state, bearer_lookup_verifier, bearer_lookup_key_version,
+        status, created_at_ms, last_active_at_ms, revoked_at_ms
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `),
+    updateSession: database.query(`
+      UPDATE foundation_grant_sessions SET
+        grant_id = ?, grant_version = ?, event_game_id = ?, browser_context_digest = ?,
+        browser_context_key_version = ?, bearer_material_state = ?, bearer_lookup_verifier = ?,
+        bearer_lookup_key_version = ?, status = ?, created_at_ms = ?,
+        last_active_at_ms = ?, revoked_at_ms = ?
+      WHERE session_id = ?
+    `),
+    insertAudit: database.query(`
+      INSERT INTO foundation_grant_audit (
+        audit_id, action, outcome, actor_reference, grant_id, grant_type, grant_version,
+        event_id, game_day_id, pitch_id, pitch_slot_id, session_id, replaced_session_id,
+        event_game_id, credential_kind, credential_fingerprint, before_status, after_status,
+        created_at_ms
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `),
+  };
+}
+
+export function readGrantByStatement(
+  statement: SqlStatement,
+  ...parameters: string[]
+): StoredControlGrant | null {
+  const row = statement.get(...parameters) as GrantRow | null;
+  return row === null ? null : readStoredControlGrant(row);
+}
+
+export function readSessionByStatement(
+  statement: SqlStatement,
+  ...parameters: string[]
+): StoredGrantSession | null {
+  const row = statement.get(...parameters) as GrantRow | null;
+  return row === null ? null : readStoredGrantSession(row);
+}
+
+export function listGrantSessions(statement: SqlStatement, grantId: string): StoredGrantSession[] {
+  return statement.all(grantId).map((row) => readStoredGrantSession(asRecord(row)));
+}
+
+export function listGrantAudit(statement: SqlStatement, grantId: string): StoredGrantAuditEntry[] {
+  return statement.all(grantId).map((row) => readStoredGrantAuditEntry(asRecord(row)));
+}
+
+export function insertGrant(statements: GrantSqliteStatements, grant: StoredControlGrant): void {
+  statements.insertGrant.run(
+    grant.grantId,
+    grant.grantType,
+    grant.grantVersion,
+    grant.scope.eventId,
+    grant.scope.gameDayId,
+    grant.scope.pitchId,
+    grant.scope.pitchSlotId,
+    grant.status,
+    grant.createdAtMs,
+    grant.expiresAtMs,
+    grant.credential.formatVersion,
+    grant.credential.kind,
+    grant.credential.materialState,
+    grant.credential.encryptionKeyVersion,
+    grant.credential.lookupKeyVersion,
+    grant.credential.iv,
+    grant.credential.ciphertext,
+    grant.credential.tag,
+    grant.credential.lookupDigest,
+    grant.credential.fingerprint,
+  );
+}
+
+export function updateGrant(statements: GrantSqliteStatements, grant: StoredControlGrant): void {
+  statements.updateGrant.run(
+    grant.grantType,
+    grant.grantVersion,
+    grant.scope.eventId,
+    grant.scope.gameDayId,
+    grant.scope.pitchId,
+    grant.scope.pitchSlotId,
+    grant.status,
+    grant.createdAtMs,
+    grant.expiresAtMs,
+    grant.credential.formatVersion,
+    grant.credential.kind,
+    grant.credential.materialState,
+    grant.credential.encryptionKeyVersion,
+    grant.credential.lookupKeyVersion,
+    grant.credential.iv,
+    grant.credential.ciphertext,
+    grant.credential.tag,
+    grant.credential.lookupDigest,
+    grant.credential.fingerprint,
+    grant.grantId,
+  );
+}
+
+export function insertGrantSession(
+  statements: GrantSqliteStatements,
+  session: StoredGrantSession,
+): void {
+  statements.insertSession.run(
+    session.sessionId,
+    session.grantId,
+    session.grantVersion,
+    session.eventGameId,
+    session.browserContextDigest,
+    session.browserContextKeyVersion,
+    session.bearerMaterialState,
+    session.bearerLookupVerifier,
+    session.bearerLookupKeyVersion,
+    session.status,
+    session.createdAtMs,
+    session.lastActiveAtMs,
+    session.revokedAtMs,
+  );
+}
+
+export function updateGrantSession(
+  statements: GrantSqliteStatements,
+  session: StoredGrantSession,
+): void {
+  statements.updateSession.run(
+    session.grantId,
+    session.grantVersion,
+    session.eventGameId,
+    session.browserContextDigest,
+    session.browserContextKeyVersion,
+    session.bearerMaterialState,
+    session.bearerLookupVerifier,
+    session.bearerLookupKeyVersion,
+    session.status,
+    session.createdAtMs,
+    session.lastActiveAtMs,
+    session.revokedAtMs,
+    session.sessionId,
+  );
+}
+
+export function appendGrantAudit(
+  statements: GrantSqliteStatements,
+  entry: StoredGrantAuditEntry,
+): void {
+  statements.insertAudit.run(
+    entry.auditId,
+    entry.action,
+    entry.outcome,
+    entry.actorReference,
+    entry.grantId,
+    entry.grantType,
+    entry.grantVersion,
+    entry.scope.eventId,
+    entry.scope.gameDayId,
+    entry.scope.pitchId,
+    entry.scope.pitchSlotId,
+    entry.sessionId,
+    entry.replacedSessionId,
+    entry.eventGameId,
+    entry.credentialKind,
+    entry.credentialFingerprint,
+    entry.beforeStatus,
+    entry.afterStatus,
+    entry.createdAtMs,
+  );
+}
+
+function readStoredControlGrant(row: GrantRow): StoredControlGrant {
+  const grantType = readText(row.grant_type);
+  const status = readText(row.status);
+  if (grantType !== GRANT_TYPE || !isStoredGrantStatus(status)) {
+    throw new Error("Stored Grant state is invalid.");
+  }
+  const formatVersion = readInteger(row.credential_format_version);
+  const kind = readText(row.credential_kind);
+  if (formatVersion !== GRANT_CREDENTIAL_FORMAT_VERSION || kind !== GRANT_CREDENTIAL_KIND) {
+    throw new Error("Stored Grant credential metadata is invalid.");
+  }
+  const materialState = readText(row.credential_material_state);
+  const encryptionKeyVersion = readNullableText(row.encryption_key_version);
+  const lookupKeyVersion = readNullableText(row.lookup_key_version);
+  const iv = readNullableText(row.credential_iv);
+  const ciphertext = readNullableText(row.credential_ciphertext);
+  const tag = readNullableText(row.credential_tag);
+  const lookupDigest = readNullableText(row.credential_lookup_digest);
+  const materialPresent =
+    materialState === "present" &&
+    encryptionKeyVersion !== null &&
+    lookupKeyVersion !== null &&
+    iv !== null &&
+    ciphertext !== null &&
+    tag !== null &&
+    lookupDigest !== null;
+  const materialErased =
+    materialState === "erased" &&
+    encryptionKeyVersion === null &&
+    lookupKeyVersion === null &&
+    iv === null &&
+    ciphertext === null &&
+    tag === null &&
+    lookupDigest === null;
+  if (!materialPresent && !materialErased) {
+    throw new Error("Stored Grant credential material state is invalid.");
+  }
+  if ((status === "expired") !== (materialState === "erased")) {
+    throw new Error("Stored Grant lifecycle and credential material state do not match.");
+  }
+  return {
+    grantId: readText(row.grant_id),
+    grantType,
+    grantVersion: readText(row.grant_version),
+    scope: {
+      eventId: readText(row.event_id),
+      gameDayId: readText(row.game_day_id),
+      pitchId: readText(row.pitch_id),
+      pitchSlotId: readText(row.pitch_slot_id),
+    },
+    status,
+    createdAtMs: readInteger(row.created_at_ms),
+    expiresAtMs: readNullableInteger(row.expires_at_ms),
+    credential: {
+      materialState: materialState as "present" | "erased",
+      formatVersion,
+      kind,
+      encryptionKeyVersion,
+      lookupKeyVersion,
+      iv,
+      ciphertext,
+      tag,
+      lookupDigest,
+      fingerprint: readText(row.credential_fingerprint),
+    },
+  };
+}
+
+function readStoredGrantSession(row: GrantRow): StoredGrantSession {
+  const status = readText(row.status);
+  if (!isStoredGrantSessionStatus(status)) {
+    throw new Error("Stored Grant Session state is invalid.");
+  }
+  const bearerMaterialState = readText(row.bearer_material_state);
+  const bearerLookupVerifier = readNullableText(row.bearer_lookup_verifier);
+  const bearerLookupKeyVersion = readNullableText(row.bearer_lookup_key_version);
+  if (
+    !(
+      (bearerMaterialState === "present" &&
+        bearerLookupVerifier !== null &&
+        bearerLookupKeyVersion !== null) ||
+      (bearerMaterialState === "erased" &&
+        bearerLookupVerifier === null &&
+        bearerLookupKeyVersion === null)
+    )
+  ) {
+    throw new Error("Stored Grant Session bearer material state is invalid.");
+  }
+  if ((status === "expired") !== (bearerMaterialState === "erased")) {
+    throw new Error("Stored Grant Session lifecycle and bearer material state do not match.");
+  }
+  return {
+    sessionId: readText(row.session_id),
+    grantId: readText(row.grant_id),
+    grantVersion: readText(row.grant_version),
+    eventGameId: readText(row.event_game_id),
+    browserContextDigest: readText(row.browser_context_digest),
+    browserContextKeyVersion: readText(row.browser_context_key_version),
+    bearerMaterialState: bearerMaterialState as "present" | "erased",
+    bearerLookupVerifier,
+    bearerLookupKeyVersion,
+    status,
+    createdAtMs: readInteger(row.created_at_ms),
+    lastActiveAtMs: readInteger(row.last_active_at_ms),
+    revokedAtMs: readNullableInteger(row.revoked_at_ms),
+  };
+}
+
+function readStoredGrantAuditEntry(row: GrantRow): StoredGrantAuditEntry {
+  const action = readText(row.action);
+  const allowedActions: readonly StoredGrantAuditEntry["action"][] = [
+    "grant-created",
+    "credential-revealed",
+    "credential-rotated",
+    "grant-expired",
+    "grant-disabled",
+    "grant-revoked",
+    "session-admitted",
+    "session-replaced",
+  ];
+  if (!allowedActions.includes(action as StoredGrantAuditEntry["action"])) {
+    throw new Error("Stored Grant Audit Trail action is invalid.");
+  }
+  if (readText(row.outcome) !== "accepted" || readText(row.grant_type) !== GRANT_TYPE) {
+    throw new Error("Stored Grant Audit Trail outcome is invalid.");
+  }
+  const credentialKind = readNullableText(row.credential_kind);
+  if (credentialKind !== null && credentialKind !== GRANT_CREDENTIAL_KIND) {
+    throw new Error("Stored Grant Audit Trail credential kind is invalid.");
+  }
+  const beforeStatus = readNullableText(row.before_status);
+  const afterStatus = readNullableText(row.after_status);
+  if (
+    (beforeStatus !== null && !isStoredGrantStatus(beforeStatus)) ||
+    (afterStatus !== null && !isStoredGrantStatus(afterStatus))
+  ) {
+    throw new Error("Stored Grant Audit Trail status is invalid.");
+  }
+  return {
+    auditId: readText(row.audit_id),
+    action: action as StoredGrantAuditEntry["action"],
+    outcome: "accepted",
+    actorReference: readText(row.actor_reference),
+    grantId: readText(row.grant_id),
+    grantType: GRANT_TYPE,
+    grantVersion: readText(row.grant_version),
+    scope: {
+      eventId: readText(row.event_id),
+      gameDayId: readText(row.game_day_id),
+      pitchId: readText(row.pitch_id),
+      pitchSlotId: readText(row.pitch_slot_id),
+    },
+    sessionId: readNullableText(row.session_id),
+    replacedSessionId: readNullableText(row.replaced_session_id),
+    eventGameId: readNullableText(row.event_game_id),
+    credentialKind: credentialKind as StoredGrantAuditEntry["credentialKind"],
+    credentialFingerprint: readNullableText(row.credential_fingerprint),
+    beforeStatus: beforeStatus as StoredGrantAuditEntry["beforeStatus"],
+    afterStatus: afterStatus as StoredGrantAuditEntry["afterStatus"],
+    createdAtMs: readInteger(row.created_at_ms),
+  };
+}
+
+function asRecord(value: unknown): GrantRow {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error("SQLite returned an invalid Grant row.");
+  }
+  return value as GrantRow;
+}
+
+function readText(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "bigint") return String(value);
+  throw new Error("SQLite returned an invalid Grant value.");
+}
+
+function readInteger(value: unknown): number {
+  const parsed = Number(readText(value));
+  if (!Number.isSafeInteger(parsed)) throw new Error("SQLite returned an invalid Grant integer.");
+  return parsed;
+}
+
+function readNullableText(value: unknown): string | null {
+  return value === null ? null : readText(value);
+}
+
+function readNullableInteger(value: unknown): number | null {
+  return value === null ? null : readInteger(value);
+}

--- a/src/lib/grant-types.ts
+++ b/src/lib/grant-types.ts
@@ -1,0 +1,184 @@
+import { validateOpaqueIdentifier, type ValidationResult } from "@/lib/validation-policy";
+
+export const GRANT_CREDENTIAL_FORMAT_VERSION = 1 as const;
+export const GRANT_CREDENTIAL_KIND = "qr" as const;
+export const GRANT_TYPE = "control" as const;
+export const OPAQUE_MIGRATION_CREDENTIAL_REFERENCE_PREFIX =
+  "opaque-migration-reference-v1:" as const;
+
+export type GrantType = typeof GRANT_TYPE;
+export type GrantCredentialKind = typeof GRANT_CREDENTIAL_KIND;
+
+export type ControlGrantScope = {
+  eventId: string;
+  gameDayId: string;
+  pitchId: string;
+  pitchSlotId: string;
+};
+
+export type GrantClock = {
+  nowMs(): number;
+};
+
+export type GrantRandomness = {
+  bytes(length: number): Uint8Array;
+};
+
+export type GrantKeyRing = {
+  encryption: GrantKeySet;
+  lookup: GrantKeySet;
+};
+
+export type GrantKeySet = {
+  currentVersion: string;
+  keys: ReadonlyMap<string, Uint8Array>;
+};
+
+export type GrantAuthorityActor = {
+  kind: "fixture";
+  id: string;
+};
+
+export type ControlGrantScopeResolution =
+  | { status: "eligible"; eventGameId: string }
+  | { status: "empty" | "conflict" | "mismatch" | "unavailable"; detail?: string };
+
+export type ControlGrantScopeResolver = {
+  resolve(scope: ControlGrantScope): ControlGrantScopeResolution;
+};
+
+export type StoredGrantStatus = "active" | "disabled" | "revoked" | "expired";
+
+export type StoredGrantCredential = {
+  materialState: "present" | "erased";
+  formatVersion: typeof GRANT_CREDENTIAL_FORMAT_VERSION;
+  kind: GrantCredentialKind;
+  encryptionKeyVersion: string | null;
+  lookupKeyVersion: string | null;
+  iv: string | null;
+  ciphertext: string | null;
+  tag: string | null;
+  lookupDigest: string | null;
+  fingerprint: string;
+};
+
+export type StoredControlGrant = {
+  grantId: string;
+  grantType: GrantType;
+  grantVersion: string;
+  scope: ControlGrantScope;
+  status: StoredGrantStatus;
+  createdAtMs: number;
+  expiresAtMs: number | null;
+  credential: StoredGrantCredential;
+};
+
+export type StoredGrantSessionStatus = "active" | "revoked" | "expired";
+
+export type StoredGrantSession = {
+  sessionId: string;
+  grantId: string;
+  grantVersion: string;
+  eventGameId: string;
+  browserContextDigest: string;
+  browserContextKeyVersion: string;
+  bearerMaterialState: "present" | "erased";
+  bearerLookupVerifier: string | null;
+  bearerLookupKeyVersion: string | null;
+  status: StoredGrantSessionStatus;
+  createdAtMs: number;
+  lastActiveAtMs: number;
+  revokedAtMs: number | null;
+};
+
+export type GrantAuditAction =
+  | "grant-created"
+  | "credential-revealed"
+  | "credential-rotated"
+  | "grant-expired"
+  | "grant-disabled"
+  | "grant-revoked"
+  | "session-admitted"
+  | "session-replaced";
+
+export type StoredGrantAuditEntry = {
+  auditId: string;
+  action: GrantAuditAction;
+  outcome: "accepted";
+  actorReference: string;
+  grantId: string;
+  grantType: GrantType;
+  grantVersion: string;
+  scope: ControlGrantScope;
+  sessionId: string | null;
+  replacedSessionId: string | null;
+  eventGameId: string | null;
+  credentialKind: GrantCredentialKind | null;
+  credentialFingerprint: string | null;
+  beforeStatus: StoredGrantStatus | null;
+  afterStatus: StoredGrantStatus | null;
+  createdAtMs: number;
+};
+
+export type GrantSessionSummary = {
+  sessionId: string;
+  grantId: string;
+  grantVersion: string;
+  eventGameId: string;
+  status: StoredGrantSessionStatus;
+  createdAtMs: number;
+  lastActiveAtMs: number;
+  revokedAtMs: number | null;
+};
+
+export function validateControlGrantScope(value: unknown): ValidationResult<ControlGrantScope> {
+  if (!isRecord(value)) return invalid("Control Grant scope must be an object.");
+
+  const eventId = validateOpaqueIdentifier(value.eventId, "scope.eventId");
+  const gameDayId = validateOpaqueIdentifier(value.gameDayId, "scope.gameDayId");
+  const pitchId = validateOpaqueIdentifier(value.pitchId, "scope.pitchId");
+  const pitchSlotId = validateOpaqueIdentifier(value.pitchSlotId, "scope.pitchSlotId");
+  if (!eventId.ok) return eventId;
+  if (!gameDayId.ok) return gameDayId;
+  if (!pitchId.ok) return pitchId;
+  if (!pitchSlotId.ok) return pitchSlotId;
+
+  return valid({
+    eventId: eventId.value,
+    gameDayId: gameDayId.value,
+    pitchId: pitchId.value,
+    pitchSlotId: pitchSlotId.value,
+  });
+}
+
+export function cloneStoredControlGrant(grant: StoredControlGrant): StoredControlGrant {
+  return structuredClone(grant);
+}
+
+export function cloneStoredGrantSession(session: StoredGrantSession): StoredGrantSession {
+  return structuredClone(session);
+}
+
+export function cloneStoredGrantAuditEntry(entry: StoredGrantAuditEntry): StoredGrantAuditEntry {
+  return structuredClone(entry);
+}
+
+export function isStoredGrantStatus(value: unknown): value is StoredGrantStatus {
+  return value === "active" || value === "disabled" || value === "revoked" || value === "expired";
+}
+
+export function isStoredGrantSessionStatus(value: unknown): value is StoredGrantSessionStatus {
+  return value === "active" || value === "revoked" || value === "expired";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function valid<T>(value: T): ValidationResult<T> {
+  return { ok: true, value };
+}
+
+function invalid<T>(error: string): ValidationResult<T> {
+  return { ok: false, error };
+}


### PR DESCRIPTION
## Summary

- Add the Control Grant authority deep module for scoped QR credential creation, reveal, admission, authorization, replacement, revocation, and audit.
- Protect reusable credentials with AES-256-GCM, independently index them with keyed HMACs, and store only keyed Grant Session bearer verifiers.
- Provide shared memory/SQLite lifecycle contracts, atomic state-and-audit writes, pseudonymous provenance, cryptographic erasure migration, and bounded independent-process contention coverage.

## Why

Control authority needs a durable capability boundary that does not expose credential plaintext, database errors, or natural-person identity. This is the minimum complete QR-to-device-session path required by later lifecycle and Event Game binding layers.

## Impact

Presenting a valid scoped QR credential creates a pseudonymous device session; rescanning in the same browser context replaces only that session. Invalid credentials and storage failures remain generic, secrets never enter durable audit evidence, and corruption freezes authoritative writes.

## Validation

- `bun install --frozen-lockfile`
- `bun audit` — no vulnerabilities
- `bun run check`
- relevant Fast and SQLite tests — 29 passed
- `bun run test` — 177 passed
- `bun run test:focused:grant` — 14 passed
- `bun run build`
- `bun run build:executable`

No Qualification Test or `bun run check:sqlite-runtime` workload was run.

## Stack

Fourth layer of stack #103. Depends on #101 and is followed by #124.

Closes #74.
