### PR TITLE
Harden the SQLite qualification harness boundary

### DIFF
--- a/docs/agents/sqlite-runtime-gate.md
+++ b/docs/agents/sqlite-runtime-gate.md
@@ -12,10 +12,67 @@ rejects SQLite earlier than 3.51.3 and failed integrity as a human database-choi
 
 Run it deliberately on the native Linux artifact during release qualification or the coordinator's
 bounded native-Ubuntu verification. A native run should normally finish in under a second and is
-bounded by a 15-second watchdog, capped diagnostics, and a small temporary workspace. The exact
+bounded by a 15-second total deadline covering setup, workload, evidence, result handling, and
+cleanup, with five seconds reserved for final termination, cgroup/filesystem cleanup, and final
+evidence; at most seven observed workload descendants, an OS-enforced 512 MiB cgroup peak-memory
+limit, an OS-enforced 16 MiB temporary `tmpfs` disk, 4 KiB raw-byte captured diagnostics, and a
+small temporary workspace. The exact
 writer/checkpoint workload must not be reduced, deleted, retried automatically, or moved into
 ordinary tests without an explicit acceptance decision because fast unit tests cover orchestration
-and safety boundaries, not this compiled-runtime property. The wrapper owns a private temporary
-container and one detached process group; the inner worker deadline is five seconds, leaving
-cleanup and final reaping margin inside the outer 15-second deadline. A stubborn descendant is
-terminated with TERM then KILL, and the wrapper removes the owned container after bounded reaping.
+and safety boundaries, not this compiled-runtime property. The wrapper owns a sanitized
+no-credential environment, a private temporary container, and one detached process group; the
+inner worker deadline is five seconds, leaving cleanup and final
+reaping margin inside the outer 15-second deadline. A stubborn descendant is terminated with TERM
+then KILL, and the wrapper removes the owned container after bounded reaping. One wrapper-owned
+`unshare --user --map-root-user --mount --net` namespace both verifies the network boundary and
+executes the artifact; no separately verified disposable namespace is reused. The wrapper makes
+host mounts read-only in that private namespace, mounts the owned workspace as the only writable
+16 MiB `tmpfs`, sets cwd and `TMPDIR` inside it, and fails closed if any writable host mount cannot
+be sealed. Its readiness marker is emitted only after namespace, tmpfs, network, and cgroup setup;
+the parent then verifies the artifact cgroup before sending the bounded release signal.
+After launcher self-attachment, `/sys/fs/cgroup` is bind-remounted read-only and positively
+verified with non-empty `ro` and absent `rw` options before readiness is emitted.
+
+Each invocation creates one capability-marked cgroup root below a validated delegated parent.
+Helper and workload controllers are children of that root; broad, pre-existing, symlinked,
+replaced, or ambiguous targets fail closed, and path/inode/marker evidence is revalidated before
+kill or removal. Members of the invocation root itself are included in TERM/KILL, reap,
+emptiness, and removal checks; an empty leaf does not make a populated root safe to certify.
+Partial creation or cleanup returns explicit retained-controller evidence, keeps the capability
+marker while any owned target remains, and blocks generic workspace cleanup until the host
+controller is verified gone. The workload child has `pids.max=8`: the outer artifact process plus the seven
+registered descendants. Admission/controller helpers use the sibling helper child. The
+harness measures `pids.current` and `pids.peak`, cgroup peak memory, bounded raw output, and the
+final wrapper disk marker; wrapper control frames (`READY`, `DISK_BYTES`, and `TMPFS_REMOVED`) stay
+on stderr so the exact artifact JSON remains the sole stdout document. The wrapper leaves the
+mounted workspace as its cwd before unmounting it; `tmpfs` remains the hard disk enforcement
+mechanism, so sampling cannot permit an overrun or a reparented/setsid descendant to escape.
+
+The deadline is a composed safety budget, not a copied workload observation: the 10-second
+admission/work window leaves up to 1 second for namespace/tool admission, 5 seconds for the inner
+artifact gate, and 4 seconds for private-controller setup and evidence handling; the 5-second
+cleanup reserve covers the 250 ms TERM grace, 1 second cgroup-wide reap, private mount/controller
+teardown, and bounded result construction/emission with remaining margin. The separately named
+`bun run test:focused-admission` gate measures safe native namespace/cgroup/tmpfs/readiness,
+sampling, emitter, and teardown components with a harmless filesystem-boundary helper (never the
+Qualification workload); `bun run test:focused-signal` records native startup and signal-to-exit
+measurements for all three installed signals, including direct-child-exit descendant cleanup.
+The focused-admission command retains capped portable JSON under one five-second lifecycle
+deadline with a two-second cleanup reserve. On a non-Linux-x86-64 host it records a blocker and
+null native measurements without attempting the Qualification workload. The production budget
+remains conservative but is not empirically accepted until harmless native Linux x86-64 evidence
+is captured.
+
+Before removing that container on every terminal path, the wrapper emits one capped pre-cleanup
+JSON result with cleanup pending and `temporaryDataRemoved: false`; after bounded cleanup it emits
+a separately retained final JSON result with verified cleanup success or failure. Both records carry
+the exact command, current commit, platform and Bun/SQLite identity, timestamps, duration, measured
+resources, outcome, separate descendant termination/reap, controller-empty/removal,
+tmpfs/workspace-removal facts, bounded retained-controller state, named cleanup failures, and
+truthful evidence disposition/retention, and
+raw-byte references to capped diagnostics. Unavailable failure-path measurements are `null`; raw
+database files and diagnostics are never retained. Focused-admission evidence reports descendant
+termination/reap, controller empty/removal, tmpfs removal, workspace removal, retained-controller
+state, and named failures as separate facts; its total duration is measured after bounded teardown
+and evidence emission. A non-native run records the platform blocker and null native measurements
+without attempting the Qualification workload.

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -24,11 +24,11 @@ Classify an executable test by its purpose, risk, and execution boundary. Durati
 
 The timing values are review targets, not hard assertions. Crossing one requires investigation and an explicit decision; elapsed time alone does not reclassify a test or justify weakening or removing it.
 
+The reference environment for timing review is the supported Bun version from `package.json` on a native development environment. Record the operating system, architecture, Bun version, and relevant resource measurements when investigating a target overrun.
+
 ### Issue #75 generated convergence coverage
 
-The fixed-seed 1,000-sequence Event Game correction test remains a Fast Test: it uses the in-memory adapter, injected clocks, and deterministic action fixtures. After splitting the correction tests, the generated file measured 2.54 seconds on Darwin arm64 with Bun 1.3.14, narrowly over the two-second per-file review target while remaining within the ten-second ordinary-suite target. The test retains the required 1,000 sequences and is not weakened; revisit the implementation if the file grows materially or the ordinary suite approaches its ten-second target.
-
-The reference environment for timing review is the supported Bun version from `package.json` on a native development environment. Record the operating system, architecture, Bun version, and relevant resource measurements when investigating a target overrun.
+The fixed-seed 1,000-sequence Event Game correction test remains a Fast Test: it uses the in-memory adapter, injected clocks, and deterministic action fixtures. After splitting the correction tests, the generated file measured 2.54 seconds on Darwin arm64 with Bun 1.3.14, narrowly over the two-second per-file review target while remaining within the ten-second ordinary-suite target. The test retains the required 1,000 sequences and is not weakened; revisit the implementation if the file grows materially or the ordinary suite approaches the ten-second target.
 
 ## Ordinary execution boundary
 
@@ -38,6 +38,8 @@ The ordinary boundary is:
 - `check`, ordinary implementation, and ordinary code review do not run Focused Integration Tests or Qualification Tests;
 - automatically triggered CI and deployment workflows run Fast Tests only, plus the existing quality and build work they already own;
 - Focused Integration Tests use distinct commands and are intentional task work;
+- `bun run test:focused-signal` is the separately named bounded signal-path Focused Integration Test; it is never part of ordinary tests, checks, or CI;
+- `bun run test:focused-admission` is the separately named bounded native-admission Focused Integration Test; it is never part of ordinary tests, checks, or CI and never launches the Qualification workload;
 - Qualification Tests use distinct commands and are never inferred from a request to test, check, build, implement, or review.
 
 An isolated GitHub Actions workflow is allowed only when a complete registry entry authorizes it, it is manually dispatched, and it has no deployment dependency, Production credential, or Production target. Local/native execution is the default.
@@ -46,7 +48,7 @@ For a Fast Test, ordinary review, or Focused Integration Test, this ordinary bou
 
 ## Qualification admission contract
 
-The active registry below is intentionally empty on `main`. A command is not a Qualification Test merely because it is slow, production-shaped, mentioned in an issue, present on another branch, or useful as a research probe. Do not add speculative candidates.
+The active registry below is intentionally small. A command is not a Qualification Test merely because it is slow, production-shaped, mentioned in an issue, present on another branch, or useful as a research probe. Do not add speculative candidates.
 
 Every registered entry must be complete before the command can run. The entry must identify:
 
@@ -65,13 +67,27 @@ The owner is a subsystem or acceptance concern, not a person's name. An optional
 
 ### Active Qualification Test registry
 
-There are currently no registered Qualification Tests.
+#### `bun run check:sqlite-runtime [compiled-executable]`
+
+- **Owner:** compiled Bun Linux runtime and SQLite/WAL integrity.
+- **Protected risk:** the delivered `bun-linux-x64-modern` artifact may embed an unsafe SQLite build or fail concurrent writer/checkpoint integrity despite a supported version label. This is the #71/#70 exact-artifact acceptance risk.
+- **Why cheaper evidence is insufficient:** Fast Tests cover routing, ownership, cleanup, process supervision, output limits, and deterministic database assertions. A Focused Integration Test can exercise disposable SQLite through the development runtime, but neither establishes the embedded SQLite runtime or the exact compiled-artifact concurrency behavior.
+- **Platform and artifact:** native Linux x86-64, using the exact executable produced by `bun run build:executable`. The command rejects other host platforms before launching the artifact.
+- **Isolation and filesystem:** one unique 0700 directory beneath the operating-system temporary directory, nested beneath one wrapper-owned 0700 container and mounted only inside the wrapper's verified private mount+network namespace. Every host-backed mount has positively verified non-empty `ro` and absent `rw` options; cwd and `TMPDIR` are inside the owned 16 MiB `tmpfs`, and the harness owns and validates the capability marker, database, WAL, and shared-memory sidecars. It never writes under the repository or a Production path. Each invocation creates one capability-marked cgroup root below a validated delegated parent, with helper and workload children. Broad, pre-existing, symlinked, replaced, or ambiguous targets fail closed; root members are included in TERM/KILL, reap, emptiness, and removal evidence; partial controller cleanup retains ownership evidence and blocks generic workspace cleanup. After self-attachment, `/sys/fs/cgroup` is positively verified read-only before readiness.
+- **Expected duration and resource envelope:** normally under one second; hard outer timeout 15 seconds for setup, workload, evidence, result handling, and cleanup, reserving five seconds for final termination, cgroup/filesystem cleanup, and final evidence; inner worker deadline 5 seconds; the artifact cgroup enforces at most 7 observed workload descendants (8 processes including the outer artifact), while admission/controller helpers use a separate bounded cgroup; `pids.current`/`pids.peak`, at most 512 MiB cgroup peak memory, at most 16 MiB OS-enforced temporary `tmpfs` disk, and at most 4 KiB raw-byte captured diagnostics are measured; descendants are reaped within 1 second after forced termination.
+- **Deadline justification:** the 10-second admission/work window budgets 1 second for namespace/tool admission, 5 seconds for the inner artifact gate, and 4 seconds for private-controller setup/evidence; the 5-second reserve budgets 250 ms TERM grace, 1 second cgroup-wide reap, private mount/controller teardown, and bounded result construction/emission with remaining margin. The separately named `bun run test:focused-admission` gate retains capped portable evidence for harmless native namespace/cgroup/tmpfs/readiness, sampling, emitter, and teardown under one five-second lifecycle deadline with a two-second cleanup reserve; the signal Focused Integration Test records native startup and signal-to-exit measurements for SIGINT, SIGTERM, and SIGHUP, including direct-child-exit descendant cleanup, without launching this workload. A non-Linux-x86-64 run records null native measurements and an explicit blocker. The 15-second/5-second production budget remains conservative and is not empirically accepted until harmless focused-admission evidence is captured on native Linux x86-64.
+- **Approved occasions and venue:** explicit release qualification or coordinator-directed bounded native-Ubuntu verification only. It is never part of ordinary `test`, `check`, `build`, deployment, or automatic CI. No manual CI venue is authorized by this entry.
+- **Network and credentials:** one wrapper-owned Linux `unshare --user --map-root-user --mount --net` namespace verifies and launches the workload with no non-loopback interface or route; it fails closed if that actual exec namespace or its host-mount sealing cannot be established. The workload has no network destination or loopback target and receives a sanitized child environment. No credential, token, cookie, Production environment, or server data is passed to the artifact.
+- **Production exclusions:** no Production target, database, deployment state, credential, or durable evidence destination. The exact 6-writer/6,000-row/5,000-checkpoint workload remains unchanged and is never reduced, retried as a workload, or moved into ordinary checks.
+- **Result and diagnostics:** each invocation has one stable invocation identity. Before removing the temporary container, the harness emits one capped JSON result with `phase: pre-cleanup`, `temporaryDataRemoved: false`, and cleanup `status: pending`; after bounded cleanup it emits a separately retained final JSON result with verified cleanup success/failure. Both contain schema version, invocation identity, exact command identity, commit, platform and artifact runtime identity, start/end timestamps, duration, measured process/memory/disk/output resources, outcome, separate descendant termination/reap, controller-empty/removal, tmpfs/workspace-removal facts, retained-controller state, and named cleanup failures, transient evidence disposition, and raw-byte references to capped stdout/stderr diagnostics. Unavailable or pending facts and failure-path measurements are `null`, never fabricated.
+- **Retention:** the temporary database, sidecars, capability markers, and raw diagnostics are removed on success, failure, interruption, and timeout. The redacted structured result is retained only in the invoking coordinator's handoff; no raw evidence remains in `/tmp`.
+- **Replacement/removal condition:** weaken, replace, or remove this entry only after explicit maintainer approval tied to evidence that the exact-artifact SQLite/WAL risk no longer exists or that a cheaper trustworthy proof establishes the same property.
 
 The committed security proof-of-concept programs under `docs/security/findings/` are research evidence and remain outside this executable-test taxonomy. Human-only device, accessibility, deployment, restore, and rehearsal procedures are operational acceptance work and also remain outside it.
 
 ### Main-branch inventory
 
-The production-shaped compiled-executable SQLite/WAL probe described in `docs/research/sqm-2026-safe-platform-baseline-refresh.md` was a completed disposable research run, not a maintained command committed on `main`. Its documented exact-artifact and concurrency gates are follow-up acceptance work for the future platform/package delivery they concern; they are not an active Qualification Test and are not executable through this policy. If that probe becomes a maintained command, its governing implementation task must add one complete registry entry before execution.
+The production-shaped compiled-executable SQLite/WAL probe described in `docs/research/sqm-2026-safe-platform-baseline-refresh.md` is now maintained as the registered `check:sqlite-runtime` Qualification Test above. Its governing implementation task is #71, and the exact-artifact/concurrency gate remains explicit-only and outside ordinary checks/tests.
 
 ## Harness contract
 
@@ -79,14 +95,22 @@ The Qualification Test harness owns its own safety behavior. Before admission, t
 
 Every harness must:
 
-- enforce a hard wall-clock timeout and bounded process count, memory, disk, and captured output;
+- enforce a hard wall-clock timeout and OS-enforced bounded process count, memory, disk, and captured output;
 - isolate every target and use only owned filesystem paths;
-- deny network access by default; authorize loopback or an isolated disposable non-Production target only when the registry entry says so, and explicitly allowlist every other destination;
+- establish and verify OS-enforced network and private mount namespaces before launch with bounded asynchronous admission; authorize loopback or an isolated disposable non-Production target only when the registry entry says so, and explicitly allowlist every other destination;
 - use only purpose-specific non-Production credentials when credentials are unavoidable; Production credentials, Production targets, and Production/server data are prohibited;
 - own the full descendant process tree, handle interruption and timeout, terminate descendants, and verify termination;
 - clean its owned temporary data on success, failure, interruption, and timeout;
 - run a correctness failure exactly once, without automatic retry;
-- emit the bounded result record before cleanup.
+- emit a bounded pre-cleanup result with cleanup pending, then a separately retained bounded final result after cleanup verification.
+
+For cgroup-backed harnesses, the invocation-root controller is part of the owned workload tree:
+root members are included in TERM/KILL, reap, emptiness, and removal evidence. Partial controller
+creation or cleanup must retain explicit ownership evidence, prevent generic workspace cleanup
+from erasing that evidence, and fail cleanup certification while any owned host cgroup remains.
+Focused-admission evidence reports descendant termination/reap, controller empty/removal,
+tmpfs/workspace removal, and named failures separately, with total duration measured after bounded
+teardown and evidence emission.
 
 Before any real workload is admitted, deterministic Fast Tests must cover the harness orchestration and safety boundaries through injected clocks, process runners, filesystem seams, and other test doubles. Those tests cover timeout, interruption, output and resource limits, target and credential gating, descendant cleanup, result emission, and the no-retry rule without launching the expensive workload.
 
@@ -94,14 +118,17 @@ Before any real workload is admitted, deterministic Fast Tests must cover the ha
 
 Raw workload files are transient. Each invocation creates a unique, validated directory beneath the operating system's temporary directory; it does not write evidence under the repository's `out/` directory. Workload files and diagnostics are bounded by the registry entry.
 
-Before removing that directory, the harness emits a capped structured result containing:
+Before removing that directory, the harness emits a capped pre-cleanup structured result containing:
 
 - command identity and commit;
 - platform and start/end timestamps;
 - duration and measured resource use;
 - outcome and cleanup result;
-- evidence location or transient-cleanup disposition;
+- explicit retained-controller state and truthful evidence disposition/retention;
 - references to capped diagnostics.
+
+After bounded cleanup, it emits a final structured result with verified cleanup success or failure;
+failure-path measurements that cannot be observed are explicitly `null`.
 
 The harness removes its owned temporary directory on every terminal path. Durable evidence is exceptional: it must be redacted, have an explicit destination and retention period in its registry entry, and contain no Production data or credentials. A run must not leave old raw evidence in `/tmp`.
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "build": "bun run build.ts",
     "build:executable": "bun run build.ts --compile --compile-target=bun-linux-x64-modern --outfile=dist/quadball-timer",
     "check:sqlite-runtime": "bun scripts/check-sqlite-runtime.ts",
+    "test:focused-signal": "bun scripts/test-focused-signal.ts",
+    "test:focused-admission": "bun scripts/test-focused-admission.ts",
     "test": "bun test --isolate",
     "test:focused:sqlite": "bun test --isolate ./src/lib/event-game-actions-sqlite.focused.ts",
     "test:focused:grant": "bun test ./src/lib/grant-authority.focused.ts",

--- a/scripts/check-sqlite-runtime.ts
+++ b/scripts/check-sqlite-runtime.ts
@@ -22,9 +22,16 @@ const executablePath = cliArguments[0] ?? "dist/quadball-timer";
 if (!(await Bun.file(executablePath).exists())) {
   throw new Error(`Compiled executable does not exist: ${executablePath}`);
 }
