### PR TITLE
Enroll and sign in as Technical Admin

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -24,6 +24,7 @@
         "oxfmt": "^0.63.0",
         "oxlint": "^1.78.0",
         "oxlint-tsgolint": "^7.0.2001",
+        "playwright": "1.62.1",
         "tailwindcss": "^4.2.4",
         "tw-animate-css": "^1.4.0",
       },
@@ -244,6 +245,8 @@
 
     "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
+    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+
     "get-nonce": ["get-nonce@1.0.1", "", {}, "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q=="],
 
     "happy-dom": ["happy-dom@20.11.2", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "buffer-image-size": "^0.6.4", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.21.0" } }, "sha512-7MB+bJLkxu3SowAfBJbjW+c55kNz5tkR45gu2qzrxznezhLeN5YIlJbwUgSzlGc+qWoZ8Ykg71H5ezz69xixrw=="],
@@ -255,6 +258,10 @@
     "oxlint": ["oxlint@1.78.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.78.0", "@oxlint/binding-android-arm64": "1.78.0", "@oxlint/binding-darwin-arm64": "1.78.0", "@oxlint/binding-darwin-x64": "1.78.0", "@oxlint/binding-freebsd-x64": "1.78.0", "@oxlint/binding-linux-arm-gnueabihf": "1.78.0", "@oxlint/binding-linux-arm-musleabihf": "1.78.0", "@oxlint/binding-linux-arm64-gnu": "1.78.0", "@oxlint/binding-linux-arm64-musl": "1.78.0", "@oxlint/binding-linux-ppc64-gnu": "1.78.0", "@oxlint/binding-linux-riscv64-gnu": "1.78.0", "@oxlint/binding-linux-riscv64-musl": "1.78.0", "@oxlint/binding-linux-s390x-gnu": "1.78.0", "@oxlint/binding-linux-x64-gnu": "1.78.0", "@oxlint/binding-linux-x64-musl": "1.78.0", "@oxlint/binding-openharmony-arm64": "1.78.0", "@oxlint/binding-win32-arm64-msvc": "1.78.0", "@oxlint/binding-win32-ia32-msvc": "1.78.0", "@oxlint/binding-win32-x64-msvc": "1.78.0" }, "peerDependencies": { "oxlint-tsgolint": ">=7.0.2001", "vite-plus": "*" }, "optionalPeers": ["oxlint-tsgolint", "vite-plus"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-QgQePuxIqKOzo1KSjG2EnITEeWvWnKAm77eq8nrMtf6AGoA+zyGc4PFYtDNJSD25g/ibOwfQ851hZ4/SPkMVoA=="],
 
     "oxlint-tsgolint": ["oxlint-tsgolint@7.0.2001", "", { "optionalDependencies": { "@oxlint-tsgolint/darwin-arm64": "7.0.2001", "@oxlint-tsgolint/darwin-x64": "7.0.2001", "@oxlint-tsgolint/linux-arm64": "7.0.2001", "@oxlint-tsgolint/linux-x64": "7.0.2001", "@oxlint-tsgolint/win32-arm64": "7.0.2001", "@oxlint-tsgolint/win32-x64": "7.0.2001" }, "bin": { "tsgolint": "./bin/tsgolint.js" } }, "sha512-KjK/XLcXr1DSyonKhsuFqJRiuKqcyG9j3LJ8nkOsrLzGvodBPqzHOKauy10asLMDI0sUpvb+1sxlzff3udZvfg=="],
+
+    "playwright": ["playwright@1.62.1", "", { "dependencies": { "playwright-core": "1.62.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg=="],
+
+    "playwright-core": ["playwright-core@1.62.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw=="],
 
     "react": ["react@19.2.6", "", {}, "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q=="],
 

--- a/package.json
+++ b/package.json
@@ -3,10 +3,11 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
-  "packageManager": "bun@1.3.14",
   "scripts": {
     "dev": "bun --hot src/index.ts",
     "start": "cd dist && NODE_ENV=production bun index.js",
+    "admin:enroll": "bun scripts/enroll-technical-admin.ts",
+    "test:focused:technical-admin-browser": "bun scripts/test-technical-admin-browser.ts",
     "build": "bun run build.ts",
     "build:executable": "bun run build.ts --compile --compile-target=bun-linux-x64-modern --outfile=dist/quadball-timer",
     "check:sqlite-runtime": "bun scripts/check-sqlite-runtime.ts",
@@ -43,7 +44,9 @@
     "oxfmt": "^0.63.0",
     "oxlint": "^1.78.0",
     "oxlint-tsgolint": "^7.0.2001",
+    "playwright": "1.62.1",
     "tailwindcss": "^4.2.4",
     "tw-animate-css": "^1.4.0"
-  }
+  },
+  "packageManager": "bun@1.3.14"
 }

--- a/scripts/enroll-technical-admin.ts
+++ b/scripts/enroll-technical-admin.ts
@@ -1,0 +1,33 @@
+#!/usr/bin/env bun
+import {
+  createSqliteTechnicalAdminAuthRepository,
+  createTechnicalAdminAuth,
+} from "@/lib/technical-admin-auth";
+import { readTechnicalAdminConfig } from "@/lib/technical-admin-config";
+
+const config = readTechnicalAdminConfig();
+const { environment } = config;
+const databasePath = config.databasePath ?? `data/${environment}/technical-admin.sqlite`;
+
+const auth = createTechnicalAdminAuth(
+  config,
+  createSqliteTechnicalAdminAuthRepository(databasePath, {
+    environment,
+    origin: config.origin,
+    rpId: config.rpId,
+  }),
+);
+const result = auth.issueEnrollmentAuthorization();
+if (!result.ok) {
+  console.error(
+    result.error === "not-enrollable"
+      ? "Technical Admin enrollment is already complete."
+      : "Unable to create enrollment authorization.",
+  );
+  process.exitCode = 1;
+} else {
+  console.log(result.value.url);
+  console.error(
+    `Enrollment authorization expires at ${new Date(result.value.expiresAtMs).toISOString()}.`,
+  );
+}

--- a/scripts/test-technical-admin-browser.ts
+++ b/scripts/test-technical-admin-browser.ts
@@ -1,0 +1,185 @@
+#!/usr/bin/env bun
+import { chromium, type Page } from "playwright";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+const directory = mkdtempSync(join(tmpdir(), "quadball-timer-admin-browser-"));
+const certificatePath = join(directory, "localhost.crt");
+const keyPath = join(directory, "localhost.key");
+const databasePath = join(directory, "technical-admin.sqlite");
+const port = 38_000 + Math.floor(Math.random() * 1_000);
+const origin = `https://localhost:${port}`;
+const environment = {
+  ...process.env,
+  NODE_ENV: "test",
+  QUADBALL_ENVIRONMENT: "test",
+  PUBLIC_ORIGIN: origin,
+  WEBAUTHN_RP_ID: "localhost",
+  TECHNICAL_ADMIN_DATABASE: databasePath,
+  TLS_CERT_FILE: certificatePath,
+  TLS_KEY_FILE: keyPath,
+  PORT: String(port),
+};
+
+let server: Bun.Subprocess | null = null;
+let serverStderr: Promise<string> | null = null;
+let browser: Awaited<ReturnType<typeof chromium.launch>> | null = null;
+let browserPage: Page | null = null;
+
+try {
+  const certificate = Bun.spawnSync([
+    "openssl",
+    "req",
+    "-x509",
+    "-newkey",
+    "rsa:2048",
+    "-nodes",
+    "-subj",
+    "/CN=localhost",
+    "-addext",
+    "subjectAltName=DNS:localhost",
+    "-days",
+    "1",
+    "-keyout",
+    keyPath,
+    "-out",
+    certificatePath,
+  ]);
+  if (certificate.exitCode !== 0)
+    throw new Error("openssl could not create a temporary certificate.");
+
+  server = Bun.spawn(["bun", "run", "src/index.ts"], {
+    cwd: process.cwd(),
+    env: environment,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  serverStderr = new Response(server.stderr as unknown as BodyInit).text();
+  await waitForServer(`${origin}/internal/healthz`);
+
+  const enrollmentProcess = Bun.spawn(["bun", "scripts/enroll-technical-admin.ts"], {
+    cwd: process.cwd(),
+    env: environment,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  if (typeof enrollmentProcess.stdout === "number" || enrollmentProcess.stdout === undefined) {
+    throw new Error("Enrollment command did not expose stdout.");
+  }
+  const enrollmentOutput = await new Response(
+    enrollmentProcess.stdout as unknown as BodyInit,
+  ).text();
+  const enrollmentExitCode = await enrollmentProcess.exited;
+  if (enrollmentExitCode !== 0) throw new Error("Host-local enrollment command failed.");
+  const enrollmentUrl = enrollmentOutput
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .find((line) => line.startsWith(`${origin}/admin/enroll#token=`));
+  if (!enrollmentUrl) throw new Error("Enrollment command did not return an HTTPS fragment URL.");
+  const enrollmentToken = new URL(enrollmentUrl).hash.slice("#token=".length);
+
+  browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({ ignoreHTTPSErrors: true });
+  const page = await context.newPage();
+  browserPage = page;
+  const cdp = await context.newCDPSession(page);
+  await cdp.send("WebAuthn.enable");
+  await cdp.send("WebAuthn.addVirtualAuthenticator", {
+    options: {
+      protocol: "ctap2",
+      transport: "internal",
+      hasResidentKey: true,
+      hasUserVerification: true,
+      isUserVerified: true,
+      automaticPresenceSimulation: true,
+    },
+  });
+
+  await page.goto(enrollmentUrl);
+  await page.getByRole("button", { name: "Register passkey" }).waitFor();
+  assert(
+    page.url() === `${origin}/admin/enroll`,
+    "enrollment fragment was scrubbed before registration",
+  );
+  await page.getByRole("button", { name: "Register passkey" }).click();
+  await page.waitForURL(`${origin}/admin`);
+  await page.getByRole("button", { name: "Sign in with passkey" }).waitFor();
+  assert(
+    (await page.evaluate(() => window.location.hash)) === "",
+    "enrollment fragment was scrubbed",
+  );
+
+  const replayStatus = await page.evaluate(async (token) => {
+    const response = await fetch("/api/admin/enrollment/options", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ token }),
+    });
+    return response.status;
+  }, enrollmentToken);
+  assert(replayStatus === 401 || replayStatus === 409, "enrollment replay was rejected");
+
+  await page.getByRole("button", { name: "Sign in with passkey" }).click();
+  await page.getByText("Technical Admin administration").waitFor();
+  console.log(
+    JSON.stringify({
+      status: "passed",
+      enrollment: true,
+      authentication: true,
+      replayRejected: true,
+    }),
+  );
+} catch (error) {
+  console.error(
+    redactDiagnosticText(
+      error instanceof Error ? error.message : "Technical Admin browser test failed.",
+    ),
+  );
+  if (browserPage) {
+    console.error(`browser_url=${redactBrowserUrl(browserPage.url())}`);
+    console.error(
+      `browser_text=${redactDiagnosticText(
+        (await browserPage.locator("body").innerText()).slice(0, 1_000),
+      )}`,
+    );
+  }
+  process.exitCode = 1;
+} finally {
+  if (browser) await browser.close();
+  if (server) {
+    server.kill();
+    await server.exited;
+    const diagnostics = serverStderr ? await serverStderr : "";
+    if (diagnostics.trim().length > 0) console.error(redactDiagnosticText(diagnostics.trim()));
+  }
+  rmSync(directory, { recursive: true, force: true });
+}
+
+async function waitForServer(url: string) {
+  const deadline = Date.now() + 15_000;
+  while (Date.now() < deadline) {
+    const response = Bun.spawnSync(["curl", "-k", "-sSf", "-H", `host: localhost:${port}`, url]);
+    if (response.exitCode === 0) return;
+    await Bun.sleep(100);
+  }
+  throw new Error("Technical Admin browser server did not become ready.");
+}
+
+function assert(condition: boolean, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+function redactBrowserUrl(value: string) {
+  try {
+    const url = new URL(value);
+    url.hash = "";
+    return url.toString();
+  } catch {
+    return value.replace(/#.*$/u, "");
+  }
+}
+
+function redactDiagnosticText(value: string) {
+  return value.replace(/(https?:\/\/[^\s"'<>#]+)#\S+/giu, "$1");
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { DEFAULT_AWAY_TEAM_COLOR, DEFAULT_HOME_TEAM_COLOR } from "@/lib/team-col
 import { ColorTestPage } from "@/pages/color-test-page";
 import { EventOperationsPrototypePage } from "@/pages/event-operations-prototype-page";
 import { GamePage } from "@/pages/game-page";
+import { TechnicalAdminPage } from "@/pages/technical-admin-page";
 import "./index.css";
 
 type Route =
@@ -19,6 +20,10 @@ type Route =
     }
   | {
       type: "event-operations-prototype";
+    }
+  | {
+      type: "technical-admin";
+      enrollment: boolean;
     }
   | {
       type: "game";
@@ -41,6 +46,10 @@ export function App() {
 
   if (route.type === "event-operations-prototype") {
     return <EventOperationsPrototypePage />;
+  }
+
+  if (route.type === "technical-admin") {
+    return <TechnicalAdminPage enrollment={route.enrollment} />;
   }
 
   return <GamePage gameId={route.gameId} role={route.role} />;
@@ -313,6 +322,14 @@ function useRoute(): Route {
 }
 
 function parseRoute(pathname: string, search: string): Route {
+  if (pathname === "/admin" || pathname === "/admin/") {
+    return { type: "technical-admin", enrollment: false };
+  }
+
+  if (pathname === "/admin/enroll" || pathname === "/admin/enroll/") {
+    return { type: "technical-admin", enrollment: true };
+  }
+
   if (pathname === "/color-test") {
     return { type: "color-test" };
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,14 @@ import {
 } from "@/lib/sqlite-foundation-probe";
 import { isAllowedWebSocketOrigin } from "@/lib/ws-origin";
 import { parseClientWsMessage, type ServerWsMessage } from "@/lib/ws-protocol";
+import {
+  clearTechnicalAdminCookie,
+  createSqliteTechnicalAdminAuthRepository,
+  createTechnicalAdminAuth,
+  technicalAdminCookie,
+  type CeremonyBinding,
+} from "@/lib/technical-admin-auth";
+import { readTechnicalAdminConfig } from "@/lib/technical-admin-config";
 
 type ManagedGame = {
   state: GameState;
@@ -66,9 +74,28 @@ async function main() {
 }
 
 function startServer() {
+  const port = Number(process.env.PORT ?? 3000);
+  const technicalAdminConfig = readTechnicalAdminConfig();
+  const { environment } = technicalAdminConfig;
+  const databasePath =
+    technicalAdminConfig.databasePath ?? `data/${environment}/technical-admin.sqlite`;
+  const technicalAdminAuth = createTechnicalAdminAuth(
+    technicalAdminConfig,
+    createSqliteTechnicalAdminAuthRepository(databasePath, {
+      environment: technicalAdminConfig.environment,
+      origin: technicalAdminConfig.origin,
+      rpId: technicalAdminConfig.rpId,
+    }),
+  );
+  const tls =
+    process.env.TLS_CERT_FILE && process.env.TLS_KEY_FILE
+      ? { cert: Bun.file(process.env.TLS_CERT_FILE), key: Bun.file(process.env.TLS_KEY_FILE) }
+      : undefined;
+
   const server = serve<SessionData>({
     hostname: process.env.HOST ?? "127.0.0.1",
-    port: Number(process.env.PORT ?? 3000),
+    port,
+    ...(tls ? { tls } : {}),
     routes: {
       "/ws": (req: Bun.BunRequest<"/ws">, routeServer: Bun.Server<SessionData>) => {
         if (!isAllowedWebSocketOrigin(req.headers.get("origin"), req.headers.get("host"))) {
@@ -126,6 +153,79 @@ function startServer() {
           }
 
           return json({ game: projectGameView(game.state, Date.now()) });
+        },
+      },
+      "/api/admin/enrollment/options": {
+        async POST(req: Request) {
+          const body = await readJsonRecord(req);
+          const token = body?.token;
+          if (typeof token !== "string") return genericAuthFailure(400);
+          const result = technicalAdminAuth.beginEnrollment(token, requestBinding(req));
+          return result.ok
+            ? json(result.value)
+            : genericAuthFailure(result.error === "not-enrollable" ? 409 : 401);
+        },
+      },
+      "/api/admin/enrollment/complete": {
+        async POST(req: Request) {
+          const body = await readJsonRecord(req);
+          if (!body || typeof body.challengeId !== "string" || body.response === undefined) {
+            return genericAuthFailure(400);
+          }
+          const result = await technicalAdminAuth.completeEnrollment(
+            body.challengeId,
+            body.response,
+            requestBinding(req),
+          );
+          return result.ok ? json({ enrolled: true }) : genericAuthFailure(401);
+        },
+      },
+      "/api/admin/authentication/options": {
+        POST(req: Request) {
+          const result = technicalAdminAuth.beginAuthentication(requestBinding(req));
+          return result.ok ? json(result.value) : genericAuthFailure(401);
+        },
+      },
+      "/api/admin/authentication/complete": {
+        async POST(req: Request) {
+          const body = await readJsonRecord(req);
+          if (!body || typeof body.challengeId !== "string" || body.response === undefined) {
+            return genericAuthFailure(400);
+          }
+          const result = await technicalAdminAuth.completeAuthentication(
+            body.challengeId,
+            body.response,
+            requestBinding(req),
+          );
+          if (!result.ok) return genericAuthFailure(401);
+          return new Response(JSON.stringify({ authenticated: true }), {
+            headers: {
+              "content-type": "application/json",
+              "set-cookie": technicalAdminCookie(result.value.token),
+            },
+          });
+        },
+      },
+      "/api/admin/session": {
+        GET(req: Request) {
+          const token = readTechnicalAdminCookie(req.headers.get("cookie"));
+          if (token === null || !technicalAdminAuth.authenticateSession(token))
+            return genericAuthFailure(401);
+          return json({ authenticated: true, environment });
+        },
+      },
+      "/api/admin/logout": {
+        POST(req: Request) {
+          if (!technicalAdminAuth.isExpectedBinding(requestBinding(req)))
+            return genericAuthFailure(403);
+          const token = readTechnicalAdminCookie(req.headers.get("cookie"));
+          if (token !== null) technicalAdminAuth.logout(token);
+          return new Response(JSON.stringify({ loggedOut: true }), {
+            headers: {
+              "content-type": "application/json",
+              "set-cookie": clearTechnicalAdminCookie(),
+            },
+          });
         },
       },
       "/internal/healthz": {
@@ -496,6 +596,35 @@ function json(payload: unknown, status = 200) {
       "content-type": "application/json",
     },
   });
+}
+
+async function readJsonRecord(req: Request): Promise<Record<string, unknown> | null> {
+  try {
+    const value: unknown = await req.json();
+    return isRecord(value) ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+function requestBinding(req: Request): CeremonyBinding {
+  return {
+    origin: req.headers.get("origin") ?? "",
+    host: req.headers.get("host") ?? "",
+  };
+}
+
+function genericAuthFailure(status: number) {
+  return json({ error: "Authentication failed." }, status);
+}
+
+function readTechnicalAdminCookie(header: string | null): string | null {
+  if (header === null) return null;
+  for (const part of header.split(";")) {
+    const [name, ...value] = part.trim().split("=");
+    if (name === "__Host-technical-admin" && value.length > 0) return value.join("=");
+  }
+  return null;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/lib/technical-admin-auth.test.ts
+++ b/src/lib/technical-admin-auth.test.ts
@@ -1,0 +1,361 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  MemoryTechnicalAdminAuthRepository,
+  NativeWebAuthnVerifier,
+  SqliteTechnicalAdminAuthRepository,
+  createTechnicalAdminAuth,
+  type TechnicalAdminAuthRepository,
+  technicalAdminCookie,
+  technicalAdminSessionTtls,
+  type WebAuthnVerifier,
+} from "@/lib/technical-admin-auth";
+
+const binding = { origin: "https://timer.example", host: "timer.example" };
+
+function createFixture() {
+  let nowMs = 1_000;
+  const repository = new MemoryTechnicalAdminAuthRepository();
+  const verifier: WebAuthnVerifier = {
+    async verifyRegistration() {
+      return {
+        credentialId: "credential-1",
+        publicKey: { kty: "OKP", crv: "Ed25519", x: "public-key" },
+        signCount: 1,
+      };
+    },
+    async verifyAuthentication() {
+      return { signCount: 2 };
+    },
+  };
+  const auth = createTechnicalAdminAuth(
+    { environment: "production", origin: binding.origin, rpId: "timer.example" },
+    repository,
+    verifier,
+    () => nowMs,
+  );
+  return { auth, repository, verifier, advance: (amount: number) => (nowMs += amount) };
+}
+
+describe("Technical Admin authentication", () => {
+  test("issues a bounded enrollment URL and consumes its authorization once", async () => {
+    const fixture = createFixture();
+    const issued = fixture.auth.issueEnrollmentAuthorization();
+    expect(issued.ok).toBe(true);
+    if (!issued.ok) return;
+    expect(issued.value.url).toMatch(/^https:\/\/timer\.example\/admin\/enroll#token=[^&]+$/u);
+    const token = decodeURIComponent(issued.value.url.split("token=")[1] ?? "");
+
+    expect(
+      fixture.auth.beginEnrollment(token, { ...binding, origin: "https://other.example" }).ok,
+    ).toBe(false);
+    const options = fixture.auth.beginEnrollment(token, binding);
+    expect(options).toMatchObject({
+      ok: true,
+      value: {
+        rp: { id: "timer.example" },
+        authenticatorSelection: { residentKey: "required", userVerification: "required" },
+      },
+    });
+    expect(fixture.auth.beginEnrollment(token, binding)).toEqual({
+      ok: false,
+      error: "invalid-enrollment",
+    });
+
+    if (!options.ok) return;
+    expect(await fixture.auth.completeEnrollment(options.value.challengeId, {}, binding)).toEqual({
+      ok: true,
+      value: undefined,
+    });
+    expect(fixture.repository.getCredential()?.credentialId).toBe("credential-1");
+    expect(fixture.auth.issueEnrollmentAuthorization()).toEqual({
+      ok: false,
+      error: "not-enrollable",
+    });
+  });
+
+  test("requires the exact host and origin for authentication ceremonies", async () => {
+    const fixture = createFixture();
+    const issued = fixture.auth.issueEnrollmentAuthorization();
+    if (!issued.ok) throw new Error("Expected enrollment authorization.");
+    const token = decodeURIComponent(issued.value.url.split("token=")[1] ?? "");
+    const enrollment = fixture.auth.beginEnrollment(token, binding);
+    if (!enrollment.ok) throw new Error("Expected enrollment options.");
+    expect(fixture.auth.beginAuthentication(binding)).toEqual({
+      ok: false,
+      error: "invalid-credentials",
+    });
+    const wrongBindingResult = await fixture.auth.completeEnrollment(
+      enrollment.value.challengeId,
+      {},
+      { ...binding, host: "evil.example" },
+    );
+    expect(wrongBindingResult).toEqual({ ok: false, error: "invalid-ceremony" });
+  });
+
+  test("creates a rotated nonpersistent session and enforces idle and absolute expiry", async () => {
+    const fixture = createFixture();
+    const issued = fixture.auth.issueEnrollmentAuthorization();
+    if (!issued.ok) throw new Error("Expected enrollment authorization.");
+    const token = decodeURIComponent(issued.value.url.split("token=")[1] ?? "");
+    const enrollment = fixture.auth.beginEnrollment(token, binding);
+    if (!enrollment.ok) throw new Error("Expected enrollment options.");
+    await fixture.auth.completeEnrollment(enrollment.value.challengeId, {}, binding);
+
+    const authentication = fixture.auth.beginAuthentication(binding);
+    if (!authentication.ok) throw new Error("Expected authentication options.");
+    const session = await fixture.auth.completeAuthentication(
+      authentication.value.challengeId,
+      {},
+      binding,
+    );
+    expect(session.ok).toBe(true);
+    if (!session.ok) return;
+    expect(technicalAdminCookie(session.value.token)).toContain("__Host-technical-admin=");
+    expect(technicalAdminCookie(session.value.token)).toContain(
+      "Secure; HttpOnly; SameSite=Strict",
+    );
+    expect(fixture.auth.authenticateSession(session.value.token)).toBe(true);
+
+    fixture.advance(technicalAdminSessionTtls().idleMs);
+    expect(fixture.auth.authenticateSession(session.value.token)).toBe(false);
+  });
+
+  test("rejects authentication replay and enforces the absolute deadline despite activity", async () => {
+    const fixture = createFixture();
+    await enroll(fixture);
+    const options = fixture.auth.beginAuthentication(binding);
+    if (!options.ok) throw new Error("Expected authentication options.");
+    const first = await fixture.auth.completeAuthentication(options.value.challengeId, {}, binding);
+    expect(first.ok).toBe(true);
+    expect(
+      await fixture.auth.completeAuthentication(options.value.challengeId, {}, binding),
+    ).toEqual({
+      ok: false,
+      error: "invalid-ceremony",
+    });
+    if (!first.ok) return;
+    const hour = 60 * 60 * 1_000;
+    for (let elapsed = 0; elapsed < 11 * hour; elapsed += hour) {
+      fixture.advance(hour);
+      expect(fixture.auth.authenticateSession(first.value.token)).toBe(true);
+    }
+    fixture.advance(hour - 1_000);
+    expect(fixture.auth.authenticateSession(first.value.token)).toBe(true);
+    fixture.advance(1_000);
+    expect(fixture.auth.authenticateSession(first.value.token)).toBe(false);
+  });
+
+  test("rejects an HTTP origin and an RP ID that is not the exact origin host", () => {
+    expect(() =>
+      createTechnicalAdminAuth(
+        { environment: "test", origin: "http://localhost:3000", rpId: "localhost" },
+        new MemoryTechnicalAdminAuthRepository(),
+      ),
+    ).toThrow();
+    expect(() =>
+      createTechnicalAdminAuth(
+        { environment: "test", origin: binding.origin, rpId: "example" },
+        new MemoryTechnicalAdminAuthRepository(),
+      ),
+    ).toThrow();
+  });
+
+  test("binds SQLite state to one environment, origin, and RP identity", () => {
+    const directory = mkdtempSync(join(tmpdir(), "technical-admin-auth-"));
+    const databasePath = join(directory, "auth.sqlite");
+    const first = new SqliteTechnicalAdminAuthRepository(databasePath, {
+      environment: "test",
+      origin: "https://localhost:3000",
+      rpId: "localhost",
+    });
+    first.database.close();
+    expect(
+      () =>
+        new SqliteTechnicalAdminAuthRepository(databasePath, {
+          environment: "production",
+          origin: "https://timer.example",
+          rpId: "timer.example",
+        }),
+    ).toThrow();
+    rmSync(directory, { recursive: true, force: true });
+  });
+
+  test("native verification rejects missing UV and a wrong RP hash", async () => {
+    const verifier = new NativeWebAuthnVerifier();
+    const challenge = "Y2hhbGxlbmdl";
+    const clientDataJSON = encodeBase64Url(
+      JSON.stringify({ type: "webauthn.get", challenge, origin: binding.origin }),
+    );
+    const validRpHash = new Uint8Array(
+      new Bun.CryptoHasher("sha256").update("timer.example").digest(),
+    );
+    const missingUvAuthData = new Uint8Array(37);
+    missingUvAuthData.set(validRpHash);
+    missingUvAuthData[32] = 0x01;
+    let missingUvError: unknown;
+    try {
+      await verifier.verifyAuthentication(
+        {
+          id: "credential-1",
+          response: {
+            clientDataJSON,
+            authenticatorData: encodeBase64Url(missingUvAuthData),
+            signature: encodeBase64Url(new Uint8Array()),
+          },
+        },
+        {
+          challenge,
+          origin: binding.origin,
+          rpId: "timer.example",
+          credential: {
+            credentialId: "credential-1",
+            publicKey: { kty: "OKP", crv: "Ed25519", x: "AA" },
+            signCount: 0,
+            createdAtMs: 0,
+          },
+          requireUserVerification: true,
+        },
+      );
+    } catch (error) {
+      missingUvError = error;
+    }
+    expect(String(missingUvError)).toContain("User verification required");
+    const wrongRpAuthData = new Uint8Array(missingUvAuthData);
+    wrongRpAuthData[0] = (wrongRpAuthData[0] ?? 0) ^ 0xff;
+    let wrongRpError: unknown;
+    try {
+      await verifier.verifyAuthentication(
+        {
+          id: "credential-1",
+          response: {
+            clientDataJSON,
+            authenticatorData: encodeBase64Url(wrongRpAuthData),
+            signature: encodeBase64Url(new Uint8Array()),
+          },
+        },
+        {
+          challenge,
+          origin: binding.origin,
+          rpId: "timer.example",
+          credential: {
+            credentialId: "credential-1",
+            publicKey: { kty: "OKP", crv: "Ed25519", x: "AA" },
+            signCount: 0,
+            createdAtMs: 0,
+          },
+          requireUserVerification: true,
+        },
+      );
+    } catch (error) {
+      wrongRpError = error;
+    }
+    expect(String(wrongRpError)).toContain("Invalid RP ID");
+  });
+
+  test("contains storage and commit failures without acknowledging state", async () => {
+    const issueFailure = createTechnicalAdminAuth(
+      { environment: "test", origin: binding.origin, rpId: "timer.example" },
+      throwingRepository("hasCredential"),
+    );
+    expect(issueFailure.issueEnrollmentAuthorization()).toEqual({
+      ok: false,
+      error: "storage-failure",
+    });
+
+    const fixture = createFixture();
+    await enroll(fixture);
+    const enrolledOptions = fixture.auth.beginAuthentication(binding);
+    if (!enrolledOptions.ok) throw new Error("Expected authentication options.");
+    const enrolledSession = await fixture.auth.completeAuthentication(
+      enrolledOptions.value.challengeId,
+      {},
+      binding,
+    );
+    if (!enrolledSession.ok) throw new Error("Expected session.");
+    const credentialReadFailure = createTechnicalAdminAuth(
+      { environment: "test", origin: binding.origin, rpId: "timer.example" },
+      throwingRepository("getCredential", fixture.repository),
+      fixture.verifier,
+    );
+    expect(credentialReadFailure.beginAuthentication(binding)).toEqual({
+      ok: false,
+      error: "storage-failure",
+    });
+    const commitFailure = createTechnicalAdminAuth(
+      { environment: "test", origin: binding.origin, rpId: "timer.example" },
+      throwingRepository("commitAuthentication", fixture.repository),
+      fixture.verifier,
+    );
+    const authentication = commitFailure.beginAuthentication(binding);
+    if (!authentication.ok) throw new Error("Expected authentication options.");
+    expect(
+      await commitFailure.completeAuthentication(authentication.value.challengeId, {}, binding),
+    ).toEqual({ ok: false, error: "invalid-ceremony" });
+    const readFailure = createTechnicalAdminAuth(
+      { environment: "test", origin: binding.origin, rpId: "timer.example" },
+      throwingRepository("getSession", fixture.repository),
+      fixture.verifier,
+    );
+    expect(readFailure.authenticateSession("missing")).toBe(false);
+    const touchFailure = createTechnicalAdminAuth(
+      { environment: "test", origin: binding.origin, rpId: "timer.example" },
+      throwingRepository("touchSession", fixture.repository),
+      fixture.verifier,
+    );
+    expect(touchFailure.authenticateSession(enrolledSession.value.token)).toBe(false);
+    const revokeFailure = createTechnicalAdminAuth(
+      { environment: "test", origin: binding.origin, rpId: "timer.example" },
+      throwingRepository("revokeSession", fixture.repository),
+      fixture.verifier,
+    );
+    expect(() => revokeFailure.logout(enrolledSession.value.token)).not.toThrow();
+  });
+});
+
+async function enroll(fixture: ReturnType<typeof createFixture>) {
+  const issued = fixture.auth.issueEnrollmentAuthorization();
+  if (!issued.ok) throw new Error("Expected enrollment authorization.");
+  const token = decodeURIComponent(issued.value.url.split("token=")[1] ?? "");
+  const options = fixture.auth.beginEnrollment(token, binding);
+  if (!options.ok) throw new Error("Expected enrollment options.");
+  expect(await fixture.auth.completeEnrollment(options.value.challengeId, {}, binding)).toEqual({
+    ok: true,
+    value: undefined,
+  });
+}
+
+function encodeBase64Url(value: string | Uint8Array) {
+  const bytes = typeof value === "string" ? new TextEncoder().encode(value) : value;
+  return Buffer.from(bytes).toString("base64url");
+}
+
+function throwingRepository(
+  failure: string,
+  base = new MemoryTechnicalAdminAuthRepository(),
+): TechnicalAdminAuthRepository {
+  const fail = () => {
+    throw new Error(`injected ${failure} failure`);
+  };
+  return {
+    hasCredential: failure === "hasCredential" ? fail : () => base.hasCredential(),
+    getCredential: failure === "getCredential" ? fail : () => base.getCredential(),
+    issueEnrollment:
+      failure === "issueEnrollment" ? fail : (...args) => base.issueEnrollment(...args),
+    consumeEnrollment:
+      failure === "consumeEnrollment" ? fail : (...args) => base.consumeEnrollment(...args),
+    createChallenge:
+      failure === "createChallenge" ? fail : (...args) => base.createChallenge(...args),
+    consumeChallenge:
+      failure === "consumeChallenge" ? fail : (...args) => base.consumeChallenge(...args),
+    commitEnrollment:
+      failure === "commitEnrollment" ? fail : (...args) => base.commitEnrollment(...args),
+    commitAuthentication:
+      failure === "commitAuthentication" ? fail : (...args) => base.commitAuthentication(...args),
+    getSession: failure === "getSession" ? fail : (...args) => base.getSession(...args),
+    touchSession: failure === "touchSession" ? fail : (...args) => base.touchSession(...args),
+    revokeSession: failure === "revokeSession" ? fail : (...args) => base.revokeSession(...args),
+  };
+}

--- a/src/lib/technical-admin-auth.ts
+++ b/src/lib/technical-admin-auth.ts
@@ -1,0 +1,964 @@
+import { Database } from "bun:sqlite";
+import { mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+
+export type TechnicalAdminEnvironment = "production" | "test";
+
+export type TechnicalAdminAuthConfig = {
+  environment: TechnicalAdminEnvironment;
+  origin: string;
+  rpId: string;
+  databasePath?: string;
+};
+
+export type CeremonyBinding = {
+  origin: string;
+  host: string;
+};
+
+export type EnrollmentAuthorization = {
+  url: string;
+  expiresAtMs: number;
+};
+
+export type RegistrationOptions = {
+  challengeId: string;
+  challenge: string;
+  rp: { id: string; name: string };
+  user: { id: string; name: string; displayName: string };
+  timeout: number;
+  attestation: "none";
+  authenticatorSelection: { residentKey: "required"; userVerification: "required" };
+};
+
+export type AuthenticationOptions = {
+  challengeId: string;
+  challenge: string;
+  rpId: string;
+  allowCredentials: Array<{ id: string; type: "public-key" }>;
+  timeout: number;
+  userVerification: "required";
+};
+
+export type TechnicalAdminSession = {
+  token: string;
+  expiresAtMs: number;
+};
+
+export type AuthFailure =
+  | "not-enrollable"
+  | "invalid-enrollment"
+  | "invalid-ceremony"
+  | "invalid-credentials"
+  | "not-authenticated"
+  | "storage-failure";
+
+export type AuthResult<T> = { ok: true; value: T } | { ok: false; error: AuthFailure };
+
+export type CredentialRecord = {
+  credentialId: string;
+  publicKey: JsonWebKey;
+  signCount: number;
+  createdAtMs: number;
+};
+
+type ChallengeRecord = {
+  id: string;
+  value: string;
+  purpose: "registration" | "authentication";
+  expiresAtMs: number;
+  usedAtMs: number | null;
+};
+
+type SessionRecord = {
+  id: string;
+  tokenHash: string;
+  createdAtMs: number;
+  lastSeenAtMs: number;
+  absoluteExpiresAtMs: number;
+  revokedAtMs: number | null;
+};
+
+type EnrollmentRecord = {
+  tokenHash: string;
+  expiresAtMs: number;
+  usedAtMs: number | null;
+};
+
+export interface TechnicalAdminAuthRepository {
+  hasCredential(): boolean;
+  getCredential(): CredentialRecord | null;
+  issueEnrollment(tokenHash: string, expiresAtMs: number): void;
+  consumeEnrollment(tokenHash: string, nowMs: number): boolean;
+  createChallenge(challenge: ChallengeRecord): void;
+  consumeChallenge(id: string, purpose: ChallengeRecord["purpose"], nowMs: number): string | null;
+  commitEnrollment(challengeId: string, credential: CredentialRecord): boolean;
+  commitAuthentication(
+    challengeId: string,
+    credentialId: string,
+    signCount: number,
+    session: SessionRecord,
+  ): boolean;
+  getSession(tokenHash: string): SessionRecord | null;
+  touchSession(id: string, nowMs: number): void;
+  revokeSession(id: string, nowMs: number): void;
+}
+
+export type TechnicalAdminStorageIdentity = {
+  environment: TechnicalAdminEnvironment;
+  origin: string;
+  rpId: string;
+};
+
+const ENROLLMENT_TTL_MS = 10 * 60 * 1_000;
+const CHALLENGE_TTL_MS = 5 * 60 * 1_000;
+const SESSION_IDLE_TTL_MS = 2 * 60 * 60 * 1_000;
+const SESSION_ABSOLUTE_TTL_MS = 12 * 60 * 60 * 1_000;
+const TOKEN_BYTES = 32;
+
+export function createTechnicalAdminAuth(
+  config: TechnicalAdminAuthConfig,
+  repository: TechnicalAdminAuthRepository,
+  verifier: WebAuthnVerifier = new NativeWebAuthnVerifier(),
+  now: () => number = () => Date.now(),
+): TechnicalAdminAuth {
+  const expectedOrigin = new URL(config.origin).origin;
+  const expectedUrl = new URL(config.origin);
+  const expectedHost = expectedUrl.host;
+  if (
+    expectedOrigin !== config.origin ||
+    expectedUrl.protocol !== "https:" ||
+    config.rpId !== expectedUrl.hostname
+  ) {
+    throw new Error("Technical Admin origin must be an exact origin.");
+  }
+
+  return {
+    issueEnrollmentAuthorization(): AuthResult<EnrollmentAuthorization> {
+      try {
+        if (repository.hasCredential()) return { ok: false, error: "not-enrollable" };
+        const secret = randomToken();
+        const expiresAtMs = now() + ENROLLMENT_TTL_MS;
+        repository.issueEnrollment(hashToken(secret), expiresAtMs);
+        return {
+          ok: true,
+          value: {
+            url: `${config.origin}/admin/enroll#token=${encodeURIComponent(secret)}`,
+            expiresAtMs,
+          },
+        };
+      } catch {
+        return { ok: false, error: "storage-failure" };
+      }
+    },
+
+    beginEnrollment(token: string, binding: CeremonyBinding): AuthResult<RegistrationOptions> {
+      try {
+        if (!isExactBinding(binding, expectedOrigin, expectedHost) || repository.hasCredential()) {
+          return { ok: false, error: "invalid-enrollment" };
+        }
+        const current = now();
+        if (!repository.consumeEnrollment(hashToken(token), current)) {
+          return { ok: false, error: "invalid-enrollment" };
+        }
+        const challenge = createChallenge("registration", current);
+        repository.createChallenge(challenge);
+        return {
+          ok: true,
+          value: {
+            challengeId: challenge.id,
+            challenge: challenge.value,
+            rp: { id: config.rpId, name: "Quadball Timer" },
+            user: {
+              id: base64UrlEncode(
+                new TextEncoder().encode(`${config.environment}:technical-admin`),
+              ),
+              name: "technical-admin",
+              displayName: "Technical Admin",
+            },
+            timeout: CHALLENGE_TTL_MS,
+            attestation: "none",
+            authenticatorSelection: { residentKey: "required", userVerification: "required" },
+          },
+        };
+      } catch {
+        return { ok: false, error: "storage-failure" };
+      }
+    },
+
+    async completeEnrollment(
+      challengeId: string,
+      response: unknown,
+      binding: CeremonyBinding,
+    ): Promise<AuthResult<void>> {
+      if (!isExactBinding(binding, expectedOrigin, expectedHost)) {
+        return { ok: false, error: "invalid-ceremony" };
+      }
+      try {
+        const challenge = consumeChallenge(repository, challengeId, "registration", now());
+        if (challenge === null || repository.hasCredential()) {
+          return { ok: false, error: "invalid-ceremony" };
+        }
+        const credential = await verifier.verifyRegistration(response, {
+          challenge,
+          origin: expectedOrigin,
+          rpId: config.rpId,
+          requireUserVerification: true,
+        });
+        if (
+          !repository.commitEnrollment(challengeId, {
+            ...credential,
+            createdAtMs: now(),
+          })
+        ) {
+          return { ok: false, error: "invalid-ceremony" };
+        }
+        return { ok: true, value: undefined };
+      } catch {
+        return { ok: false, error: "invalid-ceremony" };
+      }
+    },
+
+    beginAuthentication(binding: CeremonyBinding): AuthResult<AuthenticationOptions> {
+      if (!isExactBinding(binding, expectedOrigin, expectedHost)) {
+        return { ok: false, error: "invalid-ceremony" };
+      }
+      try {
+        const credential = repository.getCredential();
+        if (credential === null) return { ok: false, error: "invalid-credentials" };
+        const challenge = createChallenge("authentication", now());
+        repository.createChallenge(challenge);
+        return {
+          ok: true,
+          value: {
+            challengeId: challenge.id,
+            challenge: challenge.value,
+            rpId: config.rpId,
+            allowCredentials: [{ id: credential.credentialId, type: "public-key" }],
+            timeout: CHALLENGE_TTL_MS,
+            userVerification: "required",
+          },
+        };
+      } catch {
+        return { ok: false, error: "storage-failure" };
+      }
+    },
+
+    async completeAuthentication(
+      challengeId: string,
+      response: unknown,
+      binding: CeremonyBinding,
+    ): Promise<AuthResult<TechnicalAdminSession>> {
+      if (!isExactBinding(binding, expectedOrigin, expectedHost)) {
+        return { ok: false, error: "invalid-ceremony" };
+      }
+      try {
+        const credential = repository.getCredential();
+        const challenge = consumeChallenge(repository, challengeId, "authentication", now());
+        if (credential === null || challenge === null) {
+          return { ok: false, error: "invalid-ceremony" };
+        }
+        const result = await verifier.verifyAuthentication(response, {
+          challenge,
+          origin: expectedOrigin,
+          rpId: config.rpId,
+          credential,
+          requireUserVerification: true,
+        });
+        const nextSignCount = result.signCount === 0 ? credential.signCount : result.signCount;
+        const current = now();
+        const token = randomToken();
+        const session: SessionRecord = {
+          id: crypto.randomUUID(),
+          tokenHash: hashToken(token),
+          createdAtMs: current,
+          lastSeenAtMs: current,
+          absoluteExpiresAtMs: current + SESSION_ABSOLUTE_TTL_MS,
+          revokedAtMs: null,
+        };
+        if (
+          !repository.commitAuthentication(
+            challengeId,
+            credential.credentialId,
+            nextSignCount,
+            session,
+          )
+        ) {
+          return { ok: false, error: "invalid-ceremony" };
+        }
+        return {
+          ok: true,
+          value: { token, expiresAtMs: session.absoluteExpiresAtMs },
+        };
+      } catch {
+        return { ok: false, error: "invalid-ceremony" };
+      }
+    },
+
+    authenticateSession(token: string): boolean {
+      try {
+        const current = now();
+        const session = repository.getSession(hashToken(token));
+        if (
+          session === null ||
+          session.revokedAtMs !== null ||
+          current >= session.absoluteExpiresAtMs ||
+          current - session.lastSeenAtMs >= SESSION_IDLE_TTL_MS
+        ) {
+          return false;
+        }
+        repository.touchSession(session.id, current);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+
+    logout(token: string): void {
+      try {
+        const session = repository.getSession(hashToken(token));
+        if (session !== null) repository.revokeSession(session.id, now());
+      } catch {
+        // Logout is intentionally idempotent and fail-closed.
+      }
+    },
+
+    isExpectedBinding(binding: CeremonyBinding): boolean {
+      return isExactBinding(binding, expectedOrigin, expectedHost);
+    },
+
+    config,
+  };
+}
+
+export interface TechnicalAdminAuth {
+  issueEnrollmentAuthorization(): AuthResult<EnrollmentAuthorization>;
+  beginEnrollment(token: string, binding: CeremonyBinding): AuthResult<RegistrationOptions>;
+  completeEnrollment(
+    challengeId: string,
+    response: unknown,
+    binding: CeremonyBinding,
+  ): Promise<AuthResult<void>>;
+  beginAuthentication(binding: CeremonyBinding): AuthResult<AuthenticationOptions>;
+  completeAuthentication(
+    challengeId: string,
+    response: unknown,
+    binding: CeremonyBinding,
+  ): Promise<AuthResult<TechnicalAdminSession>>;
+  authenticateSession(token: string): boolean;
+  logout(token: string): void;
+  isExpectedBinding(binding: CeremonyBinding): boolean;
+  config: TechnicalAdminAuthConfig;
+}
+
+export type WebAuthnRegistrationExpectation = {
+  challenge: string;
+  origin: string;
+  rpId: string;
+  requireUserVerification: boolean;
+};
+
+export type WebAuthnAuthenticationExpectation = WebAuthnRegistrationExpectation & {
+  credential: CredentialRecord;
+};
+
+export interface WebAuthnVerifier {
+  verifyRegistration(
+    response: unknown,
+    expectation: WebAuthnRegistrationExpectation,
+  ): Promise<Omit<CredentialRecord, "createdAtMs">>;
+  verifyAuthentication(
+    response: unknown,
+    expectation: WebAuthnAuthenticationExpectation,
+  ): Promise<{ signCount: number }>;
+}
+
+export class NativeWebAuthnVerifier implements WebAuthnVerifier {
+  async verifyRegistration(
+    response: unknown,
+    expectation: WebAuthnRegistrationExpectation,
+  ): Promise<Omit<CredentialRecord, "createdAtMs">> {
+    const parsed = parseCredentialResponse(response, "registration");
+    parseClientData(parsed.clientDataJSON, "webauthn.create", expectation);
+    const attestation = decodeCbor(parsed.attestationObject);
+    if (!(attestation instanceof Map)) throw new Error("Invalid attestation object.");
+    if (attestation.get("fmt") !== "none") throw new Error("Unsupported attestation format.");
+    const authData = bytesFrom(attestation.get("authData"));
+    const parsedAuthData = parseAuthenticatorData(authData, true, expectation.rpId);
+    if (!parsedAuthData.credentialId || !parsedAuthData.publicKey) {
+      throw new Error("Missing attested credential data.");
+    }
+    return {
+      credentialId: base64UrlEncode(parsedAuthData.credentialId),
+      publicKey: parsedAuthData.publicKey,
+      signCount: parsedAuthData.signCount,
+    };
+  }
+
+  async verifyAuthentication(
+    response: unknown,
+    expectation: WebAuthnAuthenticationExpectation,
+  ): Promise<{ signCount: number }> {
+    const parsed = parseCredentialResponse(response, "authentication");
+    if (parsed.id !== expectation.credential.credentialId)
+      throw new Error("Unexpected credential.");
+    parseClientData(parsed.clientDataJSON, "webauthn.get", expectation);
+    const authData = parseAuthenticatorData(parsed.authenticatorData, false, expectation.rpId);
+    if (!authData.userVerification || !authData.userPresent) throw new Error("UV required.");
+    const clientDataHash = new Uint8Array(
+      await crypto.subtle.digest("SHA-256", parsed.clientDataJSON as BufferSource),
+    );
+    const signedData = concatBytes(parsed.authenticatorData, clientDataHash);
+    const valid = await verifyWebAuthnSignature(
+      expectation.credential.publicKey,
+      parsed.signature,
+      signedData,
+    );
+    if (!valid) throw new Error("Invalid signature.");
+    if (
+      expectation.credential.signCount !== 0 &&
+      authData.signCount !== 0 &&
+      authData.signCount <= expectation.credential.signCount
+    ) {
+      throw new Error("Authenticator counter did not advance.");
+    }
+    return { signCount: authData.signCount };
+  }
+}
+
+export class MemoryTechnicalAdminAuthRepository implements TechnicalAdminAuthRepository {
+  credential: CredentialRecord | null = null;
+  enrollment: EnrollmentRecord | null = null;
+  challenges = new Map<string, ChallengeRecord>();
+  sessions = new Map<string, SessionRecord>();
+
+  hasCredential() {
+    return this.credential !== null;
+  }
+  getCredential() {
+    return this.credential;
+  }
+  issueEnrollment(tokenHash: string, expiresAtMs: number) {
+    this.enrollment = { tokenHash, expiresAtMs, usedAtMs: null };
+  }
+  consumeEnrollment(tokenHash: string, nowMs: number) {
+    if (
+      this.enrollment === null ||
+      this.enrollment.tokenHash !== tokenHash ||
+      this.enrollment.usedAtMs !== null ||
+      nowMs >= this.enrollment.expiresAtMs
+    )
+      return false;
+    this.enrollment.usedAtMs = nowMs;
+    return true;
+  }
+  createChallenge(challenge: ChallengeRecord) {
+    this.challenges.set(challenge.id, challenge);
+  }
+  consumeChallenge(id: string, purpose: ChallengeRecord["purpose"], nowMs: number) {
+    const challenge = this.challenges.get(id);
+    if (
+      challenge === undefined ||
+      challenge.purpose !== purpose ||
+      challenge.usedAtMs !== null ||
+      nowMs >= challenge.expiresAtMs
+    )
+      return null;
+    challenge.usedAtMs = nowMs;
+    return challenge.value;
+  }
+  commitEnrollment(challengeId: string, credential: CredentialRecord) {
+    if (this.credential !== null || !this.challenges.has(challengeId)) return false;
+    this.credential = credential;
+    return true;
+  }
+  commitAuthentication(
+    _challengeId: string,
+    credentialId: string,
+    signCount: number,
+    session: SessionRecord,
+  ) {
+    if (this.credential === null || this.credential.credentialId !== credentialId) return false;
+    this.credential = { ...this.credential, signCount };
+    this.sessions.set(session.id, session);
+    return true;
+  }
+  getSession(tokenHash: string) {
+    return [...this.sessions.values()].find((session) => session.tokenHash === tokenHash) ?? null;
+  }
+  touchSession(id: string, nowMs: number) {
+    const session = this.sessions.get(id);
+    if (session) session.lastSeenAtMs = nowMs;
+  }
+  revokeSession(id: string, nowMs: number) {
+    const session = this.sessions.get(id);
+    if (session) session.revokedAtMs = nowMs;
+  }
+}
+
+export class SqliteTechnicalAdminAuthRepository implements TechnicalAdminAuthRepository {
+  readonly database: Database;
+  constructor(databasePath: string, identity?: TechnicalAdminStorageIdentity) {
+    mkdirSync(dirname(databasePath), { recursive: true });
+    this.database = new Database(databasePath, { create: true, readwrite: true });
+    this.database.exec(`
+      CREATE TABLE IF NOT EXISTS technical_admin_credentials (
+        credential_id TEXT PRIMARY KEY, public_key_json TEXT NOT NULL, sign_count INTEGER NOT NULL, created_at_ms INTEGER NOT NULL
+      );
+      CREATE TABLE IF NOT EXISTS technical_admin_enrollment (
+        token_hash TEXT PRIMARY KEY, expires_at_ms INTEGER NOT NULL, used_at_ms INTEGER
+      );
+      CREATE TABLE IF NOT EXISTS technical_admin_challenges (
+        challenge_id TEXT PRIMARY KEY, challenge TEXT NOT NULL, purpose TEXT NOT NULL, expires_at_ms INTEGER NOT NULL, used_at_ms INTEGER
+      );
+      CREATE TABLE IF NOT EXISTS technical_admin_sessions (
+        session_id TEXT PRIMARY KEY, token_hash TEXT UNIQUE NOT NULL, created_at_ms INTEGER NOT NULL, last_seen_at_ms INTEGER NOT NULL,
+        absolute_expires_at_ms INTEGER NOT NULL, revoked_at_ms INTEGER
+      );
+      CREATE TABLE IF NOT EXISTS technical_admin_storage_identity (
+        id INTEGER PRIMARY KEY CHECK (id = 1), environment TEXT NOT NULL, origin TEXT NOT NULL, rp_id TEXT NOT NULL
+      );
+    `);
+    if (identity) {
+      const existing = this.database
+        .query(
+          "SELECT environment, origin, rp_id FROM technical_admin_storage_identity WHERE id = 1",
+        )
+        .get() as { environment: string; origin: string; rp_id: string } | null;
+      if (
+        existing &&
+        (existing.environment !== identity.environment ||
+          existing.origin !== identity.origin ||
+          existing.rp_id !== identity.rpId)
+      ) {
+        throw new Error("Technical Admin storage identity does not match the environment.");
+      }
+      if (!existing)
+        this.database
+          .query("INSERT INTO technical_admin_storage_identity VALUES (1, ?, ?, ?)")
+          .run(identity.environment, identity.origin, identity.rpId);
+    }
+  }
+  hasCredential() {
+    return this.database.query("SELECT 1 FROM technical_admin_credentials LIMIT 1").get() !== null;
+  }
+  getCredential() {
+    const row = this.database.query("SELECT * FROM technical_admin_credentials LIMIT 1").get() as {
+      credential_id: string;
+      public_key_json: string;
+      sign_count: number;
+      created_at_ms: number;
+    } | null;
+    return row
+      ? {
+          credentialId: row.credential_id,
+          publicKey: JSON.parse(row.public_key_json) as JsonWebKey,
+          signCount: row.sign_count,
+          createdAtMs: row.created_at_ms,
+        }
+      : null;
+  }
+  issueEnrollment(tokenHash: string, expiresAtMs: number) {
+    this.database.exec(
+      "DELETE FROM technical_admin_enrollment; DELETE FROM technical_admin_challenges WHERE expires_at_ms <= strftime('%s','now') * 1000;",
+    );
+    this.database
+      .query("INSERT INTO technical_admin_enrollment (token_hash, expires_at_ms) VALUES (?, ?)")
+      .run(tokenHash, expiresAtMs);
+  }
+  consumeEnrollment(tokenHash: string, nowMs: number) {
+    const result = this.database
+      .query(
+        "UPDATE technical_admin_enrollment SET used_at_ms = ? WHERE token_hash = ? AND used_at_ms IS NULL AND expires_at_ms > ?",
+      )
+      .run(nowMs, tokenHash, nowMs);
+    return result.changes === 1;
+  }
+  createChallenge(challenge: ChallengeRecord) {
+    this.database
+      .query("INSERT INTO technical_admin_challenges VALUES (?, ?, ?, ?, NULL)")
+      .run(challenge.id, challenge.value, challenge.purpose, challenge.expiresAtMs);
+  }
+  consumeChallenge(id: string, purpose: ChallengeRecord["purpose"], nowMs: number) {
+    const row = this.database
+      .query(
+        "SELECT challenge FROM technical_admin_challenges WHERE challenge_id = ? AND purpose = ? AND used_at_ms IS NULL AND expires_at_ms > ?",
+      )
+      .get(id, purpose, nowMs) as { challenge: string } | null;
+    if (!row) return null;
+    const result = this.database
+      .query(
+        "UPDATE technical_admin_challenges SET used_at_ms = ? WHERE challenge_id = ? AND used_at_ms IS NULL AND expires_at_ms > ?",
+      )
+      .run(nowMs, id, nowMs);
+    return result.changes === 1 ? row.challenge : null;
+  }
+  commitEnrollment(challengeId: string, credential: CredentialRecord) {
+    try {
+      return this.database.transaction(() => {
+        if (this.hasCredential()) return false;
+        const challenge = this.database
+          .query(
+            "SELECT 1 FROM technical_admin_challenges WHERE challenge_id = ? AND used_at_ms IS NOT NULL",
+          )
+          .get(challengeId);
+        if (!challenge) return false;
+        this.database
+          .query("INSERT INTO technical_admin_credentials VALUES (?, ?, ?, ?)")
+          .run(
+            credential.credentialId,
+            JSON.stringify(credential.publicKey),
+            credential.signCount,
+            credential.createdAtMs,
+          );
+        return true;
+      })();
+    } catch {
+      return false;
+    }
+  }
+  commitAuthentication(
+    challengeId: string,
+    credentialId: string,
+    signCount: number,
+    session: SessionRecord,
+  ) {
+    try {
+      return this.database.transaction(() => {
+        const challenge = this.database
+          .query(
+            "SELECT 1 FROM technical_admin_challenges WHERE challenge_id = ? AND used_at_ms IS NOT NULL",
+          )
+          .get(challengeId);
+        if (!challenge) return false;
+        const update = this.database
+          .query("UPDATE technical_admin_credentials SET sign_count = ? WHERE credential_id = ?")
+          .run(signCount, credentialId);
+        if (update.changes !== 1) return false;
+        this.database
+          .query("INSERT INTO technical_admin_sessions VALUES (?, ?, ?, ?, ?, NULL)")
+          .run(
+            session.id,
+            session.tokenHash,
+            session.createdAtMs,
+            session.lastSeenAtMs,
+            session.absoluteExpiresAtMs,
+          );
+        return true;
+      })();
+    } catch {
+      return false;
+    }
+  }
+  getSession(tokenHash: string) {
+    const row = this.database
+      .query("SELECT * FROM technical_admin_sessions WHERE token_hash = ?")
+      .get(tokenHash) as Record<string, number | string | null> | null;
+    return row
+      ? {
+          id: String(row.session_id),
+          tokenHash: String(row.token_hash),
+          createdAtMs: Number(row.created_at_ms),
+          lastSeenAtMs: Number(row.last_seen_at_ms),
+          absoluteExpiresAtMs: Number(row.absolute_expires_at_ms),
+          revokedAtMs: row.revoked_at_ms === null ? null : Number(row.revoked_at_ms),
+        }
+      : null;
+  }
+  touchSession(id: string, nowMs: number) {
+    this.database
+      .query("UPDATE technical_admin_sessions SET last_seen_at_ms = ? WHERE session_id = ?")
+      .run(nowMs, id);
+  }
+  revokeSession(id: string, nowMs: number) {
+    this.database
+      .query("UPDATE technical_admin_sessions SET revoked_at_ms = ? WHERE session_id = ?")
+      .run(nowMs, id);
+  }
+}
+
+function consumeChallenge(
+  repository: TechnicalAdminAuthRepository,
+  id: string,
+  purpose: ChallengeRecord["purpose"],
+  nowMs: number,
+) {
+  return repository.consumeChallenge(id, purpose, nowMs);
+}
+
+function createChallenge(purpose: ChallengeRecord["purpose"], nowMs: number): ChallengeRecord {
+  return {
+    id: crypto.randomUUID(),
+    value: randomToken(),
+    purpose,
+    expiresAtMs: nowMs + CHALLENGE_TTL_MS,
+    usedAtMs: null,
+  };
+}
+
+function isExactBinding(binding: CeremonyBinding, origin: string, host: string) {
+  return binding.origin === origin && binding.host === host;
+}
+
+function randomToken() {
+  return base64UrlEncode(crypto.getRandomValues(new Uint8Array(TOKEN_BYTES)));
+}
+function hashToken(token: string) {
+  return bytesToHex(new Uint8Array(new Bun.CryptoHasher("sha256").update(token).digest()));
+}
+
+function parseCredentialResponse(
+  value: unknown,
+  kind: "registration",
+): {
+  id: string;
+  clientDataJSON: Uint8Array;
+  attestationObject: Uint8Array;
+};
+function parseCredentialResponse(
+  value: unknown,
+  kind: "authentication",
+): {
+  id: string;
+  clientDataJSON: Uint8Array;
+  authenticatorData: Uint8Array;
+  signature: Uint8Array;
+};
+function parseCredentialResponse(
+  value: unknown,
+  kind: "registration" | "authentication",
+):
+  | { id: string; clientDataJSON: Uint8Array; attestationObject: Uint8Array }
+  | {
+      id: string;
+      clientDataJSON: Uint8Array;
+      authenticatorData: Uint8Array;
+      signature: Uint8Array;
+    } {
+  if (!isRecord(value) || typeof value.id !== "string" || !isRecord(value.response))
+    throw new Error("Invalid credential response.");
+  const response = value.response;
+  const parsed = {
+    id: value.id,
+    clientDataJSON: base64UrlDecode(requiredString(response.clientDataJSON)),
+  };
+  if (kind === "registration") {
+    return {
+      ...parsed,
+      attestationObject: base64UrlDecode(
+        requiredString(response.attestationObject, "attestationObject"),
+      ),
+    };
+  }
+  return {
+    ...parsed,
+    authenticatorData: base64UrlDecode(
+      requiredString(response.authenticatorData, "authenticatorData"),
+    ),
+    signature: base64UrlDecode(requiredString(response.signature, "signature")),
+  };
+}
+
+function parseClientData(
+  bytes: Uint8Array,
+  type: string,
+  expectation: WebAuthnRegistrationExpectation,
+) {
+  const data = JSON.parse(new TextDecoder().decode(bytes)) as Record<string, unknown>;
+  if (
+    data.type !== type ||
+    data.origin !== expectation.origin ||
+    data.challenge !== expectation.challenge
+  )
+    throw new Error("Invalid client data.");
+  return data;
+}
+
+function parseAuthenticatorData(bytes: Uint8Array, registration: boolean, rpId: string) {
+  if (bytes.length < 37) throw new Error("Invalid authenticator data.");
+  const expectedRpIdHash = new Uint8Array(new Bun.CryptoHasher("sha256").update(rpId).digest());
+  if (!bytesEqual(bytes.slice(0, 32), expectedRpIdHash)) throw new Error("Invalid RP ID.");
+  const flags = bytes[32] ?? 0;
+  if ((flags & 0x01) === 0) throw new Error("User presence required.");
+  if ((flags & 0x04) === 0) throw new Error("User verification required.");
+  const signCount = new DataView(bytes.buffer, bytes.byteOffset + 33, 4).getUint32(0);
+  if (!registration) return { signCount, userVerification: true, userPresent: true };
+  if ((flags & 0x40) === 0 || bytes.length < 55)
+    throw new Error("Missing attested credential data.");
+  let offset = 37 + 16;
+  const credentialLength = new DataView(bytes.buffer, bytes.byteOffset + offset, 2).getUint16(0);
+  offset += 2;
+  const credentialId = bytes.slice(offset, offset + credentialLength);
+  offset += credentialLength;
+  const key = decodeCbor(bytes.slice(offset));
+  return {
+    signCount,
+    userVerification: true,
+    userPresent: true,
+    credentialId,
+    publicKey: coseKeyToJwk(key),
+  };
+}
+
+async function verifyWebAuthnSignature(
+  publicKey: JsonWebKey,
+  signature: Uint8Array,
+  data: Uint8Array,
+) {
+  const algorithm =
+    publicKey.kty === "EC" ? { name: "ECDSA", namedCurve: "P-256" } : { name: "Ed25519" };
+  const key = await crypto.subtle.importKey("jwk", publicKey, algorithm, false, ["verify"]);
+  const normalizedSignature = publicKey.kty === "EC" ? derToP1363(signature) : signature;
+  return crypto.subtle.verify(
+    publicKey.kty === "EC" ? { name: "ECDSA", hash: "SHA-256" } : { name: "Ed25519" },
+    key,
+    normalizedSignature as BufferSource,
+    data as BufferSource,
+  );
+}
+
+function coseKeyToJwk(value: unknown): JsonWebKey {
+  if (!(value instanceof Map)) throw new Error("Invalid COSE key.");
+  const kty = Number(value.get(1));
+  if (kty === 2)
+    return {
+      kty: "EC",
+      crv: "P-256",
+      x: base64UrlEncode(bytesFrom(value.get(-2))),
+      y: base64UrlEncode(bytesFrom(value.get(-3))),
+      alg: "ES256",
+      ext: true,
+    };
+  if (kty === 1)
+    return {
+      kty: "OKP",
+      crv: "Ed25519",
+      x: base64UrlEncode(bytesFrom(value.get(-2))),
+      alg: "EdDSA",
+      ext: true,
+    };
+  if (kty === 3)
+    return {
+      kty: "RSA",
+      n: base64UrlEncode(bytesFrom(value.get(-1))),
+      e: base64UrlEncode(bytesFrom(value.get(-2))),
+      alg: "RS256",
+      ext: true,
+    };
+  throw new Error("Unsupported COSE key.");
+}
+
+function derToP1363(signature: Uint8Array) {
+  if (signature[0] !== 0x30) return signature;
+  let offset = 2;
+  if (signature[offset] !== 0x02) throw new Error("Invalid ECDSA signature.");
+  const rLength = signature[offset + 1] ?? 0;
+  const r = signature.slice(offset + 2, offset + 2 + rLength);
+  offset += 2 + rLength;
+  if (signature[offset] !== 0x02) throw new Error("Invalid ECDSA signature.");
+  const sLength = signature[offset + 1] ?? 0;
+  const s = signature.slice(offset + 2, offset + 2 + sLength);
+  return concatBytes(leftPad32(trimLeadingZeroes(r)), leftPad32(trimLeadingZeroes(s)));
+}
+
+function trimLeadingZeroes(bytes: Uint8Array) {
+  return bytes.slice(
+    Math.max(
+      0,
+      bytes.findIndex((byte) => byte !== 0),
+    ),
+  );
+}
+function leftPad32(bytes: Uint8Array) {
+  const result = new Uint8Array(32);
+  result.set(bytes.slice(-32), 32 - Math.min(32, bytes.length));
+  return result;
+}
+function concatBytes(...values: Uint8Array[]) {
+  const result = new Uint8Array(values.reduce((sum, value) => sum + value.length, 0));
+  let offset = 0;
+  for (const value of values) {
+    result.set(value, offset);
+    offset += value.length;
+  }
+  return result;
+}
+function bytesEqual(left: Uint8Array, right: Uint8Array) {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+function bytesFrom(value: unknown) {
+  if (value instanceof Uint8Array) return value;
+  if (value instanceof ArrayBuffer) return new Uint8Array(value);
+  throw new Error("Expected bytes.");
+}
+function requiredString(value: unknown, name = "clientDataJSON") {
+  if (typeof value !== "string") throw new Error(`Missing ${name}.`);
+  return value;
+}
+function base64UrlEncode(bytes: Uint8Array) {
+  return Buffer.from(bytes).toString("base64url");
+}
+function base64UrlDecode(value: string) {
+  return new Uint8Array(Buffer.from(value, "base64url"));
+}
+function bytesToHex(bytes: Uint8Array) {
+  return [...bytes].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function decodeCbor(bytes: Uint8Array): unknown {
+  let offset = 0;
+  const read = (): unknown => {
+    const initial = bytes[offset++];
+    if (initial === undefined) throw new Error("Invalid CBOR.");
+    const major = initial >> 5;
+    const additional = initial & 0x1f;
+    const length = readLength(additional);
+    if (major === 0) return length;
+    if (major === 1) return -1 - length;
+    if (major === 2) {
+      const result = bytes.slice(offset, offset + length);
+      offset += length;
+      return result;
+    }
+    if (major === 3) {
+      const result = new TextDecoder().decode(bytes.slice(offset, offset + length));
+      offset += length;
+      return result;
+    }
+    if (major === 4) return Array.from({ length }, () => read());
+    if (major === 5) {
+      const map = new Map<unknown, unknown>();
+      for (let index = 0; index < length; index++) map.set(read(), read());
+      return map;
+    }
+    throw new Error("Unsupported CBOR value.");
+  };
+  const readLength = (additional: number): number => {
+    if (additional < 24) return additional;
+    const width = additional === 24 ? 1 : additional === 25 ? 2 : additional === 26 ? 4 : 0;
+    if (width === 0 || offset + width > bytes.length) throw new Error("Invalid CBOR length.");
+    let value = 0;
+    for (let index = 0; index < width; index++) value = value * 256 + (bytes[offset++] ?? 0);
+    return value;
+  };
+  return read();
+}
+
+export function createSqliteTechnicalAdminAuthRepository(
+  databasePath: string,
+  identity?: TechnicalAdminStorageIdentity,
+) {
+  return new SqliteTechnicalAdminAuthRepository(databasePath, identity);
+}
+export function technicalAdminCookie(token: string) {
+  return `__Host-technical-admin=${token}; Path=/; Secure; HttpOnly; SameSite=Strict`;
+}
+export function clearTechnicalAdminCookie() {
+  return "__Host-technical-admin=; Path=/; Secure; HttpOnly; SameSite=Strict; Max-Age=0";
+}
+export function technicalAdminSessionTtls() {
+  return { idleMs: SESSION_IDLE_TTL_MS, absoluteMs: SESSION_ABSOLUTE_TTL_MS };
+}

--- a/src/lib/technical-admin-config.ts
+++ b/src/lib/technical-admin-config.ts
@@ -1,0 +1,24 @@
+import type {
+  TechnicalAdminAuthConfig,
+  TechnicalAdminEnvironment,
+} from "@/lib/technical-admin-auth";
+
+export function readTechnicalAdminConfig(
+  environmentVariables: Record<string, string | undefined> = process.env,
+): TechnicalAdminAuthConfig {
+  const port = Number(environmentVariables.PORT ?? 3000);
+  const environment: TechnicalAdminEnvironment =
+    environmentVariables.QUADBALL_ENVIRONMENT === "production"
+      ? "production"
+      : environmentVariables.QUADBALL_ENVIRONMENT === "test" ||
+          environmentVariables.NODE_ENV !== "production"
+        ? "test"
+        : "production";
+  const origin =
+    environmentVariables.PUBLIC_ORIGIN ??
+    (environment === "test" ? `https://localhost:${port}` : "https://timer.quadball.app");
+  const rpId = environmentVariables.WEBAUTHN_RP_ID ?? new URL(origin).hostname;
+  const databasePath =
+    environmentVariables.TECHNICAL_ADMIN_DATABASE ?? `data/${environment}/technical-admin.sqlite`;
+  return { environment, origin, rpId, databasePath };
+}

--- a/src/pages/technical-admin-page.tsx
+++ b/src/pages/technical-admin-page.tsx
@@ -1,0 +1,247 @@
+import { useEffect, useState, type ReactNode } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+type AdminSession = { authenticated: true; environment: "production" | "test" };
+
+export function TechnicalAdminPage({ enrollment }: { enrollment: boolean }) {
+  const [session, setSession] = useState<AdminSession | null>(null);
+  const [enrollmentToken, setEnrollmentToken] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (enrollment) {
+      const token = new URLSearchParams(window.location.hash.slice(1)).get("token");
+      setEnrollmentToken(token);
+      window.history.replaceState(
+        window.history.state,
+        "",
+        `${window.location.pathname}${window.location.search}`,
+      );
+      return;
+    }
+    void fetch("/api/admin/session").then(async (response) => {
+      if (response.ok) setSession((await response.json()) as AdminSession);
+    });
+  }, [enrollment]);
+
+  const run = async (action: () => Promise<void>) => {
+    setBusy(true);
+    setMessage(null);
+    try {
+      await action();
+    } catch {
+      setMessage("Authentication failed. Try again with the same environment and passkey.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (enrollment) {
+    return (
+      <AdminCard
+        title="Enroll Technical Admin"
+        description="Register the sole passkey for this environment."
+      >
+        <p className="text-sm text-muted-foreground">
+          The enrollment authorization is single-use and expires after ten minutes.
+        </p>
+        <Button
+          disabled={busy || enrollmentToken === null}
+          onClick={() =>
+            void run(async () => {
+              if (enrollmentToken === null) throw new Error("Missing enrollment authorization.");
+              const optionsResponse = await fetch("/api/admin/enrollment/options", {
+                method: "POST",
+                headers: { "content-type": "application/json" },
+                body: JSON.stringify({ token: enrollmentToken }),
+              });
+              if (!optionsResponse.ok) throw new Error("Enrollment is unavailable.");
+              const options = (await optionsResponse.json()) as RegistrationOptionsResponse;
+              const credential = await createCredential(options);
+              const complete = await fetch("/api/admin/enrollment/complete", {
+                method: "POST",
+                headers: { "content-type": "application/json" },
+                body: JSON.stringify({
+                  challengeId: options.challengeId,
+                  response: serializeCredential(credential),
+                }),
+              });
+              if (!complete.ok) throw new Error("Enrollment failed.");
+              window.location.assign("/admin");
+            })
+          }
+        >
+          {busy ? "Waiting for passkey…" : "Register passkey"}
+        </Button>
+        {message ? <p className="text-sm text-destructive">{message}</p> : null}
+      </AdminCard>
+    );
+  }
+
+  if (session === null) {
+    return (
+      <AdminCard title="Technical Admin" description="Passkey authentication is required.">
+        <Button
+          disabled={busy}
+          onClick={() =>
+            void run(async () => {
+              const optionsResponse = await fetch("/api/admin/authentication/options", {
+                method: "POST",
+              });
+              if (!optionsResponse.ok) throw new Error("Sign-in unavailable.");
+              const options = (await optionsResponse.json()) as AuthenticationOptionsResponse;
+              const credential = await getCredential(options);
+              const complete = await fetch("/api/admin/authentication/complete", {
+                method: "POST",
+                headers: { "content-type": "application/json" },
+                body: JSON.stringify({
+                  challengeId: options.challengeId,
+                  response: serializeCredential(credential),
+                }),
+              });
+              if (!complete.ok) throw new Error("Sign-in failed.");
+              const sessionResponse = await fetch("/api/admin/session");
+              if (!sessionResponse.ok) throw new Error("Session was not created.");
+              setSession((await sessionResponse.json()) as AdminSession);
+            })
+          }
+        >
+          {busy ? "Waiting for passkey…" : "Sign in with passkey"}
+        </Button>
+        {message ? <p className="text-sm text-destructive">{message}</p> : null}
+      </AdminCard>
+    );
+  }
+
+  return (
+    <AdminCard
+      title="Technical Admin administration"
+      description={`Authenticated in the ${session.environment} environment.`}
+    >
+      <p className="text-sm text-muted-foreground">
+        Event administration is available from this protected shell.
+      </p>
+      <Button
+        variant="outline"
+        onClick={() =>
+          void run(async () => {
+            await fetch("/api/admin/logout", { method: "POST" });
+            setSession(null);
+          })
+        }
+      >
+        Sign out
+      </Button>
+    </AdminCard>
+  );
+}
+
+function AdminCard({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description: string;
+  children: ReactNode;
+}) {
+  return (
+    <main className="mx-auto flex min-h-screen w-full max-w-xl items-center justify-center p-4">
+      <Card className="w-full">
+        <CardHeader>
+          <CardTitle>{title}</CardTitle>
+          <CardDescription>{description}</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">{children}</CardContent>
+      </Card>
+    </main>
+  );
+}
+
+type RegistrationOptionsResponse = {
+  challengeId: string;
+  challenge: string;
+  rp: { id: string; name: string };
+  user: { id: string; name: string; displayName: string };
+  timeout: number;
+  attestation: "none";
+  authenticatorSelection: { residentKey: "required"; userVerification: "required" };
+};
+
+type AuthenticationOptionsResponse = {
+  challengeId: string;
+  challenge: string;
+  rpId: string;
+  allowCredentials: Array<{ id: string; type: "public-key" }>;
+  timeout: number;
+  userVerification: "required";
+};
+
+async function createCredential(options: RegistrationOptionsResponse) {
+  if (!window.PublicKeyCredential || !navigator.credentials.create)
+    throw new Error("WebAuthn unavailable.");
+  const credential = await navigator.credentials.create({
+    publicKey: {
+      ...options,
+      challenge: decode(options.challenge),
+      user: { ...options.user, id: decode(options.user.id) },
+      pubKeyCredParams: [{ type: "public-key", alg: -7 }],
+    },
+  });
+  if (!(credential instanceof PublicKeyCredential)) throw new Error("No passkey returned.");
+  return credential;
+}
+
+async function getCredential(options: AuthenticationOptionsResponse) {
+  if (!window.PublicKeyCredential || !navigator.credentials.get)
+    throw new Error("WebAuthn unavailable.");
+  const credential = await navigator.credentials.get({
+    publicKey: {
+      ...options,
+      challenge: decode(options.challenge),
+      allowCredentials: options.allowCredentials.map((item) => ({ ...item, id: decode(item.id) })),
+    },
+  });
+  if (!(credential instanceof PublicKeyCredential)) throw new Error("No passkey returned.");
+  return credential;
+}
+
+function serializeCredential(credential: PublicKeyCredential) {
+  const response = credential.response;
+  const common = { clientDataJSON: encode(new Uint8Array(response.clientDataJSON)) };
+  if ("attestationObject" in response) {
+    const registration = response as AuthenticatorAttestationResponse;
+    return {
+      id: credential.id,
+      type: credential.type,
+      response: {
+        ...common,
+        attestationObject: encode(new Uint8Array(registration.attestationObject)),
+      },
+    };
+  }
+  const assertion = response as AuthenticatorAssertionResponse;
+  return {
+    id: credential.id,
+    type: credential.type,
+    response: {
+      ...common,
+      authenticatorData: encode(new Uint8Array(assertion.authenticatorData)),
+      signature: encode(new Uint8Array(assertion.signature)),
+    },
+  };
+}
+
+function encode(value: Uint8Array) {
+  return btoa(String.fromCharCode(...value))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/u, "");
+}
+function decode(value: string) {
+  const padded = value.replace(/-/g, "+").replace(/_/g, "/") + "===".slice((value.length + 3) % 4);
+  const binary = atob(padded);
+  return Uint8Array.from(binary, (character) => character.charCodeAt(0));
+}


### PR DESCRIPTION
## What changed

This implements [issue #106](https://github.com/netzhuffle/quadball-timer/issues/106), based on the [parent event-administration specification #105](https://github.com/netzhuffle/quadball-timer/issues/105):

- Added Technical Admin enrollment and passkey sign-in flows with a deep `TechnicalAdminAuth` interface.
- Added strict origin, RP ID, WebAuthn challenge, user-verification, credential, signature, and authenticator-counter validation.
- Added single-use enrollment authorization, ceremony challenges, bounded sessions, logout, and generic fail-closed storage/error handling.
- Added `/admin/enroll` and `/admin` browser flows, ephemeral enrollment-fragment handling, and real Chromium virtual-authenticator coverage.
- Centralized runtime and CLI configuration, including the TLS test-server seam.

## Why it changed

Event administration needs a secure, host-local way to enroll and authenticate a Technical Admin without introducing a shallow facade over the authentication domain. The implementation keeps repository and WebAuthn concerns behind stable interfaces, rejects replay and environment/origin/RP mismatches, and contains storage failures without acknowledging state or leaking uncontrolled errors.

## User and developer impact

Technical Admins can enroll one discoverable passkey from a host-local enrollment URL and use it to sign in to the administration area. Enrollment fragments are scrubbed from the current URL before registration and retained only ephemerally in memory. Developers get deterministic interface-level tests plus a real browser virtual-authenticator scenario for the end-to-end ceremony.

## Validation

- `bun run check` passed (Bun version, formatting, Oxlint type-aware/type-check, and ShellCheck).
- `bun run test` passed: 289 tests, 0 failures, 14,000 assertions.
- `bun run build` passed.
- Focused Technical Admin auth contract passed: 8 tests, 0 failures, 43 assertions.
- `bun run test:focused:technical-admin-browser` passed: 1 real Chromium virtual-authenticator scenario covering enrollment, authentication, pre-registration fragment scrubbing, and replay rejection.

