### PR TITLE
Converge Event Game corrections and overrides (#75)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -112,6 +112,10 @@ _Avoid_: Mutable event, current value
 A Control Action that names one stable Game Fact and makes it ineffective or effective again without removing either the fact or earlier Corrections from the Control Audit Trail.
 _Avoid_: Delete, edit history, undo latest
 
+**Opposing Concurrent Corrections**:
+Corrections against one stable Game Fact with opposing effectiveness values and no causal relation. Their canonical occurrence and operation identity order selects the effective outcome while retaining the conflict evidence; a later causal Correction may replace it.
+_Avoid_: Socket-arrival resolution, conflict UI, undo latest
+
 **Locked-Game Correction**:
 An Event Admin-submitted Control Action that directly reconciles a locked Event Game's current score, flag-catching team, catch time, end time, or other displayed end-state fact without reopening Controller operation. It atomically states the corrected values, preserves the previous values in the Control Audit Trail, and requires no reason or stated basis. A rule-inconsistent value receives one confirmation and records an Official Override.
 _Avoid_: Reopen Game, edit history, correction reason

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -24,6 +24,10 @@ Classify an executable test by its purpose, risk, and execution boundary. Durati
 
 The timing values are review targets, not hard assertions. Crossing one requires investigation and an explicit decision; elapsed time alone does not reclassify a test or justify weakening or removing it.
 
+### Issue #75 generated convergence coverage
+
+The fixed-seed 1,000-sequence Event Game correction test remains a Fast Test: it uses the in-memory adapter, injected clocks, and deterministic action fixtures. After splitting the correction tests, the generated file measured 2.54 seconds on Darwin arm64 with Bun 1.3.14, narrowly over the two-second per-file review target while remaining within the ten-second ordinary-suite target. The test retains the required 1,000 sequences and is not weakened; revisit the implementation if the file grows materially or the ordinary suite approaches its ten-second target.
+
 The reference environment for timing review is the supported Bun version from `package.json` on a native development environment. Record the operating system, architecture, Bun version, and relevant resource measurements when investigating a target overrun.
 
 ## Ordinary execution boundary

--- a/src/lib/event-game-action-codecs.ts
+++ b/src/lib/event-game-action-codecs.ts
@@ -46,7 +46,7 @@ export function createControlActionCodecRegistry(
 }
 
 export function createDefaultControlActionCodecs(): readonly ControlActionCodec[] {
-  return [createGameFactCodec(), createCorrectionCodec()];
+  return [createGameFactCodec(), createCorrectionCodec(), createTeamAssignmentCorrectionCodec()];
 }
 
 export function createDeterministicTestIqaInterpreter(version: string): IqaGameRulesInterpreter {
@@ -74,6 +74,13 @@ type CorrectionPayload = {
   correctionId: string;
   targetFactId: string;
   effective: boolean;
+};
+
+type TeamAssignmentCorrectionPayload = {
+  correctionId: string;
+  gameSideId: string;
+  eventTeamId: string;
+  teamInterpretationRef: string;
 };
 
 function createGameFactCodec(): ControlActionCodec<GameFactPayload> {
@@ -164,6 +171,49 @@ function createCorrectionCodec(): ControlActionCodec<CorrectionPayload> {
         correctionId: payload.correctionId,
         targetFactId: payload.targetFactId,
         effective: payload.effective,
+      };
+    },
+  };
+}
+
+function createTeamAssignmentCorrectionCodec(): ControlActionCodec<TeamAssignmentCorrectionPayload> {
+  return {
+    kind: "team-assignment-correction",
+    version: "1",
+    decode(payload) {
+      if (!isRecord(payload))
+        return invalid("Team Assignment Correction payload must be an object.");
+      const correctionId = validateId(payload.correctionId, "payload.correctionId");
+      const gameSideId = validateId(payload.gameSideId, "payload.gameSideId");
+      const eventTeamId = validateId(payload.eventTeamId, "payload.eventTeamId");
+      const teamInterpretationRef = validateId(
+        payload.teamInterpretationRef,
+        "payload.teamInterpretationRef",
+      );
+      if (!correctionId.ok) return correctionId;
+      if (!gameSideId.ok) return gameSideId;
+      if (!eventTeamId.ok) return eventTeamId;
+      if (!teamInterpretationRef.ok) return teamInterpretationRef;
+      return valid({
+        correctionId: correctionId.value,
+        gameSideId: gameSideId.value,
+        eventTeamId: eventTeamId.value,
+        teamInterpretationRef: teamInterpretationRef.value,
+      });
+    },
+    canonicalize(payload) {
+      return canonicalizeJson(payload);
+    },
+    fingerprint(payload) {
+      return sha256(canonicalizeJson(payload));
+    },
+    interpret(payload) {
+      return {
+        type: "team-assignment-correction",
+        correctionId: payload.correctionId,
+        gameSideId: payload.gameSideId,
+        eventTeamId: payload.eventTeamId,
+        teamInterpretationRef: payload.teamInterpretationRef,
       };
     },
   };
@@ -337,7 +387,7 @@ export function validateRecoveryProvenance(
   return shape;
 }
 
-function validateRecoveryProvenanceShape(
+export function validateRecoveryProvenanceShape(
   value: unknown,
 ): ValidationResult<ControlActionRecoveryProvenance | undefined> {
   if (value === undefined) return valid(undefined);
@@ -425,6 +475,26 @@ export function validateInterpretation(
       correctionId: correctionId.value,
       targetFactId: targetFactId.value,
       effective: value.effective,
+    });
+  }
+  if (value.type === "team-assignment-correction") {
+    const correctionId = validateId(value.correctionId, "interpretation.correctionId");
+    const gameSideId = validateId(value.gameSideId, "interpretation.gameSideId");
+    const eventTeamId = validateId(value.eventTeamId, "interpretation.eventTeamId");
+    const teamInterpretationRef = validateId(
+      value.teamInterpretationRef,
+      "interpretation.teamInterpretationRef",
+    );
+    if (!correctionId.ok) return correctionId;
+    if (!gameSideId.ok) return gameSideId;
+    if (!eventTeamId.ok) return eventTeamId;
+    if (!teamInterpretationRef.ok) return teamInterpretationRef;
+    return valid({
+      type: "team-assignment-correction",
+      correctionId: correctionId.value,
+      gameSideId: gameSideId.value,
+      eventTeamId: eventTeamId.value,
+      teamInterpretationRef: teamInterpretationRef.value,
     });
   }
   if (value.type === "non-fact") {

--- a/src/lib/event-game-actions-sqlite.focused.ts
+++ b/src/lib/event-game-actions-sqlite.focused.ts
@@ -5,12 +5,25 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   createDeterministicTestIqaInterpreter,
+  createControlActionCodecRegistry,
+  actionIdentity,
+  LEGACY_CONTROL_ACTION_VERSION,
+  LEGACY_CONTROL_AUDIT_VERSION,
+  materializeControlAction,
+  prepareControlAction,
+  sha256,
   type ControlActionInput,
 } from "@/lib/event-game-actions";
 import { createEventGameRecord, type ExternalScopeResolver } from "@/lib/event-game-record";
-import { ACCEPTED_AUDIT_DETAIL, createAuditEntry } from "@/lib/event-game-record-helpers";
+import {
+  ACCEPTED_AUDIT_DETAIL,
+  createAuditEntry,
+  createConflictAuditEntry,
+} from "@/lib/event-game-record-helpers";
 import { openSqliteFoundationStorage } from "@/lib/foundation-storage-sqlite";
 import type { EventGameRecordRoot } from "@/lib/foundation-record-types";
+import { canonicalizeEventGameRecordRoot } from "@/lib/foundation-record-types";
+import { FOUNDATION_MIGRATIONS } from "@/lib/foundation-migrations";
 
 describe("SQLite immutable Event Game actions", () => {
   test("persists the action, idempotency, metadata, and audit across restart", async () => {
@@ -31,9 +44,235 @@ describe("SQLite immutable Event Game actions", () => {
         status: "duplicate-accepted",
       });
       expect(await reopenedRecord.readMetadata()).toMatchObject({ actionCount: 1 });
-      expect((await reopenedRecord.readAudit(createAuditAuthority())).length).toBe(1);
+      const audit = await reopenedRecord.readAudit(createAuditAuthority());
+      expect(audit.length).toBe(1);
+      expect(audit[0]).toMatchObject({
+        links: {
+          actionId: expect.any(String),
+          targetFactId: null,
+          causalPredecessorIds: [],
+          relatedOperationIds: [],
+        },
+        provenance: {
+          occurrence: action.occurrence,
+          grant: action.grant,
+          lifecycle: action.lifecycle,
+          override: null,
+          recoveryProvenance: null,
+        },
+      });
       expect(await reopenedRecord.rebuild()).toMatchObject({ status: "ready" });
       expect(await reopenedRecord.readiness()).toMatchObject({ ok: true, actionCount: 1 });
+      reopenedStorage.close();
+    });
+  });
+
+  test("fails closed for an out-of-scope Team Assignment Correction without SQLite partial retention", async () => {
+    await withDatabase(async (databasePath) => {
+      const root = createRoot("record-sqlite-team-scope");
+      const storage = openSqliteFoundationStorage(databasePath);
+      await storage.applyMigrations();
+      const record = createRecord(storage, root);
+      expect(await record.registerRoot(root)).toMatchObject({ status: "registered" });
+      const correction: ControlActionInput = {
+        ...createFact(root, "operation-team-out-of-scope", 1_000),
+        kind: { id: "team-assignment-correction", version: "1" },
+        payload: {
+          correctionId: "correction-team-out-of-scope",
+          gameSideId: "side-a",
+          eventTeamId: "team-not-in-event",
+          teamInterpretationRef: "interpretation-out-of-scope",
+        },
+      };
+      expect(await record.acceptAction(correction)).toMatchObject({
+        status: "rejected",
+        reason: "invalid-action",
+      });
+      expect(await record.acceptAction(correction)).toMatchObject({
+        status: "rejected",
+        reason: "invalid-action",
+      });
+      expect(await record.readActions()).toHaveLength(0);
+      expect(await record.readiness()).toMatchObject({ ok: true, actionCount: 0 });
+      storage.close();
+    });
+  });
+
+  test("uses current effective team assignments for SQLite reuse and rejects causal duplicates", async () => {
+    await withDatabase(async (databasePath) => {
+      const root = createRoot("record-sqlite-team-history");
+      const storage = openSqliteFoundationStorage(databasePath);
+      await storage.applyMigrations();
+      const record = createRecord(storage, root);
+      expect(await record.registerRoot(root)).toMatchObject({ status: "registered" });
+      const moveSideB = createTeamAssignmentCorrection(
+        root,
+        "operation-team-b-to-d",
+        "side-b",
+        "team-d",
+        "interpretation-b-d",
+        1_000,
+      );
+      const reuseFreedTeam = createTeamAssignmentCorrection(
+        root,
+        "operation-team-a-to-b",
+        "side-a",
+        "team-b",
+        "interpretation-a-b",
+        2_000,
+        ["operation-team-b-to-d"],
+      );
+      expect(await record.acceptAction(moveSideB)).toMatchObject({ status: "accepted" });
+      expect(await record.acceptAction(reuseFreedTeam)).toMatchObject({ status: "accepted" });
+      expect(await record.readiness()).toMatchObject({ ok: true, actionCount: 2 });
+      storage.close();
+
+      const reopenedStorage = openSqliteFoundationStorage(databasePath);
+      const reopened = createRecord(reopenedStorage, root);
+      expect(await reopened.registerRoot(root)).toMatchObject({ status: "idempotent" });
+      expect(await reopened.readiness()).toMatchObject({ ok: true, actionCount: 2 });
+      const rebuilt = await reopened.rebuild();
+      expect(rebuilt).toMatchObject({ status: "ready" });
+      if (rebuilt.status !== "ready") throw new Error("Expected a ready rebuild.");
+      expect(rebuilt.effectiveTeamAssignments).toEqual([
+        {
+          gameSideId: "side-a",
+          eventTeamId: "team-b",
+          teamInterpretationRef: "interpretation-a-b",
+        },
+        {
+          gameSideId: "side-b",
+          eventTeamId: "team-d",
+          teamInterpretationRef: "interpretation-b-d",
+        },
+      ]);
+
+      const first = createTeamAssignmentCorrection(
+        root,
+        "operation-team-a-to-c",
+        "side-a",
+        "team-c",
+        "interpretation-a-c",
+        3_000,
+        ["operation-team-a-to-b"],
+      );
+      const duplicate = createTeamAssignmentCorrection(
+        root,
+        "operation-team-b-to-c",
+        "side-b",
+        "team-c",
+        "interpretation-b-c",
+        4_000,
+        ["operation-team-a-to-c"],
+      );
+      expect(await reopened.acceptAction(first)).toMatchObject({ status: "accepted" });
+      expect(await reopened.acceptAction(duplicate)).toMatchObject({
+        status: "rejected",
+        reason: "invalid-action",
+      });
+      expect((await reopened.readActions()).map((stored) => stored.action.operationId)).toEqual([
+        "operation-team-b-to-d",
+        "operation-team-a-to-b",
+        "operation-team-a-to-c",
+      ]);
+      expect(await reopened.readiness()).toMatchObject({ ok: true, actionCount: 3 });
+      reopenedStorage.close();
+    });
+  });
+
+  test("rebuilds overlapping team-conflict components and accepts a causal repair after restart", async () => {
+    await withDatabase(async (databasePath) => {
+      const root = createRoot("record-sqlite-team-component");
+      const storage = openSqliteFoundationStorage(databasePath);
+      await storage.applyMigrations();
+      const record = createRecord(storage, root);
+      expect(await record.registerRoot(root)).toMatchObject({ status: "registered" });
+      const assignmentA1 = createTeamAssignmentCorrection(
+        root,
+        "team-component-a-1",
+        "side-a",
+        "team-c",
+        "interpretation-a-c-1",
+        1_000,
+      );
+      const assignmentB = createTeamAssignmentCorrection(
+        root,
+        "team-component-b",
+        "side-b",
+        "team-c",
+        "interpretation-b-c",
+        1_001,
+      );
+      const assignmentA2 = createTeamAssignmentCorrection(
+        root,
+        "team-component-a-2",
+        "side-a",
+        "team-c",
+        "interpretation-a-c-2",
+        1_002,
+      );
+      for (const action of [assignmentB, assignmentA2, assignmentA1]) {
+        expect(await record.acceptAction(action)).toMatchObject({ status: "accepted" });
+      }
+      expect(await record.readiness()).toMatchObject({ ok: true, actionCount: 3 });
+      storage.close();
+
+      const reopenedStorage = openSqliteFoundationStorage(databasePath);
+      const reopened = createRecord(reopenedStorage, root);
+      expect(await reopened.registerRoot(root)).toMatchObject({ status: "idempotent" });
+      expect(await reopened.readiness()).toMatchObject({ ok: true, actionCount: 3 });
+      const rebuilt = await reopened.rebuild();
+      expect(rebuilt).toMatchObject({ status: "ready" });
+      if (rebuilt.status !== "ready") throw new Error("Expected a ready rebuild.");
+      expect(rebuilt.effectiveTeamAssignments).toEqual([
+        {
+          gameSideId: "side-a",
+          eventTeamId: "team-c",
+          teamInterpretationRef: "interpretation-a-c-2",
+        },
+        {
+          gameSideId: "side-b",
+          eventTeamId: "team-b",
+          teamInterpretationRef: "interpretation-b",
+        },
+      ]);
+      expect(rebuilt.conflicts).toEqual([
+        expect.objectContaining({
+          operationIds: ["team-component-a-1", "team-component-b"],
+          winnerOperationId: "team-component-b",
+        }),
+        expect.objectContaining({
+          operationIds: ["team-component-b", "team-component-a-2"],
+          winnerOperationId: "team-component-a-2",
+        }),
+      ]);
+
+      const repair = createTeamAssignmentCorrection(
+        root,
+        "team-component-repair",
+        "side-b",
+        "team-d",
+        "interpretation-b-d-repair",
+        2_000,
+        ["team-component-a-1", "team-component-b", "team-component-a-2"],
+      );
+      expect(await reopened.acceptAction(repair)).toMatchObject({ status: "accepted" });
+      expect(await reopened.readiness()).toMatchObject({ ok: true, actionCount: 4 });
+      const repaired = await reopened.rebuild();
+      expect(repaired).toMatchObject({ status: "ready" });
+      if (repaired.status !== "ready") throw new Error("Expected a ready rebuild.");
+      expect(repaired.effectiveTeamAssignments).toEqual([
+        {
+          gameSideId: "side-a",
+          eventTeamId: "team-c",
+          teamInterpretationRef: "interpretation-a-c-2",
+        },
+        {
+          gameSideId: "side-b",
+          eventTeamId: "team-d",
+          teamInterpretationRef: "interpretation-b-d-repair",
+        },
+      ]);
       reopenedStorage.close();
     });
   });
@@ -47,20 +286,182 @@ describe("SQLite immutable Event Game actions", () => {
       await record.registerRoot(root);
       const action = createFact(root, "operation-conflict", 1_000);
       expect(await record.acceptAction(action)).toMatchObject({ status: "accepted" });
-      expect(
-        await record.acceptAction({
+      const candidates: readonly ControlActionInput[] = [
+        {
           ...action,
           payload: {
             ...(action.payload as Record<string, unknown>),
             data: { changed: true },
           },
-        }),
-      ).toMatchObject({ status: "rejected", reason: "operation-conflict" });
+        },
+        {
+          ...action,
+          occurrence: { trustedAtMs: 1_001, clientOriginAtMs: 1_001, source: "online" },
+        },
+        {
+          ...action,
+          grant: { sessionId: "session-2", versionId: "grant-version-1" },
+        },
+        {
+          ...action,
+          causalPredecessorIds: ["operation-conflict"],
+        },
+        {
+          ...action,
+          kind: { id: "correction", version: "1" },
+          payload: {
+            correctionId: "correction-reused-operation",
+            targetFactId: "fact-operation-conflict",
+            effective: false,
+          },
+        },
+      ];
+      for (const candidate of candidates) {
+        expect(await record.acceptAction(candidate)).toMatchObject({
+          status: "rejected",
+          reason: "operation-conflict",
+        });
+      }
       expect((await record.readActions()).length).toBe(1);
       expect(await record.readMetadata()).toMatchObject({ actionCount: 1 });
-      expect((await record.readAudit(createAuditAuthority())).length).toBe(2);
+      expect(await record.readiness()).toMatchObject({ ok: true, actionCount: 1 });
+      expect((await record.readAudit(createAuditAuthority())).length).toBe(candidates.length + 1);
       storage.close();
+
+      const reopened = openSqliteFoundationStorage(databasePath);
+      const reopenedRecord = createRecord(reopened, root);
+      expect(await reopenedRecord.registerRoot(root)).toMatchObject({ status: "idempotent" });
+      expect(await reopenedRecord.readiness()).toMatchObject({ ok: true, actionCount: 1 });
+      expect(
+        await reopenedRecord.acceptAction(createFact(root, "operation-after-conflict", 2_000)),
+      ).toMatchObject({ status: "accepted" });
+      reopened.close();
     });
+  });
+
+  test("fails readiness when durable rejected-collision evidence is not content-bound", async () => {
+    const mutations: readonly [string, (audit: Record<string, unknown>) => void][] = [
+      [
+        "interpretation",
+        (audit) => {
+          const rejected = requiredRejectedAttempt(audit);
+          const interpretation = rejected.interpretation as Record<string, unknown>;
+          interpretation.factType = "tampered-fact-type";
+        },
+      ],
+      [
+        "canonical-content",
+        (audit) => {
+          requiredRejectedAttempt(audit).canonicalContent = "{}";
+        },
+      ],
+      [
+        "fingerprint",
+        (audit) => {
+          const rejected = requiredRejectedAttempt(audit);
+          rejected.contentFingerprint = "f".repeat(64);
+          audit.auditId = `audit-${sha256(`${String(audit.recordId)}:operation-conflict:${String(audit.operationId)}:${String(rejected.contentFingerprint)}`)}`;
+        },
+      ],
+      [
+        "accepted-operation",
+        (audit) => {
+          const collision = (audit.links as Record<string, unknown>).collision as Record<
+            string,
+            unknown
+          >;
+          collision.acceptedOperationId = "operation-not-retained";
+        },
+      ],
+      [
+        "accepted-action-id",
+        (audit) => {
+          const links = audit.links as Record<string, unknown>;
+          links.actionId = "action-not-retained";
+        },
+      ],
+      [
+        "ordering-operation",
+        (audit) => {
+          const links = audit.links as Record<string, unknown>;
+          (links.ordering as Record<string, unknown>).operationId = "operation-not-retained";
+        },
+      ],
+      [
+        "entry-operation",
+        (audit) => {
+          audit.operationId = "operation-retargeted";
+        },
+      ],
+      [
+        "accepted-fingerprint",
+        (audit) => {
+          const collision = (audit.links as Record<string, unknown>).collision as Record<
+            string,
+            unknown
+          >;
+          collision.acceptedContentFingerprint = "f".repeat(64);
+        },
+      ],
+      [
+        "accepted-provenance",
+        (audit) => {
+          const provenance = audit.provenance as Record<string, unknown>;
+          (provenance.grant as Record<string, unknown>).sessionId = "session-retargeted";
+        },
+      ],
+    ];
+
+    for (const [label, mutate] of mutations) {
+      await withDatabase(async (databasePath) => {
+        const root = createRoot(`record-sqlite-collision-${label}`);
+        const storage = openSqliteFoundationStorage(databasePath);
+        await storage.applyMigrations();
+        const record = createRecord(storage, root);
+        await record.registerRoot(root);
+        const accepted = createFact(root, "operation-collision", 1_000);
+        expect(await record.acceptAction(accepted)).toMatchObject({ status: "accepted" });
+        expect(
+          await record.acceptAction({
+            ...accepted,
+            payload: {
+              ...(accepted.payload as Record<string, unknown>),
+              data: { rejected: true },
+            },
+          }),
+        ).toMatchObject({ status: "rejected", reason: "operation-conflict" });
+        expect(await record.readiness()).toMatchObject({ ok: true, actionCount: 1 });
+        storage.close();
+
+        const database = new Database(databasePath);
+        const row = database
+          .query(
+            "SELECT audit_id, audit_json FROM foundation_event_game_record_audit WHERE audit_kind = 'action-conflict'",
+          )
+          .get() as { audit_id: string; audit_json: string } | null;
+        if (row === null) throw new Error("Expected rejected collision evidence.");
+        const audit = JSON.parse(row.audit_json) as Record<string, unknown>;
+        mutate(audit);
+        database
+          .query(
+            "UPDATE foundation_event_game_record_audit SET audit_id = ?, audit_json = ? WHERE audit_id = ?",
+          )
+          .run(String(audit.auditId), JSON.stringify(audit), row.audit_id);
+        database.close();
+
+        const reopened = openSqliteFoundationStorage(databasePath);
+        const reopenedRecord = createRecord(reopened, root);
+        expect(await reopenedRecord.registerRoot(root)).toMatchObject({ status: "idempotent" });
+        expect(await reopenedRecord.readiness(), label).toMatchObject({
+          ok: false,
+          status: "rebuild-failure",
+        });
+        expect(
+          await reopenedRecord.acceptAction(createFact(root, "operation-after-corruption", 2_000)),
+        ).toMatchObject({ status: "rejected", reason: "storage-not-ready" });
+        reopened.close();
+      });
+    }
   });
 
   test("rolls back action, idempotency, metadata, and audit when the commit fails", async () => {
@@ -94,6 +495,171 @@ describe("SQLite immutable Event Game actions", () => {
       expect(await record.readMetadata()).toMatchObject({ actionCount: 0 });
       expect((await record.readAudit(createAuditAuthority())).length).toBe(0);
       storage.close();
+    });
+  });
+
+  test("fails readiness when a conflict audit consistently rewrites the loser as canonical winner", async () => {
+    await withDatabase(async (databasePath) => {
+      const root = createRoot("record-sqlite-conflict-winner-corrupt");
+      const storage = openSqliteFoundationStorage(databasePath);
+      await storage.applyMigrations();
+      const record = createRecord(storage, root);
+      await record.registerRoot(root);
+      expect(await record.acceptAction(createFact(root, "operation-fact", 1_000))).toMatchObject({
+        status: "accepted",
+      });
+      expect(
+        await record.acceptAction(createCorrection(root, "correction-false", false, 2_000)),
+      ).toMatchObject({ status: "accepted" });
+      expect(
+        await record.acceptAction(createCorrection(root, "correction-true", true, 2_000)),
+      ).toMatchObject({ status: "accepted" });
+      storage.close();
+
+      const database = new Database(databasePath);
+      const conflictRow = database
+        .query(
+          "SELECT audit_id, audit_json FROM foundation_event_game_record_audit WHERE audit_kind = 'action-conflict'",
+        )
+        .get() as { audit_id: string; audit_json: string } | null;
+      const loserRow = database
+        .query(
+          "SELECT audit_json FROM foundation_event_game_record_audit WHERE operation_id = ? AND audit_kind = 'action-accepted'",
+        )
+        .get("correction-false") as { audit_json: string } | null;
+      if (conflictRow === null || loserRow === null)
+        throw new Error("Expected conflict audit rows.");
+      const conflict = JSON.parse(conflictRow.audit_json) as Record<string, any>;
+      const loser = JSON.parse(loserRow.audit_json) as Record<string, any>;
+      conflict.links = {
+        ...loser.links,
+        relatedOperationIds: ["correction-false", "correction-true"],
+      };
+      conflict.provenance = loser.provenance;
+      conflict.redactedDetail =
+        "Opposing Concurrent Corrections resolved for fact-operation-fact; winner correction-false";
+      conflict.auditId = `audit-${sha256(
+        `${root.recordId}:concurrent-correction:fact-operation-fact:correction-false:correction-true:correction-false`,
+      )}`;
+      database
+        .query(
+          "UPDATE foundation_event_game_record_audit SET audit_id = ?, redacted_detail = ?, audit_json = ? WHERE audit_id = ?",
+        )
+        .run(
+          conflict.auditId,
+          conflict.redactedDetail,
+          JSON.stringify(conflict),
+          conflictRow.audit_id,
+        );
+      database.close();
+
+      const reopened = openSqliteFoundationStorage(databasePath);
+      const reopenedRecord = createRecord(reopened, root);
+      expect(await reopenedRecord.registerRoot(root)).toMatchObject({ status: "idempotent" });
+      expect(await reopenedRecord.readiness()).toMatchObject({
+        ok: false,
+        status: "rebuild-failure",
+      });
+      reopened.close();
+    });
+  });
+
+  test("freezes writes after restart when a correction conflict audit is deleted", async () => {
+    await withDatabase(async (databasePath) => {
+      const root = createRoot("record-sqlite-missing-correction-conflict");
+      const storage = openSqliteFoundationStorage(databasePath);
+      await storage.applyMigrations();
+      const record = createRecord(storage, root);
+      await record.registerRoot(root);
+      expect(await record.acceptAction(createFact(root, "operation-fact", 1_000))).toMatchObject({
+        status: "accepted",
+      });
+      expect(
+        await record.acceptAction(createCorrection(root, "correction-false", false, 2_000)),
+      ).toMatchObject({ status: "accepted" });
+      expect(
+        await record.acceptAction(createCorrection(root, "correction-true", true, 2_000)),
+      ).toMatchObject({ status: "accepted" });
+      storage.close();
+
+      const database = new Database(databasePath);
+      const deletion = database
+        .query(
+          "DELETE FROM foundation_event_game_record_audit WHERE audit_kind = 'action-conflict' AND outcome = 'conflict-resolved' AND redacted_detail LIKE 'Opposing Concurrent Corrections resolved %'",
+        )
+        .run();
+      expect(deletion.changes).toBe(1);
+      database.close();
+
+      const reopened = openSqliteFoundationStorage(databasePath);
+      const reopenedRecord = createRecord(reopened, root);
+      expect(await reopenedRecord.registerRoot(root)).toMatchObject({ status: "idempotent" });
+      expect(await reopenedRecord.readiness()).toMatchObject({
+        ok: false,
+        status: "rebuild-failure",
+        detail: "Control Audit Trail is missing canonical conflict evidence.",
+      });
+      expect(
+        await reopenedRecord.acceptAction(createFact(root, "operation-after-delete", 3_000)),
+      ).toMatchObject({ status: "rejected", reason: "storage-not-ready" });
+      reopened.close();
+    });
+  });
+
+  test("freezes writes after restart when a team-assignment conflict audit is deleted", async () => {
+    await withDatabase(async (databasePath) => {
+      const root = createRoot("record-sqlite-missing-team-conflict");
+      const storage = openSqliteFoundationStorage(databasePath);
+      await storage.applyMigrations();
+      const record = createRecord(storage, root);
+      await record.registerRoot(root);
+      expect(
+        await record.acceptAction(
+          createTeamAssignmentCorrection(
+            root,
+            "team-assignment-a",
+            "side-a",
+            "team-c",
+            "interpretation-a-c",
+            1_000,
+          ),
+        ),
+      ).toMatchObject({ status: "accepted" });
+      expect(
+        await record.acceptAction(
+          createTeamAssignmentCorrection(
+            root,
+            "team-assignment-b",
+            "side-b",
+            "team-c",
+            "interpretation-b-c",
+            1_000,
+          ),
+        ),
+      ).toMatchObject({ status: "accepted" });
+      storage.close();
+
+      const database = new Database(databasePath);
+      const deletion = database
+        .query(
+          "DELETE FROM foundation_event_game_record_audit WHERE audit_kind = 'action-conflict' AND outcome = 'conflict-resolved' AND redacted_detail LIKE 'Opposing Concurrent Team Assignments resolved %'",
+        )
+        .run();
+      expect(deletion.changes).toBe(1);
+      database.close();
+
+      const reopened = openSqliteFoundationStorage(databasePath);
+      const reopenedRecord = createRecord(reopened, root);
+      expect(await reopenedRecord.registerRoot(root)).toMatchObject({ status: "idempotent" });
+      expect(await reopenedRecord.readiness()).toMatchObject({
+        ok: false,
+        status: "rebuild-failure",
+        detail: "Control Audit Trail is missing canonical conflict evidence.",
+      });
+      expect(
+        await reopenedRecord.acceptAction(createFact(root, "operation-after-delete", 2_000)),
+      ).toMatchObject({ status: "rejected", reason: "storage-not-ready" });
+      reopened.close();
     });
   });
 
@@ -140,6 +706,287 @@ describe("SQLite immutable Event Game actions", () => {
           (entry) => entry.operationId === "operation-after-unknown-version",
         ),
       ).toHaveLength(0);