+if (process.platform !== "linux" || process.arch !== "x64") {
+  throw new Error("SQLite runtime qualification requires native Linux x86-64.");
+}
 
 const result = await runCompiledSqliteFoundationProbe(executablePath, {
   timeoutMs: SQLITE_FOUNDATION_PROBE_TIMEOUT_MS,
+  command: "bun run check:sqlite-runtime [compiled-executable]",
+  emitResult: (qualificationResult) => {
+    console.log(JSON.stringify(qualificationResult));
+  },
 });
 const report = JSON.parse(result.stdout.trim()) as {
   bunVersion: string;

--- a/scripts/check-testing-policy.ts
+++ b/scripts/check-testing-policy.ts
@@ -1,29 +1,57 @@
+import { readdir } from "node:fs/promises";
+import path from "node:path";
 import {
+  isCompleteQualificationEntry,
+  parseQualificationRegistry,
   routeQualificationRequest,
   type QualificationEntry,
   type QualificationRequest,
   type RoutingDecision,
 } from "@/lib/testing-policy";
+import {
+  SQLITE_FOUNDATION_PROBE_COMMAND,
+  SQLITE_FOUNDATION_PROBE_MAX_DISK_BYTES,
+  SQLITE_FOUNDATION_PROBE_MAX_MEMORY_BYTES,
+} from "@/lib/sqlite-foundation-probe-result";
+import {
+  SQLITE_FOUNDATION_PROBE_MAX_OUTPUT_BYTES,
+  SQLITE_FOUNDATION_PROBE_MAX_PROCESS_COUNT,
+  SQLITE_FOUNDATION_PROBE_REAP_TIMEOUT_MS,
+  SQLITE_FOUNDATION_PROBE_TIMEOUT_MS,
+} from "@/lib/sqlite-foundation-probe-process";
 
-const syntheticRegistry = {
-  "example-qualification": {
-    complete: true,
-    riskStillExists: true,
-    safe: true,
-  },
-} satisfies Readonly<Record<string, QualificationEntry>>;
+const policyMarkdown = await Bun.file("docs/agents/testing.md").text();
+const registry = parseQualificationRegistry(policyMarkdown);
+const registryEntries = Object.values(registry);
+const registeredEntry = registryEntries[0];
+if (
+  registeredEntry === undefined ||
+  registryEntries.some((entry) => !isCompleteQualificationEntry(entry))
+) {
+  throw new Error("The canonical Qualification Test registry is missing or incomplete.");
+}
+if (registeredEntry.command !== SQLITE_FOUNDATION_PROBE_COMMAND) {
+  throw new Error("Canonical Qualification Test command diverges from the harness command.");
+}
+const limits = registeredEntry.resourceLimits;
+if (
+  limits.timeoutMs !== SQLITE_FOUNDATION_PROBE_TIMEOUT_MS ||
+  limits.processCount !== SQLITE_FOUNDATION_PROBE_MAX_PROCESS_COUNT ||
+  limits.memoryBytes !== SQLITE_FOUNDATION_PROBE_MAX_MEMORY_BYTES ||
+  limits.diskBytes !== SQLITE_FOUNDATION_PROBE_MAX_DISK_BYTES ||
+  limits.outputBytes !== SQLITE_FOUNDATION_PROBE_MAX_OUTPUT_BYTES ||
+  limits.descendantCleanupMs !== SQLITE_FOUNDATION_PROBE_REAP_TIMEOUT_MS
+) {
+  throw new Error("Canonical Qualification Test resource limits diverge from the harness limits.");
+}
 
 const dryRunCases: ReadonlyArray<
   [string, QualificationRequest, Readonly<Record<string, QualificationEntry>>, RoutingDecision]
 > = [
   [
     "explicit registered qualification request",
-    {
-      kind: "qualification",
-      mode: "run",
-      name: "example-qualification",
-    },
-    syntheticRegistry,
+    { kind: "qualification", mode: "run", name: registeredEntry.command },
+    registry,
     "invoke-once",
   ],
   ["ordinary test request", { kind: "ordinary" }, {}, "ordinary-boundary"],
@@ -33,31 +61,19 @@ const dryRunCases: ReadonlyArray<
   ["ordinary review request", { kind: "ordinary" }, {}, "ordinary-boundary"],
   [
     "validate-only qualification request",
-    {
-      kind: "qualification",
-      mode: "validate",
-      name: "example-qualification",
-    },
-    syntheticRegistry,
+    { kind: "qualification", mode: "validate", name: registeredEntry.command },
+    registry,
     "inspect-without-invocation",
   ],
   [
     "review-only qualification request",
-    {
-      kind: "qualification",
-      mode: "review",
-      name: "example-qualification",
-    },
-    syntheticRegistry,
+    { kind: "qualification", mode: "review", name: registeredEntry.command },
+    registry,
     "inspect-without-invocation",
   ],
   [
     "empty-registry qualification request",
-    {
-      kind: "qualification",
-      mode: "run",
-      name: "example-qualification",
-    },
+    { kind: "qualification", mode: "run", name: registeredEntry.command },
     {},
     "refuse-unregistered",
   ],
@@ -71,8 +87,8 @@ function assertDecision(actual: RoutingDecision, expected: RoutingDecision, requ
 
 console.log("Testing policy routing dry-run:");
 let simulatedLaunchCount = 0;
-for (const [requestName, request, registry, expected] of dryRunCases) {
-  const decision = routeQualificationRequest(request, registry);
+for (const [requestName, request, caseRegistry, expected] of dryRunCases) {
+  const decision = routeQualificationRequest(request, caseRegistry);
   assertDecision(decision, expected, requestName);
   if (decision === "invoke-once") simulatedLaunchCount += 1;
   console.log(`- ${requestName}: ${decision}`);
@@ -82,4 +98,42 @@ if (simulatedLaunchCount !== 1) {
   throw new Error(`expected one simulated explicit invocation, received ${simulatedLaunchCount}`);
 }
 
+const commandToken = registeredEntry.command.split(" ")[2];
+if (commandToken === undefined)
+  throw new Error("Canonical Qualification Test command is malformed.");
+const qualificationScript = path.join("scripts", `${commandToken.replaceAll(":", "-")}.ts`);
+const packageJson = (await Bun.file("package.json").json()) as {
+  scripts: Record<string, string>;
+};
+for (const [scriptName, command] of Object.entries(packageJson.scripts)) {
+  if (scriptName !== commandToken && command.includes(commandToken)) {
+    throw new Error(`Ordinary package script invokes the Qualification Test: ${scriptName}`);
+  }
+}
+
+for (const filePath of [
+  ...(await filesUnder(".github/workflows")),
+  ...(await filesUnder("scripts")),
+  ...(await filesUnder("deploy")),
+  "build.ts",
+]) {
+  if (filePath === qualificationScript) continue;
+  const contents = await Bun.file(filePath).text();
+  if (contents.includes(commandToken)) {
+    throw new Error(`Ordinary workflow/script invokes the Qualification Test: ${filePath}`);
+  }
+}
+
+console.log("Literal qualification command is absent from ordinary workflow/script chains.");
 console.log("Dry-run passed; no qualification workload was launched.");
+
+async function filesUnder(directoryPath: string): Promise<string[]> {
+  const entries = await readdir(directoryPath, { withFileTypes: true }).catch(() => []);
+  const files: string[] = [];
+  for (const entry of entries) {
+    const childPath = path.join(directoryPath, entry.name);
+    if (entry.isDirectory()) files.push(...(await filesUnder(childPath)));
+    else if (entry.isFile()) files.push(childPath);
+  }
+  return files;
+}

--- a/scripts/test-focused-admission.ts
+++ b/scripts/test-focused-admission.ts
@@ -1,0 +1,356 @@
+import { performance } from "node:perf_hooks";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+  cleanupOwnedProbeWorkspaceContainer,
+  createProbeOuterEnvironment,
+  createProbeWorkspaceContainer,
+  type ProbeWorkspaceContainer,
+} from "@/lib/sqlite-foundation-probe-containment";
+import { createProbeNetworkBoundary } from "@/lib/sqlite-foundation-probe-network";
+import {
+  createProbeOutputBudget,
+  spawnProbeCommand,
+  superviseProbeWorkers,
+} from "@/lib/sqlite-foundation-probe-process";
+import {
+  createProbeResourceController,
+  readProbeTmpfsDisposition,
+  type ProbeResourceController,
+} from "@/lib/sqlite-foundation-probe-resources";
+import { createFocusedAdmissionDeadline } from "@/lib/sqlite-foundation-probe-focused-deadline";
+import {
+  focusedAdmissionExitCode,
+  focusedAdmissionRecordByteLength,
+  runFocusedBounded,
+} from "@/lib/sqlite-foundation-probe-focused-admission";
+import { capProbeEvidenceString } from "@/lib/sqlite-foundation-probe-evidence";
+
+const FOCUSED_TOTAL_DEADLINE_MS = 5_000;
+const FOCUSED_CLEANUP_RESERVE_MS = 2_000;
+const startedAt = performance.now();
+const deadline = createFocusedAdmissionDeadline(
+  FOCUSED_TOTAL_DEADLINE_MS,
+  FOCUSED_CLEANUP_RESERVE_MS,
+);
+const workSignal = deadline.workSignal;
+const overallSignal = deadline.overallSignal;
+
+let container: ProbeWorkspaceContainer | undefined;
+let controller: ProbeResourceController | undefined;
+let worker: ReturnType<typeof spawnProbeCommand> | undefined;
+let controllerEmpty: boolean | null = null;
+let controllerRemoved: boolean | null = null;
+let workspaceRemoved: boolean | null = null;
+let tmpfsRemoved: boolean | null = null;
+let descendantsTerminated: boolean | null = null;
+let descendantsReaped: boolean | null = null;
+let retainedController = false;
+const failures: string[] = [];
+let outcome: "passed" | "failed" | "blocked" = "blocked";
+let errorReference: string | null = null;
+const measurements: Record<string, number | null> = {
+  admissionMs: null,
+  readinessMs: null,
+  releaseAndExitMs: null,
+  sampleMs: null,
+  emitterMs: null,
+  teardownMs: null,
+  totalMs: null,
+};
+
+try {
+  if (process.platform !== "linux" || process.arch !== "x64") {
+    errorReference = "native-linux-x64-controls-unavailable";
+  } else {
+    const admissionStartedAt = performance.now();
+    container = await bounded(
+      createProbeWorkspaceContainer(workSignal),
+      workSignal,
+      "container creation",
+    );
+    const networkBoundary = await bounded(
+      createProbeNetworkBoundary({ signal: workSignal, timeoutMs: remainingMs() }),
+      workSignal,
+      "network admission",
+    );
+    controller = await bounded(
+      createProbeResourceController(container.workspaceDirectoryPath ?? container.directoryPath, {
+        networkBoundary,
+        container,
+        invocationId: crypto.randomUUID(),
+        signal: workSignal,
+      }),
+      workSignal,
+      "controller creation",
+    );
+    measurements.admissionMs = elapsed(admissionStartedAt);
+
+    const workspacePath = container.workspaceDirectoryPath ?? container.directoryPath;
+    const hostProbePaths = [
+      path.join(container.directoryPath, ".host-write-probe"),
+      path.join(process.cwd(), ".host-write-probe"),
+      path.join(tmpdir(), ".host-write-probe"),
+    ];
+    const launch = await bounded(
+      controller.prepare([
+        "/bin/sh",
+        "-eu",
+        "-c",
+        'for target in "$1" "$2" "$3"; do if printf x > "$target" 2>/dev/null; then exit 42; fi; done; test "$PWD" = "$4"; test "$TMPDIR" = "$4/tmp"',
+        "focused-admission",
+        ...hostProbePaths,
+        workspacePath,
+      ]),
+      workSignal,
+      "launch preparation",
+    );
+    const readyStartedAt = performance.now();
+    worker = spawnProbeCommand([...launch.command], {
+      detached: true,
+      env: createProbeOuterEnvironment(container),
+      outputBudget: createProbeOutputBudget(),
+      readyMarker: "READY\n",
+    });
+    const ready = await bounded(worker.ready ?? Promise.resolve(true), workSignal, "readiness");
+    if (!ready) throw new Error("focused admission did not reach readiness");
+    measurements.readinessMs = elapsed(readyStartedAt);
+    await bounded(controller.attach(worker.process.pid), workSignal, "attachment");
+    const releaseStartedAt = performance.now();
+    await bounded(launch.release(worker.process.pid), workSignal, "release");
+    const [result] = await bounded(
+      superviseProbeWorkers([worker], {
+        signal: workSignal,
+        timeoutMs: remainingMs(),
+        killWorkloadTree: () => controller?.kill() ?? Promise.resolve(),
+      }),
+      workSignal,
+      "harmless helper exit",
+    );
+    descendantsTerminated = result?.exitCode !== null && result?.exitCode !== undefined;
+    tmpfsRemoved = readProbeTmpfsDisposition(result?.stdout ?? "");
+    measurements.releaseAndExitMs = elapsed(releaseStartedAt);
+    const sampleStartedAt = performance.now();
+    await bounded(
+      controller.sample(
+        worker.process.pid,
+        workspacePath,
+        result?.stdoutBytes ?? 0,
+        result?.stdout,
+        result?.stderr,
+      ),
+      workSignal,
+      "resource sample",
+    );
+    measurements.sampleMs = elapsed(sampleStartedAt);
+    outcome = "passed";
+  }
+} catch (error) {
+  outcome = "failed";
+  errorReference = boundedErrorReference(error);
+  if (hasRetainedController(error)) {
+    retainedController = true;
+    controllerEmpty = false;
+    controllerRemoved = false;
+    failures.push("retained-controller");
+  }
+} finally {
+  const teardownStartedAt = performance.now();
+  if (controller !== undefined) {
+    try {
+      await bounded(controller.reap(overallSignal), overallSignal, "controller reap");
+      controllerEmpty = await bounded(
+        controller.isEmpty?.() ?? Promise.resolve(true),
+        overallSignal,
+        "controller empty verification",
+      );
+      descendantsReaped = controllerEmpty;
+      if (controllerEmpty) {
+        await bounded(controller.close(overallSignal), overallSignal, "controller close");
+        controllerRemoved = true;
+        controller = undefined;
+      } else {
+        controllerRemoved = false;
+        failures.push("controller-empty");
+        outcome = "failed";
+      }
+    } catch (error) {
+      retainedController = true;
+      controllerEmpty = false;
+      controllerRemoved = false;
+      descendantsReaped = false;
+      if (hasRetainedController(error)) retainedController = true;
+      failures.push("descendant-reap", "controller-empty", "controller-removal");
+      if (tmpfsRemoved !== true) failures.push("tmpfs-removal");
+      outcome = "failed";
+      errorReference ??= boundedErrorReference(error);
+    }
+  }
+  if (worker !== undefined && worker.process.exitCode === null) {
+    worker.process.kill("SIGKILL");
+    await bounded(worker.process.exited, overallSignal, "direct helper reap").catch((error) => {
+      outcome = "failed";
+      errorReference ??= boundedErrorReference(error);
+    });
+  }
+  if (worker !== undefined && worker.process.exitCode !== null) descendantsTerminated = true;
+  if (
+    container !== undefined &&
+    (controller === undefined || controllerRemoved) &&
+    !retainedController
+  ) {
+    try {
+      await bounded(
+        cleanupOwnedProbeWorkspaceContainer(
+          container.directoryPath,
+          container.capability,
+          overallSignal,
+        ),
+        overallSignal,
+        "workspace cleanup",
+      );
+      workspaceRemoved = true;
+    } catch (error) {
+      workspaceRemoved = false;
+      outcome = "failed";
+      errorReference ??= boundedErrorReference(error);
+    }
+  }
+  measurements.teardownMs = elapsed(teardownStartedAt);
+  const emitterStartedAt = performance.now();
+  const evidence = {
+    schemaVersion: 1,
+    kind: "sqlite-focused-admission-evidence",
+    platform: { os: process.platform, arch: process.arch, bunVersion: Bun.version },
+    qualificationWorkloadRan: false,
+    totalDeadlineMs: FOCUSED_TOTAL_DEADLINE_MS,
+    cleanupReserveMs: FOCUSED_CLEANUP_RESERVE_MS,
+    outcome,
+    measurements,
+    cleanup: {
+      descendantsTerminated,
+      descendantsReaped,
+      controllerEmpty,
+      controllerRemoved,
+      tmpfsRemoved,
+      workspaceRemoved,
+      failures: [...new Set(failures)],
+      retainedController: {
+        state: retainedController ? "retained" : "none",
+        scope: retainedController ? "invocation-cgroup" : null,
+        resources: [],
+      },
+    },
+    evidence: {
+      disposition: retainedController
+        ? "retained-owned-state"
+        : outcome === "failed"
+          ? "cleanup-failure"
+          : "transient-cleanup",
+      retention: retainedController || outcome === "failed" ? "coordinator-handoff" : "none",
+    },
+    blocker:
+      process.platform === "linux" && process.arch === "x64"
+        ? null
+        : "Native Linux x86-64 admission and teardown measurements remain required.",
+    errorReference,
+  };
+  measurements.emitterMs = elapsed(emitterStartedAt);
+  measurements.totalMs = elapsed(startedAt);
+  const emittedEvidence = boundedFocusedEvidence({
+    ...evidence,
+    outcome,
+    errorReference,
+    measurements,
+    cleanup: { ...evidence.cleanup, failures: [...new Set(failures)] },
+  });
+  if (emittedEvidence.outcome === "failed") outcome = "failed";
+  process.stdout.write(`${JSON.stringify(emittedEvidence)}\n`);
+  deadline.cleanup();
+  process.exitCode = focusedAdmissionExitCode(outcome);
+}
+
+async function bounded<T>(operation: Promise<T>, signal: AbortSignal, label: string): Promise<T> {
+  try {
+    return await runFocusedBounded(operation, signal, label);
+  } catch (error) {
+    if (signal.aborted && !overallSignal.aborted) {
+      await Promise.race([
+        operation.then(
+          () => undefined,
+          () => undefined,
+        ),
+        waitForAbort(overallSignal),
+      ]);
+    }
+    throw error;
+  }
+}
+
+function waitForAbort(signal: AbortSignal): Promise<void> {
+  if (signal.aborted) return Promise.resolve();
+  return new Promise((resolve) =>
+    signal.addEventListener("abort", () => resolve(), { once: true }),
+  );
+}
+
+function remainingMs(): number {
+  return Math.max(1, FOCUSED_TOTAL_DEADLINE_MS - elapsed(startedAt));
+}
+
+function elapsed(start: number): number {
+  return Math.max(0, Math.ceil(performance.now() - start));
+}
+
+function boundedErrorReference(error: unknown): string {
+  const name = error instanceof Error ? error.name : "UnknownError";
+  return capProbeEvidenceString(name.replace(/[^A-Za-z0-9_-]/g, ""), 64, "UnknownError");
+}
+
+function boundedFocusedEvidence(record: Record<string, unknown>): Record<string, unknown> {
+  if (focusedAdmissionRecordByteLength(record) <= 4 * 1024) return record;
+  return {
+    schemaVersion: 1,
+    kind: "sqlite-focused-admission-evidence",
+    platform: {
+      os: capProbeEvidenceString(process.platform, 16),
+      arch: capProbeEvidenceString(process.arch, 16),
+      bunVersion: capProbeEvidenceString(Bun.version, 32),
+    },
+    qualificationWorkloadRan: false,
+    totalDeadlineMs: FOCUSED_TOTAL_DEADLINE_MS,
+    cleanupReserveMs: FOCUSED_CLEANUP_RESERVE_MS,
+    outcome: "failed",
+    measurements: {
+      admissionMs: null,
+      readinessMs: null,
+      releaseAndExitMs: null,
+      sampleMs: null,
+      emitterMs: 0,
+      teardownMs: null,
+      totalMs: elapsed(startedAt),
+    },
+    cleanup: {
+      descendantsTerminated: null,
+      descendantsReaped: false,
+      controllerEmpty: null,
+      controllerRemoved: false,
+      tmpfsRemoved: null,
+      workspaceRemoved: false,
+      failures: ["evidence-size"],
+      retainedController: { state: "unknown", scope: "invocation-cgroup", resources: [] },
+    },
+    evidence: { disposition: "cleanup-failure", retention: "coordinator-handoff" },
+    blocker: null,
+    errorReference: "focused-evidence-size-limit",
+  };
+}
+
+function hasRetainedController(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "retainedController" in error &&
+    (error as { retainedController?: unknown }).retainedController !== null
+  );
+}

--- a/scripts/test-focused-signal.ts
+++ b/scripts/test-focused-signal.ts
@@ -1,0 +1,303 @@
+import { installProbeSignalHandlers } from "@/lib/sqlite-foundation-probe-process";
+
+const CHILD_ARGUMENT = "--focused-signal-child";
+const GRANDCHILD_ARGUMENT = "--focused-signal-grandchild";
+const SIGNALS: NodeJS.Signals[] = ["SIGINT", "SIGTERM", "SIGHUP"];
+const TIMEOUT_MS = 2_000;
+const MAX_OUTPUT_BYTES = 1_024;
+
+if (process.argv.includes(GRANDCHILD_ARGUMENT)) {
+  process.on("SIGTERM", () => {});
+  const keepAlive = setInterval(() => {}, 1_000);
+  await new Promise<void>(() => {});
+  clearInterval(keepAlive);
+} else if (process.argv.includes(CHILD_ARGUMENT)) {
+  await runSignalChild();
+} else {
+  await runDirectChildExitCase();
+  const measurements: SignalMeasurement[] = [];
+  for (const signal of SIGNALS) {
+    measurements.push(await runSignalCase(signal));
+  }
+  const maxStartupMs = Math.max(...measurements.map((measurement) => measurement.startupMs));
+  const maxSignalCleanupMs = Math.max(
+    ...measurements.map((measurement) => measurement.signalCleanupMs),
+  );
+  console.log(
+    `Focused signal integration test passed for SIGINT, SIGTERM, and SIGHUP; no retry was attempted. measurements=${JSON.stringify({ maxStartupMs, maxSignalCleanupMs })}`,
+  );
+}
+
+async function runSignalChild(): Promise<void> {
+  const signalScope = installProbeSignalHandlers();
+  const grandchild = Bun.spawn(
+    [process.execPath, process.argv[1] ?? import.meta.filename, GRANDCHILD_ARGUMENT],
+    {
+      detached: !process.argv.includes("--direct-exit"),
+      env: allowlistedEnvironment(),
+      stdout: "ignore",
+      stderr: "ignore",
+    },
+  );
+  process.stdout.write("RE");
+  await Bun.sleep(5);
+  process.stdout.write("ADY\n");
+  process.stderr.write("diagnostic\n");
+  if (process.argv.includes("--direct-exit")) {
+    signalScope.cleanup();
+    process.exit(0);
+  }
+  await new Promise<void>((resolve) => {
+    signalScope.signal.addEventListener("abort", () => resolve(), { once: true });
+  });
+  process.stdout.write(`ABORTED ${signalScope.signal.reason ?? "signal"}\n`);
+  grandchild.kill("SIGTERM");
+  const exited = await Promise.race([grandchild.exited, Bun.sleep(100).then(() => null)]);
+  if (exited === null) {
+    grandchild.kill("SIGKILL");
+    try {
+      process.kill(grandchild.pid, "SIGKILL");
+    } catch {
+      // The process may have exited between TERM grace and the bounded KILL.
+    }
+  }
+  const exitedAfterKill = await waitForProcessGone(grandchild.pid, TIMEOUT_MS);
+  if (!exitedAfterKill)
+    throw new Error("focused signal grandchild did not exit after bounded KILL");
+  process.stdout.write("REAPED\n");
+  signalScope.cleanup();
+}
+
+async function runDirectChildExitCase(): Promise<void> {
+  const child = Bun.spawn(
+    [process.execPath, process.argv[1] ?? import.meta.filename, CHILD_ARGUMENT, "--direct-exit"],
+    {
+      detached: true,
+      env: allowlistedEnvironment(),
+      stdout: "pipe",
+      stderr: "pipe",
+    },
+  );
+  const stdout = readBoundedOutput(child.stdout, true);
+  const stderr = readBoundedOutput(child.stderr, false);
+  try {
+    if (!(await waitForReady(stdout.ready, TIMEOUT_MS))) {
+      throw new Error("direct-exit signal child did not become ready");
+    }
+    await Promise.race([
+      Promise.all([child.exited, stdout.completed, stderr.completed]),
+      Bun.sleep(TIMEOUT_MS).then(() => {
+        throw new Error("direct-exit signal child did not exit within its bound");
+      }),
+    ]);
+    await assertProcessGroupExists(child.pid);
+  } finally {
+    await terminateOwnedProcessGroup(child.pid);
+  }
+}
+
+type SignalMeasurement = {
+  signal: NodeJS.Signals;
+  startupMs: number;
+  signalCleanupMs: number;
+};
+
+async function runSignalCase(signal: NodeJS.Signals): Promise<SignalMeasurement> {
+  const startedAt = performance.now();
+  const child = Bun.spawn(
+    [process.execPath, process.argv[1] ?? import.meta.filename, CHILD_ARGUMENT],
+    {
+      detached: true,
+      env: allowlistedEnvironment(),
+      stdout: "pipe",
+      stderr: "pipe",
+    },
+  );
+  const stdout = readBoundedOutput(child.stdout, true);
+  const stderr = readBoundedOutput(child.stderr, false);
+  let failure: unknown;
+  let processGroupVerifiedGone = false;
+  try {
+    const ready = await waitForReady(stdout.ready, TIMEOUT_MS);
+    if (!ready) throw new Error(`${signal} child did not become ready`);
+    const readyAt = performance.now();
+    child.kill(signal);
+    const [exitCode, stdoutText, stderrText] = await waitForExit(
+      child,
+      stdout.completed,
+      stderr.completed,
+      TIMEOUT_MS,
+    );
+    if (
+      exitCode !== 0 ||
+      !stdoutText.includes("READY\n") ||
+      !stdoutText.includes("REAPED\n") ||
+      !stdoutText.includes("ABORTED") ||
+      !stderrText.includes("diagnostic\n")
+    ) {
+      throw new Error(
+        `${signal} child did not complete installed-signal cleanup (exitCode=${exitCode}, stdout=${JSON.stringify(stdoutText)}, stderr=${JSON.stringify(stderrText)})`,
+      );
+    }
+    await assertProcessGroupGone(child.pid);
+    processGroupVerifiedGone = true;
+    return {
+      signal,
+      startupMs: Math.ceil(readyAt - startedAt),
+      signalCleanupMs: Math.ceil(performance.now() - readyAt),
+    };
+  } catch (error) {
+    failure = error;
+  } finally {
+    if (!processGroupVerifiedGone) {
+      try {
+        await terminateOwnedProcessGroup(child.pid);
+      } catch (cleanupError) {
+        failure ??= cleanupError;
+      }
+    }
+  }
+  throw failure ?? new Error(`${signal} signal case failed without an error`);
+}
+
+function allowlistedEnvironment(): Record<string, string> {
+  const environment: Record<string, string> = { NODE_ENV: "test" };
+  for (const key of ["PATH", "LANG", "LC_ALL", "TZ"]) {
+    const value = process.env[key];
+    if (value !== undefined) environment[key] = value;
+  }
+  return environment;
+}
+
+type BoundedOutput = {
+  ready: Promise<boolean>;
+  completed: Promise<string>;
+};
+
+function readBoundedOutput(
+  stream: ReadableStream<Uint8Array<ArrayBuffer>>,
+  detectsReady: boolean,
+): BoundedOutput {
+  let resolveReady: (ready: boolean) => void = () => {};
+  let readyResolved = false;
+  const ready = new Promise<boolean>((resolve) => {
+    resolveReady = resolve;
+  });
+  const completed = (async () => {
+    const reader = stream.getReader();
+    const chunks: Uint8Array[] = [];
+    const decoder = new TextDecoder();
+    let size = 0;
+    let text = "";
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        size += value.byteLength;
+        if (size > MAX_OUTPUT_BYTES) throw new Error("focused signal output exceeded its bound");
+        chunks.push(value);
+        text += decoder.decode(value, { stream: true });
+        if (detectsReady && !readyResolved && text.includes("READY\n")) {
+          readyResolved = true;
+          resolveReady(true);
+        }
+      }
+      text += decoder.decode();
+    } finally {
+      reader.releaseLock();
+    }
+    if (detectsReady && !readyResolved) resolveReady(false);
+    const output = new Uint8Array(size);
+    let offset = 0;
+    for (const chunk of chunks) {
+      output.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+    return new TextDecoder().decode(output);
+  })();
+  completed.catch(() => {
+    if (detectsReady && !readyResolved) resolveReady(false);
+  });
+  return { ready, completed };
+}
+
+async function waitForReady(ready: Promise<boolean>, timeoutMs: number): Promise<boolean> {
+  return await Promise.race([ready, Bun.sleep(timeoutMs).then(() => false)]);
+}
+
+async function waitForExit(
+  child: ReturnType<typeof Bun.spawn>,
+  stdout: Promise<string>,
+  stderr: Promise<string>,
+  timeoutMs: number,
+): Promise<[number, string, string]> {
+  return await Promise.race([
+    Promise.all([child.exited, stdout, stderr]),
+    Bun.sleep(timeoutMs).then(() => {
+      throw new Error("focused signal child exceeded its bounded cleanup timeout");
+    }),
+  ]);
+}
+
+async function assertProcessGroupGone(pid: number): Promise<void> {
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    try {
+      process.kill(-pid, 0);
+    } catch {
+      return;
+    }
+    await Bun.sleep(10);
+  }
+  throw new Error("focused signal process group was not reaped");
+}
+
+async function assertProcessGroupExists(pid: number): Promise<void> {
+  try {
+    process.kill(-pid, 0);
+  } catch {
+    throw new Error("direct-exit signal grandchild did not remain in the owned group");
+  }
+}
+
+async function waitForProcessGone(pid: number, timeoutMs: number): Promise<boolean> {
+  const deadline = performance.now() + timeoutMs;
+  while (performance.now() < deadline) {
+    try {
+      process.kill(pid, 0);
+    } catch {
+      return true;
+    }
+    await Bun.sleep(10);
+  }
+  return false;
+}
+
+async function terminateOwnedProcessGroup(pid: number): Promise<void> {
+  try {
+    process.kill(-pid, "SIGTERM");
+  } catch {
+    return await assertProcessGroupGone(pid);
+  }
+  if (await waitForGroupGone(pid, 250)) return;
+  try {
+    process.kill(-pid, "SIGKILL");
+  } catch {
+    // The group may have exited between the grace check and KILL.
+  }
+  if (!(await waitForGroupGone(pid, 1_000))) {
+    throw new Error("focused signal process group exceeded bounded TERM/KILL cleanup");
+  }
+}
+
+async function waitForGroupGone(pid: number, timeoutMs: number): Promise<boolean> {
+  const deadline = performance.now() + timeoutMs;
+  while (performance.now() < deadline) {
+    try {
+      process.kill(-pid, 0);
+    } catch {
+      return true;
+    }
+    await Bun.sleep(10);
+  }
+  return false;
+}

--- a/src/lib/grant-concurrency-process.test.ts
+++ b/src/lib/grant-concurrency-process.test.ts
@@ -134,6 +134,8 @@ function fakeWorker(): ProbeWorkerHandle {
     exitCode: 0,
     stdout: "{}",
     stderr: "",
+    stdoutBytes: 2,
+    stderrBytes: 0,
     outputExceeded: false,
   };
   return {

--- a/src/lib/sqlite-foundation-probe-cgroup.test.ts
+++ b/src/lib/sqlite-foundation-probe-cgroup.test.ts
@@ -1,0 +1,282 @@
+import { describe, expect, test } from "bun:test";
+import {
+  createProbeCgroupTree,
+  ProbeCgroupCleanupError,
+  ProbeCgroupCreationError,
+  ProbeCgroupOwnershipError,
+  type ProbeCgroupFileSystem,
+  type ProbeCgroupStat,
+} from "@/lib/sqlite-foundation-probe-cgroup";
+
+const PARENT = "/sys/fs/cgroup/delegated";
+const MARKER = "/tmp/owned/.probe-cgroup-capability";
+
+describe("sqlite-foundation-probe cgroup ownership", () => {
+  test("rejects a broad cgroup root before creating a target", async () => {
+    const fileSystem = createFakeCgroupFileSystem();
+    expect(
+      await captureRejection(() =>
+        createProbeCgroupTree({
+          fileSystem,
+          currentCgroup: "0::/\n",
+          markerPath: MARKER,
+          capability: "00000000-0000-0000-0000-000000000000",
+          invocationId: "11111111-1111-1111-1111-111111111111",
+        }),
+      ),
+    ).toBeInstanceOf(ProbeCgroupOwnershipError);
+    expect(fileSystem.createdPaths).toEqual([]);
+    expect(fileSystem.removedPaths).toEqual([]);
+  });
+
+  test("does not remove a colliding pre-existing target", async () => {
+    const fileSystem = createFakeCgroupFileSystem({ collideInvocationRoot: true });
+    expect(
+      await captureRejection(() =>
+        createProbeCgroupTree({
+          fileSystem,
+          currentCgroup: "0::/delegated\n",
+          markerPath: MARKER,
+          capability: "00000000-0000-0000-0000-000000000000",
+          invocationId: "11111111-1111-1111-1111-111111111111",
+        }),
+      ),
+    ).toBeInstanceOf(ProbeCgroupOwnershipError);
+    expect(fileSystem.removedPaths).toEqual([]);
+  });
+
+  test("revalidates inode and capability evidence before kill or removal", async () => {
+    const fileSystem = createFakeCgroupFileSystem();
+    const tree = await createProbeCgroupTree({
+      fileSystem,
+      currentCgroup: "0::/delegated\n",
+      markerPath: MARKER,
+      capability: "00000000-0000-0000-0000-000000000000",
+      invocationId: "11111111-1111-1111-1111-111111111111",
+    });
+    fileSystem.swapPath(tree.workloadPath);
+
+    expect(await captureRejection(() => tree.kill())).toBeInstanceOf(ProbeCgroupOwnershipError);
+    expect(await captureRejection(() => tree.remove())).toBeInstanceOf(ProbeCgroupOwnershipError);
+    expect(fileSystem.writes.some(([target]) => target.endsWith("cgroup.kill"))).toBe(false);
+    expect(fileSystem.removedPaths).toEqual([]);
+  });
+
+  test("rejects marker replacement before cleanup", async () => {
+    const fileSystem = createFakeCgroupFileSystem();
+    const tree = await createProbeCgroupTree({
+      fileSystem,
+      currentCgroup: "0::/delegated\n",
+      markerPath: MARKER,
+      capability: "00000000-0000-0000-0000-000000000000",
+      invocationId: "11111111-1111-1111-1111-111111111111",
+    });
+    fileSystem.replaceFile(MARKER, "not-owned");
+
+    expect(await captureRejection(() => tree.remove())).toBeInstanceOf(ProbeCgroupOwnershipError);
+    expect(fileSystem.removedPaths).toEqual([]);
+  });
+
+  test("kills through the owned invocation root instead of independent leaf targets", async () => {
+    const fileSystem = createFakeCgroupFileSystem();
+    const tree = await createProbeCgroupTree({
+      fileSystem,
+      currentCgroup: "0::/delegated\n",
+      markerPath: MARKER,
+      capability: "00000000-0000-0000-0000-000000000000",
+      invocationId: "11111111-1111-1111-1111-111111111111",
+    });
+
+    await tree.kill();
+
+    expect(fileSystem.writes.filter(([target]) => target.endsWith("cgroup.kill"))).toEqual([
+      [`${tree.rootPath}/cgroup.kill`, "1\n"],
+    ]);
+  });
+
+  test("treats invocation-root members as populated and cleanup-owned", async () => {
+    const fileSystem = createFakeCgroupFileSystem();
+    const tree = await createProbeCgroupTree({
+      fileSystem,
+      currentCgroup: "0::/delegated\n",
+      markerPath: MARKER,
+      capability: "00000000-0000-0000-0000-000000000000",
+      invocationId: "11111111-1111-1111-1111-111111111111",
+    });
+    fileSystem.setMembers(tree.rootPath, "9001\n");
+
+    expect(await tree.isEmpty()).toBe(false);
+    const error = await captureRejection(() => tree.remove());
+    expect(error).toBeInstanceOf(ProbeCgroupCleanupError);
+    expect((error as ProbeCgroupCleanupError).retainedController.retainedPaths).toContain(
+      tree.rootPath,
+    );
+    expect(fileSystem.removedPaths).toEqual([]);
+  });
+
+  test.each(["workload", "root"] as const)(
+    "retains ownership evidence when %s removal fails",
+    async (failureTarget) => {
+      const fileSystem = createFakeCgroupFileSystem();
+      const tree = await createProbeCgroupTree({
+        fileSystem,
+        currentCgroup: "0::/delegated\n",
+        markerPath: MARKER,
+        capability: "00000000-0000-0000-0000-000000000000",
+        invocationId: "11111111-1111-1111-1111-111111111111",
+      });
+      fileSystem.failRemovalPath(failureTarget === "root" ? tree.rootPath : tree.workloadPath);
+
+      const error = await captureRejection(() => tree.remove());
+      expect(error).toBeInstanceOf(ProbeCgroupCleanupError);
+      const retained = (error as ProbeCgroupCleanupError).retainedController;
+      expect(retained.retainedPaths).toContain(
+        failureTarget === "root" ? tree.rootPath : tree.workloadPath,
+      );
+      expect(fileSystem.readFile(MARKER)).resolves.toBeTruthy();
+    },
+  );
+
+  test("surfaces retained ownership when partial creation cleanup fails", async () => {
+    const fileSystem = createFakeCgroupFileSystem();
+    const rootPath = `${PARENT}/quadball-timer-sqlite-11111111-1111-1111-1111-111111111111`;
+    fileSystem.failWritePath(`${rootPath}/workload/pids.max`);
+    fileSystem.failRemovalPath(rootPath);
+
+    const error = await captureRejection(() =>
+      createProbeCgroupTree({
+        fileSystem,
+        currentCgroup: "0::/delegated\n",
+        markerPath: MARKER,
+        capability: "00000000-0000-0000-0000-000000000000",
+        invocationId: "11111111-1111-1111-1111-111111111111",
+      }),
+    );
+
+    expect(error).toBeInstanceOf(ProbeCgroupCreationError);
+    expect((error as ProbeCgroupCreationError).retainedController.retainedPaths).toEqual([
+      rootPath,
+    ]);
+  });
+});
+
+type FakeCgroupFileSystem = ProbeCgroupFileSystem & {
+  createdPaths: string[];
+  removedPaths: string[];
+  writes: Array<[string, string]>;
+  swapPath(path: string): void;
+  replaceFile(path: string, value: string): void;
+  setMembers(path: string, value: string): void;
+  failRemovalPath(path: string): void;
+  failWritePath(path: string): void;
+};
+
+function createFakeCgroupFileSystem(
+  options: { collideInvocationRoot?: boolean } = {},
+): FakeCgroupFileSystem {
+  let nextInode = 10n;
+  const stats = new Map<string, ProbeCgroupStat>([[PARENT, directoryStat(1n)]]);
+  const files = new Map<string, string>([
+    [`${PARENT}/cgroup.controllers`, "memory pids\n"],
+    [`${PARENT}/cgroup.subtree_control`, "memory pids\n"],
+  ]);
+  const createdPaths: string[] = [];
+  const removedPaths: string[] = [];
+  const writes: Array<[string, string]> = [];
+  let collisionPending = options.collideInvocationRoot === true;
+  let failedRemovalPath: string | undefined;
+  let failedWritePath: string | undefined;
+
+  return {
+    createdPaths,
+    removedPaths,
+    writes,
+    async mkdir(target) {
+      if (collisionPending) {
+        collisionPending = false;
+        const error = new Error("exists") as NodeJS.ErrnoException;
+        error.code = "EEXIST";
+        throw error;
+      }
+      if (stats.has(target)) throw new Error("unexpected collision");
+      stats.set(target, directoryStat(nextInode++));
+      createdPaths.push(target);
+      files.set(`${target}/cgroup.controllers`, "memory pids\n");
+      files.set(`${target}/cgroup.subtree_control`, "memory pids\n");
+      files.set(`${target}/cgroup.procs`, "\n");
+      files.set(`${target}/pids.current`, "0\n");
+      files.set(`${target}/pids.peak`, "0\n");
+      files.set(`${target}/memory.peak`, "0\n");
+      files.set(`${target}/cgroup.kill`, "\n");
+    },
+    async lstat(target) {
+      const stat = stats.get(target);
+      if (stat === undefined) throw missing(target);
+      return stat;
+    },
+    async readFile(target) {
+      const value = files.get(target);
+      if (value === undefined) throw missing(target);
+      return value;
+    },
+    async writeFile(target, value, writeOptions) {
+      if (target === failedWritePath) throw new Error(`write failed for ${target}`);
+      if (writeOptions?.exclusive === true && files.has(target)) {
+        const error = new Error("exists") as NodeJS.ErrnoException;
+        error.code = "EEXIST";
+        throw error;
+      }
+      files.set(target, value);
+      if (target === MARKER && !stats.has(target)) stats.set(target, fileStat(nextInode++));
+      writes.push([target, value]);
+    },
+    async remove(target) {
+      if (target === failedRemovalPath) {
+        throw new Error(`remove failed for ${target}`);
+      }
+      stats.delete(target);
+      for (const key of files.keys()) {
+        if (key === target || key.startsWith(`${target}/`)) files.delete(key);
+      }
+      removedPaths.push(target);
+    },
+    swapPath(target) {
+      stats.set(target, directoryStat(nextInode++));
+    },
+    replaceFile(target, value) {
+      files.set(target, value);
+    },
+    setMembers(target, value) {
+      files.set(`${target}/cgroup.procs`, value);
+    },
+    failRemovalPath(target) {
+      failedRemovalPath = target;
+    },
+    failWritePath(target) {
+      failedWritePath = target;
+    },
+  };
+}
+
+function directoryStat(ino: bigint): ProbeCgroupStat {
+  return { dev: 1n, ino, isDirectory: true, isSymbolicLink: false };
+}
+
+function fileStat(ino: bigint): ProbeCgroupStat {
+  return { dev: 1n, ino, isDirectory: false, isSymbolicLink: false };
+}
+
+function missing(target: string): NodeJS.ErrnoException {
+  const error = new Error(`missing ${target}`) as NodeJS.ErrnoException;
+  error.code = "ENOENT";
+  return error;
+}
+
+async function captureRejection(operation: () => Promise<unknown>): Promise<unknown> {
+  try {
+    await operation();
+  } catch (error) {
+    return error;
+  }
+  throw new Error("Expected operation to reject.");
+}

--- a/src/lib/sqlite-foundation-probe-cgroup.ts
+++ b/src/lib/sqlite-foundation-probe-cgroup.ts
@@ -1,0 +1,629 @@
+import { lstat, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+const CGROUP_ROOT = "/sys/fs/cgroup";
+const CGROUP_NAME_PREFIX = "quadball-timer-sqlite-";
+const CAPABILITY_PATTERN = /^[0-9a-f-]{36}$/;
+
+export type ProbeCgroupStat = {
+  dev: bigint;
+  ino: bigint;
+  isDirectory: boolean;
+  isSymbolicLink: boolean;
+};
+
+export type ProbeCgroupFileSystem = {
+  mkdir(target: string): Promise<void>;
+  lstat(target: string): Promise<ProbeCgroupStat>;
+  readFile(target: string): Promise<string>;
+  writeFile(target: string, value: string, options?: { exclusive?: boolean }): Promise<void>;
+  remove(target: string): Promise<void>;
+};
+
+export type ProbeCgroupTree = {
+  rootPath: string;
+  helperPath: string;
+  workloadPath: string;
+  markerPath: string;
+  verify(): Promise<void>;
+  kill(): Promise<void>;
+  isEmpty(): Promise<boolean>;
+  remove(): Promise<void>;
+  readNumber(group: "helper" | "workload", fileName: string): Promise<number>;
+};
+
+export type ProbeRetainedCgroupController = {
+  rootPath: string;
+  helperPath: string;
+  workloadPath: string;
+  markerPath: string;
+  retainedPaths: string[];
+};
+
+export type CreateProbeCgroupTreeOptions = {
+  fileSystem?: ProbeCgroupFileSystem;
+  cgroupRoot?: string;
+  currentCgroup: string;
+  markerPath: string;
+  capability: string;
+  invocationId: string;
+  helperProcessLimit?: number;
+  helperMemoryLimit?: number;
+  workloadProcessLimit?: number;
+  workloadMemoryLimit?: number;
+  signal?: AbortSignal;
+};
+
+type OwnedIdentity = {
+  path: string;
+  dev: bigint;
+  ino: bigint;
+};
+
+type MarkerEvidence = {
+  schemaVersion: 1;
+  capability: string;
+  invocationId: string;
+  parentPath: string;
+  root: SerializedIdentity;
+  helper: SerializedIdentity;
+  workload: SerializedIdentity;
+};
+
+type SerializedIdentity = {
+  path: string;
+  dev: string;
+  ino: string;
+};
+
+export async function createProbeCgroupTree(
+  options: CreateProbeCgroupTreeOptions,
+): Promise<ProbeCgroupTree> {
+  const fileSystem = options.fileSystem ?? nodeProbeCgroupFileSystem;
+  const cgroupRoot = path.resolve(options.cgroupRoot ?? CGROUP_ROOT);
+  validateToken(options.capability, "cgroup capability");
+  validateToken(options.invocationId, "cgroup invocation identity");
+  throwIfAborted(options.signal);
+
+  const parentPath = resolveDelegatedParent(cgroupRoot, options.currentCgroup);
+  await validateDelegatedParent(fileSystem, cgroupRoot, parentPath);
+  const rootPath = path.join(parentPath, `${CGROUP_NAME_PREFIX}${options.invocationId}`);
+  const helperPath = path.join(rootPath, "helper");
+  const workloadPath = path.join(rootPath, "workload");
+  validateOwnedLayout(cgroupRoot, parentPath, rootPath, helperPath, workloadPath);
+
+  let rootIdentity: OwnedIdentity | undefined;
+  let helperIdentity: OwnedIdentity | undefined;
+  let workloadIdentity: OwnedIdentity | undefined;
+  let markerIdentity: OwnedIdentity | undefined;
+  let markerText: string | undefined;
+  try {
+    await createNewDirectory(fileSystem, rootPath);
+    rootIdentity = await readDirectoryIdentity(fileSystem, rootPath);
+    throwIfAborted(options.signal);
+    await fileSystem.writeFile(path.join(rootPath, "cgroup.subtree_control"), "+memory +pids\n");
+    await requireControllers(fileSystem, rootPath, "cgroup.controllers");
+    await requireControllers(fileSystem, rootPath, "cgroup.subtree_control");
+    await fileSystem.readFile(path.join(rootPath, "cgroup.kill"));
+
+    await createNewDirectory(fileSystem, helperPath);
+    helperIdentity = await readDirectoryIdentity(fileSystem, helperPath);
+    await configureLeaf(
+      fileSystem,
+      helperPath,
+      options.helperProcessLimit ?? 16,
+      options.helperMemoryLimit ?? 128 * 1024 * 1024,
+    );
+    throwIfAborted(options.signal);
+
+    await createNewDirectory(fileSystem, workloadPath);
+    workloadIdentity = await readDirectoryIdentity(fileSystem, workloadPath);
+    await configureLeaf(
+      fileSystem,
+      workloadPath,
+      options.workloadProcessLimit ?? 8,
+      options.workloadMemoryLimit ?? 512 * 1024 * 1024,
+    );
+    throwIfAborted(options.signal);
+
+    const evidence: MarkerEvidence = {
+      schemaVersion: 1,
+      capability: options.capability,
+      invocationId: options.invocationId,
+      parentPath,
+      root: serializeIdentity(rootIdentity),
+      helper: serializeIdentity(helperIdentity),
+      workload: serializeIdentity(workloadIdentity),
+    };
+    markerText = JSON.stringify(evidence);
+    await fileSystem.writeFile(options.markerPath, markerText, { exclusive: true });
+    markerIdentity = await readFileIdentity(fileSystem, options.markerPath);
+    throwIfAborted(options.signal);
+  } catch (error) {
+    const cleanup = await cleanupCreatedTree(fileSystem, {
+      markerPath: options.markerPath,
+      markerIdentity,
+      markerText,
+      workloadIdentity,
+      helperIdentity,
+      rootIdentity,
+      rootPath,
+      helperPath,
+      workloadPath,
+    });
+    if (cleanup.retainedController !== null) {
+      throw new ProbeCgroupCreationError(
+        "Owned cgroup setup failed and retained an owned controller.",
+        cleanup.retainedController,
+      );
+    }
+    if (error instanceof ProbeCgroupOwnershipError) throw error;
+    throw new ProbeCgroupOwnershipError("Owned cgroup tree could not be created safely.");
+  }
+
+  const identities = {
+    root: requireIdentity(rootIdentity),
+    helper: requireIdentity(helperIdentity),
+    workload: requireIdentity(workloadIdentity),
+    marker: requireIdentity(markerIdentity),
+  };
+  const expectedMarker = markerText ?? "";
+
+  const verify = async () => {
+    validateOwnedLayout(cgroupRoot, parentPath, rootPath, helperPath, workloadPath);
+    await verifyIdentity(fileSystem, identities.root, true);
+    await verifyIdentity(fileSystem, identities.helper, true);
+    await verifyIdentity(fileSystem, identities.workload, true);
+    await verifyIdentity(fileSystem, identities.marker, false);
+    const observedMarker = await fileSystem.readFile(options.markerPath).catch(() => null);
+    if (observedMarker !== expectedMarker) {
+      throw new ProbeCgroupOwnershipError("Owned cgroup capability evidence changed.");
+    }
+  };
+
+  return {
+    rootPath,
+    helperPath,
+    workloadPath,
+    markerPath: options.markerPath,
+    verify,
+    async kill() {
+      await verify();
+      await fileSystem.writeFile(path.join(rootPath, "cgroup.kill"), "1\n");
+    },
+    async isEmpty() {
+      await verify();
+      return await ownedTreeIsEmpty(fileSystem, rootPath, helperPath, workloadPath);
+    },
+    async remove() {
+      await verify();
+      if (!(await ownedTreeIsEmpty(fileSystem, rootPath, helperPath, workloadPath))) {
+        throw new ProbeCgroupCleanupError(
+          "Owned cgroup tree remains populated.",
+          await retainedController(fileSystem, {
+            rootPath,
+            helperPath,
+            workloadPath,
+            markerPath: options.markerPath,
+            identities,
+          }),
+        );
+      }
+      for (const identity of [identities.workload, identities.helper, identities.root]) {
+        try {
+          await removeVerified(fileSystem, identity, true);
+        } catch (error) {
+          throw new ProbeCgroupCleanupError(
+            "Owned cgroup controller removal could not be verified.",
+            await retainedController(fileSystem, {
+              rootPath,
+              helperPath,
+              workloadPath,
+              markerPath: options.markerPath,
+              identities,
+            }),
+            error,
+          );
+        }
+      }
+      try {
+        await removeVerified(fileSystem, identities.marker, false);
+      } catch (error) {
+        throw new ProbeCgroupCleanupError(
+          "Owned cgroup capability evidence removal could not be verified.",
+          await retainedController(fileSystem, {
+            rootPath,
+            helperPath,
+            workloadPath,
+            markerPath: options.markerPath,
+            identities,
+          }),
+          error,
+        );
+      }
+    },
+    async readNumber(group, fileName) {
+      await verify();
+      return await readSafeNumber(
+        fileSystem,
+        group === "helper" ? helperPath : workloadPath,
+        fileName,
+      );
+    },
+  };
+}
+
+export const nodeProbeCgroupFileSystem: ProbeCgroupFileSystem = {
+  async mkdir(target) {
+    await mkdir(target, { mode: 0o700 });
+  },
+  async lstat(target) {
+    const stat = await lstat(target, { bigint: true });
+    return {
+      dev: stat.dev,
+      ino: stat.ino,
+      isDirectory: stat.isDirectory(),
+      isSymbolicLink: stat.isSymbolicLink(),
+    };
+  },
+  async readFile(target) {
+    return await readFile(target, "utf8");
+  },
+  async writeFile(target, value, options) {
+    await writeFile(target, value, {
+      encoding: "utf8",
+      ...(options?.exclusive === true ? { flag: "wx", mode: 0o600 } : {}),
+    });
+  },
+  async remove(target) {
+    await rm(target, { recursive: false, force: false });
+  },
+};
+
+function resolveDelegatedParent(cgroupRoot: string, currentCgroup: string): string {
+  const matches = [...currentCgroup.matchAll(/^0::([^\r\n]+)$/gm)];
+  if (matches.length !== 1) {
+    throw new ProbeCgroupOwnershipError("Current cgroup delegation is ambiguous.");
+  }
+  const relativePath = matches[0]?.[1];
+  if (relativePath === undefined || relativePath === "/" || !relativePath.startsWith("/")) {
+    throw new ProbeCgroupOwnershipError("Broad cgroup roots are not valid delegated parents.");
+  }
+  const parentPath = path.resolve(cgroupRoot, `.${relativePath}`);
+  if (parentPath === cgroupRoot || !parentPath.startsWith(`${cgroupRoot}${path.sep}`)) {
+    throw new ProbeCgroupOwnershipError("Delegated cgroup parent escaped its root.");
+  }
+  return parentPath;
+}
+
+async function validateDelegatedParent(
+  fileSystem: ProbeCgroupFileSystem,
+  cgroupRoot: string,
+  parentPath: string,
+): Promise<void> {
+  if (parentPath === cgroupRoot) {
+    throw new ProbeCgroupOwnershipError("Broad cgroup roots are not valid delegated parents.");
+  }
+  await readDirectoryIdentity(fileSystem, parentPath);
+  await requireControllers(fileSystem, parentPath, "cgroup.controllers");
+  await requireControllers(fileSystem, parentPath, "cgroup.subtree_control");
+}
+
+function validateOwnedLayout(
+  cgroupRoot: string,
+  parentPath: string,
+  rootPath: string,
+  helperPath: string,
+  workloadPath: string,
+): void {
+  if (
+    parentPath === cgroupRoot ||
+    path.dirname(rootPath) !== parentPath ||
+    path.dirname(helperPath) !== rootPath ||
+    path.dirname(workloadPath) !== rootPath ||
+    rootPath === cgroupRoot ||
+    !rootPath.startsWith(`${parentPath}${path.sep}${CGROUP_NAME_PREFIX}`)
+  ) {
+    throw new ProbeCgroupOwnershipError("Owned cgroup layout is broad or ambiguous.");
+  }
+}
+
+async function configureLeaf(
+  fileSystem: ProbeCgroupFileSystem,
+  groupPath: string,
+  processLimit: number,
+  memoryLimit: number,
+): Promise<void> {
+  requirePositiveLimit(processLimit);
+  requirePositiveLimit(memoryLimit);
+  await fileSystem.writeFile(path.join(groupPath, "pids.max"), `${processLimit}\n`);
+  await fileSystem.writeFile(path.join(groupPath, "memory.max"), `${memoryLimit}\n`);
+  if (
+    (await readSafeNumber(fileSystem, groupPath, "pids.max")) !== processLimit ||
+    (await readSafeNumber(fileSystem, groupPath, "memory.max")) !== memoryLimit
+  ) {
+    throw new ProbeCgroupOwnershipError("Owned cgroup limits were not enforced.");
+  }
+  for (const fileName of ["pids.current", "pids.peak", "memory.peak"]) {
+    await readSafeNumber(fileSystem, groupPath, fileName);
+  }
+  await fileSystem.readFile(path.join(groupPath, "cgroup.kill"));
+}
+
+async function requireControllers(
+  fileSystem: ProbeCgroupFileSystem,
+  groupPath: string,
+  fileName: string,
+): Promise<void> {
+  const value = await fileSystem.readFile(path.join(groupPath, fileName)).catch(() => "");
+  const controllers = value
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((controller) => controller.replace(/^\+/, ""));
+  if (!controllers.includes("memory") || !controllers.includes("pids")) {
+    throw new ProbeCgroupOwnershipError("Required delegated cgroup controllers are unavailable.");
+  }
+}
+
+async function createNewDirectory(
+  fileSystem: ProbeCgroupFileSystem,
+  target: string,
+): Promise<void> {
+  try {
+    await fileSystem.mkdir(target);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+      throw new ProbeCgroupOwnershipError("Refusing a pre-existing cgroup target.");
+    }
+    throw error;
+  }
+}
+
+async function readDirectoryIdentity(
+  fileSystem: ProbeCgroupFileSystem,
+  target: string,
+): Promise<OwnedIdentity> {
+  const stat = await fileSystem.lstat(target).catch(() => null);
+  if (
+    stat === null ||
+    !stat.isDirectory ||
+    stat.isSymbolicLink ||
+    stat.dev <= 0n ||
+    stat.ino <= 0n
+  ) {
+    throw new ProbeCgroupOwnershipError("Cgroup target identity is invalid.");
+  }
+  return { path: target, dev: stat.dev, ino: stat.ino };
+}
+
+async function readFileIdentity(
+  fileSystem: ProbeCgroupFileSystem,
+  target: string,
+): Promise<OwnedIdentity> {
+  const stat = await fileSystem.lstat(target).catch(() => null);
+  if (
+    stat === null ||
+    stat.isDirectory ||
+    stat.isSymbolicLink ||
+    stat.dev <= 0n ||
+    stat.ino <= 0n
+  ) {
+    throw new ProbeCgroupOwnershipError("Cgroup capability marker identity is invalid.");
+  }
+  return { path: target, dev: stat.dev, ino: stat.ino };
+}
+
+async function verifyIdentity(
+  fileSystem: ProbeCgroupFileSystem,
+  identity: OwnedIdentity,
+  directory: boolean,
+): Promise<void> {
+  const stat = await fileSystem.lstat(identity.path).catch(() => null);
+  if (
+    stat === null ||
+    stat.isDirectory !== directory ||
+    stat.isSymbolicLink ||
+    stat.dev !== identity.dev ||
+    stat.ino !== identity.ino
+  ) {
+    throw new ProbeCgroupOwnershipError("Owned cgroup identity changed before mutation.");
+  }
+}
+
+async function removeVerified(
+  fileSystem: ProbeCgroupFileSystem,
+  identity: OwnedIdentity,
+  directory: boolean,
+): Promise<void> {
+  await verifyIdentity(fileSystem, identity, directory);
+  await fileSystem.remove(identity.path);
+}
+
+async function ownedTreeIsEmpty(
+  fileSystem: ProbeCgroupFileSystem,
+  rootPath: string,
+  helperPath: string,
+  workloadPath: string,
+): Promise<boolean> {
+  for (const groupPath of [rootPath, helperPath, workloadPath]) {
+    if ((await fileSystem.readFile(path.join(groupPath, "cgroup.procs"))).trim().length !== 0) {
+      return false;
+    }
+  }
+  return true;
+}
+
+async function readSafeNumber(
+  fileSystem: ProbeCgroupFileSystem,
+  groupPath: string,
+  fileName: string,
+): Promise<number> {
+  const raw = await fileSystem.readFile(path.join(groupPath, fileName)).catch(() => "");
+  const value = Number(raw.trim());
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new ProbeCgroupOwnershipError(`Unable to measure owned cgroup ${fileName}.`);
+  }
+  return value;
+}
+
+async function cleanupCreatedTree(
+  fileSystem: ProbeCgroupFileSystem,
+  created: {
+    markerPath: string;
+    markerIdentity?: OwnedIdentity;
+    markerText?: string;
+    workloadIdentity?: OwnedIdentity;
+    helperIdentity?: OwnedIdentity;
+    rootIdentity?: OwnedIdentity;
+    rootPath: string;
+    helperPath: string;
+    workloadPath: string;
+  },
+): Promise<{ retainedController: ProbeRetainedCgroupController | null }> {
+  for (const identity of [created.workloadIdentity, created.helperIdentity, created.rootIdentity]) {
+    if (identity === undefined) continue;
+    try {
+      await verifyIdentity(fileSystem, identity, true);
+      if ((await fileSystem.readFile(path.join(identity.path, "cgroup.procs"))).trim() !== "") {
+        continue;
+      }
+      await fileSystem.remove(identity.path);
+    } catch {
+      // Refuse to remove any target whose exact identity can no longer be established.
+    }
+  }
+  const retainedPaths = await existingPaths(fileSystem, [
+    created.rootPath,
+    created.helperPath,
+    created.workloadPath,
+  ]);
+  if (
+    retainedPaths.length === 0 &&
+    created.markerIdentity !== undefined &&
+    created.markerText !== undefined
+  ) {
+    try {
+      await verifyIdentity(fileSystem, created.markerIdentity, false);
+      if ((await fileSystem.readFile(created.markerPath)) === created.markerText) {
+        await fileSystem.remove(created.markerPath);
+      }
+    } catch {
+      // Refuse to remove replaced capability evidence.
+    }
+  }
+  const retainedAfterMarker = await existingPaths(fileSystem, [created.markerPath]);
+  if (retainedPaths.length === 0 && retainedAfterMarker.length === 0) {
+    return { retainedController: null };
+  }
+  return {
+    retainedController: {
+      rootPath: created.rootPath,
+      helperPath: created.helperPath,
+      workloadPath: created.workloadPath,
+      markerPath: created.markerPath,
+      retainedPaths: [...retainedPaths, ...retainedAfterMarker],
+    },
+  };
+}
+
+async function existingPaths(
+  fileSystem: ProbeCgroupFileSystem,
+  paths: string[],
+): Promise<string[]> {
+  const retained: string[] = [];
+  for (const target of paths) {
+    if (
+      await fileSystem.lstat(target).then(
+        () => true,
+        () => false,
+      )
+    )
+      retained.push(target);
+  }
+  return retained;
+}
+
+async function retainedController(
+  fileSystem: ProbeCgroupFileSystem,
+  input: {
+    rootPath: string;
+    helperPath: string;
+    workloadPath: string;
+    markerPath: string;
+    identities: {
+      root: OwnedIdentity;
+      helper: OwnedIdentity;
+      workload: OwnedIdentity;
+      marker: OwnedIdentity;
+    };
+  },
+): Promise<ProbeRetainedCgroupController> {
+  const retainedPaths = await existingPaths(fileSystem, [
+    input.rootPath,
+    input.helperPath,
+    input.workloadPath,
+    input.markerPath,
+  ]);
+  return {
+    rootPath: input.rootPath,
+    helperPath: input.helperPath,
+    workloadPath: input.workloadPath,
+    markerPath: input.markerPath,
+    retainedPaths,
+  };
+}
+
+function serializeIdentity(identity: OwnedIdentity): SerializedIdentity {
+  return { path: identity.path, dev: String(identity.dev), ino: String(identity.ino) };
+}
+
+function requireIdentity(identity: OwnedIdentity | undefined): OwnedIdentity {
+  if (identity === undefined)
+    throw new ProbeCgroupOwnershipError("Owned cgroup identity is missing.");
+  return identity;
+}
+
+function validateToken(value: string, label: string): void {
+  if (!CAPABILITY_PATTERN.test(value)) {
+    throw new ProbeCgroupOwnershipError(`Invalid ${label}.`);
+  }
+}
+
+function requirePositiveLimit(value: number): void {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new ProbeCgroupOwnershipError("Invalid cgroup resource limit.");
+  }
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) throw new ProbeCgroupOwnershipError("Cgroup setup was interrupted.");
+}
+
+export class ProbeCgroupOwnershipError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ProbeCgroupOwnershipError";
+  }
+}
+
+export class ProbeCgroupCreationError extends ProbeCgroupOwnershipError {
+  readonly retainedController: ProbeRetainedCgroupController;
+
+  constructor(message: string, retainedController: ProbeRetainedCgroupController) {
+    super(message);
+    this.name = "ProbeCgroupCreationError";
+    this.retainedController = retainedController;
+  }
+}
+
+export class ProbeCgroupCleanupError extends ProbeCgroupOwnershipError {
+  readonly retainedController: ProbeRetainedCgroupController;
+
+  constructor(message: string, retainedController: ProbeRetainedCgroupController, cause?: unknown) {
+    super(message);
+    this.name = "ProbeCgroupCleanupError";
+    this.retainedController = retainedController;
+    if (cause !== undefined) this.cause = cause;
+  }
+}

