### PR TITLE
Bind Control sessions to eligible Event Games

### DIFF
--- a/docs/agents/grant-authority.md
+++ b/docs/agents/grant-authority.md
@@ -18,12 +18,20 @@ support. The public lifecycle is:
    update and permanent `credential-rotated` audit evidence commit atomically;
    any cryptographic, collision, audit, or storage failure leaves the old
    credential and versions usable.
-4. `admitGrant` validates the QR credential, resolves the current event
-   game, and creates a separately random session bearer. A second admission in
+4. `admitGrant` validates the QR credential and, for a Control Grant, resolves
+   exactly one eligible Event Game for its Pitch Slot through the injected
+   scope resolver. It generically rejects missing, conflicted, or malformed
+   resolution and otherwise creates a separately random session bearer bound
+   to that Event Game. A second admission in
    the same browser context revokes that context's active session and records a
    replacement; other contexts remain active.
-5. `authorizeGrant` accepts only the session bearer and rechecks the
-   Grant version, lifecycle, scope resolution, and session state.
+5. `authorizeGrant` accepts the session bearer and, for a Control Grant, the
+   explicit Event Game identity of the work being authorized. It rechecks the
+   Grant version, lifecycle, scope resolution, and Grant Session state without
+   inferring a new Event Game for queued work. Before Game Commencement the
+   caller may retain the prior Event Game binding or atomically accept the
+   resolver's old/new switch relationship; after commencement the Grant
+   Session remains pinned to its unfinished Event Game.
 6. Disable, revoke, rotation, metadata correction, targeted session
    revocation, reveal, and reads all re-resolve the current trusted authority
    and management matrix in their transaction. Metadata correction rebinds
@@ -58,6 +66,14 @@ operation contains storage failures at the module boundary; list operations
 return a typed unavailable result and mutations return redacted failure
 details. Storage writes for a Grant and its mandatory audit evidence are
 transactional in both adapters, including expiry erasure and audit evidence.
+Accepted Game Lock evidence drives a trusted internal lifecycle transition
+that terminates only Control Grant Sessions bound to the locked Event Game and
+atomically invokes the future Grant Code state hook. Reopening permits fresh
+admission but never revives old session or code authority. Fresh current Grant
+Sessions may authorize content-bound replay only for preserved work from a
+different, non-active originating Grant Session on the same unfinished,
+unlocked Event Game; the permanent audit binds both sessions, their Grant
+versions, and the replay evidence identity.
 Expired Grants have no credential key versions, ciphertext, IV, authentication
 tag, lookup digest, or session verifier material and cannot rotate. Migration
 006 upgrades legacy active, disabled, revoked, due, and expired rows in one
@@ -91,8 +107,10 @@ manufacture current trusted evidence.
 The reusable semantic contract runs against in-memory storage in the ordinary
 Fast Test boundary and against disposable SQLite storage in the focused
 integration boundary. The SQLite contract covers replacement, generic failure,
+Event Game binding and switching, replay provenance, trusted Game Lock,
 atomic credential key rotation, expiry erasure, migration upgrade and rollback,
-redaction, restart, and real independent-worker admission contention. The
+tamper-triggered write freeze, redaction, restart, and real independent-worker
+admission contention. The
 contention harness uses an allowlisted child environment, a private owner-only
 credential file, capped streaming diagnostics, and one bounded deadline for
 barrier, work, TERM/KILL escalation, reap, and artifact cleanup. The focused
@@ -114,4 +132,5 @@ bun run test:focused:grant
 The focused file is intentionally outside ordinary test discovery. This slice
 does not implement QR URL or fragment handling, cookies, React UI, Technical
 Admin Passkey authentication itself, Grant Codes, Event administration UI, or
-Pitch Slot/Event Game catalog binding.
+the Event catalog implementation behind the injected Pitch Slot/Event Game
+resolver.