+      reopened.close();
+    });
+  });
+
+  test("does not allow current evidence to be downgraded into the legacy validation path", async () => {
+    const mutations: readonly [string, (database: Database, root: EventGameRecordRoot) => void][] =
+      [
+        [
+          "action",
+          (database, root) => {
+            const row = database
+              .query(
+                "SELECT action_json FROM foundation_event_game_record_actions WHERE record_id = ?",
+              )
+              .get(root.recordId) as { action_json: string } | null;
+            if (row === null) throw new Error("Expected a current action.");
+            const action = JSON.parse(row.action_json) as Record<string, unknown>;
+            action.controlActionVersion = "control-action-legacy-v0";
+            database
+              .query(
+                "UPDATE foundation_event_game_record_actions SET action_json = ?, control_action_version = ?, action_evidence_format = ? WHERE record_id = ?",
+              )
+              .run(JSON.stringify(action), "control-action-legacy-v0", "legacy", root.recordId);
+          },
+        ],
+        [
+          "audit",
+          (database, root) => {
+            const row = database
+              .query(
+                "SELECT audit_id, audit_json FROM foundation_event_game_record_audit WHERE record_id = ? LIMIT 1",
+              )
+              .get(root.recordId) as { audit_id: string; audit_json: string } | null;
+            if (row === null) throw new Error("Expected current audit evidence.");
+            const audit = JSON.parse(row.audit_json) as Record<string, unknown>;
+            audit.auditVersion = "control-audit-legacy-v0";
+            delete audit.links;
+            delete audit.provenance;
+            database
+              .query(
+                "UPDATE foundation_event_game_record_audit SET audit_json = ?, audit_version = ?, audit_evidence_format = ? WHERE audit_id = ?",
+              )
+              .run(JSON.stringify(audit), "control-audit-legacy-v0", "legacy", row.audit_id);
+          },
+        ],
+      ];
+
+    for (const [label, mutate] of mutations) {
+      await withDatabase(async (databasePath) => {
+        const root = createRoot(`record-sqlite-evidence-downgrade-${label}`);
+        const storage = openSqliteFoundationStorage(databasePath);
+        await storage.applyMigrations();
+        const record = createRecord(storage, root);
+        await record.registerRoot(root);
+        expect(
+          await record.acceptAction(createFact(root, "operation-current", 1_000)),
+        ).toMatchObject({
+          status: "accepted",
+        });
+        storage.close();
+
+        const database = new Database(databasePath);
+        mutate(database, root);
+        database.close();
+
+        const reopened = openSqliteFoundationStorage(databasePath);
+        const reopenedRecord = createRecord(reopened, root);
+        expect(await reopenedRecord.registerRoot(root)).toMatchObject({ status: "idempotent" });
+        expect(await reopenedRecord.readiness(), label).toMatchObject({
+          ok: false,
+          status: "rebuild-failure",
+        });
+        reopened.close();
+      });
+    }
+  });
+
+  test("preserves genuine pre-#75 legacy rows through migration while current provenance stays distinct", async () => {
+    await withDatabase(async (databasePath) => {
+      const root = createRoot("record-sqlite-legacy-migration");
+      const legacy = openSqliteFoundationStorage(databasePath, {
+        migrations: [
+          (await import("@/lib/foundation-migrations")).FOUNDATION_MIGRATIONS[0]!,
+          (await import("@/lib/foundation-migrations")).FOUNDATION_MIGRATIONS[1]!,
+          (await import("@/lib/foundation-migrations")).FOUNDATION_MIGRATIONS[2]!,
+        ],
+      });
+      await legacy.applyMigrations({ requireCandidate: false });
+      legacy.close();
+
+      const legacyDatabase = new Database(databasePath);
+      legacyDatabase
+        .query(
+          "INSERT INTO foundation_event_game_record_roots (record_id, event_id, event_game_id, owner_event_id, owner_event_game_id, scope_event_id, game_day_id, pitch_id, pitch_slot_id, lifecycle_phase, commenced_at_ms, finished_at_ms, locked_at_ms, lock_reason, record_version, schema_version, interpreter_version, creation_operation_id, creation_actor_reference, creation_source, creation_created_at_ms, canonical_content, root_json) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .run(
+          root.recordId,
+          root.eventId,
+          root.eventGameId,
+          root.ownership.eventId,
+          root.ownership.eventGameId,
+          root.externalScope.eventId,
+          root.externalScope.gameDayId,
+          root.externalScope.pitchId,
+          root.externalScope.pitchSlotId,
+          root.lifecycle.phase,
+          root.lifecycle.commencedAtMs,
+          root.lifecycle.finishedAtMs,
+          root.lifecycle.lockedAtMs,
+          root.lifecycle.lockReason,
+          root.compatibility.recordVersion,
+          root.compatibility.schemaVersion,
+          root.compatibility.interpreterVersion,
+          root.creationEvidence.operationId,
+          root.creationEvidence.actorReference,
+          root.creationEvidence.source,
+          root.creationEvidence.createdAtMs,
+          canonicalizeEventGameRecordRoot(root),
+          JSON.stringify(root),
+        );
+      legacyDatabase
+        .query(
+          "INSERT INTO foundation_event_game_record_sides (side_id, record_id, side_position, event_team_id, team_interpretation_ref) VALUES (?, ?, ?, ?, ?)",
+        )
+        .run(
+          root.gameSides[0]!.id,
+          root.recordId,
+          "a",
+          root.gameSides[0]!.eventTeamId,
+          root.gameSides[0]!.teamInterpretationRef,
+        );
+      legacyDatabase
+        .query(
+          "INSERT INTO foundation_event_game_record_sides (side_id, record_id, side_position, event_team_id, team_interpretation_ref) VALUES (?, ?, ?, ?, ?)",
+        )
+        .run(
+          root.gameSides[1]!.id,
+          root.recordId,
+          "b",
+          root.gameSides[1]!.eventTeamId,
+          root.gameSides[1]!.teamInterpretationRef,
+        );
+      legacyDatabase
+        .query(
+          "INSERT INTO foundation_event_game_record_metadata (record_id, action_count, ordering_version, last_accepted_at_ms, updated_at_ms) VALUES (?, 0, ?, NULL, ?)",
+        )
+        .run(root.recordId, "causal-occurrence-operation-v1", root.creationEvidence.createdAtMs);
+      legacyDatabase.close();
+
+      const input = createFact(root, "legacy-operation", 1_000);
+      const prepared = prepareControlAction(
+        input,
+        root,
+        createControlActionCodecRegistry(),
+        10_000,
+      );
+      if (!prepared.ok) throw new Error(prepared.error);
+      const action = materializeControlAction(prepared.value, 10_000);
+      action.controlActionVersion = LEGACY_CONTROL_ACTION_VERSION;
+      const audit = createAuditEntry(input, "action-accepted", ACCEPTED_AUDIT_DETAIL, 10_000, {
+        interpretation: prepared.value.interpretation,
+      });
+      audit.auditVersion = LEGACY_CONTROL_AUDIT_VERSION;
+      delete audit.links;
+      delete audit.provenance;
+      const database = new Database(databasePath);
+      database
+        .query(
+          "INSERT INTO foundation_event_game_record_actions (action_id, record_id, event_game_id, operation_id, action_kind, action_version, accepted_at_ms, content_fingerprint, canonical_content, action_json) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .run(
+          actionIdentity(root.recordId, action.operationId),
+          root.recordId,
+          root.eventGameId,
+          action.operationId,
+          action.kind.id,
+          action.kind.version,
+          action.acceptedAtMs,
+          prepared.value.contentFingerprint,
+          prepared.value.canonicalContent,
+          JSON.stringify(action),
+        );
+      database
+        .query(
+          "INSERT INTO foundation_event_game_record_idempotency (action_id, record_id, operation_id, content_fingerprint, accepted_at_ms) VALUES (?, ?, ?, ?, ?)",
+        )
+        .run(
+          actionIdentity(root.recordId, action.operationId),
+          root.recordId,
+          action.operationId,
+          prepared.value.contentFingerprint,
+          action.acceptedAtMs,
+        );
+      database
+        .query(
+          "UPDATE foundation_event_game_record_metadata SET action_count = 1, last_accepted_at_ms = ?, updated_at_ms = ? WHERE record_id = ?",
+        )
+        .run(action.acceptedAtMs, action.acceptedAtMs, root.recordId);
+      database
+        .query(
+          "INSERT INTO foundation_event_game_record_audit (audit_id, record_id, event_game_id, operation_id, audit_kind, outcome, created_at_ms, redacted_detail, audit_json) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .run(
+          audit.auditId,
+          audit.recordId,
+          audit.eventGameId,
+          audit.operationId,
+          audit.kind,
+          audit.outcome,
+          audit.createdAtMs,
+          audit.redactedDetail,
+          JSON.stringify(audit),
+        );
+      database.close();
+
+      const current = openSqliteFoundationStorage(databasePath);
+      expect((await current.applyMigrations()).schemaVersion).toBe(9);
+      const currentRecord = createRecord(current, root);
+      expect(await currentRecord.registerRoot(root)).toMatchObject({ status: "idempotent" });
+      expect(await currentRecord.readiness()).toMatchObject({ ok: true, actionCount: 1 });
+      expect(await currentRecord.rebuild()).toMatchObject({ status: "ready" });
+      current.close();
+    });
+  });
+
+  test("keeps a migrated legacy opposing pair ready after an unrelated current Fact", async () => {
+    await withDatabase(async (databasePath) => {
+      const root = createRoot("record-sqlite-legacy-conflict-unrelated-current");
+      await seedLegacyConflictHistory(databasePath, root);
+
+      const storage = openSqliteFoundationStorage(databasePath);
+      expect((await storage.applyMigrations()).schemaVersion).toBe(9);
+      const record = createRecord(storage, root);
+      expect(await record.registerRoot(root)).toMatchObject({ status: "idempotent" });
+      expect(await record.readiness()).toMatchObject({ ok: true, actionCount: 3 });
+      expect(await record.acceptAction(createFact(root, "current-unrelated", 3_000))).toMatchObject(
+        { status: "accepted" },
+      );
+      expect(await record.readiness()).toMatchObject({ ok: true, actionCount: 4 });
+      expect(
+        await record.acceptAction(createFact(root, "current-after-legacy", 4_000)),
+      ).toMatchObject({ status: "accepted" });
+      storage.close();
+    });
+  });
+
+  test("requires and freezes on missing current evidence added to migrated legacy conflict history", async () => {
+    await withDatabase(async (databasePath) => {
+      const root = createRoot("record-sqlite-legacy-conflict-current-participant");
+      await seedLegacyConflictHistory(databasePath, root);
+
+      const storage = openSqliteFoundationStorage(databasePath);
+      expect((await storage.applyMigrations()).schemaVersion).toBe(9);
+      const record = createRecord(storage, root);
+      expect(await record.registerRoot(root)).toMatchObject({ status: "idempotent" });
+      expect(
+        await record.acceptAction(createCorrection(root, "correction-z-current", false, 3_000)),
+      ).toMatchObject({ status: "accepted" });
+      expect(await record.readiness()).toMatchObject({ ok: true, actionCount: 4 });
+      storage.close();
+
+      const database = new Database(databasePath);
+      const deletion = database
+        .query(
+          "DELETE FROM foundation_event_game_record_audit WHERE audit_kind = 'action-conflict' AND outcome = 'conflict-resolved' AND redacted_detail LIKE 'Opposing Concurrent Corrections resolved %winner correction-z-current'",
+        )
+        .run();
+      expect(deletion.changes).toBe(1);
+      database.close();
+
+      const reopened = openSqliteFoundationStorage(databasePath);
+      const reopenedRecord = createRecord(reopened, root);
+      expect(await reopenedRecord.registerRoot(root)).toMatchObject({ status: "idempotent" });
+      expect(await reopenedRecord.readiness()).toMatchObject({
+        ok: false,
+        status: "rebuild-failure",
+        detail: "Control Audit Trail is missing canonical conflict evidence.",
+      });
+      expect(
+        await reopenedRecord.acceptAction(createFact(root, "current-after-delete", 4_000)),
+      ).toMatchObject({ status: "rejected", reason: "storage-not-ready" });
       reopened.close();
     });
   });
@@ -269,6 +1116,106 @@ describe("SQLite immutable Event Game actions", () => {
     });
   });
 