--- a/src/lib/sqlite-foundation-probe-containment.ts
+++ b/src/lib/sqlite-foundation-probe-containment.ts
@@ -1,6 +1,7 @@
 import {
   chmod,
   lstat,
+  mkdir,
   mkdtemp,
   readFile,
   readdir,
@@ -47,6 +48,7 @@ export type ProbeWorkspace = {
 
 export type ProbeWorkspaceContainer = {
   directoryPath: string;
+  workspaceDirectoryPath?: string;
   capabilityPath: string;
   capability: string;
 };
@@ -112,7 +114,7 @@ export async function createProbeWorkspace(
           configuredContainer.directoryPath,
           configuredContainer.capability,
         );
-  const parentDirectory = ownedContainer?.directoryPath;
+  const parentDirectory = ownedContainer?.workspaceDirectoryPath ?? ownedContainer?.directoryPath;
   const directoryPath = await mkdtemp(
     path.join(parentDirectory ?? tmpdir(), PROBE_DIRECTORY_PREFIX),
   );
@@ -125,22 +127,30 @@ export async function createProbeWorkspace(
     await chmod(capabilityPath, 0o600);
     return await validateOwnedProbeWorkspace(canonicalDirectoryPath, capability, "fresh");
   } catch (error) {
-    await rm(directoryPath, { recursive: true, force: true }).catch(() => undefined);
+    await removeOwnedPath(directoryPath);
     throw error;
   }
 }
 
-export async function createProbeWorkspaceContainer(): Promise<ProbeWorkspaceContainer> {
+export async function createProbeWorkspaceContainer(
+  signal?: AbortSignal,
+): Promise<ProbeWorkspaceContainer> {
+  throwIfProbeAborted(signal);
   const directoryPath = await mkdtemp(path.join(tmpdir(), PROBE_CONTAINER_DIRECTORY_PREFIX));
   try {
+    throwIfProbeAborted(signal);
     await chmod(directoryPath, 0o700);
     const capability = crypto.randomUUID();
     const capabilityPath = path.join(directoryPath, CONTAINER_CAPABILITY_FILE_NAME);
     await writeFile(capabilityPath, capability, { encoding: "utf8", flag: "wx", mode: 0o600 });
     await chmod(capabilityPath, 0o600);
+    const workspaceDirectoryPath = path.join(directoryPath, "workspace");
+    await mkdir(workspaceDirectoryPath, { mode: 0o700 });
+    await chmod(workspaceDirectoryPath, 0o700);
+    throwIfProbeAborted(signal);
     return await validateOwnedProbeWorkspaceContainer(directoryPath, capability);
   } catch (error) {
-    await rm(directoryPath, { recursive: true, force: true }).catch(() => undefined);
+    await removeOwnedPath(directoryPath);
     throw error;
   }
 }
@@ -160,20 +170,26 @@ export async function readProbeWorkspaceContainerFromEnv(): Promise<ProbeWorkspa
 export async function cleanupOwnedProbeWorkspaceContainer(
   directoryPath: string,
   capability: string,
+  signal?: AbortSignal,
 ): Promise<void> {
   const container = await validateOwnedProbeWorkspaceContainer(directoryPath, capability);
-  await rm(container.directoryPath, { recursive: true, force: true });
+  throwIfProbeAborted(signal);
+  await removeOwnedPath(container.directoryPath);
+}
+
+function throwIfProbeAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) throw new ProbeOwnershipError();
 }
 
 export function createProbeOuterEnvironment(
   container: ProbeWorkspaceContainer,
 ): Record<string, string> {
   const environment: Record<string, string> = {};
-  for (const [key, value] of Object.entries(process.env)) {
-    if (value !== undefined) {
-      environment[key] = value;
-    }
+  for (const key of ["LANG", "LC_ALL", "PATH", "TMPDIR", "TZ"]) {
+    const value = process.env[key];
+    if (value !== undefined) environment[key] = value;
   }
+  environment.NODE_ENV = "test";
   environment[SQLITE_FOUNDATION_PROBE_PARENT_DIRECTORY_ENV] = container.directoryPath;
   environment[SQLITE_FOUNDATION_PROBE_PARENT_CAPABILITY_ENV] = container.capability;
   environment[SQLITE_FOUNDATION_PROBE_SHARED_GROUP_ENV] = "1";
@@ -260,7 +276,10 @@ export async function validateOwnedProbeWorkerWorkspace(
     throw new ProbeOwnershipError();
   }
   const workspace = await validateOwnedProbeWorkspace(directoryPath, capability, state);
-  if (path.dirname(workspace.directoryPath) !== container.directoryPath) {
+  if (
+    path.dirname(workspace.directoryPath) !==
+    (container.workspaceDirectoryPath ?? container.directoryPath)
+  ) {
     throw new ProbeOwnershipError();
   }
   return workspace;
@@ -274,7 +293,7 @@ export async function cleanupOwnedProbeWorkspace(
   await rm(workspace.directoryPath, { recursive: true, force: true });
 }
 
-async function validateOwnedProbeWorkspaceContainer(
+export async function validateOwnedProbeWorkspaceContainer(
   directoryPath: string,
   capability: string,
 ): Promise<ProbeWorkspaceContainer> {
@@ -294,7 +313,22 @@ async function validateOwnedProbeWorkspaceContainer(
   if (storedCapability !== capability) {
     throw new ProbeOwnershipError();
   }
-  return { directoryPath: canonicalDirectoryPath, capabilityPath, capability };
+  const workspaceDirectoryPath = path.join(canonicalDirectoryPath, "workspace");
+  const workspaceStat = await safeLstat(workspaceDirectoryPath);
+  if (
+    workspaceStat === null ||
+    !workspaceStat.isDirectory() ||
+    workspaceStat.isSymbolicLink() ||
+    (workspaceStat.mode & 0o077) !== 0
+  ) {
+    throw new ProbeOwnershipError();
+  }
+  return {
+    directoryPath: canonicalDirectoryPath,
+    workspaceDirectoryPath,
+    capabilityPath,
+    capability,
+  };
 }
 
 async function validateProbeDirectory(directoryPath: string): Promise<string> {
@@ -323,7 +357,8 @@ async function validateProbeDirectory(directoryPath: string): Promise<string> {
     temporaryRoot === null ||
     canonicalParentPath === null ||
     (canonicalParentPath !== temporaryRoot &&
-      !(await isOwnedProbeContainerDirectory(canonicalParentPath)))
+      !(await isOwnedProbeContainerDirectory(canonicalParentPath)) &&
+      !(await isOwnedProbeContainerWorkspaceDirectory(canonicalParentPath)))
   ) {
     throw new ProbeOwnershipError();
   }
@@ -380,8 +415,45 @@ async function isOwnedProbeContainerDirectory(directoryPath: string): Promise<bo
   }
 }
 
+async function isOwnedProbeContainerWorkspaceDirectory(directoryPath: string): Promise<boolean> {
+  try {
+    const workspacePath = path.resolve(directoryPath);
+    if (path.basename(workspacePath) !== "workspace") return false;
+    const containerPath = path.dirname(workspacePath);
+    const container = await validateOwnedProbeWorkspaceContainerByDirectory(containerPath);
+    return container.workspaceDirectoryPath === workspacePath;
+  } catch {
+    return false;
+  }
+}
+
+async function validateOwnedProbeWorkspaceContainerByDirectory(
+  directoryPath: string,
+): Promise<ProbeWorkspaceContainer> {
+  const canonicalDirectoryPath = await validateProbeContainerDirectory(directoryPath);
+  const capabilityPath = path.join(canonicalDirectoryPath, CONTAINER_CAPABILITY_FILE_NAME);
+  const capability = await readFile(capabilityPath, "utf8").catch(() => null);
+  if (capability === null) throw new ProbeOwnershipError();
+  return validateOwnedProbeWorkspaceContainer(canonicalDirectoryPath, capability);
+}
+
 async function safeLstat(filePath: string) {
   return lstat(filePath).catch(() => null);
+}
+
+async function removeOwnedPath(directoryPath: string): Promise<void> {
+  try {
+    await rm(directoryPath, { recursive: true, force: true });
+  } catch {
+    throw new ProbeOwnershipError();
+  }
+  try {
+    await lstat(directoryPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+    throw new ProbeOwnershipError();
+  }
+  throw new ProbeOwnershipError();
 }
 
 function stripEntrypointArgument(rawArguments: readonly string[]): string[] {

--- a/src/lib/sqlite-foundation-probe-errors.ts
+++ b/src/lib/sqlite-foundation-probe-errors.ts
@@ -1,0 +1,38 @@
+import {
+  ProbeInterruptedError,
+  ProbeReapTimeoutError,
+  ProbeTimeoutError,
+  ProbeWorkerFailureError,
+} from "@/lib/sqlite-foundation-probe-process";
+import { ProbeNetworkBoundaryError } from "@/lib/sqlite-foundation-probe-network";
+import {
+  ProbeResourceControlError,
+  ProbeResourceLimitError,
+} from "@/lib/sqlite-foundation-probe-resources";
+
+export class SqliteFoundationGateError extends Error {
+  readonly decisionRequired = true;
+
+  constructor(message: string) {
+    super(message);
+    this.name = "SqliteFoundationGateError";
+  }
+}
+
+export function translateProbeError(error: unknown): SqliteFoundationGateError {
+  if (error instanceof SqliteFoundationGateError) return error;
+  if (
+    error instanceof ProbeTimeoutError ||
+    error instanceof ProbeInterruptedError ||
+    error instanceof ProbeReapTimeoutError ||
+    error instanceof ProbeWorkerFailureError ||
+    error instanceof ProbeNetworkBoundaryError ||
+    error instanceof ProbeResourceControlError ||
+    error instanceof ProbeResourceLimitError
+  ) {
+    return new SqliteFoundationGateError(error.message);
+  }
+  return new SqliteFoundationGateError(
+    "SQLite integrity probe could not complete. Return the database choice to a human; do not substitute a canary or custom Bun build.",
+  );
+}

--- a/src/lib/sqlite-foundation-probe-evidence.test.ts
+++ b/src/lib/sqlite-foundation-probe-evidence.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+import {
+  boundedProbeQualificationResult,
+  SQLITE_FOUNDATION_PROBE_RESULT_MAX_BYTES,
+} from "@/lib/sqlite-foundation-probe-evidence";
+import type { ProbeQualificationResult } from "@/lib/sqlite-foundation-probe-result";
+
+describe("sqlite qualification evidence", () => {
+  test("caps external commit and command strings before emission", () => {
+    const result: ProbeQualificationResult = {
+      schemaVersion: 1,
+      invocationId: "invocation",
+      phase: "final",
+      command: "x".repeat(20_000),
+      commit: "secret-and-not-a-commit".repeat(20_000),
+      platform: {
+        os: "linux",
+        arch: "x64",
+        bunVersion: "1.3.14",
+        bunRevision: "revision",
+        sqliteVersion: null,
+      },
+      startedAt: "2026-08-14T00:00:00.000Z",
+      endedAt: "2026-08-14T00:00:01.000Z",
+      durationMs: 1,
+      measuredResources: {
+        processCount: 7,
+        peakMemoryBytes: 512,
+        diskBytes: 4096,
+        outputBytes: 123,
+      },
+      outcome: "failed",
+      cleanup: {
+        descendantsTerminated: null,
+        descendantsReaped: false,
+        controllerEmpty: null,
+        controllerRemoved: false,
+        tmpfsRemoved: null,
+        workspaceRemoved: false,
+        temporaryDataRemoved: false,
+        retainedController: { state: "unknown", scope: "invocation-cgroup", resources: [] },
+        status: "failed",
+        failures: ["failure"],
+      },
+      evidence: {
+        disposition: "cleanup-failure",
+        location: null,
+        retention: "coordinator-handoff",
+      },
+      diagnostics: { references: [], stdoutBytes: 0, stderrBytes: 0 },
+    };
+    const bounded = boundedProbeQualificationResult(result);
+    expect(new TextEncoder().encode(JSON.stringify(bounded)).byteLength).toBeLessThanOrEqual(
+      SQLITE_FOUNDATION_PROBE_RESULT_MAX_BYTES,
+    );
+    expect(bounded.commit).toBe("unknown");
+    expect(bounded.measuredResources).toEqual({
+      processCount: 7,
+      peakMemoryBytes: 512,
+      diskBytes: 4096,
+      outputBytes: 123,
+    });
+    expect(JSON.stringify(bounded)).not.toContain("secret-and-not-a-commit");
+  });
+});

--- a/src/lib/sqlite-foundation-probe-evidence.ts
+++ b/src/lib/sqlite-foundation-probe-evidence.ts
@@ -1,0 +1,166 @@
+import type { ProbeRetainedCgroupController } from "@/lib/sqlite-foundation-probe-cgroup";
+import type { ProbeQualificationResult } from "@/lib/sqlite-foundation-probe-result";
+
+export const SQLITE_FOUNDATION_PROBE_RESULT_MAX_BYTES = 4 * 1024;
+
+export function capProbeEvidenceString(
+  value: unknown,
+  maximumBytes = 128,
+  fallback = "unknown",
+): string {
+  if (typeof value !== "string" || value.length === 0) return fallback;
+  let normalized = "";
+  for (const character of value) {
+    const code = character.codePointAt(0) ?? 0;
+    if (code > 0x1f && code !== 0x7f) normalized += character;
+  }
+  const bytes = new TextEncoder().encode(normalized);
+  if (bytes.byteLength <= maximumBytes) return normalized;
+  return (
+    new TextDecoder().decode(bytes.slice(0, maximumBytes)).replace(/[\uFFFD]/g, "") || fallback
+  );
+}
+
+export function capProbeEvidenceList(values: readonly unknown[], maximum = 16): string[] {
+  return values
+    .slice(0, maximum)
+    .map((value) => capProbeEvidenceString(value, 96))
+    .filter((value) => value !== "unknown");
+}
+
+export function retainedControllerEvidence(
+  controller: ProbeRetainedCgroupController | null,
+  cleanupUnknown = false,
+): ProbeQualificationResult["cleanup"]["retainedController"] {
+  if (controller === null) {
+    return {
+      state: cleanupUnknown ? "unknown" : "none",
+      scope: cleanupUnknown ? "invocation-cgroup" : null,
+      resources: [],
+    };
+  }
+  const resources: ProbeQualificationResult["cleanup"]["retainedController"]["resources"] = [];
+  for (const retainedPath of controller.retainedPaths) {
+    if (retainedPath === controller.rootPath) resources.push("root");
+    else if (retainedPath === controller.helperPath) resources.push("helper");
+    else if (retainedPath === controller.workloadPath) resources.push("workload");
+    else if (retainedPath === controller.markerPath) resources.push("capability-marker");
+  }
+  return {
+    state: "retained",
+    scope: "invocation-cgroup",
+    resources: [...new Set(resources)],
+  };
+}
+
+export function boundedProbeQualificationResult(
+  result: ProbeQualificationResult,
+): ProbeQualificationResult {
+  if (jsonByteLength(result) <= SQLITE_FOUNDATION_PROBE_RESULT_MAX_BYTES) return result;
+  const fallback: ProbeQualificationResult = {
+    schemaVersion: 1,
+    invocationId: capProbeEvidenceString(result.invocationId, 64, "unknown"),
+    phase: result.phase,
+    command: "qualification-harness",
+    commit: validCommit(result.commit),
+    platform: {
+      os: capProbeEvidenceString(result.platform.os, 16),
+      arch: capProbeEvidenceString(result.platform.arch, 16),
+      bunVersion: capProbeEvidenceString(result.platform.bunVersion, 32),
+      bunRevision: capProbeEvidenceString(result.platform.bunRevision, 64),
+      sqliteVersion: capProbeEvidenceString(result.platform.sqliteVersion, 32, "unknown"),
+    },
+    startedAt: capProbeEvidenceString(result.startedAt, 32),
+    endedAt: capProbeEvidenceString(result.endedAt, 32),
+    durationMs: Number.isSafeInteger(result.durationMs) ? result.durationMs : 0,
+    measuredResources: {
+      processCount: boundedMeasurement(result.measuredResources.processCount),
+      peakMemoryBytes: boundedMeasurement(result.measuredResources.peakMemoryBytes),
+      diskBytes: boundedMeasurement(result.measuredResources.diskBytes),
+      outputBytes: boundedMeasurement(result.measuredResources.outputBytes),
+    },
+    outcome: result.outcome,
+    cleanup: {
+      ...result.cleanup,
+      failures: ["evidence-size"],
+      temporaryDataRemoved: false,
+      status: "failed",
+    },
+    evidence: {
+      disposition: "cleanup-failure",
+      location: null,
+      retention: "coordinator-handoff",
+    },
+    diagnostics: { references: [], stdoutBytes: 0, stderrBytes: 0 },
+  };
+  if (jsonByteLength(fallback) <= SQLITE_FOUNDATION_PROBE_RESULT_MAX_BYTES) return fallback;
+  return {
+    schemaVersion: 1,
+    invocationId: "unknown",
+    phase: result.phase,
+    command: "qualification-harness",
+    commit: "unknown",
+    platform: {
+      os: "unknown",
+      arch: "unknown",
+      bunVersion: "unknown",
+      bunRevision: "unknown",
+      sqliteVersion: null,
+    },
+    startedAt: "unknown",
+    endedAt: "unknown",
+    durationMs: 0,
+    measuredResources: {
+      processCount: null,
+      peakMemoryBytes: null,
+      diskBytes: null,
+      outputBytes: null,
+    },
+    outcome: result.outcome,
+    cleanup: {
+      descendantsTerminated: null,
+      descendantsReaped: false,
+      controllerEmpty: null,
+      controllerRemoved: false,
+      tmpfsRemoved: null,
+      workspaceRemoved: false,
+      temporaryDataRemoved: false,
+      retainedController: { state: "unknown", scope: "invocation-cgroup", resources: [] },
+      status: "failed",
+      failures: ["evidence-size"],
+    },
+    evidence: { disposition: "cleanup-failure", location: null, retention: "coordinator-handoff" },
+    diagnostics: { references: [], stdoutBytes: 0, stderrBytes: 0 },
+  };
+}
+
+export function markProbeResultEmissionFailed(
+  result: ProbeQualificationResult,
+): ProbeQualificationResult {
+  return boundedProbeQualificationResult({
+    ...result,
+    outcome: result.outcome === "passed" ? "failed" : result.outcome,
+    cleanup: {
+      ...result.cleanup,
+      status: "failed",
+      failures: [...new Set([...result.cleanup.failures, "result-emission"])],
+    },
+    evidence: {
+      disposition: "cleanup-failure",
+      location: null,
+      retention: "coordinator-handoff",
+    },
+  });
+}
+
+export function jsonByteLength(value: unknown): number {
+  return new TextEncoder().encode(JSON.stringify(value)).byteLength;
+}
+
+function validCommit(value: unknown): string {
+  return typeof value === "string" && /^[0-9a-f]{7,64}$/i.test(value) ? value : "unknown";
+}
+
+function boundedMeasurement(value: number | null): number | null {
+  return value !== null && Number.isSafeInteger(value) && value >= 0 ? value : null;
+}

--- a/src/lib/sqlite-foundation-probe-focused-admission.test.ts
+++ b/src/lib/sqlite-foundation-probe-focused-admission.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import {
+  focusedAdmissionExitCode,
+  focusedAdmissionRecordByteLength,
+  runFocusedBounded,
+} from "@/lib/sqlite-foundation-probe-focused-admission";
+
+describe("focused admission evidence boundary", () => {
+  test("fails the process contract only for failed admission", () => {
+    expect(focusedAdmissionExitCode("passed")).toBe(0);
+    expect(focusedAdmissionExitCode("blocked")).toBe(0);
+    expect(focusedAdmissionExitCode("failed")).toBe(1);
+  });
+
+  test("measures the complete record in UTF-8 bytes", () => {
+    expect(focusedAdmissionRecordByteLength({ value: "😀" })).toBe(16);
+  });
+
+  test("does not wait for a never-settling cleanup operation after abort", async () => {
+    const controller = new AbortController();
+    const never = new Promise<void>(() => {});
+    const result = runFocusedBounded(never, controller.signal, "cleanup");
+    controller.abort();
+    try {
+      await result;
+      throw new Error("expected cleanup to reject");
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toContain("cleanup exceeded");
+    }
+  });
+});

--- a/src/lib/sqlite-foundation-probe-focused-admission.ts
+++ b/src/lib/sqlite-foundation-probe-focused-admission.ts
@@ -1,0 +1,28 @@
+export type FocusedAdmissionOutcome = "passed" | "failed" | "blocked";
+
+export function focusedAdmissionExitCode(outcome: FocusedAdmissionOutcome): number {
+  return outcome === "failed" ? 1 : 0;
+}
+
+export function focusedAdmissionRecordByteLength(record: unknown): number {
+  return new TextEncoder().encode(JSON.stringify(record)).byteLength;
+}
+
+export async function runFocusedBounded<T>(
+  operation: Promise<T>,
+  signal: AbortSignal,
+  label: string,
+): Promise<T> {
+  if (signal.aborted) throw new Error(`${label} exceeded the focused lifecycle deadline`);
+  let removeAbort = () => {};
+  const aborted = new Promise<never>((_, reject) => {
+    const abort = () => reject(new Error(`${label} exceeded the focused lifecycle deadline`));
+    signal.addEventListener("abort", abort, { once: true });
+    removeAbort = () => signal.removeEventListener("abort", abort);
+  });
+  try {
+    return await Promise.race([operation, aborted]);
+  } finally {
+    removeAbort();
+  }
+}

--- a/src/lib/sqlite-foundation-probe-focused-deadline.test.ts
+++ b/src/lib/sqlite-foundation-probe-focused-deadline.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import { createFocusedAdmissionDeadline } from "@/lib/sqlite-foundation-probe-focused-deadline";
+
+describe("focused admission lifecycle deadline", () => {
+  test("reserves cleanup inside one overall deadline and aborts all work at the hard stop", () => {
+    const scheduled: Array<{ callback: () => void; milliseconds: number }> = [];
+    const cleared: unknown[] = [];
+    const deadline = createFocusedAdmissionDeadline(
+      5_000,
+      2_000,
+      (callback, milliseconds) => {
+        const handle = { callback, milliseconds };
+        scheduled.push(handle);
+        return handle;
+      },
+      (handle) => cleared.push(handle),
+    );
+
+    expect(scheduled.map(({ milliseconds }) => milliseconds)).toEqual([3_000, 5_000]);
+    scheduled[0]?.callback();
+    expect(deadline.workSignal.aborted).toBe(true);
+    expect(deadline.overallSignal.aborted).toBe(false);
+    scheduled[1]?.callback();
+    expect(deadline.overallSignal.aborted).toBe(true);
+    deadline.cleanup();
+    expect(cleared).toHaveLength(2);
+  });
+});

--- a/src/lib/sqlite-foundation-probe-focused-deadline.ts
+++ b/src/lib/sqlite-foundation-probe-focused-deadline.ts
@@ -1,0 +1,39 @@
+export type FocusedAdmissionDeadline = {
+  workSignal: AbortSignal;
+  overallSignal: AbortSignal;
+  cleanup(): void;
+};
+
+export function createFocusedAdmissionDeadline(
+  totalMs: number,
+  cleanupReserveMs: number,
+  schedule: (callback: () => void, milliseconds: number) => unknown = setTimeout,
+  clear: (handle: unknown) => void = (handle) => clearTimeout(handle as NodeJS.Timeout),
+): FocusedAdmissionDeadline {
+  if (
+    !Number.isSafeInteger(totalMs) ||
+    !Number.isSafeInteger(cleanupReserveMs) ||
+    totalMs <= 0 ||
+    cleanupReserveMs <= 0 ||
+    cleanupReserveMs >= totalMs
+  ) {
+    throw new Error("Invalid focused admission deadline.");
+  }
+  const overall = new AbortController();
+  const work = new AbortController();
+  const workTimer = schedule(() => work.abort(), totalMs - cleanupReserveMs);
+  const overallTimer = schedule(() => overall.abort(), totalMs);
+  const abortWork = () => work.abort();
+  overall.signal.addEventListener("abort", abortWork, { once: true });
+  return {
+    workSignal: work.signal,
+    overallSignal: overall.signal,
+    cleanup() {
+      clear(workTimer);
+      clear(overallTimer);
+      overall.signal.removeEventListener("abort", abortWork);
+      work.abort();
+      overall.abort();
+    },
+  };
+}

--- a/src/lib/sqlite-foundation-probe-network.ts
+++ b/src/lib/sqlite-foundation-probe-network.ts
@@ -1,0 +1,75 @@
+import { readlinkSync } from "node:fs";
+
+export type ProbeNetworkBoundary = {
+  commandPrefix?: readonly string[];
+  namespace: string;
+  unshare?: string;
+  shell?: string;
+  verified: true;
+};
+
+export type ProbeNetworkBoundaryOptions = {
+  platform?: NodeJS.Platform;
+  which?: (command: string) => string | undefined;
+  parentNamespace?: () => string | null;
+  signal?: AbortSignal;
+  timeoutMs?: number;
+};
+
+export async function createProbeNetworkBoundary(
+  options: ProbeNetworkBoundaryOptions = {},
+): Promise<ProbeNetworkBoundary> {
+  if (options.signal?.aborted) {
+    throw new ProbeNetworkBoundaryError("Linux no-network boundary admission was interrupted.");
+  }
+  const platform = options.platform ?? process.platform;
+  if (platform !== "linux") {
+    throw new ProbeNetworkBoundaryError(
+      "SQLite runtime qualification requires Linux network namespaces.",
+    );
+  }
+
+  const which = options.which ?? ((command: string) => Bun.which(command) ?? undefined);
+  const unshare = which("unshare");
+  const shell = which("sh");
+  const parentNamespace = (options.parentNamespace ?? readParentNetworkNamespace)();
+  if (unshare === undefined || shell === undefined || parentNamespace === null) {
+    throw new ProbeNetworkBoundaryError("Linux no-network boundary controls are unavailable.");
+  }
+  if (options.signal?.aborted) {
+    throw new ProbeNetworkBoundaryError("Linux no-network boundary admission was interrupted.");
+  }
+
+  return {
+    namespace: parentNamespace,
+    unshare,
+    shell,
+    verified: true,
+  };
+}
+
+export function buildNoNetworkProbeCommand(
+  boundary: ProbeNetworkBoundary,
+  executablePath: string,
+  arguments_: readonly string[],
+): string[] {
+  if (boundary.verified !== true || boundary.namespace.length === 0) {
+    throw new ProbeNetworkBoundaryError("Verified no-network boundary is required before launch.");
+  }
+  return [executablePath, ...arguments_];
+}
+
+function readParentNetworkNamespace(): string | null {
+  try {
+    return readlinkSync("/proc/self/ns/net");
+  } catch {
+    return null;
+  }
+}
+
+export class ProbeNetworkBoundaryError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ProbeNetworkBoundaryError";
+  }
+}

--- a/src/lib/sqlite-foundation-probe-process.ts
+++ b/src/lib/sqlite-foundation-probe-process.ts
@@ -1,10 +1,14 @@
 import path from "node:path";
+import type { ProbeResourceMeasurement } from "@/lib/sqlite-foundation-probe-result";
+import { createProbeReadiness } from "@/lib/sqlite-foundation-probe-readiness";
 
 export const SQLITE_FOUNDATION_PROBE_TIMEOUT_MS = 15_000;
 export const SQLITE_FOUNDATION_PROBE_INNER_TIMEOUT_MS = 5_000;
 export const SQLITE_FOUNDATION_PROBE_TERMINATION_GRACE_MS = 250;
 export const SQLITE_FOUNDATION_PROBE_REAP_TIMEOUT_MS = 1_000;
+export const SQLITE_FOUNDATION_PROBE_CLEANUP_RESERVE_MS = 5_000;
 export const SQLITE_FOUNDATION_PROBE_MAX_OUTPUT_BYTES = 4 * 1024;
+export const SQLITE_FOUNDATION_PROBE_MAX_PROCESS_COUNT = 7;
 export const SQLITE_FOUNDATION_PROBE_SHARED_GROUP_ENV = "QUADBALL_TIMER_SQLITE_PROBE_SHARED_GROUP";
 
 export type ProbeProcess = {
@@ -26,12 +30,24 @@ export type ProbeWorkerResult = {
   exitCode: number;
   stdout: string;
   stderr: string;
+  stdoutBytes: number;
+  stderrBytes: number;
   outputExceeded: boolean;
+  observedOutputBytes?: number;
+};
+
+export type ProbeOutputBudget = {
+  readonly maximumBytes: number;
+  readonly consumedBytes: number;
+  readonly observedBytes: number;
+  readonly exceeded: boolean;
+  consume(bytes: number): number;
 };
 
 export type ProbeWorkerHandle = {
   process: ProbeProcess;
   result: Promise<ProbeWorkerResult>;
+  ready?: Promise<boolean>;
 };
 
 type ProbeTimerHandle = number | NodeJS.Timeout;
@@ -45,13 +61,49 @@ export type ProbeSupervisionOptions = {
   clearTimeout?: (handle: ProbeTimerHandle) => void;
   sleep?: (milliseconds: number) => Promise<void>;
   signalProcessGroup?: (pid: number, signal: NodeJS.Signals) => boolean;
+  killWorkloadTree?: () => Promise<void>;
+  resourceCheck?: () => Promise<void>;
+  resourcePollMs?: number;
 };
 
 export type ProbeSpawnOptions = {
   detached?: boolean;
   env?: Record<string, string>;
   processGroupId?: number;
+  outputBudget?: ProbeOutputBudget;
+  readyMarker?: string;
 };
+
+export function createProbeOutputBudget(
+  maximumBytes = SQLITE_FOUNDATION_PROBE_MAX_OUTPUT_BYTES,
+): ProbeOutputBudget {
+  let consumedBytes = 0;
+  let observedBytes = 0;
+  let exceeded = false;
+  return {
+    maximumBytes,
+    get consumedBytes() {
+      return consumedBytes;
+    },
+    get observedBytes() {
+      return observedBytes;
+    },
+    get exceeded() {
+      return exceeded;
+    },
+    consume(bytes) {
+      if (!Number.isSafeInteger(bytes) || bytes < 0) {
+        exceeded = true;
+        return 0;
+      }
+      observedBytes += bytes;
+      const remaining = Math.max(0, maximumBytes - consumedBytes);
+      consumedBytes = Math.min(maximumBytes, consumedBytes + bytes);
+      if (bytes > remaining) exceeded = true;
+      return Math.min(bytes, remaining);
+    },
+  };
+}
 
 export function capDiagnosticOutput(
   value: string,
@@ -78,6 +130,7 @@ export async function terminateProbeWorkers(
     | "scheduleTimeout"
     | "clearTimeout"
     | "signalProcessGroup"
+    | "killWorkloadTree"
   > = {},
 ): Promise<void> {
   const signalProcessGroup = options.signalProcessGroup ?? signalProbeProcessGroup;
@@ -87,12 +140,15 @@ export async function terminateProbeWorkers(
   const reapTimeoutMs = options.reapTimeoutMs ?? SQLITE_FOUNDATION_PROBE_REAP_TIMEOUT_MS;
 
   signalWorkers(workers, "SIGTERM", signalProcessGroup);
-
   const allExited = Promise.allSettled(workers.map((worker) => worker.process.exited)).then(
     () => true,
   );
   const exitedBeforeGrace = await waitForPromise(allExited, terminationGraceMs, sleep);
   if (!exitedBeforeGrace) {
+    const killWorkloadTree = options.killWorkloadTree;
+    if (killWorkloadTree !== undefined) {
+      await killWorkloadTree();
+    }
     signalWorkers(workers, "SIGKILL", signalProcessGroup);
     const reapedAfterKill = await waitForPromise(allExited, reapTimeoutMs, sleep);
     if (!reapedAfterKill) {
@@ -108,6 +164,9 @@ export async function superviseProbeWorkers(
   if (workers.length === 0) {
     return [];
   }
+  if (workers.length > SQLITE_FOUNDATION_PROBE_MAX_PROCESS_COUNT) {
+    throw new ProbeResourceLimitError("process count");
+  }
 
   const scheduleTimeout = options.scheduleTimeout ?? setTimeout;
   const clearTimeout = options.clearTimeout ?? globalThis.clearTimeout;
@@ -121,6 +180,25 @@ export async function superviseProbeWorkers(
   const completion = new Promise<ProbeWorkerResult[]>((resolve, reject) => {
     resolveCompletion = resolve;
     rejectCompletion = reject;
+  });
+
+  let resourceTimer: ProbeTimerHandle | undefined;
+  let resourceCheckStopped = false;
+  const resourceFailure = new Promise<never>((_, reject) => {
+    const poll = () => {
+      if (resourceCheckStopped || options.resourceCheck === undefined) return;
+      void options.resourceCheck().then(
+        () => {
+          if (!resourceCheckStopped) {
+            resourceTimer = scheduleTimeout(poll, options.resourcePollMs ?? 25);
+          }
+        },
+        (error) => reject(error),
+      );
+    };
+    if (options.resourceCheck !== undefined) {
+      resourceTimer = scheduleTimeout(poll, options.resourcePollMs ?? 25);
+    }
   });
 
   workers.forEach((worker, index) => {
@@ -164,7 +242,7 @@ export async function superviseProbeWorkers(
   let operationError: unknown;
   let operationFailed = false;
   try {
-    operationResult = await Promise.race([completion, timeout, interruption]);
+    operationResult = await Promise.race([completion, timeout, interruption, resourceFailure]);
   } catch (error) {
     operationFailed = true;
     operationError = error;
@@ -173,6 +251,8 @@ export async function superviseProbeWorkers(
   if (timeoutHandle !== undefined) {
     clearTimeout(timeoutHandle);
   }
+  resourceCheckStopped = true;
+  if (resourceTimer !== undefined) clearTimeout(resourceTimer);
   removeAbortListener();
 
   let terminationError: unknown;
@@ -205,10 +285,12 @@ export function spawnProbeWorker(
   executablePath: string,
   workerFlag: "--sqlite-foundation-probe-writer" | "--sqlite-foundation-probe-checkpoint",
   arguments_: string[],
+  options: ProbeSpawnOptions = {},
 ): ProbeWorkerHandle {
   const command = buildProbeWorkerCommand(executablePath, workerFlag, arguments_);
   const shareProcessGroup = process.env[SQLITE_FOUNDATION_PROBE_SHARED_GROUP_ENV] === "1";
   return spawnProbeCommand(command, {
+    ...options,
     detached: !shareProcessGroup,
     processGroupId: shareProcessGroup ? process.pid : undefined,
   });
@@ -259,9 +341,11 @@ export function spawnProbeCommand(
     stdout: child.stdout,
     stderr: child.stderr,
   };
+  const readiness = createProbeReadiness(options.readyMarker);
   return {
     process: processHandle,
-    result: collectProbeWorkerResult(processHandle),
+    result: collectProbeWorkerResult(processHandle, options, readiness.observe, readiness.finish),
+    ready: readiness.ready,
   };
 }
 
@@ -299,7 +383,12 @@ export function readSingleValueFromWorker(output: string, key: string): string |
   }
 }
 
-async function collectProbeWorkerResult(child: SpawnedProbeProcess): Promise<ProbeWorkerResult> {
+async function collectProbeWorkerResult(
+  child: SpawnedProbeProcess,
+  options: ProbeSpawnOptions,
+  observeOutput: (bytes: Uint8Array) => void,
+  finishReadiness: () => void,
+): Promise<ProbeWorkerResult> {
   let outputExceeded = false;
   const markOutputExceeded = () => {
     if (outputExceeded) {
@@ -309,22 +398,33 @@ async function collectProbeWorkerResult(child: SpawnedProbeProcess): Promise<Pro
     signalProbeProcess(child, "SIGTERM");
   };
   const [stdout, stderr] = await Promise.all([
-    readCappedStream(child.stdout, markOutputExceeded),
-    readCappedStream(child.stderr, markOutputExceeded),
+    readCappedStream(child.stdout, markOutputExceeded, options.outputBudget, observeOutput),
+    readCappedStream(child.stderr, markOutputExceeded, options.outputBudget, observeOutput),
   ]);
+  finishReadiness();
   const exitCode = await child.exited;
   return {
     exitCode,
     stdout: stdout.text,
     stderr: stderr.text,
-    outputExceeded: outputExceeded || stdout.truncated || stderr.truncated,
+    stdoutBytes: stdout.byteLength,
+    stderrBytes: stderr.byteLength,
+    outputExceeded:
+      outputExceeded ||
+      stdout.truncated ||
+      stderr.truncated ||
+      options.outputBudget?.exceeded === true,
+    observedOutputBytes:
+      options.outputBudget?.observedBytes ?? stdout.byteLength + stderr.byteLength,
   };
 }
 
 async function readCappedStream(
   stream: ReadableStream<Uint8Array<ArrayBuffer>>,
   onExceeded: () => void,
-): Promise<{ text: string; truncated: boolean }> {
+  outputBudget?: ProbeOutputBudget,
+  observeOutput?: (bytes: Uint8Array) => void,
+): Promise<{ text: string; truncated: boolean; byteLength: number }> {
   const reader = stream.getReader();
   const chunks: Uint8Array[] = [];
   let byteLength = 0;
@@ -335,14 +435,22 @@ async function readCappedStream(
       if (done) {
         break;
       }
-      const remaining = SQLITE_FOUNDATION_PROBE_MAX_OUTPUT_BYTES - byteLength;
+      observeOutput?.(value);
+      const budgetRemaining = outputBudget
+        ? outputBudget.maximumBytes - outputBudget.consumedBytes
+        : SQLITE_FOUNDATION_PROBE_MAX_OUTPUT_BYTES - byteLength;
+      const acceptedBytes = outputBudget?.consume(value.byteLength) ?? value.byteLength;
+      const remaining = Math.min(
+        SQLITE_FOUNDATION_PROBE_MAX_OUTPUT_BYTES - byteLength,
+        budgetRemaining,
+      );
       if (remaining <= 0) {
         truncated = true;
         onExceeded();
         await reader.cancel();
         break;
       }
-      if (value.byteLength > remaining) {
+      if (value.byteLength > remaining || acceptedBytes < value.byteLength) {
         chunks.push(value.slice(0, remaining));
         byteLength += remaining;
         truncated = true;
@@ -369,6 +477,7 @@ async function readCappedStream(
   return {
     text: new TextDecoder().decode(combined),
     truncated,
+    byteLength,
   };
 }
 
@@ -523,6 +632,8 @@ export class ProbeReapTimeoutError extends Error {
 }
 
 export class ProbeWorkerFailureError extends Error {
+  readonly result: ProbeWorkerResult | undefined;
+
   constructor(index: number, result?: ProbeWorkerResult) {
     const diagnostics = result === undefined ? "" : ` ${formatProbeWorkerDiagnostics(result)}`;
     super(
@@ -531,6 +642,17 @@ export class ProbeWorkerFailureError extends Error {
         : `SQLite integrity probe worker ${index} exited unsuccessfully.${diagnostics}`,
     );
     this.name = "ProbeWorkerFailureError";
+    this.result = result;
+  }
+}
+
+export class ProbeResourceLimitError extends Error {
+  readonly measurement: ProbeResourceMeasurement | null;
+
+  constructor(resource: string, measurement: ProbeResourceMeasurement | null = null) {
+    super(`SQLite integrity probe exceeded its ${resource} limit.`);
+    this.name = "ProbeResourceLimitError";
+    this.measurement = measurement;
   }
 }
 

--- a/src/lib/sqlite-foundation-probe-readiness.ts
+++ b/src/lib/sqlite-foundation-probe-readiness.ts
@@ -1,0 +1,33 @@
+export type ProbeReadiness = {
+  ready: Promise<boolean>;
+  observe: (bytes: Uint8Array) => void;
+  finish: () => void;
+};
+
+export function createProbeReadiness(marker: string | undefined): ProbeReadiness {
+  if (marker === undefined) {
+    return { ready: Promise.resolve(true), observe: () => {}, finish: () => {} };
+  }
+  let resolved = false;
+  let resolveReady: (value: boolean) => void = () => {};
+  const ready = new Promise<boolean>((resolve) => {
+    resolveReady = resolve;
+  });
+  let text = "";
+  const decoder = new TextDecoder();
+  const observe = (bytes: Uint8Array) => {
+    if (resolved) return;
+    text += decoder.decode(bytes, { stream: true });
+    if (text.includes(marker)) {
+      resolved = true;
+      resolveReady(true);
+    }
+  };
+  const finish = () => {
+    if (!resolved) {
+      resolved = true;
+      resolveReady(false);
+    }
+  };
+  return { ready, observe, finish };
+}

--- a/src/lib/sqlite-foundation-probe-resources.ts
+++ b/src/lib/sqlite-foundation-probe-resources.ts
@@ -1,0 +1,541 @@
+import { readFile, readdir } from "node:fs/promises";
+import { readlinkSync } from "node:fs";
+import path from "node:path";
+import type { ProbeNetworkBoundary } from "@/lib/sqlite-foundation-probe-network";
+import {
+  createProbeCgroupTree,
+  ProbeCgroupCleanupError,
+  ProbeCgroupCreationError,
+  type ProbeCgroupFileSystem,
+  type ProbeRetainedCgroupController,
+  type ProbeCgroupTree,
+} from "@/lib/sqlite-foundation-probe-cgroup";
+import {
+  validateOwnedProbeWorkspaceContainer,
+  type ProbeWorkspaceContainer,
+} from "@/lib/sqlite-foundation-probe-containment";
+import {
+  SQLITE_FOUNDATION_PROBE_MAX_OUTPUT_BYTES,
+  SQLITE_FOUNDATION_PROBE_REAP_TIMEOUT_MS,
+  SQLITE_FOUNDATION_PROBE_TERMINATION_GRACE_MS,
+} from "@/lib/sqlite-foundation-probe-process";
+import {
+  isProbeResourceMeasurementWithinLimits,
+  SQLITE_FOUNDATION_PROBE_MAX_DISK_BYTES,
+  SQLITE_FOUNDATION_PROBE_MAX_MEMORY_BYTES,
+  SQLITE_FOUNDATION_PROBE_MAX_PROCESS_COUNT,
+  type ProbeResourceMeasurement,
+} from "@/lib/sqlite-foundation-probe-result";
+
+export type ProbeResourceController = {
+  prepare: (command: readonly string[]) => Promise<ProbePreparedLaunch>;
+  attach: (rootPid: number) => Promise<void>;
+  kill: () => Promise<void>;
+  reap: (signal?: AbortSignal) => Promise<void>;
+  isEmpty?: () => Promise<boolean>;
+  sample: (
+    rootPid: number,
+    directoryPath: string,
+    outputBytes: number,
+    stdout?: string,
+    stderr?: string,
+  ) => Promise<ProbeResourceMeasurement>;
+  close: (signal?: AbortSignal) => Promise<void>;
+};
+
+export type ProbePreparedLaunch = {
+  command: readonly string[];
+  release: (rootPid?: number) => Promise<void>;
+};
+
+export type ProbeResourceControllerOptions = {
+  platform?: NodeJS.Platform;
+  which?: (command: string) => string | undefined;
+  sleep?: (milliseconds: number) => Promise<void>;
+  signal?: AbortSignal;
+  parentMountNamespace?: () => string | null;
+  networkBoundary?: ProbeNetworkBoundary;
+  container?: ProbeWorkspaceContainer;
+  invocationId?: string;
+  currentCgroup?: string;
+  cgroupFileSystem?: ProbeCgroupFileSystem;
+};
+
+const SQLITE_FOUNDATION_PROBE_CGROUP_MAX_PROCESS_COUNT =
+  SQLITE_FOUNDATION_PROBE_MAX_PROCESS_COUNT + 1;
+const SQLITE_FOUNDATION_PROBE_HELPER_PROCESS_LIMIT = 16;
+
+export type ProbePrivateMountCommandOptions = {
+  unshare: string;
+  shell: string;
+  mount: string;
+  stat: string;
+  umount: string;
+  du: string;
+  awk: string;
+  findmnt: string;
+  parentMountNamespace: string;
+  parentNetworkNamespace: string;
+  helperCgroupProcessesPath: string;
+  workloadCgroupProcessesPath: string;
+  workspacePath: string;
+  command: readonly string[];
+};
+
+export async function createProbeResourceController(
+  directoryPath: string,
+  options: ProbeResourceControllerOptions = {},
+): Promise<ProbeResourceController> {
+  throwIfProbeAborted(options.signal);
+  const platform = options.platform ?? process.platform;
+  if (platform !== "linux") {
+    throw new ProbeResourceControlError("OS-enforced Linux resource controls are unavailable.");
+  }
+
+  const container = options.container;
+  if (container === undefined || options.invocationId === undefined) {
+    throw new ProbeResourceControlError("An owned invocation container is required.");
+  }
+  const ownedContainer = await validateOwnedProbeWorkspaceContainer(
+    container.directoryPath,
+    container.capability,
+  ).catch(() => {
+    throw new ProbeResourceControlError("The invocation container capability is invalid.");
+  });
+  const currentCgroup =
+    options.currentCgroup ?? (await readFile("/proc/self/cgroup", "utf8").catch(() => null));
+  if (currentCgroup === null) {
+    throw new ProbeResourceControlError("The current cgroup delegation could not be identified.");
+  }
+  const cgroups = await createProbeCgroupTree({
+    fileSystem: options.cgroupFileSystem,
+    currentCgroup,
+    markerPath: path.join(ownedContainer.directoryPath, ".probe-cgroup-capability"),
+    capability: ownedContainer.capability,
+    invocationId: options.invocationId,
+    helperProcessLimit: SQLITE_FOUNDATION_PROBE_HELPER_PROCESS_LIMIT,
+    helperMemoryLimit: 128 * 1024 * 1024,
+    workloadProcessLimit: SQLITE_FOUNDATION_PROBE_CGROUP_MAX_PROCESS_COUNT,
+    workloadMemoryLimit: SQLITE_FOUNDATION_PROBE_MAX_MEMORY_BYTES,
+    signal: options.signal,
+  }).catch((error) => {
+    throw new ProbeResourceControlError(
+      "Required owned cgroup controls could not be enabled.",
+      readRetainedController(error),
+    );
+  });
+  let diskTools: ProbePrivateMountTools;
+  try {
+    diskTools = createProbeDiskBoundary(directoryPath, options);
+  } catch (error) {
+    try {
+      await cgroups.remove();
+    } catch (cleanupError) {
+      throw new ProbeResourceControlError(
+        "Resource-controller setup failed and its cgroup cleanup could not be verified.",
+        readRetainedController(cleanupError),
+      );
+    }
+    throw error;
+  }
+  const shell = (options.which ?? ((command) => Bun.which(command) ?? undefined))("sh");
+  if (shell === undefined) {
+    await removeCgroupsOrThrow(cgroups);
+    throw new ProbeResourceControlError("A workload start barrier shell is unavailable.");
+  }
+  const networkBoundary = options.networkBoundary;
+  if (networkBoundary === undefined) {
+    await removeCgroupsOrThrow(cgroups);
+    throw new ProbeResourceControlError("A verified network boundary is required.");
+  }
+  throwIfProbeAborted(options.signal);
+  const sleep = options.sleep ?? Bun.sleep;
+  const parentMountNamespace = (options.parentMountNamespace ?? readParentMountNamespace)();
+  if (parentMountNamespace === null) {
+    await removeCgroupsOrThrow(cgroups);
+    throw new ProbeResourceControlError("The caller mount namespace could not be verified.");
+  }
+  let lastProcessCount: number | null = null;
+  let lastDiskBytes: number | null = null;
+  return {
+    prepare: async (command) => {
+      throwIfProbeAborted(options.signal);
+      const barrierCommand = buildProbePrivateMountCommand({
+        ...diskTools,
+        shell,
+        parentNetworkNamespace: networkBoundary.namespace,
+        helperCgroupProcessesPath: path.join(cgroups.helperPath, "cgroup.procs"),
+        workloadCgroupProcessesPath: path.join(cgroups.workloadPath, "cgroup.procs"),
+        workspacePath: directoryPath,
+        command,
+      });
+      return {
+        command: barrierCommand,
+        release: async (rootPid) => {
+          throwIfProbeAborted(options.signal);
+          if (rootPid === undefined || process.platform === "win32") {
+            throw new ProbeResourceControlError("The workload release signal is unavailable.");
+          }
+          try {
+            process.kill(rootPid, "SIGUSR1");
+          } catch {
+            throw new ProbeResourceControlError("The workload release signal could not be sent.");
+          }
+        },
+      };
+    },
+    attach: async (rootPid) => {
+      throwIfProbeAborted(options.signal);
+      await cgroups.verify();
+      const helperMembers = await readFile(path.join(cgroups.helperPath, "cgroup.procs"), "utf8");
+      const workloadMembers = await readFile(
+        path.join(cgroups.workloadPath, "cgroup.procs"),
+        "utf8",
+      );
+      const processLimit = await cgroups.readNumber("workload", "pids.max");
+      const memoryLimit = await cgroups.readNumber("workload", "memory.max");
+      if (
+        !helperMembers.split(/\s+/).includes(String(rootPid)) ||
+        workloadMembers.trim().length === 0 ||
+        processLimit !== SQLITE_FOUNDATION_PROBE_CGROUP_MAX_PROCESS_COUNT ||
+        memoryLimit !== SQLITE_FOUNDATION_PROBE_MAX_MEMORY_BYTES
+      ) {
+        throw new ProbeResourceControlError(
+          "Workload readiness did not establish the expected cgroup boundaries.",
+        );
+      }
+    },
+    kill: async () => {
+      await forceKillCgroups(cgroups, sleep);
+    },
+    reap: async (signal) => {
+      throwIfProbeAborted(signal);
+      await cgroups.verify();
+      const membersPaths = cgroupMemberPaths(cgroups);
+      await signalProbeCgroupMembers(membersPaths, "SIGTERM", undefined, undefined, signal);
+      const graceDeadline = Date.now() + SQLITE_FOUNDATION_PROBE_TERMINATION_GRACE_MS;
+      while (Date.now() < graceDeadline) {
+        throwIfProbeAborted(signal);
+        if (await cgroupsAreEmpty(membersPaths, signal)) {
+          await cgroups.verify();
+          return;
+        }
+        await sleep(10);
+      }
+      await forceKillCgroups(cgroups, sleep, signal);
+    },
+    isEmpty: async () => await cgroups.isEmpty(),
+    sample: async (_rootPid, _directoryPath, outputBytes, stdout = "", stderr = "") => {
+      throwIfProbeAborted(options.signal);
+      const currentProcesses = await cgroups.readNumber("workload", "pids.current");
+      const peakProcesses = await cgroups.readNumber("workload", "pids.peak");
+      lastProcessCount = Math.max(0, peakProcesses - 1);
+      const controlOutput = `${stdout}\n${stderr}`;
+      const diskMatch = /(?:^|\n)DISK_BYTES=(\d+)(?:\n|$)/.exec(controlOutput);
+      if (diskMatch?.[1] !== undefined) lastDiskBytes = Number(diskMatch[1]);
+      const measurement = {
+        processCount: lastProcessCount,
+        peakMemoryBytes: await cgroups.readNumber("workload", "memory.peak"),
+        diskBytes: lastDiskBytes,
+        outputBytes,
+      } satisfies ProbeResourceMeasurement;
+      const processMemoryAndOutputWithinLimits =
+        measurement.processCount !== null &&
+        measurement.peakMemoryBytes !== null &&
+        measurement.outputBytes !== null &&
+        measurement.processCount <= SQLITE_FOUNDATION_PROBE_MAX_PROCESS_COUNT &&
+        measurement.peakMemoryBytes <= SQLITE_FOUNDATION_PROBE_MAX_MEMORY_BYTES &&
+        measurement.outputBytes <= SQLITE_FOUNDATION_PROBE_MAX_OUTPUT_BYTES;
+      if (currentProcesses > SQLITE_FOUNDATION_PROBE_CGROUP_MAX_PROCESS_COUNT) {
+        throw new ProbeResourceLimitError(measurement);
+      }
+      if (!processMemoryAndOutputWithinLimits) {
+        throw new ProbeResourceLimitError(measurement);
+      }
+      if (lastDiskBytes !== null && !isProbeResourceMeasurementWithinLimits(measurement)) {
+        throw new ProbeResourceLimitError(measurement);
+      }
+      return measurement;
+    },
+    close: async (signal) => {
+      throwIfProbeAborted(signal);
+      if (!(await cgroups.isEmpty())) {
+        throw new ProbeResourceControlError("Workload cgroup remains populated during cleanup.");
+      }
+      throwIfProbeAborted(signal);
+      try {
+        await cgroups.remove();
+      } catch (error) {
+        throw new ProbeResourceControlError(
+          "Workload cgroup removal could not be verified.",
+          readRetainedController(error),
+        );
+      }
+    },
+  };
+}
+
+async function forceKillCgroups(
+  cgroups: ProbeCgroupTree,
+  sleep: (milliseconds: number) => Promise<void>,
+  signal?: AbortSignal,
+): Promise<void> {
+  throwIfProbeAborted(signal);
+  await cgroups.kill();
+  const deadline = Date.now() + SQLITE_FOUNDATION_PROBE_REAP_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    throwIfProbeAborted(signal);
+    if (await cgroups.isEmpty()) return;
+    await sleep(10);
+  }
+  throw new ProbeResourceControlError("Workload cgroup descendants were not reaped.");
+}
+
+function cgroupMemberPaths(cgroups: ProbeCgroupTree): string[] {
+  return [
+    path.join(cgroups.rootPath, "cgroup.procs"),
+    path.join(cgroups.workloadPath, "cgroup.procs"),
+    path.join(cgroups.helperPath, "cgroup.procs"),
+  ];
+}
+
+export async function signalProbeCgroupMembers(
+  membersPaths: readonly string[],
+  signal: NodeJS.Signals,
+  readMembers: (path: string) => Promise<string> = (path) => readFile(path, "utf8"),
+  signalMember: (pid: number, signal: NodeJS.Signals) => void = (pid, memberSignal) =>
+    process.kill(pid, memberSignal),
+  abortSignal?: AbortSignal,
+): Promise<void> {
+  for (const membersPath of membersPaths) {
+    throwIfProbeAborted(abortSignal);
+    const members = await readMembers(membersPath);
+    for (const pid of members
+      .split(/\s+/)
+      .map(Number)
+      .filter((value) => Number.isSafeInteger(value) && value > 0)) {
+      throwIfProbeAborted(abortSignal);
+      try {
+        signalMember(pid, signal);
+      } catch {
+        // The process may have exited between membership observation and signaling.
+      }
+    }
+  }
+}
+
+async function cgroupsAreEmpty(
+  membersPaths: readonly string[],
+  signal?: AbortSignal,
+): Promise<boolean> {
+  for (const membersPath of membersPaths) {
+    throwIfProbeAborted(signal);
+    if ((await readFile(membersPath, "utf8")).trim().length !== 0) return false;
+  }
+  return true;
+}
+
+async function removeCgroupsOrThrow(cgroups: ProbeCgroupTree): Promise<void> {
+  try {
+    await cgroups.remove();
+  } catch (error) {
+    const retainedController = readRetainedController(error);
+    throw new ProbeResourceControlError(
+      "Owned cgroup cleanup could not be verified during admission.",
+      retainedController,
+    );
+  }
+}
+
+type ProbePrivateMountTools = Omit<
+  ProbePrivateMountCommandOptions,
+  | "shell"
+  | "command"
+  | "parentNetworkNamespace"
+  | "helperCgroupProcessesPath"
+  | "workloadCgroupProcessesPath"
+  | "workspacePath"
+>;
+
+export function createProbeDiskBoundary(
+  directoryPath: string,
+  options: ProbeResourceControllerOptions,
+): ProbePrivateMountTools {
+  throwIfProbeAborted(options.signal);
+  const which = options.which ?? ((command: string) => Bun.which(command) ?? undefined);
+  const unshare = which("unshare");
+  const mount = which("mount");
+  const stat = which("stat");
+  const umount = which("umount");
+  const du = which("du");
+  const awk = which("awk");
+  const findmnt = which("findmnt");
+  if (
+    unshare === undefined ||
+    mount === undefined ||
+    stat === undefined ||
+    umount === undefined ||
+    du === undefined ||
+    awk === undefined ||
+    findmnt === undefined
+  ) {
+    throw new ProbeResourceControlError("OS-enforced temporary-disk controls are unavailable.");
+  }
+  const parentMountNamespace = (options.parentMountNamespace ?? readParentMountNamespace)();
+  if (parentMountNamespace === null) {
+    throw new ProbeResourceControlError("The caller mount namespace could not be verified.");
+  }
+  throwIfProbeAborted(options.signal);
+  void directoryPath;
+  return {
+    unshare,
+    mount,
+    stat,
+    umount,
+    du,
+    awk,
+    findmnt,
+    parentMountNamespace,
+  };
+}
+
+function readParentMountNamespace(): string | null {
+  try {
+    return readlinkSync("/proc/self/ns/mnt");
+  } catch {
+    return null;
+  }
+}
+
+export function buildProbePrivateMountCommand(options: ProbePrivateMountCommandOptions): string[] {
+  const script = [
+    "set -eu; umask 077",
+    "helper_cgroup_processes=$1; workload_cgroup_processes=$2; parent_mount_namespace=$3; parent_network_namespace=$4; workspace_path=$5; shift 5",
+    'printf "%s\\n" "$$" > "$helper_cgroup_processes"',
+    `"${options.mount}" --make-rprivate /`,
+    `for target in $("${options.findmnt}" -rn -o TARGET); do case "$target" in /sys/fs/cgroup|/sys/fs/cgroup/*) continue;; esac; if "${options.mount}" --bind "$target" "$target" 2>/dev/null; then "${options.mount}" -o remount,bind,ro "$target"; fi; mount_options=$("${options.findmnt}" -rn -o OPTIONS --target "$target" 2>/dev/null || true); test -n "$mount_options"; case ",$mount_options," in *,ro,*) :;; *) exit 125;; esac; case ",$mount_options," in *,rw,*) exit 125;; esac; done`,
+    `root_options=$("${options.findmnt}" -rn -o OPTIONS --target / 2>/dev/null || true); test -n "$root_options"; case ",$root_options," in *,ro,*) :;; *) exit 125;; esac; case ",$root_options," in *,rw,*) exit 125;; esac`,
+    `"${options.mount}" -t tmpfs -o size=${SQLITE_FOUNDATION_PROBE_MAX_DISK_BYTES},mode=700 tmpfs "$workspace_path"`,
+    `capacity=$("${options.stat}" -f -c "%S %b" "$workspace_path" | "${options.awk}" '{print $1 * $2}'); test "$capacity" -le ${SQLITE_FOUNDATION_PROBE_MAX_DISK_BYTES}`,
+    'test "$(readlink /proc/self/ns/mnt)" != "$parent_mount_namespace"',
+    'test "$(readlink /proc/self/ns/net)" != "$parent_network_namespace"',
+    `test -z "$("${options.awk}" 'NR > 2 && $1 !~ /^[[:space:]]*lo[[:space:]]*:/ { print }' /proc/net/dev)"`,
+    `test -z "$("${options.awk}" 'NR > 1 && NF > 0 { print }' /proc/net/route)"`,
+    `test -z "$("${options.awk}" 'NF > 0 { print }' /proc/net/ipv6_route)"`,
+    'mkdir -m 700 "$workspace_path/tmp"; cd "$workspace_path"; export TMPDIR="$workspace_path/tmp"',
+    `release=0; attached=0; workload_pid=; trap 'release=1; if [ -n "$workload_pid" ]; then kill -USR1 "$workload_pid" 2>/dev/null || true; fi' USR1; trap 'attached=1' USR2`,
+    `"${options.shell}" -eu -c 'workload_cgroup=$1; parent_pid=$2; shift 2; release=0; printf "%s\\n" "$$" > "$workload_cgroup"; trap "release=1" USR1; kill -USR2 "$parent_pid"; while [ "$release" -eq 0 ]; do sleep 0.01; done; exec "$@"' probe-workload "$workload_cgroup_processes" "$$" "$@" & workload_pid=$!`,
+    'while [ "$attached" -eq 0 ]; do kill -0 "$workload_pid" 2>/dev/null || exit 125; sleep 0.01; done',
+    `"${options.mount}" --bind /sys/fs/cgroup /sys/fs/cgroup; "${options.mount}" -o remount,bind,ro "/sys/fs/cgroup"`,
+    `cgroup_options=$("${options.findmnt}" -rn -o OPTIONS --target /sys/fs/cgroup 2>/dev/null || true); test -n "$cgroup_options"; case ",$cgroup_options," in *,ro,*) :;; *) exit 125;; esac; case ",$cgroup_options," in *,rw,*) exit 125;; esac`,
+    'printf "READY\\n" >&2',
+    'while kill -0 "$workload_pid" 2>/dev/null; do usage_line=$("' +
+      options.du +
+      '" -sb "$workspace_path" 2>/dev/null || true); set -- $usage_line; if [ -n "${1:-}" ] && [ "$1" -gt ' +
+      SQLITE_FOUNDATION_PROBE_MAX_DISK_BYTES +
+      ' ]; then kill -TERM "$workload_pid" 2>/dev/null || true; fi; sleep 0.01; done',
+    'set +e; wait "$workload_pid"; status=$?; set -e',
+    `usage_line=$("${options.du}" -sb "$workspace_path" 2>/dev/null || true); set -- $usage_line; printf "DISK_BYTES=%s\\n" "\${1:-0}" >&2`,
+    "cd /; unset TMPDIR",
+    'tmpfs_removed=0; if "' +
+      options.umount +
+      '" "$workspace_path"; then tmpfs_removed=1; else status=125; fi',
+    'printf "TMPFS_REMOVED=%s\\n" "$tmpfs_removed" >&2',
+    'exit "$status"',
+  ].join("; ");
+  return [
+    options.unshare,
+    "--user",
+    "--map-root-user",
+    "--mount",
+    "--net",
+    "--propagation",
+    "private",
+    "--",
+    options.shell,
+    "-eu",
+    "-c",
+    script,
+    "probe-private-mount",
+    options.helperCgroupProcessesPath,
+    options.workloadCgroupProcessesPath,
+    options.parentMountNamespace,
+    options.parentNetworkNamespace,
+    options.workspacePath,
+    ...options.command,
+  ];
+}
+
+export function readProbeTmpfsDisposition(output: string): boolean | null {
+  if (typeof output !== "string" || new TextEncoder().encode(output).byteLength > 16 * 1024) {
+    return null;
+  }
+  const lines = output.split(/\r?\n/).filter((line) => line.startsWith("TMPFS_REMOVED="));
+  if (lines.length !== 1 || !/^TMPFS_REMOVED=[01]$/.test(lines[0] ?? "")) return null;
+  return lines[0] === "TMPFS_REMOVED=1";
+}
+
+export async function countProbeDescendants(rootPid: number): Promise<number> {
+  if (process.platform !== "linux") {
+    throw new ProbeResourceControlError("Process-tree measurement requires Linux /proc.");
+  }
+  const entries = await readdir("/proc");
+  const parentByPid = new Map<number, number>();
+  await Promise.all(
+    entries
+      .filter((entry) => /^\d+$/.test(entry))
+      .map(async (entry) => {
+        const statLine = await readFile(`/proc/${entry}/stat`, "utf8").catch(() => null);
+        if (statLine === null) return;
+        const closingName = statLine.lastIndexOf(")");
+        const fields = statLine.slice(closingName + 2).split(" ");
+        const parentPid = Number(fields[1]);
+        if (Number.isSafeInteger(parentPid)) parentByPid.set(Number(entry), parentPid);
+      }),
+  );
+
+  const descendants = new Set<number>();
+  let frontier = [rootPid];
+  while (frontier.length > 0) {
+    const children = [...parentByPid.entries()]
+      .filter(([pid, parentPid]) => frontier.includes(parentPid) && !descendants.has(pid))
+      .map(([pid]) => pid);
+    for (const child of children) descendants.add(child);
+    frontier = children;
+  }
+  return descendants.size;
+}
+
+function throwIfProbeAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) {
+    throw new ProbeResourceControlError("SQLite resource-controller setup was interrupted.");
+  }
+}
+
+export class ProbeResourceControlError extends Error {
+  readonly retainedController: ProbeRetainedCgroupController | null;
+
+  constructor(message: string, retainedController: ProbeRetainedCgroupController | null = null) {
+    super(message);
+    this.name = "ProbeResourceControlError";
+    this.retainedController = retainedController;
+  }
+}
+
+export class ProbeResourceLimitError extends Error {
+  readonly measurement: ProbeResourceMeasurement;
+
+  constructor(measurement: ProbeResourceMeasurement) {
+    super("SQLite integrity probe exceeded an enforced process, memory, disk, or output limit.");
+    this.name = "ProbeResourceLimitError";
+    this.measurement = measurement;
+  }
+}
+
+function readRetainedController(error: unknown): ProbeRetainedCgroupController | null {
+  if (error instanceof ProbeCgroupCreationError || error instanceof ProbeCgroupCleanupError) {
+    return error.retainedController;
+  }
+  if (error instanceof ProbeResourceControlError) return error.retainedController;
+  return null;
+}

--- a/src/lib/sqlite-foundation-probe-result.ts
+++ b/src/lib/sqlite-foundation-probe-result.ts
@@ -1,0 +1,82 @@
+import {
+  SQLITE_FOUNDATION_PROBE_MAX_OUTPUT_BYTES,
+  SQLITE_FOUNDATION_PROBE_MAX_PROCESS_COUNT,
+} from "@/lib/sqlite-foundation-probe-process";
+
+export { SQLITE_FOUNDATION_PROBE_MAX_PROCESS_COUNT } from "@/lib/sqlite-foundation-probe-process";
+
+export const SQLITE_FOUNDATION_PROBE_COMMAND = "bun run check:sqlite-runtime [compiled-executable]";
+export const SQLITE_FOUNDATION_PROBE_MAX_MEMORY_BYTES = 512 * 1024 * 1024;
+export const SQLITE_FOUNDATION_PROBE_MAX_DISK_BYTES = 16 * 1024 * 1024;
+
+export type ProbeOutcome = "passed" | "failed" | "timed-out" | "interrupted";
+
+export type ProbeRetainedControllerEvidence = {
+  state: "none" | "retained" | "unknown";
+  scope: "invocation-cgroup" | null;
+  resources: Array<"root" | "helper" | "workload" | "capability-marker">;
+};
+
+export type ProbeResourceMeasurement = {
+  processCount: number | null;
+  peakMemoryBytes: number | null;
+  diskBytes: number | null;
+  outputBytes: number | null;
+};
+
+export type ProbeQualificationResult = {
+  schemaVersion: 1;
+  invocationId: string;
+  phase: "pre-cleanup" | "final";
+  command: string;
+  commit: string;
+  platform: {
+    os: string;
+    arch: string;
+    bunVersion: string;
+    bunRevision: string;
+    sqliteVersion: string | null;
+  };
+  startedAt: string;
+  endedAt: string;
+  durationMs: number;
+  measuredResources: ProbeResourceMeasurement;
+  outcome: ProbeOutcome;
+  cleanup: {
+    descendantsTerminated: boolean | null;
+    descendantsReaped: boolean;
+    controllerEmpty: boolean | null;
+    controllerRemoved: boolean | null;
+    tmpfsRemoved: boolean | null;
+    workspaceRemoved: boolean | null;
+    temporaryDataRemoved: boolean;
+    retainedController: ProbeRetainedControllerEvidence;
+    status: "pending" | "verified" | "failed";
+    failures: string[];
+  };
+  evidence: {
+    disposition: "transient-cleanup" | "retained-owned-state" | "cleanup-failure";
+    location: null;
+    retention: "none" | "coordinator-handoff";
+  };
+  diagnostics: {
+    references: string[];
+    stdoutBytes: number;
+    stderrBytes: number;
+  };
+};
+
+export function isProbeResourceMeasurementWithinLimits(
+  resources: ProbeResourceMeasurement,
+): boolean {
+  return (
+    resources.processCount !== null &&
+    resources.peakMemoryBytes !== null &&
+    resources.diskBytes !== null &&
+    resources.outputBytes !== null &&
+    resources.processCount <= SQLITE_FOUNDATION_PROBE_MAX_PROCESS_COUNT &&
+    resources.peakMemoryBytes <= SQLITE_FOUNDATION_PROBE_MAX_MEMORY_BYTES &&
+    resources.diskBytes <= SQLITE_FOUNDATION_PROBE_MAX_DISK_BYTES &&
+    resources.outputBytes <= SQLITE_FOUNDATION_PROBE_MAX_OUTPUT_BYTES
+  );
+}

--- a/src/lib/sqlite-foundation-probe-runner-evidence.ts
+++ b/src/lib/sqlite-foundation-probe-runner-evidence.ts
@@ -1,0 +1,286 @@
+import {
+  SQLITE_FOUNDATION_PROBE_COMMAND,
+  type ProbeOutcome,
+  type ProbeQualificationResult,
+  type ProbeResourceMeasurement,
+} from "@/lib/sqlite-foundation-probe-result";
+import {
+  boundedProbeQualificationResult,
+  capProbeEvidenceString,
+  retainedControllerEvidence,
+} from "@/lib/sqlite-foundation-probe-evidence";
+import {
+  ProbeInterruptedError,
+  ProbeTimeoutError,
+  type ProbeWorkerResult,
+} from "@/lib/sqlite-foundation-probe-process";
+import type { SqliteFoundationGateError } from "@/lib/sqlite-foundation-probe-errors";
+import type { ProbeRetainedCgroupController } from "@/lib/sqlite-foundation-probe-cgroup";
+
+export type QualificationResultInput = {
+  phase: "pre-cleanup" | "final";
+  invocationId: string;
+  command: string | undefined;
+  commit: string | ((signal?: AbortSignal) => string | Promise<string>) | undefined;
+  spawnCommit?: (signal?: AbortSignal) => ProbeCommitChild;
+  startedAtMs: number;
+  now: () => number;
+  measuredResources: ProbeResourceMeasurement;
+  result: ProbeWorkerResult | undefined;
+  terminalError: unknown;
+  probeError: SqliteFoundationGateError | undefined;
+  descendantsReaped: boolean;
+  descendantsTerminated: boolean | null;
+  controllerEmpty: boolean | null;
+  controllerRemoved: boolean | null;
+  tmpfsRemoved: boolean | null;
+  workspaceRemoved: boolean | null;
+  cleanupFailures: string[];
+  temporaryDataRemoved: boolean;
+  cleanupStatus: "pending" | "verified" | "failed";
+  retainedController: ProbeRetainedCgroupController | null;
+  retainedControllerUnverified?: boolean;
+  signal: AbortSignal;
+};
+
+export type ProbeCommitChild = {
+  stdout: ReadableStream<Uint8Array>;
+  exited: Promise<number>;
+  kill: (signal: NodeJS.Signals) => void;
+};
+
+export class ProbeCommitCleanupError extends Error {
+  constructor() {
+    super("The Git commit helper did not confirm bounded termination and reap.");
+    this.name = "ProbeCommitCleanupError";
+  }
+}
+
+export async function buildQualificationResult(
+  input: QualificationResultInput,
+): Promise<ProbeQualificationResult> {
+  try {
+    return boundedProbeQualificationResult(
+      createQualificationResult(
+        input,
+        await resolveProbeCommit(input.commit, input.signal, input.spawnCommit),
+      ),
+    );
+  } catch (error) {
+    if (!(error instanceof ProbeCommitCleanupError)) throw error;
+    return boundedProbeQualificationResult(
+      createQualificationResult(
+        {
+          ...input,
+          cleanupFailures: [...input.cleanupFailures, "commit-helper-reap-unverified"],
+          cleanupStatus: "failed",
+          descendantsTerminated: null,
+          descendantsReaped: false,
+          retainedControllerUnverified: false,
+        },
+        "unknown",
+      ),
+    );
+  }
+}
+
+export function buildFallbackQualificationResult(
+  input: QualificationResultInput,
+): ProbeQualificationResult {
+  return boundedProbeQualificationResult(createQualificationResult(input, "unknown"));
+}
+
+function createQualificationResult(
+  input: QualificationResultInput,
+  commit: string,
+): ProbeQualificationResult {
+  const controllerEvidence = retainedControllerEvidence(
+    input.retainedController,
+    input.retainedControllerUnverified ??
+      (input.cleanupStatus === "failed" && input.retainedController === null),
+  );
+  const cleanupFailure = input.cleanupStatus === "failed" || input.cleanupFailures.length > 0;
+  return {
+    schemaVersion: 1,
+    invocationId: capProbeEvidenceString(input.invocationId, 64),
+    phase: input.phase,
+    command: capProbeEvidenceString(input.command, 192, SQLITE_FOUNDATION_PROBE_COMMAND),
+    commit: capProbeEvidenceString(commit, 64),
+    platform: {
+      os: capProbeEvidenceString(process.platform, 16),
+      arch: capProbeEvidenceString(process.arch, 16),
+      bunVersion: capProbeEvidenceString(Bun.version, 32),
+      bunRevision: capProbeEvidenceString(Bun.revision, 64),
+      sqliteVersion: readRuntimeField(input.result?.stdout ?? "", "sqliteVersion"),
+    },
+    startedAt: new Date(input.startedAtMs).toISOString(),
+    endedAt: new Date(input.now()).toISOString(),
+    durationMs: Math.max(0, input.now() - input.startedAtMs),
+    measuredResources: input.measuredResources,
+    outcome: getOutcome(input.terminalError, input.probeError, input.cleanupFailures),
+    cleanup: {
+      descendantsTerminated: input.descendantsTerminated,
+      descendantsReaped: input.descendantsReaped,
+      controllerEmpty: input.controllerEmpty,
+      controllerRemoved: input.controllerRemoved,
+      tmpfsRemoved: input.tmpfsRemoved,
+      workspaceRemoved: input.workspaceRemoved,
+      temporaryDataRemoved: input.phase === "final" && input.temporaryDataRemoved,
+      retainedController: controllerEvidence,
+      status: input.cleanupStatus,
+      failures: [...new Set(input.cleanupFailures)].slice(0, 16),
+    },
+    evidence: {
+      disposition:
+        controllerEvidence.state === "retained"
+          ? "retained-owned-state"
+          : cleanupFailure
+            ? "cleanup-failure"
+            : "transient-cleanup",
+      location: null,
+      retention:
+        controllerEvidence.state === "retained" || cleanupFailure ? "coordinator-handoff" : "none",
+    },
+    diagnostics: {
+      references:
+        input.result === undefined ? [] : ["outer-process.stdout", "outer-process.stderr"],
+      stdoutBytes: boundedNumber(input.result?.stdoutBytes ?? 0),
+      stderrBytes: boundedNumber(input.result?.stderrBytes ?? 0),
+    },
+  };
+}
+
+function getOutcome(
+  error: unknown,
+  probeError: SqliteFoundationGateError | undefined,
+  cleanupFailures: readonly string[],
+): ProbeOutcome {
+  if (error instanceof ProbeTimeoutError) return "timed-out";
+  if (error instanceof ProbeInterruptedError) return "interrupted";
+  if (cleanupFailures.includes("commit-helper-reap-unverified")) return "failed";
+  return probeError === undefined ? "passed" : "failed";
+}
+
+export async function resolveProbeCommit(
+  commit: string | ((signal?: AbortSignal) => string | Promise<string>) | undefined,
+  signal: AbortSignal,
+  spawnCommit?: (signal?: AbortSignal) => ProbeCommitChild,
+): Promise<string> {
+  if (typeof commit === "string") return validCommit(commit);
+  if (commit !== undefined) {
+    try {
+      return validCommit(
+        await raceWithAbort(
+          Promise.resolve().then(() => commit(signal)),
+          signal,
+        ),
+      );
+    } catch {
+      return "unknown";
+    }
+  }
+  const configured = process.env.GIT_COMMIT;
+  if (configured !== undefined && configured.length > 0) {
+    return /^[0-9a-f]{7,64}$/i.test(configured) ? configured : "unknown";
+  }
+  try {
+    const child =
+      spawnCommit?.(signal) ??
+      (() => {
+        const process = Bun.spawn(["git", "rev-parse", "HEAD"], {
+          maxBuffer: 256,
+          stdout: "pipe",
+          stderr: "ignore",
+        });
+        return {
+          stdout: process.stdout,
+          exited: process.exited,
+          kill: (killSignal: NodeJS.Signals) => process.kill(killSignal),
+        } satisfies ProbeCommitChild;
+      })();
+    const output = new Response(child.stdout).text();
+    const revision = await raceCommitChild(child, output, signal);
+    if (revision[0] === 0 && /^[0-9a-f]{7,64}$/i.test(revision[1].trim()))
+      return revision[1].trim();
+  } catch (error) {
+    if (error instanceof ProbeCommitCleanupError) throw error;
+    // A copied production artifact may not have Git metadata.
+  }
+  return "unknown";
+}
+
+function validCommit(value: unknown): string {
+  return typeof value === "string" && /^[0-9a-f]{7,64}$/i.test(value) ? value : "unknown";
+}
+
+async function raceWithAbort<T>(operation: Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) throw new ProbeTimeoutError(1);
+  let remove = () => {};
+  const aborted = new Promise<never>((_, reject) => {
+    const onAbort = () => reject(new ProbeTimeoutError(1));
+    signal.addEventListener("abort", onAbort, { once: true });
+    remove = () => signal.removeEventListener("abort", onAbort);
+  });
+  try {
+    return await Promise.race([operation, aborted]);
+  } finally {
+    remove();
+  }
+}
+
+async function raceCommitChild(
+  child: ProbeCommitChild,
+  output: Promise<string>,
+  signal: AbortSignal,
+): Promise<[number, string]> {
+  const operation = Promise.all([child.exited, output]);
+  if (signal.aborted) {
+    await terminateCommitChild(child);
+    throw new ProbeTimeoutError(1);
+  }
+  let remove = () => {};
+  const aborted = new Promise<never>((_, reject) => {
+    const onAbort = () => {
+      void terminateCommitChild(child).then(
+        () => reject(new ProbeTimeoutError(1)),
+        (error) => reject(error),
+      );
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    remove = () => signal.removeEventListener("abort", onAbort);
+  });
+  try {
+    return await Promise.race([operation, aborted]);
+  } finally {
+    remove();
+  }
+}
+
+async function terminateCommitChild(child: ProbeCommitChild): Promise<void> {
+  try {
+    child.kill("SIGKILL");
+  } catch {
+    // The child may have exited concurrently.
+  }
+  const observedExit = await Promise.race([
+    child.exited.then(
+      () => true,
+      () => false,
+    ),
+    Bun.sleep(100).then(() => false),
+  ]);
+  if (!observedExit) throw new ProbeCommitCleanupError();
+}
+
+function readRuntimeField(output: string, key: string): string | null {
+  try {
+    const value = (JSON.parse(output.trim()) as Record<string, unknown>)[key];
+    return typeof value === "string" ? capProbeEvidenceString(value, 64) : null;
+  } catch {
+    return null;
+  }
+}
+
+function boundedNumber(value: number): number {
+  return Number.isSafeInteger(value) && value >= 0 ? value : 0;
+}

--- a/src/lib/sqlite-foundation-probe-runner.test.ts
+++ b/src/lib/sqlite-foundation-probe-runner.test.ts
@@ -1,0 +1,946 @@
+import { describe, expect, test } from "bun:test";
+import {
+  runCompiledSqliteFoundationProbe,
+  type ProbeProcess,
+  type ProbeQualificationResult,
+  type ProbeWorkerHandle,
+  type ProbeWorkerResult,
+  type ProbeWorkspaceContainer,
+} from "@/lib/sqlite-foundation-probe";
+import {
+  buildQualificationResult,
+  resolveProbeCommit,
+  type ProbeCommitChild,
+} from "@/lib/sqlite-foundation-probe-runner-evidence";
+import type { ProbeNetworkBoundary } from "@/lib/sqlite-foundation-probe-network";
+import { createProbeOutputBudget, spawnProbeCommand } from "@/lib/sqlite-foundation-probe-process";
+import {
+  ProbeResourceLimitError,
+  type ProbeResourceController,
+} from "@/lib/sqlite-foundation-probe-resources";
+
+const CAPABILITY = "00000000-0000-0000-0000-000000000000";
+
+describe("sqlite-foundation-probe runner", () => {
+  test("bounds nested wrapper cleanup for success, failure, timeout, and interruption", async () => {
+    const cases = [
+      { label: "success", outcome: "success" as const, expectedSignals: [] },
+      { label: "failure", outcome: "failure" as const, expectedSignals: ["701:SIGTERM"] },
+      {
+        label: "timeout",
+        outcome: "timeout" as const,
+        expectedSignals: ["701:SIGTERM", "701:SIGKILL"],
+      },
+    ];
+
+    for (const testCase of cases) {
+      const nested = createNestedProbe(testCase.outcome);
+
+      let workspaceRemoved = false;
+      const signals: string[] = [];
+      const emittedResults: Array<{
+        phase: "pre-cleanup" | "final";
+        outcome: string;
+        cleanup: { temporaryDataRemoved: boolean };
+        platform: { sqliteVersion: string | null };
+      }> = [];
+      const networkBoundary: ProbeNetworkBoundary = {
+        commandPrefix: ["unshare", "--net", "--"],
+        namespace: "net:[fake]",
+        verified: true,
+      };
+      const resourceController: ProbeResourceController = {
+        prepare: async (command) => ({ command, release: async () => {} }),
+        attach: async () => {},
+        kill: async () => {},
+        reap: async () => {},
+        sample: async () => ({
+          processCount: 7,
+          peakMemoryBytes: 512 * 1024 * 1024,
+          diskBytes: 0,
+          outputBytes: 0,
+        }),
+        close: async () => {},
+      };
+      const options = {
+        timeoutMs: 15_000,
+        scheduleTimeout: (callback: () => void) => {
+          if (testCase.outcome === "timeout") callback();
+          return 0;
+        },
+        clearTimeout: () => {},
+        sleep: async () => {},
+        signalProcessGroup: (pid: number, signal: NodeJS.Signals) => {
+          signals.push(`${pid}:${signal}`);
+          nested.terminateGroup(signal);
+          return true;
+        },
+        createWorkspaceContainer: async () => nested.container,
+        networkBoundary,
+        resourceController,
+        cleanupWorkspaceContainer: async () => {
+          expect(emittedResults).toHaveLength(1);
+          workspaceRemoved = true;
+        },
+        spawnOuter: () => nested.outer,
+        emitResult: (result: ProbeQualificationResult) => {
+          expect(workspaceRemoved).toBe(result.phase === "final");
+          emittedResults.push(result);
+        },
+      };
+
+      const operation = () => runCompiledSqliteFoundationProbe("compiled-probe", options);
+      if (testCase.outcome === "success") await operation();
+      else await captureRejection(operation);
+
+      expect(signals, `${testCase.label} TERM/KILL order`).toEqual(testCase.expectedSignals);
+      expect(nested.outer.process.exitCode, `${testCase.label} outer reaped`).not.toBeNull();
+      expect(nested.childReaped, `${testCase.label} descendants reaped`).toBe(true);
+      expect(workspaceRemoved, `${testCase.label} workspace removed`).toBe(true);
+      expect(emittedResults[0]?.outcome, `${testCase.label} result`).toBe(
+        testCase.outcome === "success"
+          ? "passed"
+          : testCase.outcome === "timeout"
+            ? "timed-out"
+            : "failed",
+      );
+      expect(emittedResults[0]?.cleanup.temporaryDataRemoved).toBe(false);
+      expect(emittedResults[1]?.cleanup.temporaryDataRemoved).toBe(true);
+      if (testCase.outcome === "success") {
+        expect(emittedResults[1]?.platform.sqliteVersion).toBe("3.53.0");
+      }
+    }
+  });
+
+  test("retains a final cleanup failure instead of claiming temporary data was removed", async () => {
+    const nested = createNestedProbe("success");
+    const resourceController: ProbeResourceController = {
+      prepare: async (command) => ({ command, release: async () => {} }),
+      attach: async () => {},
+      kill: async () => {},
+      reap: async () => {},
+      sample: async () => ({
+        processCount: 7,
+        peakMemoryBytes: 512 * 1024 * 1024,
+        diskBytes: 0,
+        outputBytes: 0,
+      }),
+      close: async () => {},
+    };
+    const results: ProbeQualificationResult[] = [];
+
+    await captureRejection(() =>
+      runCompiledSqliteFoundationProbe("compiled-probe", {
+        networkBoundary: {
+          commandPrefix: ["unshare", "--net", "--"],
+          namespace: "net:[fake]",
+          verified: true,
+        },
+        resourceController,
+        createWorkspaceContainer: async () => nested.container,
+        spawnOuter: () => nested.outer,
+        cleanupWorkspaceContainer: async () => {
+          throw new Error("cleanup unavailable");
+        },
+        emitResult: (result) => {
+          results.push(result);
+        },
+        emitResultFallback: (result) => {
+          results.push(result);
+        },
+      }),
+    );
+
+    expect(results).toHaveLength(2);
+    expect(results[0]?.invocationId).toBe(results[1]?.invocationId);
+    expect(results[0]?.cleanup).toEqual({
+      descendantsTerminated: true,
+      descendantsReaped: true,
+      controllerEmpty: true,
+      controllerRemoved: null,
+      tmpfsRemoved: true,
+      workspaceRemoved: null,
+      temporaryDataRemoved: false,
+      retainedController: { state: "none", scope: null, resources: [] },
+      status: "pending",
+      failures: [],
+    });
+    expect(results[1]?.cleanup).toEqual({
+      descendantsTerminated: true,
+      descendantsReaped: true,
+      controllerEmpty: true,
+      controllerRemoved: true,
+      tmpfsRemoved: true,
+      workspaceRemoved: false,
+      temporaryDataRemoved: false,
+      retainedController: { state: "unknown", scope: "invocation-cgroup", resources: [] },
+      status: "failed",
+      failures: ["workspace-removal"],
+    });
+  });
+
+  test("does not infer tree cleanup from an outer exit when cgroup reaping fails", async () => {
+    const nested = createNestedProbe("success");
+    const results: ProbeQualificationResult[] = [];
+    let workspaceCleanupCalls = 0;
+
+    await captureRejection(() =>
+      runCompiledSqliteFoundationProbe("compiled-probe", {
+        networkBoundary: {
+          commandPrefix: ["unshare", "--net", "--"],
+          namespace: "net:[fake]",
+          verified: true,
+        },
+        resourceController: {
+          prepare: async (command) => ({ command, release: async () => {} }),
+          attach: async () => {},
+          kill: async () => {},
+          reap: async () => {
+            throw new Error("cgroup membership unavailable");
+          },
+          sample: async () => ({
+            processCount: 7,
+            peakMemoryBytes: 512 * 1024 * 1024,
+            diskBytes: 0,
+            outputBytes: 0,
+          }),
+          close: async () => {},
+        },
+        createWorkspaceContainer: async () => nested.container,
+        cleanupWorkspaceContainer: async () => {
+          workspaceCleanupCalls += 1;
+        },
+        spawnOuter: () => nested.outer,
+        emitResult: (result) => {
+          results.push(result);
+        },
+      }),
+    );
+
+    expect(workspaceCleanupCalls).toBe(0);
+    expect(results[0]?.cleanup.descendantsReaped).toBe(false);
+    expect(results[1]?.cleanup.descendantsReaped).toBe(false);
+    expect(results[1]?.cleanup).toMatchObject({
+      descendantsTerminated: false,
+      controllerEmpty: false,
+      controllerRemoved: null,
+      tmpfsRemoved: true,
+      workspaceRemoved: null,
+      failures: ["descendant-termination-or-reap", "controller-empty"],
+    });
+    expect(results[1]?.cleanup.temporaryDataRemoved).toBe(false);
+    expect(results[1]?.cleanup.status).toBe("failed");
+  });
+
+  test("retains a partial controller and blocks generic workspace cleanup", async () => {
+    const results: ProbeQualificationResult[] = [];
+    let workspaceCleanupCalls = 0;
+    const retainedController = {
+      rootPath: "/sys/fs/cgroup/delegated/quadball-timer-sqlite-root",
+      helperPath: "/sys/fs/cgroup/delegated/quadball-timer-sqlite-root/helper",
+      workloadPath: "/sys/fs/cgroup/delegated/quadball-timer-sqlite-root/workload",
+      markerPath: "/tmp/container/.probe-cgroup-capability",
+      retainedPaths: ["/sys/fs/cgroup/delegated/quadball-timer-sqlite-root"],
+    };
+
+    await captureRejection(() =>
+      runCompiledSqliteFoundationProbe("compiled-probe", {
+        networkBoundary: {
+          commandPrefix: ["unshare", "--net", "--"],
+          namespace: "net:[fake]",
+          verified: true,
+        },
+        createWorkspaceContainer: async () => createNestedProbe("success").container,
+        createResourceController: async () => {
+          const error = new Error("controller setup retained a cgroup") as Error & {
+            retainedController: typeof retainedController;
+          };
+          error.retainedController = retainedController;
+          throw error;
+        },
+        cleanupWorkspaceContainer: async () => {
+          workspaceCleanupCalls += 1;
+        },
+        emitResult: (result) => {
+          results.push(result);
+        },
+      }),
+    );
+
+    expect(workspaceCleanupCalls).toBe(0);
+    expect(results).toHaveLength(2);
+    expect(results[1]?.cleanup).toMatchObject({
+      descendantsReaped: false,
+      controllerEmpty: false,
+      controllerRemoved: false,
+      workspaceRemoved: null,
+      temporaryDataRemoved: false,
+      status: "failed",
+      failures: ["retained-controller"],
+    });
+    expect(results[1]?.cleanup.retainedController).toEqual({
+      state: "retained",
+      scope: "invocation-cgroup",
+      resources: ["root"],
+    });
+    expect(results[1]?.evidence).toEqual({
+      disposition: "retained-owned-state",
+      location: null,
+      retention: "coordinator-handoff",
+    });
+    expect(JSON.stringify(results[1])).not.toContain("/sys/fs/cgroup");
+  });
+
+  test("uses the installed signal scope to interrupt setup, reap descendants, and retain cleanup", async () => {
+    const nested = createNestedProbe("timeout");
+    const interruption = new AbortController();
+    const results: ProbeQualificationResult[] = [];
+    const signals: string[] = [];
+    let signalScopeCleaned = false;
+
+    await captureRejection(() =>
+      runCompiledSqliteFoundationProbe("compiled-probe", {
+        networkBoundary: {
+          commandPrefix: ["unshare", "--net", "--"],
+          namespace: "net:[fake]",
+          verified: true,
+        },
+        resourceController: {
+          prepare: async (command) => ({ command, release: async () => {} }),
+          attach: async () => {
+            interruption.abort();
+          },
+          kill: async () => {},
+          reap: async () => {},
+          sample: async () => ({
+            processCount: 7,
+            peakMemoryBytes: 512 * 1024 * 1024,
+            diskBytes: 0,
+            outputBytes: 0,
+          }),
+          close: async () => {},
+        },
+        createWorkspaceContainer: async () => nested.container,
+        cleanupWorkspaceContainer: async () => {},
+        spawnOuter: () => nested.outer,
+        installSignalHandlers: () => ({
+          signal: interruption.signal,
+          cleanup: () => {
+            signalScopeCleaned = true;
+          },
+        }),
+        scheduleTimeout: () => 0,
+        clearTimeout: () => {},
+        sleep: async () => {},
+        signalProcessGroup: (pid, signal) => {
+          signals.push(`${pid}:${signal}`);
+          nested.terminateGroup(signal);
+          return true;
+        },
+        emitResult: (result) => {
+          results.push(result);
+        },
+        emitResultFallback: (result) => {
+          results.push(result);
+        },
+      }),
+    );
+
+    expect(signals).toEqual(["701:SIGTERM", "701:SIGKILL"]);
+    expect(nested.childReaped).toBe(true);
+    expect(results[0]?.outcome).toBe("interrupted");
+    expect(results[1]?.cleanup).toEqual({
+      descendantsTerminated: true,
+      descendantsReaped: true,
+      controllerEmpty: true,
+      controllerRemoved: true,
+      tmpfsRemoved: null,
+      workspaceRemoved: true,
+      temporaryDataRemoved: true,
+      retainedController: { state: "none", scope: null, resources: [] },
+      status: "verified",
+      failures: [],
+    });
+    expect(signalScopeCleaned).toBe(true);
+  });
+
+  test("retains the violating resource measurement in both bounded result records", async () => {
+    const nested = createNestedProbe("timeout");
+    const violatingMeasurement = {
+      processCount: 8,
+      peakMemoryBytes: 513 * 1024 * 1024,
+      diskBytes: 16 * 1024 * 1024 + 1,
+      outputBytes: 4 * 1024 + 1,
+    };
+    const results: ProbeQualificationResult[] = [];
+
+    await captureRejection(() =>
+      runCompiledSqliteFoundationProbe("compiled-probe", {
+        networkBoundary: {
+          commandPrefix: ["unshare", "--net", "--"],
+          namespace: "net:[fake]",
+          verified: true,
+        },
+        resourceController: {
+          prepare: async (command) => ({ command, release: async () => {} }),
+          attach: async () => {},
+          kill: async () => {},
+          reap: async () => {},
+          sample: async () => {
+            throw new ProbeResourceLimitError(violatingMeasurement);
+          },
+          close: async () => {},
+        },
+        createWorkspaceContainer: async () => nested.container,
+        cleanupWorkspaceContainer: async () => {},
+        spawnOuter: () => nested.outer,
+        signalProcessGroup: (pid, signal) => {
+          nested.terminateGroup(signal);
+          return true;
+        },
+        sleep: async () => {},
+        emitResult: (result) => {
+          results.push(result);
+        },
+      }),
+    );
+
+    expect(results).toHaveLength(2);
+    expect(results[0]?.measuredResources).toEqual(violatingMeasurement);
+    expect(results[1]?.measuredResources).toEqual(violatingMeasurement);
+  });
+
+  test("retains the observed byte count on the actual captured-output overflow path", async () => {
+    const results: ProbeQualificationResult[] = [];
+    const container = createNestedProbe("success").container;
+    const overflowingCommand = [process.execPath, "-e", 'process.stdout.write("x".repeat(5000))'];
+
+    await captureRejection(() =>
+      runCompiledSqliteFoundationProbe("unused", {
+        networkBoundary: {
+          commandPrefix: overflowingCommand,
+          namespace: "net:[fake]",
+          verified: true,
+        },
+        resourceController: {
+          prepare: async (command) => ({ command, release: async () => {} }),
+          attach: async () => {},
+          kill: async () => {},
+          reap: async () => {},
+          sample: async () => ({
+            processCount: 7,
+            peakMemoryBytes: 512 * 1024 * 1024,
+            diskBytes: 0,
+            outputBytes: 0,
+          }),
+          close: async () => {},
+        },
+        createWorkspaceContainer: async () => container,
+        cleanupWorkspaceContainer: async () => {},
+        spawnOuter: () =>
+          spawnProbeCommand(overflowingCommand, {
+            detached: true,
+            outputBudget: createProbeOutputBudget(),
+          }),
+        emitResult: (result) => {
+          results.push(result);
+        },
+      }),
+    );
+
+    expect(results).toHaveLength(2);
+    expect(results[0]?.measuredResources.outputBytes).toBe(5000);
+    expect(results[1]?.measuredResources.outputBytes).toBe(5000);
+  });
+
+  test("prepares the cgroup start barrier before spawning the artifact", async () => {
+    const nested = createNestedProbe("success");
+    const events: string[] = [];
+
+    await runCompiledSqliteFoundationProbe("compiled-probe", {
+      networkBoundary: {
+        commandPrefix: ["unshare", "--net", "--"],
+        namespace: "net:[fake]",
+        verified: true,
+      },
+      resourceController: {
+        prepare: async (command) => {
+          events.push("prepare");
+          return {
+            command,
+            release: async () => {
+              events.push("release");
+            },
+          };
+        },
+        attach: async () => {
+          events.push("attach");
+        },
+        kill: async () => {},
+        reap: async () => {},
+        sample: async () => ({
+          processCount: 7,
+          peakMemoryBytes: 512 * 1024 * 1024,
+          diskBytes: 0,
+          outputBytes: 0,
+        }),
+        close: async () => {},
+      },
+      createWorkspaceContainer: async () => nested.container,
+      cleanupWorkspaceContainer: async () => {},
+      spawnOuter: () => {
+        events.push("spawn");
+        return {
+          ...nested.outer,
+          ready: Promise.resolve().then(() => {
+            events.push("ready");
+            return true;
+          }),
+        };
+      },
+      emitResult: () => {},
+    });
+
+    expect(events).toEqual(["prepare", "spawn", "ready", "attach", "release"]);
+  });
+
+  test("reconciles a late setup completion before retaining final evidence", async () => {
+    const results: ProbeQualificationResult[] = [];
+    let expireSetup: (() => void) | undefined;
+    let lateSetupSettled = false;
+
+    await captureRejection(() =>
+      runCompiledSqliteFoundationProbe("compiled-probe", {
+        scheduleTotalTimeout: (callback) => {
+          expireSetup ??= callback;
+          return 0;
+        },
+        createWorkspaceContainer: async (signal) => {
+          signal?.addEventListener("abort", () => {}, { once: true });
+          expireSetup?.();
+          await Promise.resolve();
+          lateSetupSettled = true;
+          throw new Error("cooperative setup abort");
+        },
+        emitResult: (result) => {
+          results.push(result);
+        },
+      }),
+    );
+
+    expect(lateSetupSettled).toBe(true);
+    expect(results[1]?.cleanup).toEqual({
+      descendantsTerminated: true,
+      descendantsReaped: true,
+      controllerEmpty: null,
+      controllerRemoved: null,
+      tmpfsRemoved: null,
+      workspaceRemoved: null,
+      temporaryDataRemoved: false,
+      retainedController: { state: "none", scope: null, resources: [] },
+      status: "verified",
+      failures: [],
+    });
+  });
+
+  test("uses the total deadline to stop the workload while retaining bounded final cleanup", async () => {
+    const nested = createNestedProbe("timeout");
+    const results: ProbeQualificationResult[] = [];
+    let totalTimerCalls = 0;
+    let expireWork: (() => void) | undefined;
+    const signals: string[] = [];
+
+    await captureRejection(() =>
+      runCompiledSqliteFoundationProbe("compiled-probe", {
+        networkBoundary: {
+          commandPrefix: ["unshare", "--net", "--"],
+          namespace: "net:[fake]",
+          verified: true,
+        },
+        resourceController: {
+          prepare: async (command) => ({ command, release: async () => {} }),
+          attach: async () => {
+            expireWork?.();
+          },
+          kill: async () => {},
+          reap: async () => {},
+          sample: async () => ({
+            processCount: 7,
+            peakMemoryBytes: 512 * 1024 * 1024,
+            diskBytes: 0,
+            outputBytes: 0,
+          }),
+          close: async () => {},
+        },
+        createWorkspaceContainer: async () => nested.container,
+        cleanupWorkspaceContainer: async () => {},
+        spawnOuter: () => nested.outer,
+        scheduleTotalTimeout: (callback) => {
+          totalTimerCalls += 1;
+          if (totalTimerCalls === 1) expireWork = callback;
+          return totalTimerCalls;
+        },
+        scheduleTimeout: () => 0,
+        clearTimeout: () => {},
+        sleep: async () => {},
+        signalProcessGroup: (pid, signal) => {
+          signals.push(`${pid}:${signal}`);
+          nested.terminateGroup(signal);
+          return true;
+        },
+        emitResult: (result) => {
+          results.push(result);
+        },
+      }),
+    );
+
+    expect(signals).toEqual(["701:SIGTERM", "701:SIGKILL"]);
+    expect(results).toHaveLength(2);
+    expect(results[0]?.outcome).toBe("timed-out");
+    expect(results[0]?.cleanup.temporaryDataRemoved).toBe(false);
+    expect(results[1]?.cleanup).toEqual({
+      descendantsTerminated: true,
+      descendantsReaped: true,
+      controllerEmpty: true,
+      controllerRemoved: true,
+      tmpfsRemoved: null,
+      workspaceRemoved: true,
+      temporaryDataRemoved: true,
+      retainedController: { state: "none", scope: null, resources: [] },
+      status: "verified",
+      failures: [],
+    });
+  });
+
+  test("retains final cleanup evidence when the hard deadline interrupts cleanup", async () => {
+    const nested = createNestedProbe("success");
+    const results: ProbeQualificationResult[] = [];
+    let totalTimerCalls = 0;
+    let expireHardDeadline: (() => void) | undefined;
+
+    await captureRejection(() =>
+      runCompiledSqliteFoundationProbe("compiled-probe", {
+        networkBoundary: {
+          commandPrefix: ["unshare", "--net", "--"],
+          namespace: "net:[fake]",
+          verified: true,
+        },
+        resourceController: {
+          prepare: async (command) => ({ command, release: async () => {} }),
+          attach: async () => {},
+          kill: async () => {},
+          reap: async () => {},
+          sample: async () => ({
+            processCount: 7,
+            peakMemoryBytes: 512 * 1024 * 1024,
+            diskBytes: 0,
+            outputBytes: 0,
+          }),
+          close: async () => {
+            expireHardDeadline?.();
+          },
+        },
+        createWorkspaceContainer: async () => nested.container,
+        cleanupWorkspaceContainer: async () => {},
+        spawnOuter: () => nested.outer,
+        scheduleTotalTimeout: (callback) => {
+          totalTimerCalls += 1;
+          if (totalTimerCalls === 2) expireHardDeadline = callback;
+          return totalTimerCalls;
+        },
+        scheduleTimeout: () => 0,
+        clearTimeout: () => {},
+        emitResult: (result) => {
+          results.push(result);
+        },
+        emitResultFallback: (result) => {
+          results.push(result);
+        },
+      }),
+    );
+
+    expect(results).toHaveLength(2);
+    expect(results[0]?.cleanup.temporaryDataRemoved).toBe(false);
+    expect(results[1]?.cleanup.temporaryDataRemoved).toBe(false);
+    expect(results[1]?.cleanup.status).toBe("failed");
+  });
+
+  test("falls back to bounded final evidence when the async emitter stalls", async () => {
+    const nested = createNestedProbe("success");
+    const primaryResults: ProbeQualificationResult[] = [];
+    const fallbackResults: ProbeQualificationResult[] = [];
+    let timerCalls = 0;
+    let expireHardDeadline: (() => void) | undefined;
+
+    await captureRejection(() =>
+      runCompiledSqliteFoundationProbe("compiled-probe", {
+        networkBoundary: {
+          commandPrefix: ["unshare", "--net", "--"],
+          namespace: "net:[fake]",
+          verified: true,
+        },
+        resourceController: {
+          prepare: async (command) => ({ command, release: async () => {} }),
+          attach: async () => {},
+          kill: async () => {},
+          reap: async () => {},
+          sample: async () => ({
+            processCount: 7,
+            peakMemoryBytes: 512 * 1024 * 1024,
+            diskBytes: 0,
+            outputBytes: 0,
+          }),
+          close: async () => {},
+        },
+        createWorkspaceContainer: async () => nested.container,
+        cleanupWorkspaceContainer: async () => {},
+        spawnOuter: () => nested.outer,
+        scheduleTotalTimeout: (callback) => {
+          timerCalls += 1;
+          if (timerCalls === 2) expireHardDeadline = callback;
+          return timerCalls;
+        },
+        scheduleTimeout: () => 0,
+        clearTimeout: () => {},
+        emitResult: (result) => {
+          if (result.phase === "final") {
+            expireHardDeadline?.();
+            return new Promise<void>(() => {});
+          }
+          primaryResults.push(result);
+        },
+        emitResultFallback: (result) => {
+          fallbackResults.push(result);
+        },
+      }),
+    );
+
+    expect(primaryResults).toHaveLength(1);
+    expect(fallbackResults).toHaveLength(1);
+    expect(fallbackResults[0]?.phase).toBe("final");
+    expect(fallbackResults[0]?.outcome).toBe("failed");
+    expect(fallbackResults[0]?.cleanup.status).toBe("failed");
+    expect(fallbackResults[0]?.cleanup.failures).toContain("result-emission");
+    expect(fallbackResults[0]?.evidence.retention).toBe("coordinator-handoff");
+    expect(fallbackResults[0]?.cleanup.temporaryDataRemoved).toBe(true);
+  });
+
+  test("retains incomplete cleanup when cgroup reap never settles", async () => {
+    const nested = createNestedProbe("success");
+    const results: ProbeQualificationResult[] = [];
+    let hardDeadline: (() => void) | undefined;
+    let timerCalls = 0;
+    await captureRejection(() =>
+      runCompiledSqliteFoundationProbe("compiled-probe", {
+        networkBoundary: {
+          commandPrefix: ["unshare", "--net", "--"],
+          namespace: "net:[fake]",
+          verified: true,
+        },
+        resourceController: {
+          prepare: async (command) => ({ command, release: async () => {} }),
+          attach: async () => {},
+          kill: async () => {},
+          reap: async () => {
+            hardDeadline?.();
+            await new Promise<void>(() => {});
+          },
+          sample: async () => ({
+            processCount: 7,
+            peakMemoryBytes: 0,
+            diskBytes: 0,
+            outputBytes: 0,
+          }),
+          close: async () => {},
+        },
+        createWorkspaceContainer: async () => nested.container,
+        spawnOuter: () => nested.outer,
+        scheduleTotalTimeout: (callback) => {
+          timerCalls += 1;
+          if (timerCalls === 2) hardDeadline = callback;
+          return timerCalls;
+        },
+        clearTotalTimeout: () => {},
+        emitResult: (result) => {
+          results.push(result);
+        },
+        emitResultFallback: (result) => {
+          results.push(result);
+        },
+      }),
+    );
+    expect(results.at(-1)?.cleanup.status).toBe("failed");
+    expect(results.at(-1)?.cleanup.retainedController.state).toBe("unknown");
+    expect(results.at(-1)?.cleanup.temporaryDataRemoved).toBe(false);
+    expect(results.at(-1)?.evidence.retention).toBe("coordinator-handoff");
+  });
+
+  test("aborts injected commit resolution through the lifecycle signal", async () => {
+    const controller = new AbortController();
+    let receivedSignal: AbortSignal | undefined;
+    const result = resolveProbeCommit((signal) => {
+      receivedSignal = signal;
+      return new Promise<string>(() => {});
+    }, controller.signal);
+    controller.abort();
+    expect(await result).toBe("unknown");
+    expect(receivedSignal).toBe(controller.signal);
+  });
+
+  test("retains explicit evidence failure when the commit helper cannot be reaped", async () => {
+    const controller = new AbortController();
+    let killed = false;
+    const child: ProbeCommitChild = {
+      stdout: new ReadableStream<Uint8Array>(),
+      exited: new Promise<number>(() => {}),
+      kill: () => {
+        killed = true;
+      },
+    };
+    const result = buildQualificationResult({
+      phase: "final",
+      invocationId: "invocation",
+      command: undefined,
+      commit: undefined,
+      spawnCommit: (signal) => {
+        queueMicrotask(() => controller.abort());
+        expect(signal).toBe(controller.signal);
+        return child;
+      },
+      startedAtMs: 0,
+      now: () => 1,
+      measuredResources: { processCount: 7, peakMemoryBytes: 512, diskBytes: 1, outputBytes: 1 },
+      result: {
+        exitCode: 0,
+        stdout: '{"sqliteVersion":"3.53.0"}',
+        stderr: "",
+        stdoutBytes: 27,
+        stderrBytes: 0,
+        outputExceeded: false,
+      },
+      terminalError: undefined,
+      probeError: undefined,
+      descendantsReaped: true,
+      descendantsTerminated: true,
+      controllerEmpty: true,
+      controllerRemoved: true,
+      tmpfsRemoved: true,
+      workspaceRemoved: true,
+      cleanupFailures: [],
+      temporaryDataRemoved: true,
+      cleanupStatus: "verified",
+      retainedController: null,
+      signal: controller.signal,
+    });
+    const evidence = await result;
+    expect(evidence.outcome).toBe("failed");
+    expect(evidence.cleanup.status).toBe("failed");
+    expect(evidence.cleanup.failures).toContain("commit-helper-reap-unverified");
+    expect(evidence.cleanup.descendantsTerminated).toBeNull();
+    expect(evidence.cleanup.descendantsReaped).toBe(false);
+    expect(evidence.cleanup.retainedController.state).toBe("none");
+    expect(evidence.evidence).toEqual({
+      disposition: "cleanup-failure",
+      location: null,
+      retention: "coordinator-handoff",
+    });
+    expect(killed).toBe(true);
+  });
+
+  test("retains a successful bounded commit-helper reap", async () => {
+    const child: ProbeCommitChild = {
+      stdout: new ReadableStream<Uint8Array>({
+        start(stream) {
+          stream.enqueue(new TextEncoder().encode("abcdef1\n"));
+          stream.close();
+        },
+      }),
+      exited: Promise.resolve(0),
+      kill: () => {},
+    };
+    expect(await resolveProbeCommit(undefined, new AbortController().signal, () => child)).toBe(
+      "abcdef1",
+    );
+  });
+});
+
+function createNestedProbe(outcome: "success" | "failure" | "timeout" | "interruption"): {
+  outer: ProbeWorkerHandle;
+  container: ProbeWorkspaceContainer;
+  childReaped: boolean;
+  terminateGroup: (signal: NodeJS.Signals) => void;
+} {
+  let exitCode: number | null = null;
+  let resolveExited: (code: number) => void = () => {};
+  let resolveResult: (result: ProbeWorkerResult) => void = () => {};
+  let childReaped = outcome === "success";
+  const exited = new Promise<number>((resolve) => {
+    resolveExited = resolve;
+  });
+  const result = new Promise<ProbeWorkerResult>((resolve) => {
+    resolveResult = resolve;
+  });
+  const process: ProbeProcess = {
+    pid: 701,
+    processGroupOwned: true,
+    get exitCode() {
+      return exitCode;
+    },
+    get killed() {
+      return exitCode !== null;
+    },
+    exited,
+    kill(signal) {
+      if (signal !== undefined) terminateGroup(signal);
+    },
+  };
+  const outer = { process, result };
+  const container: ProbeWorkspaceContainer = {
+    directoryPath: "/tmp/fake-probe-container",
+    capabilityPath: "/tmp/fake-probe-container/.capability",
+    capability: CAPABILITY,
+  };
+
+  if (outcome === "success") completeOuter(0);
+  else if (outcome === "failure") completeOuter(1);
+
+  function completeOuter(code: number) {
+    if (exitCode !== null) return;
+    exitCode = code;
+    resolveExited(code);
+    const artifact = '{"sqliteVersion":"3.53.0"}';
+    resolveResult({
+      exitCode: code,
+      stdout: artifact,
+      stderr: code === 0 || code === 1 ? "TMPFS_REMOVED=1\n" : "",
+      stdoutBytes: new TextEncoder().encode(artifact).byteLength,
+      stderrBytes: code === 0 || code === 1 ? 16 : 0,
+      outputExceeded: false,
+    });
+  }
+
+  function terminateGroup(signal: NodeJS.Signals) {
+    if (signal === "SIGTERM" && (outcome === "timeout" || outcome === "interruption")) return;
+    childReaped = true;
+    completeOuter(signal === "SIGKILL" ? 137 : 143);
+  }
+
+  return {
+    outer,
+    container,
+    get childReaped() {
+      return childReaped;
+    },
+    terminateGroup,
+  };
+}
+
+async function captureRejection(operation: () => Promise<unknown>): Promise<Error> {
+  try {
+    await operation();
+  } catch (error) {
+    if (error instanceof Error) return error;
+    throw new Error("Expected an Error rejection.");
+  }
+  throw new Error("Expected the operation to reject.");
+}

--- a/src/lib/sqlite-foundation-probe-runner.ts
+++ b/src/lib/sqlite-foundation-probe-runner.ts
@@ -1,0 +1,668 @@
+import {
+  capDiagnosticOutput,
+  createProbeOutputBudget,
+  installProbeSignalHandlers,
+  ProbeInterruptedError,
+  ProbeTimeoutError,
+  ProbeWorkerFailureError,
+  SQLITE_FOUNDATION_PROBE_CLEANUP_RESERVE_MS,
+  spawnProbeCommand,
+  superviseProbeWorkers,
+  type ProbeSupervisionOptions,
+  type ProbeWorkerHandle,
+  type ProbeWorkerResult,
+} from "@/lib/sqlite-foundation-probe-process";
+import {
+  buildNoNetworkProbeCommand,
+  createProbeNetworkBoundary,
+  type ProbeNetworkBoundary,
+} from "@/lib/sqlite-foundation-probe-network";
+import {
+  createProbeResourceController,
+  readProbeTmpfsDisposition,
+  type ProbeResourceControllerOptions,
+  type ProbeResourceController,
+} from "@/lib/sqlite-foundation-probe-resources";
+import {
+  type ProbeQualificationResult,
+  type ProbeResourceMeasurement,
+} from "@/lib/sqlite-foundation-probe-result";
+import {
+  SqliteFoundationGateError,
+  translateProbeError,
+} from "@/lib/sqlite-foundation-probe-errors";
+import {
+  cleanupOwnedProbeWorkspaceContainer,
+  createProbeOuterEnvironment,
+  createProbeWorkspaceContainer,
+  type ProbeWorkspaceContainer,
+} from "@/lib/sqlite-foundation-probe-containment";
+import path from "node:path";
+import type { ProbeRetainedCgroupController } from "@/lib/sqlite-foundation-probe-cgroup";
+import { markProbeResultEmissionFailed } from "@/lib/sqlite-foundation-probe-evidence";
+import {
+  buildFallbackQualificationResult,
+  buildQualificationResult,
+  type ProbeCommitChild,
+  type QualificationResultInput,
+} from "@/lib/sqlite-foundation-probe-runner-evidence";
+
+export type CompiledSqliteFoundationProbeOptions = ProbeSupervisionOptions & {
+  createWorkspaceContainer?: (signal?: AbortSignal) => Promise<ProbeWorkspaceContainer>;
+  cleanupWorkspaceContainer?: (
+    container: ProbeWorkspaceContainer,
+    signal?: AbortSignal,
+  ) => Promise<void>;
+  createNetworkBoundary?: () => Promise<ProbeNetworkBoundary>;
+  networkBoundary?: ProbeNetworkBoundary;
+  createResourceController?: (
+    directoryPath: string,
+    options?: ProbeResourceControllerOptions,
+  ) => Promise<ProbeResourceController>;
+  resourceController?: ProbeResourceController;
+  spawnOuter?: (
+    command: readonly string[],
+    container: ProbeWorkspaceContainer,
+  ) => ProbeWorkerHandle;
+  command?: string;
+  commit?: string | ((signal?: AbortSignal) => string | Promise<string>);
+  spawnCommit?: (signal?: AbortSignal) => ProbeCommitChild;
+  now?: () => number;
+  scheduleTotalTimeout?: (callback: () => void, milliseconds: number) => number | NodeJS.Timeout;
+  clearTotalTimeout?: (handle: number | NodeJS.Timeout) => void;
+  installSignalHandlers?: typeof installProbeSignalHandlers;
+  emitResult?: (result: ProbeQualificationResult) => void | Promise<void>;
+  emitResultFallback?: (result: ProbeQualificationResult) => void;
+};
+
+export type CompiledSqliteFoundationProbeResult = ProbeWorkerResult & {
+  qualificationResult: ProbeQualificationResult;
+};
+
+export async function runCompiledSqliteFoundationProbe(
+  executablePath: string,
+  options: CompiledSqliteFoundationProbeOptions = {},
+): Promise<CompiledSqliteFoundationProbeResult> {
+  const signalScope =
+    options.signal === undefined
+      ? (options.installSignalHandlers ?? installProbeSignalHandlers)()
+      : null;
+  const activeSignal = options.signal ?? signalScope?.signal;
+  const now = options.now ?? Date.now;
+  const startedAtMs = now();
+  const invocationId = crypto.randomUUID();
+  const timeoutMs = options.timeoutMs ?? 15_000;
+  const cleanupReserveMs = Math.min(SQLITE_FOUNDATION_PROBE_CLEANUP_RESERVE_MS, timeoutMs);
+  const workDeadline = startedAtMs + timeoutMs - cleanupReserveMs;
+  const setupAbort = new AbortController();
+  const cleanupAbort = new AbortController();
+  const supervisionAbort = new AbortController();
+  let deadlineExpired = false;
+  const workTimer = (options.scheduleTotalTimeout ?? setTimeout)(
+    () => {
+      deadlineExpired = true;
+      setupAbort.abort();
+      supervisionAbort.abort();
+    },
+    Math.max(1, workDeadline - startedAtMs),
+  );
+  const hardTimer = (options.scheduleTotalTimeout ?? setTimeout)(() => {
+    deadlineExpired = true;
+    cleanupAbort.abort();
+  }, timeoutMs);
+  const clearTotalTimeout = options.clearTotalTimeout ?? clearTimeout;
+  let removeCallerAbort = () => {};
+  let interrupted = false;
+  if (activeSignal !== undefined) {
+    const abortCaller = () => {
+      interrupted = true;
+      setupAbort.abort();
+      supervisionAbort.abort();
+    };
+    if (activeSignal.aborted) abortCaller();
+    else {
+      activeSignal.addEventListener("abort", abortCaller, { once: true });
+      removeCallerAbort = () => activeSignal.removeEventListener("abort", abortCaller);
+    }
+  }
+
+  let container: ProbeWorkspaceContainer | undefined;
+  let resourceController: ProbeResourceController | undefined;
+  let worker: ProbeWorkerHandle | undefined;
+  let result: ProbeWorkerResult | undefined;
+  let probeError: SqliteFoundationGateError | undefined;
+  let terminalError: unknown;
+  let supervisionAttempted = false;
+  let descendantsTerminated: boolean | null = null;
+  let descendantsReaped = false;
+  let controllerEmpty: boolean | null = null;
+  let controllerRemoved: boolean | null = null;
+  let tmpfsRemoved: boolean | null = null;
+  let workspaceRemoved: boolean | null = null;
+  const cleanupFailures: string[] = [];
+  let temporaryDataRemoved = false;
+  let cleanupStatus: "pending" | "verified" | "failed" = "pending";
+  let retainedController: ProbeRetainedCgroupController | null = null;
+  let resultEmissionFailed = false;
+  let finalQualificationResult: ProbeQualificationResult | undefined;
+  let measuredResources: ProbeResourceMeasurement = {
+    processCount: null,
+    peakMemoryBytes: null,
+    diskBytes: null,
+    outputBytes: null,
+  };
+  const outputBudget = createProbeOutputBudget();
+
+  try {
+    container = await runUntilDeadline(
+      setupAbort.signal,
+      () => (options.createWorkspaceContainer ?? createProbeWorkspaceContainer)(setupAbort.signal),
+      () => new ProbeTimeoutError(timeoutMs),
+      true,
+      startedAtMs + timeoutMs,
+    );
+    const boundary =
+      options.networkBoundary ??
+      (await runUntilDeadline(
+        setupAbort.signal,
+        () =>
+          (
+            options.createNetworkBoundary ??
+            (() =>
+              createProbeNetworkBoundary({
+                signal: setupAbort.signal,
+                timeoutMs: Math.max(1, workDeadline - now()),
+              }))
+          )(),
+        () => new ProbeTimeoutError(timeoutMs),
+        true,
+        startedAtMs + timeoutMs,
+      ));
+    const command = buildNoNetworkProbeCommand(boundary, path.resolve(executablePath), [
+      "--sqlite-foundation-probe",
+    ]);
+    resourceController = options.resourceController;
+    if (resourceController === undefined) {
+      const resourceOptions: ProbeResourceControllerOptions = {
+        signal: setupAbort.signal,
+        networkBoundary: boundary,
+        container,
+        invocationId,
+      };
+      resourceController = await runUntilDeadline(
+        setupAbort.signal,
+        () =>
+          (options.createResourceController ?? createProbeResourceController)(
+            container?.workspaceDirectoryPath ?? container?.directoryPath ?? "",
+            resourceOptions,
+          ),
+        () => new ProbeTimeoutError(timeoutMs),
+        true,
+        startedAtMs + timeoutMs,
+      );
+    }
+    const launch = await runUntilDeadline(
+      setupAbort.signal,
+      () => resourceController?.prepare(command) ?? Promise.reject(new Error()),
+      () => new ProbeTimeoutError(timeoutMs),
+      true,
+      startedAtMs + timeoutMs,
+    );
+    worker = options.spawnOuter
+      ? options.spawnOuter(launch.command, container)
+      : spawnProbeCommand([...launch.command], {
+          detached: true,
+          env: createProbeOuterEnvironment(container),
+          outputBudget,
+          readyMarker: "READY\n",
+        });
+    await runUntilDeadline(
+      setupAbort.signal,
+      async () => {
+        const ready = await worker?.ready;
+        if (ready === false) {
+          throw new SqliteFoundationGateError(
+            "SQLite resource and network boundaries did not reach readiness.",
+          );
+        }
+      },
+      () => new ProbeTimeoutError(timeoutMs),
+    );
+    await runUntilDeadline(
+      setupAbort.signal,
+      () => resourceController?.attach(worker?.process.pid ?? -1) ?? Promise.reject(new Error()),
+      () => new ProbeTimeoutError(timeoutMs),
+      true,
+      startedAtMs + timeoutMs,
+    );
+    await runUntilDeadline(
+      setupAbort.signal,
+      () => launch.release(worker?.process.pid),
+      () => new ProbeTimeoutError(timeoutMs),
+      true,
+      startedAtMs + timeoutMs,
+    );
+    const sample = () =>
+      resourceController?.sample(
+        worker?.process.pid ?? -1,
+        container?.workspaceDirectoryPath ?? container?.directoryPath ?? "",
+        outputBudget.consumedBytes,
+        result?.stdout,
+        result?.stderr,
+      ) ?? Promise.reject(new Error("Resource controller is unavailable."));
+    measuredResources = await runUntilDeadline(
+      setupAbort.signal,
+      sample,
+      () => new ProbeTimeoutError(timeoutMs),
+    );
+    const supervisionOptions: ProbeSupervisionOptions = {
+      ...options,
+      signal: supervisionAbort.signal,
+      killWorkloadTree: () => resourceController?.kill() ?? Promise.resolve(),
+      timeoutMs: Math.max(1, workDeadline - now()),
+      resourceCheck: async () => {
+        measuredResources = await sample();
+      },
+    };
+    supervisionAttempted = true;
+    const supervised = await superviseProbeWorkers(
+      [worker as ProbeWorkerHandle],
+      supervisionOptions,
+    );
+    result = supervised[0];
+    if (result === undefined) {
+      throw new SqliteFoundationGateError(
+        "SQLite runtime probe returned no result; return the database choice to a human.",
+      );
+    }
+    tmpfsRemoved = readProbeTmpfsDisposition(result.stderr);
+    measuredResources = await runUntilDeadline(
+      cleanupAbort.signal,
+      sample,
+      () => new ProbeTimeoutError(timeoutMs),
+    );
+  } catch (error) {
+    terminalError = error;
+    probeError = translateProbeError(error);
+    retainedController ??= readRetainedController(error);
+    if (retainedController !== null) {
+      controllerEmpty = false;
+      controllerRemoved = false;
+      appendCleanupFailure(cleanupFailures, "retained-controller");
+      cleanupStatus = "failed";
+    }
+    const violatingMeasurement = readViolatingMeasurement(error);
+    if (violatingMeasurement !== null) measuredResources = violatingMeasurement;
+    if (error instanceof ProbeWorkerFailureError && error.result?.outputExceeded) {
+      measuredResources = {
+        ...measuredResources,
+        outputBytes: error.result.observedOutputBytes ?? outputBudget.observedBytes,
+      };
+    }
+    if (interrupted && !deadlineExpired) {
+      terminalError = new ProbeInterruptedError();
+      probeError = translateProbeError(terminalError);
+    }
+    if (worker !== undefined && !supervisionAttempted && !cleanupAbort.signal.aborted) {
+      supervisionAbort.abort();
+      supervisionAttempted = true;
+      try {
+        await runUntilDeadline(
+          cleanupAbort.signal,
+          () =>
+            superviseProbeWorkers([worker as ProbeWorkerHandle], {
+              ...options,
+              signal: supervisionAbort.signal,
+              killWorkloadTree: () => resourceController?.kill() ?? Promise.resolve(),
+              resourceCheck: undefined,
+              timeoutMs: Math.max(1, workDeadline - now()),
+            }),
+          () => new ProbeTimeoutError(timeoutMs),
+          false,
+          startedAtMs + timeoutMs,
+        );
+      } catch {
+        // The resource controller performs the authoritative cgroup-wide reap below.
+      }
+    }
+  }
+
+  if (deadlineExpired) {
+    terminalError = new ProbeTimeoutError(timeoutMs);
+    probeError = translateProbeError(terminalError);
+  } else if (interrupted) {
+    terminalError = new ProbeInterruptedError();
+    probeError = translateProbeError(terminalError);
+  }
+
+  if (resourceController !== undefined) {
+    try {
+      await runUntilDeadline(
+        cleanupAbort.signal,
+        () => resourceController?.reap(cleanupAbort.signal) ?? Promise.resolve(),
+        () => new ProbeTimeoutError(timeoutMs),
+        false,
+        startedAtMs + timeoutMs,
+      );
+      descendantsTerminated = true;
+      descendantsReaped = true;
+      controllerEmpty = true;
+    } catch (error) {
+      retainedController ??= readRetainedController(error);
+      descendantsTerminated = false;
+      descendantsReaped = false;
+      controllerEmpty = false;
+      tmpfsRemoved ??= null;
+      appendCleanupFailure(cleanupFailures, "descendant-termination-or-reap");
+      appendCleanupFailure(cleanupFailures, "controller-empty");
+      if (tmpfsRemoved !== true) appendCleanupFailure(cleanupFailures, "tmpfs-removal");
+      if (retainedController !== null) {
+        controllerRemoved = false;
+        appendCleanupFailure(cleanupFailures, "retained-controller");
+      }
+      cleanupStatus = "failed";
+      probeError ??= translateProbeError(error);
+      terminalError ??= error;
+    }
+  } else if (worker === undefined && retainedController === null) {
+    descendantsTerminated = true;
+    descendantsReaped = true;
+  } else if (retainedController !== null) {
+    descendantsTerminated = false;
+    descendantsReaped = false;
+  }
+
+  const emit = async (phase: "pre-cleanup" | "final") => {
+    if (options.emitResult === undefined) return;
+    const input = (): QualificationResultInput => ({
+      phase,
+      invocationId,
+      command: options.command,
+      commit: options.commit,
+      spawnCommit: options.spawnCommit,
+      startedAtMs,
+      now,
+      measuredResources,
+      result,
+      terminalError,
+      probeError,
+      descendantsReaped,
+      descendantsTerminated,
+      controllerEmpty,
+      controllerRemoved,
+      tmpfsRemoved,
+      workspaceRemoved,
+      cleanupFailures,
+      signal: cleanupAbort.signal,
+      temporaryDataRemoved: phase === "final" && temporaryDataRemoved,
+      cleanupStatus: phase === "pre-cleanup" ? "pending" : cleanupStatus,
+      retainedController,
+    });
+    let qualificationResult: ProbeQualificationResult;
+    try {
+      qualificationResult = await runUntilDeadline(
+        cleanupAbort.signal,
+        () => buildQualificationResult(input()),
+        () => new ProbeTimeoutError(timeoutMs),
+      );
+    } catch {
+      qualificationResult = buildFallbackQualificationResult(input());
+    }
+    if (qualificationResult.cleanup.failures.includes("commit-helper-reap-unverified")) {
+      cleanupStatus = "failed";
+      appendCleanupFailure(cleanupFailures, "commit-helper-reap-unverified");
+      const commitCleanupError = new SqliteFoundationGateError(
+        "The Git commit helper did not confirm bounded termination and reap.",
+      );
+      probeError ??= commitCleanupError;
+      terminalError ??= commitCleanupError;
+    }
+    if (phase === "final") finalQualificationResult = qualificationResult;
+    const emitFallback = () => {
+      resultEmissionFailed = true;
+      qualificationResult = markProbeResultEmissionFailed(qualificationResult);
+      if (phase === "final") finalQualificationResult = qualificationResult;
+      try {
+        if (options.emitResultFallback !== undefined) {
+          options.emitResultFallback(qualificationResult);
+        } else {
+          const bounded = capDiagnosticOutput(JSON.stringify(qualificationResult)).text;
+          process.stderr.write(`${bounded}\n`);
+        }
+      } catch {
+        // The in-memory result remains truthful even if the fallback sink fails.
+      }
+    };
+    if (cleanupAbort.signal.aborted) {
+      emitFallback();
+      return;
+    }
+    try {
+      await runUntilDeadline(
+        cleanupAbort.signal,
+        () => options.emitResult?.(qualificationResult) ?? Promise.resolve(),
+        () => new ProbeTimeoutError(timeoutMs),
+      );
+    } catch {
+      emitFallback();
+    }
+  };
+
+  try {
+    await emit("pre-cleanup");
+  } catch (error) {
+    probeError ??= translateProbeError(error);
+  }
+
+  let resourceControllerClosed = resourceController === undefined;
+  if (resourceController !== undefined && descendantsReaped) {
+    try {
+      await runUntilDeadline(
+        cleanupAbort.signal,
+        () => resourceController?.close(cleanupAbort.signal) ?? Promise.resolve(),
+        () => new ProbeTimeoutError(timeoutMs),
+        true,
+        startedAtMs + timeoutMs,
+      );
+      resourceControllerClosed = true;
+      controllerRemoved = true;
+    } catch (error) {
+      retainedController ??= readRetainedController(error);
+      controllerRemoved = false;
+      appendCleanupFailure(cleanupFailures, "controller-removal");
+      if (retainedController !== null) appendCleanupFailure(cleanupFailures, "retained-controller");
+      cleanupStatus = "failed";
+    }
+  } else if (resourceController !== undefined) {
+    cleanupStatus = "failed";
+  }
+  if (container !== undefined && resourceControllerClosed && retainedController === null) {
+    try {
+      await runUntilDeadline(
+        cleanupAbort.signal,
+        () =>
+          (
+            options.cleanupWorkspaceContainer ??
+            ((owned, signal) =>
+              cleanupOwnedProbeWorkspaceContainer(owned.directoryPath, owned.capability, signal))
+          )(container as ProbeWorkspaceContainer, cleanupAbort.signal),
+        () => new ProbeTimeoutError(timeoutMs),
+        true,
+        startedAtMs + timeoutMs,
+      );
+      temporaryDataRemoved = true;
+      workspaceRemoved = true;
+    } catch {
+      workspaceRemoved = false;
+      cleanupFailures.push("workspace-removal");
+      cleanupStatus = "failed";
+    }
+  } else if (container !== undefined) {
+    cleanupStatus = "failed";
+  }
+  if (cleanupStatus !== "failed") cleanupStatus = "verified";
+  if (cleanupStatus === "failed") {
+    const cleanupError = new SqliteFoundationGateError(
+      "SQLite integrity probe cleanup could not be verified; return the database choice to a human.",
+    );
+    probeError ??= cleanupError;
+    terminalError ??= cleanupError;
+  }
+  if (interrupted && !deadlineExpired) {
+    terminalError = new ProbeInterruptedError();
+    probeError = translateProbeError(terminalError);
+  }
+  try {
+    await emit("final");
+  } catch (error) {
+    probeError ??= translateProbeError(error);
+  }
+  if (resultEmissionFailed) {
+    probeError ??= new SqliteFoundationGateError(
+      "SQLite integrity probe result emission could not be completed within the total deadline.",
+    );
+  }
+  clearTotalTimeout(workTimer);
+  clearTotalTimeout(hardTimer);
+  removeCallerAbort();
+  setupAbort.abort();
+  cleanupAbort.abort();
+  signalScope?.cleanup();
+
+  if (probeError !== undefined) throw probeError;
+  if (result === undefined) {
+    throw new SqliteFoundationGateError(
+      "SQLite runtime probe returned no result; return the database choice to a human.",
+    );
+  }
+  return {
+    ...result,
+    qualificationResult:
+      finalQualificationResult ??
+      buildFallbackQualificationResult({
+        phase: "final",
+        invocationId,
+        command: options.command,
+        commit: options.commit,
+        spawnCommit: options.spawnCommit,
+        startedAtMs,
+        now,
+        measuredResources,
+        result,
+        terminalError: undefined,
+        probeError: undefined,
+        descendantsReaped,
+        descendantsTerminated,
+        controllerEmpty,
+        controllerRemoved,
+        tmpfsRemoved,
+        workspaceRemoved,
+        cleanupFailures,
+        signal: cleanupAbort.signal,
+        temporaryDataRemoved,
+        cleanupStatus,
+        retainedController,
+      }),
+  };
+}
+
+async function runUntilDeadline<T>(
+  signal: AbortSignal,
+  operation: () => Promise<T>,
+  timeoutError: () => Error,
+  reconcile = false,
+  hardDeadlineMs = Number.POSITIVE_INFINITY,
+): Promise<T> {
+  if (signal.aborted) throw timeoutError();
+  const operationPromise = Promise.resolve().then(operation);
+  let removeAbort = () => {};
+  const aborted = new Promise<never>((_, reject) => {
+    const onAbort = () => reject(timeoutError());
+    signal.addEventListener("abort", onAbort, { once: true });
+    removeAbort = () => signal.removeEventListener("abort", onAbort);
+  });
+  try {
+    return await Promise.race([operationPromise, aborted]);
+  } catch (error) {
+    if (reconcile) {
+      const reconciliationMs = Math.min(250, Math.max(0, hardDeadlineMs - Date.now()));
+      if (reconciliationMs > 0) {
+        let timer: ReturnType<typeof setTimeout> | undefined;
+        const reconciliationTimeout = new Promise<void>((resolve) => {
+          timer = setTimeout(resolve, reconciliationMs);
+        });
+        await Promise.race([
+          operationPromise.then(
+            () => undefined,
+            () => undefined,
+          ),
+          reconciliationTimeout,
+        ]);
+        if (timer !== undefined) clearTimeout(timer);
+      }
+    }
+    throw error;
+  } finally {
+    removeAbort();
+  }
+}
+
+function readViolatingMeasurement(error: unknown): ProbeResourceMeasurement | null {
+  if (typeof error !== "object" || error === null || !("measurement" in error)) return null;
+  const measurement = (error as { measurement?: unknown }).measurement;
+  if (typeof measurement !== "object" || measurement === null) return null;
+  const value = measurement as Record<string, unknown>;
+  if (
+    !isNullableMeasurementValue(value.processCount) ||
+    !isNullableMeasurementValue(value.peakMemoryBytes) ||
+    !isNullableMeasurementValue(value.diskBytes) ||
+    !isNullableMeasurementValue(value.outputBytes)
+  ) {
+    return null;
+  }
+  return {
+    processCount: value.processCount,
+    peakMemoryBytes: value.peakMemoryBytes,
+    diskBytes: value.diskBytes,
+    outputBytes: value.outputBytes,
+  };
+}
+
+function isNullableMeasurementValue(value: unknown): value is number | null {
+  return value === null || (typeof value === "number" && Number.isFinite(value));
+}
+
+function readRetainedController(error: unknown): ProbeRetainedCgroupController | null {
+  if (typeof error !== "object" || error === null || !("retainedController" in error)) {
+    return null;
+  }
+  const retainedController = (error as { retainedController?: unknown }).retainedController;
+  if (
+    typeof retainedController !== "object" ||
+    retainedController === null ||
+    !Array.isArray((retainedController as { retainedPaths?: unknown }).retainedPaths)
+  ) {
+    return null;
+  }
+  const value = retainedController as Record<string, unknown>;
+  if (
+    typeof value.rootPath !== "string" ||
+    typeof value.helperPath !== "string" ||
+    typeof value.workloadPath !== "string" ||
+    typeof value.markerPath !== "string" ||
+    !(value.retainedPaths as unknown[]).every((pathValue) => typeof pathValue === "string")
+  ) {
+    return null;
+  }
+  return {
+    rootPath: value.rootPath,
+    helperPath: value.helperPath,
+    workloadPath: value.workloadPath,
+    markerPath: value.markerPath,
+    retainedPaths: [...(value.retainedPaths as string[])],
+  };
+}
+
+function appendCleanupFailure(failures: string[], failure: string): void {
+  if (!failures.includes(failure)) failures.push(failure);
+}

--- a/src/lib/sqlite-foundation-probe-safety.test.ts
+++ b/src/lib/sqlite-foundation-probe-safety.test.ts
@@ -1,0 +1,347 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildNoNetworkProbeCommand,
+  createProbeOutputBudget,
+  runCompiledSqliteFoundationProbe,
+  type ProbeWorkspaceContainer,
+  superviseProbeWorkers,
+  type ProbeProcess,
+  type ProbeWorkerHandle,
+  type ProbeWorkerResult,
+} from "@/lib/sqlite-foundation-probe";
+import { createProbeNetworkBoundary } from "@/lib/sqlite-foundation-probe-network";
+import { readSingleValueFromWorker } from "@/lib/sqlite-foundation-probe-process";
+import {
+  buildProbePrivateMountCommand,
+  createProbeDiskBoundary,
+  readProbeTmpfsDisposition,
+  ProbeResourceControlError,
+  ProbeResourceLimitError,
+  signalProbeCgroupMembers,
+} from "@/lib/sqlite-foundation-probe-resources";
+
+const CAPABILITY = "00000000-0000-0000-0000-000000000000";
+
+describe("sqlite-foundation-probe safety", () => {
+  test("builds the workload launch inside a private mount namespace before mounting tmpfs", () => {
+    const command = buildProbePrivateMountCommand({
+      unshare: "/usr/bin/unshare",
+      shell: "/bin/sh",
+      mount: "/bin/mount",
+      stat: "/usr/bin/stat",
+      umount: "/bin/umount",
+      du: "/usr/bin/du",
+      awk: "/usr/bin/awk",
+      findmnt: "/usr/bin/findmnt",
+      parentMountNamespace: "mnt:[parent]",
+      parentNetworkNamespace: "net:[parent]",
+      helperCgroupProcessesPath: "/owned/helper-cgroup.procs",
+      workloadCgroupProcessesPath: "/owned/workload-cgroup.procs",
+      workspacePath: "/owned/workspace",
+      command: ["/owned/probe", "--sqlite-foundation-probe"],
+    });
+
+    expect(command.slice(0, 11)).toEqual([
+      "/usr/bin/unshare",
+      "--user",
+      "--map-root-user",
+      "--mount",
+      "--net",
+      "--propagation",
+      "private",
+      "--",
+      "/bin/sh",
+      "-eu",
+      "-c",
+    ]);
+    expect(command.join(" ")).toContain(
+      'test "$(readlink /proc/self/ns/mnt)" != "$parent_mount_namespace"',
+    );
+    expect(command.join(" ")).toContain(
+      'test "$(readlink /proc/self/ns/net)" != "$parent_network_namespace"',
+    );
+    expect(command.join(" ")).toContain('export TMPDIR="$workspace_path/tmp"');
+    expect(command.join(" ")).toContain("--bind");
+    expect(command.join(" ")).toContain("-t tmpfs");
+    expect(command.join(" ")).toContain("umount");
+
+    const script = command[11] ?? "";
+    const selfAttach = script.indexOf('printf "%s\\n" "$$" > "$workload_cgroup"');
+    const sealCgroup = script.indexOf('remount,bind,ro "/sys/fs/cgroup"');
+    const ready = script.indexOf('printf "READY\\n"');
+    const leaveWorkspace = script.indexOf("cd /; unset TMPDIR");
+    const unmount = script.indexOf('"/bin/umount" "$workspace_path"');
+    const tmpfsMarker = script.indexOf('printf "TMPFS_REMOVED=%s\\n" "$tmpfs_removed" >&2');
+    expect(selfAttach).toBeGreaterThan(-1);
+    expect(sealCgroup).toBeGreaterThan(selfAttach);
+    expect(ready).toBeGreaterThan(sealCgroup);
+    expect(leaveWorkspace).toBeGreaterThan(ready);
+    expect(unmount).toBeGreaterThan(leaveWorkspace);
+    expect(tmpfsMarker).toBeGreaterThan(unmount);
+    expect(script).toContain('printf "READY\\n" >&2');
+    expect(script).toContain('printf "DISK_BYTES=%s\\n" "${1:-0}" >&2');
+    expect(script).toContain('test -n "$mount_options"');
+    expect(script).toContain('test -n "$cgroup_options"');
+    expect(script).toContain('case ",$cgroup_options," in *,ro,*)');
+    expect(script).toContain('case ",$cgroup_options," in *,rw,*) exit 125');
+    expect(script).toContain("*,ro,*");
+    expect(script).toContain("*,rw,*) exit 125");
+    expect(script).toContain('printf "TMPFS_REMOVED=%s\\n" "$tmpfs_removed"');
+  });
+
+  test("reports tmpfs removal independently from workload correctness", () => {
+    expect(readProbeTmpfsDisposition("workload failed\nTMPFS_REMOVED=1\n")).toBe(true);
+    expect(readProbeTmpfsDisposition("TMPFS_REMOVED=0\n")).toBe(false);
+    expect(readProbeTmpfsDisposition("workload failed\n")).toBeNull();
+    expect(readProbeTmpfsDisposition("TMPFS_REMOVED=1\nTMPFS_REMOVED=0\n")).toBeNull();
+  });
+
+  test("keeps artifact JSON parseable while control frames stay separate", () => {
+    expect(readSingleValueFromWorker('{"sqliteVersion":"3.53.0"}', "sqliteVersion")).toBe("3.53.0");
+    expect(
+      readSingleValueFromWorker('READY\n{"sqliteVersion":"3.53.0"}\nDISK_BYTES=1', "sqliteVersion"),
+    ).toBeNull();
+    expect(readProbeTmpfsDisposition("READY\nDISK_BYTES=1\nTMPFS_REMOVED=1\n")).toBe(true);
+  });
+
+  test("requires and verifies an OS network namespace before building the workload command", async () => {
+    const boundary = await createProbeNetworkBoundary({
+      platform: "linux",
+      which: (command) => `/usr/bin/${command}`,
+      parentNamespace: () => "net:[parent]",
+    });
+    const command = buildNoNetworkProbeCommand(boundary, "/owned/quadball-timer", [
+      "--sqlite-foundation-probe",
+    ]);
+
+    expect(command).toEqual(["/owned/quadball-timer", "--sqlite-foundation-probe"]);
+    expect(boundary.namespace).toBe("net:[parent]");
+  });
+
+  test("counts captured output as raw bytes and stops at the shared cap", () => {
+    const budget = createProbeOutputBudget(4);
+    expect(budget.consume(new TextEncoder().encode("😀").byteLength)).toBe(4);
+    expect(budget.consumedBytes).toBe(4);
+    expect(budget.observedBytes).toBe(4);
+    expect(budget.exceeded).toBe(false);
+    expect(budget.consume(1)).toBe(0);
+    expect(budget.observedBytes).toBe(5);
+    expect(budget.exceeded).toBe(true);
+  });
+
+  test("requires an OS-enforced temporary-disk boundary before admission", async () => {
+    const tools = createProbeDiskBoundary("/owned/workspace", {
+      platform: "linux",
+      which: (command) => `/usr/bin/${command}`,
+      parentMountNamespace: () => "mnt:[parent]",
+    });
+
+    expect(tools).toEqual({
+      unshare: "/usr/bin/unshare",
+      mount: "/usr/bin/mount",
+      stat: "/usr/bin/stat",
+      umount: "/usr/bin/umount",
+      du: "/usr/bin/du",
+      awk: "/usr/bin/awk",
+      findmnt: "/usr/bin/findmnt",
+      parentMountNamespace: "mnt:[parent]",
+    });
+
+    const diskError = await captureRejection(async () => {
+      createProbeDiskBoundary("/owned/workspace", {
+        platform: "linux",
+        which: (command) => (command === "mount" ? undefined : `/usr/bin/${command}`),
+        parentMountNamespace: () => "mnt:[parent]",
+      });
+    });
+    expect(diskError).toBeInstanceOf(ProbeResourceControlError);
+  });
+
+  test("fails closed on boundary verification and does not launch the workload", async () => {
+    let launches = 0;
+    const container: ProbeWorkspaceContainer = {
+      directoryPath: "/tmp/fake-probe-container",
+      capabilityPath: "/tmp/fake-probe-container/.capability",
+      capability: CAPABILITY,
+    };
+    const operation = () =>
+      runCompiledSqliteFoundationProbe("compiled-probe", {
+        createWorkspaceContainer: async () => container,
+        createNetworkBoundary: () =>
+          createProbeNetworkBoundary({
+            platform: "linux",
+            which: (command) => `/usr/bin/${command}`,
+            parentNamespace: () => null,
+          }),
+        cleanupWorkspaceContainer: async () => {},
+        spawnOuter: () => {
+          launches += 1;
+          throw new Error("must not launch");
+        },
+        emitResult: () => {},
+      });
+
+    await captureRejection(operation);
+    expect(launches).toBe(0);
+  });
+
+  test.each(["process count", "peak memory", "temporary disk", "captured output"])(
+    "stops the full process tree when the observed %s bound overruns",
+    async (resource) => {
+      const first = createFakeWorker(601, false);
+      const second = createFakeWorker(602, false);
+      const signals: string[] = [];
+      let timerCalls = 0;
+      const measurement = {
+        processCount: 7,
+        peakMemoryBytes: 512 * 1024 * 1024,
+        diskBytes: 16 * 1024 * 1024,
+        outputBytes: 4 * 1024,
+      };
+
+      expect(
+        await captureRejection(() =>
+          superviseProbeWorkers([first.worker, second.worker], {
+            scheduleTimeout: (callback) => {
+              timerCalls += 1;
+              if (timerCalls === 1) callback();
+              return 0;
+            },
+            clearTimeout: () => {},
+            sleep: async () => {},
+            resourceCheck: async () => {
+              throw new ProbeResourceLimitError(measurement);
+            },
+            signalProcessGroup: (pid, signal) => {
+              signals.push(`${pid}:${signal}`);
+              (pid === first.worker.process.pid ? first : second).terminate(signal);
+              return true;
+            },
+          }),
+        ),
+      ).toHaveProperty(
+        "message",
+        expect.stringContaining("enforced process, memory, disk, or output"),
+      );
+      expect(signals).toEqual(["601:SIGTERM", "602:SIGTERM"]);
+      expect(resource).toBeString();
+    },
+  );
+
+  test("uses cgroup-wide termination to reap descendants that escaped a process group", async () => {
+    const first = createFakeWorker(701, true);
+    const second = createFakeWorker(702, true);
+    const signals: string[] = [];
+    const terminationOrder: string[] = [];
+    let cgroupKills = 0;
+
+    const killError = await captureRejection(() =>
+      superviseProbeWorkers([first.worker, second.worker], {
+        scheduleTimeout: (callback) => {
+          callback();
+          return 0;
+        },
+        clearTimeout: () => {},
+        sleep: async () => {},
+        resourceCheck: async () => {
+          throw new ProbeResourceLimitError({
+            processCount: 8,
+            peakMemoryBytes: 0,
+            diskBytes: 0,
+            outputBytes: 0,
+          });
+        },
+        signalProcessGroup: (pid, signal) => {
+          signals.push(`${pid}:${signal}`);
+          terminationOrder.push(`group:${signal}`);
+          return true;
+        },
+        killWorkloadTree: async () => {
+          cgroupKills += 1;
+          terminationOrder.push("cgroup:kill");
+          first.terminate("SIGKILL");
+          second.terminate("SIGKILL");
+        },
+      }),
+    );
+    expect(killError).toBeInstanceOf(Error);
+
+    expect(signals).toEqual(["701:SIGTERM", "702:SIGTERM"]);
+    expect(terminationOrder).toEqual(["group:SIGTERM", "group:SIGTERM", "cgroup:kill"]);
+    expect(cgroupKills).toBe(1);
+    expect(first.worker.process.exitCode).toBe(137);
+    expect(second.worker.process.exitCode).toBe(137);
+  });
+
+  test("signals invocation-root members during cgroup reap", async () => {
+    const signals: Array<[number, NodeJS.Signals]> = [];
+    await signalProbeCgroupMembers(
+      ["/owned/invocation-root/cgroup.procs"],
+      "SIGTERM",
+      async () => "9001\n",
+      (pid, signal) => {
+        signals.push([pid, signal]);
+      },
+    );
+    expect(signals).toEqual([[9001, "SIGTERM"]]);
+  });
+});
+
+function createFakeWorker(
+  pid: number,
+  ignoreTerminationSignal: boolean,
+  processGroupId?: number,
+): {
+  worker: ProbeWorkerHandle;
+  terminate: (signal: NodeJS.Signals) => void;
+} {
+  let exitCode: number | null = null;
+  let resolveExited: (code: number) => void = () => {};
+  let resolveResult: (result: ProbeWorkerResult) => void = () => {};
+  const exited = new Promise<number>((resolve) => {
+    resolveExited = resolve;
+  });
+  const result = new Promise<ProbeWorkerResult>((resolve) => {
+    resolveResult = resolve;
+  });
+  const process: ProbeProcess = {
+    pid,
+    processGroupId,
+    get exitCode() {
+      return exitCode;
+    },
+    get killed() {
+      return exitCode !== null;
+    },
+    exited,
+    kill(signal) {
+      if (signal !== undefined) terminate(signal);
+    },
+  };
+
+  function terminate(signal: NodeJS.Signals) {
+    if (signal === "SIGTERM" && ignoreTerminationSignal) return;
+    exitCode = signal === "SIGKILL" ? 137 : 143;
+    resolveExited(exitCode);
+    resolveResult({
+      exitCode,
+      stdout: "",
+      stderr: "",
+      stdoutBytes: 0,
+      stderrBytes: 0,
+      outputExceeded: false,
+    });
+  }
+
+  return { worker: { process, result }, terminate };
+}
+
+async function captureRejection(operation: () => Promise<unknown>): Promise<Error> {
+  try {
+    await operation();
+  } catch (error) {
+    if (error instanceof Error) return error;
+    throw new Error("Expected an Error rejection.");
+  }
+  throw new Error("Expected the operation to reject.");
+}

--- a/src/lib/sqlite-foundation-probe.test.ts
+++ b/src/lib/sqlite-foundation-probe.test.ts
@@ -11,7 +11,6 @@ import {
   createProbeWorkspaceContainer,
   isSupportedSqliteVersion,
   parseSqliteProbeInvocation,
-  runCompiledSqliteFoundationProbe,
   SQLITE_FOUNDATION_PROBE_MAX_OUTPUT_BYTES,
   SQLITE_FOUNDATION_PROBE_WORKLOAD,
   superviseProbeWorkers,
@@ -19,7 +18,6 @@ import {
   type ProbeWorkerHandle,
   type ProbeWorkerResult,
   SqliteFoundationGateError,
-  type ProbeWorkspaceContainer,
   validateOwnedProbeWorkspace,
   validateOwnedProbeWorkerWorkspace,
 } from "@/lib/sqlite-foundation-probe";
@@ -250,7 +248,14 @@ describe("sqlite-foundation-probe", () => {
     const second = createFakeWorker(102, false);
     const workers = [first.worker, second.worker];
     const signals: string[] = [];
-    first.complete({ exitCode: 1, stdout: "", stderr: "", outputExceeded: false });
+    first.complete({
+      exitCode: 1,
+      stdout: "",
+      stderr: "",
+      stdoutBytes: 0,
+      stderrBytes: 0,
+      outputExceeded: false,
+    });
 
     expect(
       await captureRejection(() =>
@@ -286,6 +291,12 @@ describe("sqlite-foundation-probe", () => {
         exitCode: 1,
         stdout: `worker opened ${secretPath}; then "${quotedPosixPath}".\n${"x".repeat(10_000)}`,
         stderr: `capability=${secretCapability}; failed at '${quotedWindowsPath}',`,
+        stdoutBytes: new TextEncoder().encode(
+          `worker opened ${secretPath}; then "${quotedPosixPath}".\n${"x".repeat(10_000)}`,
+        ).byteLength,
+        stderrBytes: new TextEncoder().encode(
+          `capability=${secretCapability}; failed at '${quotedWindowsPath}',`,
+        ).byteLength,
         outputExceeded: false,
       });
       return captureRejection(() =>
@@ -329,6 +340,12 @@ describe("sqlite-foundation-probe", () => {
       exitCode: 1,
       stdout: `${"x".repeat(perStreamBoundary - 6)}${capabilityPrefix}-1234-1234-123456789abc`,
       stderr: `${"y".repeat(perStreamBoundary - 6)}${pathPrefix}/probe.sqlite`,
+      stdoutBytes: new TextEncoder().encode(
+        `${"x".repeat(perStreamBoundary - 6)}${capabilityPrefix}-1234-1234-123456789abc`,
+      ).byteLength,
+      stderrBytes: new TextEncoder().encode(
+        `${"y".repeat(perStreamBoundary - 6)}${pathPrefix}/probe.sqlite`,
+      ).byteLength,
       outputExceeded: false,
     });
 
@@ -352,7 +369,14 @@ describe("sqlite-foundation-probe", () => {
     const first = createFakeWorker(501, false, 500);
     const second = createFakeWorker(502, false, 500);
     const signals: string[] = [];
-    first.complete({ exitCode: 1, stdout: "", stderr: "", outputExceeded: false });
+    first.complete({
+      exitCode: 1,
+      stdout: "",
+      stderr: "",
+      stdoutBytes: 0,
+      stderrBytes: 0,
+      outputExceeded: false,
+    });
 
     expect(
       await captureRejection(() =>
@@ -458,68 +482,6 @@ describe("sqlite-foundation-probe", () => {
 
     expect(signals).toEqual(["301:SIGTERM"]);
   });
-
-  test("bounds nested wrapper cleanup for success, failure, timeout, and interruption", async () => {
-    const cases = [
-      { label: "success", outcome: "success" as const, expectedSignals: [] },
-      { label: "failure", outcome: "failure" as const, expectedSignals: ["701:SIGTERM"] },
-      {
-        label: "timeout",
-        outcome: "timeout" as const,
-        expectedSignals: ["701:SIGTERM", "701:SIGKILL"],
-      },
-      {
-        label: "interruption",
-        outcome: "interruption" as const,
-        expectedSignals: ["701:SIGTERM", "701:SIGKILL"],
-      },
-    ];
-
-    for (const testCase of cases) {
-      const nested = createNestedProbe(testCase.outcome);
-      const controller = new AbortController();
-      if (testCase.outcome === "interruption") {
-        controller.abort();
-      }
-
-      let workspaceRemoved = false;
-      const signals: string[] = [];
-      const options = {
-        signal: controller.signal,
-        timeoutMs: 15_000,
-        scheduleTimeout: (callback: () => void) => {
-          if (testCase.outcome === "timeout") {
-            callback();
-          }
-          return 0;
-        },
-        clearTimeout: () => {},
-        sleep: async () => {},
-        signalProcessGroup: (pid: number, signal: NodeJS.Signals) => {
-          signals.push(`${pid}:${signal}`);
-          nested.terminateGroup(signal);
-          return true;
-        },
-        createWorkspaceContainer: async () => nested.container,
-        cleanupWorkspaceContainer: async () => {
-          workspaceRemoved = true;
-        },
-        spawnOuter: () => nested.outer,
-      };
-
-      const operation = () => runCompiledSqliteFoundationProbe("compiled-probe", options);
-      if (testCase.outcome === "success") {
-        await operation();
-      } else {
-        await captureRejection(operation);
-      }
-
-      expect(signals, `${testCase.label} TERM/KILL order`).toEqual(testCase.expectedSignals);
-      expect(nested.outer.process.exitCode, `${testCase.label} outer reaped`).not.toBeNull();
-      expect(nested.childReaped, `${testCase.label} descendants reaped`).toBe(true);
-      expect(workspaceRemoved, `${testCase.label} workspace removed`).toBe(true);
-    }
-  });
 });
 
 function createFakeWorker(
@@ -572,88 +534,13 @@ function createFakeWorker(
       exitCode: signal === "SIGKILL" ? 137 : 143,
       stdout: "",
       stderr: "",
+      stdoutBytes: 0,
+      stderrBytes: 0,
       outputExceeded: false,
     });
   }
 
   return { worker, complete, terminate };
-}
-
-function createNestedProbe(outcome: "success" | "failure" | "timeout" | "interruption"): {
-  outer: ProbeWorkerHandle;
-  container: ProbeWorkspaceContainer;
-  childReaped: boolean;
-  terminateGroup: (signal: NodeJS.Signals) => void;
-} {
-  let exitCode: number | null = null;
-  let resolveExited: (code: number) => void = () => {};
-  let resolveResult: (result: ProbeWorkerResult) => void = () => {};
-  let childReaped = outcome === "success";
-  const exited = new Promise<number>((resolve) => {
-    resolveExited = resolve;
-  });
-  const result = new Promise<ProbeWorkerResult>((resolve) => {
-    resolveResult = resolve;
-  });
-  const process: ProbeProcess = {
-    pid: 701,
-    processGroupOwned: true,
-    get exitCode() {
-      return exitCode;
-    },
-    get killed() {
-      return exitCode !== null;
-    },
-    exited,
-    kill(signal) {
-      if (signal !== undefined) {
-        terminateGroup(signal);
-      }
-    },
-  };
-  const outer = { process, result };
-  const container: ProbeWorkspaceContainer = {
-    directoryPath: "/tmp/fake-probe-container",
-    capabilityPath: "/tmp/fake-probe-container/.capability",
-    capability: CAPABILITY,
-  };
-
-  if (outcome === "success") {
-    completeOuter(0);
-  } else if (outcome === "failure") {
-    completeOuter(1);
-  }
-
-  function completeOuter(code: number) {
-    if (exitCode !== null) {
-      return;
-    }
-    exitCode = code;
-    resolveExited(code);
-    resolveResult({
-      exitCode: code,
-      stdout: "{}",
-      stderr: "",
-      outputExceeded: false,
-    });
-  }
-
-  function terminateGroup(signal: NodeJS.Signals) {
-    if (signal === "SIGTERM" && (outcome === "timeout" || outcome === "interruption")) {
-      return;
-    }
-    childReaped = true;
-    completeOuter(signal === "SIGKILL" ? 137 : 143);
-  }
-
-  return {
-    outer,
-    container,
-    get childReaped() {
-      return childReaped;
-    },
-    terminateGroup,
-  };
 }
 
 async function captureRejection(operation: () => Promise<unknown>): Promise<Error> {

--- a/src/lib/sqlite-foundation-probe.ts
+++ b/src/lib/sqlite-foundation-probe.ts
@@ -2,13 +2,9 @@ import { Database } from "bun:sqlite";
 import {
   buildProbeWorkerCommand,
   capDiagnosticOutput,
+  createProbeOutputBudget,
   installProbeSignalHandlers,
-  ProbeInterruptedError,
-  ProbeReapTimeoutError,
-  ProbeTimeoutError,
-  ProbeWorkerFailureError,
   readSingleValueFromWorker,
-  spawnProbeCommand,
   spawnProbeWorker,
   SQLITE_FOUNDATION_PROBE_INNER_TIMEOUT_MS,
   SQLITE_FOUNDATION_PROBE_MAX_OUTPUT_BYTES,
@@ -16,9 +12,23 @@ import {
   SQLITE_FOUNDATION_PROBE_TIMEOUT_MS,
   superviseProbeWorkers,
   type ProbeSupervisionOptions,
-  type ProbeWorkerHandle,
   type ProbeWorkerResult,
 } from "@/lib/sqlite-foundation-probe-process";
+export {
+  buildNoNetworkProbeCommand,
+  createProbeNetworkBoundary,
+  ProbeNetworkBoundaryError,
+} from "@/lib/sqlite-foundation-probe-network";
+export {
+  countProbeDescendants,
+  createProbeResourceController,
+  ProbeResourceControlError,
+  ProbeResourceLimitError,
+} from "@/lib/sqlite-foundation-probe-resources";
+import {
+  SqliteFoundationGateError,
+  translateProbeError,
+} from "@/lib/sqlite-foundation-probe-errors";
 import {
   cleanupOwnedProbeWorkspace,
   cleanupOwnedProbeWorkspaceContainer,
@@ -40,10 +50,12 @@ import {
 export {
   buildProbeWorkerCommand,
   capDiagnosticOutput,
+  createProbeOutputBudget,
   cleanupOwnedProbeWorkspace,
   cleanupOwnedProbeWorkspaceContainer,
   createProbeWorkspace,
   createProbeWorkspaceContainer,
+  createProbeOuterEnvironment,
   parseSqliteProbeInvocation,
   validateOwnedProbeWorkspace,
   validateOwnedProbeWorkerWorkspace,
@@ -65,6 +77,19 @@ export type {
   ProbeWorkspaceState,
   SqliteProbeInvocation,
 } from "@/lib/sqlite-foundation-probe-containment";
+export {
+  SQLITE_FOUNDATION_PROBE_COMMAND,
+  SQLITE_FOUNDATION_PROBE_MAX_DISK_BYTES,
+  SQLITE_FOUNDATION_PROBE_MAX_MEMORY_BYTES,
+  SQLITE_FOUNDATION_PROBE_MAX_PROCESS_COUNT,
+} from "@/lib/sqlite-foundation-probe-result";
+export type { ProbeQualificationResult, ProbeOutcome } from "@/lib/sqlite-foundation-probe-result";
+export { runCompiledSqliteFoundationProbe } from "@/lib/sqlite-foundation-probe-runner";
+export type {
+  CompiledSqliteFoundationProbeOptions,
+  CompiledSqliteFoundationProbeResult,
+} from "@/lib/sqlite-foundation-probe-runner";
+export { SqliteFoundationGateError } from "@/lib/sqlite-foundation-probe-errors";
 
 const SQLITE_MINIMUM_VERSION = [3, 51, 3] as const;
 const SQLITE_OWNERSHIP_TABLE = "foundation_probe_ownership";
@@ -96,15 +121,6 @@ export type SqliteFoundationProbeReport = {
   foreignKeyViolations: number;
   duplicateKeys: number;
 };
-
-export class SqliteFoundationGateError extends Error {
-  readonly decisionRequired = true;
-
-  constructor(message: string) {
-    super(message);
-    this.name = "SqliteFoundationGateError";
-  }
-}
 
 export function isSupportedSqliteVersion(version: string): boolean {
   const parsed = parseSqliteVersion(version);
@@ -161,18 +177,22 @@ export async function runSqliteFoundationProbe(
       );
     }
 
+    const outputBudget = createProbeOutputBudget();
     const workers = [
       ...Array.from({ length: SQLITE_FOUNDATION_PROBE_WORKLOAD.writerCount }, (_, writer) =>
-        spawnProbeWorker(executablePath, "--sqlite-foundation-probe-writer", [
-          probeWorkspace.directoryPath,
-          probeWorkspace.capability,
-          String(writer),
-        ]),
+        spawnProbeWorker(
+          executablePath,
+          "--sqlite-foundation-probe-writer",
+          [probeWorkspace.directoryPath, probeWorkspace.capability, String(writer)],
+          { outputBudget },
+        ),
       ),
-      spawnProbeWorker(executablePath, "--sqlite-foundation-probe-checkpoint", [
-        probeWorkspace.directoryPath,
-        probeWorkspace.capability,
-      ]),
+      spawnProbeWorker(
+        executablePath,
+        "--sqlite-foundation-probe-checkpoint",
+        [probeWorkspace.directoryPath, probeWorkspace.capability],
+        { outputBudget },
+      ),
     ];
     const results = await superviseProbeWorkers(workers, supervisionOptions);
     report = await verifyProbeDatabase(probeWorkspace, runtime, results);
@@ -220,78 +240,6 @@ export async function runSqliteFoundationProbe(
     );
   }
   return report;
-}
-
-export type CompiledSqliteFoundationProbeOptions = ProbeSupervisionOptions & {
-  createWorkspaceContainer?: () => Promise<ProbeWorkspaceContainer>;
-  cleanupWorkspaceContainer?: (container: ProbeWorkspaceContainer) => Promise<void>;
-  spawnOuter?: (executablePath: string, container: ProbeWorkspaceContainer) => ProbeWorkerHandle;
-};
-
-export async function runCompiledSqliteFoundationProbe(
-  executablePath: string,
-  options: CompiledSqliteFoundationProbeOptions = {},
-): Promise<ProbeWorkerResult> {
-  const signalScope = options.signal === undefined ? installProbeSignalHandlers() : null;
-  const supervisionOptions = {
-    ...options,
-    timeoutMs: options.timeoutMs ?? SQLITE_FOUNDATION_PROBE_TIMEOUT_MS,
-    ...(signalScope === null ? {} : { signal: signalScope.signal }),
-  };
-  let container: ProbeWorkspaceContainer | undefined;
-  let result: ProbeWorkerResult | undefined;
-  let probeError: SqliteFoundationGateError | undefined;
-  try {
-    container = await (options.createWorkspaceContainer ?? createProbeWorkspaceContainer)();
-    const worker =
-      options.spawnOuter?.(executablePath, container) ??
-      spawnProbeCommand([executablePath, "--sqlite-foundation-probe"], {
-        detached: true,
-        env: createProbeOuterEnvironment(container),
-      });
-    const [workerResult] = await superviseProbeWorkers([worker], supervisionOptions);
-    if (workerResult === undefined) {
-      throw new SqliteFoundationGateError(
-        "SQLite runtime probe returned no result; return the database choice to a human.",
-      );
-    }
-    if (workerResult.exitCode !== 0 || workerResult.outputExceeded) {
-      throw new SqliteFoundationGateError(
-        "SQLite runtime probe failed or exceeded its diagnostic output limit; return the database choice to a human.",
-      );
-    }
-    result = workerResult;
-  } catch (error) {
-    probeError = translateProbeError(error);
-  }
-
-  let cleanupError: SqliteFoundationGateError | undefined;
-  if (container !== undefined) {
-    try {
-      await (
-        options.cleanupWorkspaceContainer ??
-        ((owned) => cleanupOwnedProbeWorkspaceContainer(owned.directoryPath, owned.capability))
-      )(container);
-    } catch {
-      cleanupError = new SqliteFoundationGateError(
-        "SQLite integrity probe cleanup could not be verified; return the database choice to a human.",
-      );
-    }
-  }
-  signalScope?.cleanup();
-
-  if (probeError !== undefined) {
-    throw probeError;
-  }
-  if (cleanupError !== undefined) {
-    throw cleanupError;
-  }
-  if (result === undefined) {
-    throw new SqliteFoundationGateError(
-      "SQLite runtime probe returned no result; return the database choice to a human.",
-    );
-  }
-  return result;
 }
 
 export async function runSqliteFoundationProbeWorker(
@@ -537,21 +485,4 @@ function parseSqliteVersion(version: string): [number, number, number] | null {
 
 function isBusyError(error: unknown): boolean {
   return error instanceof Error && /busy|locked/i.test(error.message);
-}
-
-function translateProbeError(error: unknown): SqliteFoundationGateError {
-  if (error instanceof SqliteFoundationGateError) {
-    return error;
-  }
-  if (
-    error instanceof ProbeTimeoutError ||
-    error instanceof ProbeInterruptedError ||
-    error instanceof ProbeReapTimeoutError ||
-    error instanceof ProbeWorkerFailureError
-  ) {
-    return new SqliteFoundationGateError(error.message);
-  }
-  return new SqliteFoundationGateError(
-    "SQLite integrity probe could not complete. Return the database choice to a human; do not substitute a canary or custom Bun build.",
-  );
 }

--- a/src/lib/testing-policy.test.ts
+++ b/src/lib/testing-policy.test.ts
@@ -1,22 +1,42 @@
 import { describe, expect, test } from "bun:test";
-import { routeQualificationRequest, type QualificationEntry } from "@/lib/testing-policy";
+import {
+  isCompleteQualificationEntry,
+  parseQualificationRegistry,
+  routeQualificationRequest,
+} from "@/lib/testing-policy";
 
-const registeredEntry: QualificationEntry = {
-  complete: true,
-  riskStillExists: true,
-  safe: true,
-};
+const policyMarkdown = await Bun.file("docs/agents/testing.md").text();
+const registry = parseQualificationRegistry(policyMarkdown);
+const registeredEntry = Object.values(registry)[0];
+if (registeredEntry === undefined) throw new Error("Canonical SQLite qualification is missing.");
 
 describe("testing policy routing", () => {
+  test("registers the exact compiled SQLite workload with every admission field", () => {
+    expect(Object.keys(registry)).toEqual([registeredEntry.command]);
+    expect(registeredEntry.command).toMatch(/^bun run [^ ]+ \[compiled-executable\]$/);
+    expect(registeredEntry.resourceLimits).toEqual({
+      timeoutMs: 15_000,
+      processCount: 7,
+      memoryBytes: 512 * 1024 * 1024,
+      diskBytes: 16 * 1024 * 1024,
+      outputBytes: 4 * 1024,
+      descendantCleanupMs: 1_000,
+    });
+    for (const value of Object.values(registeredEntry)) {
+      if (typeof value === "string") expect(value.length).toBeGreaterThan(0);
+    }
+    expect(isCompleteQualificationEntry(registeredEntry)).toBe(true);
+  });
+
   test("invokes exactly one named registered qualification request", () => {
     expect(
       routeQualificationRequest(
         {
           kind: "qualification",
           mode: "run",
-          name: "sqlite-artifact-gate",
+          name: registeredEntry.command,
         },
-        { "sqlite-artifact-gate": registeredEntry },
+        { [registeredEntry.command]: registeredEntry },
       ),
     ).toBe("invoke-once");
   });
@@ -36,9 +56,9 @@ describe("testing policy routing", () => {
           {
             kind: "qualification",
             mode: mode as "validate" | "review",
-            name: "sqlite-artifact-gate",
+            name: registeredEntry.command,
           },
-          { "sqlite-artifact-gate": registeredEntry },
+          { [registeredEntry.command]: registeredEntry },
         ),
       ).toBe("inspect-without-invocation");
     },
@@ -50,18 +70,18 @@ describe("testing policy routing", () => {
         {
           kind: "qualification",
           mode: "run",
-          name: "sqlite-artifact-gate",
+          name: registeredEntry.command,
         },
         {},
       ),
     ).toBe("refuse-unregistered");
   });
 
-  test("refuses ambiguous, unsafe, incomplete, and mismatched requests", () => {
+  test("refuses ambiguous, incomplete, and mismatched requests", () => {
     expect(
       routeQualificationRequest(
         { kind: "qualification", mode: "run" },
-        { "sqlite-artifact-gate": registeredEntry },
+        { [registeredEntry.command]: registeredEntry },
       ),
     ).toBe("refuse-ambiguous");
     expect(
@@ -69,28 +89,37 @@ describe("testing policy routing", () => {
         {
           kind: "qualification",
           mode: "run",
-          name: "sqlite-artifact-gate",
+          name: registeredEntry.command,
           parametersMatch: false,
         },
-        { "sqlite-artifact-gate": registeredEntry },
+        { [registeredEntry.command]: registeredEntry },
       ),
     ).toBe("refuse-parameter-mismatch");
     expect(
       routeQualificationRequest(
-        { kind: "qualification", mode: "run", name: "unsafe" },
-        { unsafe: { ...registeredEntry, safe: false } },
+        { kind: "qualification", mode: "run", name: "incomplete" },
+        { incomplete: { ...registeredEntry, owner: "" } },
       ),
-    ).toBe("refuse-unsafe");
+    ).toBe("refuse-incomplete");
     expect(
       routeQualificationRequest(
         { kind: "qualification", mode: "run", name: "incomplete" },
-        { incomplete: { ...registeredEntry, complete: false } },
+        { incomplete: { ...registeredEntry, owner: "" } },
       ),
     ).toBe("refuse-incomplete");
   });
 
-  test("deployment workflow contains no automatic qualification trigger", async () => {
+  test("literal qualification command is absent from ordinary workflow and script chains", async () => {
     const workflow = await Bun.file(".github/workflows/deploy-production.yml").text();
-    expect(workflow).not.toMatch(/qualification/i);
+    expect(workflow).not.toContain(registeredEntry.command.split(" ")[2]);
+    const packageJson = (await Bun.file("package.json").json()) as {
+      scripts: Record<string, string>;
+    };
+    const qualificationScriptName = registeredEntry.command.split(" ")[2];
+    for (const [name, command] of Object.entries(packageJson.scripts)) {
+      if (name !== qualificationScriptName) {
+        expect(command).not.toContain(registeredEntry.command.split(" ")[2]);
+      }
+    }
   });
 });

--- a/src/lib/testing-policy.ts
+++ b/src/lib/testing-policy.ts
@@ -1,8 +1,118 @@
 export type QualificationEntry = {
-  complete: boolean;
-  riskStillExists: boolean;
-  safe: boolean;
+  command: string;
+  owner: string;
+  protectedRisk: string;
+  cheaperEvidence: string;
+  platform: string;
+  artifact: string;
+  isolation: string;
+  expectedDuration: string;
+  resourceLimits: {
+    timeoutMs: number;
+    processCount: number;
+    memoryBytes: number;
+    diskBytes: number;
+    outputBytes: number;
+    descendantCleanupMs: number;
+  };
+  occasions: string;
+  network: string;
+  credentials: string;
+  filesystem: string;
+  productionExclusions: string;
+  result: string;
+  retention: string;
+  replacementCondition: string;
 };
+
+export type QualificationRegistry = Readonly<Record<string, QualificationEntry>>;
+
+const REGISTRY_LABELS = {
+  Owner: "owner",
+  "Protected risk": "protectedRisk",
+  "Why cheaper evidence is insufficient": "cheaperEvidence",
+  "Platform and artifact": "platformArtifact",
+  "Isolation and filesystem": "isolationFilesystem",
+  "Expected duration and resource envelope": "expectedDurationAndResources",
+  "Approved occasions and venue": "occasions",
+  "Network and credentials": "networkCredentials",
+  "Production exclusions": "productionExclusions",
+  "Result and diagnostics": "resultDiagnostics",
+  Retention: "retention",
+  "Replacement/removal condition": "replacementCondition",
+} as const;
+
+export function parseQualificationRegistry(markdown: string): QualificationRegistry {
+  const lines = markdown.split(/\r?\n/);
+  const registry: Record<string, QualificationEntry> = {};
+  for (let index = 0; index < lines.length; index += 1) {
+    const heading = /^#### `([^`]+)`$/.exec(lines[index] ?? "");
+    if (heading === null) continue;
+    const fields: Partial<Record<(typeof REGISTRY_LABELS)[keyof typeof REGISTRY_LABELS], string>> =
+      {};
+    index += 1;
+    for (; index < lines.length; index += 1) {
+      const line = lines[index] ?? "";
+      if (/^#{1,4} /.test(line)) {
+        index -= 1;
+        break;
+      }
+      const field = /^- \*\*([^*]+):\*\* (.+)$/.exec(line);
+      if (field === null) continue;
+      const key = REGISTRY_LABELS[field[1] as keyof typeof REGISTRY_LABELS];
+      if (key !== undefined) fields[key] = field[2];
+    }
+
+    const required = Object.values(fields);
+    if (
+      required.length !== Object.keys(REGISTRY_LABELS).length ||
+      required.some((value) => !value)
+    ) {
+      throw new Error(`Qualification registry entry is incomplete: ${heading[1]}`);
+    }
+    const resources = parseResourceLimits(fields.expectedDurationAndResources ?? "");
+    const command = heading[1];
+    if (command === undefined) throw new Error("Qualification registry command is missing.");
+    const [platform, artifact] = splitField(fields.platformArtifact, ", using ");
+    const [isolation, filesystem] = splitField(fields.isolationFilesystem, "; ");
+    const [network, credentials] = splitField(fields.networkCredentials, ". No credential");
+    registry[command] = {
+      command,
+      owner: fields.owner ?? "",
+      protectedRisk: fields.protectedRisk ?? "",
+      cheaperEvidence: fields.cheaperEvidence ?? "",
+      platform,
+      artifact,
+      isolation,
+      expectedDuration: fields.expectedDurationAndResources ?? "",
+      resourceLimits: resources,
+      occasions: fields.occasions ?? "",
+      network,
+      credentials: credentials === "" ? "none stated" : `No credential${credentials}`,
+      filesystem,
+      productionExclusions: fields.productionExclusions ?? "",
+      result: fields.resultDiagnostics ?? "",
+      retention: fields.retention ?? "",
+      replacementCondition: fields.replacementCondition ?? "",
+    };
+  }
+  return registry;
+}
+
+function splitField(value: string | undefined, separator: string): [string, string] {
+  const [first, ...rest] = (value ?? "").split(separator);
+  return [first?.trim() ?? "", rest.length === 0 ? "" : rest.join(separator).trim()];
+}
+
+export function isCompleteQualificationEntry(entry: QualificationEntry): boolean {
+  return (
+    Object.entries(entry).every(([key, value]) => {
+      if (key === "resourceLimits") return true;
+      return typeof value === "string" && value.trim().length > 0;
+    }) &&
+    Object.values(entry.resourceLimits).every((value) => Number.isSafeInteger(value) && value > 0)
+  );
+}
 
 export type QualificationRequest =
   | { kind: "ordinary" }
@@ -20,23 +130,41 @@ export type RoutingDecision =
   | "refuse-ambiguous"
   | "refuse-unregistered"
   | "refuse-incomplete"
-  | "refuse-unsafe"
-  | "refuse-parameter-mismatch"
-  | "refuse-risk-not-established";
+  | "refuse-parameter-mismatch";
 
 export function routeQualificationRequest(
   request: QualificationRequest,
-  registry: Readonly<Record<string, QualificationEntry>>,
+  registry: QualificationRegistry,
 ): RoutingDecision {
   if (request.kind === "ordinary") return "ordinary-boundary";
   if (!request.name) return "refuse-ambiguous";
 
   const entry = registry[request.name];
   if (!entry) return "refuse-unregistered";
-  if (!entry.complete) return "refuse-incomplete";
-  if (!entry.riskStillExists) return "refuse-risk-not-established";
-  if (!entry.safe) return "refuse-unsafe";
+  if (!isCompleteQualificationEntry(entry)) return "refuse-incomplete";
   if (request.parametersMatch === false) return "refuse-parameter-mismatch";
   if (request.mode !== "run") return "inspect-without-invocation";
   return "invoke-once";
+}
+
+function parseResourceLimits(value: string): QualificationEntry["resourceLimits"] {
+  const read = (pattern: RegExp, label: string) => {
+    const match = pattern.exec(value);
+    if (match === null) throw new Error(`Qualification registry resource is missing: ${label}`);
+    return Number(match[1]);
+  };
+  return {
+    timeoutMs: read(/hard outer timeout (\d+) seconds/, "timeout") * 1_000,
+    processCount: read(
+      /at most (\d+) (?:observed )?workload (?:processes|descendants)/,
+      "process count",
+    ),
+    memoryBytes: read(/at most (\d+) MiB .*peak memory/, "memory") * 1024 * 1024,
+    diskBytes:
+      read(/at most (\d+) MiB (?:(?:OS-enforced|monitored) )?temporary (?:`tmpfs` )?disk/, "disk") *
+      1024 *
+      1024,
+    outputBytes: read(/at most (\d+) KiB raw-byte captured diagnostics/, "output") * 1024,
+    descendantCleanupMs: read(/within (\d+) second after forced termination/, "cleanup") * 1_000,
+  };
 }


### PR DESCRIPTION
## Summary

- Harden the explicit compiled SQLite qualification harness with bounded Linux namespace, cgroup-v2, tmpfs, process-tree, network, output, interruption, and cleanup controls.
- Emit linked, capped, redacted pre-cleanup and final evidence with truthful resource and cleanup dispositions.
- Add deterministic Fast seams plus separately named real-signal and native-admission Focused Integration Tests while keeping the workload out of ordinary tests and CI.

## Why

The original #71 harness preserved the right exact-artifact risk but its supervision and evidence boundaries could hang, outlive cancellation, exceed host resources, or report cleanup before it was established. This correction aligns that gate with the repository testing policy without weakening or automatically invoking the workload.

## Impact

The qualification workload can start only after fail-closed native isolation and resource admission. Timeout, interruption, limit violation, and cleanup paths are bounded and evidence-backed, reducing risk to developer machines, servers, credentials, and CI quota.

## Validation

- `bun install --frozen-lockfile`
- `bun audit` — no vulnerabilities
- `bun run check`
- `bun run test` — 263 passed
- `bun run test:focused-signal` — SIGINT, SIGTERM, and SIGHUP passed
- `bun run test:focused-admission` — correctly recorded the portable Darwin/arm64 blocker
- `bun run build`

No Qualification Test or `bun run check:sqlite-runtime` workload was run. One harmless native Linux x86-64 `test:focused-admission` record remains required before #104 can be fully resolved.

## Stack

Sixth layer of stack #103. Depends on #124 and is followed by #126.

Tracks #104; intentionally does not close it while native admission evidence is outstanding.