--- a/src/lib/event-game-actions-sqlite.focused.ts
+++ b/src/lib/event-game-actions-sqlite.focused.ts
@@ -922,7 +922,7 @@ describe("SQLite immutable Event Game actions", () => {
       database.close();
 
       const current = openSqliteFoundationStorage(databasePath);
-      expect((await current.applyMigrations()).schemaVersion).toBe(14);
+      expect((await current.applyMigrations()).schemaVersion).toBe(16);
       const currentRecord = createRecord(current, root);
       expect(await currentRecord.registerRoot(root)).toMatchObject({ status: "idempotent" });
       expect(await currentRecord.readiness()).toMatchObject({ ok: true, actionCount: 1 });
@@ -937,7 +937,7 @@ describe("SQLite immutable Event Game actions", () => {
       await seedLegacyConflictHistory(databasePath, root);
 
       const storage = openSqliteFoundationStorage(databasePath);
-      expect((await storage.applyMigrations()).schemaVersion).toBe(14);
+      expect((await storage.applyMigrations()).schemaVersion).toBe(16);
       const record = createRecord(storage, root);
       expect(await record.registerRoot(root)).toMatchObject({ status: "idempotent" });
       expect(await record.readiness()).toMatchObject({ ok: true, actionCount: 3 });
@@ -958,7 +958,7 @@ describe("SQLite immutable Event Game actions", () => {
       await seedLegacyConflictHistory(databasePath, root);
 
       const storage = openSqliteFoundationStorage(databasePath);
-      expect((await storage.applyMigrations()).schemaVersion).toBe(14);
+      expect((await storage.applyMigrations()).schemaVersion).toBe(16);
       const record = createRecord(storage, root);
       expect(await record.registerRoot(root)).toMatchObject({ status: "idempotent" });
       expect(

--- a/src/lib/event-game-actions.test.ts
+++ b/src/lib/event-game-actions.test.ts
@@ -519,6 +519,7 @@ async function readSnapshot(
     readRecordMetadata: () => metadata,
     listAuditEntries: () => audits,
     findGrantById: () => null,
+    listGrants: () => [],
     findGrantByCredentialLookupDigest: () => null,
     findActiveSessionByGrantAndContext: () => null,
     findSessionByBearerVerifier: () => null,

--- a/src/lib/event-game-record.ts
+++ b/src/lib/event-game-record.ts
@@ -275,6 +275,7 @@ export function createEventGameRecord(
         readRecordMetadata: () => metadata,
         listAuditEntries: () => auditEntries,
         findGrantById: () => null,
+        listGrants: () => [],
         findGrantByCredentialLookupDigest: () => null,
         findActiveSessionByGrantAndContext: () => null,
         findSessionByBearerVerifier: () => null,

--- a/src/lib/foundation-grant-erasure-migration.test.ts
+++ b/src/lib/foundation-grant-erasure-migration.test.ts
@@ -210,7 +210,7 @@ describe("Grant cryptographic erasure migration", () => {
 
       const current = openSqliteFoundationStorage(databasePath);
       await current.applyMigrations({ requireCandidate: false });
-      expect(await current.readiness()).toMatchObject({ ok: true, schemaVersion: "14" });
+      expect(await current.readiness()).toMatchObject({ ok: true, schemaVersion: "16" });
       current.close();
 
       const raw = new Database(databasePath);
@@ -330,7 +330,7 @@ describe("Grant cryptographic erasure migration", () => {
       raw.close();
 
       const reopened = openSqliteFoundationStorage(databasePath);
-      expect(await reopened.readiness()).toMatchObject({ ok: true, schemaVersion: "14" });
+      expect(await reopened.readiness()).toMatchObject({ ok: true, schemaVersion: "16" });
       const restartedAudit = await reopened.transaction((transaction) =>
         transaction.listGrantAudit("grant-expired"),
       );

--- a/src/lib/foundation-migrations.test.ts
+++ b/src/lib/foundation-migrations.test.ts
@@ -13,9 +13,9 @@ const migrations: readonly FoundationMigration[] = [
 ];
 
 describe("foundation migration ledger compatibility", () => {
-  test("keeps accepted migrations 001 through 014 byte-for-byte immutable", () => {
+  test("keeps accepted migrations 001 through 016 byte-for-byte immutable", () => {
     expect(
-      FOUNDATION_MIGRATIONS.slice(0, 14).map(({ id, checksum }) => ({ id, checksum })),
+      FOUNDATION_MIGRATIONS.slice(0, 16).map(({ id, checksum }) => ({ id, checksum })),
     ).toEqual([
       {
         id: "001-foundation-event-game-record-roots",
@@ -72,6 +72,14 @@ describe("foundation migration ledger compatibility", () => {
       {
         id: "014-grant-provenance-integrity",
         checksum: "2dbb23e24340a998baeb48c77365781763e42ef8c47f10b0097b3df4c1e9d2d8",
+      },
+      {
+        id: "015-control-session-binding",
+        checksum: "844f8d804dc6a243090de9f5c8cf9c9d04170cfbea7443c23e9403eebc0be73f",
+      },
+      {
+        id: "016-replay-content-provenance",
+        checksum: "ec5b1d9dbead810498648018572b87635c034da1f9fbe291a31519230e1d80ee",
       },
     ]);
   });

--- a/src/lib/foundation-migrations.ts
+++ b/src/lib/foundation-migrations.ts
@@ -400,6 +400,23 @@ export const FOUNDATION_TYPED_GRANT_AUDIT_TABLE_V11_SQL =
     "    audit_integrity_tag TEXT NOT NULL CHECK (audit_integrity_tag = 'legacy-migration-v1' OR audit_integrity_tag GLOB 'hmac-sha256-v1:*'),\n    created_at_ms INTEGER NOT NULL",
   );
 
+/** Schema-15 audit shape. Earlier migration SQL remains byte-stable. */
+export const FOUNDATION_TYPED_GRANT_AUDIT_TABLE_V15_SQL =
+  FOUNDATION_TYPED_GRANT_AUDIT_TABLE_V11_SQL.replace(
+    "'session-terminated'))",
+    "'session-terminated', 'session-switched', 'replay-authorized'))",
+  ).replace(
+    "    terminal_reason TEXT CHECK (terminal_reason IS NULL OR terminal_reason IN ('game-locked', 'accepted-game-switch', 'past-game-day'))",
+    "    previous_event_game_id TEXT,\n    terminal_reason TEXT CHECK (terminal_reason IS NULL OR terminal_reason IN ('game-locked', 'accepted-game-switch', 'past-game-day'))",
+  );
+
+/** Schema-16 adds immutable content-bound replay provenance. */
+export const FOUNDATION_TYPED_GRANT_AUDIT_TABLE_V16_SQL =
+  FOUNDATION_TYPED_GRANT_AUDIT_TABLE_V15_SQL.replace(
+    "    previous_event_game_id TEXT,",
+    "    previous_event_game_id TEXT,\n    replay_evidence_id TEXT,",
+  );
+
 export const FOUNDATION_TYPED_GRANT_SESSION_TABLE_SQL = FOUNDATION_GRANT_SESSION_TABLE_SQL.replace(
   "    revoked_at_ms INTEGER,",
   "    revoked_at_ms INTEGER,\n    device_class TEXT NOT NULL,\n    browser_class TEXT NOT NULL,",
@@ -473,6 +490,18 @@ export const FOUNDATION_GRANT_AUDIT_PROVENANCE_TABLE_SQL = `
   ) STRICT
 `;
 
+export const FOUNDATION_GRANT_AUDIT_PROVENANCE_TABLE_V15_SQL =
+  FOUNDATION_GRANT_AUDIT_PROVENANCE_TABLE_SQL.replace(
+    "    terminal_reason TEXT,",
+    "    previous_event_game_id TEXT,\n    terminal_reason TEXT,",
+  );
+
+export const FOUNDATION_GRANT_AUDIT_PROVENANCE_TABLE_V16_SQL =
+  FOUNDATION_GRANT_AUDIT_PROVENANCE_TABLE_V15_SQL.replace(
+    "    previous_event_game_id TEXT,",
+    "    previous_event_game_id TEXT,\n    replay_evidence_id TEXT,",
+  );
+
 export const FOUNDATION_GRANT_AUDIT_PROVENANCE_GRANT_INDEX_SQL = `
   CREATE INDEX foundation_grant_audit_provenance_grant_id
     ON foundation_grant_audit_provenance (grant_id, audit_id)
@@ -537,6 +566,36 @@ export const FOUNDATION_GRANT_AUDIT_PROVENANCE_AFTER_INSERT_TRIGGER_SQL = `
       );
     END
 `;
+
+export const FOUNDATION_GRANT_AUDIT_PROVENANCE_AFTER_INSERT_TRIGGER_V15_SQL = `
+  CREATE TRIGGER foundation_grant_audit_provenance_after_insert
+    AFTER INSERT ON foundation_grant_audit
+    BEGIN
+      INSERT INTO foundation_grant_audit_provenance (
+        audit_id, action, outcome, actor_reference, grant_id, grant_type, grant_version,
+        event_id, game_day_id, pitch_id, pitch_slot_id, session_id, replaced_session_id,
+        event_game_id, previous_event_game_id, credential_kind, credential_fingerprint,
+        before_status, after_status, before_expires_at_ms, after_expires_at_ms,
+        terminal_reason, audit_integrity_tag, created_at_ms
+      ) VALUES (
+        NEW.audit_id, NEW.action, NEW.outcome, NEW.actor_reference, NEW.grant_id, NEW.grant_type,
+        NEW.grant_version, NEW.event_id, NEW.game_day_id, NEW.pitch_id, NEW.pitch_slot_id,
+        NEW.session_id, NEW.replaced_session_id, NEW.event_game_id, NEW.previous_event_game_id,
+        NEW.credential_kind, NEW.credential_fingerprint, NEW.before_status, NEW.after_status,
+        NEW.before_expires_at_ms, NEW.after_expires_at_ms, NEW.terminal_reason,
+        NEW.audit_integrity_tag, NEW.created_at_ms
+      );
+    END
+`;
+
+export const FOUNDATION_GRANT_AUDIT_PROVENANCE_AFTER_INSERT_TRIGGER_V16_SQL =
+  FOUNDATION_GRANT_AUDIT_PROVENANCE_AFTER_INSERT_TRIGGER_V15_SQL.replace(
+    "event_game_id, previous_event_game_id, credential_kind",
+    "event_game_id, previous_event_game_id, replay_evidence_id, credential_kind",
+  ).replace(
+    "NEW.event_game_id, NEW.previous_event_game_id,\n        NEW.credential_kind",
+    "NEW.event_game_id, NEW.previous_event_game_id, NEW.replay_evidence_id,\n        NEW.credential_kind",
+  );
 export const FOUNDATION_GRANT_AUDIT_NO_LEGACY_TAG_INSERT_TRIGGER_SQL = `
   CREATE TRIGGER foundation_grant_audit_no_legacy_integrity_tag
     BEFORE INSERT ON foundation_grant_audit
@@ -933,6 +992,98 @@ const FOUNDATION_TYPED_GRANT_AUDIT_EVIDENCE_MIGRATION_SQL = `
   ${FOUNDATION_GRANT_AUDIT_GRANT_INDEX_SQL};
 `;
 
+const FOUNDATION_CONTROL_SESSION_BINDING_MIGRATION_SQL = `
+  CREATE TABLE foundation_grant_audit_control_session_copy AS SELECT * FROM foundation_grant_audit;
+  DROP TABLE foundation_grant_audit;
+  ${FOUNDATION_TYPED_GRANT_AUDIT_TABLE_V15_SQL};
+  INSERT INTO foundation_grant_audit (
+    audit_id, action, outcome, actor_reference, grant_id, grant_type, grant_version,
+    event_id, game_day_id, pitch_id, pitch_slot_id, session_id, replaced_session_id,
+    event_game_id, previous_event_game_id, credential_kind, credential_fingerprint,
+    before_status, after_status, before_expires_at_ms, after_expires_at_ms,
+    terminal_reason, audit_integrity_tag, created_at_ms
+  )
+  SELECT
+    audit_id, action, outcome, actor_reference, grant_id, grant_type, grant_version,
+    event_id, game_day_id, pitch_id, pitch_slot_id, session_id, replaced_session_id,
+    event_game_id, NULL, credential_kind, credential_fingerprint, before_status,
+    after_status, before_expires_at_ms, after_expires_at_ms, terminal_reason,
+    audit_integrity_tag, created_at_ms
+  FROM foundation_grant_audit_control_session_copy;
+  DROP TABLE foundation_grant_audit_control_session_copy;
+  CREATE TABLE foundation_grant_audit_provenance_control_session_copy AS
+    SELECT * FROM foundation_grant_audit_provenance;
+  DROP TABLE foundation_grant_audit_provenance;
+  ${FOUNDATION_GRANT_AUDIT_PROVENANCE_TABLE_V15_SQL};
+  INSERT INTO foundation_grant_audit_provenance (
+    audit_id, action, outcome, actor_reference, grant_id, grant_type, grant_version,
+    event_id, game_day_id, pitch_id, pitch_slot_id, session_id, replaced_session_id,
+    event_game_id, previous_event_game_id, credential_kind, credential_fingerprint,
+    before_status, after_status, before_expires_at_ms, after_expires_at_ms,
+    terminal_reason, audit_integrity_tag, created_at_ms
+  )
+  SELECT
+    audit_id, action, outcome, actor_reference, grant_id, grant_type, grant_version,
+    event_id, game_day_id, pitch_id, pitch_slot_id, session_id, replaced_session_id,
+    event_game_id, NULL, credential_kind, credential_fingerprint, before_status,
+    after_status, before_expires_at_ms, after_expires_at_ms, terminal_reason,
+    audit_integrity_tag, created_at_ms
+  FROM foundation_grant_audit_provenance_control_session_copy;
+  DROP TABLE foundation_grant_audit_provenance_control_session_copy;
+  ${FOUNDATION_GRANT_AUDIT_PROVENANCE_GRANT_INDEX_SQL};
+  ${FOUNDATION_GRANT_AUDIT_PROVENANCE_NO_UPDATE_TRIGGER_SQL};
+  ${FOUNDATION_GRANT_AUDIT_PROVENANCE_NO_DELETE_TRIGGER_SQL};
+  ${FOUNDATION_GRANT_AUDIT_GRANT_INDEX_SQL};
+  ${FOUNDATION_GRANT_AUDIT_NO_LEGACY_TAG_INSERT_TRIGGER_SQL};
+  ${FOUNDATION_GRANT_AUDIT_PROVENANCE_AFTER_INSERT_TRIGGER_V15_SQL};
+`;
+
+const FOUNDATION_REPLAY_PROVENANCE_MIGRATION_SQL = `
+  CREATE TABLE foundation_grant_audit_replay_provenance_copy AS SELECT * FROM foundation_grant_audit;
+  DROP TABLE foundation_grant_audit;
+  ${FOUNDATION_TYPED_GRANT_AUDIT_TABLE_V16_SQL};
+  INSERT INTO foundation_grant_audit (
+    audit_id, action, outcome, actor_reference, grant_id, grant_type, grant_version,
+    event_id, game_day_id, pitch_id, pitch_slot_id, session_id, replaced_session_id,
+    event_game_id, previous_event_game_id, replay_evidence_id, credential_kind,
+    credential_fingerprint, before_status, after_status, before_expires_at_ms,
+    after_expires_at_ms, terminal_reason, audit_integrity_tag, created_at_ms
+  )
+  SELECT
+    audit_id, action, outcome, actor_reference, grant_id, grant_type, grant_version,
+    event_id, game_day_id, pitch_id, pitch_slot_id, session_id, replaced_session_id,
+    event_game_id, previous_event_game_id, NULL, credential_kind, credential_fingerprint,
+    before_status, after_status, before_expires_at_ms, after_expires_at_ms, terminal_reason,
+    audit_integrity_tag, created_at_ms
+  FROM foundation_grant_audit_replay_provenance_copy;
+  DROP TABLE foundation_grant_audit_replay_provenance_copy;
+  CREATE TABLE foundation_grant_audit_provenance_replay_copy AS
+    SELECT * FROM foundation_grant_audit_provenance;
+  DROP TABLE foundation_grant_audit_provenance;
+  ${FOUNDATION_GRANT_AUDIT_PROVENANCE_TABLE_V16_SQL};
+  INSERT INTO foundation_grant_audit_provenance (
+    audit_id, action, outcome, actor_reference, grant_id, grant_type, grant_version,
+    event_id, game_day_id, pitch_id, pitch_slot_id, session_id, replaced_session_id,
+    event_game_id, previous_event_game_id, replay_evidence_id, credential_kind,
+    credential_fingerprint, before_status, after_status, before_expires_at_ms,
+    after_expires_at_ms, terminal_reason, audit_integrity_tag, created_at_ms
+  )
+  SELECT
+    audit_id, action, outcome, actor_reference, grant_id, grant_type, grant_version,
+    event_id, game_day_id, pitch_id, pitch_slot_id, session_id, replaced_session_id,
+    event_game_id, previous_event_game_id, NULL, credential_kind, credential_fingerprint,
+    before_status, after_status, before_expires_at_ms, after_expires_at_ms, terminal_reason,
+    audit_integrity_tag, created_at_ms
+  FROM foundation_grant_audit_provenance_replay_copy;
+  DROP TABLE foundation_grant_audit_provenance_replay_copy;
+  ${FOUNDATION_GRANT_AUDIT_PROVENANCE_GRANT_INDEX_SQL};
+  ${FOUNDATION_GRANT_AUDIT_PROVENANCE_NO_UPDATE_TRIGGER_SQL};
+  ${FOUNDATION_GRANT_AUDIT_PROVENANCE_NO_DELETE_TRIGGER_SQL};
+  ${FOUNDATION_GRANT_AUDIT_GRANT_INDEX_SQL};
+  ${FOUNDATION_GRANT_AUDIT_NO_LEGACY_TAG_INSERT_TRIGGER_SQL};
+  ${FOUNDATION_GRANT_AUDIT_PROVENANCE_AFTER_INSERT_TRIGGER_V16_SQL};
+`;
+
 export const FOUNDATION_MIGRATIONS: readonly FoundationMigration[] = Object.freeze([
   createMigration({
     id: "001-foundation-event-game-record-roots",
@@ -1017,6 +1168,18 @@ export const FOUNDATION_MIGRATIONS: readonly FoundationMigration[] = Object.free
     ordinal: 14,
     schemaVersion: 14,
     sql: FOUNDATION_GRANT_PROVENANCE_MIGRATION_SQL,
+  }),
+  createMigration({
+    id: "015-control-session-binding",
+    ordinal: 15,
+    schemaVersion: 15,
+    sql: FOUNDATION_CONTROL_SESSION_BINDING_MIGRATION_SQL,
+  }),
+  createMigration({
+    id: "016-replay-content-provenance",
+    ordinal: 16,
+    schemaVersion: 16,
+    sql: FOUNDATION_REPLAY_PROVENANCE_MIGRATION_SQL,
   }),
 ]);
 

--- a/src/lib/foundation-schema.ts
+++ b/src/lib/foundation-schema.ts
@@ -15,7 +15,7 @@ import {
   FOUNDATION_SIDE_RECORD_INDEX_SQL,
   FOUNDATION_SIDE_TABLE_SQL,
   FOUNDATION_GRANT_AUDIT_GRANT_INDEX_SQL,
-  FOUNDATION_TYPED_GRANT_AUDIT_TABLE_V11_SQL,
+  FOUNDATION_TYPED_GRANT_AUDIT_TABLE_V16_SQL,
   FOUNDATION_GRANT_SESSION_CONTEXT_INDEX_SQL,
   FOUNDATION_GRANT_SESSION_GRANT_INDEX_SQL,
   FOUNDATION_EVIDENCE_PROVENANCE_TABLE_SQL,
@@ -25,7 +25,7 @@ import {
   FOUNDATION_TYPED_GRANT_SESSION_TABLE_SQL,
   FOUNDATION_GRANT_MIGRATION_PROVENANCE_TABLE_SQL,
   FOUNDATION_GRANT_MIGRATION_PROVENANCE_STATE_TABLE_SQL,
-  FOUNDATION_GRANT_AUDIT_PROVENANCE_TABLE_SQL,
+  FOUNDATION_GRANT_AUDIT_PROVENANCE_TABLE_V16_SQL,
   FOUNDATION_GRANT_AUDIT_PROVENANCE_GRANT_INDEX_SQL,
   FOUNDATION_GRANT_MIGRATION_PROVENANCE_NO_UPDATE_TRIGGER_SQL,
   FOUNDATION_GRANT_MIGRATION_PROVENANCE_NO_INSERT_TRIGGER_SQL,
@@ -35,10 +35,13 @@ import {
   FOUNDATION_GRANT_MIGRATION_PROVENANCE_STATE_NO_DELETE_TRIGGER_SQL,
   FOUNDATION_GRANT_AUDIT_PROVENANCE_NO_UPDATE_TRIGGER_SQL,
   FOUNDATION_GRANT_AUDIT_PROVENANCE_NO_DELETE_TRIGGER_SQL,
-  FOUNDATION_GRANT_AUDIT_PROVENANCE_AFTER_INSERT_TRIGGER_SQL,
+  FOUNDATION_GRANT_AUDIT_PROVENANCE_AFTER_INSERT_TRIGGER_V16_SQL,
   FOUNDATION_GRANT_AUDIT_NO_LEGACY_TAG_INSERT_TRIGGER_SQL,
 } from "@/lib/foundation-migrations";
-import { computeGrantAuditIntegrityTag } from "@/lib/grant-crypto";
+import {
+  computeGrantAuditIntegrityTag,
+  computeLegacyGrantAuditIntegrityTag,
+} from "@/lib/grant-crypto";
 import { readStoredGrantAuditEntry, scanGrantState } from "@/lib/grant-storage-sqlite";
 import type { GrantStateValidationContext } from "@/lib/grant-state-validation";
 import { GRANT_AUDIT_LEGACY_INTEGRITY_TAG } from "@/lib/grant-types";
@@ -126,7 +129,7 @@ const expectedManifest: FoundationSchemaManifest = {
       "table",
       GRANT_AUDIT_TABLE,
       GRANT_AUDIT_TABLE,
-      FOUNDATION_TYPED_GRANT_AUDIT_TABLE_V11_SQL,
+      FOUNDATION_TYPED_GRANT_AUDIT_TABLE_V16_SQL,
     ),
     object("table", PROVENANCE_TABLE, PROVENANCE_TABLE, FOUNDATION_EVIDENCE_PROVENANCE_TABLE_SQL),
     object(
@@ -157,7 +160,7 @@ const expectedManifest: FoundationSchemaManifest = {
       "table",
       GRANT_AUDIT_PROVENANCE_TABLE,
       GRANT_AUDIT_PROVENANCE_TABLE,
-      FOUNDATION_GRANT_AUDIT_PROVENANCE_TABLE_SQL,
+      FOUNDATION_GRANT_AUDIT_PROVENANCE_TABLE_V16_SQL,
     ),
     object(
       "trigger",
@@ -217,7 +220,7 @@ const expectedManifest: FoundationSchemaManifest = {
       "trigger",
       "foundation_grant_audit_provenance_after_insert",
       GRANT_AUDIT_TABLE,
-      FOUNDATION_GRANT_AUDIT_PROVENANCE_AFTER_INSERT_TRIGGER_SQL,
+      FOUNDATION_GRANT_AUDIT_PROVENANCE_AFTER_INSERT_TRIGGER_V16_SQL,
     ),
     object(
       "index",
@@ -546,6 +549,8 @@ const expectedManifest: FoundationSchemaManifest = {
         column("after_status", "TEXT", 0, 0),
         column("before_expires_at_ms", "INTEGER", 0, 0),
         column("after_expires_at_ms", "INTEGER", 0, 0),
+        column("previous_event_game_id", "TEXT", 0, 0),
+        column("replay_evidence_id", "TEXT", 0, 0),
         column("terminal_reason", "TEXT", 0, 0),
         column("audit_integrity_tag", "TEXT", 1, 0),
         column("created_at_ms", "INTEGER", 1, 0),
@@ -629,6 +634,8 @@ const expectedManifest: FoundationSchemaManifest = {
         column("after_status", "TEXT", 0, 0),
         column("before_expires_at_ms", "INTEGER", 0, 0),
         column("after_expires_at_ms", "INTEGER", 0, 0),
+        column("previous_event_game_id", "TEXT", 0, 0),
+        column("replay_evidence_id", "TEXT", 0, 0),
         column("terminal_reason", "TEXT", 0, 0),
         column("audit_integrity_tag", "TEXT", 1, 0),
         column("created_at_ms", "INTEGER", 1, 0),
@@ -871,6 +878,8 @@ function verifyGrantProvenance(
     "after_status",
     "before_expires_at_ms",
     "after_expires_at_ms",
+    "previous_event_game_id",
+    "replay_evidence_id",
     "terminal_reason",
     "audit_integrity_tag",
     "created_at_ms",
@@ -890,12 +899,23 @@ function verifyGrantProvenance(
       throw new Error("Grant Audit Trail integrity cannot be verified.");
     }
     const audit = readStoredGrantAuditEntry(row);
+    if (
+      audit.action !== "session-switched" &&
+      audit.action !== "replay-authorized" &&
+      audit.previousEventGameId !== null
+    ) {
+      throw new Error("Grant Audit Trail previous Event Game provenance is invalid.");
+    }
     const tagParts = tag.split(":");
     const keyVersion = tagParts[1];
     if (
       tagParts.length !== 3 ||
       keyVersion === undefined ||
-      computeGrantAuditIntegrityTag(audit, validationContext.keyRing, keyVersion) !== tag
+      (computeGrantAuditIntegrityTag(audit, validationContext.keyRing, keyVersion) !== tag &&
+        (audit.action === "session-switched" ||
+          audit.action === "replay-authorized" ||
+          computeLegacyGrantAuditIntegrityTag(audit, validationContext.keyRing, keyVersion) !==
+            tag))
     ) {
       throw new Error("Grant Audit Trail integrity is invalid.");
     }

--- a/src/lib/foundation-storage-memory.ts
+++ b/src/lib/foundation-storage-memory.ts
@@ -498,6 +498,11 @@ function createTransaction(
       const grant = state.grants.get(grantId);
       return grant === undefined ? null : cloneStoredGrant(grant);
     },
+    listGrants() {
+      return [...state.grants.values()]
+        .sort((left, right) => left.grantId.localeCompare(right.grantId))
+        .map(cloneStoredGrant);
+    },
     findGrantByCredentialLookupDigest(lookupDigest) {
       return findGrant(state.grants, (grant) => grant.credential.lookupDigest === lookupDigest);
     },

--- a/src/lib/foundation-storage-sqlite.test.ts
+++ b/src/lib/foundation-storage-sqlite.test.ts
@@ -56,7 +56,7 @@ describe("SQLite foundation storage", () => {
       first.close();
 
       const reopened = openSqliteFoundationStorage(databasePath);
-      expect(await reopened.readiness()).toMatchObject({ ok: true, schemaVersion: "14" });
+      expect(await reopened.readiness()).toMatchObject({ ok: true, schemaVersion: "16" });
       const reopenedRecord = createEventGameRecord(reopened, {
         externalScopeResolver: createScopeResolver(root),
       });
@@ -74,12 +74,12 @@ describe("SQLite foundation storage", () => {
       const storage = openSqliteFoundationStorage(databasePath);
       const candidate = await storage.validateCandidate();
       expect(candidate.ready).toBe(true);
-      expect(candidate.readiness).toMatchObject({ ok: true, schemaVersion: "14" });
+      expect(candidate.readiness).toMatchObject({ ok: true, schemaVersion: "16" });
       expect(existsSync(candidate.candidatePath)).toBe(false);
       expect(await storage.readiness()).toMatchObject({ ok: false, status: "pending" });
 
       const migration = await storage.applyMigrations({ requireCandidate: true });
-      expect(migration.schemaVersion).toBe(14);
+      expect(migration.schemaVersion).toBe(16);
       expect(await storage.readiness()).toMatchObject({ ok: true });
       storage.close();
     });
@@ -101,6 +101,8 @@ describe("SQLite foundation storage", () => {
       const terminalAuditMigration = FOUNDATION_MIGRATIONS[11];
       const auditEvidenceMigration = FOUNDATION_MIGRATIONS[12];
       const provenanceMigration = FOUNDATION_MIGRATIONS[13];
+      const bindingMigration = FOUNDATION_MIGRATIONS[14];
+      const replayProvenanceMigration = FOUNDATION_MIGRATIONS[15];
       if (
         initialMigration === undefined ||
         repairMigration === undefined ||
@@ -115,7 +117,9 @@ describe("SQLite foundation storage", () => {
         summaryMigration === undefined ||
         terminalAuditMigration === undefined ||
         auditEvidenceMigration === undefined ||
-        provenanceMigration === undefined
+        provenanceMigration === undefined ||
+        bindingMigration === undefined ||
+        replayProvenanceMigration === undefined
       ) {
         throw new Error("Expected the foundation migrations.");
       }
@@ -142,8 +146,10 @@ describe("SQLite foundation storage", () => {
         terminalAuditMigration.id,
         auditEvidenceMigration.id,
         provenanceMigration.id,
+        bindingMigration.id,
+        replayProvenanceMigration.id,
       ]);
-      expect(await current.readiness()).toMatchObject({ ok: true, schemaVersion: "14" });
+      expect(await current.readiness()).toMatchObject({ ok: true, schemaVersion: "16" });
       current.close();
     });
   });
@@ -152,9 +158,9 @@ describe("SQLite foundation storage", () => {
     await withDatabase(async (databasePath) => {
       const baseMigrations = FOUNDATION_MIGRATIONS;
       const failingMigration = createMigration(
-        "015-failing-test-migration",
-        15,
-        15,
+        "017-failing-test-migration",
+        17,
+        17,
         "CREATE TABLE migration_failure_probe (id TEXT) STRICT; THIS IS NOT SQL;",
       );
       const store = openSqliteFoundationStorage(databasePath, {
@@ -174,7 +180,7 @@ describe("SQLite foundation storage", () => {
       });
       expect(await priorBinary.readiness()).toMatchObject({
         ok: true,
-        schemaVersion: "14",
+        schemaVersion: "16",
       });
       priorBinary.close();
 
@@ -246,7 +252,7 @@ describe("SQLite foundation storage", () => {
         .query(
           "INSERT INTO foundation_migration_ledger (migration_id, ordinal, schema_version, checksum, status, applied_at_ms) VALUES (?, ?, ?, ?, ?, ?)",
         )
-        .run("future-999", 15, 15, "future-checksum", "complete", 2_000);
+        .run("future-999", 17, 17, "future-checksum", "complete", 2_000);
       futureDatabase.close();
       const future = openSqliteFoundationStorage(databasePath);
       expect(await future.readiness()).toMatchObject({ ok: false });

--- a/src/lib/foundation-storage-sqlite.ts
+++ b/src/lib/foundation-storage-sqlite.ts
@@ -9,6 +9,7 @@ import {
   insertGrant,
   insertGrantSession,
   listGrantAudit,
+  listGrants,
   listGrantSessions,
   readGrantByStatement,
   readSessionByStatement,
@@ -404,6 +405,7 @@ export class SqliteFoundationStorage implements FoundationStorage {
       appendAuditEntry: (entry) => this.appendAuditEntry(statements, entry),
       findGrantById: (grantId) =>
         readGrantByStatement(this.getGrantStatements().byGrantId, grantId),
+      listGrants: () => listGrants(this.getGrantStatements().allGrants),
       findGrantByCredentialLookupDigest: (lookupDigest) =>
         readGrantByStatement(this.getGrantStatements().byCredentialDigest, lookupDigest),
       findActiveSessionByGrantAndContext: (grantId, browserContextDigest) =>

--- a/src/lib/foundation-storage.ts
+++ b/src/lib/foundation-storage.ts
@@ -81,6 +81,7 @@ export type FoundationStorageSnapshot = {
   readRecordMetadata(recordId: string): StoredEventGameRecordMetadata | null;
   listAuditEntries(recordId: string): StoredControlAuditEntry[];
   findGrantById(grantId: string): StoredGrant | null;
+  listGrants(): StoredGrant[];
   findGrantByCredentialLookupDigest(lookupDigest: string): StoredGrant | null;
   findActiveSessionByGrantAndContext(
     grantId: string,

--- a/src/lib/grant-authority-contract.ts
+++ b/src/lib/grant-authority-contract.ts
@@ -6,6 +6,8 @@ import {
   GENERIC_GRANT_ADMISSION_FAILURE,
   type ControlGrantScope,
   type ControlGrantScopeResolution,
+  type ControlGrantSessionResolution,
+  type ControlGrantReplayResolution,
   type GrantAuthorityActor,
   type GrantKeyRing,
   type GrantRandomness,
@@ -17,6 +19,8 @@ import {
   createGrantTestAuthorityVerifier,
   createLegacyControlGrantTestAuthority,
 } from "@/lib/grant-authority-test-support";
+import { lockControlGrantEventGame } from "@/lib/grant-management-sessions";
+import type { GrantAuthorityOptions } from "@/lib/grant-authority";
 
 export type GrantAuthorityContractStorage = {
   storage: FoundationStorage;
@@ -96,18 +100,27 @@ export function registerGrantAuthorityContract(
       const otherContext = await admit(authority, created.qrCredential, "browser-b");
       const replacement = await admit(authority, created.qrCredential, "browser-a");
 
-      expect(await authority.authorizeControlGrant({ sessionBearer: first.sessionBearer })).toEqual(
-        {
-          status: "rejected",
-          code: "grant-authorization-failed",
-          message: "Unable to authorize this Grant Session.",
-        },
-      );
       expect(
-        await authority.authorizeControlGrant({ sessionBearer: otherContext.sessionBearer }),
+        await authority.authorizeControlGrant({
+          sessionBearer: first.sessionBearer,
+          eventGameId: "game-1",
+        }),
+      ).toEqual({
+        status: "rejected",
+        code: "grant-authorization-failed",
+        message: "Unable to authorize this Grant Session.",
+      });
+      expect(
+        await authority.authorizeControlGrant({
+          sessionBearer: otherContext.sessionBearer,
+          eventGameId: "game-1",
+        }),
       ).toMatchObject({ status: "authorized", grantSessionId: otherContext.grantSessionId });
       expect(
-        await authority.authorizeControlGrant({ sessionBearer: replacement.sessionBearer }),
+        await authority.authorizeControlGrant({
+          sessionBearer: replacement.sessionBearer,
+          eventGameId: "game-1",
+        }),
       ).toMatchObject({ status: "authorized", grantSessionId: replacement.grantSessionId });
 
       const sessions = await readGrantSessions(authority, created.grantId);
@@ -189,7 +202,10 @@ export function registerGrantAuthorityContract(
         }),
       ).toEqual(GENERIC_GRANT_ADMISSION_FAILURE);
       expect(
-        await authority.authorizeControlGrant({ sessionBearer: admitted.sessionBearer }),
+        await authority.authorizeControlGrant({
+          sessionBearer: admitted.sessionBearer,
+          eventGameId: "game-1",
+        }),
       ).toMatchObject({ status: "rejected" });
 
       const lifecycle = await storage.transaction((transaction) => ({
@@ -208,6 +224,45 @@ export function registerGrantAuthorityContract(
       );
     });
   });
+
+  register(
+    "rejects malformed eligible Event Game identities without admission mutation",
+    async () => {
+      await withStorage(createStorage, async (storage) => {
+        let eventGameId = "game-1";
+        const authority = createAuthority(storage, {
+          resolve: () => ({ status: "eligible", eventGameId }),
+        });
+        const created = await createGrant(authority);
+        for (const malformed of ["", "game-☃", "g".repeat(129)]) {
+          eventGameId = malformed;
+          const before = await storage.transaction((transaction) => ({
+            sessions: transaction.listGrantSessions(created.grantId),
+            audits: transaction.listGrantAudit(created.grantId),
+          }));
+          expect(
+            await authority.admitControlGrant({
+              qrCredential: created.qrCredential,
+              browserContext: "browser-malformed-scope",
+            }),
+          ).toEqual(GENERIC_GRANT_ADMISSION_FAILURE);
+          expect(
+            await storage.transaction((transaction) => ({
+              sessions: transaction.listGrantSessions(created.grantId),
+              audits: transaction.listGrantAudit(created.grantId),
+            })),
+          ).toEqual(before);
+        }
+        eventGameId = "game-1";
+        expect(
+          await authority.admitControlGrant({
+            qrCredential: created.qrCredential,
+            browserContext: "browser-malformed-scope",
+          }),
+        ).toMatchObject({ status: "admitted", eventGameId: "game-1" });
+      });
+    },
+  );
 
   register("rejects repeated Grant status transitions without audit mutation", async () => {
     await withStorage(createStorage, async (storage) => {
@@ -487,6 +542,510 @@ export function registerGrantAuthorityContract(
     });
   });
 
+  register("binds Grant Sessions to eligible Event Games through reassignment", async () => {
+    await withStorage(createStorage, async (storage) => {
+      let currentEventGameId = "game-1";
+      let relationship: ControlGrantSessionResolution = {
+        status: "current",
+        eventGameId: "game-1",
+      };
+      const authority = createAuthority(storage, {
+        resolve: () => ({ status: "eligible", eventGameId: currentEventGameId }),
+        resolveSession: (_scope, sessionEventGameId) =>
+          sessionEventGameId === "game-3"
+            ? { status: "current", eventGameId: "game-3" }
+            : relationship,
+      });
+      const created = await createGrant(authority);
+      const admitted = await admit(authority, created.qrCredential, "browser-bind");
+
+      relationship = {
+        status: "switchable",
+        previousEventGameId: "game-1",
+        currentEventGameId: "game-2",
+      };
+      currentEventGameId = "game-2";
+      expect(
+        await authority.authorizeControlGrant({
+          sessionBearer: admitted.sessionBearer,
+          eventGameId: "game-1",
+        }),
+      ).toMatchObject({
+        status: "switch-required",
+        previousEventGameId: "game-1",
+        currentEventGameId: "game-2",
+      });
+      expect(
+        await authority.authorizeControlGrant({
+          sessionBearer: admitted.sessionBearer,
+          eventGameId: "game-1",
+          controlSessionDecision: "stay",
+        }),
+      ).toMatchObject({ status: "authorized", eventGameId: "game-1" });
+      expect(await authority.acceptControlGrantSessionSwitch(admitted)).toEqual({
+        status: "switched",
+        grantId: created.grantId,
+        grantVersion: created.grantVersion,
+        grantSessionId: admitted.grantSessionId,
+        previousEventGameId: "game-1",
+        eventGameId: "game-2",
+      });
+      expect(
+        await authority.authorizeControlGrant({
+          sessionBearer: admitted.sessionBearer,
+          eventGameId: "game-1",
+        }),
+      ).toMatchObject({ status: "rejected" });
+      expect(
+        await authority.authorizeControlGrant({ sessionBearer: admitted.sessionBearer }),
+      ).toMatchObject({ status: "rejected" });
+
+      relationship = {
+        status: "pinned",
+        sessionEventGameId: "game-2",
+        currentEventGameId: "game-3",
+      };
+      currentEventGameId = "game-3";
+      expect(
+        await authority.authorizeControlGrant({
+          sessionBearer: admitted.sessionBearer,
+          eventGameId: "game-2",
+        }),
+      ).toMatchObject({ status: "authorized", eventGameId: "game-2" });
+      const fresh = await admit(authority, created.qrCredential, "browser-fresh");
+      expect(fresh.eventGameId).toBe("game-3");
+
+      const acceptedLockEvidence = { kind: "accepted-event-game-lock", eventGameId: "game-3" };
+      let lockHookEventGameId: string | null = null;
+      let failLockTransition = false;
+      const lockAuthority = createAuthority(storage, {
+        resolve: () => ({ status: "eligible", eventGameId: currentEventGameId }),
+        resolveSession: (_scope, sessionEventGameId) =>
+          sessionEventGameId === "game-3"
+            ? { status: "current", eventGameId: "game-3" }
+            : relationship,
+        resolveEventGameLock: (evidence) =>
+          evidence === acceptedLockEvidence
+            ? {
+                eventGameId: "game-3",
+                apply: () => {
+                  lockHookEventGameId = "game-3";
+                  if (failLockTransition) throw new Error("future Grant-Code mutation failed");
+                },
+              }
+            : null,
+      });
+      expect("lockControlGrantEventGame" in lockAuthority).toBe(false);
+      expect(
+        await lockAuthority.lockControlGrantEventGameForTest({
+          eventGameId: "game-3",
+        }),
+      ).toMatchObject({ status: "rejected" });
+      expect(
+        await lockAuthority.authorizeControlGrant({
+          sessionBearer: fresh.sessionBearer,
+          eventGameId: "game-3",
+        }),
+      ).toMatchObject({ status: "authorized", eventGameId: "game-3" });
+      expect(await lockAuthority.lockControlGrantEventGameForTest(acceptedLockEvidence)).toEqual({
+        status: "locked",
+        eventGameId: "game-3",
+        terminatedSessionCount: 1,
+      });
+      if (lockHookEventGameId !== "game-3") throw new Error("Expected the lock lifecycle hook.");
+      expect(
+        await lockAuthority.authorizeControlGrant({
+          sessionBearer: fresh.sessionBearer,
+          eventGameId: "game-3",
+        }),
+      ).toMatchObject({
+        status: "rejected",
+      });
+      expect(
+        await lockAuthority.authorizeControlGrant({
+          sessionBearer: admitted.sessionBearer,
+          eventGameId: "game-2",
+        }),
+      ).toMatchObject({ status: "authorized", eventGameId: "game-2" });
+
+      relationship = { status: "current", eventGameId: "game-3" };
+      const reopened = await admit(authority, created.qrCredential, "browser-reopened");
+      expect(reopened.eventGameId).toBe("game-3");
+      failLockTransition = true;
+      expect(await lockAuthority.lockControlGrantEventGameForTest(acceptedLockEvidence)).toEqual({
+        status: "rejected",
+        reason: "unavailable",
+      });
+      expect(
+        await lockAuthority.authorizeControlGrant({
+          sessionBearer: reopened.sessionBearer,
+          eventGameId: "game-3",
+        }),
+      ).toMatchObject({ status: "authorized", eventGameId: "game-3" });
+      const audit = await readGrantAudit(authority, created.grantId);
+      expect(audit).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            action: "session-switched",
+            previousEventGameId: "game-1",
+            eventGameId: "game-2",
+          }),
+          expect.objectContaining({
+            action: "session-terminated",
+            terminalReason: "game-locked",
+          }),
+        ]),
+      );
+    });
+  });
+
+  register(
+    "validates repeated Control Grant Session switches as an ordered immutable chain",
+    async () => {
+      await withStorage(createStorage, async (storage) => {
+        let relationship: ControlGrantSessionResolution = {
+          status: "current",
+          eventGameId: "game-1",
+        };
+        const authority = createAuthority(storage, { resolveSession: () => relationship });
+        const created = await createGrant(authority);
+        const admitted = await admit(authority, created.qrCredential, "browser-switch-chain");
+        relationship = {
+          status: "switchable",
+          previousEventGameId: "game-1",
+          currentEventGameId: "game-2",
+        };
+        expect(await authority.acceptControlGrantSessionSwitch(admitted)).toMatchObject({
+          status: "switched",
+          previousEventGameId: "game-1",
+          eventGameId: "game-2",
+        });
+        relationship = {
+          status: "switchable",
+          previousEventGameId: "game-2",
+          currentEventGameId: "game-3",
+        };
+        expect(await authority.acceptControlGrantSessionSwitch(admitted)).toMatchObject({
+          status: "switched",
+          previousEventGameId: "game-2",
+          eventGameId: "game-3",
+        });
+        const snapshot = await storage.transaction((transaction) => ({
+          grant: transaction.findGrantById(created.grantId),
+          sessions: transaction.listGrantSessions(created.grantId),
+          audits: transaction.listGrantAudit(created.grantId),
+        }));
+        expect(snapshot.grant).not.toBeNull();
+        const switches = snapshot.audits.filter((audit) => audit.action === "session-switched");
+        expect(switches).toHaveLength(2);
+        expect(await storage.readiness()).toMatchObject({ ok: true });
+        const firstSwitch = switches[0];
+        expect(firstSwitch).not.toBeUndefined();
+        if (snapshot.grant === null || firstSwitch === undefined)
+          throw new Error("Expected repeated-switch evidence.");
+        const tampered = snapshot.audits.map((audit) =>
+          audit.auditId === firstSwitch.auditId
+            ? { ...audit, previousEventGameId: "game-3" }
+            : audit,
+        );
+        expect(validateGrantState([snapshot.grant], snapshot.sessions, tampered)).not.toBeNull();
+      });
+    },
+  );
+
+  register("binds Grant Session state to admission provenance", async () => {
+    await withStorage(createStorage, async (storage) => {
+      const authority = createAuthority(storage);
+      const created = await createGrant(authority);
+      const admitted = await admit(authority, created.qrCredential, "browser-admission-provenance");
+      const snapshot = await storage.transaction((transaction) => ({
+        grant: transaction.findGrantById(created.grantId),
+        sessions: transaction.listGrantSessions(created.grantId),
+        audits: transaction.listGrantAudit(created.grantId),
+      }));
+      if (snapshot.grant === null) throw new Error("Expected the stored Grant.");
+      expect(
+        validateGrantState(
+          [snapshot.grant],
+          snapshot.sessions.map((session) =>
+            session.sessionId === admitted.grantSessionId
+              ? { ...session, eventGameId: "game-forged" }
+              : session,
+          ),
+          snapshot.audits,
+        ),
+      ).not.toBeNull();
+      const admission = snapshot.audits.find(
+        (audit) =>
+          audit.action === "session-admitted" && audit.sessionId === admitted.grantSessionId,
+      );
+      if (admission === undefined) throw new Error("Expected admission provenance.");
+      for (const tampered of [
+        { ...admission, grantId: "grant-forged" },
+        { ...admission, grantVersion: "grant-version-forged" },
+        { ...admission, eventGameId: "game-forged" },
+      ]) {
+        expect(
+          validateGrantState(
+            [snapshot.grant],
+            snapshot.sessions,
+            snapshot.audits.map((audit) =>
+              audit.auditId === admission.auditId ? tampered : audit,
+            ),
+          ),
+        ).not.toBeNull();
+      }
+    });
+  });
+
+  register(
+    "authorizes content-bound same Event Game replay across devices and Grant rotation",
+    async () => {
+      await withStorage(createStorage, async (storage) => {
+        let currentEventGameId = "game-1";
+        const replayEvidenceId = "replay-content-1";
+        let replay: ControlGrantReplayResolution = { status: "eligible", eventGameId: "game-1" };
+        const authority = createAuthority(storage, {
+          resolve: () => ({ status: "eligible", eventGameId: currentEventGameId }),
+          resolveReplay: (_scope, eventGameId, evidenceId) =>
+            replay.status === "eligible" &&
+            (replay.eventGameId !== eventGameId || evidenceId !== replayEvidenceId)
+              ? { status: "mismatch" }
+              : replay,
+        });
+        const created = await createGrant(authority);
+        const originating = await admit(authority, created.qrCredential, "browser-origin");
+        const unrelated = await admit(authority, created.qrCredential, "browser-unrelated");
+        const replacement = await admit(authority, created.qrCredential, "browser-fresh-device");
+        expect(replacement.eventGameId).toBe("game-1");
+        expect(
+          await authority.authorizeControlGrantReplay({
+            sessionBearer: replacement.sessionBearer,
+            originatingSessionId: replacement.grantSessionId,
+            eventGameId: "game-1",
+            replayEvidenceId,
+          }),
+        ).toMatchObject({ status: "rejected" });
+        expect(
+          await authority.authorizeControlGrantReplay({
+            sessionBearer: replacement.sessionBearer,
+            originatingSessionId: originating.grantSessionId,
+            eventGameId: "game-1",
+            replayEvidenceId,
+          }),
+        ).toMatchObject({ status: "rejected" });
+        await admit(authority, created.qrCredential, "browser-origin");
+        expect(
+          await authority.authorizeControlGrant({
+            sessionBearer: originating.sessionBearer,
+            eventGameId: "game-1",
+          }),
+        ).toMatchObject({ status: "rejected" });
+
+        currentEventGameId = "game-2";
+        expect(
+          await authority.authorizeControlGrantReplay({
+            sessionBearer: replacement.sessionBearer,
+            originatingSessionId: unrelated.grantSessionId,
+            eventGameId: "game-1",
+            replayEvidenceId: "unrelated-content",
+          }),
+        ).toMatchObject({ status: "rejected" });
+        expect(
+          await authority.authorizeControlGrantReplay({
+            sessionBearer: replacement.sessionBearer,
+            originatingSessionId: originating.grantSessionId,
+            eventGameId: "game-1",
+            replayEvidenceId,
+          }),
+        ).toMatchObject({
+          status: "authorized",
+          grantSessionId: replacement.grantSessionId,
+          originatingSessionId: originating.grantSessionId,
+          eventGameId: "game-1",
+          replayEvidenceId,
+        });
+        expect(await readGrantAudit(authority, created.grantId)).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              action: "replay-authorized",
+              sessionId: replacement.grantSessionId,
+              replacedSessionId: originating.grantSessionId,
+              replayEvidenceId,
+            }),
+          ]),
+        );
+        const replaySnapshot = await storage.transaction((transaction) => ({
+          grant: transaction.findGrantById(created.grantId),
+          sessions: transaction.listGrantSessions(created.grantId),
+          audits: transaction.listGrantAudit(created.grantId),
+        }));
+        if (replaySnapshot.grant === null) throw new Error("Expected replay Grant state.");
+        const replayAudit = replaySnapshot.audits.find(
+          (audit) => audit.action === "replay-authorized",
+        );
+        if (replayAudit === undefined) throw new Error("Expected replay provenance.");
+        expect(
+          validateGrantState(
+            [replaySnapshot.grant],
+            replaySnapshot.sessions,
+            replaySnapshot.audits.map((audit) =>
+              audit.auditId === replayAudit.auditId
+                ? { ...audit, replacedSessionId: replayAudit.sessionId }
+                : audit,
+            ),
+          ),
+        ).not.toBeNull();
+        expect(
+          validateGrantState(
+            [replaySnapshot.grant],
+            replaySnapshot.sessions.map((session) =>
+              session.sessionId === originating.grantSessionId
+                ? { ...session, status: "active", revokedAtMs: null }
+                : session,
+            ),
+            replaySnapshot.audits,
+          ),
+        ).not.toBeNull();
+
+        replay = { status: "finished" };
+        expect(
+          await authority.authorizeControlGrantReplay({
+            sessionBearer: replacement.sessionBearer,
+            originatingSessionId: originating.grantSessionId,
+            eventGameId: "game-1",
+            replayEvidenceId,
+          }),
+        ).toMatchObject({ status: "rejected" });
+        expect(await authority.rotateControlGrant(created.grantId, createActor())).toMatchObject({
+          status: "updated",
+        });
+        expect(
+          await authority.authorizeControlGrant({
+            sessionBearer: replacement.sessionBearer,
+            eventGameId: "game-1",
+          }),
+        ).toMatchObject({ status: "rejected" });
+        currentEventGameId = "game-1";
+        const rotatedCredential = await authority.revealControlGrant(
+          created.grantId,
+          createActor(),
+        );
+        expect(rotatedCredential.status).toBe("revealed");
+        if (rotatedCredential.status !== "revealed")
+          throw new Error("Expected the rotated Grant credential.");
+        replay = { status: "eligible", eventGameId: "game-1" };
+        const postRotation = await admit(
+          authority,
+          rotatedCredential.qrCredential,
+          "browser-post-rotation",
+        );
+        expect(
+          await authority.authorizeControlGrantReplay({
+            sessionBearer: postRotation.sessionBearer,
+            originatingSessionId: originating.grantSessionId,
+            eventGameId: "game-1",
+            replayEvidenceId,
+          }),
+        ).toMatchObject({ status: "authorized", eventGameId: "game-1" });
+        expect(
+          await authority.authorizeControlGrantReplay({
+            sessionBearer: postRotation.sessionBearer,
+            originatingSessionId: originating.grantSessionId,
+            eventGameId: "game-2",
+            replayEvidenceId,
+          }),
+        ).toMatchObject({ status: "rejected" });
+
+        const otherGrantResult = await authority.createControlGrant({
+          scope: { ...createScope(), pitchSlotId: "slot-other-grant" },
+          actor: createActor(),
+        });
+        expect(otherGrantResult.status).toBe("created");
+        if (otherGrantResult.status !== "created") throw new Error("Expected the unrelated Grant.");
+        const otherOrigin = await admit(
+          authority,
+          otherGrantResult.qrCredential,
+          "browser-other-grant",
+        );
+        expect(
+          await authority.authorizeControlGrantReplay({
+            sessionBearer: postRotation.sessionBearer,
+            originatingSessionId: otherOrigin.grantSessionId,
+            eventGameId: "game-1",
+            replayEvidenceId,
+          }),
+        ).toMatchObject({ status: "rejected" });
+
+        const revokedGrantResult = await authority.createControlGrant({
+          scope: { ...createScope(), pitchSlotId: "slot-revoked" },
+          actor: createActor(),
+        });
+        expect(revokedGrantResult.status).toBe("created");
+        if (revokedGrantResult.status !== "created")
+          throw new Error("Expected a revoked replay Grant.");
+        const revokedGrant = revokedGrantResult;
+        const revokedOrigin = await admit(authority, revokedGrant.qrCredential, "browser-revoked");
+        const revokedReplacement = await admit(
+          authority,
+          revokedGrant.qrCredential,
+          "browser-revoked-fresh",
+        );
+        expect(
+          await authority.revokeControlGrant(revokedGrant.grantId, createActor()),
+        ).toMatchObject({
+          status: "updated",
+        });
+        expect(
+          await authority.authorizeControlGrantReplay({
+            sessionBearer: revokedReplacement.sessionBearer,
+            originatingSessionId: revokedOrigin.grantSessionId,
+            eventGameId: "game-1",
+            replayEvidenceId,
+          }),
+        ).toMatchObject({ status: "rejected" });
+        const unavailableReplayAuthority = createAuthority(storage, {
+          resolve: () => ({ status: "eligible", eventGameId: "game-1" }),
+        });
+        expect(
+          await unavailableReplayAuthority.authorizeControlGrantReplay({
+            sessionBearer: postRotation.sessionBearer,
+            originatingSessionId: originating.grantSessionId,
+            eventGameId: "game-1",
+            replayEvidenceId,
+          }),
+        ).toMatchObject({ status: "rejected" });
+      });
+    },
+  );
+
+  register("rejects malformed Grant Session lifecycle relationships", async () => {
+    await withStorage(createStorage, async (storage) => {
+      let relationship: ControlGrantSessionResolution = {
+        status: "current",
+        eventGameId: "game-1",
+      };
+      const authority = createAuthority(storage, { resolveSession: () => relationship });
+      const created = await createGrant(authority);
+      const admitted = await admit(authority, created.qrCredential, "browser-malformed");
+      const malformed: ControlGrantSessionResolution[] = [
+        { status: "current", eventGameId: "game-2" },
+        { status: "switchable", previousEventGameId: "game-2", currentEventGameId: "game-2" },
+        { status: "pinned", sessionEventGameId: "game-2", currentEventGameId: "game-3" },
+        { status: "game-locked", eventGameId: "game-2" },
+      ];
+      for (const candidate of malformed) {
+        relationship = candidate;
+        expect(
+          await authority.authorizeControlGrant({
+            sessionBearer: admitted.sessionBearer,
+            eventGameId: "game-1",
+          }),
+        ).toMatchObject({ status: "rejected" });
+      }
+    });
+  });
+
   registerGrantRotationContract(register, createStorage);
 }
 
@@ -544,7 +1103,10 @@ async function runGrantScenario(storage: FoundationStorage): Promise<void> {
   expect(admitted.eventGameId).toBe("game-1");
   expect(admitted.sessionBearer).toEqual(expect.any(String));
   expect(
-    await authority.authorizeControlGrant({ sessionBearer: admitted.sessionBearer }),
+    await authority.authorizeControlGrant({
+      sessionBearer: admitted.sessionBearer,
+      eventGameId: "game-1",
+    }),
   ).toMatchObject({
     status: "authorized",
     grantId: created.grantId,
@@ -589,9 +1151,23 @@ function createAuthority(
     randomness?: GrantRandomness;
     nowMs?: () => number;
     resolve?: (scope: ControlGrantScope) => ControlGrantScopeResolution;
+    resolveSession?: (
+      scope: ControlGrantScope,
+      sessionEventGameId: string,
+    ) => ControlGrantSessionResolution;
+    resolveReplay?: (
+      scope: ControlGrantScope,
+      eventGameId: string,
+      replayEvidenceId: string,
+    ) => ControlGrantReplayResolution;
+    resolveEventGameLock?: NonNullable<
+      GrantAuthorityOptions["controlGrantLifecycle"]
+    >["resolveEventGameLock"];
   } = {},
-): GrantAuthority {
-  return createLegacyControlGrantTestAuthority(storage, {
+): GrantAuthority & {
+  lockControlGrantEventGameForTest(evidence: unknown): Promise<unknown>;
+} {
+  const options: GrantAuthorityOptions = {
     environmentId: configuration.environmentId ?? "test-environment",
     clock: { nowMs: configuration.nowMs ?? (() => 1_000) },
     randomness: configuration.randomness ?? createDeterministicRandomness(),
@@ -603,8 +1179,21 @@ function createAuthority(
         expect(scope).toEqual(createScope());
         return { status: "eligible", eventGameId: "game-1" };
       },
+      resolveSession: configuration.resolveSession,
+      resolveReplay: configuration.resolveReplay,
     },
+    controlGrantLifecycle:
+      configuration.resolveEventGameLock === undefined
+        ? undefined
+        : { resolveEventGameLock: configuration.resolveEventGameLock },
+  };
+  const authority = createLegacyControlGrantTestAuthority(storage, options) as GrantAuthority & {
+    lockControlGrantEventGameForTest(evidence: unknown): Promise<unknown>;
+  };
+  Object.defineProperty(authority, "lockControlGrantEventGameForTest", {
+    value: (evidence: unknown) => lockControlGrantEventGame(storage, options, evidence),
   });
+  return authority;
 }
 
 export function createGrantTestScope(): ControlGrantScope {

--- a/src/lib/grant-authority-test-support.ts
+++ b/src/lib/grant-authority-test-support.ts
@@ -77,11 +77,24 @@ export function createLegacyControlGrantTestAuthority(
         lookupKeyVersion: options.keyRing.lookup.currentVersion,
       };
     },
+    async rotateControlGrant(grantId, actor) {
+      return (await typed.rotateGrant(grantId, actor)) as GrantMutationResult;
+    },
     async admitControlGrant(input) {
       return (await typed.admitGrant(input)) as AdmitControlGrantResult;
     },
     async authorizeControlGrant(input) {
       return (await typed.authorizeGrant(input)) as AuthorizeControlGrantResult;
+    },
+    async acceptControlGrantSessionSwitch(input) {
+      return (await typed.acceptControlGrantSessionSwitch(input)) as Awaited<
+        ReturnType<GrantAuthority["acceptControlGrantSessionSwitch"]>
+      >;
+    },
+    async authorizeControlGrantReplay(input) {
+      return (await typed.authorizeControlGrantReplay(input)) as Awaited<
+        ReturnType<GrantAuthority["authorizeControlGrantReplay"]>
+      >;
     },
     async disableControlGrant(grantId, actor) {
       return (await typed.disableGrant(grantId, actor)) as GrantMutationResult;

--- a/src/lib/grant-authority-types.ts
+++ b/src/lib/grant-authority-types.ts
@@ -1,6 +1,7 @@
 import { GRANT_CREDENTIAL_FORMAT_VERSION, GRANT_TYPE } from "@/lib/grant-types";
 import type {
   ControlGrantScope,
+  ControlGrantSessionDecision,
   GrantAuthorityActor,
   GrantSessionSummary,
   StoredGrantAuditEntry,
@@ -63,6 +64,8 @@ export type AdmitControlGrantResult =
 
 export type AuthorizeControlGrantInput = {
   sessionBearer: string;
+  eventGameId?: string;
+  controlSessionDecision?: ControlGrantSessionDecision;
 };
 
 export type AuthorizeControlGrantResult =
@@ -74,6 +77,28 @@ export type AuthorizeControlGrantResult =
       scope: ControlGrantScope;
       eventGameId: string;
       grantSessionId: string;
+    }
+  | typeof GENERIC_GRANT_AUTHORIZATION_FAILURE;
+
+export type ControlGrantSessionSwitchResult =
+  | {
+      status: "switched";
+      grantId: string;
+      grantVersion: string;
+      grantSessionId: string;
+      previousEventGameId: string;
+      eventGameId: string;
+    }
+  | typeof GENERIC_GRANT_AUTHORIZATION_FAILURE;
+
+export type ControlGrantReplayAuthorizationResult =
+  | {
+      status: "authorized";
+      grantId: string;
+      grantVersion: string;
+      grantSessionId: string;
+      originatingSessionId: string;
+      eventGameId: string;
     }
   | typeof GENERIC_GRANT_AUTHORIZATION_FAILURE;
 
@@ -122,8 +147,18 @@ export type GrantAuthority = {
     grantId: string,
     actor: GrantAuthorityActor,
   ): Promise<RotateControlGrantCredentialKeysResult>;
+  rotateControlGrant(grantId: string, actor: GrantAuthorityActor): Promise<GrantMutationResult>;
   admitControlGrant(input: AdmitControlGrantInput): Promise<AdmitControlGrantResult>;
   authorizeControlGrant(input: AuthorizeControlGrantInput): Promise<AuthorizeControlGrantResult>;
+  acceptControlGrantSessionSwitch(input: {
+    sessionBearer: string;
+  }): Promise<ControlGrantSessionSwitchResult>;
+  authorizeControlGrantReplay(input: {
+    sessionBearer: string;
+    originatingSessionId: string;
+    eventGameId: string;
+    replayEvidenceId: string;
+  }): Promise<ControlGrantReplayAuthorizationResult>;
   disableControlGrant(grantId: string, actor: GrantAuthorityActor): Promise<GrantMutationResult>;
   revokeControlGrant(grantId: string, actor: GrantAuthorityActor): Promise<GrantMutationResult>;
   listGrantSessions(

--- a/src/lib/grant-authority.focused.ts
+++ b/src/lib/grant-authority.focused.ts
@@ -9,6 +9,7 @@ import { FOUNDATION_MIGRATIONS } from "@/lib/foundation-migrations";
 import {
   createTypedGrantAuthority,
   type ControlGrantScope,
+  type ControlGrantSessionResolution,
   type ControlGrantScopeResolution,
   type GrantKeyRing,
 } from "@/lib/grant-authority";
@@ -140,7 +141,7 @@ describe("focused SQLite Grant authority boundary", () => {
           /^opaque-migration-reference-v1:[a-f0-9]{64}$/,
         );
         expect(beforeRotation.audit[0]?.credentialFingerprint).toBeNull();
-        expect(await current.readiness()).toMatchObject({ ok: true, schemaVersion: "14" });
+        expect(await current.readiness()).toMatchObject({ ok: true, schemaVersion: "16" });
 
         const forged = new Database(databasePath);
         expect(() =>
@@ -224,6 +225,219 @@ describe("focused SQLite Grant authority boundary", () => {
     } finally {
       legacy.close();
       await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("freezes SQLite after previous Event Game audit provenance tampering", async () => {
+    const handle = await createStorage();
+    let relationship: ControlGrantSessionResolution = {
+      status: "current",
+      eventGameId: "game-1",
+    };
+    const authority = createAuthority(
+      handle.storage,
+      createGrantTestRandomness(201),
+      createGrantTestKeyRing(),
+      () => 1_000,
+      () => relationship,
+    );
+    try {
+      const created = await createGrant(authority);
+      const admitted = await admit(authority, created.qrCredential, "tamper-switch");
+      relationship = {
+        status: "switchable",
+        previousEventGameId: "game-1",
+        currentEventGameId: "game-2",
+      };
+      expect(await authority.acceptControlGrantSessionSwitch(admitted)).toMatchObject({
+        status: "switched",
+      });
+      relationship = {
+        status: "switchable",
+        previousEventGameId: "game-2",
+        currentEventGameId: "game-3",
+      };
+      expect(await authority.acceptControlGrantSessionSwitch(admitted)).toMatchObject({
+        status: "switched",
+      });
+      const restarted = openSqliteFoundationStorage(handle.databasePath, {
+        grantKeyRing: createGrantTestKeyRing(),
+      });
+      expect(await restarted.readiness()).toMatchObject({ ok: true, schemaVersion: "16" });
+      restarted.close();
+      const database = new Database(handle.databasePath);
+      database
+        .query(
+          "UPDATE foundation_grant_audit SET previous_event_game_id = ? WHERE action = 'session-switched' AND event_game_id = ?",
+        )
+        .run("game-3", "game-2");
+      database.close();
+      expect(await handle.storage.readiness()).toMatchObject({
+        ok: false,
+        status: "integrity-failure",
+      });
+      expect(
+        await authority.createControlGrant({
+          scope: createGrantTestScope(),
+          actor: createActor(),
+        }),
+      ).toMatchObject({ status: "rejected", reason: "unavailable" });
+    } finally {
+      await handle.cleanup();
+    }
+  });
+
+  test("freezes restarted SQLite after external Grant Session Event Game mutation", async () => {
+    const handle = await createStorage();
+    const keyRing = createGrantTestKeyRing();
+    const authority = createAuthority(handle.storage, createGrantTestRandomness(203), keyRing);
+    try {
+      const created = await createGrant(authority);
+      const admitted = await admit(authority, created.qrCredential, "external-game-tamper");
+      const gameTamperDatabase = new Database(handle.databasePath);
+      gameTamperDatabase
+        .query("UPDATE foundation_grant_sessions SET event_game_id = ? WHERE session_id = ?")
+        .run("game-forged", admitted.grantSessionId);
+      gameTamperDatabase.close();
+
+      const restarted = openSqliteFoundationStorage(handle.databasePath, { grantKeyRing: keyRing });
+      try {
+        expect(await restarted.readiness()).toMatchObject({
+          ok: false,
+          status: "integrity-failure",
+        });
+        const restartedAuthority = createAuthority(
+          restarted,
+          createGrantTestRandomness(204),
+          keyRing,
+        );
+        expect(
+          await restartedAuthority.createControlGrant({
+            scope: createGrantTestScope(),
+            actor: createActor(),
+          }),
+        ).toMatchObject({ status: "rejected", reason: "unavailable" });
+      } finally {
+        restarted.close();
+      }
+    } finally {
+      await handle.cleanup();
+    }
+  });
+
+  test("rejects replay self-links and active origins across SQLite restart validation", async () => {
+    const handle = await createStorage();
+    const keyRing = createGrantTestKeyRing();
+    const options = {
+      environmentId: "test-environment",
+      clock: { nowMs: () => 1_000 },
+      randomness: createGrantTestRandomness(205),
+      keyRing,
+      privilegedAuthorityVerifier: createGrantTestAuthorityVerifier(),
+      controlScopeResolver: {
+        resolve: () => ({ status: "eligible" as const, eventGameId: "game-1" }),
+        resolveReplay: (
+          _scope: ControlGrantScope,
+          eventGameId: string,
+          replayEvidenceId: string,
+        ) =>
+          eventGameId === "game-1" && replayEvidenceId === "replay-sqlite"
+            ? { status: "eligible" as const, eventGameId: "game-1" }
+            : { status: "mismatch" as const },
+      },
+    };
+    const authority = createLegacyControlGrantTestAuthority(handle.storage, options);
+    try {
+      const created = await createGrant(authority);
+      const origin = await admit(authority, created.qrCredential, "sqlite-origin");
+      const replacement = await admit(authority, created.qrCredential, "sqlite-replacement");
+      expect(
+        await authority.authorizeControlGrantReplay({
+          sessionBearer: replacement.sessionBearer,
+          originatingSessionId: replacement.grantSessionId,
+          eventGameId: "game-1",
+          replayEvidenceId: "replay-sqlite",
+        }),
+      ).toMatchObject({ status: "rejected" });
+      expect(
+        await authority.authorizeControlGrantReplay({
+          sessionBearer: replacement.sessionBearer,
+          originatingSessionId: origin.grantSessionId,
+          eventGameId: "game-1",
+          replayEvidenceId: "replay-sqlite",
+        }),
+      ).toMatchObject({ status: "rejected" });
+      const originReplacement = await admit(authority, created.qrCredential, "sqlite-origin");
+      expect(
+        await authority.authorizeControlGrantReplay({
+          sessionBearer: replacement.sessionBearer,
+          originatingSessionId: origin.grantSessionId,
+          eventGameId: "game-1",
+          replayEvidenceId: "replay-sqlite",
+        }),
+      ).toMatchObject({ status: "authorized" });
+
+      const readyRestart = openSqliteFoundationStorage(handle.databasePath, {
+        grantKeyRing: keyRing,
+      });
+      expect(await readyRestart.readiness()).toMatchObject({ ok: true, schemaVersion: "16" });
+      readyRestart.close();
+
+      const selfLinkDatabase = new Database(handle.databasePath);
+      selfLinkDatabase
+        .query(
+          "UPDATE foundation_grant_audit SET replaced_session_id = session_id WHERE action = 'replay-authorized'",
+        )
+        .run();
+      selfLinkDatabase.close();
+      const selfLinkedRestart = openSqliteFoundationStorage(handle.databasePath, {
+        grantKeyRing: keyRing,
+      });
+      expect(await selfLinkedRestart.readiness()).toMatchObject({
+        ok: false,
+        status: "integrity-failure",
+      });
+      selfLinkedRestart.close();
+
+      const repairedDatabase = new Database(handle.databasePath);
+      repairedDatabase
+        .query(
+          "UPDATE foundation_grant_audit SET replaced_session_id = ? WHERE action = 'replay-authorized'",
+        )
+        .run(origin.grantSessionId);
+      repairedDatabase.close();
+      const repairedRestart = openSqliteFoundationStorage(handle.databasePath, {
+        grantKeyRing: keyRing,
+      });
+      expect(await repairedRestart.readiness()).toMatchObject({ ok: true, schemaVersion: "16" });
+      repairedRestart.close();
+
+      const activeOriginDatabase = new Database(handle.databasePath);
+      activeOriginDatabase
+        .query(
+          "UPDATE foundation_grant_sessions SET status = 'revoked', revoked_at_ms = ? WHERE session_id = ?",
+        )
+        .run(2_000, originReplacement.grantSessionId);
+      activeOriginDatabase
+        .query(
+          "UPDATE foundation_grant_sessions SET status = 'active', revoked_at_ms = NULL WHERE session_id = ?",
+        )
+        .run(origin.grantSessionId);
+      activeOriginDatabase.close();
+
+      const rejectedRestart = openSqliteFoundationStorage(handle.databasePath, {
+        grantKeyRing: keyRing,
+      });
+      try {
+        expect(await rejectedRestart.readiness()).toMatchObject({
+          ok: false,
+          status: "integrity-failure",
+        });
+      } finally {
+        rejectedRestart.close();
+      }
+    } finally {
+      await handle.cleanup();
     }
   });
 
@@ -405,7 +619,7 @@ describe("focused SQLite Grant authority boundary", () => {
       let currentClosed = false;
       try {
         const report = await current.applyMigrations({ requireCandidate: false });
-        expect(report.schemaVersion).toBe(14);
+        expect(report.schemaVersion).toBe(16);
         expect(report.appliedMigrationIds).toEqual([
           "007-anchor-control-action-audit-versions",
           "008-anchor-current-evidence-format",
@@ -415,10 +629,12 @@ describe("focused SQLite Grant authority boundary", () => {
           "012-terminal-grant-session-audit",
           "013-grant-audit-evidence-fields",
           "014-grant-provenance-integrity",
+          "015-control-session-binding",
+          "016-replay-content-provenance",
         ]);
         expect(await current.readiness()).toMatchObject({
           ok: true,
-          schemaVersion: "14",
+          schemaVersion: "16",
         });
         const migrated = await current.transaction((transaction) => ({
           grant: transaction.findGrantById(grantId),
@@ -467,7 +683,7 @@ describe("focused SQLite Grant authority boundary", () => {
 
         const restarted = openSqliteFoundationStorage(databasePath, { grantKeyRing: keyRing });
         try {
-          expect(await restarted.readiness()).toMatchObject({ ok: true, schemaVersion: "14" });
+          expect(await restarted.readiness()).toMatchObject({ ok: true, schemaVersion: "16" });
           const restartedAudit = await restarted.transaction((transaction) =>
             transaction.listGrantAudit(grantId),
           );
@@ -864,7 +1080,7 @@ describe("focused SQLite Grant authority boundary", () => {
         grantKeyRing: options.keyRing,
       });
       try {
-        expect(await reopened.readiness()).toMatchObject({ ok: true, schemaVersion: "14" });
+        expect(await reopened.readiness()).toMatchObject({ ok: true, schemaVersion: "16" });
         const rotated = createTypedGrantAuthority(reopened, {
           ...options,
           keyRing: createGrantTestRotatedKeyRing(keyRing),
@@ -957,7 +1173,12 @@ describe("focused SQLite Grant authority boundary", () => {
         throw new Error("Expected Control Sessions.");
 
       resolution = { status: "terminal", reason: "game-locked", eventGameId: "game-1" };
-      expect(await authority.authorizeGrant({ sessionBearer: first.sessionBearer })).toMatchObject({
+      expect(
+        await authority.authorizeGrant({
+          sessionBearer: first.sessionBearer,
+          eventGameId: "game-1",
+        }),
+      ).toMatchObject({
         status: "rejected",
       });
       const sessions = await authority.listGrantSessions(control.grantId, {
@@ -987,7 +1208,7 @@ describe("focused SQLite Grant authority boundary", () => {
         grantKeyRing: options.keyRing,
       });
       try {
-        expect(await reopened.readiness()).toMatchObject({ ok: true, schemaVersion: "14" });
+        expect(await reopened.readiness()).toMatchObject({ ok: true, schemaVersion: "16" });
         const reopenedAuthority = createTypedGrantAuthority(reopened, options);
         const reopenedAudit = await reopenedAuthority.listGrantAudit(control.grantId, {
           kind: "technical-admin",
@@ -1040,6 +1261,7 @@ describe("focused SQLite Grant authority boundary", () => {
         expect(
           await reopenedAuthority.authorizeControlGrant({
             sessionBearer: readmitted.sessionBearer,
+            eventGameId: "game-1",
           }),
         ).toMatchObject({ status: "authorized", grantId: created.grantId });
       } finally {
@@ -1307,6 +1529,7 @@ function createAuthority(
   randomness: ReturnType<typeof createGrantTestRandomness>,
   keyRing: GrantKeyRing = createGrantTestKeyRing(),
   nowMs: () => number = () => 1_000,
+  resolveSession?: () => ControlGrantSessionResolution,
 ): GrantAuthority {
   return createLegacyControlGrantTestAuthority(storage, {
     environmentId: "test-environment",
@@ -1319,6 +1542,7 @@ function createAuthority(
         expect(scope).toEqual(createGrantTestScope());
         return { status: "eligible", eventGameId: "game-1" };
       },
+      resolveSession,
     },
   });
 }

--- a/src/lib/grant-authority.ts
+++ b/src/lib/grant-authority.ts
@@ -1,4 +1,4 @@
-import type { FoundationStorage } from "@/lib/foundation-storage";
+import type { FoundationStorage, FoundationStorageTransaction } from "@/lib/foundation-storage";
 import type { GrantAuthorityVerifier } from "@/lib/grant-authority-trust";
 import { createTypedGrantAuthority, type TypedGrantAuthority } from "@/lib/grant-management";
 import type {
@@ -14,6 +14,8 @@ export {
   type CreateTypedGrantInput,
   type GrantManagementAuthority,
   type TypedGrantAuthority,
+  type TypedControlGrantSwitch,
+  type TypedGrantReplayAuthorization,
 } from "@/lib/grant-management";
 export type { GrantAuthorityVerification } from "@/lib/grant-authority-trust";
 export { EVENT_ADMIN_GRANT_TYPE, GRANT_TYPE, PITCH_MANAGER_GRANT_TYPE } from "@/lib/grant-types";
@@ -21,6 +23,9 @@ export type {
   ControlGrantScope,
   ControlGrantScopeResolution,
   ControlGrantScopeResolver,
+  ControlGrantSessionResolution,
+  ControlGrantReplayResolution,
+  ControlGrantSessionDecision,
   GrantClock,
   GrantAuthorityActor,
   GrantKeyRing,
@@ -37,6 +42,12 @@ export type GrantAuthorityOptions = {
   randomness: GrantRandomness;
   keyRing: GrantKeyRing;
   controlScopeResolver: ControlGrantScopeResolver;
+  controlGrantLifecycle?: {
+    /** Trusted Event Game lifecycle seam for atomic Game Lock transitions. */
+    resolveEventGameLock: (
+      evidence: unknown,
+    ) => { eventGameId: string; apply(transaction: FoundationStorageTransaction): void } | null;
+  };
   privilegedAuthorityVerifier: GrantAuthorityVerifier;
 };
 

--- a/src/lib/grant-crypto.ts
+++ b/src/lib/grant-crypto.ts
@@ -233,6 +233,24 @@ export function computeGrantAuditIntegrityTag(
   keyRing: GrantKeyRing,
   keyVersion = keyRing.audit.currentVersion,
 ): string {
+  return computeGrantAuditIntegrityTagWithPreviousEventGameId(entry, keyRing, keyVersion, true);
+}
+
+/** Compatibility verifier for keyed audit rows written before migration 015. */
+export function computeLegacyGrantAuditIntegrityTag(
+  entry: StoredGrantAuditEntry,
+  keyRing: GrantKeyRing,
+  keyVersion = keyRing.audit.currentVersion,
+): string {
+  return computeGrantAuditIntegrityTagWithPreviousEventGameId(entry, keyRing, keyVersion, false);
+}
+
+function computeGrantAuditIntegrityTagWithPreviousEventGameId(
+  entry: StoredGrantAuditEntry,
+  keyRing: GrantKeyRing,
+  keyVersion: string,
+  includePreviousEventGameId: boolean,
+): string {
   const payload = JSON.stringify({
     domain: "grant-audit-integrity-v1",
     auditId: entry.auditId,
@@ -246,6 +264,12 @@ export function computeGrantAuditIntegrityTag(
     sessionId: entry.sessionId,
     replacedSessionId: entry.replacedSessionId,
     eventGameId: entry.eventGameId,
+    ...(includePreviousEventGameId
+      ? { previousEventGameId: entry.previousEventGameId ?? null }
+      : {}),
+    ...(includePreviousEventGameId && entry.replayEvidenceId !== null
+      ? { replayEvidenceId: entry.replayEvidenceId }
+      : {}),
     credentialKind: entry.credentialKind,
     credentialFingerprint: entry.credentialFingerprint,
     beforeStatus: entry.beforeStatus,

--- a/src/lib/grant-lifecycle.ts
+++ b/src/lib/grant-lifecycle.ts
@@ -35,6 +35,8 @@ export function createAuditEntry(
     sessionId: string | null;
     replacedSessionId: string | null;
     eventGameId: string | null;
+    previousEventGameId?: string | null;
+    replayEvidenceId?: string | null;
     beforeStatus: StoredGrantStatus | null;
     afterStatus: StoredGrantStatus | null;
     beforeExpiresAtMs?: number | null;
@@ -55,6 +57,8 @@ export function createAuditEntry(
     sessionId: input.sessionId,
     replacedSessionId: input.replacedSessionId,
     eventGameId: input.eventGameId,
+    previousEventGameId: input.previousEventGameId ?? null,
+    replayEvidenceId: input.replayEvidenceId ?? null,
     credentialKind: GRANT_CREDENTIAL_KIND,
     credentialFingerprint: input.grant.credential.fingerprint.startsWith(
       OPAQUE_MIGRATION_CREDENTIAL_REFERENCE_PREFIX,

--- a/src/lib/grant-management-audit.ts
+++ b/src/lib/grant-management-audit.ts
@@ -24,6 +24,8 @@ export function auditInput(
   terminalReason: TerminalGrantSessionReason | null = null,
   beforeExpiresAtMs: number | null = null,
   afterExpiresAtMs: number | null = null,
+  previousEventGameId: string | null = null,
+  replayEvidenceId: string | null = null,
 ) {
   let actor:
     | { kind: "authority"; value: GrantAuthorityActor }
@@ -48,6 +50,8 @@ export function auditInput(
     sessionId,
     replacedSessionId,
     eventGameId,
+    previousEventGameId,
+    replayEvidenceId,
     beforeStatus,
     afterStatus,
     beforeExpiresAtMs,

--- a/src/lib/grant-management-policy.ts
+++ b/src/lib/grant-management-policy.ts
@@ -147,7 +147,15 @@ export function canManageInTransaction(
   if (caller.grantType === "control") {
     const resolved = options.controlScopeResolver.resolve(caller.scope as ControlGrantScope);
     if (resolved.status === "terminal") {
-      terminateControlSession(transaction, options, caller, resolved.reason);
+      if (resolved.reason === "game-locked")
+        terminateControlSessionForEventGame(
+          transaction,
+          options,
+          caller,
+          resolved.reason,
+          resolved.eventGameId ?? session.eventGameId,
+        );
+      else terminateControlSession(transaction, options, caller, resolved.reason);
       return false;
     }
     if (resolved.status !== "eligible" || resolved.eventGameId !== session.eventGameId)
@@ -197,7 +205,15 @@ export function canCreateInTransaction(
   if (caller.grantType === "control") {
     const resolved = options.controlScopeResolver.resolve(caller.scope as ControlGrantScope);
     if (resolved.status === "terminal") {
-      terminateControlSession(transaction, options, caller, resolved.reason);
+      if (resolved.reason === "game-locked")
+        terminateControlSessionForEventGame(
+          transaction,
+          options,
+          caller,
+          resolved.reason,
+          resolved.eventGameId ?? session.eventGameId,
+        );
+      else terminateControlSession(transaction, options, caller, resolved.reason);
       return false;
     }
     if (resolved.status !== "eligible" || resolved.eventGameId !== session.eventGameId)
@@ -359,9 +375,24 @@ export function terminateControlSession(
   grant: StoredGrant,
   reason: "accepted-game-switch" | "past-game-day" | "game-locked",
 ): void {
+  terminateControlSessionForEventGame(transaction, options, grant, reason, null);
+}
+
+export function terminateControlSessionForEventGame(
+  transaction: FoundationStorageTransaction,
+  options: GrantAuthorityOptions,
+  grant: StoredGrant,
+  reason: "accepted-game-switch" | "past-game-day" | "game-locked",
+  eventGameId: string | null,
+): number {
   const nowMs = readNow(options);
+  let terminated = 0;
   for (const affected of transaction.listGrantSessions(grant.grantId)) {
-    if (affected.status !== "active") continue;
+    if (
+      affected.status !== "active" ||
+      (eventGameId !== null && affected.eventGameId !== eventGameId)
+    )
+      continue;
     transaction.updateGrantSession({
       ...affected,
       status: "expired",
@@ -383,7 +414,9 @@ export function terminateControlSession(
         terminalReason: reason,
       }),
     );
+    terminated += 1;
   }
+  return terminated;
 }
 
 function sameScope(left: GrantScope, right: GrantScope): boolean {

--- a/src/lib/grant-management-sessions.ts
+++ b/src/lib/grant-management-sessions.ts
@@ -9,6 +9,7 @@ import {
   EVENT_ADMIN_GRANT_TYPE,
   GRANT_TYPE,
   type ControlGrantScope,
+  type ControlGrantSessionResolution,
   type StoredGrantSession,
 } from "@/lib/grant-types";
 import {
@@ -27,7 +28,7 @@ import {
   findSessionByBearer,
   refreshEventAdminSession,
   resolveManagementAuthority,
-  terminateControlSession,
+  terminateControlSessionForEventGame,
 } from "@/lib/grant-management-policy";
 import { verifyGrantAuthority } from "@/lib/grant-authority-trust";
 import { auditInput, coarse, sessionLabel } from "@/lib/grant-management-audit";
@@ -35,6 +36,8 @@ import type {
   GrantManagementAuthority,
   TypedGrantAdmission,
   TypedGrantAuthorization,
+  TypedControlGrantSwitch,
+  TypedGrantReplayAuthorization,
   TypedGrantMutation,
 } from "@/lib/grant-management-types";
 import {
@@ -73,7 +76,11 @@ export async function admitGrant(
       let eventGameId: string | null = null;
       if (current.grantType === GRANT_TYPE) {
         const resolved = options.controlScopeResolver.resolve(current.scope as ControlGrantScope);
-        if (resolved.status !== "eligible") return GENERIC_GRANT_ADMISSION_FAILURE;
+        if (
+          resolved.status !== "eligible" ||
+          !validateOpaqueIdentifier(resolved.eventGameId, "eventGameId").ok
+        )
+          return GENERIC_GRANT_ADMISSION_FAILURE;
         eventGameId = resolved.eventGameId;
       }
       const nowMs = readGrantNow(options);
@@ -147,12 +154,22 @@ export async function admitGrant(
 export async function authorizeGrant(
   storage: FoundationStorage,
   options: GrantAuthorityOptions,
-  bearer: string,
+  input: {
+    sessionBearer: string;
+    eventGameId?: string;
+    controlSessionDecision?: "stay";
+  },
 ): Promise<TypedGrantAuthorization> {
-  if (!isValidGrantSecret(bearer)) return GENERIC_GRANT_AUTHORIZATION_FAILURE;
+  if (
+    !isValidGrantSecret(input.sessionBearer) ||
+    (input.eventGameId !== undefined &&
+      !validateOpaqueIdentifier(input.eventGameId, "eventGameId").ok) ||
+    (input.controlSessionDecision !== undefined && input.controlSessionDecision !== "stay")
+  )
+    return GENERIC_GRANT_AUTHORIZATION_FAILURE;
   try {
     return await storage.transaction((transaction) => {
-      const session = findSessionByBearer(transaction, options, bearer);
+      const session = findSessionByBearer(transaction, options, input.sessionBearer);
       if (session === null) return GENERIC_GRANT_AUTHORIZATION_FAILURE;
       const stored = transaction.findGrantById(session.grantId);
       if (stored === null) return GENERIC_GRANT_AUTHORIZATION_FAILURE;
@@ -177,14 +194,58 @@ export async function authorizeGrant(
       }
       let eventGameId: string | null = null;
       if (grant.grantType === GRANT_TYPE) {
-        const resolved = options.controlScopeResolver.resolve(grant.scope as ControlGrantScope);
-        if (resolved.status === "terminal") {
-          terminateControlSession(transaction, options, grant, resolved.reason);
+        if (input.eventGameId === undefined) return GENERIC_GRANT_AUTHORIZATION_FAILURE;
+        const relationship = resolveControlSession(
+          options,
+          grant.scope as ControlGrantScope,
+          session.eventGameId,
+        );
+        if (relationship.status === "game-locked") {
+          terminateControlSessionForEventGame(
+            transaction,
+            options,
+            grant,
+            "game-locked",
+            relationship.eventGameId,
+          );
           return GENERIC_GRANT_AUTHORIZATION_FAILURE;
         }
-        if (resolved.status !== "eligible" || resolved.eventGameId !== session.eventGameId)
+        if (relationship.status === "switchable") {
+          if (
+            input.controlSessionDecision === "stay" &&
+            input.eventGameId === relationship.previousEventGameId
+          ) {
+            eventGameId = relationship.previousEventGameId;
+          } else if (
+            input.eventGameId === relationship.currentEventGameId ||
+            (input.controlSessionDecision === undefined &&
+              input.eventGameId === relationship.previousEventGameId)
+          ) {
+            return {
+              status: "switch-required",
+              grantId: grant.grantId,
+              grantVersion: grant.grantVersion,
+              grantType: GRANT_TYPE,
+              scope: structuredClone(grant.scope as ControlGrantScope),
+              grantSessionId: session.sessionId,
+              previousEventGameId: relationship.previousEventGameId,
+              currentEventGameId: relationship.currentEventGameId,
+            } satisfies TypedGrantAuthorization;
+          } else {
+            return GENERIC_GRANT_AUTHORIZATION_FAILURE;
+          }
+        }
+        if (relationship.status === "pinned") {
+          if (input.eventGameId !== relationship.sessionEventGameId)
+            return GENERIC_GRANT_AUTHORIZATION_FAILURE;
+          eventGameId = relationship.sessionEventGameId;
+        } else if (relationship.status === "current") {
+          if (input.eventGameId !== relationship.eventGameId)
+            return GENERIC_GRANT_AUTHORIZATION_FAILURE;
+          eventGameId = relationship.eventGameId;
+        } else if (relationship.status !== "switchable") {
           return GENERIC_GRANT_AUTHORIZATION_FAILURE;
-        eventGameId = resolved.eventGameId;
+        }
       }
       transaction.updateGrantSession({ ...session, lastActiveAtMs: nowMs });
       return {
@@ -200,6 +261,278 @@ export async function authorizeGrant(
   } catch {
     return GENERIC_GRANT_AUTHORIZATION_FAILURE;
   }
+}
+
+export async function acceptControlGrantSessionSwitch(
+  storage: FoundationStorage,
+  options: GrantAuthorityOptions,
+  bearer: string,
+): Promise<TypedControlGrantSwitch> {
+  if (!isValidGrantSecret(bearer)) return GENERIC_GRANT_AUTHORIZATION_FAILURE;
+  try {
+    return await storage.transaction((transaction) => {
+      const session = findSessionByBearer(transaction, options, bearer);
+      if (session === null || session.status !== "active")
+        return GENERIC_GRANT_AUTHORIZATION_FAILURE;
+      const stored = transaction.findGrantById(session.grantId);
+      if (stored === null || stored.grantType !== GRANT_TYPE)
+        return GENERIC_GRANT_AUTHORIZATION_FAILURE;
+      const grant = expireGrantIfDue(transaction, options, stored);
+      if (grant.status !== "active" || grant.grantVersion !== session.grantVersion)
+        return GENERIC_GRANT_AUTHORIZATION_FAILURE;
+      const relationship = resolveControlSession(
+        options,
+        grant.scope as ControlGrantScope,
+        session.eventGameId,
+      );
+      if (relationship.status !== "switchable") return GENERIC_GRANT_AUTHORIZATION_FAILURE;
+      const nowMs = readGrantNow(options);
+      transaction.updateGrantSession({
+        ...session,
+        eventGameId: relationship.currentEventGameId,
+        lastActiveAtMs: nowMs,
+      });
+      transaction.appendGrantAudit(
+        createAuditEntry(
+          options,
+          auditInput(
+            "session-switched",
+            grant,
+            {
+              kind: "session",
+              sessionId: session.sessionId,
+              pseudonymKeyVersion: session.browserContextKeyVersion,
+            },
+            "active",
+            session.sessionId,
+            null,
+            relationship.currentEventGameId,
+            null,
+            null,
+            null,
+            null,
+            relationship.previousEventGameId,
+          ),
+        ),
+      );
+      return {
+        status: "switched",
+        grantId: grant.grantId,
+        grantVersion: grant.grantVersion,
+        grantSessionId: session.sessionId,
+        previousEventGameId: relationship.previousEventGameId,
+        eventGameId: relationship.currentEventGameId,
+      } satisfies TypedControlGrantSwitch;
+    });
+  } catch {
+    return GENERIC_GRANT_AUTHORIZATION_FAILURE;
+  }
+}
+
+export async function lockControlGrantEventGame(
+  storage: FoundationStorage,
+  options: GrantAuthorityOptions,
+  evidence: unknown,
+): Promise<
+  | {
+      status: "locked";
+      eventGameId: string;
+      terminatedSessionCount: number;
+    }
+  | { status: "rejected"; reason: "invalid-input" | "unavailable" }
+> {
+  let transition:
+    | {
+        eventGameId: string;
+        apply(transaction: import("@/lib/foundation-storage").FoundationStorageTransaction): void;
+      }
+    | null
+    | undefined;
+  try {
+    transition = options.controlGrantLifecycle?.resolveEventGameLock(evidence);
+  } catch {
+    return { status: "rejected", reason: "unavailable" };
+  }
+  if (
+    transition === undefined ||
+    transition === null ||
+    !validateOpaqueIdentifier(transition.eventGameId, "eventGameId").ok ||
+    typeof transition.apply !== "function"
+  )
+    return { status: "rejected", reason: "invalid-input" };
+  try {
+    return await storage.transaction((transaction) => {
+      let terminatedSessionCount = 0;
+      for (const grant of transaction.listGrants()) {
+        if (grant.grantType !== GRANT_TYPE) continue;
+        terminatedSessionCount += terminateControlSessionForEventGame(
+          transaction,
+          options,
+          grant,
+          "game-locked",
+          transition.eventGameId,
+        );
+      }
+      transition.apply(transaction);
+      return { status: "locked", eventGameId: transition.eventGameId, terminatedSessionCount };
+    });
+  } catch {
+    return { status: "rejected", reason: "unavailable" };
+  }
+}
+
+export async function authorizeControlGrantReplay(
+  storage: FoundationStorage,
+  options: GrantAuthorityOptions,
+  input: {
+    sessionBearer: string;
+    originatingSessionId: string;
+    eventGameId: string;
+    replayEvidenceId: string;
+  },
+): Promise<TypedGrantReplayAuthorization> {
+  if (
+    !isValidGrantSecret(input.sessionBearer) ||
+    !validateOpaqueIdentifier(input.originatingSessionId, "originatingSessionId").ok ||
+    !validateOpaqueIdentifier(input.eventGameId, "eventGameId").ok ||
+    !validateOpaqueIdentifier(input.replayEvidenceId, "replayEvidenceId").ok
+  )
+    return GENERIC_GRANT_AUTHORIZATION_FAILURE;
+  try {
+    return await storage.transaction((transaction) => {
+      const replacement = findSessionByBearer(transaction, options, input.sessionBearer);
+      if (replacement === null || replacement.status !== "active")
+        return GENERIC_GRANT_AUTHORIZATION_FAILURE;
+      const stored = transaction.findGrantById(replacement.grantId);
+      if (stored === null || stored.grantType !== GRANT_TYPE)
+        return GENERIC_GRANT_AUTHORIZATION_FAILURE;
+      const grant = expireGrantIfDue(transaction, options, stored);
+      if (
+        grant.status !== "active" ||
+        replacement.grantVersion !== grant.grantVersion ||
+        replacement.eventGameId !== input.eventGameId
+      )
+        return GENERIC_GRANT_AUTHORIZATION_FAILURE;
+      const replay = options.controlScopeResolver.resolveReplay?.(
+        grant.scope as ControlGrantScope,
+        input.eventGameId,
+        input.replayEvidenceId,
+      );
+      if (replay === undefined) return GENERIC_GRANT_AUTHORIZATION_FAILURE;
+      if (replay.status !== "eligible" || replay.eventGameId !== input.eventGameId)
+        return GENERIC_GRANT_AUTHORIZATION_FAILURE;
+      const originating = transaction
+        .listGrantSessions(grant.grantId)
+        .find((candidate) => candidate.sessionId === input.originatingSessionId);
+      if (
+        originating === undefined ||
+        originating.sessionId === replacement.sessionId ||
+        originating.status === "active" ||
+        originating.grantId !== grant.grantId ||
+        originating.eventGameId !== input.eventGameId
+      )
+        return GENERIC_GRANT_AUTHORIZATION_FAILURE;
+      const originatingEvidence = transaction
+        .listGrantAudit(grant.grantId)
+        .some(
+          (audit) =>
+            (audit.action === "session-admitted" || audit.action === "session-replaced") &&
+            audit.sessionId === originating.sessionId &&
+            audit.grantVersion === originating.grantVersion &&
+            audit.eventGameId === input.eventGameId &&
+            audit.grantId === originating.grantId,
+        );
+      if (!originatingEvidence) return GENERIC_GRANT_AUTHORIZATION_FAILURE;
+      transaction.updateGrantSession({
+        ...replacement,
+        lastActiveAtMs: readGrantNow(options),
+      });
+      transaction.appendGrantAudit(
+        createAuditEntry(
+          options,
+          auditInput(
+            "replay-authorized",
+            grant,
+            {
+              kind: "session",
+              sessionId: replacement.sessionId,
+              pseudonymKeyVersion: replacement.browserContextKeyVersion,
+            },
+            "active",
+            replacement.sessionId,
+            originating.sessionId,
+            input.eventGameId,
+            null,
+            null,
+            null,
+            null,
+            null,
+            input.replayEvidenceId,
+          ),
+        ),
+      );
+      return {
+        status: "authorized",
+        grantId: grant.grantId,
+        grantVersion: grant.grantVersion,
+        grantSessionId: replacement.sessionId,
+        originatingSessionId: originating.sessionId,
+        eventGameId: input.eventGameId,
+        replayEvidenceId: input.replayEvidenceId,
+      } satisfies TypedGrantReplayAuthorization;
+    });
+  } catch {
+    return GENERIC_GRANT_AUTHORIZATION_FAILURE;
+  }
+}
+
+function resolveControlSession(
+  options: GrantAuthorityOptions,
+  scope: ControlGrantScope,
+  sessionEventGameId: string,
+): ControlGrantSessionResolution {
+  if (options.controlScopeResolver.resolveSession !== undefined) {
+    const resolved = options.controlScopeResolver.resolveSession(scope, sessionEventGameId);
+    if (resolved.status === "current")
+      return resolved.eventGameId === sessionEventGameId &&
+        validateOpaqueIdentifier(resolved.eventGameId, "eventGameId").ok
+        ? resolved
+        : { status: "mismatch" };
+    if (resolved.status === "pinned")
+      return resolved.sessionEventGameId === sessionEventGameId &&
+        validateOpaqueIdentifier(resolved.sessionEventGameId, "sessionEventGameId").ok &&
+        validateOpaqueIdentifier(resolved.currentEventGameId, "currentEventGameId").ok
+        ? resolved
+        : { status: "mismatch" };
+    if (resolved.status === "switchable")
+      return resolved.previousEventGameId === sessionEventGameId &&
+        resolved.previousEventGameId !== resolved.currentEventGameId &&
+        validateOpaqueIdentifier(resolved.previousEventGameId, "previousEventGameId").ok &&
+        validateOpaqueIdentifier(resolved.currentEventGameId, "currentEventGameId").ok
+        ? resolved
+        : { status: "mismatch" };
+    if (resolved.status === "game-locked")
+      return resolved.eventGameId === sessionEventGameId &&
+        validateOpaqueIdentifier(resolved.eventGameId, "eventGameId").ok
+        ? resolved
+        : { status: "mismatch" };
+    return resolved;
+  }
+  const current = options.controlScopeResolver.resolve(scope);
+  if (
+    current.status === "eligible" &&
+    current.eventGameId === sessionEventGameId &&
+    validateOpaqueIdentifier(current.eventGameId, "eventGameId").ok
+  )
+    return { status: "current", eventGameId: current.eventGameId };
+  if (
+    current.status === "terminal" &&
+    current.reason === "game-locked" &&
+    current.eventGameId === sessionEventGameId &&
+    validateOpaqueIdentifier(current.eventGameId, "eventGameId").ok
+  )
+    return { status: "game-locked", eventGameId: current.eventGameId };
+  return { status: "mismatch" };
 }
 
 export async function revokeGrantSession(

--- a/src/lib/grant-management-types.ts
+++ b/src/lib/grant-management-types.ts
@@ -1,6 +1,7 @@
 import {
   GRANT_CREDENTIAL_FORMAT_VERSION,
   type ControlGrantScope,
+  type ControlGrantSessionDecision,
   type EventAdminGrantScope,
   type GrantScope,
   type GrantType,
@@ -59,6 +60,39 @@ export type TypedGrantAuthorization =
       eventGameId: string | null;
       grantSessionId: string;
     }
+  | {
+      status: "switch-required";
+      grantId: string;
+      grantVersion: string;
+      grantType: "control";
+      scope: ControlGrantScope;
+      grantSessionId: string;
+      previousEventGameId: string;
+      currentEventGameId: string;
+    }
+  | typeof GENERIC_GRANT_AUTHORIZATION_FAILURE;
+
+export type TypedControlGrantSwitch =
+  | {
+      status: "switched";
+      grantId: string;
+      grantVersion: string;
+      grantSessionId: string;
+      previousEventGameId: string;
+      eventGameId: string;
+    }
+  | typeof GENERIC_GRANT_AUTHORIZATION_FAILURE;
+
+export type TypedGrantReplayAuthorization =
+  | {
+      status: "authorized";
+      grantId: string;
+      grantVersion: string;
+      grantSessionId: string;
+      originatingSessionId: string;
+      eventGameId: string;
+      replayEvidenceId: string;
+    }
   | typeof GENERIC_GRANT_AUTHORIZATION_FAILURE;
 
 export type TypedGrantMutation =
@@ -107,7 +141,20 @@ export type TypedGrantAuthority = {
     deviceClass?: string;
     browserClass?: string;
   }): Promise<TypedGrantAdmission>;
-  authorizeGrant(input: { sessionBearer: string }): Promise<TypedGrantAuthorization>;
+  authorizeGrant(input: {
+    sessionBearer: string;
+    eventGameId?: string;
+    controlSessionDecision?: ControlGrantSessionDecision;
+  }): Promise<TypedGrantAuthorization>;
+  acceptControlGrantSessionSwitch(input: {
+    sessionBearer: string;
+  }): Promise<TypedControlGrantSwitch>;
+  authorizeControlGrantReplay(input: {
+    sessionBearer: string;
+    originatingSessionId: string;
+    eventGameId: string;
+    replayEvidenceId: string;
+  }): Promise<TypedGrantReplayAuthorization>;
   revealGrant(grantId: string, authority: GrantManagementAuthority): Promise<TypedGrantReveal>;
   disableGrant(grantId: string, authority: GrantManagementAuthority): Promise<TypedGrantMutation>;
   revokeGrant(grantId: string, authority: GrantManagementAuthority): Promise<TypedGrantMutation>;

--- a/src/lib/grant-management.test.ts
+++ b/src/lib/grant-management.test.ts
@@ -317,12 +317,20 @@ describe("typed Grant management", () => {
       }),
     ).toMatchObject({ status: "updated" });
     expect(
-      await authority.authorizeGrant({ sessionBearer: controllerSession.sessionBearer }),
+      await authority.authorizeGrant({
+        sessionBearer: controllerSession.sessionBearer,
+        eventGameId: "game-1",
+      }),
     ).toMatchObject({ status: "rejected" });
     expect(await authority.leaveGrantSession(leaver.sessionBearer)).toMatchObject({
       status: "updated",
     });
-    expect(await authority.authorizeGrant({ sessionBearer: leaver.sessionBearer })).toMatchObject({
+    expect(
+      await authority.authorizeGrant({
+        sessionBearer: leaver.sessionBearer,
+        eventGameId: "game-1",
+      }),
+    ).toMatchObject({
       status: "rejected",
     });
     expect(
@@ -608,11 +616,21 @@ describe("typed Grant management", () => {
     });
     if (secondSession.status !== "admitted") throw new Error("Expected second Control Session.");
     resolution = { status: "terminal", reason: "game-locked", eventGameId: "game-1" };
-    expect(await authority.authorizeGrant({ sessionBearer: session.sessionBearer })).toMatchObject({
+    expect(
+      await authority.authorizeGrant({
+        sessionBearer: session.sessionBearer,
+        eventGameId: "game-1",
+      }),
+    ).toMatchObject({
       status: "rejected",
     });
     resolution = { status: "eligible", eventGameId: "game-1" };
-    expect(await authority.authorizeGrant({ sessionBearer: session.sessionBearer })).toMatchObject({
+    expect(
+      await authority.authorizeGrant({
+        sessionBearer: session.sessionBearer,
+        eventGameId: "game-1",
+      }),
+    ).toMatchObject({
       status: "rejected",
     });
     const stored = await storage.transaction((transaction) =>

--- a/src/lib/grant-management.ts
+++ b/src/lib/grant-management.ts
@@ -11,7 +11,9 @@ import { recalculateExpiry } from "@/lib/grant-management-lifecycle";
 import { listAudit, listSessions } from "@/lib/grant-management-queries";
 import {
   admitGrant,
+  acceptControlGrantSessionSwitch,
   authorizeGrant,
+  authorizeControlGrantReplay,
   leaveGrantSession,
   revokeGrantSession,
 } from "@/lib/grant-management-sessions";
@@ -24,6 +26,8 @@ export type {
   TypedGrantAuthorization,
   TypedGrantAuthority,
   TypedGrantCreated,
+  TypedControlGrantSwitch,
+  TypedGrantReplayAuthorization,
   TypedGrantMutation,
   TypedGrantReveal,
   TypedSessionSummary,
@@ -49,7 +53,10 @@ export function createTypedGrantAuthority(
     createControlGrant: (input) =>
       createGrant(storage, options, { ...input, grantType: GRANT_TYPE }),
     admitGrant: (input) => admitGrant(storage, options, input),
-    authorizeGrant: (input) => authorizeGrant(storage, options, input.sessionBearer),
+    authorizeGrant: (input) => authorizeGrant(storage, options, input),
+    acceptControlGrantSessionSwitch: (input) =>
+      acceptControlGrantSessionSwitch(storage, options, input.sessionBearer),
+    authorizeControlGrantReplay: (input) => authorizeControlGrantReplay(storage, options, input),
     revealGrant: (grantId, authority) => revealGrant(storage, options, grantId, authority),
     disableGrant: (grantId, authority) =>
       updateGrantStatus(storage, options, grantId, authority, "disabled", "grant-disabled"),

--- a/src/lib/grant-rotation-contract.ts
+++ b/src/lib/grant-rotation-contract.ts
@@ -64,7 +64,10 @@ export function registerGrantRotationContract(
       });
       const admitted = await admit(currentOnly, created.qrCredential, "browser-a");
       expect(
-        await currentOnly.authorizeControlGrant({ sessionBearer: admitted.sessionBearer }),
+        await currentOnly.authorizeControlGrant({
+          sessionBearer: admitted.sessionBearer,
+          eventGameId: "game-1",
+        }),
       ).toMatchObject({ status: "authorized" });
     });
   });

--- a/src/lib/grant-state-validation.ts
+++ b/src/lib/grant-state-validation.ts
@@ -1,5 +1,6 @@
 import {
   computeGrantAuditIntegrityTag,
+  computeLegacyGrantAuditIntegrityTag,
   computeCredentialFingerprint,
   computeLookupDigest,
   decryptCredential,
@@ -64,7 +65,10 @@ export function validateGrantState(
       if (
         tagParts.length !== 3 ||
         keyVersion === undefined ||
-        tag !== computeGrantAuditIntegrityTag(audit, context.keyRing, keyVersion)
+        (tag !== computeGrantAuditIntegrityTag(audit, context.keyRing, keyVersion) &&
+          (audit.action === "session-switched" ||
+            audit.action === "replay-authorized" ||
+            tag !== computeLegacyGrantAuditIntegrityTag(audit, context.keyRing, keyVersion)))
       ) {
         return "Stored Grant Audit Trail integrity is invalid.";
       }
@@ -101,10 +105,13 @@ export function validateGrantState(
     sessionMap.set(session.sessionId, session);
   }
 
+  const switchFailure = validateSessionSwitchChains(auditEntries, sessionMap, grantMap);
+  if (switchFailure !== null) return switchFailure;
+
   for (const audit of auditEntries) {
     const grant = grantMap.get(audit.grantId);
     if (grant === undefined) return "Stored Grant Audit Trail references an unknown Grant.";
-    const failure = validateAudit(audit, grant, sessionMap, context);
+    const failure = validateAudit(audit, grant, sessionMap, auditEntries, context);
     if (failure !== null) return failure;
   }
   for (const grant of grantMap.values()) {
@@ -414,7 +421,7 @@ function validateSession(
     !validateOpaqueIdentifier(session.sessionId, "sessionId").ok ||
     !validateOpaqueIdentifier(session.grantId, "session.grantId").ok ||
     !validateOpaqueIdentifier(session.grantVersion, "session.grantVersion").ok ||
-    session.eventGameId.length === 0 ||
+    !validateOpaqueIdentifier(session.eventGameId, "session.eventGameId").ok ||
     session.browserContextKeyVersion.length === 0 ||
     !isStoredGrantSessionStatus(session.status) ||
     !Number.isSafeInteger(session.createdAtMs) ||
@@ -457,6 +464,7 @@ function validateAudit(
   audit: StoredGrantAuditEntry,
   grant: StoredGrant,
   sessions: ReadonlyMap<string, StoredGrantSession>,
+  audits: readonly StoredGrantAuditEntry[],
   context: GrantStateValidationContext,
 ): string | null {
   const deepCredentialValidation =
@@ -474,6 +482,8 @@ function validateAudit(
     "session-replaced",
     "session-revoked",
     "session-terminated",
+    "session-switched",
+    "replay-authorized",
   ];
   const allowedTerminalReasons: readonly TerminalGrantSessionReason[] = [
     "game-locked",
@@ -500,8 +510,9 @@ function validateAudit(
     (audit.afterExpiresAtMs !== null &&
       (!Number.isSafeInteger(audit.afterExpiresAtMs) || audit.afterExpiresAtMs < 0)) ||
     (audit.terminalReason !== null && !allowedTerminalReasons.includes(audit.terminalReason))
-  )
+  ) {
     return "Stored Grant Audit Trail provenance is invalid.";
+  }
   if (audit.action === "session-terminated") {
     if (audit.terminalReason === null || audit.sessionId === null || audit.eventGameId === null)
       return "Stored terminal Grant Audit Trail evidence is incomplete.";
@@ -516,6 +527,73 @@ function validateAudit(
   } else if (audit.terminalReason !== null) {
     return "Stored non-terminal Grant Audit Trail evidence has a terminal reason.";
   }
+  if (audit.action === "session-admitted" || audit.action === "session-replaced") {
+    if (audit.sessionId === null || (grant.grantType === "control" && audit.eventGameId === null))
+      return "Stored admitted Grant Audit Trail evidence is incomplete.";
+    const session = sessions.get(audit.sessionId);
+    if (
+      session === undefined ||
+      session.grantId !== audit.grantId ||
+      session.grantVersion !== audit.grantVersion ||
+      (audit.eventGameId !== null &&
+        !validateOpaqueIdentifier(audit.eventGameId, "audit.eventGameId").ok)
+    )
+      return "Stored admitted Grant Audit Trail provenance is invalid.";
+  }
+  if (audit.action === "session-switched") {
+    if (
+      audit.sessionId === null ||
+      audit.eventGameId === null ||
+      audit.previousEventGameId === null
+    )
+      return "Stored switched Grant Audit Trail evidence is incomplete.";
+    const session = sessions.get(audit.sessionId);
+    if (
+      session === undefined ||
+      session.grantId !== audit.grantId ||
+      session.grantVersion !== audit.grantVersion
+    ) {
+      return "Stored switched Grant Audit Trail provenance is invalid.";
+    }
+  }
+  if (
+    audit.action !== "session-switched" &&
+    audit.action !== "replay-authorized" &&
+    audit.previousEventGameId !== null
+  )
+    return "Stored Grant Audit Trail previous Event Game provenance is invalid.";
+  if (audit.action === "replay-authorized") {
+    if (audit.sessionId === null || audit.replacedSessionId === null || audit.eventGameId === null)
+      return "Stored replay Grant Audit Trail evidence is incomplete.";
+    const replacement = sessions.get(audit.sessionId);
+    const originating = sessions.get(audit.replacedSessionId);
+    if (
+      replacement === undefined ||
+      originating === undefined ||
+      replacement.sessionId === originating.sessionId ||
+      originating.status === "active" ||
+      replacement.grantId !== audit.grantId ||
+      originating.grantId !== audit.grantId ||
+      replacement.grantVersion !== audit.grantVersion ||
+      replacement.eventGameId !== audit.eventGameId ||
+      originating.eventGameId !== audit.eventGameId ||
+      (audit.replayEvidenceId !== null &&
+        audit.replayEvidenceId !== undefined &&
+        !validateOpaqueIdentifier(audit.replayEvidenceId, "replayEvidenceId").ok)
+    )
+      return "Stored replay Grant Audit Trail provenance is invalid.";
+    if (
+      !audits.some(
+        (candidate) =>
+          (candidate.action === "session-admitted" || candidate.action === "session-replaced") &&
+          candidate.sessionId === originating.sessionId &&
+          candidate.grantId === originating.grantId &&
+          candidate.grantVersion === originating.grantVersion &&
+          candidate.eventGameId === audit.eventGameId,
+      )
+    )
+      return "Stored replay Grant Audit Trail originating evidence is invalid.";
+  }
   if (audit.credentialFingerprint !== null) {
     if (migrationReferenceFor(grant, context) !== null)
       return "Stored migration Grant Audit Trail credential evidence must be erased.";
@@ -525,6 +603,58 @@ function validateAudit(
       !isBase64UrlBytes(audit.credentialFingerprint, 32)
     )
       return "Stored Grant Audit Trail credential evidence is malformed.";
+  }
+  return null;
+}
+
+function validateSessionSwitchChains(
+  audits: readonly StoredGrantAuditEntry[],
+  sessions: ReadonlyMap<string, StoredGrantSession>,
+  grants: ReadonlyMap<string, StoredGrant>,
+): string | null {
+  const switchedBySession = new Map<string, StoredGrantAuditEntry[]>();
+  for (const audit of audits) {
+    if (audit.action !== "session-switched" || audit.sessionId === null) continue;
+    const history = switchedBySession.get(audit.sessionId) ?? [];
+    history.push(audit);
+    switchedBySession.set(audit.sessionId, history);
+  }
+  for (const session of sessions.values()) {
+    const grant = grants.get(session.grantId);
+    if (grant?.grantType !== "control") continue;
+    const admissions = audits.filter(
+      (audit) =>
+        (audit.action === "session-admitted" || audit.action === "session-replaced") &&
+        audit.sessionId === session.sessionId,
+    );
+    if (admissions.length !== 1)
+      return "Stored Grant Session lacks exactly one admission provenance record.";
+    const admission = admissions[0];
+    if (
+      admission === undefined ||
+      admission.eventGameId === null ||
+      admission.grantId !== session.grantId ||
+      admission.grantVersion !== session.grantVersion
+    )
+      return "Stored Grant Session admission provenance is invalid.";
+    let expectedPreviousEventGameId = admission.eventGameId;
+    const remaining = [...(switchedBySession.get(session.sessionId) ?? [])];
+    while (remaining.length > 0) {
+      const index = remaining.findIndex(
+        (audit) => audit.previousEventGameId === expectedPreviousEventGameId,
+      );
+      if (index < 0) return "Stored switched Grant Audit Trail relationship chain is invalid.";
+      const [audit] = remaining.splice(index, 1);
+      if (
+        audit === undefined ||
+        audit.eventGameId === null ||
+        audit.eventGameId === expectedPreviousEventGameId
+      )
+        return "Stored switched Grant Audit Trail relationship chain is invalid.";
+      expectedPreviousEventGameId = audit.eventGameId;
+    }
+    if (session.eventGameId !== expectedPreviousEventGameId)
+      return "Stored switched Grant Audit Trail relationship chain is incomplete.";
   }
   return null;
 }

--- a/src/lib/grant-storage-sqlite.ts
+++ b/src/lib/grant-storage-sqlite.ts
@@ -24,6 +24,7 @@ type GrantRow = Record<string, unknown>;
 
 export type GrantSqliteStatements = {
   byGrantId: SqlStatement;
+  allGrants: SqlStatement;
   byCredentialDigest: SqlStatement;
   activeSessionByContext: SqlStatement;
   sessionByBearer: SqlStatement;
@@ -79,6 +80,8 @@ const AUDIT_SELECT_COLUMNS = `
   audit.before_status AS before_status, audit.after_status AS after_status,
   audit.before_expires_at_ms AS before_expires_at_ms,
   audit.after_expires_at_ms AS after_expires_at_ms,
+  audit.previous_event_game_id AS previous_event_game_id,
+  audit.replay_evidence_id AS replay_evidence_id,
   audit.terminal_reason AS terminal_reason,
   audit.created_at_ms AS created_at_ms
 `;
@@ -87,6 +90,9 @@ export function createGrantSqliteStatements(database: Database): GrantSqliteStat
   return {
     byGrantId: database.query(
       `SELECT ${GRANT_SELECT_COLUMNS} FROM foundation_grant_roots AS grants WHERE grants.grant_id = ?`,
+    ),
+    allGrants: database.query(
+      `SELECT ${GRANT_SELECT_COLUMNS} FROM foundation_grant_roots AS grants ORDER BY grants.grant_id`,
     ),
     byCredentialDigest: database.query(
       `SELECT ${GRANT_SELECT_COLUMNS} FROM foundation_grant_roots AS grants WHERE grants.credential_lookup_digest = ?`,
@@ -148,8 +154,10 @@ export function createGrantSqliteStatements(database: Database): GrantSqliteStat
         audit_id, action, outcome, actor_reference, grant_id, grant_type, grant_version,
         event_id, game_day_id, pitch_id, pitch_slot_id, session_id, replaced_session_id,
         event_game_id, credential_kind, credential_fingerprint, before_status, after_status,
-        before_expires_at_ms, after_expires_at_ms, terminal_reason, audit_integrity_tag, created_at_ms
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        before_expires_at_ms, after_expires_at_ms, previous_event_game_id, replay_evidence_id,
+        terminal_reason,
+        audit_integrity_tag, created_at_ms
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `),
   };
 }
@@ -160,6 +168,10 @@ export function readGrantByStatement(
 ): StoredGrant | null {
   const row = statement.get(...parameters) as GrantRow | null;
   return row === null ? null : readStoredControlGrant(row);
+}
+
+export function listGrants(statement: SqlStatement): StoredGrant[] {
+  return statement.all().map((row) => readStoredControlGrant(asRecord(row)));
 }
 
 export function readSessionByStatement(
@@ -337,6 +349,8 @@ export function appendGrantAudit(
     entry.afterStatus,
     entry.beforeExpiresAtMs,
     entry.afterExpiresAtMs,
+    entry.previousEventGameId ?? null,
+    entry.replayEvidenceId ?? null,
     entry.terminalReason,
     integrityTag,
     entry.createdAtMs,
@@ -570,6 +584,8 @@ export function readStoredGrantAuditEntry(row: GrantRow): StoredGrantAuditEntry 
     "grant-metadata-updated",
     "session-revoked",
     "session-terminated",
+    "session-switched",
+    "replay-authorized",
   ];
   if (!allowedActions.includes(action)) {
     throw new Error("Stored Grant Audit Trail action is invalid.");
@@ -628,6 +644,8 @@ export function readStoredGrantAuditEntry(row: GrantRow): StoredGrantAuditEntry 
     afterStatus: afterStatus as StoredGrantAuditEntry["afterStatus"],
     beforeExpiresAtMs,
     afterExpiresAtMs,
+    previousEventGameId: readNullableText(row.previous_event_game_id),
+    replayEvidenceId: readNullableText(row.replay_evidence_id),
     terminalReason: terminalReason as StoredGrantAuditEntry["terminalReason"],
     createdAtMs: readInteger(row.created_at_ms),
   };

--- a/src/lib/grant-types.ts
+++ b/src/lib/grant-types.ts
@@ -72,8 +72,40 @@ export type ControlGrantScopeResolution =
     }
   | { status: "empty" | "conflict" | "mismatch" | "unavailable"; detail?: string };
 
+export type ControlGrantSessionResolution =
+  | { status: "current"; eventGameId: string }
+  | {
+      status: "switchable";
+      previousEventGameId: string;
+      currentEventGameId: string;
+    }
+  | {
+      status: "pinned";
+      sessionEventGameId: string;
+      currentEventGameId: string;
+    }
+  | { status: "game-locked"; eventGameId: string }
+  | { status: "empty" | "conflict" | "mismatch" | "unavailable"; detail?: string };
+
+export type ControlGrantReplayResolution =
+  | { status: "eligible"; eventGameId: string }
+  | { status: "finished" | "game-locked" | "mismatch" | "unavailable"; detail?: string };
+
+export type ControlGrantSessionDecision = "stay";
+
 export type ControlGrantScopeResolver = {
   resolve(scope: ControlGrantScope): ControlGrantScopeResolution;
+  /** Optional lifecycle-aware seam used after a session has already been admitted. */
+  resolveSession?: (
+    scope: ControlGrantScope,
+    sessionEventGameId: string,
+  ) => ControlGrantSessionResolution;
+  /** Optional lifecycle-aware seam used by explicit offline replay authorization. */
+  resolveReplay?: (
+    scope: ControlGrantScope,
+    eventGameId: string,
+    replayEvidenceId: string,
+  ) => ControlGrantReplayResolution;
 };
 
 export type StoredGrantStatus = "active" | "disabled" | "revoked" | "expired";
@@ -141,7 +173,9 @@ export type GrantAuditAction =
   | "session-revoked"
   | "session-terminated"
   | "session-admitted"
-  | "session-replaced";
+  | "session-replaced"
+  | "session-switched"
+  | "replay-authorized";
 
 export type StoredGrantAuditEntry = {
   auditId: string;
@@ -155,6 +189,8 @@ export type StoredGrantAuditEntry = {
   sessionId: string | null;
   replacedSessionId: string | null;
   eventGameId: string | null;
+  previousEventGameId?: string | null;
+  replayEvidenceId?: string | null;
   credentialKind: GrantCredentialKind | null;
   credentialFingerprint: string | null;
   beforeStatus: StoredGrantStatus | null;


### PR DESCRIPTION
## Summary

- Bind Control Grant Sessions to the eligible Event Game resolved from their Pitch Slot.
- Preserve explicit stay/switch behavior across reassignment and commencement, with pinned sessions, trusted atomic Game Lock termination, and no authority revival after reopening.
- Add content-bound, same-Game replay authorization with distinct replacement/origin sessions, ordered switch provenance, audit integrity, and fail-closed restart validation.

## Why

A Pitch Slot can be reassigned while controllers hold queued work. Session authority therefore cannot be inferred from only the Grant’s current scope: it must preserve the accepted Event Game relationship, distinguish pre- and post-commencement behavior, and prevent cross-Game replay or lock revival.

## Impact

Existing sessions remain pinned where the lifecycle permits, new scans target the current assignment, and accepted switches invalidate the old queue without deleting client-held evidence. Revocation, rotation, expiry, and Game Lock invalidate authority while a fresh eligible session can authorize original-identity replay only for the same unfinished Game.

## Validation

- `bun install --frozen-lockfile`
- `bun audit` — no vulnerabilities
- `bun run check`
- `bun run test` — 281 passed
- `bun run test:focused:grant` — 36 passed
- `bun run test:focused:sqlite` — 21 passed
- `bun run build`
- `bun run build:executable`

No Qualification Test or `bun run check:sqlite-runtime` workload was run.

## Stack

Eighth layer of stack #103. Depends on #126. Further accepted specification tickets will be appended above this PR.

Closes #77.