+  test("fails closed on #75 audit linkage, predecessor, provenance, and rejected-entry corruption", async () => {
+    const mutations: readonly [string, (audit: Record<string, unknown>) => void][] = [
+      [
+        "missing-version",
+        (audit) => {
+          delete audit.auditVersion;
+          delete audit.links;
+          delete audit.provenance;
+        },
+      ],
+      ["missing-links", (audit) => delete audit.links],
+      [
+        "wrong-predecessors",
+        (audit) => {
+          const links = audit.links as Record<string, unknown>;
+          links.causalPredecessorIds = ["operation-retained"];
+        },
+      ],
+      [
+        "missing-override-evidence",
+        (audit) => {
+          const provenance = audit.provenance as Record<string, unknown>;
+          delete provenance.override;
+        },
+      ],
+      [
+        "invalid-recovery-id",
+        (audit) => {
+          const provenance = audit.provenance as Record<string, unknown>;
+          provenance.recoveryProvenance = {
+            importId: "import-1",
+            sourceRecordId: "record-audit-corrupt-invalid-recovery-id",
+            sourceEventGameId: "event-game-record-audit-corrupt-invalid-recovery-id",
+            sourceOperationId: "operation-retained",
+            sourceReference: "é",
+            sourceAcceptedAtMs: 1,
+          };
+        },
+      ],
+    ];
+    for (const [label, mutate] of mutations) {
+      await withDatabase(async (databasePath) => {
+        const root = createRoot(`record-audit-corrupt-${label}`);
+        const storage = openSqliteFoundationStorage(databasePath);
+        await storage.applyMigrations();
+        const record = createRecord(storage, root);
+        await record.registerRoot(root);
+        await record.acceptAction(createFact(root, "operation-retained", 1_000));
+        if (label === "missing-links" || label === "missing-override-evidence") {
+          await record.acceptAction({
+            ...createFact(root, "operation-rejected", 2_000),
+            kind: { id: "correction", version: "1" },
+            payload: {
+              correctionId: "correction-rejected",
+              targetFactId: "missing-fact",
+              effective: false,
+            },
+          });
+        }
+        storage.close();
+        const database = new Database(databasePath);
+        const row = database
+          .query(
+            "SELECT audit_id, audit_json FROM foundation_event_game_record_audit WHERE record_id = ? ORDER BY rowid DESC LIMIT 1",
+          )
+          .get(root.recordId) as { audit_id: string; audit_json: string } | null;
+        if (row === null) throw new Error("Expected a durable audit row.");
+        const audit = JSON.parse(row.audit_json) as Record<string, unknown>;
+        mutate(audit);
+        database
+          .query("UPDATE foundation_event_game_record_audit SET audit_json = ? WHERE audit_id = ?")
+          .run(JSON.stringify(audit), row.audit_id);
+        if (label === "missing-version") {
+          const actionRow = database
+            .query(
+              "SELECT action_json FROM foundation_event_game_record_actions WHERE operation_id = ?",
+            )
+            .get("operation-retained") as { action_json: string } | null;
+          if (actionRow === null) throw new Error("Expected a durable action row.");
+          const action = JSON.parse(actionRow.action_json) as Record<string, unknown>;
+          delete action.controlActionVersion;
+          database
+            .query(
+              "UPDATE foundation_event_game_record_actions SET action_json = ? WHERE operation_id = ?",
+            )
+            .run(JSON.stringify(action), "operation-retained");
+        }
+        database.close();
+        const reopened = openSqliteFoundationStorage(databasePath);
+        const reopenedRecord = createRecord(reopened, root);
+        expect(await reopenedRecord.registerRoot(root)).toMatchObject({ status: "idempotent" });
+        expect(await reopenedRecord.readiness()).toMatchObject({ ok: false });
+        expect(
+          await reopenedRecord.acceptAction(createFact(root, "operation-after-corruption", 3_000)),
+        ).toMatchObject({ status: "rejected", reason: "storage-not-ready" });
+        reopened.close();
+      });
+    }
+  });
+
   test("blocks a new SQLite action when the injected interpreter is nondeterministic", async () => {
     await withDatabase(async (databasePath) => {
       const root = createRoot("record-sqlite-nondeterministic");
@@ -358,6 +1305,147 @@ async function withDatabase(work: (databasePath: string) => Promise<void>): Prom
   }
 }
 
+async function seedLegacyConflictHistory(
+  databasePath: string,
+  root: EventGameRecordRoot,
+): Promise<void> {
+  const legacy = openSqliteFoundationStorage(databasePath, {
+    migrations: FOUNDATION_MIGRATIONS.slice(0, 3),
+  });
+  await legacy.applyMigrations({ requireCandidate: false });
+  legacy.close();
+
+  const database = new Database(databasePath);
+  database
+    .query(
+      "INSERT INTO foundation_event_game_record_roots (record_id, event_id, event_game_id, owner_event_id, owner_event_game_id, scope_event_id, game_day_id, pitch_id, pitch_slot_id, lifecycle_phase, commenced_at_ms, finished_at_ms, locked_at_ms, lock_reason, record_version, schema_version, interpreter_version, creation_operation_id, creation_actor_reference, creation_source, creation_created_at_ms, canonical_content, root_json) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .run(
+      root.recordId,
+      root.eventId,
+      root.eventGameId,
+      root.ownership.eventId,
+      root.ownership.eventGameId,
+      root.externalScope.eventId,
+      root.externalScope.gameDayId,
+      root.externalScope.pitchId,
+      root.externalScope.pitchSlotId,
+      root.lifecycle.phase,
+      root.lifecycle.commencedAtMs,
+      root.lifecycle.finishedAtMs,
+      root.lifecycle.lockedAtMs,
+      root.lifecycle.lockReason,
+      root.compatibility.recordVersion,
+      root.compatibility.schemaVersion,
+      root.compatibility.interpreterVersion,
+      root.creationEvidence.operationId,
+      root.creationEvidence.actorReference,
+      root.creationEvidence.source,
+      root.creationEvidence.createdAtMs,
+      canonicalizeEventGameRecordRoot(root),
+      JSON.stringify(root),
+    );
+  for (const [side, position] of root.gameSides.map(
+    (side, index) => [side, index === 0 ? "a" : "b"] as const,
+  )) {
+    database
+      .query(
+        "INSERT INTO foundation_event_game_record_sides (side_id, record_id, side_position, event_team_id, team_interpretation_ref) VALUES (?, ?, ?, ?, ?)",
+      )
+      .run(side.id, root.recordId, position, side.eventTeamId, side.teamInterpretationRef);
+  }
+  database
+    .query(
+      "INSERT INTO foundation_event_game_record_metadata (record_id, action_count, ordering_version, last_accepted_at_ms, updated_at_ms) VALUES (?, 0, ?, NULL, ?)",
+    )
+    .run(root.recordId, "causal-occurrence-operation-v1", root.creationEvidence.createdAtMs);
+
+  const inputs = [
+    createFact(root, "operation-fact", 1_000),
+    createCorrection(root, "correction-false", false, 2_000),
+    createCorrection(root, "correction-true", true, 2_000),
+  ];
+  const preparedActions = inputs.map((input) => {
+    const prepared = prepareControlAction(input, root, createControlActionCodecRegistry(), 10_000);
+    if (!prepared.ok) throw new Error(prepared.error);
+    const action = materializeControlAction(prepared.value, 10_000);
+    action.controlActionVersion = LEGACY_CONTROL_ACTION_VERSION;
+    return { input, prepared, action };
+  });
+  for (const { prepared, action } of preparedActions) {
+    database
+      .query(
+        "INSERT INTO foundation_event_game_record_actions (action_id, record_id, event_game_id, operation_id, action_kind, action_version, accepted_at_ms, content_fingerprint, canonical_content, action_json) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+      )
+      .run(
+        actionIdentity(root.recordId, action.operationId),
+        root.recordId,
+        root.eventGameId,
+        action.operationId,
+        action.kind.id,
+        action.kind.version,
+        action.acceptedAtMs,
+        prepared.value.contentFingerprint,
+        prepared.value.canonicalContent,
+        JSON.stringify(action),
+      );
+    database
+      .query(
+        "INSERT INTO foundation_event_game_record_idempotency (action_id, record_id, operation_id, content_fingerprint, accepted_at_ms) VALUES (?, ?, ?, ?, ?)",
+      )
+      .run(
+        actionIdentity(root.recordId, action.operationId),
+        root.recordId,
+        action.operationId,
+        prepared.value.contentFingerprint,
+        action.acceptedAtMs,
+      );
+  }
+  const audits = preparedActions.map(({ input, prepared }) => {
+    const audit = createAuditEntry(input, "action-accepted", ACCEPTED_AUDIT_DETAIL, 10_000, {
+      interpretation: prepared.value.interpretation,
+    });
+    audit.auditVersion = LEGACY_CONTROL_AUDIT_VERSION;
+    delete audit.links;
+    delete audit.provenance;
+    return audit;
+  });
+  const conflictAudit = createConflictAuditEntry(
+    preparedActions[1]!.action,
+    preparedActions[2]!.action,
+    "fact-operation-fact",
+    "correction-true",
+    10_000,
+  );
+  conflictAudit.auditVersion = LEGACY_CONTROL_AUDIT_VERSION;
+  delete conflictAudit.links;
+  delete conflictAudit.provenance;
+  audits.push(conflictAudit);
+  for (const audit of audits) {
+    database
+      .query(
+        "INSERT INTO foundation_event_game_record_audit (audit_id, record_id, event_game_id, operation_id, audit_kind, outcome, created_at_ms, redacted_detail, audit_json) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+      )
+      .run(
+        audit.auditId,
+        audit.recordId,
+        audit.eventGameId,
+        audit.operationId,
+        audit.kind,
+        audit.outcome,
+        audit.createdAtMs,
+        audit.redactedDetail,
+        JSON.stringify(audit),
+      );
+  }
+  database
+    .query(
+      "UPDATE foundation_event_game_record_metadata SET action_count = ?, last_accepted_at_ms = ?, updated_at_ms = ? WHERE record_id = ?",
+    )
+    .run(inputs.length, 10_000, 10_000, root.recordId);
+  database.close();
+}
+
 function createRecord(
   storage: ReturnType<typeof openSqliteFoundationStorage>,
   root: EventGameRecordRoot,
@@ -392,6 +1480,55 @@ function createFact(
     grant: { sessionId: "session-1", versionId: "grant-version-1" },
     lifecycle: structuredClone(root.lifecycle),
   };
+}
+
+function createCorrection(
+  root: EventGameRecordRoot,
+  operationId: string,
+  effective: boolean,
+  trustedAtMs: number,
+): ControlActionInput {
+  return {
+    ...createFact(root, operationId, trustedAtMs),
+    kind: { id: "correction", version: "1" },
+    payload: {
+      correctionId: operationId,
+      targetFactId: "fact-operation-fact",
+      effective,
+    },
+  };
+}
+
+function createTeamAssignmentCorrection(
+  root: EventGameRecordRoot,
+  operationId: string,
+  gameSideId: string,
+  eventTeamId: string,
+  teamInterpretationRef: string,
+  trustedAtMs: number,
+  causalPredecessorIds: readonly string[] = [],
+): ControlActionInput {
+  return {
+    ...createFact(root, operationId, trustedAtMs),
+    kind: { id: "team-assignment-correction", version: "1" },
+    payload: {
+      correctionId: operationId,
+      gameSideId,
+      eventTeamId,
+      teamInterpretationRef,
+    },
+    causalPredecessorIds,
+  };
+}
+
+function requiredRejectedAttempt(audit: Record<string, unknown>): Record<string, unknown> {
+  const links = audit.links as Record<string, unknown> | undefined;
+  const collision = links?.collision as Record<string, unknown> | undefined;
+  const rejectedAttempt = collision?.rejectedAttempt;
+  if (typeof rejectedAttempt !== "object" || rejectedAttempt === null) {
+    throw new Error("Expected rejected collision evidence.");
+  }
+  return rejectedAttempt as Record<string, unknown>;
 }
 
 function createRoot(recordId: string): EventGameRecordRoot {
@@ -437,6 +1574,12 @@ function createScopeResolver(root: EventGameRecordRoot): ExternalScopeResolver {
       return JSON.stringify(scope) === JSON.stringify(root.externalScope)
         ? { status: "resolved", scope: structuredClone(scope) }
         : { status: "mismatch", detail: "The external scope does not match the root." };
+    },
+    resolveEventTeam(eventId, eventTeamId) {
+      return eventId === root.eventId &&
+        ["team-a", "team-b", "team-c", "team-d", "team-e"].includes(eventTeamId)
+        ? { status: "resolved" }
+        : { status: "mismatch", detail: "The Event Team is outside the Event scope." };
     },
   };
 }

--- a/src/lib/event-game-actions.test.ts
+++ b/src/lib/event-game-actions.test.ts
@@ -3,7 +3,9 @@ import {
   createControlActionCodecRegistry,
   createDeterministicTestIqaInterpreter,
   prepareControlAction,
+  sha256,
   type ControlActionInput,
+  type ControlAuditEntry,
 } from "@/lib/event-game-actions";
 import {
   createEventGameRecord,
@@ -331,6 +333,81 @@ describe("immutable Event Game actions", () => {
     }
   });
 
+  test("binds retained memory collision evidence to the rejected Control Action input", async () => {
+    const root = createRoot("record-collision-evidence");
+    const baseStorage = createInMemoryFoundationStorage();
+    const writer = createEventGameRecord(baseStorage, {
+      externalScopeResolver: createScopeResolver(root),
+      clock: () => 10_000,
+      interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
+    });
+    expect(await writer.registerRoot(root)).toMatchObject({ status: "registered" });
+    const accepted = createFact(root, "operation-collision", 1_000);
+    expect(await writer.acceptAction(accepted)).toMatchObject({ status: "accepted" });
+    expect(
+      await writer.acceptAction({
+        ...accepted,
+        payload: { ...(accepted.payload as Record<string, unknown>), data: { rejected: true } },
+      }),
+    ).toMatchObject({ status: "rejected", reason: "operation-conflict" });
+    expect(await writer.readiness()).toMatchObject({ ok: true, actionCount: 1 });
+    expect(
+      await writer.acceptAction(createFact(root, "operation-after-collision", 2_000)),
+    ).toMatchObject({ status: "accepted" });
+
+    const corruptions: readonly [string, (entry: ControlAuditEntry) => void][] = [
+      [
+        "interpretation",
+        (entry) => {
+          const rejected = requiredCollision(entry).rejectedAttempt;
+          if (rejected.interpretation.type !== "fact") throw new Error("Expected Fact evidence.");
+          rejected.interpretation = {
+            ...rejected.interpretation,
+            factType: "tampered-fact-type",
+          };
+        },
+      ],
+      [
+        "canonical-content",
+        (entry) => {
+          requiredCollision(entry).rejectedAttempt.canonicalContent = "{}";
+        },
+      ],
+      [
+        "fingerprint",
+        (entry) => {
+          const rejected = requiredCollision(entry).rejectedAttempt;
+          rejected.contentFingerprint = "f".repeat(64);
+          entry.auditId = `audit-${sha256(`${root.recordId}:operation-conflict:${entry.operationId}:${rejected.contentFingerprint}`)}`;
+        },
+      ],
+    ];
+
+    for (const [label, mutate] of corruptions) {
+      const corruptStorage = createCorruptingStorage(baseStorage, (snapshot) => ({
+        ...snapshot,
+        listAuditEntries: (recordId) =>
+          snapshot.listAuditEntries(recordId).map((entry) => {
+            if (entry.kind !== "action-conflict") return entry;
+            const corrupted = structuredClone(entry);
+            mutate(corrupted);
+            return corrupted;
+          }),
+      }));
+      const record = createEventGameRecord(corruptStorage, {
+        externalScopeResolver: createScopeResolver(root),
+        clock: () => 10_000,
+        interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
+      });
+      expect(await record.registerRoot(root)).toMatchObject({ status: "idempotent" });
+      expect(await record.readiness(), label).toMatchObject({
+        ok: false,
+        status: "rebuild-failure",
+      });
+    }
+    baseStorage.close();
+  });
+
   test("retains explicit recovery provenance with the immutable action", async () => {
     const root = createRoot("record-recovery-provenance");
     const record = await createRecord(root);
@@ -410,6 +487,12 @@ function createCorruptingStorage(
     readiness: () => storage.readiness(),
     close: () => storage.close(),
   };
+}
+
+function requiredCollision(entry: ControlAuditEntry) {
+  const collision = entry.links?.collision;
+  if (collision === undefined) throw new Error("Expected rejected collision evidence.");
+  return collision;
 }
 
 async function readSnapshot(
@@ -552,6 +635,11 @@ function createScopeResolver(root: EventGameRecordRoot): ExternalScopeResolver {
       return JSON.stringify(scope) === JSON.stringify(root.externalScope)
         ? { status: "resolved", scope: structuredClone(scope) }
         : { status: "mismatch", detail: "The external scope does not match the root." };
+    },
+    resolveEventTeam(eventId, eventTeamId) {
+      return eventId === root.eventId && eventTeamId.length > 0
+        ? { status: "resolved" }
+        : { status: "mismatch", detail: "The Event Team is outside the Event scope." };
     },
   };
 }

--- a/src/lib/event-game-actions.ts
+++ b/src/lib/event-game-actions.ts
@@ -18,6 +18,7 @@ import {
   validateTimestamp,
   valid,
 } from "@/lib/event-game-action-codecs";
+import { DURABLE_EVIDENCE_PROVENANCE } from "@/lib/foundation-storage";
 
 export { canonicalizeJson, sha256 } from "@/lib/event-game-action-json";
 export {
@@ -107,6 +108,14 @@ export type CorrectionInterpretation = {
   effective: boolean;
 };
 
+export type TeamAssignmentCorrectionInterpretation = {
+  type: "team-assignment-correction";
+  correctionId: string;
+  gameSideId: string;
+  eventTeamId: string;
+  teamInterpretationRef: string;
+};
+
 export type NonFactInterpretation = {
   type: "non-fact";
   stableId: string;
@@ -115,14 +124,65 @@ export type NonFactInterpretation = {
 export type ControlActionInterpretation =
   | FactInterpretation
   | CorrectionInterpretation
+  | TeamAssignmentCorrectionInterpretation
   | NonFactInterpretation;
 
+export type ControlAuditCollisionEvidence = {
+  acceptedActionId: string;
+  acceptedOperationId: string;
+  acceptedContentFingerprint: string;
+  rejectedAttempt: {
+    input: ControlActionInput;
+    canonicalContent: string;
+    contentFingerprint: string;
+    interpretation: ControlActionInterpretation;
+  };
+};
+
+export type ControlAuditLinkage = {
+  actionId: string | null;
+  targetFactId: string | null;
+  causalPredecessorIds: readonly string[];
+  relatedOperationIds: readonly string[];
+  ordering: {
+    trustedAtMs: number;
+    operationId: string;
+  } | null;
+  collision?: ControlAuditCollisionEvidence;
+};
+
+export type ControlAuditProvenance = {
+  occurrence: ControlActionOccurrence | null;
+  grant: ControlActionGrantProvenance | null;
+  lifecycle: ControlActionLifecycleContext | null;
+  override: OfficialOverrideMetadata | null;
+  recoveryProvenance: ControlActionRecoveryProvenance | null;
+};
+
+/**
+ * Audit rows written by #75 carry complete action linkage and provenance.
+ * Rows from the pre-#75 durable format are read as LEGACY and are validated
+ * by the explicit compatibility path in validateAuditHistory.
+ */
+export const CONTROL_AUDIT_VERSION = "control-audit-v1";
+export const LEGACY_CONTROL_AUDIT_VERSION = "control-audit-legacy-v0";
+export type ControlAuditVersion =
+  | typeof CONTROL_AUDIT_VERSION
+  | typeof LEGACY_CONTROL_AUDIT_VERSION;
+export const CONTROL_ACTION_VERSION = "control-action-v1";
+export const LEGACY_CONTROL_ACTION_VERSION = "control-action-legacy-v0";
+export type ControlActionVersion =
+  | typeof CONTROL_ACTION_VERSION
+  | typeof LEGACY_CONTROL_ACTION_VERSION;
+
 export type ControlAction = ControlActionInput & {
+  controlActionVersion: ControlActionVersion;
   acceptedAtMs: number;
   interpretation: ControlActionInterpretation;
 };
 
 export type ControlAuditEntry = {
+  auditVersion: ControlAuditVersion;
   auditId: string;
   recordId: string;
   eventGameId: string;
@@ -131,6 +191,8 @@ export type ControlAuditEntry = {
   outcome: string;
   createdAtMs: number;
   redactedDetail: string;
+  links?: ControlAuditLinkage;
+  provenance?: ControlAuditProvenance;
 };
 
 export type EventGameRecordMetadata = {
@@ -149,10 +211,26 @@ export type EffectiveGameFact = {
   interpretation: FactInterpretation;
 };
 
+export type EffectiveGameSideAssignment = {
+  gameSideId: string;
+  eventTeamId: string;
+  teamInterpretationRef: string;
+};
+
+export type ControlActionConflict = {
+  targetFactId: string | null;
+  operationIds: readonly [string, string];
+  winnerOperationId: string;
+  reason: "opposing-concurrent-corrections" | "opposing-concurrent-team-assignments";
+  eventTeamId?: string;
+  gameSideIds?: readonly [string, string];
+};
+
 export type IqaGameRulesRebuildInput = {
   root: EventGameRecordRoot;
   canonicalActions: readonly ControlAction[];
   effectiveFacts: readonly EffectiveGameFact[];
+  effectiveTeamAssignments: readonly EffectiveGameSideAssignment[];
 };
 
 export type IqaGameRulesInterpreter = {
@@ -189,7 +267,9 @@ export type ActionRebuildResult =
       status: "ready";
       canonicalActions: readonly ControlAction[];
       effectiveFacts: readonly EffectiveGameFact[];
+      effectiveTeamAssignments: readonly EffectiveGameSideAssignment[];
       derivedGameState: unknown;
+      conflicts: readonly ControlActionConflict[];
     }
   | {
       status: "failed";
@@ -209,6 +289,7 @@ export function prepareControlAction(
   root: EventGameRecordRoot,
   registry: ControlActionCodecRegistry,
   serverNowMs: number,
+  options: { allowConcurrentTeamAssignment?: boolean } = {},
 ): ValidationResult<PreparedControlAction> {
   if (!isRecord(input)) return invalid("Control Action must be an object.");
 
@@ -256,6 +337,20 @@ export function prepareControlAction(
     const { gameSideId } = interpretationResult.value;
     if (gameSideId !== null && !root.gameSides.some((side) => side.id === gameSideId)) {
       return invalid("Game Fact references an unknown stable Game Side.");
+    }
+  }
+  if (interpretationResult.value.type === "team-assignment-correction") {
+    const { gameSideId, eventTeamId } = interpretationResult.value;
+    if (!root.gameSides.some((candidate) => candidate.id === gameSideId)) {
+      return invalid("Team Assignment Correction references an unknown stable Game Side.");
+    }
+    if (
+      !options.allowConcurrentTeamAssignment &&
+      root.gameSides.some(
+        (candidate) => candidate.id !== gameSideId && candidate.eventTeamId === eventTeamId,
+      )
+    ) {
+      return invalid("Team Assignment Correction would assign both Game Sides to one Event Team.");
     }
   }
 
@@ -311,6 +406,7 @@ export function materializeControlAction(
 ): ControlAction {
   return {
     ...structuredClone(prepared.input),
+    controlActionVersion: CONTROL_ACTION_VERSION,
     acceptedAtMs,
     interpretation: structuredClone(prepared.interpretation),
   };
@@ -328,8 +424,19 @@ export function parseStoredControlAction(value: unknown): ValidationResult<Contr
   if (!inputResult.ok) return inputResult;
   const interpretationResult = validateInterpretation(value.interpretation);
   if (!interpretationResult.ok) return interpretationResult;
+  const controlActionVersion =
+    value.controlActionVersion === undefined
+      ? LEGACY_CONTROL_ACTION_VERSION
+      : value.controlActionVersion;
+  if (
+    controlActionVersion !== CONTROL_ACTION_VERSION &&
+    controlActionVersion !== LEGACY_CONTROL_ACTION_VERSION
+  ) {
+    return invalid("Stored Control Action version is unsupported.");
+  }
   return valid({
     ...inputResult.value,
+    controlActionVersion,
     acceptedAtMs: acceptedAtMs.value,
     interpretation: interpretationResult.value,
   });
@@ -342,7 +449,9 @@ export function validateStoredControlAction(
   root: EventGameRecordRoot,
   registry: ControlActionCodecRegistry,
 ): ActionHistoryReadiness {
-  const prepared = prepareControlAction(action, root, registry, action.occurrence.trustedAtMs);
+  const prepared = prepareControlAction(action, root, registry, action.occurrence.trustedAtMs, {
+    allowConcurrentTeamAssignment: true,
+  });
   if (!prepared.ok) return { ok: false, detail: prepared.error };
   if (prepared.value.canonicalContent !== canonicalContent) {
     return { ok: false, detail: "Stored Control Action canonical content is inconsistent." };
@@ -362,6 +471,8 @@ export function rebuildControlActionHistory(
     action: ControlAction;
     canonicalContent: string;
     contentFingerprint: string;
+    durableFormat?: "current" | "legacy";
+    [DURABLE_EVIDENCE_PROVENANCE]?: "current" | "legacy";
   }[],
   registry: ControlActionCodecRegistry,
   interpreter: IqaGameRulesInterpreter,
@@ -376,6 +487,18 @@ export function rebuildControlActionHistory(
 
   const actions: ControlAction[] = [];
   for (const stored of storedActions) {
+    if (
+      (stored[DURABLE_EVIDENCE_PROVENANCE] === "current" &&
+        stored.action.controlActionVersion !== CONTROL_ACTION_VERSION) ||
+      (stored[DURABLE_EVIDENCE_PROVENANCE] === "legacy" &&
+        stored.action.controlActionVersion !== LEGACY_CONTROL_ACTION_VERSION)
+    ) {
+      return {
+        status: "failed",
+        reason: "invalid-history",
+        detail: "Durable Control Action evidence was downgraded across its storage boundary.",
+      };
+    }
     const validity = validateStoredControlAction(
       stored.action,
       stored.canonicalContent,
@@ -419,6 +542,22 @@ export function rebuildControlActionHistory(
   }
 
   const effectiveByFactId = new Map([...factsById.keys()].map((factId) => [factId, true]));
+  const effectiveTeamAssignments = new Map(
+    root.gameSides.map((side) => [
+      side.id,
+      {
+        gameSideId: side.id,
+        eventTeamId: side.eventTeamId,
+        teamInterpretationRef: side.teamInterpretationRef,
+      },
+    ]),
+  );
+  const actionMap = actionsByOperationId(actions);
+  const conflicts = [
+    ...findConcurrentCorrectionConflictsInOrder(ordered.actions, actionMap),
+    ...findConcurrentTeamAssignmentConflictsInOrder(ordered.actions, actionMap),
+  ];
+  const teamConflictWinners = globalTeamConflictWinners(ordered.actions, conflicts);
   for (const action of ordered.actions) {
     if (action.interpretation.type !== "correction") continue;
     if (!factsById.has(action.interpretation.targetFactId)) {
@@ -429,6 +568,39 @@ export function rebuildControlActionHistory(
       };
     }
     effectiveByFactId.set(action.interpretation.targetFactId, action.interpretation.effective);
+  }
+  for (const action of ordered.actions) {
+    if (action.interpretation.type !== "team-assignment-correction") continue;
+    const { gameSideId, eventTeamId, teamInterpretationRef } = action.interpretation;
+    const current = effectiveTeamAssignments.get(gameSideId);
+    if (current === undefined) {
+      return {
+        status: "failed",
+        reason: "invalid-history",
+        detail: "A Team Assignment Correction targets a missing stable Game Side.",
+      };
+    }
+    const teamConflictWinner = teamConflictWinners.get(action.operationId);
+    if (teamConflictWinner !== undefined && teamConflictWinner !== action.operationId) {
+      continue;
+    }
+    if (
+      [...effectiveTeamAssignments.values()].some(
+        (assignment) =>
+          assignment.gameSideId !== gameSideId && assignment.eventTeamId === eventTeamId,
+      )
+    ) {
+      return {
+        status: "failed",
+        reason: "invalid-history",
+        detail: "Effective Game Side assignments must reference distinct Event Teams.",
+      };
+    }
+    effectiveTeamAssignments.set(gameSideId, {
+      ...current,
+      eventTeamId,
+      teamInterpretationRef,
+    });
   }
 
   const effectiveFacts: EffectiveGameFact[] = [];
@@ -450,11 +622,13 @@ export function rebuildControlActionHistory(
       root: structuredClone(root),
       canonicalActions: structuredClone(ordered.actions),
       effectiveFacts: structuredClone(effectiveFacts),
+      effectiveTeamAssignments: structuredClone([...effectiveTeamAssignments.values()]),
     });
     secondState = interpreter.rebuild({
       root: structuredClone(root),
       canonicalActions: structuredClone(ordered.actions),
       effectiveFacts: structuredClone(effectiveFacts),
+      effectiveTeamAssignments: structuredClone([...effectiveTeamAssignments.values()]),
     });
   } catch {
     return {
@@ -487,8 +661,172 @@ export function rebuildControlActionHistory(
     status: "ready",
     canonicalActions: ordered.actions,
     effectiveFacts,
+    effectiveTeamAssignments: [...effectiveTeamAssignments.values()],
     derivedGameState: firstState,
+    conflicts,
   };
+}
+
+export function findConcurrentCorrectionConflicts(
+  actions: readonly ControlAction[],
+): readonly ControlActionConflict[] {
+  const ordered = canonicalizeActionHistory(actions);
+  return ordered.ok
+    ? findConcurrentCorrectionConflictsInOrder(ordered.actions, actionsByOperationId(actions))
+    : [];
+}
+
+export function findConcurrentTeamAssignmentConflicts(
+  actions: readonly ControlAction[],
+): readonly ControlActionConflict[] {
+  const ordered = canonicalizeActionHistory(actions);
+  return ordered.ok
+    ? findConcurrentTeamAssignmentConflictsInOrder(ordered.actions, actionsByOperationId(actions))
+    : [];
+}
+
+function findConcurrentCorrectionConflictsInOrder(
+  orderedActions: readonly ControlAction[],
+  actions: ReadonlyMap<string, ControlAction>,
+): ControlActionConflict[] {
+  const conflicts: ControlActionConflict[] = [];
+  for (let leftIndex = 0; leftIndex < orderedActions.length; leftIndex += 1) {
+    const left = orderedActions[leftIndex];
+    if (left === undefined || left.interpretation.type !== "correction") continue;
+    for (let rightIndex = leftIndex + 1; rightIndex < orderedActions.length; rightIndex += 1) {
+      const right = orderedActions[rightIndex];
+      if (
+        right === undefined ||
+        right.interpretation.type !== "correction" ||
+        left.interpretation.targetFactId !== right.interpretation.targetFactId ||
+        left.interpretation.effective === right.interpretation.effective ||
+        causallyRelated(left, right, actions)
+      ) {
+        continue;
+      }
+      conflicts.push({
+        targetFactId: left.interpretation.targetFactId,
+        operationIds: [left.operationId, right.operationId],
+        winnerOperationId: right.operationId,
+        reason: "opposing-concurrent-corrections",
+      });
+    }
+  }
+  return conflicts;
+}
+
+function findConcurrentTeamAssignmentConflictsInOrder(
+  orderedActions: readonly ControlAction[],
+  actions: ReadonlyMap<string, ControlAction>,
+): ControlActionConflict[] {
+  const conflicts: ControlActionConflict[] = [];
+  for (let leftIndex = 0; leftIndex < orderedActions.length; leftIndex += 1) {
+    const left = orderedActions[leftIndex];
+    if (left === undefined || left.interpretation.type !== "team-assignment-correction") continue;
+    for (let rightIndex = leftIndex + 1; rightIndex < orderedActions.length; rightIndex += 1) {
+      const right = orderedActions[rightIndex];
+      if (
+        right === undefined ||
+        right.interpretation.type !== "team-assignment-correction" ||
+        left.interpretation.eventTeamId !== right.interpretation.eventTeamId ||
+        left.interpretation.gameSideId === right.interpretation.gameSideId ||
+        causallyRelated(left, right, actions)
+      )
+        continue;
+      conflicts.push({
+        targetFactId: null,
+        eventTeamId: left.interpretation.eventTeamId,
+        gameSideIds: [left.interpretation.gameSideId, right.interpretation.gameSideId],
+        operationIds: [left.operationId, right.operationId],
+        winnerOperationId: right.operationId,
+        reason: "opposing-concurrent-team-assignments",
+      });
+    }
+  }
+  return conflicts;
+}
+
+function globalTeamConflictWinners(
+  orderedActions: readonly ControlAction[],
+  conflicts: readonly ControlActionConflict[],
+): ReadonlyMap<string, string> {
+  const adjacency = new Map<string, Set<string>>();
+  for (const conflict of conflicts) {
+    if (conflict.reason !== "opposing-concurrent-team-assignments") continue;
+    const [left, right] = conflict.operationIds;
+    if (left === undefined || right === undefined) continue;
+    const leftNeighbours = adjacency.get(left) ?? new Set<string>();
+    const rightNeighbours = adjacency.get(right) ?? new Set<string>();
+    leftNeighbours.add(right);
+    rightNeighbours.add(left);
+    adjacency.set(left, leftNeighbours);
+    adjacency.set(right, rightNeighbours);
+  }
+
+  const canonicalIndex = new Map(
+    orderedActions.map((action, index) => [action.operationId, index] as const),
+  );
+  const winners = new Map<string, string>();
+  const visited = new Set<string>();
+  for (const operationId of adjacency.keys()) {
+    if (visited.has(operationId)) continue;
+    const component: string[] = [];
+    const pending = [operationId];
+    while (pending.length > 0) {
+      const current = pending.pop();
+      if (current === undefined || visited.has(current)) continue;
+      visited.add(current);
+      component.push(current);
+      for (const neighbour of adjacency.get(current) ?? []) pending.push(neighbour);
+    }
+    const winner = component.reduce((latest, candidate) =>
+      (canonicalIndex.get(candidate) ?? -1) > (canonicalIndex.get(latest) ?? -1)
+        ? candidate
+        : latest,
+    );
+    for (const member of component) winners.set(member, winner);
+  }
+  return winners;
+}
+
+function actionsByOperationId(actions: readonly ControlAction[]): Map<string, ControlAction> {
+  return new Map(actions.map((action) => [action.operationId, action]));
+}
+
+function causallyRelated(
+  left: ControlAction,
+  right: ControlAction,
+  actions: ReadonlyMap<string, ControlAction>,
+): boolean {
+  return (
+    reaches(left.operationId, right.operationId, actions) ||
+    reaches(right.operationId, left.operationId, actions)
+  );
+}
+
+/** Shared canonical reachability predicate for conflict and audit validation. */
+export function isCausallyRelated(
+  left: ControlAction,
+  right: ControlAction,
+  actions: ReadonlyMap<string, ControlAction>,
+): boolean {
+  return causallyRelated(left, right, actions);
+}
+
+function reaches(
+  predecessorOperationId: string,
+  descendantOperationId: string,
+  actions: ReadonlyMap<string, ControlAction>,
+): boolean {
+  const pending = [...(actions.get(descendantOperationId)?.causalPredecessorIds ?? [])];
+  const visited = new Set<string>();
+  while (pending.length > 0) {
+    const operationId = pending.pop();
+    if (operationId === undefined || !visited.add(operationId)) continue;
+    if (operationId === predecessorOperationId) return true;
+    pending.push(...(actions.get(operationId)?.causalPredecessorIds ?? []));
+  }
+  return false;
 }
 
 function canonicalizeActionHistory(actions: readonly ControlAction[]):
@@ -568,8 +906,12 @@ function canonicalizeActionHistory(actions: readonly ControlAction[]):
 }
 
 function compareCanonicalActions(left: ControlAction, right: ControlAction): number {
-  return (
-    left.occurrence.trustedAtMs - right.occurrence.trustedAtMs ||
-    left.operationId.localeCompare(right.operationId)
-  );
+  if (left.occurrence.trustedAtMs !== right.occurrence.trustedAtMs) {
+    return left.occurrence.trustedAtMs < right.occurrence.trustedAtMs ? -1 : 1;
+  }
+  return compareOpaqueIdentifiers(left.operationId, right.operationId);
+}
+
+function compareOpaqueIdentifiers(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
 }

--- a/src/lib/event-game-convergence.ts
+++ b/src/lib/event-game-convergence.ts
@@ -1,0 +1,64 @@
+import type {
+  ActionRebuildResult,
+  ControlAction,
+  ControlAuditEntry,
+  EffectiveGameFact,
+} from "@/lib/event-game-actions";
+import type { ControlActionAcceptanceOutcome } from "@/lib/event-game-record";
+
+/**
+ * The server acceptance clock is durable evidence, but it is arrival-specific:
+ * two valid replicas can accept the same offline action at different server
+ * times. Convergence comparisons must project only that evidence out; the
+ * stored action, audit entry, and acknowledgement retain the original value.
+ */
+export type ConvergentControlAction = Omit<ControlAction, "acceptedAtMs">;
+export type ConvergentControlAuditEntry = Omit<ControlAuditEntry, "createdAtMs">;
+
+export function projectControlActionForConvergence(action: ControlAction): ConvergentControlAction {
+  const { acceptedAtMs: _acceptedAtMs, ...projected } = structuredClone(action);
+  return projected;
+}
+
+export function projectControlAuditEntryForConvergence(
+  entry: ControlAuditEntry,
+): ConvergentControlAuditEntry {
+  const { createdAtMs: _createdAtMs, ...projected } = structuredClone(entry);
+  return projected;
+}
+
+export function projectAcceptanceOutcomeForConvergence(outcome: ControlActionAcceptanceOutcome):
+  | ControlActionAcceptanceOutcome
+  | (Omit<
+      Extract<ControlActionAcceptanceOutcome, { status: "accepted" | "duplicate-accepted" }>,
+      "action"
+    > & {
+      action: ConvergentControlAction;
+    }) {
+  if (outcome.status !== "accepted" && outcome.status !== "duplicate-accepted") {
+    return structuredClone(outcome);
+  }
+  return {
+    ...structuredClone(outcome),
+    action: projectControlActionForConvergence(outcome.action),
+  };
+}
+
+export function projectRebuildForConvergence(
+  rebuild: Extract<ActionRebuildResult, { status: "ready" }>,
+): Omit<
+  Extract<ActionRebuildResult, { status: "ready" }>,
+  "canonicalActions" | "effectiveFacts"
+> & {
+  canonicalActions: ConvergentControlAction[];
+  effectiveFacts: Array<Omit<EffectiveGameFact, "action"> & { action: ConvergentControlAction }>;
+} {
+  return {
+    ...structuredClone(rebuild),
+    canonicalActions: rebuild.canonicalActions.map(projectControlActionForConvergence),
+    effectiveFacts: rebuild.effectiveFacts.map((fact) => ({
+      ...structuredClone(fact),
+      action: projectControlActionForConvergence(fact.action),
+    })),
+  };
+}

--- a/src/lib/event-game-corrections.generated.test.ts
+++ b/src/lib/event-game-corrections.generated.test.ts
@@ -1,0 +1,469 @@
+import { describe, expect, test } from "bun:test";
+import {
+  REGISTERED_CORRECTION_SHAPES,
+  acceptScenario,
+  corruptMemoryAudit,
+  createFact,
+  createRecord,
+  createRoot,
+  createCorrectionActions,
+  minimizeFailingSequence,
+  observePermutation,
+  randomInt,
+  resolveActionOrder,
+  seededRandom,
+  snapshot,
+  sortAcknowledgements,
+  topologicalPermutations,
+  type CorrectionSpec,
+  type ScenarioFailure,
+} from "@/lib/event-game-corrections.support";
+import { createInMemoryFoundationStorage } from "@/lib/foundation-storage-memory";
+
+describe("Generated Event Game correction convergence", () => {
+  test("enumerates every registered noncommutative pair and causal-shape permutation", async () => {
+    for (const [shapeIndex, shape] of REGISTERED_CORRECTION_SHAPES.entries()) {
+      const permutations = topologicalPermutations(shape.actions);
+      for (const [permutationIndex, permutation] of permutations.entries()) {
+        const root = createRoot(`permutation-${shapeIndex}-${permutationIndex}`);
+        const left = await createRecord(root);
+        const right = await createRecord(root);
+        const fact = createFact(root, "fact-permutation", 1_000, "fact-goal");
+        const actions = createCorrectionActions(root, shape.actions);
+        const leftOrder = actions;
+        const rightOrder = resolveActionOrder(actions, permutation);
+        const leftAcks = await acceptScenario(left, [fact, ...leftOrder]);
+        const rightAcks = await acceptScenario(right, [fact, ...rightOrder]);
+        expect(sortAcknowledgements(rightAcks)).toEqual(sortAcknowledgements(leftAcks));
+        expect(await snapshot(right)).toEqual(await snapshot(left));
+      }
+    }
+  });
+
+  test("covers 1,000 fixed-seed multi-controller sequences with deterministic shrinking", async () => {
+    const seed = 0x75c0ffee;
+    const random = seededRandom(seed);
+    for (let sequence = 0; sequence < 1_000; sequence += 1) {
+      const shape =
+        REGISTERED_CORRECTION_SHAPES[randomInt(random, REGISTERED_CORRECTION_SHAPES.length)];
+      if (shape === undefined) throw new Error(`seed=${seed} sequence=${sequence}`);
+      const permutations = topologicalPermutations(shape.actions);
+      const selected = permutations[randomInt(random, permutations.length)];
+      if (selected === undefined) throw new Error(`seed=${seed} sequence=${sequence}`);
+      const root = createRoot(`generated-${sequence}`);
+      const actions = createCorrectionActions(root, shape.actions);
+      const failure = await observePermutation(root, actions, selected);
+      if (failure !== null) {
+        const minimized = await minimizeFailingSequence(
+          shape.actions,
+          selected,
+          async (candidate, candidatePermutation) => {
+            const candidateRoot = createRoot(`shrink-${sequence}`);
+            const candidateActions = createCorrectionActions(candidateRoot, candidate);
+            return observePermutation(candidateRoot, candidateActions, candidatePermutation);
+          },
+          seed,
+        );
+        const minimizedFailure = minimized.failure ?? failure;
+        throw new Error(
+          `seed=${minimized.seed} sequence=${sequence} shape=${shape.name} failure=${minimizedFailure.kind} minimized=${JSON.stringify(
+            minimized.sequence.map((action) => action.operationId),
+          )} arrivalOrder=${JSON.stringify(minimized.arrivalOrder)}: ${minimizedFailure.detail}`,
+        );
+      }
+    }
+  }, 30_000);
+
+  test("shrinking preserves the failing arrival relationship while removing irrelevant actions", async () => {
+    const sequence = [
+      { operationId: "first", effective: false, causalPredecessorIds: [] },
+      { operationId: "second", effective: true, causalPredecessorIds: [] },
+      { operationId: "irrelevant", effective: false, causalPredecessorIds: [] },
+    ] satisfies readonly CorrectionSpec[];
+    const failingPermutation = ["second", "first", "irrelevant"];
+    const minimized = await minimizeFailingSequence(
+      sequence,
+      failingPermutation,
+      async (candidate, candidatePermutation) =>
+        candidate.length >= 2 && candidatePermutation.slice(0, 2).join(",") === "second,first"
+          ? {
+              kind: "boolean-mismatch",
+              run: "comparison",
+              arrivalOrder: candidatePermutation,
+              fingerprint: "boolean-mismatch:second-before-first",
+              requiredOperationIds: ["first", "second"],
+              requiredEdges: [],
+              detail: "Second arrived before first.",
+            }
+          : null,
+    );
+    expect(minimized.sequence.map((action) => action.operationId)).toEqual(["first", "second"]);
+    expect(minimized.arrivalOrder).toEqual(["second", "first"]);
+  });
+
+  test("real observer attributes left and right readiness failures to their actual run order", async () => {
+    const specs = [
+      { operationId: "first", effective: false, causalPredecessorIds: [] },
+      { operationId: "second", effective: true, causalPredecessorIds: [] },
+    ] satisfies readonly CorrectionSpec[];
+    const root = createRoot("observer-readiness-runs");
+    const actions = createCorrectionActions(root, specs);
+    const rightOrder = ["second", "first"];
+    for (const failingRun of ["left", "right"] as const) {
+      const failure = await observePermutation(root, actions, rightOrder, {
+        async snapshotRecord(record, run) {
+          if (run === failingRun) throw new Error(`${run} readiness failure`);
+          return snapshot(record);
+        },
+      });
+      expect(failure).toMatchObject({
+        kind: "readiness-failure",
+        run: failingRun,
+        arrivalOrder: failingRun === "left" ? ["first", "second"] : rightOrder,
+        fingerprint: `readiness:${failingRun}:Error:${failingRun} readiness failure`,
+      });
+    }
+  });
+
+  test("real rebuild failures retain reason, detail, identity, and causal closure while shrinking", async () => {
+    const specs = [
+      { operationId: "predecessor", effective: false, causalPredecessorIds: [] },
+      { operationId: "first", effective: true, causalPredecessorIds: ["predecessor"] },
+    ] satisfies readonly CorrectionSpec[];
+    const observe = async (
+      candidate: readonly CorrectionSpec[],
+      candidateOrder: readonly string[],
+    ) => {
+      const root = createRoot("observer-real-readiness");
+      const actions = createCorrectionActions(root, candidate);
+      return observePermutation(root, actions, candidateOrder, {
+        recordFactory(candidateRoot, run) {
+          if (run !== "right") return createRecord(candidateRoot);
+          const corrupted = corruptMemoryAudit(
+            createInMemoryFoundationStorage(),
+            (entry) => {
+              if (entry.kind === "action-accepted" && entry.operationId === "first") {
+                entry.redactedDetail = "different readiness defect";
+              }
+            },
+            false,
+          );
+          return createRecord(candidateRoot, undefined, undefined, corrupted);
+        },
+      });
+    };
+    const initial = await observe(specs, ["predecessor", "first"]);
+    expect(initial).toMatchObject({
+      kind: "readiness-failure",
+      run: "right",
+      reason: "invalid-history",
+      detail: "Control Audit Trail accepted-action evidence is inconsistent.",
+      requiredOperationIds: ["predecessor", "first"],
+      requiredEdges: [["predecessor", "first"]],
+    });
+    expect(initial?.fingerprint).toContain(
+      'readiness:right:invalid-history:"Control Audit Trail accepted-action evidence is inconsistent."',
+    );
+    const minimized = await minimizeFailingSequence(
+      specs,
+      ["predecessor", "first"],
+      observe,
+      0x75c0ffee,
+    );
+    expect(minimized.sequence.map((action) => action.operationId)).toEqual([
+      "predecessor",
+      "first",
+    ]);
+    expect(minimized.failure?.fingerprint).toBe(initial?.fingerprint);
+  });
+
+  test("real observer shrinks an exact acknowledgement diff and rejects another operation's diff", async () => {
+    const specs = [
+      { operationId: "predecessor", effective: false, causalPredecessorIds: [] },
+      { operationId: "first", effective: true, causalPredecessorIds: ["predecessor"] },
+      { operationId: "second", effective: true, causalPredecessorIds: [] },
+      { operationId: "irrelevant", effective: false, causalPredecessorIds: [] },
+    ] satisfies readonly CorrectionSpec[];
+    const rightOrder = ["predecessor", "second", "first", "irrelevant"];
+    const observe = async (
+      candidate: readonly CorrectionSpec[],
+      candidateOrder: readonly string[],
+    ) => {
+      const root = createRoot("observer-ack-diff");
+      const actions = createCorrectionActions(root, candidate);
+      return observePermutation(root, actions, candidateOrder, {
+        transformAcknowledgement(acknowledgement, action, run) {
+          if (run !== "right") return acknowledgement;
+          const changedAuditId =
+            action.operationId === "first"
+              ? "audit-first-difference"
+              : action.operationId === "second"
+                ? "audit-second-difference"
+                : undefined;
+          return changedAuditId === undefined ||
+            typeof acknowledgement !== "object" ||
+            acknowledgement === null
+            ? acknowledgement
+            : { ...acknowledgement, auditId: changedAuditId };
+        },
+      });
+    };
+    const initial = await observe(specs, rightOrder);
+    expect(initial).toMatchObject({
+      kind: "boolean-mismatch",
+      run: "comparison",
+      requiredOperationIds: ["predecessor", "first"],
+    });
+    expect(initial?.fingerprint).toContain("acknowledgements:$.auditId");
+    const minimized = await minimizeFailingSequence(specs, rightOrder, observe, 0x75c0ffee);
+    expect(minimized.sequence.map((action) => action.operationId)).toEqual([
+      "predecessor",
+      "first",
+    ]);
+    expect(minimized.arrivalOrder).toEqual(["predecessor", "first"]);
+    expect(minimized.failure?.fingerprint).toBe(initial?.fingerprint);
+  });
+
+  test("real observer fingerprints the precise snapshot field and removes unrelated actions", async () => {
+    const specs = [
+      { operationId: "irrelevant", effective: true, causalPredecessorIds: [] },
+      { operationId: "first", effective: false, causalPredecessorIds: [] },
+    ] satisfies readonly CorrectionSpec[];
+    const rightOrder = ["first", "irrelevant"];
+    const observe = async (
+      candidate: readonly CorrectionSpec[],
+      candidateOrder: readonly string[],
+    ) => {
+      const root = createRoot(`observer-snapshot-${candidate.length}`);
+      const actions = createCorrectionActions(root, candidate);
+      return observePermutation(root, actions, candidateOrder, {
+        async snapshotRecord(record, run) {
+          const observed = await snapshot(record);
+          if (run !== "right") return observed;
+          const changed = structuredClone(observed);
+          const entry = changed.audit.find((audit) => audit.operationId === "first");
+          if (entry !== undefined) entry.redactedDetail = "precise changed detail";
+          return changed;
+        },
+      });
+    };
+    const initial = await observe(specs, rightOrder);
+    expect(initial).toMatchObject({
+      kind: "boolean-mismatch",
+      requiredOperationIds: ["first"],
+    });
+    expect(initial?.fingerprint).toContain("snapshot:$.audit[operationId=first]");
+    expect(initial?.fingerprint).toContain("redactedDetail");
+    const minimized = await minimizeFailingSequence(specs, rightOrder, observe);
+    expect(minimized.sequence.map((action) => action.operationId)).toEqual(["first"]);
+    expect(minimized.arrivalOrder).toEqual(["first"]);
+    expect(minimized.failure?.fingerprint).toBe(initial?.fingerprint);
+  });
+
+  test("shrinks and emits each deterministic failure class with the actual arrival relation", async () => {
+    const sequence = [
+      { operationId: "first", effective: false, causalPredecessorIds: [] },
+      { operationId: "second", effective: true, causalPredecessorIds: [] },
+      { operationId: "irrelevant", effective: false, causalPredecessorIds: [] },
+    ] satisfies readonly CorrectionSpec[];
+    const arrivalOrder = ["second", "first", "irrelevant"];
+    for (const kind of [
+      "boolean-mismatch",
+      "rejected-action",
+      "thrown",
+      "readiness-failure",
+    ] as const) {
+      const minimized = await minimizeFailingSequence(
+        sequence,
+        arrivalOrder,
+        async (candidate, candidatePermutation) =>
+          candidate.length >= 2 && candidatePermutation.slice(0, 2).join(",") === "second,first"
+            ? {
+                kind,
+                run: "right",
+                arrivalOrder: candidatePermutation,
+                fingerprint: `${kind}:second:first`,
+                requiredOperationIds: ["second", "first"],
+                requiredEdges: [],
+                detail: kind,
+              }
+            : null,
+        0x75c0ffee,
+      );
+      expect(minimized.seed).toBe(0x75c0ffee);
+      expect(minimized.failure?.kind).toBe(kind);
+      expect(minimized.sequence.map((action) => action.operationId)).toEqual(["first", "second"]);
+      expect(minimized.arrivalOrder).toEqual(["second", "first"]);
+      expect(
+        `seed=${minimized.seed} minimized=${JSON.stringify(minimized.sequence.map((action) => action.operationId))} arrivalOrder=${JSON.stringify(minimized.arrivalOrder)}`,
+      ).toContain('arrivalOrder=["second","first"]');
+    }
+  });
+
+  test("shrinker preserves the failing comparison run and exact failure relationship", async () => {
+    const sequence = [
+      { operationId: "predecessor", effective: false, causalPredecessorIds: [] },
+      { operationId: "first", effective: false, causalPredecessorIds: ["predecessor"] },
+      { operationId: "second", effective: true, causalPredecessorIds: [] },
+      { operationId: "irrelevant", effective: false, causalPredecessorIds: [] },
+    ] satisfies readonly CorrectionSpec[];
+    const rightOrder = ["second", "predecessor", "first", "irrelevant"];
+    const minimized = await minimizeFailingSequence(
+      sequence,
+      rightOrder,
+      async (candidate, candidatePermutation) =>
+        candidate.some((action) => action.operationId === "first")
+          ? {
+              kind: "rejected-action",
+              run: "right",
+              arrivalOrder: candidatePermutation,
+              fingerprint: "rejected:first:invalid-action",
+              requiredOperationIds: ["first", "predecessor"],
+              requiredEdges: [["predecessor", "first"]],
+              detail: "right-run rejection",
+            }
+          : null,
+    );
+    expect(minimized.sequence.map((action) => action.operationId)).toEqual([
+      "predecessor",
+      "first",
+    ]);
+    expect(minimized.arrivalOrder).toEqual(["predecessor", "first"]);
+    expect(minimized.failure).toMatchObject({
+      run: "right",
+      fingerprint: "rejected:first:invalid-action",
+      requiredEdges: [["predecessor", "first"]],
+    });
+  });
+
+  test("shrinker emits the actual left comparison run when that run fails", async () => {
+    const sequence = [
+      { operationId: "first", effective: false, causalPredecessorIds: [] },
+      { operationId: "second", effective: true, causalPredecessorIds: [] },
+      { operationId: "irrelevant", effective: false, causalPredecessorIds: [] },
+    ] satisfies readonly CorrectionSpec[];
+    const minimized = await minimizeFailingSequence(
+      sequence,
+      ["second", "first", "irrelevant"],
+      async (candidate, _candidatePermutation) =>
+        candidate.length >= 2
+          ? {
+              kind: "thrown",
+              run: "left",
+              arrivalOrder: candidate.map((action) => action.operationId),
+              fingerprint: "thrown:first:Error:synthetic",
+              requiredOperationIds: ["first", "second"],
+              requiredEdges: [],
+              detail: "left-run throw",
+            }
+          : null,
+    );
+    expect(minimized.sequence.map((action) => action.operationId)).toEqual(["first", "second"]);
+    expect(minimized.arrivalOrder).toEqual(["first", "second"]);
+    expect(minimized.failure).toMatchObject({
+      run: "left",
+      fingerprint: "thrown:first:Error:synthetic",
+    });
+  });
+
+  test("shrinker retains thrown outcomes instead of treating them as non-failures", async () => {
+    const sequence = [
+      { operationId: "first", effective: false, causalPredecessorIds: [] },
+      { operationId: "second", effective: true, causalPredecessorIds: [] },
+      { operationId: "irrelevant", effective: false, causalPredecessorIds: [] },
+    ] satisfies readonly CorrectionSpec[];
+    const minimized = await minimizeFailingSequence(
+      sequence,
+      ["second", "first", "irrelevant"],
+      async (candidate, _candidatePermutation) => {
+        if (candidate.length >= 2) throw new Error("synthetic acceptance failure");
+        return null;
+      },
+      0x75c0ffee,
+    );
+    expect(minimized.seed).toBe(0x75c0ffee);
+    expect(minimized.sequence.map((action) => action.operationId)).toEqual([
+      "second",
+      "irrelevant",
+    ]);
+    expect(minimized.arrivalOrder).toEqual(["second", "irrelevant"]);
+    expect(minimized.failure).toMatchObject({
+      kind: "thrown",
+      fingerprint: "thrown:shrink:Error:synthetic acceptance failure",
+    });
+  });
+
+  test("does not confuse same-kind failures or removed predecessors while shrinking", async () => {
+    const sequence = [
+      { operationId: "predecessor", effective: false, causalPredecessorIds: [] },
+      { operationId: "first", effective: false, causalPredecessorIds: ["predecessor"] },
+      { operationId: "second", effective: true, causalPredecessorIds: [] },
+    ] satisfies readonly CorrectionSpec[];
+    const failingOrder = ["second", "predecessor", "first"];
+    const minimized = await minimizeFailingSequence(
+      sequence,
+      failingOrder,
+      async (candidate, candidatePermutation) => {
+        const ids = new Set(candidate.map((action) => action.operationId));
+        if (ids.has("first") && ids.has("predecessor")) {
+          return {
+            kind: "rejected-action",
+            run: "right",
+            arrivalOrder: candidatePermutation,
+            fingerprint: "rejected:first:invalid-action",
+            requiredOperationIds: ["first", "predecessor"],
+            requiredEdges: [["predecessor", "first"]],
+            detail: "original cause",
+          } satisfies ScenarioFailure;
+        }
+        if (ids.has("first")) {
+          return {
+            kind: "rejected-action",
+            run: "right",
+            arrivalOrder: candidatePermutation,
+            fingerprint: "rejected:first:missing-predecessor",
+            requiredOperationIds: ["first"],
+            requiredEdges: [],
+            detail: "different cause",
+          } satisfies ScenarioFailure;
+        }
+        return null;
+      },
+    );
+    expect(minimized.sequence.map((action) => action.operationId)).toEqual([
+      "predecessor",
+      "first",
+    ]);
+    expect(minimized.failure).toMatchObject({
+      fingerprint: "rejected:first:invalid-action",
+      requiredEdges: [["predecessor", "first"]],
+    });
+  });
+
+  test("repairs late pre-catch scoring and preserves a shortened-stoppage override", async () => {
+    const root = createRoot("dangerous-scenarios");
+    const record = await createRecord(root, {
+      version: "rules-v1",
+      rebuild({ effectiveFacts }) {
+        const facts = effectiveFacts.map((fact) => ({ type: fact.interpretation.factType }));
+        return {
+          overtimeTarget: facts.some((fact) => fact.type === "goal") ? 90 : 80,
+          order: facts.map((fact) => fact.type),
+        };
+      },
+    });
+    const catchFact = createFact(root, "catch", 80_000, "fact-catch");
+    const lateGoal = createFact(root, "late-goal", 79_000, "fact-goal");
+    (lateGoal.payload as Record<string, unknown>).factType = "goal";
+    (catchFact.payload as Record<string, unknown>).factType = "catch";
+    expect(await record.acceptAction(catchFact)).toMatchObject({ status: "accepted" });
+    expect(await record.acceptAction(lateGoal)).toMatchObject({ status: "accepted" });
+    const rebuild = await record.rebuild();
+    expect(rebuild).toMatchObject({ status: "ready" });
+    if (rebuild.status !== "ready") throw new Error("Expected a ready rebuild.");
+    expect(rebuild.derivedGameState).toEqual({
+      overtimeTarget: 90,
+      order: ["goal", "catch"],
+    });
+  });
+});

--- a/src/lib/event-game-corrections.support.ts
+++ b/src/lib/event-game-corrections.support.ts
@@ -1,0 +1,1085 @@
+import { expect } from "bun:test";
+import {
+  canonicalizeJson,
+  createDeterministicTestIqaInterpreter,
+  LEGACY_CONTROL_ACTION_VERSION,
+  LEGACY_CONTROL_AUDIT_VERSION,
+  type ControlActionInput,
+} from "@/lib/event-game-actions";
+import { createEventGameRecord } from "@/lib/event-game-record";
+import { DURABLE_EVIDENCE_PROVENANCE } from "@/lib/foundation-storage";
+import type {
+  FoundationStorage,
+  FoundationStorageTransaction,
+  FoundationStorageTransactionWork,
+} from "@/lib/foundation-storage";
+import { createInMemoryFoundationStorage } from "@/lib/foundation-storage-memory";
+import type { EventGameRecordRoot } from "@/lib/foundation-record-types";
+import {
+  projectAcceptanceOutcomeForConvergence,
+  projectControlAuditEntryForConvergence,
+  projectRebuildForConvergence,
+} from "@/lib/event-game-convergence";
+
+export async function snapshot(record: Awaited<ReturnType<typeof createRecord>>) {
+  const rebuild = await record.rebuild();
+  if (rebuild.status !== "ready") {
+    throw new Error(`rebuild:${rebuild.reason}:${rebuild.detail}`);
+  }
+  const audit = await record.readAudit(auditCredential);
+  const projectedRebuild = projectRebuildForConvergence(rebuild);
+  return {
+    rebuild: {
+      canonicalActions: projectedRebuild.canonicalActions,
+      effectiveFacts: projectedRebuild.effectiveFacts,
+      effectiveTeamAssignments: projectedRebuild.effectiveTeamAssignments,
+      derivedGameState: projectedRebuild.derivedGameState,
+      conflicts: projectedRebuild.conflicts,
+    },
+    audit: audit.map(projectControlAuditEntryForConvergence),
+  };
+}
+
+export const auditCredential = Object.freeze({ role: "event-admin" });
+
+export type CorrectionSpec = {
+  operationId: string;
+  effective: boolean;
+  causalPredecessorIds: readonly string[];
+  kind?: "correction" | "team-assignment";
+  gameSideId?: "side-a" | "side-b";
+  eventTeamId?: string;
+  teamInterpretationRef?: string;
+};
+
+export const OVERLAPPING_TEAM_COMPONENT: readonly CorrectionSpec[] = [
+  {
+    operationId: "team-component-a-1",
+    effective: false,
+    causalPredecessorIds: [],
+    kind: "team-assignment",
+    gameSideId: "side-a",
+    eventTeamId: "team-c",
+    teamInterpretationRef: "interpretation-a-c-1",
+  },
+  {
+    operationId: "team-component-b",
+    effective: false,
+    causalPredecessorIds: [],
+    kind: "team-assignment",
+    gameSideId: "side-b",
+    eventTeamId: "team-c",
+    teamInterpretationRef: "interpretation-b-c",
+  },
+  {
+    operationId: "team-component-a-2",
+    effective: false,
+    causalPredecessorIds: [],
+    kind: "team-assignment",
+    gameSideId: "side-a",
+    eventTeamId: "team-c",
+    teamInterpretationRef: "interpretation-a-c-2",
+  },
+];
+
+export const REGISTERED_CORRECTION_SHAPES: readonly {
+  name: string;
+  actions: readonly CorrectionSpec[];
+}[] = [
+  {
+    name: "opposing-pair",
+    actions: [
+      { operationId: "correction-false", effective: false, causalPredecessorIds: [] },
+      { operationId: "correction-true", effective: true, causalPredecessorIds: [] },
+    ],
+  },
+  {
+    name: "three-chain-reinstatement",
+    actions: [
+      { operationId: "correction-first", effective: false, causalPredecessorIds: [] },
+      {
+        operationId: "correction-reinstate",
+        effective: true,
+        causalPredecessorIds: ["correction-first"],
+      },
+      {
+        operationId: "correction-reverse",
+        effective: false,
+        causalPredecessorIds: ["correction-reinstate"],
+      },
+    ],
+  },
+  {
+    name: "three-fan-in-repair",
+    actions: [
+      { operationId: "correction-left", effective: false, causalPredecessorIds: [] },
+      { operationId: "correction-right", effective: true, causalPredecessorIds: [] },
+      {
+        operationId: "correction-repair",
+        effective: false,
+        causalPredecessorIds: ["correction-left", "correction-right"],
+      },
+    ],
+  },
+  {
+    name: "three-branch",
+    actions: [
+      { operationId: "correction-root", effective: false, causalPredecessorIds: [] },
+      {
+        operationId: "correction-child",
+        effective: true,
+        causalPredecessorIds: ["correction-root"],
+      },
+      { operationId: "correction-independent", effective: false, causalPredecessorIds: [] },
+    ],
+  },
+  {
+    name: "three-team",
+    actions: [
+      {
+        operationId: "team-assignment-a-first",
+        effective: false,
+        causalPredecessorIds: [],
+        kind: "team-assignment",
+        gameSideId: "side-a",
+        eventTeamId: "team-c",
+        teamInterpretationRef: "interpretation-a-c",
+      },
+      {
+        operationId: "team-assignment-b-first",
+        effective: false,
+        causalPredecessorIds: [],
+        kind: "team-assignment",
+        gameSideId: "side-b",
+        eventTeamId: "team-d",
+        teamInterpretationRef: "interpretation-b-d",
+      },
+      {
+        operationId: "team-assignment-a-repair",
+        effective: false,
+        causalPredecessorIds: ["team-assignment-a-first"],
+        kind: "team-assignment",
+        gameSideId: "side-a",
+        eventTeamId: "team-e",
+        teamInterpretationRef: "interpretation-a-e",
+      },
+    ],
+  },
+  {
+    name: "three-team-conflict-repair",
+    actions: [
+      {
+        operationId: "team-conflict-a",
+        effective: false,
+        causalPredecessorIds: [],
+        kind: "team-assignment",
+        gameSideId: "side-a",
+        eventTeamId: "team-c",
+        teamInterpretationRef: "interpretation-a-c",
+      },
+      {
+        operationId: "team-conflict-b",
+        effective: false,
+        causalPredecessorIds: [],
+        kind: "team-assignment",
+        gameSideId: "side-b",
+        eventTeamId: "team-c",
+        teamInterpretationRef: "interpretation-b-c",
+      },
+      {
+        operationId: "team-conflict-repair",
+        effective: false,
+        causalPredecessorIds: ["team-conflict-a", "team-conflict-b"],
+        kind: "team-assignment",
+        gameSideId: "side-a",
+        eventTeamId: "team-e",
+        teamInterpretationRef: "interpretation-a-e",
+      },
+    ],
+  },
+  {
+    name: "three-team-overlapping-component",
+    actions: OVERLAPPING_TEAM_COMPONENT,
+  },
+  {
+    name: "four-team-overlapping-component-repair",
+    actions: [
+      ...OVERLAPPING_TEAM_COMPONENT,
+      {
+        operationId: "team-component-repair",
+        effective: false,
+        causalPredecessorIds: ["team-component-a-1", "team-component-b", "team-component-a-2"],
+        kind: "team-assignment",
+        gameSideId: "side-b",
+        eventTeamId: "team-d",
+        teamInterpretationRef: "interpretation-b-d-repair",
+      },
+    ],
+  },
+];
+
+export function createCorrectionActions(
+  root: EventGameRecordRoot,
+  specs: readonly CorrectionSpec[],
+): ControlActionInput[] {
+  return specs.map((spec, index) => {
+    if (spec.kind === "team-assignment") {
+      if (
+        spec.gameSideId === undefined ||
+        spec.eventTeamId === undefined ||
+        spec.teamInterpretationRef === undefined
+      ) {
+        throw new Error(`Incomplete team assignment specification: ${spec.operationId}`);
+      }
+      return createTeamAssignmentCorrection(
+        root,
+        spec.operationId,
+        spec.gameSideId,
+        spec.eventTeamId,
+        spec.teamInterpretationRef,
+        2_000 + index,
+        spec.causalPredecessorIds,
+        `controller-${index % 2 === 0 ? "a" : "b"}`,
+      );
+    }
+    return createCorrection(
+      root,
+      spec.operationId,
+      spec.effective,
+      2_000 + index,
+      spec.causalPredecessorIds,
+      "fact-goal",
+      `controller-${index % 2 === 0 ? "a" : "b"}`,
+    );
+  });
+}
+
+export function topologicalPermutations(specs: readonly CorrectionSpec[]): string[][] {
+  const results: string[][] = [];
+  const visit = (prefix: string[], remaining: readonly CorrectionSpec[]) => {
+    if (remaining.length === 0) {
+      results.push(prefix);
+      return;
+    }
+    for (const candidate of remaining) {
+      if (!candidate.causalPredecessorIds.every((predecessor) => prefix.includes(predecessor))) {
+        continue;
+      }
+      visit(
+        [...prefix, candidate.operationId],
+        remaining.filter((item) => item.operationId !== candidate.operationId),
+      );
+    }
+  };
+  visit([], specs);
+  return results;
+}
+
+export function resolveActionOrder(
+  actions: readonly ControlActionInput[],
+  operationIds: readonly string[],
+): ControlActionInput[] {
+  return operationIds.map((operationId) => {
+    const action = actions.find((candidate) => candidate.operationId === operationId);
+    if (action === undefined) throw new Error(`Unknown generated operation ${operationId}.`);
+    return action;
+  });
+}
+
+export async function acceptScenario(
+  record: Awaited<ReturnType<typeof createRecord>>,
+  actions: readonly ControlActionInput[],
+): Promise<unknown[]> {
+  const acknowledgements: unknown[] = [];
+  for (const action of actions) {
+    const acknowledgement = await record.acceptAction(action);
+    expect(acknowledgement).toMatchObject({ status: "accepted" });
+    acknowledgements.push(projectAcceptanceOutcomeForConvergence(acknowledgement));
+  }
+  return acknowledgements;
+}
+
+type ScenarioRun = "left" | "right" | "comparison";
+
+export type ScenarioFailure = {
+  kind: "boolean-mismatch" | "rejected-action" | "thrown" | "readiness-failure";
+  run: ScenarioRun;
+  arrivalOrder: readonly string[];
+  fingerprint: string;
+  reason?: string;
+  requiredOperationIds: readonly string[];
+  requiredEdges: readonly (readonly [string, string])[];
+  detail: string;
+};
+
+type ShrinkPredicateResult = ScenarioFailure | null;
+
+type ObserverOptions = {
+  recordFactory?: (
+    root: EventGameRecordRoot,
+    run: Exclude<ScenarioRun, "comparison">,
+  ) => Promise<Awaited<ReturnType<typeof createRecord>>>;
+  snapshotRecord?: (
+    record: Awaited<ReturnType<typeof createRecord>>,
+    run: Exclude<ScenarioRun, "comparison">,
+  ) => Promise<unknown>;
+  transformAcknowledgement?: (
+    acknowledgement: unknown,
+    action: ControlActionInput,
+    run: Exclude<ScenarioRun, "comparison">,
+  ) => unknown;
+};
+
+type ExactDifference = {
+  path: string;
+  left: unknown;
+  right: unknown;
+  operationIds: readonly string[];
+};
+
+export async function observePermutation(
+  root: EventGameRecordRoot,
+  actions: readonly ControlActionInput[],
+  arrivalOrder: readonly string[],
+  options: ObserverOptions = {},
+): Promise<ScenarioFailure | null> {
+  const recordFactory = options.recordFactory ?? ((candidateRoot) => createRecord(candidateRoot));
+  const left = await recordFactory(root, "left");
+  const right = await recordFactory(root, "right");
+  const fact = createFact(root, "fact-generated", 1_000, "fact-goal");
+  const rightOrder = resolveActionOrder(actions, arrivalOrder);
+  const run = async (
+    record: Awaited<ReturnType<typeof createRecord>>,
+    sequence: readonly ControlActionInput[],
+    runName: Exclude<ScenarioRun, "comparison">,
+    runArrivalOrder: readonly string[],
+  ): Promise<{ failure: ScenarioFailure | null; acknowledgements: unknown[] }> => {
+    const acknowledgements: unknown[] = [];
+    for (const action of sequence) {
+      try {
+        const acknowledgement = await record.acceptAction(action);
+        if (acknowledgement.status !== "accepted") {
+          const relationship = causalFailureRelationship([action.operationId], actions);
+          return {
+            failure: {
+              kind: "rejected-action",
+              run: runName,
+              arrivalOrder: [...runArrivalOrder],
+              fingerprint: `rejected:${action.operationId}:${failureValue(acknowledgement)}`,
+              ...relationship,
+              detail: JSON.stringify(acknowledgement),
+            },
+            acknowledgements,
+          };
+        }
+        const projectedAcknowledgement = projectAcceptanceOutcomeForConvergence(acknowledgement);
+        acknowledgements.push(
+          options.transformAcknowledgement?.(projectedAcknowledgement, action, runName) ??
+            projectedAcknowledgement,
+        );
+      } catch (error) {
+        const relationship = causalFailureRelationship([action.operationId], actions);
+        return {
+          failure: {
+            kind: "thrown",
+            run: runName,
+            arrivalOrder: [...runArrivalOrder],
+            fingerprint: `thrown:${action.operationId}:${errorSignature(error)}`,
+            ...relationship,
+            detail: error instanceof Error ? error.message : String(error),
+          },
+          acknowledgements,
+        };
+      }
+    }
+    return { failure: null, acknowledgements };
+  };
+  const leftOrder = actions.map((action) => action.operationId);
+  const leftRun = await run(left, [fact, ...actions], "left", leftOrder);
+  if (leftRun.failure !== null) return leftRun.failure;
+  const rightRun = await run(right, [fact, ...rightOrder], "right", arrivalOrder);
+  if (rightRun.failure !== null) return rightRun.failure;
+
+  const observeSnapshot = async (
+    record: Awaited<ReturnType<typeof createRecord>>,
+    runName: Exclude<ScenarioRun, "comparison">,
+    runArrivalOrder: readonly string[],
+  ): Promise<{ snapshot?: unknown; failure?: ScenarioFailure }> => {
+    const rebuild = await record.rebuild();
+    if (rebuild.status !== "ready") {
+      const relationship = readinessFailureRelationship(rebuild.detail, actions);
+      return {
+        failure: {
+          kind: "readiness-failure",
+          run: runName,
+          arrivalOrder: [...runArrivalOrder],
+          reason: rebuild.reason,
+          fingerprint: `readiness:${runName}:${rebuild.reason}:${failureValue(rebuild.detail)}:operations=${relationship.requiredOperationIds.join(",")}:edges=${failureValue(relationship.requiredEdges)}`,
+          ...relationship,
+          detail: rebuild.detail,
+        },
+      };
+    }
+    try {
+      return {
+        snapshot: options.snapshotRecord
+          ? await options.snapshotRecord(record, runName)
+          : await snapshotFromRebuild(record, rebuild),
+      };
+    } catch (error) {
+      return {
+        failure: {
+          kind: "readiness-failure",
+          run: runName,
+          arrivalOrder: [...runArrivalOrder],
+          fingerprint: `readiness:${runName}:${errorSignature(error)}`,
+          ...causalFailureRelationship(
+            actions.map((action) => action.operationId),
+            actions,
+          ),
+          detail: error instanceof Error ? error.message : String(error),
+        },
+      };
+    }
+  };
+  const leftObservation = await observeSnapshot(left, "left", leftOrder);
+  if (leftObservation.failure !== undefined) return leftObservation.failure;
+  const rightObservation = await observeSnapshot(right, "right", arrivalOrder);
+  if (rightObservation.failure !== undefined) return rightObservation.failure;
+
+  const acknowledgementDifference = findAcknowledgementDifference(
+    leftRun.acknowledgements,
+    rightRun.acknowledgements,
+  );
+  if (acknowledgementDifference !== null) {
+    return mismatchFailure("acknowledgements", acknowledgementDifference, actions, arrivalOrder);
+  }
+  const snapshotDifference = findExactDifference(
+    leftObservation.snapshot,
+    rightObservation.snapshot,
+  );
+  if (snapshotDifference !== null) {
+    return mismatchFailure("snapshot", snapshotDifference, actions, arrivalOrder);
+  }
+  return null;
+}
+
+async function snapshotFromRebuild(
+  record: Awaited<ReturnType<typeof createRecord>>,
+  rebuild: Extract<Awaited<ReturnType<typeof record.rebuild>>, { status: "ready" }>,
+) {
+  const audit = await record.readAudit(auditCredential);
+  const projectedRebuild = projectRebuildForConvergence(rebuild);
+  return {
+    rebuild: {
+      canonicalActions: projectedRebuild.canonicalActions,
+      effectiveFacts: projectedRebuild.effectiveFacts,
+      effectiveTeamAssignments: projectedRebuild.effectiveTeamAssignments,
+      derivedGameState: projectedRebuild.derivedGameState,
+      conflicts: projectedRebuild.conflicts,
+    },
+    audit: audit.map(projectControlAuditEntryForConvergence),
+  };
+}
+
+function mismatchFailure(
+  surface: "acknowledgements" | "snapshot",
+  difference: ExactDifference,
+  actions: readonly ControlActionInput[],
+  arrivalOrder: readonly string[],
+): ScenarioFailure {
+  const relationship = causalFailureRelationship(difference.operationIds, actions);
+  return {
+    kind: "boolean-mismatch",
+    run: "comparison",
+    arrivalOrder: [...arrivalOrder],
+    fingerprint: `${surface}:${difference.path}:${failureValue(difference.left)}=>${failureValue(difference.right)}:operations=${difference.operationIds.join(",")}:required=${relationship.requiredOperationIds.join(",")}:edges=${failureValue(relationship.requiredEdges)}`,
+    ...relationship,
+    detail: `${surface} differ at ${difference.path}.`,
+  };
+}
+
+function findAcknowledgementDifference(
+  leftAcknowledgements: readonly unknown[],
+  rightAcknowledgements: readonly unknown[],
+): ExactDifference | null {
+  const left = sortAcknowledgements(leftAcknowledgements);
+  const right = sortAcknowledgements(rightAcknowledgements);
+  const count = Math.max(left.length, right.length);
+  for (let index = 0; index < count; index += 1) {
+    const leftAcknowledgement = left[index];
+    const rightAcknowledgement = right[index];
+    const operationId =
+      acknowledgementOperationId(leftAcknowledgement) ??
+      acknowledgementOperationId(rightAcknowledgement);
+    const difference = findExactDifference(leftAcknowledgement, rightAcknowledgement);
+    if (difference === null) continue;
+    return {
+      ...difference,
+      operationIds:
+        operationId === undefined
+          ? difference.operationIds
+          : [...new Set([operationId, ...difference.operationIds])],
+    };
+  }
+  return null;
+}
+
+function findExactDifference(
+  left: unknown,
+  right: unknown,
+  path = "$",
+  inheritedOperationIds: readonly string[] = [],
+): ExactDifference | null {
+  if (Object.is(left, right)) return null;
+  if (path === "$" && JSON.stringify(left) === JSON.stringify(right)) return null;
+  const operationIds = [
+    ...new Set([
+      ...inheritedOperationIds,
+      ...directOperationIds(left),
+      ...directOperationIds(right),
+    ]),
+  ];
+  if (Array.isArray(left) && Array.isArray(right)) {
+    if (left.length !== right.length) {
+      return {
+        path: `${path}.length`,
+        left: left.length,
+        right: right.length,
+        operationIds: [
+          ...new Set([...operationIds, ...arrayOperationIds(left), ...arrayOperationIds(right)]),
+        ],
+      };
+    }
+    for (let index = 0; index < left.length; index += 1) {
+      const leftOperationIds = directOperationIds(left[index]);
+      const rightOperationIds = new Set(directOperationIds(right[index]));
+      const stableOperationId = leftOperationIds.find((operationId) =>
+        rightOperationIds.has(operationId),
+      );
+      const difference = findExactDifference(
+        left[index],
+        right[index],
+        stableOperationId === undefined
+          ? `${path}[${index}]`
+          : `${path}[operationId=${stableOperationId}]`,
+        operationIds,
+      );
+      if (difference !== null) return difference;
+    }
+    return null;
+  }
+  if (isPlainObject(left) && isPlainObject(right)) {
+    const keys = [...new Set([...Object.keys(left), ...Object.keys(right)])].sort();
+    for (const key of keys) {
+      const difference = findExactDifference(left[key], right[key], `${path}.${key}`, operationIds);
+      if (difference !== null) return difference;
+    }
+    return null;
+  }
+  return { path, left, right, operationIds };
+}
+
+function directOperationIds(value: unknown): string[] {
+  if (!isPlainObject(value)) return [];
+  const operationIds: string[] = [];
+  if (typeof value.operationId === "string") operationIds.push(value.operationId);
+  if (Array.isArray(value.relatedOperationIds)) {
+    for (const operationId of value.relatedOperationIds) {
+      if (typeof operationId === "string") operationIds.push(operationId);
+    }
+  }
+  return operationIds;
+}
+
+function arrayOperationIds(values: readonly unknown[]): string[] {
+  return values.flatMap((value) => [
+    ...directOperationIds(value),
+    ...(Array.isArray(value) ? arrayOperationIds(value) : []),
+  ]);
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function acknowledgementOperationId(acknowledgement: unknown): string | undefined {
+  if (!isPlainObject(acknowledgement) || !isPlainObject(acknowledgement.action)) return undefined;
+  return typeof acknowledgement.action.operationId === "string"
+    ? acknowledgement.action.operationId
+    : undefined;
+}
+
+function causalFailureRelationship(
+  targetOperationIds: readonly string[],
+  actions: readonly ControlActionInput[],
+): Pick<ScenarioFailure, "requiredOperationIds" | "requiredEdges"> {
+  const actionsByOperationId = new Map(actions.map((action) => [action.operationId, action]));
+  const required = new Set<string>();
+  const visit = (operationId: string) => {
+    const action = actionsByOperationId.get(operationId);
+    if (action === undefined || required.has(operationId)) return;
+    required.add(operationId);
+    for (const predecessor of action.causalPredecessorIds) visit(predecessor);
+  };
+  for (const operationId of targetOperationIds) visit(operationId);
+  const requiredOperationIds = actions
+    .map((action) => action.operationId)
+    .filter((operationId) => required.has(operationId));
+  const requiredEdges = actions.flatMap((action) =>
+    required.has(action.operationId)
+      ? action.causalPredecessorIds
+          .filter((predecessor) => required.has(predecessor))
+          .map((predecessor): readonly [string, string] => [predecessor, action.operationId])
+      : [],
+  );
+  return { requiredOperationIds, requiredEdges };
+}
+
+function readinessFailureRelationship(
+  detail: string,
+  actions: readonly ControlActionInput[],
+): Pick<ScenarioFailure, "requiredOperationIds" | "requiredEdges"> {
+  const mentionedOperationIds = actions
+    .map((action) => action.operationId)
+    .filter((operationId) => detail.includes(operationId));
+  return causalFailureRelationship(
+    mentionedOperationIds.length === 0
+      ? actions.map((action) => action.operationId)
+      : mentionedOperationIds,
+    actions,
+  );
+}
+
+function failureValue(value: unknown): string {
+  if (value === undefined) return "<undefined>";
+  try {
+    return canonicalizeJson(value);
+  } catch {
+    return `<noncanonical:${typeof value}>`;
+  }
+}
+
+export async function minimizeFailingSequence(
+  sequence: readonly CorrectionSpec[],
+  failingPermutation: readonly string[],
+  fails: (
+    candidate: readonly CorrectionSpec[],
+    candidatePermutation: readonly string[],
+  ) => Promise<ShrinkPredicateResult>,
+  seed?: number | string,
+): Promise<{
+  seed: number | string | undefined;
+  sequence: CorrectionSpec[];
+  arrivalOrder: string[];
+  failure: ScenarioFailure | undefined;
+}> {
+  let minimized = [...sequence];
+  const initial = await evaluateShrinkCandidate(fails, sequence, failingPermutation);
+  let failure = initial;
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (let index = 0; index < minimized.length; index += 1) {
+      const candidate = minimized.filter((_, candidateIndex) => candidateIndex !== index);
+      const candidateIds = new Set(candidate.map((action) => action.operationId));
+      const candidatePermutation = failingPermutation.filter((operationId) =>
+        candidateIds.has(operationId),
+      );
+      const candidateFailure = await evaluateShrinkCandidate(
+        fails,
+        candidate,
+        candidatePermutation,
+      );
+      if (
+        candidateFailure !== null &&
+        failure !== null &&
+        reproducesFailure(failure, candidateFailure, candidatePermutation)
+      ) {
+        minimized = candidate;
+        failure = candidateFailure;
+        changed = true;
+        break;
+      }
+    }
+  }
+  return {
+    seed,
+    sequence: minimized,
+    arrivalOrder: [...(failure?.arrivalOrder ?? [])],
+    failure: failure ?? undefined,
+  };
+}
+
+async function evaluateShrinkCandidate(
+  fails: (
+    candidate: readonly CorrectionSpec[],
+    candidatePermutation: readonly string[],
+  ) => Promise<ShrinkPredicateResult>,
+  candidate: readonly CorrectionSpec[],
+  candidatePermutation: readonly string[],
+): Promise<ScenarioFailure | null> {
+  try {
+    return await fails(candidate, candidatePermutation);
+  } catch (error) {
+    return {
+      kind: "thrown",
+      run: "comparison",
+      arrivalOrder: [...candidatePermutation],
+      fingerprint: `thrown:shrink:${errorSignature(error)}`,
+      requiredOperationIds: [],
+      requiredEdges: [],
+      detail: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+function reproducesFailure(
+  expected: ScenarioFailure,
+  candidate: ScenarioFailure,
+  candidatePermutation: readonly string[],
+): boolean {
+  if (
+    candidate.kind !== expected.kind ||
+    candidate.run !== expected.run ||
+    candidate.fingerprint !== expected.fingerprint ||
+    candidate.reason !== expected.reason ||
+    candidate.detail !== expected.detail
+  ) {
+    return false;
+  }
+  if (
+    JSON.stringify(candidate.requiredOperationIds) !==
+      JSON.stringify(expected.requiredOperationIds) ||
+    JSON.stringify(candidate.requiredEdges) !== JSON.stringify(expected.requiredEdges)
+  ) {
+    return false;
+  }
+  if (
+    !expected.requiredOperationIds.every((operationId) =>
+      candidatePermutation.includes(operationId),
+    )
+  ) {
+    return false;
+  }
+  if (
+    !expected.requiredEdges.every(
+      ([predecessor, operationId]) =>
+        candidatePermutation.includes(predecessor) && candidatePermutation.includes(operationId),
+    )
+  ) {
+    return false;
+  }
+  const expectedArrivalOrder = expected.arrivalOrder.filter((operationId) =>
+    candidatePermutation.includes(operationId),
+  );
+  return JSON.stringify(candidate.arrivalOrder) === JSON.stringify(expectedArrivalOrder);
+}
+
+function errorSignature(error: unknown): string {
+  if (error instanceof Error) return `${error.name}:${error.message}`;
+  return String(error);
+}
+
+export function sortAcknowledgements(acknowledgements: readonly unknown[]): unknown[] {
+  return [...acknowledgements].sort((left, right) => {
+    const leftOperationId =
+      typeof left === "object" &&
+      left !== null &&
+      "action" in left &&
+      typeof left.action === "object" &&
+      left.action !== null &&
+      "operationId" in left.action
+        ? String(left.action.operationId)
+        : JSON.stringify(left);
+    const rightOperationId =
+      typeof right === "object" &&
+      right !== null &&
+      "action" in right &&
+      typeof right.action === "object" &&
+      right.action !== null &&
+      "operationId" in right.action
+        ? String(right.action.operationId)
+        : JSON.stringify(right);
+    return leftOperationId.localeCompare(rightOperationId);
+  });
+}
+
+export function corruptMemoryAudit(
+  storage: FoundationStorage,
+  mutate: (entry: Awaited<ReturnType<FoundationStorage["readAuditEntries"]>>[number]) => void,
+  mutateDuringTransactions = true,
+): FoundationStorage {
+  return {
+    transaction<T>(work: FoundationStorageTransactionWork<T>) {
+      return storage.transaction((transaction) =>
+        mutateDuringTransactions
+          ? work({
+              ...transaction,
+              listAuditEntries(recordId) {
+                const entries = transaction.listAuditEntries(recordId);
+                for (const entry of entries) mutate(entry);
+                return entries;
+              },
+            } satisfies FoundationStorageTransaction)
+          : work(transaction),
+      );
+    },
+    readRoot: (recordId) => storage.readRoot(recordId),
+    readActions: (recordId) => storage.readActions(recordId),
+    readIdempotencyEntries: (recordId) => storage.readIdempotencyEntries(recordId),
+    readRecordMetadata: (recordId) => storage.readRecordMetadata(recordId),
+    readAuditEntries: async (recordId) => {
+      const entries = await storage.readAuditEntries(recordId);
+      for (const entry of entries) mutate(entry);
+      return entries;
+    },
+    readiness: () => storage.readiness(),
+    close: () => storage.close(),
+  };
+}
+
+export function removeMemoryAudit(
+  storage: FoundationStorage,
+  shouldRemove: (
+    entry: Awaited<ReturnType<FoundationStorage["readAuditEntries"]>>[number],
+  ) => boolean,
+): FoundationStorage {
+  return {
+    transaction<T>(work: FoundationStorageTransactionWork<T>) {
+      return storage.transaction((transaction) =>
+        work({
+          ...transaction,
+          listAuditEntries(recordId) {
+            return transaction.listAuditEntries(recordId).filter((entry) => !shouldRemove(entry));
+          },
+        } satisfies FoundationStorageTransaction),
+      );
+    },
+    readRoot: (recordId) => storage.readRoot(recordId),
+    readActions: (recordId) => storage.readActions(recordId),
+    readIdempotencyEntries: (recordId) => storage.readIdempotencyEntries(recordId),
+    readRecordMetadata: (recordId) => storage.readRecordMetadata(recordId),
+    readAuditEntries: async (recordId) =>
+      (await storage.readAuditEntries(recordId)).filter((entry) => !shouldRemove(entry)),
+    readiness: () => storage.readiness(),
+    close: () => storage.close(),
+  };
+}
+
+export function legacyMemoryEvidenceView(
+  storage: FoundationStorage,
+  legacyOperationIds: ReadonlySet<string>,
+): FoundationStorage {
+  const projectAction = (stored: Awaited<ReturnType<FoundationStorage["readActions"]>>[number]) => {
+    if (!legacyOperationIds.has(stored.action.operationId)) return stored;
+    const action = structuredClone(stored.action);
+    action.controlActionVersion = LEGACY_CONTROL_ACTION_VERSION;
+    return {
+      ...stored,
+      action,
+      durableFormat: "legacy" as const,
+      [DURABLE_EVIDENCE_PROVENANCE]: "legacy" as const,
+    };
+  };
+  const projectAudit = (
+    entry: Awaited<ReturnType<FoundationStorage["readAuditEntries"]>>[number],
+  ) => {
+    const relatedOperationIds = entry.links?.relatedOperationIds ?? [];
+    const legacy =
+      (entry.operationId !== null && legacyOperationIds.has(entry.operationId)) ||
+      (entry.operationId === null &&
+        relatedOperationIds.length > 0 &&
+        relatedOperationIds.every((id) => legacyOperationIds.has(id)));
+    if (!legacy) return entry;
+    const projected = structuredClone(entry);
+    projected.auditVersion = LEGACY_CONTROL_AUDIT_VERSION;
+    delete projected.links;
+    delete projected.provenance;
+    return {
+      ...projected,
+      durableFormat: "legacy" as const,
+      [DURABLE_EVIDENCE_PROVENANCE]: "legacy" as const,
+    };
+  };
+  return {
+    transaction<T>(work: FoundationStorageTransactionWork<T>) {
+      return storage.transaction((transaction) =>
+        work({
+          ...transaction,
+          findActionByOperationId(recordId, operationId) {
+            const action = transaction.findActionByOperationId(recordId, operationId);
+            return action === null ? null : projectAction(action);
+          },
+          listActions(recordId) {
+            return transaction.listActions(recordId).map(projectAction);
+          },
+          listAuditEntries(recordId) {
+            return transaction.listAuditEntries(recordId).map(projectAudit);
+          },
+        } satisfies FoundationStorageTransaction),
+      );
+    },
+    readRoot: (recordId) => storage.readRoot(recordId),
+    readActions: async (recordId) => (await storage.readActions(recordId)).map(projectAction),
+    readIdempotencyEntries: (recordId) => storage.readIdempotencyEntries(recordId),
+    readRecordMetadata: (recordId) => storage.readRecordMetadata(recordId),
+    readAuditEntries: async (recordId) =>
+      (await storage.readAuditEntries(recordId)).map(projectAudit),
+    readiness: () => storage.readiness(),
+    close: () => storage.close(),
+  };
+}
+
+export async function createRecord(
+  root: EventGameRecordRoot,
+  interpreter = createDeterministicTestIqaInterpreter("rules-v1"),
+  clock: () => number = () => 10_000,
+  storage: FoundationStorage = createInMemoryFoundationStorage(),
+) {
+  const record = createEventGameRecord(storage, {
+    externalScopeResolver: {
+      resolve(scope) {
+        return { status: "resolved", scope: structuredClone(scope) };
+      },
+      resolveEventTeam(eventId, eventTeamId) {
+        return eventId === root.eventId && eventTeamId.length > 0
+          ? { status: "resolved" }
+          : { status: "mismatch", detail: "The Event Team is outside the Event scope." };
+      },
+    },
+    clock,
+    interpreter,
+    auditAuthorityVerifier: { verify: (candidate) => candidate === auditCredential },
+  });
+  const registration = await record.registerRoot(root);
+  expect(["registered", "idempotent"]).toContain(registration.status);
+  return record;
+}
+
+export function createFact(
+  root: EventGameRecordRoot,
+  operationId: string,
+  trustedAtMs: number,
+  factId: string,
+  override?: ControlActionInput["override"],
+  sessionId = "session-1",
+): ControlActionInput {
+  return {
+    recordId: root.recordId,
+    eventGameId: root.eventGameId,
+    operationId,
+    kind: { id: "game-fact", version: "1" },
+    payload: {
+      factId,
+      factType: "deterministic-test-fact",
+      gameSideId: "side-a",
+      gameTimeMs: trustedAtMs,
+      data: { operationId },
+    },
+    causalPredecessorIds: [],
+    occurrence: { trustedAtMs, clientOriginAtMs: trustedAtMs, source: "offline" },
+    grant: { sessionId, versionId: "grant-version-1" },
+    lifecycle: structuredClone(root.lifecycle),
+    ...(override === undefined ? {} : { override }),
+  };
+}
+
+export function createCorrection(
+  root: EventGameRecordRoot,
+  operationId: string,
+  effective: boolean,
+  trustedAtMs: number,
+  causalPredecessorIds: readonly string[] = [],
+  targetFactId = "fact-goal",
+  sessionId = "session-1",
+): ControlActionInput {
+  return {
+    ...createFact(root, operationId, trustedAtMs, `fact-${operationId}`),
+    kind: { id: "correction", version: "1" },
+    payload: {
+      correctionId: operationId,
+      targetFactId,
+      effective,
+    },
+    causalPredecessorIds,
+    grant: { sessionId, versionId: "grant-version-1" },
+  };
+}
+
+export function createTeamAssignmentCorrection(
+  root: EventGameRecordRoot,
+  operationId: string,
+  gameSideId: string,
+  eventTeamId: string,
+  teamInterpretationRef: string,
+  trustedAtMs: number,
+  causalPredecessorIds: readonly string[] = [],
+  sessionId = "session-team-assignment",
+): ControlActionInput {
+  return {
+    recordId: root.recordId,
+    eventGameId: root.eventGameId,
+    operationId,
+    kind: { id: "team-assignment-correction", version: "1" },
+    payload: {
+      correctionId: operationId,
+      gameSideId,
+      eventTeamId,
+      teamInterpretationRef,
+    },
+    causalPredecessorIds,
+    occurrence: { trustedAtMs, clientOriginAtMs: trustedAtMs, source: "offline" },
+    grant: { sessionId, versionId: "grant-version-1" },
+    lifecycle: structuredClone(root.lifecycle),
+  };
+}
+
+export function createRoot(recordId: string): EventGameRecordRoot {
+  return {
+    recordId,
+    eventId: `event-${recordId}`,
+    eventGameId: `event-game-${recordId}`,
+    ownership: { eventId: `event-${recordId}`, eventGameId: `event-game-${recordId}` },
+    externalScope: {
+      eventId: `event-${recordId}`,
+      gameDayId: `day-${recordId}`,
+      pitchId: `pitch-${recordId}`,
+      pitchSlotId: `slot-${recordId}`,
+    },
+    gameSides: [
+      { id: "side-a", eventTeamId: "team-a", teamInterpretationRef: "interpretation-a" },
+      { id: "side-b", eventTeamId: "team-b", teamInterpretationRef: "interpretation-b" },
+    ],
+    lifecycle: {
+      phase: "in-progress",
+      commencedAtMs: 0,
+      finishedAtMs: null,
+      lockedAtMs: null,
+      lockReason: null,
+    },
+    compatibility: {
+      recordVersion: "record-v1",
+      schemaVersion: "schema-v1",
+      interpreterVersion: "rules-v1",
+    },
+    creationEvidence: {
+      operationId: `register-${recordId}`,
+      actorReference: "event-admin-session-1",
+      source: "event-game-registration",
+      createdAtMs: 0,
+    },
+  };
+}
+
+export function seededRandom(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (Math.imul(state, 1_664_525) + 1_013_904_223) >>> 0;
+    return state / 4_294_967_296;
+  };
+}
+
+export function randomInt(random: () => number, maximum: number): number {
+  return Math.floor(random() * maximum);
+}

--- a/src/lib/event-game-corrections.test.ts
+++ b/src/lib/event-game-corrections.test.ts
@@ -1,0 +1,841 @@
+import { describe, expect, test } from "bun:test";
+import { createDeterministicTestIqaInterpreter } from "@/lib/event-game-actions";
+import { createEventGameRecord } from "@/lib/event-game-record";
+import { DURABLE_EVIDENCE_PROVENANCE } from "@/lib/foundation-storage";
+import type {
+  FoundationStorage,
+  FoundationStorageTransaction,
+  FoundationStorageTransactionWork,
+} from "@/lib/foundation-storage";
+import { createInMemoryFoundationStorage } from "@/lib/foundation-storage-memory";
+import {
+  OVERLAPPING_TEAM_COMPONENT,
+  acceptScenario,
+  auditCredential,
+  corruptMemoryAudit,
+  createCorrection,
+  createCorrectionActions,
+  createFact,
+  legacyMemoryEvidenceView,
+  createRecord,
+  createRoot,
+  removeMemoryAudit,
+  createTeamAssignmentCorrection,
+  resolveActionOrder,
+  snapshot,
+  sortAcknowledgements,
+  topologicalPermutations,
+} from "@/lib/event-game-corrections.support";
+
+describe("Event Game corrections and Official Overrides", () => {
+  test("converges opposing offline Corrections and records a canonical linked conflict", async () => {
+    const firstRoot = createRoot("corrections-convergence");
+    const secondRoot = firstRoot;
+    const first = await createRecord(firstRoot);
+    const second = await createRecord(secondRoot);
+
+    const firstFact = createFact(firstRoot, "fact-operation", 1_000, "fact-goal");
+    const secondFact = createFact(secondRoot, "fact-operation", 1_000, "fact-goal");
+    const firstFalse = createCorrection(firstRoot, "correction-false", false, 2_000);
+    const secondFalse = createCorrection(secondRoot, "correction-false", false, 2_000);
+    const firstTrue = createCorrection(firstRoot, "correction-true", true, 2_000);
+    const secondTrue = createCorrection(secondRoot, "correction-true", true, 2_000);
+
+    expect(await first.acceptAction(firstFact)).toMatchObject({ status: "accepted" });
+    expect(await second.acceptAction(secondFact)).toMatchObject({ status: "accepted" });
+    expect(await first.acceptAction(firstTrue)).toMatchObject({ status: "accepted" });
+    expect(await first.acceptAction(firstFalse)).toMatchObject({ status: "accepted" });
+    expect(await second.acceptAction(secondFalse)).toMatchObject({ status: "accepted" });
+    expect(await second.acceptAction(secondTrue)).toMatchObject({ status: "accepted" });
+
+    const firstSnapshot = await snapshot(first);
+    const secondSnapshot = await snapshot(second);
+    expect(secondSnapshot).toEqual(firstSnapshot);
+    expect(firstSnapshot.rebuild.conflicts).toEqual([
+      {
+        targetFactId: "fact-goal",
+        operationIds: ["correction-false", "correction-true"],
+        winnerOperationId: "correction-true",
+        reason: "opposing-concurrent-corrections",
+      },
+    ]);
+    expect(firstSnapshot.rebuild.effectiveFacts.map((fact) => fact.factId)).toEqual(["fact-goal"]);
+    expect(firstSnapshot.audit).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "action-conflict",
+          outcome: "conflict-resolved",
+          links: expect.objectContaining({
+            targetFactId: "fact-goal",
+            relatedOperationIds: ["correction-false", "correction-true"],
+          }),
+        }),
+      ]),
+    );
+  });
+
+  test("lets a later causal Correction replace the automatic concurrent outcome", async () => {
+    const root = createRoot("causal-repair");
+    const record = await createRecord(root);
+    const fact = createFact(root, "fact-operation", 1_000, "fact-goal");
+    const falseCorrection = createCorrection(root, "correction-false", false, 2_000);
+    const trueCorrection = createCorrection(root, "correction-true", true, 2_000);
+    const repair = createCorrection(root, "correction-repair", false, 3_000, [
+      "correction-false",
+      "correction-true",
+    ]);
+
+    for (const action of [fact, falseCorrection, trueCorrection, repair]) {
+      expect(await record.acceptAction(action)).toMatchObject({ status: "accepted" });
+    }
+
+    const rebuild = await record.rebuild();
+    expect(rebuild).toMatchObject({ status: "ready" });
+    if (rebuild.status !== "ready") throw new Error("Expected a ready rebuild.");
+    expect(rebuild.effectiveFacts).toHaveLength(0);
+    expect(rebuild.canonicalActions.map((action) => action.operationId)).toEqual([
+      "fact-operation",
+      "correction-false",
+      "correction-true",
+      "correction-repair",
+    ]);
+  });
+
+  test("never labels causally related opposing Corrections as concurrent", async () => {
+    const root = createRoot("causal-not-concurrent");
+    const record = await createRecord(root);
+    const fact = createFact(root, "fact-operation", 1_000, "fact-goal");
+    const first = createCorrection(root, "correction-first", false, 2_000);
+    const second = createCorrection(root, "correction-second", true, 3_000, ["correction-first"]);
+    for (const action of [fact, first, second]) {
+      expect(await record.acceptAction(action)).toMatchObject({ status: "accepted" });
+    }
+    const rebuild = await record.rebuild();
+    expect(rebuild).toMatchObject({ status: "ready", conflicts: [] });
+    expect(
+      (await record.readAudit(auditCredential)).some((entry) => entry.kind === "action-conflict"),
+    ).toBe(false);
+  });
+
+  test("exhausts both valid arrival permutations of the three-action causal repair shape", async () => {
+    const operationOrders = [
+      ["correction-false", "correction-true"],
+      ["correction-true", "correction-false"],
+    ] as const;
+    const snapshots = [];
+    for (const order of operationOrders) {
+      const root = createRoot("causal-permutations");
+      const record = await createRecord(root);
+      const fact = createFact(root, "fact-operation", 1_000, "fact-goal");
+      const corrections = new Map([
+        ["correction-false", createCorrection(root, "correction-false", false, 2_000)],
+        ["correction-true", createCorrection(root, "correction-true", true, 2_000)],
+      ]);
+      const repair = createCorrection(root, "correction-repair", false, 3_000, [
+        "correction-false",
+        "correction-true",
+      ]);
+      expect(await record.acceptAction(fact)).toMatchObject({ status: "accepted" });
+      for (const operationId of order) {
+        expect(await record.acceptAction(corrections.get(operationId))).toMatchObject({
+          status: "accepted",
+        });
+      }
+      expect(await record.acceptAction(repair)).toMatchObject({ status: "accepted" });
+      snapshots.push(await snapshot(record));
+    }
+    expect(snapshots[1]).toEqual(snapshots[0]);
+    expect(snapshots[0]?.rebuild.conflicts).toHaveLength(1);
+  });
+
+  test("rejects duplicate stable Game Fact and Correction identities before retention", async () => {
+    const root = createRoot("stable-identities");
+    const record = await createRecord(root);
+    const fact = createFact(root, "fact-operation", 1_000, "fact-goal");
+    expect(await record.acceptAction(fact)).toMatchObject({ status: "accepted" });
+    expect(
+      await record.acceptAction(createFact(root, "fact-operation-duplicate", 1_001, "fact-goal")),
+    ).toMatchObject({ status: "rejected", reason: "invalid-action" });
+
+    const correction = createCorrection(root, "correction-first", false, 2_000);
+    expect(await record.acceptAction(correction)).toMatchObject({ status: "accepted" });
+    const correctionPayload = correction.payload as Record<string, unknown>;
+    expect(
+      await record.acceptAction({
+        ...createCorrection(root, "correction-second", true, 2_001),
+        payload: { ...correctionPayload, effective: true },
+      }),
+    ).toMatchObject({ status: "rejected", reason: "invalid-action" });
+    expect(await record.readActions()).toHaveLength(2);
+    expect(await record.rebuild()).toMatchObject({ status: "ready" });
+  });
+
+  test("retains Official Override evidence when its Game Fact is corrected and reinstated", async () => {
+    const root = createRoot("override-correction");
+    const record = await createRecord(root);
+    const stoppage = createFact(root, "stoppage-shortened", 12_000, "fact-stoppage", {
+      guardrail: "nominal-four-minute-heat-stoppage",
+      direction: "head-referee-end-after-two-minutes",
+      confirmation: "head-referee-confirmed",
+      authorityReference: "controller-session-referee",
+      gameTimeMs: 12_000,
+      reason: "Head Referee directed the shortened stoppage.",
+    });
+    (stoppage.payload as Record<string, unknown>).factType = "heat-stoppage";
+    const reverse = createCorrection(
+      root,
+      "stoppage-reverse",
+      false,
+      13_000,
+      ["stoppage-shortened"],
+      "fact-stoppage",
+    );
+    const reinstate = createCorrection(
+      root,
+      "stoppage-reinstate",
+      true,
+      14_000,
+      ["stoppage-reverse"],
+      "fact-stoppage",
+    );
+    const invalidOverride = createFact(root, "invalid-override", 15_000, "fact-invalid", {
+      guardrail: "guardrail",
+      direction: "head-referee-direction",
+      confirmation: "confirmed",
+      authorityReference: "controller-session-referee",
+      gameTimeMs: 15_000,
+      reason: "x".repeat(241),
+    });
+
+    expect(await record.acceptAction(stoppage)).toMatchObject({ status: "accepted" });
+    expect(await record.acceptAction(reverse)).toMatchObject({ status: "accepted" });
+    expect(await record.acceptAction(reinstate)).toMatchObject({ status: "accepted" });
+    expect(await record.acceptAction(invalidOverride)).toMatchObject({
+      status: "rejected",
+      reason: "invalid-action",
+    });
+
+    const actions = await record.readActions();
+    expect(actions[0]?.action.override).toEqual(stoppage.override);
+    expect(actions.map((stored) => stored.action.interpretation.type)).toEqual([
+      "fact",
+      "correction",
+      "correction",
+    ]);
+    const audit = await record.readAudit(auditCredential);
+    const overrideAudit = audit.find((entry) => entry.operationId === "stoppage-shortened");
+    expect(overrideAudit).toEqual(
+      expect.objectContaining({
+        provenance: expect.objectContaining({ override: stoppage.override }),
+      }),
+    );
+    expect(audit.filter((entry) => entry.links?.targetFactId === "fact-stoppage")).toHaveLength(2);
+  });
+
+  test("converges Event Team Assignment Corrections without rewriting stable Facts or Game Sides", async () => {
+    const root = createRoot("team-assignment-correction");
+    const originalGameSides = structuredClone(root.gameSides);
+    const first = await createRecord(root);
+    const second = await createRecord(root);
+    const fact = createFact(root, "fact-team-assignment", 1_000, "fact-team-assignment");
+    const firstAssignment = createTeamAssignmentCorrection(
+      root,
+      "team-assignment-a",
+      "side-a",
+      "team-c",
+      "interpretation-a-corrected",
+      2_000,
+    );
+    const secondAssignment = createTeamAssignmentCorrection(
+      root,
+      "team-assignment-b",
+      "side-a",
+      "team-d",
+      "interpretation-a-reinstated",
+      2_000,
+    );
+    expect(await first.acceptAction(fact)).toMatchObject({ status: "accepted" });
+    expect(await first.acceptAction(firstAssignment)).toMatchObject({ status: "accepted" });
+    expect(await first.acceptAction(secondAssignment)).toMatchObject({ status: "accepted" });
+    expect(await second.acceptAction(fact)).toMatchObject({ status: "accepted" });
+    expect(await second.acceptAction(secondAssignment)).toMatchObject({ status: "accepted" });
+    expect(await second.acceptAction(firstAssignment)).toMatchObject({ status: "accepted" });
+    expect(await snapshot(second)).toEqual(await snapshot(first));
+    const rebuild = await first.rebuild();
+    if (rebuild.status !== "ready") throw new Error("Expected a ready rebuild.");
+    expect(rebuild.effectiveTeamAssignments).toEqual([
+      {
+        gameSideId: "side-a",
+        eventTeamId: "team-d",
+        teamInterpretationRef: "interpretation-a-reinstated",
+      },
+      {
+        gameSideId: "side-b",
+        eventTeamId: "team-b",
+        teamInterpretationRef: "interpretation-b",
+      },
+    ]);
+    const actions = await first.readActions();
+    expect(actions[0]?.action).toMatchObject({
+      operationId: fact.operationId,
+      payload: fact.payload,
+      causalPredecessorIds: fact.causalPredecessorIds,
+      interpretation: {
+        type: "fact",
+        factId: "fact-team-assignment",
+        gameSideId: "side-a",
+      },
+    });
+    expect(actions[0]?.action.interpretation).toMatchObject({
+      type: "fact",
+      factId: "fact-team-assignment",
+    });
+    expect(actions.map((stored) => stored.action.interpretation.type)).toEqual([
+      "fact",
+      "team-assignment-correction",
+      "team-assignment-correction",
+    ]);
+    expect(root.gameSides).toEqual(originalGameSides);
+    const audit = await first.readAudit(auditCredential);
+    for (const [operationId, eventTeamId] of [
+      ["team-assignment-a", "team-c"],
+      ["team-assignment-b", "team-d"],
+    ] as const) {
+      expect(
+        actions.find((stored) => stored.action.operationId === operationId)?.action.interpretation,
+      ).toMatchObject({ type: "team-assignment-correction", eventTeamId });
+      expect(audit.find((entry) => entry.operationId === operationId)).toEqual(
+        expect.objectContaining({
+          kind: "action-accepted",
+          links: expect.objectContaining({
+            actionId: expect.stringContaining("action-"),
+            targetFactId: null,
+          }),
+          provenance: expect.objectContaining({ grant: expect.any(Object) }),
+        }),
+      );
+    }
+  });
+
+  test("rejects invalid corrected Event Team identities", async () => {
+    const root = createRoot("invalid-team-assignment-correction");
+    const record = await createRecord(root);
+    for (const eventTeamId of ["", "équipe-c"]) {
+      expect(
+        await record.acceptAction(
+          createTeamAssignmentCorrection(
+            root,
+            `team-assignment-${eventTeamId.length}`,
+            "side-a",
+            eventTeamId,
+            "interpretation-a-corrected",
+            2_000,
+          ),
+        ),
+      ).toMatchObject({ status: "rejected", reason: "invalid-action" });
+    }
+    expect(await record.readActions()).toHaveLength(0);
+  });
+
+  test("converges opposite-side same-team assignments with a canonical conflict outcome", async () => {
+    const root = createRoot("distinct-effective-teams");
+    const left = await createRecord(root);
+    const right = await createRecord(root);
+    const assignmentA = createTeamAssignmentCorrection(
+      root,
+      "team-assignment-a",
+      "side-a",
+      "team-c",
+      "interpretation-a-colliding",
+      2_000,
+    );
+    const assignmentB = createTeamAssignmentCorrection(
+      root,
+      "team-assignment-b",
+      "side-b",
+      "team-c",
+      "interpretation-b-colliding",
+      2_000,
+    );
+    const leftAcks = await acceptScenario(left, [assignmentA, assignmentB]);
+    const rightAcks = await acceptScenario(right, [assignmentB, assignmentA]);
+    expect(sortAcknowledgements(leftAcks)).toEqual(sortAcknowledgements(rightAcks));
+    expect(await snapshot(left)).toEqual(await snapshot(right));
+    const rebuild = await left.rebuild();
+    if (rebuild.status !== "ready") throw new Error("Expected a ready rebuild.");
+    expect(rebuild.effectiveTeamAssignments).toEqual([
+      { gameSideId: "side-a", eventTeamId: "team-a", teamInterpretationRef: "interpretation-a" },
+      {
+        gameSideId: "side-b",
+        eventTeamId: "team-c",
+        teamInterpretationRef: "interpretation-b-colliding",
+      },
+    ]);
+    expect(rebuild.conflicts).toEqual([
+      expect.objectContaining({
+        reason: "opposing-concurrent-team-assignments",
+        eventTeamId: "team-c",
+        winnerOperationId: "team-assignment-b",
+      }),
+    ]);
+  });
+
+  test("converges every arrival permutation of an overlapping team-conflict component", async () => {
+    const specs = OVERLAPPING_TEAM_COMPONENT;
+    const permutations = topologicalPermutations(specs);
+    expect(permutations).toHaveLength(6);
+    let expectedAcknowledgements: unknown[] | undefined;
+    let expectedSnapshot: Awaited<ReturnType<typeof snapshot>> | undefined;
+    for (const permutation of permutations) {
+      const root = createRoot("overlapping-team-component");
+      const record = await createRecord(root);
+      const actions = createCorrectionActions(root, specs);
+      const acknowledgements = await acceptScenario(
+        record,
+        resolveActionOrder(actions, permutation),
+      );
+      const actualSnapshot = await snapshot(record);
+      if (expectedSnapshot === undefined || expectedAcknowledgements === undefined) {
+        expectedSnapshot = actualSnapshot;
+        expectedAcknowledgements = sortAcknowledgements(acknowledgements);
+      } else {
+        expect(sortAcknowledgements(acknowledgements)).toEqual(expectedAcknowledgements);
+        expect(actualSnapshot).toEqual(expectedSnapshot);
+      }
+    }
+    expect(expectedSnapshot?.rebuild.effectiveTeamAssignments).toEqual([
+      {
+        gameSideId: "side-a",
+        eventTeamId: "team-c",
+        teamInterpretationRef: "interpretation-a-c-2",
+      },
+      { gameSideId: "side-b", eventTeamId: "team-b", teamInterpretationRef: "interpretation-b" },
+    ]);
+    expect(expectedSnapshot?.rebuild.conflicts).toHaveLength(2);
+  });
+
+  test("rejects a standalone correction that would make the effective sides share a team", async () => {
+    const root = createRoot("standalone-team-collision");
+    const record = await createRecord(root);
+    expect(
+      await record.acceptAction(
+        createTeamAssignmentCorrection(
+          root,
+          "standalone-team-collision-action",
+          "side-a",
+          "team-b",
+          "interpretation-a-b",
+          2_000,
+        ),
+      ),
+    ).toMatchObject({ status: "rejected", reason: "invalid-action" });
+    expect(await record.readActions()).toHaveLength(0);
+    expect(await record.rebuild()).toMatchObject({ status: "ready" });
+  });
+
+  test("derives team distinctness from the current canonical assignment history", async () => {
+    const root = createRoot("team-assignment-history");
+    const record = await createRecord(root);
+    const moveSideB = createTeamAssignmentCorrection(
+      root,
+      "team-assignment-b-to-d",
+      "side-b",
+      "team-d",
+      "interpretation-b-d",
+      2_000,
+    );
+    const reuseFreedTeam = createTeamAssignmentCorrection(
+      root,
+      "team-assignment-a-to-b",
+      "side-a",
+      "team-b",
+      "interpretation-a-b",
+      3_000,
+      ["team-assignment-b-to-d"],
+    );
+    expect(await record.acceptAction(moveSideB)).toMatchObject({ status: "accepted" });
+    expect(await record.acceptAction(reuseFreedTeam)).toMatchObject({ status: "accepted" });
+    const rebuild = await record.rebuild();
+    expect(rebuild).toMatchObject({ status: "ready" });
+    if (rebuild.status !== "ready") throw new Error("Expected a ready rebuild.");
+    expect(rebuild.effectiveTeamAssignments).toEqual([
+      {
+        gameSideId: "side-a",
+        eventTeamId: "team-b",
+        teamInterpretationRef: "interpretation-a-b",
+      },
+      {
+        gameSideId: "side-b",
+        eventTeamId: "team-d",
+        teamInterpretationRef: "interpretation-b-d",
+      },
+    ]);
+  });
+
+  test("rejects a causal duplicate team assignment without poisoning retained history", async () => {
+    const root = createRoot("causal-team-assignment-duplicate");
+    const record = await createRecord(root);
+    const first = createTeamAssignmentCorrection(
+      root,
+      "team-assignment-a-to-c",
+      "side-a",
+      "team-c",
+      "interpretation-a-c",
+      2_000,
+    );
+    const duplicate = createTeamAssignmentCorrection(
+      root,
+      "team-assignment-b-to-c",
+      "side-b",
+      "team-c",
+      "interpretation-b-c",
+      3_000,
+      ["team-assignment-a-to-c"],
+    );
+    expect(await record.acceptAction(first)).toMatchObject({ status: "accepted" });
+    expect(await record.acceptAction(duplicate)).toMatchObject({
+      status: "rejected",
+      reason: "invalid-action",
+    });
+    expect((await record.readActions()).map((stored) => stored.action.operationId)).toEqual([
+      "team-assignment-a-to-c",
+    ]);
+    expect(await record.rebuild()).toMatchObject({ status: "ready" });
+    expect(await record.readiness()).toMatchObject({ ok: true });
+  });
+
+  test("rejects out-of-scope Event Team corrections without partial retention and retries stably", async () => {
+    const root = createRoot("out-of-scope-team");
+    let resolveCalls = 0;
+    const record = createEventGameRecord(createInMemoryFoundationStorage(), {
+      externalScopeResolver: {
+        resolve(scope) {
+          return { status: "resolved", scope: structuredClone(scope) };
+        },
+        resolveEventTeam(eventId, eventTeamId) {
+          resolveCalls += 1;
+          return eventId === root.eventId && eventTeamId === "team-c"
+            ? { status: "resolved" }
+            : { status: "mismatch", detail: "The Event Team is outside the Event scope." };
+        },
+      },
+      interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
+      auditAuthorityVerifier: { verify: (candidate) => candidate === auditCredential },
+    });
+    expect(await record.registerRoot(root)).toMatchObject({ status: "registered" });
+    const invalid = createTeamAssignmentCorrection(
+      root,
+      "out-of-scope",
+      "side-a",
+      "team-z",
+      "x",
+      2_000,
+    );
+    expect(await record.acceptAction(invalid)).toMatchObject({
+      status: "rejected",
+      reason: "invalid-action",
+    });
+    expect(await record.acceptAction(invalid)).toMatchObject({
+      status: "rejected",
+      reason: "invalid-action",
+    });
+    expect(resolveCalls).toBe(2);
+    expect(await record.readActions()).toHaveLength(0);
+    expect(await record.rebuild()).toMatchObject({ status: "ready" });
+  });
+
+  test("converges action acknowledgements and audit timestamps under nonconstant arrival clocks", async () => {
+    const root = createRoot("canonical-arrival-times");
+    const firstClock = [90_000, 10_000, 80_000, 20_000];
+    const secondClock = [11_000, 99_000, 12_000, 98_000];
+    const first = await createRecord(root, undefined, () => firstClock.shift() ?? 0);
+    const second = await createRecord(root, undefined, () => secondClock.shift() ?? 0);
+    const fact = createFact(root, "fact-canonical-time", 1_000, "fact-goal");
+    const falseCorrection = createCorrection(root, "correction-canonical-false", false, 2_000);
+    const trueCorrection = createCorrection(root, "correction-canonical-true", true, 2_000);
+
+    const firstAcks = await acceptScenario(first, [fact, falseCorrection, trueCorrection]);
+    const secondAcks = await acceptScenario(second, [fact, trueCorrection, falseCorrection]);
+    expect(sortAcknowledgements(secondAcks)).toEqual(sortAcknowledgements(firstAcks));
+    expect(await snapshot(second)).toEqual(await snapshot(first));
+    expect(
+      (await first.readActions()).map(({ action }) => [action.operationId, action.acceptedAtMs]),
+    ).toEqual([
+      ["fact-canonical-time", 90_000],
+      ["correction-canonical-false", 10_000],
+      ["correction-canonical-true", 80_000],
+    ]);
+    expect(
+      (await second.readActions()).map(({ action }) => [action.operationId, action.acceptedAtMs]),
+    ).toEqual([
+      ["fact-canonical-time", 11_000],
+      ["correction-canonical-true", 99_000],
+      ["correction-canonical-false", 12_000],
+    ]);
+    expect(
+      (await first.readAudit(auditCredential))
+        .filter((entry) => entry.kind === "action-accepted")
+        .map((entry) => [entry.operationId, entry.createdAtMs]),
+    ).toEqual([
+      ["fact-canonical-time", 90_000],
+      ["correction-canonical-false", 10_000],
+      ["correction-canonical-true", 80_000],
+    ]);
+    expect(
+      (await first.readAudit(auditCredential)).find(
+        (entry) => entry.outcome === "conflict-resolved",
+      )?.createdAtMs,
+    ).toBe(80_000);
+    expect(
+      (await second.readAudit(auditCredential)).find(
+        (entry) => entry.outcome === "conflict-resolved",
+      )?.createdAtMs,
+    ).toBe(12_000);
+  });
+
+  test("fails memory readiness when collision linkage is retargeted", async () => {
+    const root = createRoot("memory-collision-linkage");
+    const baseStorage = createInMemoryFoundationStorage();
+    const storage = corruptMemoryAudit(baseStorage, (entry) => {
+      if (entry.kind !== "action-conflict" || entry.links?.collision === undefined) return;
+      if (entry.links.ordering !== null) entry.links.ordering.operationId = "retargeted-order";
+    });
+    const record = createEventGameRecord(storage, {
+      externalScopeResolver: {
+        resolve(scope) {
+          return { status: "resolved", scope: structuredClone(scope) };
+        },
+        resolveEventTeam(eventId, eventTeamId) {
+          return eventId === root.eventId && eventTeamId.length > 0
+            ? { status: "resolved" }
+            : { status: "mismatch", detail: "The Event Team is outside the Event scope." };
+        },
+      },
+      clock: () => 10_000,
+      interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
+      auditAuthorityVerifier: { verify: (candidate) => candidate === auditCredential },
+    });
+    expect(await record.registerRoot(root)).toMatchObject({ status: "registered" });
+    const accepted = createFact(root, "memory-collision", 1_000, "fact-memory-collision");
+    expect(await record.acceptAction(accepted)).toMatchObject({ status: "accepted" });
+    expect(
+      await record.acceptAction({
+        ...accepted,
+        payload: { ...(accepted.payload as Record<string, unknown>), data: { rejected: true } },
+      }),
+    ).toMatchObject({ status: "rejected", reason: "operation-conflict" });
+    expect(await record.readiness()).toMatchObject({ ok: false, status: "rebuild-failure" });
+  });
+
+  test("fails memory readiness when current action and audit evidence is jointly downgraded", async () => {
+    const root = createRoot("memory-evidence-downgrade");
+    const baseStorage = createInMemoryFoundationStorage();
+    const storage: FoundationStorage = {
+      transaction<T>(work: FoundationStorageTransactionWork<T>) {
+        return baseStorage.transaction((transaction) =>
+          work({
+            ...transaction,
+            listActions(recordId) {
+              const actions = transaction.listActions(recordId);
+              for (const stored of actions) {
+                stored.action.controlActionVersion = "control-action-legacy-v0";
+                stored.durableFormat = "legacy";
+              }
+              return actions;
+            },
+            listAuditEntries(recordId) {
+              const entries = transaction.listAuditEntries(recordId);
+              for (const entry of entries) {
+                entry.auditVersion = "control-audit-legacy-v0";
+                entry.durableFormat = "legacy";
+                delete entry.links;
+                delete entry.provenance;
+              }
+              return entries;
+            },
+          } satisfies FoundationStorageTransaction),
+        );
+      },
+      readRoot: (recordId) => baseStorage.readRoot(recordId),
+      readActions: async (recordId) => {
+        const actions = await baseStorage.readActions(recordId);
+        for (const stored of actions) {
+          stored.action.controlActionVersion = "control-action-legacy-v0";
+          stored.durableFormat = "legacy";
+        }
+        return actions;
+      },
+      readIdempotencyEntries: (recordId) => baseStorage.readIdempotencyEntries(recordId),
+      readRecordMetadata: (recordId) => baseStorage.readRecordMetadata(recordId),
+      readAuditEntries: async (recordId) => {
+        const entries = await baseStorage.readAuditEntries(recordId);
+        for (const entry of entries) {
+          entry.auditVersion = "control-audit-legacy-v0";
+          entry.durableFormat = "legacy";
+          delete entry.links;
+          delete entry.provenance;
+        }
+        return entries;
+      },
+      readiness: () => baseStorage.readiness(),
+      close: () => baseStorage.close(),
+    };
+    const record = createEventGameRecord(storage, {
+      externalScopeResolver: {
+        resolve(scope) {
+          return { status: "resolved", scope: structuredClone(scope) };
+        },
+        resolveEventTeam() {
+          return { status: "resolved" };
+        },
+      },
+      interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
+      auditAuthorityVerifier: { verify: (candidate) => candidate === auditCredential },
+    });
+    expect(await record.registerRoot(root)).toMatchObject({ status: "registered" });
+    expect(
+      await record.acceptAction(createFact(root, "memory-downgrade", 1_000, "fact")),
+    ).toMatchObject({ status: "accepted" });
+    expect(await record.readiness()).toMatchObject({ ok: false, status: "rebuild-failure" });
+  });
+
+  test("freezes memory writes when the canonical Correction conflict audit is deleted", async () => {
+    const root = createRoot("memory-missing-correction-conflict");
+    const storage = removeMemoryAudit(
+      createInMemoryFoundationStorage(),
+      (entry) =>
+        entry.kind === "action-conflict" &&
+        entry.outcome === "conflict-resolved" &&
+        entry.redactedDetail.startsWith("Opposing Concurrent Corrections resolved"),
+    );
+    const record = await createRecord(root, undefined, () => 10_000, storage);
+    expect(await record.acceptAction(createFact(root, "fact", 1_000, "fact-goal"))).toMatchObject({
+      status: "accepted",
+    });
+    for (const action of [
+      createCorrection(root, "correction-false", false, 2_000),
+      createCorrection(root, "correction-true", true, 2_000),
+    ]) {
+      expect(await record.acceptAction(action)).toMatchObject({ status: "accepted" });
+    }
+    expect(await record.readiness()).toMatchObject({
+      ok: false,
+      status: "rebuild-failure",
+      detail: "Control Audit Trail is missing canonical conflict evidence.",
+    });
+    const reopened = await createRecord(root, undefined, () => 10_000, storage);
+    expect(
+      await reopened.acceptAction(createFact(root, "after-missing-conflict", 3_000, "after-fact")),
+    ).toMatchObject({ status: "rejected", reason: "storage-not-ready" });
+  });
+
+  test("freezes memory writes when the canonical team-assignment conflict audit is deleted", async () => {
+    const root = createRoot("memory-missing-team-conflict");
+    const storage = removeMemoryAudit(
+      createInMemoryFoundationStorage(),
+      (entry) =>
+        entry.kind === "action-conflict" &&
+        entry.outcome === "conflict-resolved" &&
+        entry.redactedDetail.startsWith("Opposing Concurrent Team Assignments resolved"),
+    );
+    const record = await createRecord(root, undefined, () => 10_000, storage);
+    for (const action of [
+      createTeamAssignmentCorrection(
+        root,
+        "team-assignment-a",
+        "side-a",
+        "team-c",
+        "interpretation-a-c",
+        1_000,
+      ),
+      createTeamAssignmentCorrection(
+        root,
+        "team-assignment-b",
+        "side-b",
+        "team-c",
+        "interpretation-b-c",
+        1_000,
+      ),
+    ]) {
+      expect(await record.acceptAction(action)).toMatchObject({ status: "accepted" });
+    }
+    expect(await record.readiness()).toMatchObject({
+      ok: false,
+      status: "rebuild-failure",
+      detail: "Control Audit Trail is missing canonical conflict evidence.",
+    });
+    const reopened = await createRecord(root, undefined, () => 10_000, storage);
+    expect(
+      await reopened.acceptAction(
+        createFact(root, "after-missing-team-conflict", 2_000, "after-fact"),
+      ),
+    ).toMatchObject({ status: "rejected", reason: "storage-not-ready" });
+  });
+
+  test("keeps a genuine legacy opposing pair ready after an unrelated current Fact", async () => {
+    const root = createRoot("memory-legacy-conflict-unrelated-current");
+    const baseStorage = createInMemoryFoundationStorage();
+    const seeded = await createRecord(root, undefined, () => 10_000, baseStorage);
+    for (const action of [
+      createFact(root, "fact", 1_000, "fact-goal"),
+      createCorrection(root, "correction-false", false, 2_000),
+      createCorrection(root, "correction-true", true, 2_000),
+    ]) {
+      expect(await seeded.acceptAction(action)).toMatchObject({ status: "accepted" });
+    }
+    const legacyView = legacyMemoryEvidenceView(
+      baseStorage,
+      new Set(["fact", "correction-false", "correction-true"]),
+    );
+    const migrated = await createRecord(root, undefined, () => 10_000, legacyView);
+    expect(await migrated.readiness()).toMatchObject({ ok: true, actionCount: 3 });
+    expect(
+      await migrated.acceptAction(createFact(root, "current-unrelated", 3_000, "fact-current")),
+    ).toMatchObject({ status: "accepted" });
+    expect(await migrated.readiness()).toMatchObject({ ok: true, actionCount: 4 });
+    expect(
+      await migrated.acceptAction(createFact(root, "current-after-legacy", 4_000, "fact-after")),
+    ).toMatchObject({
+      status: "accepted",
+    });
+  });
+
+  test("requires and freezes on missing evidence for a current participant in legacy conflict history", async () => {
+    const root = createRoot("memory-legacy-conflict-current-participant");
+    const baseStorage = createInMemoryFoundationStorage();
+    const seeded = await createRecord(root, undefined, () => 10_000, baseStorage);
+    for (const action of [
+      createFact(root, "fact", 1_000, "fact-goal"),
+      createCorrection(root, "correction-false", false, 2_000),
+      createCorrection(root, "correction-true", true, 2_000),
+    ]) {
+      expect(await seeded.acceptAction(action)).toMatchObject({ status: "accepted" });
+    }
+    const legacyView = legacyMemoryEvidenceView(
+      baseStorage,
+      new Set(["fact", "correction-false", "correction-true"]),
+    );
+    const migrated = await createRecord(root, undefined, () => 10_000, legacyView);
+    expect(
+      await migrated.acceptAction(createCorrection(root, "correction-z-current", false, 3_000)),
+    ).toMatchObject({ status: "accepted" });
+    expect(await migrated.readiness()).toMatchObject({ ok: true, actionCount: 4 });
+
+    const deleted = removeMemoryAudit(
+      legacyView,
+      (entry) =>
+        entry[DURABLE_EVIDENCE_PROVENANCE] === "current" &&
+        entry.kind === "action-conflict" &&
+        entry.outcome === "conflict-resolved",
+    );
+    const reopened = await createRecord(root, undefined, () => 10_000, deleted);
+    expect(await reopened.readiness()).toMatchObject({
+      ok: false,
+      status: "rebuild-failure",
+      detail: "Control Audit Trail is missing canonical conflict evidence.",
+    });
+    expect(
+      await reopened.acceptAction(createFact(root, "current-after-delete", 4_000, "fact-after")),
+    ).toMatchObject({ status: "rejected", reason: "storage-not-ready" });
+  });
+});

--- a/src/lib/event-game-record-helpers.ts
+++ b/src/lib/event-game-record-helpers.ts
@@ -1,20 +1,34 @@
 import {
+  CONTROL_AUDIT_VERSION,
+  CONTROL_ACTION_VERSION,
+  LEGACY_CONTROL_ACTION_VERSION,
+  LEGACY_CONTROL_AUDIT_VERSION,
   CONTROL_ACTION_ORDERING_VERSION,
   actionIdentity,
+  findConcurrentCorrectionConflicts,
+  findConcurrentTeamAssignmentConflicts,
+  isCausallyRelated,
+  prepareControlAction,
   sha256,
   type ControlAction,
+  type ControlActionCodecRegistry,
   type ControlActionInput,
+  type ControlActionInterpretation,
   type ControlAuditEntry,
+  type PreparedControlAction,
 } from "@/lib/event-game-actions";
 import { canonicalizeJson } from "@/lib/event-game-action-json";
+import { projectControlAuditEntryForConvergence } from "@/lib/event-game-convergence";
 import type { EventGameRecordRoot } from "@/lib/foundation-record-types";
 import {
   FoundationStorageConstraintError,
   type FoundationStorageSnapshot,
   type FoundationStorageTransaction,
   type StoredControlAction,
+  type StoredControlAuditEntry,
   type StoredControlIdempotencyEntry,
 } from "@/lib/foundation-storage";
+import { DURABLE_EVIDENCE_PROVENANCE } from "@/lib/foundation-storage";
 import type {
   ControlActionAcceptanceOutcome,
   RootRegistrationOutcome,
@@ -40,10 +54,17 @@ export function ensureRecordMetadata(
 export function validateAuditHistory(
   root: EventGameRecordRoot,
   actions: readonly StoredControlAction[],
-  entries: readonly ControlAuditEntry[],
+  entries: readonly StoredControlAuditEntry[],
+  registry: ControlActionCodecRegistry,
 ): string | null {
   const actionsByOperationId = new Map(
     actions.map((stored) => [stored.action.operationId, stored.action]),
+  );
+  const storedActionsByOperationId = new Map(
+    actions.map((stored) => [stored.action.operationId, stored]),
+  );
+  const contentFingerprintsByOperationId = new Map(
+    actions.map((stored) => [stored.action.operationId, stored.contentFingerprint]),
   );
   const actionOperationIds = new Set(actionsByOperationId.keys());
   const acceptedOperationIds = new Set<string>();
@@ -51,13 +72,62 @@ export function validateAuditHistory(
     if (entry.recordId !== root.recordId || entry.eventGameId !== root.eventGameId) {
       return "Control Audit Trail entry references another Event Game Record.";
     }
-    const expectedOutcome =
+    const validOutcome =
       entry.kind === "action-accepted" || entry.kind === "action-duplicate"
-        ? "accepted"
-        : "rejected";
-    if (entry.outcome !== expectedOutcome) {
+        ? entry.outcome === "accepted"
+        : entry.kind === "action-conflict"
+          ? entry.outcome === "rejected" || entry.outcome === "conflict-resolved"
+          : entry.outcome === "rejected";
+    if (!validOutcome) {
       return "Control Audit Trail entry outcome is inconsistent.";
     }
+    if (
+      entry.auditVersion !== "control-audit-v1" &&
+      entry.auditVersion !== "control-audit-legacy-v0"
+    ) {
+      return "Control Audit Trail version is unsupported.";
+    }
+    if (
+      (entry[DURABLE_EVIDENCE_PROVENANCE] === "current" &&
+        entry.auditVersion !== CONTROL_AUDIT_VERSION) ||
+      (entry[DURABLE_EVIDENCE_PROVENANCE] === "legacy" &&
+        entry.auditVersion !== LEGACY_CONTROL_AUDIT_VERSION)
+    ) {
+      return "Control Audit Trail durable format marker is inconsistent.";
+    }
+    if (entry.auditVersion === "control-audit-legacy-v0") {
+      if (entry.kind === "action-accepted") {
+        const action =
+          entry.operationId === null ? undefined : actionsByOperationId.get(entry.operationId);
+        const storedAction =
+          entry.operationId === null
+            ? undefined
+            : storedActionsByOperationId.get(entry.operationId);
+        if (
+          entry.operationId === null ||
+          action === undefined ||
+          storedAction?.[DURABLE_EVIDENCE_PROVENANCE] === "current" ||
+          action.controlActionVersion !== LEGACY_CONTROL_ACTION_VERSION ||
+          entry.auditId !== acceptedAuditId(action) ||
+          entry.redactedDetail !== ACCEPTED_AUDIT_DETAIL ||
+          !acceptedOperationIds.add(entry.operationId)
+        ) {
+          return "Legacy Control Audit accepted-action evidence is inconsistent.";
+        }
+      }
+      continue;
+    }
+    if (entry.links === undefined || entry.provenance === undefined) {
+      return "#75 Control Audit Trail linkage and provenance are mandatory.";
+    }
+    const linkageFailure = validateAuditLinkage(
+      entry,
+      root,
+      actionsByOperationId,
+      contentFingerprintsByOperationId,
+      registry,
+    );
+    if (linkageFailure !== null) return linkageFailure;
     if (entry.kind === "action-accepted") {
       const action =
         entry.operationId === null ? undefined : actionsByOperationId.get(entry.operationId);
@@ -66,6 +136,7 @@ export function validateAuditHistory(
         !actionOperationIds.has(entry.operationId) ||
         action === undefined ||
         entry.auditId !== acceptedAuditId(action) ||
+        entry.createdAtMs !== action.acceptedAtMs ||
         entry.redactedDetail !== ACCEPTED_AUDIT_DETAIL ||
         !acceptedOperationIds.add(entry.operationId)
       ) {
@@ -76,7 +147,373 @@ export function validateAuditHistory(
   if (acceptedOperationIds.size !== actions.length) {
     return "Control Audit Trail is missing accepted-action evidence.";
   }
+  const conflictEvidenceFailure = validateCompleteConflictEvidence(actions, entries);
+  if (conflictEvidenceFailure !== null) return conflictEvidenceFailure;
   return null;
+}
+
+function validateCompleteConflictEvidence(
+  actions: readonly StoredControlAction[],
+  entries: readonly StoredControlAuditEntry[],
+): string | null {
+  // The legacy format predates durable conflict linkage. Keep that explicit
+  // compatibility path intact, but require the complete set once any action
+  // has crossed into the current durable format.
+  if (!actions.some((stored) => stored[DURABLE_EVIDENCE_PROVENANCE] === "current")) {
+    return null;
+  }
+
+  const currentConflictAuditIds = new Set(
+    entries
+      .filter(
+        (entry) =>
+          entry[DURABLE_EVIDENCE_PROVENANCE] === "current" &&
+          entry.kind === "action-conflict" &&
+          entry.outcome === "conflict-resolved",
+      )
+      .map((entry) => entry.auditId),
+  );
+  const expectedByAuditId = new Map(
+    createExpectedConflictAudits(actions, currentConflictAuditIds).map((entry) => [
+      entry.auditId,
+      entry,
+    ]),
+  );
+  const seenAuditIds = new Set<string>();
+  for (const entry of entries) {
+    if (
+      entry[DURABLE_EVIDENCE_PROVENANCE] !== "current" ||
+      entry.kind !== "action-conflict" ||
+      entry.outcome !== "conflict-resolved"
+    ) {
+      continue;
+    }
+    if (!seenAuditIds.add(entry.auditId)) {
+      return "Control Audit Trail contains duplicate conflict evidence.";
+    }
+    const expected = expectedByAuditId.get(entry.auditId);
+    if (expected === undefined) {
+      return "Control Audit Trail contains unexpected conflict evidence.";
+    }
+    if (
+      canonicalizeJson(projectStoredAuditEntryForConvergence(entry)) !==
+      canonicalizeJson(projectControlAuditEntryForConvergence(expected))
+    ) {
+      return "Control Audit Trail conflict evidence is not canonical.";
+    }
+  }
+  if (seenAuditIds.size !== expectedByAuditId.size) {
+    return "Control Audit Trail is missing canonical conflict evidence.";
+  }
+  return null;
+}
+
+function projectStoredAuditEntryForConvergence(
+  entry: StoredControlAuditEntry,
+): ReturnType<typeof projectControlAuditEntryForConvergence> {
+  const {
+    durableFormat: _durableFormat,
+    [DURABLE_EVIDENCE_PROVENANCE]: _durableEvidenceProvenance,
+    ...auditEntry
+  } = entry;
+  return projectControlAuditEntryForConvergence(auditEntry);
+}
+
+function createExpectedConflictAudits(
+  storedActions: readonly StoredControlAction[],
+  currentConflictAuditIds: ReadonlySet<string>,
+): ControlAuditEntry[] {
+  const actions = storedActions.map((stored) => stored.action);
+  const actionsByOperationId = new Map(actions.map((action) => [action.operationId, action]));
+  const storedActionsByOperationId = new Map(
+    storedActions.map((stored) => [stored.action.operationId, stored]),
+  );
+  const expected: ControlAuditEntry[] = [];
+  for (const conflict of findConcurrentCorrectionConflicts(actions)) {
+    if (conflict.targetFactId === null) continue;
+    const left = actionsByOperationId.get(conflict.operationIds[0]);
+    const right = actionsByOperationId.get(conflict.operationIds[1]);
+    if (left === undefined || right === undefined) continue;
+    const auditId = createConflictAuditEntry(
+      left,
+      right,
+      conflict.targetFactId,
+      conflict.winnerOperationId,
+      0,
+    ).auditId;
+    if (
+      !isCurrentStoredAction(storedActionsByOperationId.get(left.operationId)) &&
+      !isCurrentStoredAction(storedActionsByOperationId.get(right.operationId)) &&
+      !currentConflictAuditIds.has(auditId)
+    ) {
+      continue;
+    }
+    expected.push(
+      createConflictAuditEntry(left, right, conflict.targetFactId, conflict.winnerOperationId, 0),
+    );
+  }
+  for (const conflict of findConcurrentTeamAssignmentConflicts(actions)) {
+    if (conflict.eventTeamId === undefined) continue;
+    const left = actionsByOperationId.get(conflict.operationIds[0]);
+    const right = actionsByOperationId.get(conflict.operationIds[1]);
+    if (left === undefined || right === undefined) continue;
+    const auditId = createTeamAssignmentConflictAuditEntry(
+      left,
+      right,
+      conflict.eventTeamId,
+      conflict.winnerOperationId,
+      0,
+    ).auditId;
+    if (
+      !isCurrentStoredAction(storedActionsByOperationId.get(left.operationId)) &&
+      !isCurrentStoredAction(storedActionsByOperationId.get(right.operationId)) &&
+      !currentConflictAuditIds.has(auditId)
+    ) {
+      continue;
+    }
+    expected.push(
+      createTeamAssignmentConflictAuditEntry(
+        left,
+        right,
+        conflict.eventTeamId,
+        conflict.winnerOperationId,
+        0,
+      ),
+    );
+  }
+  return expected;
+}
+
+function isCurrentStoredAction(stored: StoredControlAction | undefined): boolean {
+  return stored?.[DURABLE_EVIDENCE_PROVENANCE] === "current";
+}
+
+function validateAuditLinkage(
+  entry: ControlAuditEntry,
+  root: EventGameRecordRoot,
+  actionsByOperationId: ReadonlyMap<string, ControlAction>,
+  contentFingerprintsByOperationId: ReadonlyMap<string, string>,
+  registry: ControlActionCodecRegistry,
+): string | null {
+  const links = entry.links;
+  const provenance = entry.provenance;
+  if (links === undefined || provenance === undefined) {
+    return "Control Audit Trail evidence is missing.";
+  }
+  if (links.ordering === null) return "Control Audit Trail ordering linkage is missing.";
+  if (
+    entry.operationId !== null &&
+    links.actionId !== actionIdentity(root.recordId, entry.operationId)
+  ) {
+    return "Control Audit Trail operation linkage is inconsistent.";
+  }
+  if (links.ordering.operationId.length === 0) {
+    return "Control Audit Trail ordering linkage is invalid.";
+  }
+  const orderedAction = actionsByOperationId.get(links.ordering.operationId);
+  if (orderedAction !== undefined) {
+    if (
+      (orderedAction.controlActionVersion === CONTROL_ACTION_VERSION) !==
+      (entry.auditVersion === CONTROL_AUDIT_VERSION)
+    ) {
+      return "Control Audit Trail and action compatibility versions are inconsistent.";
+    }
+    if (links.actionId !== actionIdentity(root.recordId, orderedAction.operationId)) {
+      return "Control Audit Trail action linkage is inconsistent.";
+    }
+    if (links.ordering.trustedAtMs !== orderedAction.occurrence.trustedAtMs) {
+      return "Control Audit Trail ordering evidence is inconsistent.";
+    }
+    if (
+      canonicalizeJson(links.causalPredecessorIds) !==
+      canonicalizeJson(orderedAction.causalPredecessorIds)
+    ) {
+      return "Control Audit Trail causal predecessor evidence is inconsistent.";
+    }
+    const expectedTargetFactId =
+      orderedAction.interpretation.type === "correction"
+        ? orderedAction.interpretation.targetFactId
+        : null;
+    if (links.targetFactId !== expectedTargetFactId) {
+      return "Control Audit Trail target linkage is inconsistent.";
+    }
+    if (canonicalizeJson(provenance) !== canonicalizeJson(actionProvenance(orderedAction))) {
+      return "Control Audit Trail provenance is inconsistent.";
+    }
+  } else if (entry.kind === "action-accepted" || entry.outcome === "conflict-resolved") {
+    return "Control Audit Trail references a missing accepted action.";
+  }
+
+  const collision = links.collision;
+  if (collision !== undefined) {
+    if (entry.kind !== "action-conflict" || entry.outcome !== "rejected") {
+      return "Control Audit Trail collision evidence is attached to the wrong outcome.";
+    }
+    const acceptedAction = actionsByOperationId.get(collision.acceptedOperationId);
+    const acceptedFingerprint = contentFingerprintsByOperationId.get(collision.acceptedOperationId);
+    const rejected = collision.rejectedAttempt;
+    const preparedRejected = prepareControlAction(
+      rejected.input,
+      root,
+      registry,
+      rejected.input.occurrence.trustedAtMs,
+    );
+    if (
+      !preparedRejected.ok ||
+      acceptedAction === undefined ||
+      acceptedFingerprint === undefined ||
+      collision.acceptedOperationId !== links.ordering.operationId ||
+      collision.acceptedActionId !==
+        actionIdentity(acceptedAction.recordId, acceptedAction.operationId) ||
+      links.actionId !== collision.acceptedActionId ||
+      acceptedFingerprint !== collision.acceptedContentFingerprint ||
+      entry.operationId === null ||
+      entry.operationId !== rejected.input.operationId ||
+      rejected.input.recordId !== root.recordId ||
+      rejected.input.eventGameId !== root.eventGameId ||
+      rejected.contentFingerprint === acceptedFingerprint ||
+      preparedRejected.value.canonicalContent !== rejected.canonicalContent ||
+      preparedRejected.value.contentFingerprint !== rejected.contentFingerprint ||
+      canonicalizeJson(preparedRejected.value.interpretation) !==
+        canonicalizeJson(rejected.interpretation) ||
+      links.relatedOperationIds.length !== 0 ||
+      links.targetFactId !==
+        (acceptedAction.interpretation.type === "correction"
+          ? acceptedAction.interpretation.targetFactId
+          : null) ||
+      canonicalizeJson(links.causalPredecessorIds) !==
+        canonicalizeJson(acceptedAction.causalPredecessorIds) ||
+      canonicalizeJson(provenance) !== canonicalizeJson(actionProvenance(acceptedAction)) ||
+      entry.redactedDetail !== "operation identity is already bound to different content" ||
+      entry.auditId !==
+        `audit-${sha256(`${root.recordId}:operation-conflict:${entry.operationId}:${rejected.contentFingerprint}`)}`
+    ) {
+      return "Control Audit Trail collision evidence is inconsistent.";
+    }
+  } else if (entry.kind === "action-conflict" && entry.outcome === "rejected") {
+    return "Control Audit Trail collision evidence is missing.";
+  }
+
+  if (entry.operationId !== null && collision === undefined) {
+    const action = actionsByOperationId.get(entry.operationId);
+    if (action !== undefined) {
+      const targetFactId =
+        action.interpretation.type === "correction"
+          ? action.interpretation.targetFactId
+          : undefined;
+      const targetAction =
+        targetFactId === undefined
+          ? undefined
+          : [...actionsByOperationId.values()].find(
+              (candidate) =>
+                candidate.interpretation.type === "fact" &&
+                candidate.interpretation.factId === targetFactId,
+            );
+      const expectedRelated = targetAction === undefined ? [] : [targetAction.operationId];
+      if (canonicalizeJson(links.relatedOperationIds) !== canonicalizeJson(expectedRelated)) {
+        return "Control Audit Trail related operation evidence is inconsistent.";
+      }
+    }
+  }
+
+  for (const relatedOperationId of links.relatedOperationIds) {
+    if (!actionsByOperationId.has(relatedOperationId)) {
+      return "Control Audit Trail related operation is missing.";
+    }
+  }
+  if (entry.outcome === "conflict-resolved") {
+    if (entry.operationId !== null || links.relatedOperationIds.length !== 2) {
+      return "Control Audit Trail conflict linkage is inconsistent.";
+    }
+    const relatedActions = links.relatedOperationIds.map((operationId) =>
+      actionsByOperationId.get(operationId),
+    );
+    const teamActions = relatedActions.filter(
+      (action): action is ControlAction =>
+        action?.interpretation.type === "team-assignment-correction",
+    );
+    const left = teamActions[0];
+    const right = teamActions[1];
+    const leftInterpretation = left?.interpretation;
+    const rightInterpretation = right?.interpretation;
+    if (
+      leftInterpretation?.type === "team-assignment-correction" &&
+      rightInterpretation?.type === "team-assignment-correction"
+    ) {
+      const expectedConflict = findConcurrentTeamAssignmentConflicts([
+        ...actionsByOperationId.values(),
+      ]).find(
+        (conflict) =>
+          conflict.eventTeamId === leftInterpretation.eventTeamId &&
+          canonicalizeJson([...conflict.operationIds].sort()) ===
+            canonicalizeJson(links.relatedOperationIds),
+      );
+      if (
+        leftInterpretation.eventTeamId !== rightInterpretation.eventTeamId ||
+        leftInterpretation.gameSideId === rightInterpretation.gameSideId ||
+        links.targetFactId !== null ||
+        expectedConflict === undefined ||
+        expectedConflict.winnerOperationId !== links.ordering.operationId ||
+        entry.redactedDetail !==
+          `Opposing Concurrent Team Assignments resolved for ${leftInterpretation.eventTeamId}; winner ${expectedConflict.winnerOperationId}` ||
+        entry.auditId !==
+          `audit-${sha256(`${root.recordId}:concurrent-team-assignment:${leftInterpretation.eventTeamId}:${[left!.operationId, right!.operationId].sort().join(":")}:${expectedConflict.winnerOperationId}`)}`
+      ) {
+        return "Control Audit Trail team conflict linkage is inconsistent.";
+      }
+      return null;
+    }
+    if (
+      relatedActions.some(
+        (action) => action === undefined || action.interpretation.type !== "correction",
+      ) ||
+      !links.relatedOperationIds.includes(links.ordering.operationId)
+    ) {
+      return "Control Audit Trail conflict linkage is inconsistent.";
+    }
+    const corrections = relatedActions as [ControlAction, ControlAction];
+    const expectedConflict = findConcurrentCorrectionConflicts([
+      ...actionsByOperationId.values(),
+    ]).find(
+      (conflict) =>
+        conflict.targetFactId === links.targetFactId &&
+        canonicalizeJson([...conflict.operationIds].sort()) ===
+          canonicalizeJson(links.relatedOperationIds),
+    );
+    const hasTargetFact = [...actionsByOperationId.values()].some(
+      (action) =>
+        action.interpretation.type === "fact" &&
+        action.interpretation.factId === links.targetFactId,
+    );
+    if (
+      corrections[0].interpretation.type !== "correction" ||
+      corrections[1].interpretation.type !== "correction" ||
+      corrections[0].interpretation.targetFactId !== links.targetFactId ||
+      corrections[1].interpretation.targetFactId !== links.targetFactId ||
+      corrections[0].interpretation.effective === corrections[1].interpretation.effective ||
+      isCausallyRelated(corrections[0], corrections[1], actionsByOperationId) ||
+      !hasTargetFact ||
+      expectedConflict === undefined ||
+      expectedConflict.winnerOperationId !== links.ordering.operationId ||
+      entry.redactedDetail !==
+        `Opposing Concurrent Corrections resolved for ${links.targetFactId}; winner ${expectedConflict.winnerOperationId}` ||
+      entry.auditId !==
+        `audit-${sha256(`${root.recordId}:concurrent-correction:${links.targetFactId}:${links.relatedOperationIds.join(":")}:${expectedConflict.winnerOperationId}`)}`
+    ) {
+      return "Control Audit Trail conflict linkage is inconsistent.";
+    }
+  }
+  return null;
+}
+
+function actionProvenance(action: ControlAction): Record<string, unknown> {
+  return {
+    occurrence: action.occurrence,
+    grant: action.grant,
+    lifecycle: action.lifecycle,
+    override: action.override ?? null,
+    recoveryProvenance: action.recoveryProvenance ?? null,
+  };
 }
 
 export function validateIdempotencyHistory(
@@ -168,9 +605,37 @@ export function createAuditEntry(
   kind: ControlAuditEntry["kind"],
   redactedDetail: string,
   createdAtMs: number,
+  context: {
+    interpretation?: ControlActionInterpretation;
+    relatedOperationIds?: readonly string[];
+    collision?: {
+      acceptedAction: ControlAction;
+      acceptedContentFingerprint: string;
+      rejectedAttempt: PreparedControlAction;
+    };
+  } = {},
 ): ControlAuditEntry {
+  const targetFactId =
+    (context.collision?.acceptedAction.interpretation ?? context.interpretation)?.type ===
+    "correction"
+      ? (
+          (context.collision?.acceptedAction.interpretation ?? context.interpretation) as {
+            type: "correction";
+            targetFactId: string;
+          }
+        ).targetFactId
+      : null;
+  const acceptedAction = context.collision?.acceptedAction;
+  const collision = context.collision;
+  const rejectedAttempt = context.collision?.rejectedAttempt;
+  const provenanceAction = acceptedAction ?? input;
+  const auditId =
+    acceptedAction !== undefined && rejectedAttempt !== undefined
+      ? `audit-${sha256(`${input.recordId}:operation-conflict:${input.operationId}:${rejectedAttempt.contentFingerprint}`)}`
+      : `audit-${sha256(`${input.recordId}:${input.operationId}:${kind}:${redactedDetail}:${canonicalizeJson(input.payload)}`)}`;
   return {
-    auditId: `audit-${sha256(`${input.recordId}:${input.operationId}:${kind}:${redactedDetail}:${canonicalizeJson(input.payload)}`)}`,
+    auditVersion: CONTROL_AUDIT_VERSION,
+    auditId,
     recordId: input.recordId,
     eventGameId: input.eventGameId,
     operationId: input.operationId,
@@ -178,6 +643,92 @@ export function createAuditEntry(
     outcome: kind === "action-accepted" ? "accepted" : "rejected",
     createdAtMs,
     redactedDetail,
+    links: {
+      actionId: actionIdentity(
+        (acceptedAction ?? input).recordId,
+        (acceptedAction ?? input).operationId,
+      ),
+      targetFactId,
+      causalPredecessorIds: [
+        ...(acceptedAction?.causalPredecessorIds ?? input.causalPredecessorIds),
+      ],
+      relatedOperationIds: [
+        ...(context.collision !== undefined ? [] : (context.relatedOperationIds ?? [])),
+      ],
+      ordering: {
+        trustedAtMs: (acceptedAction ?? input).occurrence.trustedAtMs,
+        operationId: (acceptedAction ?? input).operationId,
+      },
+      ...(acceptedAction !== undefined && rejectedAttempt !== undefined && collision !== undefined
+        ? {
+            collision: {
+              acceptedActionId: actionIdentity(acceptedAction.recordId, acceptedAction.operationId),
+              acceptedOperationId: acceptedAction.operationId,
+              acceptedContentFingerprint: collision.acceptedContentFingerprint,
+              rejectedAttempt: {
+                input: structuredClone(rejectedAttempt.input),
+                canonicalContent: rejectedAttempt.canonicalContent,
+                contentFingerprint: rejectedAttempt.contentFingerprint,
+                interpretation: structuredClone(rejectedAttempt.interpretation),
+              },
+            },
+          }
+        : {}),
+    },
+    provenance: {
+      occurrence: structuredClone(provenanceAction.occurrence),
+      grant: structuredClone(provenanceAction.grant),
+      lifecycle: structuredClone(provenanceAction.lifecycle),
+      override:
+        provenanceAction.override === undefined ? null : structuredClone(provenanceAction.override),
+      recoveryProvenance:
+        provenanceAction.recoveryProvenance === undefined
+          ? null
+          : structuredClone(provenanceAction.recoveryProvenance),
+    },
+  };
+}
+
+export function createConflictAuditEntry(
+  left: ControlAction,
+  right: ControlAction,
+  targetFactId: string,
+  winnerOperationId: string,
+  createdAtMs: number,
+): ControlAuditEntry {
+  const operationIds = [left.operationId, right.operationId].sort();
+  const winner = winnerOperationId === left.operationId ? left : right;
+  const relatedOperationIds = operationIds;
+  const detail = `Opposing Concurrent Corrections resolved for ${targetFactId}; winner ${winnerOperationId}`;
+  return {
+    ...createAuditEntry(winner, "action-conflict", detail, createdAtMs, {
+      interpretation: winner.interpretation,
+      relatedOperationIds,
+    }),
+    auditId: `audit-${sha256(`${winner.recordId}:concurrent-correction:${targetFactId}:${operationIds.join(":")}:${winnerOperationId}`)}`,
+    operationId: null,
+    outcome: "conflict-resolved",
+  };
+}
+
+export function createTeamAssignmentConflictAuditEntry(
+  left: ControlAction,
+  right: ControlAction,
+  eventTeamId: string,
+  winnerOperationId: string,
+  createdAtMs: number,
+): ControlAuditEntry {
+  const operationIds = [left.operationId, right.operationId].sort();
+  const winner = winnerOperationId === left.operationId ? left : right;
+  const detail = `Opposing Concurrent Team Assignments resolved for ${eventTeamId}; winner ${winnerOperationId}`;
+  return {
+    ...createAuditEntry(winner, "action-conflict", detail, createdAtMs, {
+      interpretation: winner.interpretation,
+      relatedOperationIds: operationIds,
+    }),
+    auditId: `audit-${sha256(`${winner.recordId}:concurrent-team-assignment:${eventTeamId}:${operationIds.join(":")}:${winnerOperationId}`)}`,
+    operationId: null,
+    outcome: "conflict-resolved",
   };
 }
 

--- a/src/lib/event-game-record.test.ts
+++ b/src/lib/event-game-record.test.ts
@@ -135,5 +135,10 @@ function createScopeResolver(root: EventGameRecordRoot): ExternalScopeResolver {
         ? { status: "resolved", scope: structuredClone(scope) }
         : { status: "mismatch", detail: "The external scope does not match the root." };
     },
+    resolveEventTeam(eventId, eventTeamId) {
+      return eventId === root.eventId && eventTeamId.length > 0
+        ? { status: "resolved" }
+        : { status: "mismatch", detail: "The Event Team is outside the Event scope." };
+    },
   };
 }

--- a/src/lib/event-game-record.ts
+++ b/src/lib/event-game-record.ts
@@ -9,6 +9,7 @@ import {
   FoundationStorageNotReadyError,
   type FoundationStorage,
   type FoundationStorageSnapshot,
+  type FoundationStorageTransaction,
   type StoredControlAction,
 } from "@/lib/foundation-storage";
 import {
@@ -16,6 +17,8 @@ import {
   acceptedAuditId,
   classifyRootConflict,
   constraintToConflict,
+  createConflictAuditEntry,
+  createTeamAssignmentConflictAuditEntry,
   createAuditEntry,
   ensureRecordMetadata,
   findFactById,
@@ -28,6 +31,8 @@ import {
 import {
   CONTROL_ACTION_ORDERING_VERSION,
   createControlActionCodecRegistry,
+  findConcurrentCorrectionConflicts,
+  findConcurrentTeamAssignmentConflicts,
   materializeControlAction,
   prepareControlAction,
   rebuildControlActionHistory,
@@ -63,6 +68,10 @@ export type ExternalScopeResolution =
       detail: string;
     };
 
+export type ExternalEventTeamResolution =
+  | { status: "resolved" }
+  | { status: "missing" | "mismatch"; detail: string };
+
 /**
  * Resolves the external Event hierarchy without exposing external storage rows.
  * The transaction capability is the same synchronous snapshot used to accept the owned root.
@@ -72,6 +81,11 @@ export type ExternalScopeResolver = {
     scope: EventGameRecordRoot["externalScope"],
     snapshot: FoundationStorageSnapshot,
   ): ExternalScopeResolution;
+  resolveEventTeam(
+    eventId: string,
+    eventTeamId: string,
+    snapshot: FoundationStorageSnapshot,
+  ): ExternalEventTeamResolution;
 };
 
 export type EventGameRecordOptions = {
@@ -198,7 +212,7 @@ function rebuildRecordSnapshot(
   if (idempotencyFailure !== null) {
     return { status: "failed", reason: "invalid-history", detail: idempotencyFailure };
   }
-  const auditFailure = validateAuditHistory(root, storedActions, auditEntries);
+  const auditFailure = validateAuditHistory(root, storedActions, auditEntries, registry);
   if (auditFailure !== null) {
     return { status: "failed", reason: "invalid-history", detail: auditFailure };
   }
@@ -221,6 +235,9 @@ export function createEventGameRecord(
     options.actionCodecRegistry ?? createControlActionCodecRegistry(options.actionCodecs);
   let activeRecordId: string | undefined;
   let verifiedRevision: number | undefined;
+  let stableIdentityRevision: number | undefined;
+  const factIds = new Set<string>();
+  const correctionIds = new Set<string>();
 
   function currentRecordId(): string {
     if (activeRecordId === undefined) {
@@ -370,6 +387,9 @@ export function createEventGameRecord(
         if (outcome.status === "registered" || outcome.status === "idempotent") {
           activeRecordId = root.recordId;
           verifiedRevision = undefined;
+          stableIdentityRevision = undefined;
+          factIds.clear();
+          correctionIds.clear();
         }
         return outcome;
       } catch (error) {
@@ -435,7 +455,9 @@ export function createEventGameRecord(
             } satisfies ControlActionAcceptanceOutcome;
           }
 
-          const prepared = prepareControlAction(input, root, codecRegistry, nowMs);
+          const prepared = prepareControlAction(input, root, codecRegistry, nowMs, {
+            allowConcurrentTeamAssignment: true,
+          });
           if (!prepared.ok) {
             return {
               status: "rejected",
@@ -463,6 +485,14 @@ export function createEventGameRecord(
               "action-conflict",
               "operation identity is already bound to different content",
               nowMs,
+              {
+                interpretation: prepared.value.interpretation,
+                collision: {
+                  acceptedAction: existing.action,
+                  acceptedContentFingerprint: existing.contentFingerprint,
+                  rejectedAttempt: prepared.value,
+                },
+              },
             );
             transaction.appendAuditEntry(audit);
             return {
@@ -479,6 +509,7 @@ export function createEventGameRecord(
               "action-rejected",
               dependencyReason.detail,
               nowMs,
+              { interpretation: prepared.value.interpretation },
             );
             transaction.appendAuditEntry(audit);
             return {
@@ -488,17 +519,59 @@ export function createEventGameRecord(
             } satisfies ControlActionAcceptanceOutcome;
           }
 
+          let correctionTarget: StoredControlAction | null = null;
+          const interpretation = prepared.value.interpretation;
+          if (stableIdentityRevision !== transaction.revision) {
+            factIds.clear();
+            correctionIds.clear();
+            for (const stored of transaction.listActions(root.recordId)) {
+              if (stored.action.interpretation.type === "fact") {
+                factIds.add(stored.action.interpretation.factId);
+              } else if (
+                stored.action.interpretation.type === "correction" ||
+                stored.action.interpretation.type === "team-assignment-correction"
+              ) {
+                correctionIds.add(stored.action.interpretation.correctionId);
+              }
+            }
+            stableIdentityRevision = transaction.revision;
+          }
+          const duplicateIdentity =
+            interpretation.type === "fact"
+              ? factIds.has(interpretation.factId)
+              : interpretation.type === "correction"
+                ? correctionIds.has(interpretation.correctionId)
+                : interpretation.type === "team-assignment-correction"
+                  ? correctionIds.has(interpretation.correctionId)
+                  : false;
+          if (duplicateIdentity) {
+            const audit = createAuditEntry(
+              prepared.value.input,
+              "action-rejected",
+              "stable Game Fact or Correction identity is already retained",
+              nowMs,
+              { interpretation: prepared.value.interpretation },
+            );
+            transaction.appendAuditEntry(audit);
+            return {
+              status: "rejected",
+              reason: "invalid-action",
+              detail: "The stable Game Fact or Correction identity is already retained.",
+            } satisfies ControlActionAcceptanceOutcome;
+          }
           if (prepared.value.interpretation.type === "correction") {
-            const target = findFactById(
-              transaction.listActions(root.recordId),
+            const retainedActions = transaction.listActions(root.recordId);
+            correctionTarget = findFactById(
+              retainedActions,
               prepared.value.interpretation.targetFactId,
             );
-            if (target === null) {
+            if (correctionTarget === null) {
               const audit = createAuditEntry(
                 prepared.value.input,
                 "action-rejected",
                 "correction target is not a retained Game Fact",
                 nowMs,
+                { interpretation: prepared.value.interpretation },
               );
               transaction.appendAuditEntry(audit);
               return {
@@ -510,6 +583,44 @@ export function createEventGameRecord(
           }
 
           const action = materializeControlAction(prepared.value, nowMs);
+          if (action.interpretation.type === "team-assignment-correction") {
+            const teamInterpretation = action.interpretation;
+            const teamResolution = options.externalScopeResolver.resolveEventTeam(
+              root.eventId,
+              teamInterpretation.eventTeamId,
+              transaction,
+            );
+            if (teamResolution.status !== "resolved") {
+              return {
+                status: "rejected",
+                reason: "invalid-action",
+                detail: teamResolution.detail,
+              } satisfies ControlActionAcceptanceOutcome;
+            }
+            const candidateHistory = rebuildControlActionHistory(
+              root,
+              [
+                ...transaction.listActions(root.recordId),
+                {
+                  action,
+                  canonicalContent: prepared.value.canonicalContent,
+                  contentFingerprint: prepared.value.contentFingerprint,
+                },
+              ],
+              codecRegistry,
+              options.interpreter!,
+            );
+            if (candidateHistory.status !== "ready") {
+              return {
+                status: "rejected",
+                reason:
+                  candidateHistory.reason === "invalid-history"
+                    ? "invalid-action"
+                    : "storage-not-ready",
+                detail: candidateHistory.detail,
+              } satisfies ControlActionAcceptanceOutcome;
+            }
+          }
           transaction.insertAction({
             action,
             canonicalContent: prepared.value.canonicalContent,
@@ -519,8 +630,8 @@ export function createEventGameRecord(
           const lastAcceptedAtMs =
             previousMetadata?.lastAcceptedAtMs === null ||
             previousMetadata?.lastAcceptedAtMs === undefined
-              ? nowMs
-              : Math.max(previousMetadata.lastAcceptedAtMs, nowMs);
+              ? action.acceptedAtMs
+              : Math.max(previousMetadata.lastAcceptedAtMs, action.acceptedAtMs);
           transaction.upsertRecordMetadata({
             recordId: root.recordId,
             actionCount: (previousMetadata?.actionCount ?? 0) + 1,
@@ -533,8 +644,19 @@ export function createEventGameRecord(
             "action-accepted",
             ACCEPTED_AUDIT_DETAIL,
             nowMs,
+            {
+              interpretation: prepared.value.interpretation,
+              relatedOperationIds:
+                correctionTarget === null ? [] : [correctionTarget.action.operationId],
+            },
           );
           transaction.appendAuditEntry(audit);
+          if (
+            action.interpretation.type === "correction" ||
+            action.interpretation.type === "team-assignment-correction"
+          ) {
+            appendConcurrentCorrectionAudits(transaction, root.recordId, nowMs);
+          }
           nextVerifiedRevision = transaction.revision + 1;
           return {
             status: "accepted",
@@ -544,8 +666,18 @@ export function createEventGameRecord(
         });
         if (outcome.status === "accepted" && nextVerifiedRevision !== undefined) {
           verifiedRevision = nextVerifiedRevision;
+          stableIdentityRevision = nextVerifiedRevision;
+          if (outcome.action.interpretation.type === "fact") {
+            factIds.add(outcome.action.interpretation.factId);
+          } else if (
+            outcome.action.interpretation.type === "correction" ||
+            outcome.action.interpretation.type === "team-assignment-correction"
+          ) {
+            correctionIds.add(outcome.action.interpretation.correctionId);
+          }
         } else if (outcome.status !== "duplicate-accepted") {
           verifiedRevision = undefined;
+          stableIdentityRevision = undefined;
         }
         return outcome;
       } catch (error) {
@@ -601,7 +733,8 @@ export function createEventGameRecord(
       if (!verified) {
         throw new Error("A trusted Event Admin or Technical Admin audit authority is required.");
       }
-      return storage.readAuditEntries(currentRecordId());
+      const entries = await storage.readAuditEntries(currentRecordId());
+      return entries.sort(compareAuditEntries);
     },
 
     readMetadata() {
@@ -664,4 +797,63 @@ export function createEventGameRecord(
       } satisfies EventGameRecordReadiness;
     },
   };
+}
+
+function appendConcurrentCorrectionAudits(
+  transaction: FoundationStorageTransaction,
+  recordId: string,
+  acceptedAtMs: number,
+): void {
+  const actions = transaction.listActions(recordId).map((stored) => stored.action);
+  const audits = transaction.listAuditEntries(recordId);
+  const auditIds = new Set(audits.map((entry) => entry.auditId));
+  const actionsByOperationId = new Map(actions.map((action) => [action.operationId, action]));
+  for (const conflict of findConcurrentCorrectionConflicts(actions)) {
+    if (conflict.targetFactId === null) continue;
+    const left = actionsByOperationId.get(conflict.operationIds[0]);
+    const right = actionsByOperationId.get(conflict.operationIds[1]);
+    if (left === undefined || right === undefined) continue;
+    const entry = createConflictAuditEntry(
+      left,
+      right,
+      conflict.targetFactId,
+      conflict.winnerOperationId,
+      acceptedAtMs,
+    );
+    if (auditIds.has(entry.auditId)) continue;
+    transaction.appendAuditEntry(entry);
+    auditIds.add(entry.auditId);
+  }
+  for (const conflict of findConcurrentTeamAssignmentConflicts(actions)) {
+    const left = actionsByOperationId.get(conflict.operationIds[0]);
+    const right = actionsByOperationId.get(conflict.operationIds[1]);
+    if (left === undefined || right === undefined || conflict.eventTeamId === undefined) continue;
+    const entry = createTeamAssignmentConflictAuditEntry(
+      left,
+      right,
+      conflict.eventTeamId,
+      conflict.winnerOperationId,
+      acceptedAtMs,
+    );
+    if (auditIds.has(entry.auditId)) continue;
+    transaction.appendAuditEntry(entry);
+    auditIds.add(entry.auditId);
+  }
+}
+
+function compareAuditEntries(left: ControlAuditEntry, right: ControlAuditEntry): number {
+  const leftOccurrence = left.provenance?.occurrence?.trustedAtMs ?? Number.MAX_SAFE_INTEGER;
+  const rightOccurrence = right.provenance?.occurrence?.trustedAtMs ?? Number.MAX_SAFE_INTEGER;
+  const leftOperation = left.operationId ?? left.links?.relatedOperationIds.join(":") ?? "";
+  const rightOperation = right.operationId ?? right.links?.relatedOperationIds.join(":") ?? "";
+  return (
+    (leftOccurrence === rightOccurrence ? 0 : leftOccurrence < rightOccurrence ? -1 : 1) ||
+    compareOpaqueIdentifiers(leftOperation, rightOperation) ||
+    compareOpaqueIdentifiers(left.kind, right.kind) ||
+    compareOpaqueIdentifiers(left.auditId, right.auditId)
+  );
+}
+
+function compareOpaqueIdentifiers(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
 }

--- a/src/lib/foundation-grant-erasure-migration.test.ts
+++ b/src/lib/foundation-grant-erasure-migration.test.ts
@@ -174,7 +174,7 @@ describe("Grant cryptographic erasure migration", () => {
 
       const current = openSqliteFoundationStorage(databasePath);
       await current.applyMigrations({ requireCandidate: false });
-      expect(await current.readiness()).toMatchObject({ ok: true, schemaVersion: "6" });
+      expect(await current.readiness()).toMatchObject({ ok: true, schemaVersion: "9" });
       current.close();
 
       const raw = new Database(databasePath);
@@ -270,7 +270,7 @@ describe("Grant cryptographic erasure migration", () => {
       raw.close();
 
       const reopened = openSqliteFoundationStorage(databasePath);
-      expect(await reopened.readiness()).toMatchObject({ ok: true, schemaVersion: "6" });
+      expect(await reopened.readiness()).toMatchObject({ ok: true, schemaVersion: "9" });
       const restartedAudit = await reopened.transaction((transaction) =>
         transaction.listGrantAudit("grant-expired"),
       );

--- a/src/lib/foundation-migrations.ts
+++ b/src/lib/foundation-migrations.ts
@@ -149,6 +149,16 @@ export const FOUNDATION_AUDIT_TABLE_SQL = `
   ) STRICT
 `;
 
+export const FOUNDATION_CURRENT_ACTION_TABLE_SQL = FOUNDATION_ACTION_TABLE_SQL.replace(
+  "    action_json TEXT NOT NULL CHECK (json_valid(action_json)),",
+  "    action_json TEXT NOT NULL CHECK (json_valid(action_json)),\n    control_action_version TEXT NOT NULL DEFAULT 'control-action-legacy-v0' CHECK (control_action_version IN ('control-action-v1', 'control-action-legacy-v0')),\n    action_evidence_format TEXT NOT NULL DEFAULT 'legacy' CHECK (action_evidence_format IN ('current', 'legacy')),",
+);
+
+export const FOUNDATION_CURRENT_AUDIT_TABLE_SQL = FOUNDATION_AUDIT_TABLE_SQL.replace(
+  "    audit_json TEXT NOT NULL CHECK (json_valid(audit_json)),",
+  "    audit_json TEXT NOT NULL CHECK (json_valid(audit_json)),\n    audit_version TEXT NOT NULL DEFAULT 'control-audit-legacy-v0' CHECK (audit_version IN ('control-audit-v1', 'control-audit-legacy-v0')),\n    audit_evidence_format TEXT NOT NULL DEFAULT 'legacy' CHECK (audit_evidence_format IN ('current', 'legacy')),",
+);
+
 export const FOUNDATION_ROOT_EVENT_INDEX_SQL = `
   CREATE INDEX foundation_event_game_record_roots_event_id
     ON foundation_event_game_record_roots (event_id)
@@ -556,6 +566,72 @@ const FOUNDATION_GRANT_ERASURE_MIGRATION_SQL = createFoundationGrantErasureMigra
   auditGrantIndexSql: FOUNDATION_GRANT_AUDIT_GRANT_INDEX_SQL,
 });
 
+const FOUNDATION_CONTROL_VERSION_PROJECTION_MIGRATION_SQL = `
+  ALTER TABLE foundation_event_game_record_actions
+    ADD COLUMN control_action_version TEXT NOT NULL DEFAULT 'control-action-legacy-v0'
+      CHECK (control_action_version IN ('control-action-v1', 'control-action-legacy-v0'));
+  ALTER TABLE foundation_event_game_record_audit
+    ADD COLUMN audit_version TEXT NOT NULL DEFAULT 'control-audit-legacy-v0'
+      CHECK (audit_version IN ('control-audit-v1', 'control-audit-legacy-v0'));
+`;
+
+const FOUNDATION_EVIDENCE_FORMAT_MIGRATION_SQL = `
+  ALTER TABLE foundation_event_game_record_actions
+    ADD COLUMN action_evidence_format TEXT NOT NULL DEFAULT 'legacy'
+      CHECK (action_evidence_format IN ('current', 'legacy'));
+  ALTER TABLE foundation_event_game_record_audit
+    ADD COLUMN audit_evidence_format TEXT NOT NULL DEFAULT 'legacy'
+      CHECK (audit_evidence_format IN ('current', 'legacy'));
+  UPDATE foundation_event_game_record_actions
+    SET action_evidence_format = 'current'
+    WHERE control_action_version = 'control-action-v1';
+  UPDATE foundation_event_game_record_audit
+    SET audit_evidence_format = 'current'
+    WHERE audit_version = 'control-audit-v1';
+`;
+
+export const FOUNDATION_EVIDENCE_PROVENANCE_TABLE_SQL = `
+  CREATE TABLE foundation_control_evidence_provenance (
+    evidence_kind TEXT NOT NULL CHECK (evidence_kind IN ('action', 'audit')),
+    evidence_id TEXT NOT NULL,
+    evidence_format TEXT NOT NULL CHECK (evidence_format IN ('current', 'legacy')),
+    origin TEXT NOT NULL CHECK (origin IN ('pre-75-migration', 'post-75-current')),
+    PRIMARY KEY (evidence_kind, evidence_id)
+  ) STRICT
+`;
+
+export const FOUNDATION_EVIDENCE_PROVENANCE_UPDATE_TRIGGER_SQL = `
+  CREATE TRIGGER foundation_control_evidence_provenance_no_update
+  BEFORE UPDATE ON foundation_control_evidence_provenance
+  BEGIN
+    SELECT RAISE(ABORT, 'Control evidence provenance is immutable');
+  END
+`;
+
+export const FOUNDATION_EVIDENCE_PROVENANCE_DELETE_TRIGGER_SQL = `
+  CREATE TRIGGER foundation_control_evidence_provenance_no_delete
+  BEFORE DELETE ON foundation_control_evidence_provenance
+  BEGIN
+    SELECT RAISE(ABORT, 'Control evidence provenance is immutable');
+  END
+`;
+
+const FOUNDATION_EVIDENCE_PROVENANCE_MIGRATION_SQL = `
+  ${FOUNDATION_EVIDENCE_PROVENANCE_TABLE_SQL};
+  INSERT INTO foundation_control_evidence_provenance (evidence_kind, evidence_id, evidence_format, origin)
+  SELECT 'action', action_id,
+         CASE WHEN control_action_version = 'control-action-v1' THEN 'current' ELSE 'legacy' END,
+         CASE WHEN control_action_version = 'control-action-v1' THEN 'post-75-current' ELSE 'pre-75-migration' END
+  FROM foundation_event_game_record_actions;
+  INSERT INTO foundation_control_evidence_provenance (evidence_kind, evidence_id, evidence_format, origin)
+  SELECT 'audit', audit_id,
+         CASE WHEN audit_version = 'control-audit-v1' THEN 'current' ELSE 'legacy' END,
+         CASE WHEN audit_version = 'control-audit-v1' THEN 'post-75-current' ELSE 'pre-75-migration' END
+  FROM foundation_event_game_record_audit;
+  ${FOUNDATION_EVIDENCE_PROVENANCE_UPDATE_TRIGGER_SQL};
+  ${FOUNDATION_EVIDENCE_PROVENANCE_DELETE_TRIGGER_SQL};
+`;
+
 export const FOUNDATION_MIGRATIONS: readonly FoundationMigration[] = Object.freeze([
   createMigration({
     id: "001-foundation-event-game-record-roots",
@@ -592,6 +668,24 @@ export const FOUNDATION_MIGRATIONS: readonly FoundationMigration[] = Object.free
     ordinal: 6,
     schemaVersion: 6,
     sql: FOUNDATION_GRANT_ERASURE_MIGRATION_SQL,
+  }),
+  createMigration({
+    id: "007-anchor-control-action-audit-versions",
+    ordinal: 7,
+    schemaVersion: 7,
+    sql: FOUNDATION_CONTROL_VERSION_PROJECTION_MIGRATION_SQL,
+  }),
+  createMigration({
+    id: "008-anchor-current-evidence-format",
+    ordinal: 8,
+    schemaVersion: 8,
+    sql: FOUNDATION_EVIDENCE_FORMAT_MIGRATION_SQL,
+  }),
+  createMigration({
+    id: "009-immutable-control-evidence-provenance",
+    ordinal: 9,
+    schemaVersion: 9,
+    sql: FOUNDATION_EVIDENCE_PROVENANCE_MIGRATION_SQL,
   }),
 ]);
 

--- a/src/lib/foundation-schema.ts
+++ b/src/lib/foundation-schema.ts
@@ -2,9 +2,9 @@ import { createHash } from "node:crypto";
 import { Database } from "bun:sqlite";
 import {
   FOUNDATION_ACTION_RECORD_INDEX_SQL,
-  FOUNDATION_ACTION_TABLE_SQL,
+  FOUNDATION_CURRENT_ACTION_TABLE_SQL,
   FOUNDATION_AUDIT_RECORD_INDEX_SQL,
-  FOUNDATION_AUDIT_TABLE_SQL,
+  FOUNDATION_CURRENT_AUDIT_TABLE_SQL,
   FOUNDATION_LEDGER_TABLE_SQL,
   FOUNDATION_IDEMPOTENCY_RECORD_INDEX_SQL,
   FOUNDATION_IDEMPOTENCY_TABLE_SQL,
@@ -20,6 +20,9 @@ import {
   FOUNDATION_GRANT_SESSION_GRANT_INDEX_SQL,
   FOUNDATION_GRANT_SESSION_TABLE_SQL,
   FOUNDATION_GRANT_TABLE_SQL,
+  FOUNDATION_EVIDENCE_PROVENANCE_TABLE_SQL,
+  FOUNDATION_EVIDENCE_PROVENANCE_UPDATE_TRIGGER_SQL,
+  FOUNDATION_EVIDENCE_PROVENANCE_DELETE_TRIGGER_SQL,
 } from "@/lib/foundation-migrations";
 import {
   canonicalizeEventGameRecordRoot,
@@ -80,19 +83,33 @@ const AUDIT_TABLE = "foundation_event_game_record_audit";
 const GRANT_TABLE = "foundation_grant_roots";
 const GRANT_SESSION_TABLE = "foundation_grant_sessions";
 const GRANT_AUDIT_TABLE = "foundation_grant_audit";
+const PROVENANCE_TABLE = "foundation_control_evidence_provenance";
 
 const expectedManifest: FoundationSchemaManifest = {
   objects: [
     object("table", LEDGER_TABLE, LEDGER_TABLE, FOUNDATION_LEDGER_TABLE_SQL),
     object("table", ROOT_TABLE, ROOT_TABLE, FOUNDATION_ROOT_TABLE_SQL),
     object("table", SIDE_TABLE, SIDE_TABLE, FOUNDATION_SIDE_TABLE_SQL),
-    object("table", ACTION_TABLE, ACTION_TABLE, FOUNDATION_ACTION_TABLE_SQL),
+    object("table", ACTION_TABLE, ACTION_TABLE, FOUNDATION_CURRENT_ACTION_TABLE_SQL),
     object("table", IDEMPOTENCY_TABLE, IDEMPOTENCY_TABLE, FOUNDATION_IDEMPOTENCY_TABLE_SQL),
     object("table", METADATA_TABLE, METADATA_TABLE, FOUNDATION_METADATA_TABLE_SQL),
-    object("table", AUDIT_TABLE, AUDIT_TABLE, FOUNDATION_AUDIT_TABLE_SQL),
+    object("table", AUDIT_TABLE, AUDIT_TABLE, FOUNDATION_CURRENT_AUDIT_TABLE_SQL),
     object("table", GRANT_TABLE, GRANT_TABLE, FOUNDATION_GRANT_TABLE_SQL),
     object("table", GRANT_SESSION_TABLE, GRANT_SESSION_TABLE, FOUNDATION_GRANT_SESSION_TABLE_SQL),
     object("table", GRANT_AUDIT_TABLE, GRANT_AUDIT_TABLE, FOUNDATION_GRANT_AUDIT_TABLE_SQL),
+    object("table", PROVENANCE_TABLE, PROVENANCE_TABLE, FOUNDATION_EVIDENCE_PROVENANCE_TABLE_SQL),
+    object(
+      "trigger",
+      "foundation_control_evidence_provenance_no_update",
+      PROVENANCE_TABLE,
+      FOUNDATION_EVIDENCE_PROVENANCE_UPDATE_TRIGGER_SQL,
+    ),
+    object(
+      "trigger",
+      "foundation_control_evidence_provenance_no_delete",
+      PROVENANCE_TABLE,
+      FOUNDATION_EVIDENCE_PROVENANCE_DELETE_TRIGGER_SQL,
+    ),
     object(
       "index",
       "foundation_event_game_record_roots_event_id",
@@ -225,6 +242,8 @@ const expectedManifest: FoundationSchemaManifest = {
         column("content_fingerprint", "TEXT", 1, 0),
         column("canonical_content", "TEXT", 1, 0),
         column("action_json", "TEXT", 1, 0),
+        column("control_action_version", "TEXT", 1, 0, "'control-action-legacy-v0'"),
+        column("action_evidence_format", "TEXT", 1, 0, "'legacy'"),
       ],
       foreignKeys: [
         {
@@ -371,6 +390,8 @@ const expectedManifest: FoundationSchemaManifest = {
         column("created_at_ms", "INTEGER", 1, 0),
         column("redacted_detail", "TEXT", 1, 0),
         column("audit_json", "TEXT", 1, 0),
+        column("audit_version", "TEXT", 1, 0, "'control-audit-legacy-v0'"),
+        column("audit_evidence_format", "TEXT", 1, 0, "'legacy'"),
       ],
       foreignKeys: [
         {
@@ -420,6 +441,16 @@ const expectedManifest: FoundationSchemaManifest = {
           match: "NONE",
         },
       ],
+    },
+    {
+      name: PROVENANCE_TABLE,
+      columns: [
+        column("evidence_kind", "TEXT", 1, 1),
+        column("evidence_id", "TEXT", 1, 2),
+        column("evidence_format", "TEXT", 1, 0),
+        column("origin", "TEXT", 1, 0),
+      ],
+      foreignKeys: [],
     },
   ].sort(compareNamed),
   indexes: [
@@ -663,6 +694,7 @@ function readSchemaManifest(database: Database): FoundationSchemaManifest {
     GRANT_TABLE,
     GRANT_SESSION_TABLE,
     GRANT_AUDIT_TABLE,
+    PROVENANCE_TABLE,
   ].map((name) => ({
     name,
     columns: readColumns(database, name),
@@ -797,12 +829,13 @@ function column(
   type: string,
   notNull: number,
   primaryKeyPosition: number,
+  defaultValue: string | null = null,
 ): SchemaColumn {
   return {
     name,
     type,
     notNull,
-    defaultValue: null,
+    defaultValue,
     primaryKeyPosition,
   };
 }

--- a/src/lib/foundation-storage-contract.test.ts
+++ b/src/lib/foundation-storage-contract.test.ts
@@ -157,6 +157,9 @@ function runStorageContract(name: string, factory: StorageFactory): void {
                   detail: "missing: the external scope catalog is temporarily unavailable.",
                 };
           },
+          resolveEventTeam() {
+            return { status: "resolved" };
+          },
         };
         const record = createEventGameRecord(harness.storage, {
           externalScopeResolver: resolver,
@@ -222,6 +225,9 @@ function runStorageContract(name: string, factory: StorageFactory): void {
             };
           }
           return { status: "resolved", scope: structuredClone(scope) };
+        },
+        resolveEventTeam() {
+          return { status: "resolved" };
         },
       };
       const cases: readonly [string, Partial<EventGameRecordRoot["externalScope"]>, string][] = [
@@ -423,6 +429,11 @@ function createScopeResolver(root: EventGameRecordRoot): ExternalScopeResolver {
             status: "mismatch",
             detail: "The external scope does not match the registered hierarchy.",
           };
+    },
+    resolveEventTeam(eventId, eventTeamId) {
+      return eventId === root.eventId && eventTeamId.length > 0
+        ? { status: "resolved" }
+        : { status: "mismatch", detail: "The Event Team is outside the Event scope." };
     },
   };
 }

--- a/src/lib/foundation-storage-memory.ts
+++ b/src/lib/foundation-storage-memory.ts
@@ -25,8 +25,16 @@ import {
   type StoredEventGameRecordMetadata,
   type StoredEventGameRecordRoot,
   isThenable,
+  DURABLE_EVIDENCE_PROVENANCE,
 } from "@/lib/foundation-storage";
-import { actionIdentity, parseStoredControlAction } from "@/lib/event-game-actions";
+import {
+  CONTROL_AUDIT_VERSION,
+  CONTROL_ACTION_VERSION,
+  LEGACY_CONTROL_AUDIT_VERSION,
+  LEGACY_CONTROL_ACTION_VERSION,
+  actionIdentity,
+  parseStoredControlAction,
+} from "@/lib/event-game-actions";
 
 type MemoryState = {
   roots: Map<string, StoredEventGameRecordRoot>;
@@ -34,6 +42,8 @@ type MemoryState = {
   idempotency: Map<string, Map<string, StoredControlIdempotencyEntry>>;
   metadata: Map<string, StoredEventGameRecordMetadata>;
   controlAudits: Map<string, Map<string, StoredControlAuditEntry>>;
+  actionProvenance: Map<string, Map<string, "current" | "legacy">>;
+  auditProvenance: Map<string, Map<string, "current" | "legacy">>;
   grants: Map<string, StoredControlGrant>;
   sessions: Map<string, StoredGrantSession>;
   grantAudits: Map<string, StoredGrantAuditEntry>;
@@ -50,6 +60,8 @@ class InMemoryFoundationStorage implements FoundationStorage {
     idempotency: new Map(),
     metadata: new Map(),
     controlAudits: new Map(),
+    actionProvenance: new Map(),
+    auditProvenance: new Map(),
     grants: new Map(),
     sessions: new Map(),
     grantAudits: new Map(),
@@ -92,7 +104,10 @@ class InMemoryFoundationStorage implements FoundationStorage {
   readActions(recordId: string): Promise<StoredControlAction[]> {
     return this.writerTail.then(() => {
       this.assertOpen();
-      return cloneActions(this.state.actions.get(recordId));
+      return cloneActions(
+        this.state.actions.get(recordId),
+        this.state.actionProvenance.get(recordId),
+      );
     });
   }
 
@@ -116,8 +131,9 @@ class InMemoryFoundationStorage implements FoundationStorage {
   readAuditEntries(recordId: string): Promise<StoredControlAuditEntry[]> {
     return this.writerTail.then(() => {
       this.assertOpen();
-      return [...(this.state.controlAudits.get(recordId)?.values() ?? [])].map((entry) =>
-        structuredClone(entry),
+      return cloneAudits(
+        this.state.controlAudits.get(recordId),
+        this.state.auditProvenance.get(recordId),
       );
     });
   }
@@ -146,13 +162,46 @@ class InMemoryFoundationStorage implements FoundationStorage {
           } satisfies FoundationStorageReadiness;
         }
       }
-      for (const actions of this.state.actions.values()) {
+      for (const [recordId, actions] of this.state.actions) {
         for (const stored of actions.values()) {
           if (!parseStoredControlAction(stored.action).ok) {
             return {
               ok: false,
               status: "integrity-failure",
               detail: "An in-memory Control Action failed structural validation.",
+              storage: "memory",
+            } satisfies FoundationStorageReadiness;
+          }
+          const provenance = this.state.actionProvenance
+            .get(recordId)
+            ?.get(stored.action.operationId);
+          if (provenance !== "current" && provenance !== "legacy") {
+            return {
+              ok: false,
+              status: "integrity-failure",
+              detail: "In-memory evidence provenance is missing.",
+              storage: "memory",
+            } satisfies FoundationStorageReadiness;
+          }
+          if (
+            provenance === "current" &&
+            stored.action.controlActionVersion !== CONTROL_ACTION_VERSION
+          ) {
+            return {
+              ok: false,
+              status: "integrity-failure",
+              detail: "Current in-memory action evidence was downgraded.",
+              storage: "memory",
+            } satisfies FoundationStorageReadiness;
+          }
+          if (
+            provenance === "legacy" &&
+            stored.action.controlActionVersion !== LEGACY_CONTROL_ACTION_VERSION
+          ) {
+            return {
+              ok: false,
+              status: "integrity-failure",
+              detail: "Legacy in-memory action evidence is inconsistent.",
               storage: "memory",
             } satisfies FoundationStorageReadiness;
           }
@@ -183,6 +232,22 @@ class InMemoryFoundationStorage implements FoundationStorage {
               ok: false,
               status: "integrity-failure",
               detail: "In-memory action and idempotency state is inconsistent.",
+              storage: "memory",
+            } satisfies FoundationStorageReadiness;
+          }
+        }
+      }
+      for (const [recordId, audits] of this.state.controlAudits) {
+        for (const entry of audits.values()) {
+          const provenance = this.state.auditProvenance.get(recordId)?.get(entry.auditId);
+          if (
+            (provenance === "current" && entry.auditVersion !== CONTROL_AUDIT_VERSION) ||
+            (provenance === "legacy" && entry.auditVersion !== LEGACY_CONTROL_AUDIT_VERSION)
+          ) {
+            return {
+              ok: false,
+              status: "integrity-failure",
+              detail: "In-memory audit evidence format is inconsistent.",
               storage: "memory",
             } satisfies FoundationStorageReadiness;
           }
@@ -240,10 +305,13 @@ function createTransaction(
       );
     },
     findActionByOperationId(recordId, operationId) {
-      return cloneAction(state.actions.get(recordId)?.get(operationId));
+      return cloneAction(
+        state.actions.get(recordId)?.get(operationId),
+        state.actionProvenance.get(recordId)?.get(operationId),
+      );
     },
     listActions(recordId) {
-      return cloneActions(state.actions.get(recordId));
+      return cloneActions(state.actions.get(recordId), state.actionProvenance.get(recordId));
     },
     listIdempotencyEntries(recordId) {
       return [...(state.idempotency.get(recordId)?.values() ?? [])].map((entry) =>
@@ -255,9 +323,7 @@ function createTransaction(
       return metadata === undefined ? null : structuredClone(metadata);
     },
     listAuditEntries(recordId) {
-      return [...(state.controlAudits.get(recordId)?.values() ?? [])].map((entry) =>
-        structuredClone(entry),
-      );
+      return cloneAudits(state.controlAudits.get(recordId), state.auditProvenance.get(recordId));
     },
     insertRoot(storedRoot) {
       if (state.roots.has(storedRoot.root.recordId)) {
@@ -306,7 +372,18 @@ function createTransaction(
       if (actions.has(action.operationId)) {
         throw new FoundationStorageConstraintError("operation-id");
       }
-      actions.set(action.operationId, structuredClone(storedAction));
+      actions.set(action.operationId, {
+        ...structuredClone(storedAction),
+        durableFormat: "current",
+      });
+      let provenance = state.actionProvenance.get(action.recordId);
+      if (provenance === undefined) {
+        provenance = new Map();
+        state.actionProvenance.set(action.recordId, provenance);
+        undo.push(() => state.actionProvenance.delete(action.recordId));
+      }
+      provenance.set(action.operationId, "current");
+      undo.push(() => provenance?.delete(action.operationId));
       undo.push(() => actions?.delete(action.operationId));
       const actionId = actionIdentity(action.recordId, action.operationId);
       let idempotency = state.idempotency.get(action.recordId);
@@ -345,7 +422,18 @@ function createTransaction(
       if (audits.has(entry.auditId)) {
         throw new FoundationStorageConstraintError("audit-id");
       }
-      audits.set(entry.auditId, structuredClone(entry));
+      audits.set(entry.auditId, {
+        ...structuredClone(entry),
+        durableFormat: "current",
+      });
+      let provenance = state.auditProvenance.get(entry.recordId);
+      if (provenance === undefined) {
+        provenance = new Map();
+        state.auditProvenance.set(entry.recordId, provenance);
+        undo.push(() => state.auditProvenance.delete(entry.recordId));
+      }
+      provenance.set(entry.auditId, "current");
+      undo.push(() => provenance?.delete(entry.auditId));
       undo.push(() => audits?.delete(entry.auditId));
     },
     findGrantById(grantId) {
@@ -548,14 +636,38 @@ function cloneRoot(stored: StoredEventGameRecordRoot | undefined): EventGameReco
   return stored === undefined ? null : cloneEventGameRecordRoot(stored.root);
 }
 
-function cloneAction(stored: StoredControlAction | undefined): StoredControlAction | null {
-  return stored === undefined ? null : structuredClone(stored);
+function cloneAction(
+  stored: StoredControlAction | undefined,
+  provenance: "current" | "legacy" | undefined,
+): StoredControlAction | null {
+  return stored === undefined
+    ? null
+    : {
+        ...structuredClone(stored),
+        durableFormat: provenance ?? stored.durableFormat,
+        [DURABLE_EVIDENCE_PROVENANCE]: provenance ?? stored[DURABLE_EVIDENCE_PROVENANCE],
+      };
 }
 
 function cloneActions(
   actions: Map<string, StoredControlAction> | undefined,
+  provenance: Map<string, "current" | "legacy"> | undefined,
 ): StoredControlAction[] {
-  return [...(actions?.values() ?? [])].map((stored) => structuredClone(stored));
+  return [...(actions?.values() ?? [])].map((stored) =>
+    cloneAction(stored, provenance?.get(stored.action.operationId))!,
+  );
+}
+
+function cloneAudits(
+  audits: Map<string, StoredControlAuditEntry> | undefined,
+  provenance: Map<string, "current" | "legacy"> | undefined,
+): StoredControlAuditEntry[] {
+  return [...(audits?.values() ?? [])].map((entry) => ({
+    ...structuredClone(entry),
+    durableFormat: provenance?.get(entry.auditId) ?? entry.durableFormat,
+    [DURABLE_EVIDENCE_PROVENANCE]:
+      provenance?.get(entry.auditId) ?? entry[DURABLE_EVIDENCE_PROVENANCE],
+  }));
 }
 
 function findGrant(

--- a/src/lib/foundation-storage-sqlite-helpers.ts
+++ b/src/lib/foundation-storage-sqlite-helpers.ts
@@ -1,4 +1,25 @@
-import { parseStoredControlAction, sha256 } from "@/lib/event-game-actions";
+import {
+  parseStoredControlAction,
+  CONTROL_ACTION_VERSION,
+  LEGACY_CONTROL_ACTION_VERSION,
+  LEGACY_CONTROL_AUDIT_VERSION,
+  CONTROL_AUDIT_VERSION,
+  sha256,
+  type ControlAuditLinkage,
+  type ControlAuditProvenance,
+} from "@/lib/event-game-actions";
+import {
+  validateGrant,
+  validateLifecycle,
+  validateOccurrenceWithoutClock,
+  validateOverride,
+  validatePredecessors,
+  validateRecoveryProvenanceShape,
+  validateId,
+  validateTimestamp,
+  validateInterpretation,
+  validateStoredInput,
+} from "@/lib/event-game-action-codecs";
 import {
   FoundationStorageConstraintError,
   type StoredControlAction,
@@ -6,6 +27,7 @@ import {
   type StoredControlIdempotencyEntry,
   type StoredEventGameRecordMetadata,
 } from "@/lib/foundation-storage";
+import { DURABLE_EVIDENCE_PROVENANCE } from "@/lib/foundation-storage";
 
 export type RootRow = Record<string, unknown>;
 
@@ -51,10 +73,27 @@ export function readStoredAction(row: RootRow): StoredControlAction {
   if (action.value.acceptedAtMs !== readInteger(row.accepted_at_ms)) {
     throw new Error("Stored Control Action acceptance time is inconsistent.");
   }
+  if (action.value.controlActionVersion !== readText(row.control_action_version)) {
+    throw new Error("Stored Control Action compatibility version is inconsistent.");
+  }
+  const durableFormat = readEvidenceFormat(row.action_evidence_format, "action");
+  const provenanceFormat = readEvidenceFormat(row.action_provenance_format, "action");
+  if (provenanceFormat !== durableFormat) {
+    throw new Error("Stored Control Action immutable provenance is inconsistent.");
+  }
+  if (
+    (durableFormat === "current" && action.value.controlActionVersion !== CONTROL_ACTION_VERSION) ||
+    (durableFormat === "legacy" &&
+      action.value.controlActionVersion !== LEGACY_CONTROL_ACTION_VERSION)
+  ) {
+    throw new Error("Stored Control Action durable format marker is inconsistent.");
+  }
   return {
     action: action.value,
     canonicalContent: readText(row.canonical_content),
     contentFingerprint: readText(row.content_fingerprint),
+    durableFormat,
+    [DURABLE_EVIDENCE_PROVENANCE]: provenanceFormat,
   };
 }
 
@@ -88,15 +127,50 @@ export function readAudit(row: RootRow): StoredControlAuditEntry {
   ) {
     throw new Error("Stored Control Audit entry kind is invalid.");
   }
+  const durableAuditVersion = readText(row.audit_version);
+  const durableFormat = readEvidenceFormat(row.audit_evidence_format, "audit");
+  const provenanceFormat = readEvidenceFormat(row.audit_provenance_format, "audit");
+  if (provenanceFormat !== durableFormat) {
+    throw new Error("Stored Control Audit immutable provenance is inconsistent.");
+  }
+  const jsonAuditVersion =
+    entry.auditVersion === undefined ? undefined : readText(entry.auditVersion);
+  if (jsonAuditVersion !== undefined && jsonAuditVersion !== durableAuditVersion) {
+    throw new Error("Stored Control Audit compatibility version is inconsistent.");
+  }
+  const auditVersion = durableAuditVersion;
+  if (auditVersion !== CONTROL_AUDIT_VERSION && auditVersion !== LEGACY_CONTROL_AUDIT_VERSION) {
+    throw new Error("Stored Control Audit version is invalid.");
+  }
+  if (
+    (durableFormat === "current" && auditVersion !== CONTROL_AUDIT_VERSION) ||
+    (durableFormat === "legacy" && auditVersion !== LEGACY_CONTROL_AUDIT_VERSION)
+  ) {
+    throw new Error("Stored Control Audit durable format marker is inconsistent.");
+  }
+  if (
+    auditVersion === CONTROL_AUDIT_VERSION &&
+    (entry.links === undefined || entry.provenance === undefined)
+  ) {
+    throw new Error("Stored #75 Control Audit evidence is incomplete.");
+  }
   const result: StoredControlAuditEntry = {
-    auditId: readText(entry.auditId),
-    recordId: readText(entry.recordId),
-    eventGameId: readText(entry.eventGameId),
-    operationId: entry.operationId === null ? null : readText(entry.operationId),
+    auditVersion,
+    durableFormat,
+    [DURABLE_EVIDENCE_PROVENANCE]: provenanceFormat,
+    auditId: readRequiredId(entry.auditId, "auditId"),
+    recordId: readRequiredId(entry.recordId, "recordId"),
+    eventGameId: readRequiredId(entry.eventGameId, "eventGameId"),
+    operationId:
+      entry.operationId === null ? null : readRequiredId(entry.operationId, "operationId"),
     kind,
     outcome: readText(entry.outcome),
-    createdAtMs: readInteger(entry.createdAtMs),
+    createdAtMs: readRequiredTimestamp(entry.createdAtMs, "createdAtMs"),
     redactedDetail: readText(entry.redactedDetail),
+    ...(entry.links === undefined ? {} : { links: readAuditLinks(entry.links) }),
+    ...(entry.provenance === undefined
+      ? {}
+      : { provenance: readAuditProvenance(entry.provenance) }),
   };
   if (
     result.auditId !== readText(row.audit_id) ||
@@ -111,6 +185,153 @@ export function readAudit(row: RootRow): StoredControlAuditEntry {
     throw new Error("Stored Control Audit entry projection is inconsistent.");
   }
   return result;
+}
+
+function readEvidenceFormat(value: unknown, kind: "action" | "audit"): "current" | "legacy" {
+  if (value === "current" || value === "legacy") return value;
+  throw new Error(`Stored Control ${kind} evidence format is invalid.`);
+}
+
+function readAuditLinks(value: unknown): ControlAuditLinkage {
+  if (!isObject(value)) throw new Error("Stored Control Audit linkage is invalid.");
+  const actionId = readValidatedNullableId(value.actionId, "actionId");
+  const targetFactId = readValidatedNullableId(value.targetFactId, "targetFactId");
+  const causalPredecessorIds = validatePredecessors(value.causalPredecessorIds);
+  const relatedOperationIds = readValidatedIdArray(
+    value.relatedOperationIds,
+    "relatedOperationIds",
+  );
+  if (!causalPredecessorIds.ok)
+    throw new Error("Stored Control Audit causal predecessors are invalid.");
+  const collision = value.collision === undefined ? undefined : readAuditCollision(value.collision);
+  return {
+    actionId,
+    targetFactId,
+    causalPredecessorIds: causalPredecessorIds.value,
+    relatedOperationIds,
+    ordering: readAuditOrdering(value.ordering),
+    ...(collision === undefined ? {} : { collision }),
+  };
+}
+
+function readAuditCollision(value: unknown): ControlAuditLinkage["collision"] {
+  if (!isObject(value)) throw new Error("Stored Control Audit collision is invalid.");
+  const acceptedActionId = readRequiredId(value.acceptedActionId, "acceptedActionId");
+  const acceptedOperationId = readRequiredId(value.acceptedOperationId, "acceptedOperationId");
+  const acceptedContentFingerprint = readFingerprint(
+    value.acceptedContentFingerprint,
+    "acceptedContentFingerprint",
+  );
+  if (!isObject(value.rejectedAttempt)) {
+    throw new Error("Stored Control Audit rejected attempt is invalid.");
+  }
+  const rejectedAttempt = value.rejectedAttempt;
+  if (!isObject(rejectedAttempt.input)) {
+    throw new Error("Stored Control Audit rejected attempt input is invalid.");
+  }
+  const input = validateStoredInput(rejectedAttempt.input);
+  const interpretation = validateInterpretation(rejectedAttempt.interpretation);
+  if (!input.ok || !interpretation.ok) {
+    throw new Error("Stored Control Audit rejected attempt is invalid.");
+  }
+  return {
+    acceptedActionId,
+    acceptedOperationId,
+    acceptedContentFingerprint,
+    rejectedAttempt: {
+      input: input.value,
+      canonicalContent: readText(rejectedAttempt.canonicalContent),
+      contentFingerprint: readFingerprint(
+        rejectedAttempt.contentFingerprint,
+        "rejectedContentFingerprint",
+      ),
+      interpretation: interpretation.value,
+    },
+  };
+}
+
+function readFingerprint(value: unknown, field: string): string {
+  if (typeof value !== "string" || !/^[0-9a-f]{64}$/.test(value)) {
+    throw new Error(`Stored Control Audit ${field} is invalid.`);
+  }
+  return value;
+}
+
+function readAuditOrdering(value: unknown): ControlAuditLinkage["ordering"] {
+  if (value === null) return null;
+  if (!isObject(value)) {
+    throw new Error("Stored Control Audit ordering is invalid.");
+  }
+  const trustedAtMs = validateTimestamp(value.trustedAtMs, "audit ordering trustedAtMs");
+  const operationId = validateId(value.operationId, "audit ordering operationId");
+  if (!trustedAtMs.ok || !operationId.ok)
+    throw new Error("Stored Control Audit ordering is invalid.");
+  return { trustedAtMs: trustedAtMs.value, operationId: operationId.value };
+}
+
+function readAuditProvenance(value: unknown): ControlAuditProvenance {
+  if (!isObject(value)) throw new Error("Stored Control Audit provenance is invalid.");
+  for (const field of ["occurrence", "grant", "lifecycle", "override", "recoveryProvenance"]) {
+    if (!Object.hasOwn(value, field)) {
+      throw new Error("Stored Control Audit provenance is incomplete.");
+    }
+  }
+  const occurrence = validateOccurrenceWithoutClock(value.occurrence);
+  const grant = validateGrant(value.grant);
+  const lifecycle = validateLifecycle(value.lifecycle);
+  const override = validateOverride(value.override === null ? undefined : value.override);
+  const recoveryProvenance =
+    value.recoveryProvenance === null
+      ? { ok: true as const, value: null }
+      : validateRecoveryProvenanceShape(value.recoveryProvenance);
+  if (!occurrence.ok || !grant.ok || !lifecycle.ok || !override.ok || !recoveryProvenance.ok) {
+    throw new Error("Stored Control Audit provenance is invalid.");
+  }
+  return {
+    occurrence: occurrence.value,
+    grant: grant.value,
+    lifecycle: lifecycle.value,
+    override: override.value ?? null,
+    recoveryProvenance: recoveryProvenance.value ?? null,
+  };
+}
+
+function readValidatedNullableId(value: unknown, field: string): string | null {
+  if (value === null) return null;
+  const result = validateId(value, `audit linkage ${field}`);
+  if (!result.ok) throw new Error(`Stored Control Audit ${field} is invalid.`);
+  return result.value;
+}
+
+function readRequiredId(value: unknown, field: string): string {
+  const result = validateId(value, `audit ${field}`);
+  if (!result.ok) throw new Error(`Stored Control Audit ${field} is invalid.`);
+  return result.value;
+}
+
+function readRequiredTimestamp(value: unknown, field: string): number {
+  const result = validateTimestamp(value, `audit ${field}`);
+  if (!result.ok) throw new Error(`Stored Control Audit ${field} is invalid.`);
+  return result.value;
+}
+
+function readValidatedIdArray(value: unknown, field: string): string[] {
+  if (!Array.isArray(value) || value.length > 2) {
+    throw new Error(`Stored Control Audit ${field} is invalid.`);
+  }
+  const result = value.map((item, index) => validateId(item, `audit ${field}[${index}]`));
+  const values: string[] = [];
+  for (const item of result) {
+    if (!item.ok) throw new Error(`Stored Control Audit ${field} is invalid.`);
+    values.push(item.value);
+  }
+  if (new Set(values).size !== values.length)
+    throw new Error(`Stored Control Audit ${field} is invalid.`);
+  return values;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 export function readIdempotency(row: RootRow): StoredControlIdempotencyEntry {

--- a/src/lib/foundation-storage-sqlite.test.ts
+++ b/src/lib/foundation-storage-sqlite.test.ts
@@ -56,7 +56,7 @@ describe("SQLite foundation storage", () => {
       first.close();
 
       const reopened = openSqliteFoundationStorage(databasePath);
-      expect(await reopened.readiness()).toMatchObject({ ok: true, schemaVersion: "6" });
+      expect(await reopened.readiness()).toMatchObject({ ok: true, schemaVersion: "9" });
       const reopenedRecord = createEventGameRecord(reopened, {
         externalScopeResolver: createScopeResolver(root),
       });
@@ -74,12 +74,12 @@ describe("SQLite foundation storage", () => {
       const storage = openSqliteFoundationStorage(databasePath);
       const candidate = await storage.validateCandidate();
       expect(candidate.ready).toBe(true);
-      expect(candidate.readiness).toMatchObject({ ok: true, schemaVersion: "6" });
+      expect(candidate.readiness).toMatchObject({ ok: true, schemaVersion: "9" });
       expect(existsSync(candidate.candidatePath)).toBe(false);
       expect(await storage.readiness()).toMatchObject({ ok: false, status: "pending" });
 
       const migration = await storage.applyMigrations({ requireCandidate: true });
-      expect(migration.schemaVersion).toBe(6);
+      expect(migration.schemaVersion).toBe(9);
       expect(await storage.readiness()).toMatchObject({ ok: true });
       storage.close();
     });
@@ -118,8 +118,11 @@ describe("SQLite foundation storage", () => {
         grantMigration.id,
         expiryMigration.id,
         erasureMigration.id,
+        FOUNDATION_MIGRATIONS[6]!.id,
+        FOUNDATION_MIGRATIONS[7]!.id,
+        FOUNDATION_MIGRATIONS[8]!.id,
       ]);
-      expect(await current.readiness()).toMatchObject({ ok: true, schemaVersion: "6" });
+      expect(await current.readiness()).toMatchObject({ ok: true, schemaVersion: "9" });
       current.close();
     });
   });
@@ -128,9 +131,9 @@ describe("SQLite foundation storage", () => {
     await withDatabase(async (databasePath) => {
       const baseMigrations = FOUNDATION_MIGRATIONS;
       const failingMigration = createMigration(
-        "007-failing-test-migration",
-        7,
-        7,
+        "010-failing-test-migration",
+        10,
+        10,
         "CREATE TABLE migration_failure_probe (id TEXT) STRICT; THIS IS NOT SQL;",
       );
       const store = openSqliteFoundationStorage(databasePath, {
@@ -150,7 +153,7 @@ describe("SQLite foundation storage", () => {
       });
       expect(await priorBinary.readiness()).toMatchObject({
         ok: true,
-        schemaVersion: "6",
+        schemaVersion: "9",
       });
       priorBinary.close();
 
@@ -222,7 +225,7 @@ describe("SQLite foundation storage", () => {
         .query(
           "INSERT INTO foundation_migration_ledger (migration_id, ordinal, schema_version, checksum, status, applied_at_ms) VALUES (?, ?, ?, ?, ?, ?)",
         )
-        .run("future-999", 7, 7, "future-checksum", "complete", 2_000);
+        .run("future-999", 10, 10, "future-checksum", "complete", 2_000);
       futureDatabase.close();
       const future = openSqliteFoundationStorage(databasePath);
       expect(await future.readiness()).toMatchObject({ ok: false });
@@ -373,6 +376,11 @@ function createScopeResolver(root: EventGameRecordRoot): ExternalScopeResolver {
       return JSON.stringify(scope) === JSON.stringify(root.externalScope)
         ? { status: "resolved", scope: structuredClone(scope) }
         : { status: "mismatch", detail: "The external scope does not match the root." };
+    },
+    resolveEventTeam(eventId, eventTeamId) {
+      return eventId === root.eventId && eventTeamId.length > 0
+        ? { status: "resolved" }
+        : { status: "mismatch", detail: "The Event Team is outside the Event scope." };
     },
   };
 }

--- a/src/lib/foundation-storage-sqlite.ts
+++ b/src/lib/foundation-storage-sqlite.ts
@@ -108,6 +108,7 @@ type RootStatements = {
   auditByRecordId: SqlStatement;
   idempotencyByRecordId: SqlStatement;
   insertAudit: SqlStatement;
+  insertEvidenceProvenance: SqlStatement;
 };
 
 const ROOT_SELECT_COLUMNS = `
@@ -467,7 +468,10 @@ export class SqliteFoundationStorage implements FoundationStorage {
       storedAction.contentFingerprint,
       storedAction.canonicalContent,
       JSON.stringify(action),
+      action.controlActionVersion,
+      "current",
     );
+    statements.insertEvidenceProvenance.run("action", actionId);
     statements.insertIdempotency.run(
       actionId,
       action.recordId,
@@ -501,7 +505,10 @@ export class SqliteFoundationStorage implements FoundationStorage {
       entry.createdAtMs,
       entry.redactedDetail,
       JSON.stringify(entry),
+      entry.auditVersion,
+      "current",
     );
+    statements.insertEvidenceProvenance.run("audit", entry.auditId);
   }
 
   private readRootByStatement(
@@ -578,14 +585,20 @@ export class SqliteFoundationStorage implements FoundationStorage {
         ) VALUES (?, ?, ?, ?, ?)
       `),
       actionByOperationId: this.database.query(`
-        SELECT action_json, action_kind, action_version, accepted_at_ms,
-               canonical_content, content_fingerprint
+        SELECT action_id, action_json, action_kind, action_version, accepted_at_ms,
+               canonical_content, content_fingerprint, control_action_version,
+               action_evidence_format,
+               (SELECT evidence_format FROM foundation_control_evidence_provenance
+                WHERE evidence_kind = 'action' AND evidence_id = foundation_event_game_record_actions.action_id) AS action_provenance_format
         FROM foundation_event_game_record_actions
         WHERE record_id = ? AND operation_id = ?
       `),
       actionsByRecordId: this.database.query(`
-        SELECT action_json, action_kind, action_version, accepted_at_ms,
-               canonical_content, content_fingerprint
+        SELECT action_id, action_json, action_kind, action_version, accepted_at_ms,
+               canonical_content, content_fingerprint, control_action_version,
+               action_evidence_format,
+               (SELECT evidence_format FROM foundation_control_evidence_provenance
+                WHERE evidence_kind = 'action' AND evidence_id = foundation_event_game_record_actions.action_id) AS action_provenance_format
         FROM foundation_event_game_record_actions
         WHERE record_id = ?
         ORDER BY rowid
@@ -593,8 +606,9 @@ export class SqliteFoundationStorage implements FoundationStorage {
       insertAction: this.database.query(`
         INSERT INTO foundation_event_game_record_actions (
           action_id, record_id, event_game_id, operation_id, action_kind, action_version,
-          accepted_at_ms, content_fingerprint, canonical_content, action_json
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          accepted_at_ms, content_fingerprint, canonical_content, action_json,
+          control_action_version, action_evidence_format
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `),
       insertIdempotency: this.database.query(`
         INSERT INTO foundation_event_game_record_idempotency (
@@ -618,7 +632,10 @@ export class SqliteFoundationStorage implements FoundationStorage {
       `),
       auditByRecordId: this.database.query(`
         SELECT audit_id, record_id, event_game_id, operation_id, audit_kind, outcome,
-               created_at_ms, redacted_detail, audit_json
+               created_at_ms, redacted_detail, audit_json, audit_version,
+               audit_evidence_format,
+               (SELECT evidence_format FROM foundation_control_evidence_provenance
+                WHERE evidence_kind = 'audit' AND evidence_id = foundation_event_game_record_audit.audit_id) AS audit_provenance_format
         FROM foundation_event_game_record_audit
         WHERE record_id = ?
         ORDER BY rowid
@@ -632,8 +649,14 @@ export class SqliteFoundationStorage implements FoundationStorage {
       insertAudit: this.database.query(`
         INSERT INTO foundation_event_game_record_audit (
           audit_id, record_id, event_game_id, operation_id, audit_kind, outcome,
-          created_at_ms, redacted_detail, audit_json
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+               created_at_ms, redacted_detail, audit_json, audit_version,
+               audit_evidence_format
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `),
+      insertEvidenceProvenance: this.database.query(`
+        INSERT INTO foundation_control_evidence_provenance
+          (evidence_kind, evidence_id, evidence_format, origin)
+        VALUES (?, ?, 'current', 'post-75-current')
       `),
     };
     return this.statements;

--- a/src/lib/foundation-storage.ts
+++ b/src/lib/foundation-storage.ts
@@ -15,10 +15,17 @@ export type StoredEventGameRecordRoot = {
   canonicalContent: string;
 };
 
+export type DurableEvidenceFormat = "current" | "legacy";
+
+export const DURABLE_EVIDENCE_PROVENANCE = Symbol("durable-evidence-provenance");
+
 export type StoredControlAction = {
   action: ControlAction;
   canonicalContent: string;
   contentFingerprint: string;
+  /** Storage-owned provenance; unlike action JSON, this marker is not supplied by callers. */
+  durableFormat?: DurableEvidenceFormat;
+  [DURABLE_EVIDENCE_PROVENANCE]?: DurableEvidenceFormat;
 };
 
 export type StoredControlIdempotencyEntry = {
@@ -29,7 +36,11 @@ export type StoredControlIdempotencyEntry = {
   acceptedAtMs: number;
 };
 
-export type StoredControlAuditEntry = ControlAuditEntry;
+export type StoredControlAuditEntry = ControlAuditEntry & {
+  /** Storage-owned provenance; unlike audit JSON, this marker is not supplied by callers. */
+  durableFormat?: DurableEvidenceFormat;
+  [DURABLE_EVIDENCE_PROVENANCE]?: DurableEvidenceFormat;
+};
 
 export type StoredEventGameRecordMetadata = EventGameRecordMetadata;
 


### PR DESCRIPTION
## Summary

- Add immutable Correction, Reinstatement, Event Team Assignment Correction, and Official Override semantics.
- Resolve concurrent correction components canonically while preserving stable Game Fact, Game Side, root, and original override evidence.
- Require permanent, content-bound conflict/audit evidence and add exhaustive pair, three-action, fixed-seed convergence, shrinking, corruption, and SQLite restart coverage.

## Why

Multiple controllers and offline work can deliver valid changes in different orders. Mutable edits or arrival-order decisions would produce divergent Event Game history, so correction outcomes must be derived from canonical causal evidence and remain reconstructible after restart.

## Impact

Every valid arrival permutation converges to the same effective facts, acknowledgements, conflicts, and audit projection while preserving the actual server acceptance evidence. Missing, downgraded, or retargeted correction evidence fails readiness and freezes further authoritative writes.

## Validation

- `bun install --frozen-lockfile`
- `bun audit` — no vulnerabilities
- `bun run check`
- `bun run test` — 220 passed on the integrated stack layer
- `bun run test:focused:sqlite` — 21 passed
- `bun run test:focused:grant` — 15 passed
- `bun run build`
- `bun run build:executable`

No Qualification Test or `bun run check:sqlite-runtime` workload was run.

## Stack

Fifth layer of stack #103. Depends on #102 and is followed by #125.

Closes #75.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
