### PR TITLE
Accept authorized control actions atomically

### DIFF
--- a/docs/agents/issue-79-authority-prerequisite-handoff.md
+++ b/docs/agents/issue-79-authority-prerequisite-handoff.md
@@ -1,0 +1,49 @@
+# Issue #79 authority prerequisite handoff
+
+This prerequisite starts from `15efaf351918b9f3635fb2421ac5b3afbd9ef412` and
+owns only the acceptance authority/preflight/action-transaction seam plus its
+adversarial and focused SQLite authority tests. It is not a complete #79/#70
+implementation.
+
+## Completed boundary
+
+- Authorized missing or mismatched roots prepare every codec/envelope through
+  the read-only preflight and return `record-not-found` without changing Grant,
+  Session, audit, budget, or metadata state.
+- Transaction-local preparation drift is compared before replay, budget,
+  sporting, metadata, audit, or session-activity writes and returns the exact
+  `retry-later` / `stale-preflight` boundary.
+- Focused SQLite coverage includes synchronized full `rotateControlGrant`
+  rejection of the old session/version with no action or audit, while retained
+  credential-key rotation remains accepted maintenance.
+
+## Evidence
+
+- `bun install --frozen-lockfile`: passed, no changes.
+- `bun audit`: passed, no vulnerabilities.
+- `bun run check`: passed.
+- `bun test --isolate`: 291 passed, 0 failed.
+- `bun test --isolate src/lib/foundation-acceptance-adversarial.test.ts`: 9 passed, 0 failed, 57 assertions.
+- `bun run test:focused:grant`: 36 passed, 0 failed.
+- `bun run test:focused:sqlite`: 21 passed, 0 failed.
+- `bun run test:focused:acceptance`: 5 passed, 0 failed, 61 assertions.
+- `bun run build`: passed.
+- `bun run build:executable`: passed (`bun-linux-x64-modern`).
+- `git diff --check`: passed.
+
+Qualification tests and `bun run check:sqlite-runtime` were not run. No storage,
+schema, integrity, migration, issue, PR, push, or integration changes were
+made. The containing prerequisite commit is the handoff commit.
+
+The locked-discard lookup was only renamed to carry the trusted preflight root
+through the reordered authority check; its helper and retention semantics were
+not redesigned.
+
+## Correction attempt 1
+
+The authority ordering was tightened after review: ordinary online and replay
+paths authenticate read-only before any root lookup, while the trusted lock
+path verifies only the claimed Event Game, origin, evidence, and action count
+before loading and validating the locked root. Root-read spy/throw negatives
+cover invalid ordinary bearers and invalid lock evidence. The containing
+amended commit is the authoritative correction commit.

--- a/docs/agents/issue-79-design-gate.md
+++ b/docs/agents/issue-79-design-gate.md
@@ -1,0 +1,105 @@
+# Issue #79 design gate
+
+This is the internal design gate for the fresh composed acceptance seam. It is
+deliberately kept at the module boundary: Grant owns authority, Event Game
+Record owns sporting state and ordering, and the acceptance seam owns only the
+composition, durable acceptance bookkeeping, and cross-module evidence links.
+
+## Invariant and state-transition table
+
+| State or invariant            | Allowed transition                    | Guard and observable evidence                                                                                                                                                     |
+| ----------------------------- | ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Structural batch is untrusted | `untrusted -> prepared`               | Count/bytes, envelope identity, unique operation IDs, and acyclic causal graph pass before a write transaction; one read-only authorized preflight then validates every codec and payload before any reservation, budget, action, or audit mutation. |
+| Action has no durable outcome | `pending -> accepted`                 | Current Grant/session/version/scope/Event Game/lifecycle/lock/causality/payload/rate/replay checks pass; action, metadata, Control audit, and paired Grant audit commit together. |
+| Action has no durable outcome | `pending -> duplicate-accepted`       | Same permanent operation ID and content fingerprint; current authority still passes; a new linked duplicate audit is committed without a second action.                           |
+| Action has no durable outcome | `pending -> rejected`                 | Current authority and snapshot pass, then payload/dependency/conflict/correction validation fails; paired rejection audits commit atomically.                                     |
+| Action has no durable outcome | `pending -> dependency-blocked`       | A causal predecessor has a definitive non-commit result; the dependent still gets current authorization and paired blocked evidence.                                              |
+| Action has no durable outcome | `pending -> retry-later`              | Storage/scope/budget is temporarily unavailable; no sporting mutation or acknowledgement is produced.                                                                             |
+| Action has no durable outcome | `pending -> authority-expired`        | Current authority, relationship, lifecycle, or lock check fails; no sporting mutation is produced.                                                                                |
+| Replay reservation            | `reserved -> committing -> committed` | Reservation/attempts are durable; a receipt is returned only after every action has a definitive committed outcome.                                                               |
+| Replay reservation            | `reserved/partial -> reserved`        | A retry-later or transaction failure leaves work resumable and does not acknowledge unprocessed content.                                                                          |
+| Replay reservation after lock | `reserved/partial -> discarded`       | Trusted lock seam records exactly count/session/Event Game/rejection time; no rejected content, replay identifier, fingerprint, original timestamp, receipt, attempt, or extra authorization provenance. Committed/acknowledged work remains intact. |
+| Replay receipt                | `committed -> acknowledged`           | Only a stored digest derived from server-held key material is accepted; acknowledgement is allowed without re-authorizing the already committed replay.                           |
+| Durable evidence              | `valid -> frozen`                     | Monotonic keyed anchors authenticate every budget/reservation/attempt/receipt revision and exact cardinality; canonical result JSON is bound to its operation/status/audits, and corruption, mutation, deletion, or cascade loss freezes memory and SQLite writes. |
+| Rejected candidate evidence   | `candidate -> authenticated outcome`  | Every rejected candidate, including collision evidence, retains canonical JSON plus its codec fingerprint; readiness recomputes the exact SHA-256 content fingerprint and requires equality across candidate, Control linkage, Grant evidence, and replay attempt. |
+| Rejection contract            | `adapter reason -> finite reason`     | Adapter replay-ineligibility reasons are normalized before persistence. Durable Grant evidence authenticates exact status, finite reason, and redacted detail; impossible status/reason pairs or coordinated tampering freeze memory and SQLite. |
+| Online outcome recovery       | `durable outcome -> exact replayed response` | Repeated identical duplicate, rejection, and operation-conflict submissions recover the existing paired Control/Grant outcome without deterministic-ID collision or extra evidence; the result remains exact after restart. |
+| Codec preparation identity    | `claimed kind/version -> durable codec identity` | Failed or unknown preparation records the canonical registry-derived claimed kind/version identity, never a sentinel; readiness validates identity, canonical content, and recomputed SHA-256 equality. |
+| Prepared budget retry         | `rate-budget -> accepted after refill` | Budget exhaustion occurs only after preparation and retains the same prepared input/canonical candidate; after refill an identical online retry commits with matching evidence. |
+| Replay pre-reservation recovery | `durable definitive rejection -> exact replay response` | An identical authorized replay that previously ended in replay-ineligible or invalid-action before reservation creation reuses the paired outcome, including after restart, without creating a reservation or receipt. |
+| Authorized root-missing preparation | `authorized -> generic-structural-outcome` | After trusted read-only Grant authorization, every codec envelope and payload is prepared before returning an authorized result even when the Event Game root is absent or mismatched; root-dependent semantics are not disclosed and no reservation, budget, action, or audit row is written. |
+| Transaction-local preparation | `preflight -> current-commit decision` | Every action write transaction prepares the raw action again against its transaction-local current root and requires canonical content, fingerprint, interpretation, and lifecycle equality with preflight before any replay, budget, sporting, metadata, or audit write. |
+| Trusted lock discard authority | `reserved/partial -> discarded` | A separate trusted Game Lock capability is checked before ordinary bearer lookup; only an already reserved/partial exact record/Event Game/originating-session tuple can be discarded, and an ordinary caller cannot reach this seam. |
+| Discard retention boundary | `discarded -> retained tuple` | Locked discard retains only count, originatingSessionId, eventGameId, and rejectedAtMs in its durable evidence; reservation/replay identifiers, timestamps, content, receipts, attempts, and orphan anchors are removed, with no replay identifier returned and repeated trusted calls idempotent. |
+| Historical integrity continuity | `revision 1..N` | Every live acceptance subject has exactly one authenticated canonical anchor for each contiguous revision from 1 through N; every anchor is re-authenticated from its stored canonical evidence, and any missing, mutated, extra, or orphan anchor freezes memory and SQLite writes. |
+| Independent authority races | `preflight -> synchronized writer barrier` | Focused SQLite tests use independent connections synchronized at the transaction boundary for revocation, key rotation, expiry, scope change, and Game Lock; failed authority has exact typed results and no audit, while neighboring authorized writes succeed. |
+
+Cross-cutting invariants: no authorization failure discloses action enumeration,
+receipt existence, or another session's receipt; bearer/capability plaintext is
+never persisted; online and replay budgets use separate durable bucket kinds;
+caller-order results are returned even when execution follows topological order;
+and every definitive non-lock result has exactly one Control audit linked to one
+Grant audit.
+
+## Transaction ownership and trust boundaries
+
+| Boundary                 | Owner                   | Untrusted input / trusted evidence                      | Atomic responsibility                                                                                                            |
+| ------------------------ | ----------------------- | ------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| Structural seam          | Acceptance              | Raw batch, codec registry, clock                        | No writes; creates prepared actions and a topological plan only.                                                                 |
+| Grant authority          | Grant module            | Session bearer supplied to the seam                     | Revalidates bearer lookup, grant state, version, session lifecycle, expiry, and event binding inside the acceptance transaction. |
+| External scope           | Event Game integration  | Resolver result                                         | Resolves and compares the scope snapshot inside the same storage transaction.                                                    |
+| Event Game Record        | Event Game module       | Prepared action and current root                        | Revalidates lock/lifecycle/causality/payload and owns action, idempotency, and ordering metadata.                                |
+| Durable acceptance state | Storage adapter         | Reservation IDs, fingerprints, budget subjects, digests | Serializes budgets and replay lifecycle across instances; never stores raw receipts or bearers.                                  |
+| Lock discard seam        | Trusted internal caller | Independently verified lock evidence                    | May write only the exact redacted lock discard tuple; it is not a substitute for online authorization.                           |
+| Acknowledgement          | Acceptance/storage      | Opaque receipt presented by caller                      | Matches only a keyed digest and committed receipt; does not enumerate or authorize a reservation.                                |
+
+## Migration and upgrade matrix
+
+| Database state                                                             | Expected result                                                                                                             | Verification                                                                  |
+| -------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| Current main schema 016                                                    | Candidate-only migrations 017 and 018 may be appended coherently; preserve all 001–016 checksums and behavior.             | Fresh migration and reopen readiness report schema 18.                        |
+| Fresh disposable candidate                                                 | Candidate migrations validate before production migration and remain unpublished drafts.                                  | Candidate readiness plus no surviving candidate file.                         |
+| Already-ledgered 001–016 database                                          | Apply 017 then 018 and remain readable/writable.                                                                            | Upgrade/reopen storage and acceptance tests.                                  |
+| Missing, reordered, changed, incomplete, future, or tampered ledger/schema | Refuse authoritative writes.                                                                                                | Existing migration/readiness failure matrix plus new acceptance-state checks. |
+| #78 later renumbering                                                      | Keep migration identity and SQL append-only so mechanical renumbering can update ordinal/version without rewriting 001–018. | Migration checksum/ledger tests and documented handoff boundary.              |
+
+## #79 acceptance-test matrix
+
+| Criterion                                | Observable result / negative control                                                                                                                                                       |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Composed Grant + scope + Event Game seam | One transaction produces an action and both audit owners' linked evidence; a mismatched scope is retry-later with no row.                                                                  |
+| Whole-batch structural validation        | Oversized, duplicate-ID, envelope-mismatch, and cyclic batches produce zero writes; invalid codec/payload outcomes are evaluated only after current authorization and are paired evidence. |
+| Per-action outcomes                      | Focused suite asserts accepted, duplicate, rejected, dependency-blocked, retry-later, and authority-expired results.                                                                       |
+| Only causal dependants block             | A rejected predecessor blocks its descendant while an unrelated later action commits.                                                                                                      |
+| Revalidation at every action transaction | Revocation/rotation/expiry/lock/scope/version/causality/payload/rate/replay negative controls show no stale acceptance.                                                                    |
+| Atomic action/evidence/metadata          | Read-back finds action, idempotency, metadata, Control audit, and paired Grant audit together; injected boundary failures leave none.                                                      |
+| Failure after every boundary             | Failure injection after action, metadata, Control audit, Grant audit, and receipt boundaries rolls the transaction back and returns retry-later/no receipt.                                |
+| Authority/lifecycle races                | Independent writers yield exactly one accepted-or-authority-expired result and no sporting effect after the losing transition.                                                             |
+| Duplicate/conflict SQLite races          | Two independent SQLite connections and `Promise.all` produce one permanent content-bound action; same content duplicates, different content conflicts.                                     |
+| Locked replay                            | Trusted lock seam returns discard and read-back exposes only count/session/Event Game/time; invalid trust evidence cannot discard.                                                         |
+| Durable budgets                          | Restart and independent adapters retain online-session, online-event, and replay buckets separately and return retry guidance at sustained/burst limits.                                   |
+| Replay reservation/receipt               | Partial work returns no receipt; retry resumes/returns exact outcomes; receipt acknowledgement remains possible after authority rotation/revocation/expiry.                                |
+| No raw capability at rest                | Database inspection shows only keyed lookup verifiers/digests and no supplied bearer or receipt plaintext.                                                                                 |
+| Corrupt-state freeze                     | Tampered/deleted reservation, receipt, attempt, or linked audit fails readiness and rejects both memory and SQLite writes.                                                                 |
+| Rejected evidence integrity              | Non-canonical candidate JSON, recomputed-fingerprint mismatch, collision-candidate mismatch, raw adapter reason, or impossible status/reason fails readiness and rejects both memory and SQLite writes. |
+| Final correction recovery                | Third same-content submission, repeated operation conflict/rejection, close/reopen recovery, unsupported codec/version, budget exhaustion/refill, and throwing/sensitive/oversized replay callbacks produce exact bounded durable outcomes in memory and SQLite. |
+
+The clean-correction acceptance additions are explicit gates, not inferred from
+the original rows:
+
+| Clean-correction gate           | Required proof                                                                                                                                                                                                                  |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Authorization-before-disclosure | Invalid bearer is checked before root, scope, lock, codec, payload, or reservation inspection; structurally invalid batches remain write-free.                                                                                  |
+| Whole-batch envelope identity   | Record/Event Game, Grant session/version, lifecycle, recovery provenance, duplicate IDs, and causal graph consistency are checked before any acceptance mutation.                                                               |
+| Resumable replay                | Reservations bind to the authenticated replacement session; exact completed attempts are skipped before budgets; retry-later predecessors remain retryable; receipts require all definitive attempts.                           |
+| Trusted lock discard            | Only a verified lock seam can create/discard a replay reservation; digest, replacement provenance, attempts, receipts, and replay contents are erased, with idempotent repeat.                                                  |
+| Control audit integrity         | Control-use/outcome Grant audit actions are paired in both directions and acceptance/link/action fingerprints and outcome fields are included in keyed integrity evidence.                                                      |
+| Durable readiness               | Memory and SQLite reconstruct attempt/result/timestamp/status transitions and freeze writes for missing, extra, orphaned, deleted, or coordinated acceptance evidence.                                                          |
+| Independent budgets and races   | Session and Event Game buckets consume independently; online/replay buckets remain separate; synchronized independent SQLite revocation, rotation, expiry, scope, lock, duplicate, and conflict controls produce exact reasons. |
+| Receipt key rotation            | Receipt stores only a digest and lookup-key version; restart/retry reconstructs the same opaque receipt from retained key material after lookup-key rotation. |
+
+## Gate decision
+
+The design is acceptable only when every row above has a named ordinary test or
+existing invariant check, and the final handoff records the exact commands and
+commit. Any failed adversarial check is a redesign trigger, not a waived test.

--- a/docs/agents/issue-79-handoff.md
+++ b/docs/agents/issue-79-handoff.md
@@ -1,0 +1,57 @@
+# Issue #79 handoff
+
+This is the final thin composition correction for #79: a headless acceptance
+seam over the existing Grant and Event Game modules. It does not change public
+routes, queues, WebSockets, Controller UI, or Grant Code admission. The
+authoritative invariant, ownership, migration, and acceptance matrix is
+[`issue-79-design-gate.md`](./issue-79-design-gate.md); this file is only the
+compact coordinator handoff.
+
+## Exact composition
+
+- Starting candidate: `e66a99946a87de05c096d84c22b8555c7d2b5012`.
+- Accepted authority prerequisite source: `be24d38c66a2f0315e619098ae460e54ef6dd166`; applied here as `400d85d`.
+- Included cumulative #79 candidate ancestors: `1c3136cce87fe2c0fd551a4080c4bdb0a592bfe7`, `e7f95b2cb143b682fab4db8cb8a7c501c377aa30`, `c32feedde809faeae5cea045fb7fc267549db199`, `1b657472b077e64e0d03be63d337bd6b55acfc8e`, and `e66a99946a87de05c096d84c22b8555c7d2b5012`.
+- Final composition commit: this commit; the coordinator should record its exact SHA from the handoff message.
+- Correction scope: exact online outcome recovery for duplicate/rejection/conflict, canonical claimed codec identity for failed preparation, prepared budget retry after refill, and unconditional bounded replay-ineligibility normalization.
+
+## Final gates closed
+
+- Authority and capability checks precede root, scope, codec, payload, and
+  reservation disclosure; missing-root and stale-preflight paths are
+  mutation-free, and each write transaction reprepares against its local root.
+- Replay reservations, receipts, attempts, budgets, anchors, and paired
+  Control↔Grant evidence retain exact durable transitions, redaction, recovery,
+  and rotation behavior. Locked discard retains only the required redacted
+  tuple and is idempotent.
+- Every rejected candidate, including collision evidence, retains canonical
+  content and codec identity/fingerprint. Readiness recomputes the exact
+  established SHA-256 fingerprint and requires equality across candidate,
+  Control, Grant, and replay evidence. Unsupported kinds retain their claimed
+  registered/versioned identity and never use `unprepared`.
+- Repeated identical online duplicate, rejection, and operation-conflict
+  submissions recover the exact existing paired outcome without appending
+  deterministic-ID-colliding evidence; this remains true after SQLite restart.
+- Rate-budget rejection is recorded only after preparation with its prepared
+  input; after refill, the identical action resumes as accepted. Replay
+  adapters cannot persist callback reason/detail, including on throw: all
+  ineligible outcomes use the finite `replay-ineligible` reason and bounded
+  redacted detail.
+- Authorized replay retries of a prior definitive replay-ineligible or
+  unsupported-codec rejection recover that exact paired outcome before
+  reservation creation, including after SQLite restart; no receipt or
+  reservation is created for the rejected branch.
+- Rejection reasons use one finite durable contract. Adapter-supplied replay
+  reasons are normalized before persistence; Grant HMAC evidence binds exact
+  status, reason, and detail, and impossible combinations freeze both adapters.
+- Migrations 001–016 are unchanged. Candidate migrations 017–018 remain
+  unpublished drafts and are not production migration commands.
+
+## Verification evidence
+
+The coordinator’s completion message records the exact commands and final
+results for frozen install, audit, check, Fast, focused acceptance/Grant/SQLite,
+both builds, and diff checks. Qualification tests and
+`bun run check:sqlite-runtime` are intentionally excluded. No push, pull
+request, issue mutation, or integration onto
+`codex/durable-control-foundations` was performed.

--- a/docs/agents/issue-79-ledger-prerequisite-handoff.md
+++ b/docs/agents/issue-79-ledger-prerequisite-handoff.md
@@ -1,0 +1,55 @@
+# Issue 79 ledger prerequisite handoff
+
+Base: `15efaf351918b9f3635fb2421ac5b3afbd9ef412`
+
+This prerequisite owns the FoundationStorage acceptance-state seam, memory/SQLite
+integrity readiness, and the locked-discard capability/lookup path. It does not
+implement ordinary preflight, missing-root authorization/activity, transaction-
+local codec/lifecycle preparation, or authority race orchestration.
+
+Implemented:
+
+- trusted locked replay verification receives and binds the canonical batch digest;
+  memory and SQLite reservation lookup require the same digest and fail closed on
+  ambiguous same-digest replacement-session matches. Exact live reservations take
+  precedence over the permanent four-field discard audit, and a different live
+  replacement reservation cannot be erased by tuple-only idempotency;
+- committed and acknowledged exact reservations recover their durable per-action
+  results and receipt key version after a lost response, including after Game Lock
+  and lookup-key rotation;
+- locked discard retains only the redacted count/session/game/timestamp tuple in
+  the Control audit and removes reservation, attempt, receipt, and integrity-anchor
+  state without returning a replay identifier;
+- paired Control/Grant acceptance evidence is checked bidirectionally for identity,
+  action kind, outcome/detail, acceptance ID, content fingerprint, and replay
+  attempt/result semantics. Stored replay responses now require an exact
+  status-specific canonical shape, and accepted/duplicate or rejected collision
+  fingerprints are cross-checked against durable action/idempotency evidence;
+- every paired online or replay acceptance carries independent Control-side
+  fingerprint and rejected-candidate evidence. Accepted/duplicate pairs resolve
+  against retained action plus idempotency rows; rejected pairs resolve against
+  canonical candidate/collision evidence. Nonaccepted stored results enforce the
+  exact supported status/reason discriminants and audit detail;
+- acceptance anchors authenticate their canonical live state, and readiness rejects
+  missing, gapped, extra, orphaned, or semantically retargeted history while
+  retaining key-rotation recovery.
+
+Verification completed:
+
+- `bun install --frozen-lockfile`
+- `bun audit`
+- `bun run check`
+- Fast acceptance/adversarial/storage tests
+- `bun run test:focused:acceptance`
+- `bun run test:focused:grant`
+- `bun run test:focused:sqlite`
+- `bun run build`
+- `bun run build:executable`
+- `git diff --check`
+
+The correction-specific suite includes 290 Fast tests, 7 focused SQLite
+acceptance tests, and memory/SQLite coordinated online fingerprint mismatch
+negative controls. The previously fixed exact-reservation, lock-recovery,
+receipt-rotation, result-shape, redaction, and anchor tests remain green.
+
+Qualification commands, including `bun run check:sqlite-runtime`, were not run.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test:focused-admission": "bun scripts/test-focused-admission.ts",
     "test": "bun test --isolate",
     "test:focused:sqlite": "bun test --isolate ./src/lib/event-game-actions-sqlite.focused.ts",
+    "test:focused:acceptance": "bun test --isolate ./src/lib/foundation-acceptance-sqlite.focused.ts",
     "test:focused:grant": "bun test ./src/lib/grant-authority.focused.ts",
     "test:changed": "bun test --changed",
     "format": "bunx --bun oxfmt \"**/*.{js,jsx,ts,tsx,mjs,cjs}\" \"!docs/**\"",

--- a/src/lib/event-game-actions-sqlite.focused.ts
+++ b/src/lib/event-game-actions-sqlite.focused.ts
@@ -922,7 +922,7 @@ describe("SQLite immutable Event Game actions", () => {
       database.close();
 
       const current = openSqliteFoundationStorage(databasePath);
-      expect((await current.applyMigrations()).schemaVersion).toBe(16);
+      expect((await current.applyMigrations()).schemaVersion).toBe(18);
       const currentRecord = createRecord(current, root);
       expect(await currentRecord.registerRoot(root)).toMatchObject({ status: "idempotent" });
       expect(await currentRecord.readiness()).toMatchObject({ ok: true, actionCount: 1 });
@@ -937,7 +937,7 @@ describe("SQLite immutable Event Game actions", () => {
       await seedLegacyConflictHistory(databasePath, root);
 
       const storage = openSqliteFoundationStorage(databasePath);
-      expect((await storage.applyMigrations()).schemaVersion).toBe(16);
+      expect((await storage.applyMigrations()).schemaVersion).toBe(18);
       const record = createRecord(storage, root);
       expect(await record.registerRoot(root)).toMatchObject({ status: "idempotent" });
       expect(await record.readiness()).toMatchObject({ ok: true, actionCount: 3 });
@@ -958,7 +958,7 @@ describe("SQLite immutable Event Game actions", () => {
       await seedLegacyConflictHistory(databasePath, root);
 
       const storage = openSqliteFoundationStorage(databasePath);
-      expect((await storage.applyMigrations()).schemaVersion).toBe(16);
+      expect((await storage.applyMigrations()).schemaVersion).toBe(18);
       const record = createRecord(storage, root);
       expect(await record.registerRoot(root)).toMatchObject({ status: "idempotent" });
       expect(

--- a/src/lib/event-game-actions.test.ts
+++ b/src/lib/event-game-actions.test.ts
@@ -525,6 +525,14 @@ async function readSnapshot(
     findSessionByBearerVerifier: () => null,
     listGrantSessions: () => [],
     listGrantAudit: () => [],
+    findAcceptanceBudget: () => null,
+    findReplayReservation: () => null,
+    findReplayReservationByTuple: () => null,
+    findReplayReservationByOriginTuple: () => null,
+    listReplayAttempts: () => [],
+    findReplayReceiptByDigest: () => null,
+    findReplayReceiptByReservationId: () => null,
+    listAcceptanceIntegrityAnchors: () => [],
   };
 }
 

--- a/src/lib/event-game-actions.ts
+++ b/src/lib/event-game-actions.ts
@@ -14,6 +14,7 @@ import {
   validateOverride,
   validatePredecessors,
   validateRecoveryProvenance,
+  validateRecoveryProvenanceShape,
   validateStoredInput,
   validateTimestamp,
   valid,
@@ -133,6 +134,8 @@ export type ControlAuditCollisionEvidence = {
   acceptedContentFingerprint: string;
   rejectedAttempt: {
     input: ControlActionInput;
+    codecIdentity?: string;
+    codecFingerprint?: string;
     canonicalContent: string;
     contentFingerprint: string;
     interpretation: ControlActionInterpretation;
@@ -148,6 +151,19 @@ export type ControlAuditLinkage = {
     trustedAtMs: number;
     operationId: string;
   } | null;
+  grantAuditId?: string | null;
+  acceptanceId?: string | null;
+  /** Acceptance-owned candidate identity, paired independently from Grant evidence. */
+  contentFingerprint?: string;
+  /** Acceptance-owned status discriminant for non-accepted outcomes. */
+  reason?: string;
+  /** Canonical rejected candidate retained independently from Grant evidence. */
+  rejectedCandidate?: {
+    codecIdentity: string;
+    codecFingerprint: string;
+    canonicalContent: string;
+    contentFingerprint: string;
+  };
   collision?: ControlAuditCollisionEvidence;
 };
 
@@ -193,6 +209,12 @@ export type ControlAuditEntry = {
   redactedDetail: string;
   links?: ControlAuditLinkage;
   provenance?: ControlAuditProvenance;
+  lockedReplay?: {
+    count: number;
+    originatingSessionId: string;
+    eventGameId: string;
+    rejectedAtMs: number;
+  };
 };
 
 export type EventGameRecordMetadata = {
@@ -253,12 +275,83 @@ export type ControlActionCodecRegistry = {
   entries(): readonly ControlActionCodec[];
 };
 
+export function controlActionCodecIdentity(
+  kind: { id: string; version: string },
+  registry: ControlActionCodecRegistry,
+): string {
+  const codec = registry.resolve(kind.id, kind.version);
+  return canonicalizeJson({
+    schema: "control-codec-identity-v1",
+    claimed: { id: kind.id, version: kind.version },
+    registered: codec === undefined ? null : { id: codec.kind, version: codec.version },
+  });
+}
+
 export type PreparedControlAction = {
   input: ControlActionInput;
+  codecIdentity: string;
+  codecFingerprint: string;
   canonicalContent: string;
   contentFingerprint: string;
   interpretation: ControlActionInterpretation;
 };
+
+/**
+ * The portion of an action that can be inspected before Grant authorization.
+ * Payload decoding, codec lookup, interpretation, and root-dependent checks
+ * deliberately do not belong here.
+ */
+export type ControlActionEnvelope = Omit<ControlActionInput, "payload"> & {
+  payload: unknown;
+};
+
+export function validateControlActionEnvelope(
+  input: unknown,
+  serverNowMs: number,
+): ValidationResult<ControlActionEnvelope> {
+  if (!isRecord(input)) return invalid("Control Action must be an object.");
+  const recordId = validateId(input.recordId, "recordId");
+  const eventGameId = validateId(input.eventGameId, "eventGameId");
+  const operationId = validateId(input.operationId, "operationId");
+  if (!recordId.ok) return recordId;
+  if (!eventGameId.ok) return eventGameId;
+  if (!operationId.ok) return operationId;
+
+  // Keep codec identity opaque at this boundary. In particular, resolving an
+  // unknown codec must not allow an invalid bearer to learn anything about it.
+  if (!isRecord(input.kind)) return invalid("Control Action kind must be an object.");
+  const kind = {
+    id: typeof input.kind.id === "string" ? input.kind.id : String(input.kind.id),
+    version:
+      typeof input.kind.version === "string" ? input.kind.version : String(input.kind.version),
+  };
+  const predecessors = validatePredecessors(input.causalPredecessorIds);
+  const occurrence = validateOccurrence(input.occurrence, serverNowMs);
+  const grant = validateGrant(input.grant);
+  const lifecycle = validateLifecycle(input.lifecycle);
+  const override = validateOverride(input.override);
+  const recovery = validateRecoveryProvenanceShape(input.recoveryProvenance);
+  if (!predecessors.ok) return predecessors;
+  if (!occurrence.ok) return occurrence;
+  if (!grant.ok) return grant;
+  if (!lifecycle.ok) return lifecycle;
+  if (!override.ok) return override;
+  if (!recovery.ok) return recovery;
+
+  return valid({
+    recordId: recordId.value,
+    eventGameId: eventGameId.value,
+    operationId: operationId.value,
+    kind,
+    payload: input.payload,
+    causalPredecessorIds: predecessors.value,
+    occurrence: occurrence.value,
+    grant: grant.value,
+    lifecycle: lifecycle.value,
+    ...(override.value === undefined ? {} : { override: override.value }),
+    ...(recovery.value === undefined ? {} : { recoveryProvenance: recovery.value }),
+  });
+}
 
 export type ActionHistoryReadiness = { ok: true } | { ok: false; detail: string };
 
@@ -286,7 +379,7 @@ export type ActionRebuildResult =
 
 export function prepareControlAction(
   input: unknown,
-  root: EventGameRecordRoot,
+  root: EventGameRecordRoot | null,
   registry: ControlActionCodecRegistry,
   serverNowMs: number,
   options: { allowConcurrentTeamAssignment?: boolean } = {},
@@ -299,25 +392,32 @@ export function prepareControlAction(
   if (!recordId.ok) return recordId;
   if (!eventGameId.ok) return eventGameId;
   if (!operationId.ok) return operationId;
-  if (recordId.value !== root.recordId) return invalid("Control Action references another record.");
-  if (eventGameId.value !== root.eventGameId) {
+  if (root !== null && recordId.value !== root.recordId)
+    return invalid("Control Action references another record.");
+  if (root !== null && eventGameId.value !== root.eventGameId) {
     return invalid("Control Action references another Event Game.");
   }
 
   const kindResult = validateKind(input.kind);
   if (!kindResult.ok) return kindResult;
+  const codecIdentity = controlActionCodecIdentity(kindResult.value, registry);
   const codec = registry.resolve(kindResult.value.id, kindResult.value.version);
   if (codec === undefined) {
     return invalid("The Control Action kind or version is unsupported.");
   }
 
-  const payloadResult = codec.decode(input.payload);
-  if (!payloadResult.ok) return payloadResult;
+  let decodedPayload: unknown;
   let canonicalPayloadValue: ActionJsonValue;
   let canonicalPayload: string;
   let codecFingerprint: string;
   let interpretation: ControlActionInterpretation;
   try {
+    // Codecs are supplied at the acceptance seam and are therefore untrusted
+    // implementations. Keep the complete codec call chain behind one
+    // fail-closed read-only preparation boundary.
+    const payloadResult = codec.decode(input.payload);
+    if (!payloadResult.ok) return payloadResult;
+    decodedPayload = payloadResult.value;
     canonicalPayload = codec.canonicalize(payloadResult.value);
     codecFingerprint = codec.fingerprint(payloadResult.value);
     interpretation = codec.interpret(payloadResult.value);
@@ -333,13 +433,13 @@ export function prepareControlAction(
   }
   const interpretationResult = validateInterpretation(interpretation);
   if (!interpretationResult.ok) return interpretationResult;
-  if (interpretationResult.value.type === "fact") {
+  if (root !== null && interpretationResult.value.type === "fact") {
     const { gameSideId } = interpretationResult.value;
     if (gameSideId !== null && !root.gameSides.some((side) => side.id === gameSideId)) {
       return invalid("Game Fact references an unknown stable Game Side.");
     }
   }
-  if (interpretationResult.value.type === "team-assignment-correction") {
+  if (root !== null && interpretationResult.value.type === "team-assignment-correction") {
     const { gameSideId, eventTeamId } = interpretationResult.value;
     if (!root.gameSides.some((candidate) => candidate.id === gameSideId)) {
       return invalid("Team Assignment Correction references an unknown stable Game Side.");
@@ -362,16 +462,15 @@ export function prepareControlAction(
   if (!grantResult.ok) return grantResult;
   const lifecycleResult = validateLifecycle(input.lifecycle);
   if (!lifecycleResult.ok) return lifecycleResult;
-  if (!sameLifecycle(lifecycleResult.value, root.lifecycle)) {
+  if (root !== null && !sameLifecycle(lifecycleResult.value, root.lifecycle)) {
     return invalid("Control Action lifecycle context is stale.");
   }
   const overrideResult = validateOverride(input.override);
   if (!overrideResult.ok) return overrideResult;
-  const recoveryResult = validateRecoveryProvenance(
-    input.recoveryProvenance,
-    root,
-    operationId.value,
-  );
+  const recoveryResult =
+    root === null
+      ? validateRecoveryProvenanceShape(input.recoveryProvenance)
+      : validateRecoveryProvenance(input.recoveryProvenance, root, operationId.value);
   if (!recoveryResult.ok) return recoveryResult;
 
   const normalizedInput: ControlActionInput = {
@@ -379,7 +478,7 @@ export function prepareControlAction(
     eventGameId: eventGameId.value,
     operationId: operationId.value,
     kind: kindResult.value,
-    payload: structuredClone(payloadResult.value),
+    payload: structuredClone(decodedPayload),
     causalPredecessorIds: predecessorResult.value,
     occurrence: occurrenceResult.value,
     grant: grantResult.value,
@@ -394,6 +493,8 @@ export function prepareControlAction(
   const contentFingerprint = sha256(`${codecFingerprint}:${canonicalContent}`);
   return valid({
     input: normalizedInput,
+    codecIdentity,
+    codecFingerprint,
     canonicalContent,
     contentFingerprint,
     interpretation: interpretationResult.value,

--- a/src/lib/event-game-record-helpers.ts
+++ b/src/lib/event-game-record-helpers.ts
@@ -300,6 +300,30 @@ function validateAuditLinkage(
   if (links === undefined || provenance === undefined) {
     return "Control Audit Trail evidence is missing.";
   }
+  if (entry.lockedReplay !== undefined) {
+    if (
+      entry.kind !== "action-rejected" ||
+      entry.operationId !== null ||
+      entry.outcome !== "rejected" ||
+      links.actionId !== null ||
+      links.targetFactId !== null ||
+      links.causalPredecessorIds.length !== 0 ||
+      links.relatedOperationIds.length !== 0 ||
+      links.ordering !== null ||
+      provenance.occurrence !== null ||
+      provenance.grant !== null ||
+      provenance.lifecycle !== null ||
+      provenance.override !== null ||
+      provenance.recoveryProvenance !== null ||
+      entry.lockedReplay.eventGameId !== root.eventGameId ||
+      entry.lockedReplay.count <= 0 ||
+      entry.lockedReplay.originatingSessionId.length === 0 ||
+      !Number.isSafeInteger(entry.lockedReplay.rejectedAtMs)
+    ) {
+      return "Locked replay discard evidence is inconsistent.";
+    }
+    return null;
+  }
   if (links.ordering === null) return "Control Audit Trail ordering linkage is missing.";
   if (
     entry.operationId !== null &&
@@ -667,6 +691,8 @@ export function createAuditEntry(
               acceptedContentFingerprint: collision.acceptedContentFingerprint,
               rejectedAttempt: {
                 input: structuredClone(rejectedAttempt.input),
+                codecIdentity: rejectedAttempt.codecIdentity,
+                codecFingerprint: rejectedAttempt.codecFingerprint,
                 canonicalContent: rejectedAttempt.canonicalContent,
                 contentFingerprint: rejectedAttempt.contentFingerprint,
                 interpretation: structuredClone(rejectedAttempt.interpretation),
@@ -790,6 +816,12 @@ export function constraintToConflict(
     case "grant-session-verifier":
     case "grant-session-context":
     case "grant-audit-id":
+    case "acceptance-budget-id":
+    case "replay-reservation-id":
+    case "replay-attempt-id":
+    case "replay-receipt-id":
+    case "replay-receipt-digest":
       return "content-conflict";
   }
+  return "content-conflict";
 }

--- a/src/lib/event-game-record.ts
+++ b/src/lib/event-game-record.ts
@@ -281,6 +281,14 @@ export function createEventGameRecord(
         findSessionByBearerVerifier: () => null,
         listGrantSessions: () => [],
         listGrantAudit: () => [],
+        findAcceptanceBudget: () => null,
+        findReplayReservation: () => null,
+        findReplayReservationByTuple: () => null,
+        findReplayReservationByOriginTuple: () => null,
+        listReplayAttempts: () => [],
+        findReplayReceiptByDigest: () => null,
+        findReplayReceiptByReservationId: () => null,
+        listAcceptanceIntegrityAnchors: () => [],
       };
       return rebuildRecordSnapshot(root, snapshot, codecRegistry, options.interpreter);
     } catch (error) {
@@ -800,7 +808,7 @@ export function createEventGameRecord(
   };
 }
 
-function appendConcurrentCorrectionAudits(
+export function appendConcurrentCorrectionAudits(
   transaction: FoundationStorageTransaction,
   recordId: string,
   acceptedAtMs: number,

--- a/src/lib/foundation-acceptance-adversarial.test.ts
+++ b/src/lib/foundation-acceptance-adversarial.test.ts
@@ -1,0 +1,1436 @@
+import { describe, expect, test } from "bun:test";
+import {
+  createFoundationAcceptance,
+  type FoundationAcceptanceOptions,
+} from "@/lib/foundation-acceptance";
+import {
+  createDeterministicTestIqaInterpreter,
+  createControlActionCodecRegistry,
+  sha256,
+  type ControlActionInput,
+} from "@/lib/event-game-actions";
+import { createEventGameRecord } from "@/lib/event-game-record";
+import { createInMemoryFoundationStorage } from "@/lib/foundation-storage-memory";
+import type { EventGameRecordRoot } from "@/lib/foundation-record-types";
+import type { GrantAuthorityOptions } from "@/lib/grant-authority";
+import {
+  createGrantTestAuthorityVerifier,
+  createLegacyControlGrantTestAuthority,
+} from "@/lib/grant-authority-test-support";
+import type {
+  FoundationStorage,
+  FoundationStorageTransaction,
+  FoundationStorageTransactionWork,
+} from "@/lib/foundation-storage";
+import type { GrantAuthority } from "@/lib/grant-authority-types";
+import type { GrantKeyRing } from "@/lib/grant-types";
+import { anchorFor } from "@/lib/foundation-acceptance-integrity";
+import { computeGrantAuditIntegrityTag } from "@/lib/grant-crypto";
+
+type FailureBoundary =
+  | "after-action"
+  | "after-metadata"
+  | "after-control-audit"
+  | "after-grant-audit"
+  | "before-receipt";
+
+describe("adversarial composed acceptance", () => {
+  test("authorizes before codec or payload disclosure and records a valid replay rejection", async () => {
+    const harness = await createHarness({ replay: true });
+    const invalid = createFact(
+      harness.root,
+      "invalid-payload",
+      harness.sessionId,
+      harness.grantVersion,
+    );
+    invalid.kind = { id: "unsupported-codec", version: "999" };
+    invalid.payload = { deliberately: "invalid" };
+    const unauthorized = await harness.acceptance.submitBatch({
+      recordId: harness.root.recordId,
+      eventGameId: harness.root.eventGameId,
+      sessionBearer: "not-a-current-session",
+      actions: [invalid],
+    });
+    expect(unauthorized.results[0]).toMatchObject({
+      status: "authority-expired",
+      reason: "grant-session",
+    });
+    expect(await harness.storage.readActions(harness.root.recordId)).toHaveLength(0);
+
+    const replay = await harness.acceptance.submitBatch({
+      mode: "replay",
+      recordId: harness.root.recordId,
+      eventGameId: harness.root.eventGameId,
+      replay: {
+        sessionBearer: harness.sessionBearer,
+        originatingSessionId: "origin-session",
+        replayEvidenceId: "eligible-replay",
+      },
+      actions: [invalid],
+    });
+    expect(replay).toMatchObject({ status: "committed" });
+    expect(replay.receipt).toBeUndefined();
+    expect(replay.results[0]).toMatchObject({ status: "rejected", reason: "invalid-action" });
+  });
+
+  test("does not inspect the root before ordinary bearer authority", async () => {
+    const harness = await createHarness();
+    const guarded = guardRootReads(harness.storage);
+    const acceptance = createFoundationAcceptance(guarded.storage, {
+      grant: harness.grant,
+      externalScopeResolver: createScopeResolver(harness.root),
+      clock: () => 1_000,
+      interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
+      verifyLockedReplay: () => false,
+    });
+    const result = await acceptance.submitBatch({
+      recordId: harness.root.recordId,
+      eventGameId: harness.root.eventGameId,
+      sessionBearer: "invalid-ordinary-bearer",
+      actions: [
+        createFact(harness.root, "ordinary-root-spy", harness.sessionId, harness.grantVersion),
+      ],
+    });
+    expect(result.results[0]).toMatchObject({
+      status: "authority-expired",
+      reason: "grant-session",
+    });
+    expect(guarded.rootReads()).toBe(0);
+  });
+
+  test("does not inspect the root when transaction-local authority expires", async () => {
+    const harness = await createHarness();
+    const guarded = guardRootReads(harness.storage, 1);
+    const acceptance = createFoundationAcceptance(guarded.storage, {
+      grant: harness.grant,
+      externalScopeResolver: createScopeResolver(harness.root),
+      clock: () => 1_000,
+      interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
+      afterReadOnlyPreflight: async () => {
+        await harness.authority.revokeControlGrant(harness.grantId, {
+          kind: "fixture",
+          id: "fixture",
+        });
+      },
+    });
+    const result = await acceptance.submitBatch({
+      recordId: harness.root.recordId,
+      eventGameId: harness.root.eventGameId,
+      sessionBearer: harness.sessionBearer,
+      actions: [
+        createFact(harness.root, "transaction-root-spy", harness.sessionId, harness.grantVersion),
+      ],
+    });
+    expect(result.results[0]).toMatchObject({
+      status: "authority-expired",
+      reason: "grant-session",
+    });
+    expect(guarded.rootReads()).toBe(1);
+  });
+
+  test("does not inspect the root for invalid trusted lock evidence", async () => {
+    const harness = await createHarness();
+    const guarded = guardRootReads(harness.storage);
+    const acceptance = createFoundationAcceptance(guarded.storage, {
+      grant: harness.grant,
+      externalScopeResolver: createScopeResolver(harness.root),
+      clock: () => 1_000,
+      interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
+      verifyLockedReplay: () => false,
+    });
+    const result = await acceptance.submitBatch({
+      mode: "replay",
+      recordId: harness.root.recordId,
+      eventGameId: "claimed-game",
+      replay: {
+        sessionBearer: "invalid-lock-bearer",
+        originatingSessionId: "origin-session",
+        replayEvidenceId: "invalid-lock-evidence",
+      },
+      actions: [
+        createFact(
+          { ...harness.root, eventGameId: "claimed-game" },
+          "invalid-lock-root-spy",
+          harness.sessionId,
+          harness.grantVersion,
+        ),
+      ],
+    });
+    expect(result.results[0]).toMatchObject({
+      status: "authority-expired",
+      reason: "grant-session",
+    });
+    expect(guarded.rootReads()).toBe(0);
+  });
+
+  test("prepares every codec before returning a generic authorized missing-root outcome", async () => {
+    const harness = await createHarness();
+    const before = await readAuthorityBoundaryState(harness);
+    let decodeCalls = 0;
+    const throwingCodec = {
+      kind: "throwing-codec",
+      version: "1",
+      decode() {
+        decodeCalls += 1;
+        throw new Error("codec must stay behind the read-only preparation seam");
+      },
+      canonicalize() {
+        throw new Error("unreachable");
+      },
+      fingerprint() {
+        throw new Error("unreachable");
+      },
+      interpret() {
+        throw new Error("unreachable");
+      },
+    };
+    const acceptance = createFoundationAcceptance(harness.storage, {
+      grant: createGrantOptions(harness.root.eventGameId),
+      externalScopeResolver: createScopeResolver(harness.root),
+      clock: () => 1_000,
+      interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
+      actionCodecRegistry: createControlActionCodecRegistry([throwingCodec]),
+    });
+    const action = createFact(
+      harness.root,
+      "missing-root-codec",
+      harness.sessionId,
+      harness.grantVersion,
+    );
+    action.recordId = "missing-record";
+    action.kind = { id: "throwing-codec", version: "1" };
+    const result = await acceptance.submitBatch({
+      recordId: "missing-record",
+      eventGameId: harness.root.eventGameId,
+      sessionBearer: harness.sessionBearer,
+      actions: [action],
+    });
+    expect(decodeCalls).toBe(1);
+    expect(result.results[0]).toMatchObject({ status: "rejected", reason: "record-not-found" });
+    expect(await harness.storage.readAuditEntries(harness.root.recordId)).toHaveLength(0);
+    expect(await readAuthorityBoundaryState(harness)).toEqual(before);
+  });
+
+  test("rejects structural failures before mutation and blocks only causal dependants", async () => {
+    const structural = await createHarness();
+    const invalid = createFact(
+      structural.root,
+      "duplicate-id",
+      structural.sessionId,
+      structural.grantVersion,
+    );
+    const structuralResult = await structural.acceptance.submitBatch({
+      recordId: structural.root.recordId,
+      eventGameId: structural.root.eventGameId,
+      sessionBearer: structural.sessionBearer,
+      actions: [invalid, invalid],
+    });
+    expect(structuralResult).toEqual({ status: "rejected", results: [] });
+    expect(await structural.storage.readActions(structural.root.recordId)).toHaveLength(0);
+    expect(await structural.storage.readAuditEntries(structural.root.recordId)).toHaveLength(0);
+
+    const causal = await createHarness();
+    const rejected = {
+      ...createFact(causal.root, "rejected", causal.sessionId, causal.grantVersion),
+      causalPredecessorIds: ["outside-batch"],
+    };
+    const blocked = {
+      ...createFact(causal.root, "blocked", causal.sessionId, causal.grantVersion),
+      causalPredecessorIds: ["rejected"],
+    };
+    const unrelated = createFact(causal.root, "unrelated", causal.sessionId, causal.grantVersion);
+    const outcome = await causal.acceptance.submitBatch({
+      recordId: causal.root.recordId,
+      eventGameId: causal.root.eventGameId,
+      sessionBearer: causal.sessionBearer,
+      actions: [blocked, rejected, unrelated],
+    });
+    expect(outcome.results.map((result) => result.status)).toEqual([
+      "dependency-blocked",
+      "rejected",
+      "accepted",
+    ]);
+    expect(await causal.storage.readActions(causal.root.recordId)).toHaveLength(1);
+    expect(
+      (await causal.storage.readAuditEntries(causal.root.recordId)).filter(
+        (entry) => entry.links?.grantAuditId !== undefined,
+      ),
+    ).toHaveLength(3);
+  });
+
+  test("rolls back each mutation boundary and retains evidence at the budget boundary", async () => {
+    for (const boundary of [
+      "after-action",
+      "after-metadata",
+      "after-control-audit",
+      "after-grant-audit",
+    ] as const) {
+      const harness = await createHarness({ failureBoundary: boundary });
+      const result = await harness.acceptance.submitBatch({
+        recordId: harness.root.recordId,
+        eventGameId: harness.root.eventGameId,
+        sessionBearer: harness.sessionBearer,
+        actions: [
+          createFact(harness.root, `failure-${boundary}`, harness.sessionId, harness.grantVersion),
+        ],
+      });
+      expect(result.results[0]).toMatchObject({
+        status: "retry-later",
+        reason: "storage-unavailable",
+      });
+      expect(await harness.storage.readActions(harness.root.recordId)).toHaveLength(0);
+      expect(await harness.storage.readAuditEntries(harness.root.recordId)).toHaveLength(0);
+    }
+
+    const budget = await createHarness({
+      limits: { onlineSessionCapacity: 1, onlineEventCapacity: 1 },
+    });
+    const first = createFact(budget.root, "budget-first", budget.sessionId, budget.grantVersion);
+    const second = createFact(budget.root, "budget-second", budget.sessionId, budget.grantVersion);
+    const result = await budget.acceptance.submitBatch({
+      recordId: budget.root.recordId,
+      eventGameId: budget.root.eventGameId,
+      sessionBearer: budget.sessionBearer,
+      actions: [first, second],
+    });
+    expect(result.results.map((item) => item.status)).toEqual(["accepted", "retry-later"]);
+    expect(result.results[1]).toMatchObject({ reason: "rate-budget" });
+    const budgets = await budget.storage.transaction((transaction) => ({
+      session: transaction.findAcceptanceBudget(`budget-online-session:${budget.sessionId}`),
+      event: transaction.findAcceptanceBudget(`budget-online-event:${budget.root.eventGameId}`),
+    }));
+    expect(budgets.session?.tokens).toBe(0);
+    expect(budgets.event?.tokens).toBe(0);
+    expect(
+      (await budget.storage.readAuditEntries(budget.root.recordId)).filter(
+        (entry) => entry.links?.grantAuditId,
+      ),
+    ).toHaveLength(2);
+
+    const receiptFailure = await createHarness({
+      failureBoundary: "before-receipt",
+      replay: true,
+    });
+    const noReceipt = await receiptFailure.acceptance.submitBatch({
+      mode: "replay",
+      recordId: receiptFailure.root.recordId,
+      eventGameId: receiptFailure.root.eventGameId,
+      replay: {
+        sessionBearer: receiptFailure.sessionBearer,
+        originatingSessionId: "origin-session",
+        replayEvidenceId: "eligible-replay",
+      },
+      actions: [
+        createFact(
+          receiptFailure.root,
+          "receipt-failure",
+          receiptFailure.sessionId,
+          receiptFailure.grantVersion,
+        ),
+      ],
+    });
+    expect(noReceipt.receipt).toBeUndefined();
+    expect(noReceipt.status).toBe("partial");
+    expect(noReceipt.results[0]).toMatchObject({
+      status: "retry-later",
+      reason: "storage-unavailable",
+    });
+    expect(await receiptFailure.storage.readActions(receiptFailure.root.recordId)).toHaveLength(0);
+  });
+
+  test("uses the trusted lock discard seam and keeps replay acknowledgement independent of current authority", async () => {
+    const locked = await createHarness({ locked: true });
+    const lockedResult = await locked.acceptance.submitBatch({
+      mode: "replay",
+      recordId: locked.root.recordId,
+      eventGameId: locked.root.eventGameId,
+      replay: {
+        sessionBearer: locked.sessionBearer,
+        originatingSessionId: "origin-session",
+        replayEvidenceId: "trusted-lock-evidence",
+      },
+      actions: [createFact(locked.root, "locked-action", locked.sessionId, locked.grantVersion)],
+    });
+    expect(lockedResult.results[0]).toMatchObject({
+      status: "locked-discarded",
+      count: 1,
+      eventGameId: locked.root.eventGameId,
+    });
+    const lockedAudit = (await locked.storage.readAuditEntries(locked.root.recordId))[0];
+    expect(lockedAudit?.lockedReplay).toEqual({
+      count: 1,
+      originatingSessionId: "origin-session",
+      eventGameId: locked.root.eventGameId,
+      rejectedAtMs: 1_000,
+    });
+    expect(await locked.storage.readActions(locked.root.recordId)).toHaveLength(0);
+    expect(await locked.storage.readiness()).toMatchObject({ ok: true });
+    const differentContent = await locked.acceptance.submitBatch({
+      mode: "replay",
+      recordId: locked.root.recordId,
+      eventGameId: locked.root.eventGameId,
+      replay: {
+        sessionBearer: "expired-or-absent-bearer",
+        originatingSessionId: "origin-session",
+        replayEvidenceId: "trusted-lock-evidence",
+      },
+      actions: [
+        createFact(locked.root, "different-locked-action", locked.sessionId, locked.grantVersion),
+      ],
+    });
+    expect(differentContent.results[0]).toMatchObject({
+      status: "authority-expired",
+      reason: "grant-session",
+    });
+    const repeated = await locked.acceptance.submitBatch({
+      mode: "replay",
+      recordId: locked.root.recordId,
+      eventGameId: locked.root.eventGameId,
+      replay: {
+        sessionBearer: "expired-or-absent-bearer",
+        originatingSessionId: "origin-session",
+        replayEvidenceId: "trusted-lock-evidence",
+      },
+      actions: [createFact(locked.root, "locked-action", locked.sessionId, locked.grantVersion)],
+    });
+    expect(repeated.results[0]).toMatchObject({ status: "locked-discarded", count: 1 });
+
+    const replay = await createHarness({ replay: true });
+    const replayOutcome = await replay.acceptance.submitBatch({
+      mode: "replay",
+      recordId: replay.root.recordId,
+      eventGameId: replay.root.eventGameId,
+      replay: {
+        sessionBearer: replay.sessionBearer,
+        originatingSessionId: "origin-session",
+        replayEvidenceId: "eligible-replay",
+      },
+      actions: [createFact(replay.root, "replay-action", replay.sessionId, replay.grantVersion)],
+    });
+    expect(replayOutcome.receipt).toEqual(expect.any(String));
+    const replayBudgetBefore = await replay.storage.transaction((transaction) =>
+      transaction.findAcceptanceBudget(`budget-replay-session:${replay.sessionId}`),
+    );
+    const replayRetry = await replay.acceptance.submitBatch({
+      mode: "replay",
+      recordId: replay.root.recordId,
+      eventGameId: replay.root.eventGameId,
+      replay: {
+        sessionBearer: replay.sessionBearer,
+        originatingSessionId: "origin-session",
+        replayEvidenceId: "eligible-replay",
+      },
+      actions: [createFact(replay.root, "replay-action", replay.sessionId, replay.grantVersion)],
+    });
+    expect(replayRetry).toMatchObject({ status: "committed", receipt: replayOutcome.receipt });
+    const replayBudgetAfter = await replay.storage.transaction((transaction) =>
+      transaction.findAcceptanceBudget(`budget-replay-session:${replay.sessionId}`),
+    );
+    expect(replayBudgetAfter?.tokens).toBe(replayBudgetBefore?.tokens);
+    expect(
+      await replay.authority.revokeControlGrant(replay.grantId, { kind: "fixture", id: "fixture" }),
+    ).toMatchObject({ status: "updated" });
+    expect(await replay.acceptance.acknowledgeReplay(replayOutcome.receipt)).toEqual({
+      status: "acknowledged",
+    });
+    expect(replayOutcome.receipt).not.toContain(replay.sessionBearer);
+    const durable = await replay.storage.transaction((transaction) =>
+      transaction.findReplayReservation(replayOutcome.reservationId ?? "missing"),
+    );
+    expect(durable?.batchDigest).toMatch(/^[a-f0-9]{64}$/);
+    expect(durable?.batchDigest).not.toContain("replay-action");
+  });
+
+  test("recovers an exact committed replay after a memory Game Lock", async () => {
+    const harness = await createHarness({ replay: true });
+    const evidence = "memory-lock-recovery-evidence";
+    const action = createFact(
+      harness.root,
+      "memory-lock-recovery-operation",
+      harness.sessionId,
+      harness.grantVersion,
+    );
+    const committed = await harness.acceptance.submitBatch({
+      mode: "replay",
+      recordId: harness.root.recordId,
+      eventGameId: harness.root.eventGameId,
+      replay: {
+        sessionBearer: harness.sessionBearer,
+        originatingSessionId: "origin-session",
+        replayEvidenceId: evidence,
+      },
+      actions: [action],
+    });
+    const receipt = committed.receipt;
+    expect(committed).toMatchObject({ status: "committed", receipt: expect.any(String) });
+    const lockedRoot = {
+      ...harness.root,
+      lifecycle: {
+        phase: "finished" as const,
+        commencedAtMs: 100,
+        finishedAtMs: 800,
+        lockedAtMs: 900,
+        lockReason: "administrative" as const,
+      },
+    };
+    const digest = sha256(
+      JSON.stringify({
+        recordId: harness.root.recordId,
+        eventGameId: harness.root.eventGameId,
+        mode: "replay",
+        replay: { originatingSessionId: "origin-session", replayEvidenceId: evidence },
+        actions: [action],
+      }),
+    );
+    const lockedStorage = new Proxy(harness.storage, {
+      get(target, property, receiver) {
+        if (property !== "transaction") return Reflect.get(target, property, receiver);
+        return (work: FoundationStorageTransactionWork<unknown>) =>
+          target.transaction((transaction) =>
+            work({
+              ...transaction,
+              findRootByRecordId: () => lockedRoot,
+              findRootByEventGameId: () => lockedRoot,
+            } satisfies FoundationStorageTransaction),
+          );
+      },
+    }) as FoundationStorage;
+    const lockedAcceptance = createFoundationAcceptance(lockedStorage, {
+      grant: createGrantOptions(harness.root.eventGameId),
+      externalScopeResolver: createScopeResolver(harness.root),
+      clock: () => 1_000,
+      interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
+      verifyLockedReplay: ({ batchDigest }) => batchDigest === digest,
+    });
+    const recovered = await lockedAcceptance.submitBatch({
+      mode: "replay",
+      recordId: harness.root.recordId,
+      eventGameId: harness.root.eventGameId,
+      replay: {
+        sessionBearer: "lost-response-bearer",
+        originatingSessionId: "origin-session",
+        replayEvidenceId: evidence,
+      },
+      actions: [action],
+    });
+    expect(recovered).toMatchObject({ status: "committed", receipt });
+    expect(await lockedAcceptance.acknowledgeReplay(receipt!)).toEqual({ status: "acknowledged" });
+  });
+
+  test("recovers committed replay duplicate and rejection results after memory restart", async () => {
+    for (const rejected of [false, true]) {
+      const harness = await createHarness({ replay: true });
+      const action = createFact(
+        harness.root,
+        rejected ? "memory-replay-rejected" : "memory-replay-duplicate",
+        harness.sessionId,
+        harness.grantVersion,
+      );
+      if (rejected) action.causalPredecessorIds = ["missing-replay-predecessor"];
+      if (!rejected) {
+        expect(
+          await harness.acceptance.submitBatch({
+            recordId: harness.root.recordId,
+            eventGameId: harness.root.eventGameId,
+            sessionBearer: harness.sessionBearer,
+            actions: [action],
+          }),
+        ).toMatchObject({ results: [{ status: "accepted" }] });
+      }
+      const replayInput = {
+        mode: "replay" as const,
+        recordId: harness.root.recordId,
+        eventGameId: harness.root.eventGameId,
+        replay: {
+          sessionBearer: harness.sessionBearer,
+          originatingSessionId: rejected ? "memory-rejection-origin" : "memory-duplicate-origin",
+          replayEvidenceId: "memory-restart-replay",
+        },
+        actions: [action],
+      };
+      const committed = await harness.acceptance.submitBatch(replayInput);
+      const committedReservationId = committed.reservationId;
+      const committedReceipt = committed.receipt;
+      expect(committed).toMatchObject({
+        status: "committed",
+        receipt: expect.any(String),
+        reservationId: expect.any(String),
+      });
+      const restartedAcceptance = createFoundationAcceptance(harness.storage, {
+        grant: createGrantOptions(harness.root.eventGameId),
+        externalScopeResolver: createScopeResolver(harness.root),
+        clock: () => 1_000,
+        interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
+        replayEligibility: () => ({ status: "eligible" as const }),
+      });
+      const retried = await restartedAcceptance.submitBatch(replayInput);
+      expect(retried.results[0]).toEqual(committed.results[0]);
+      expect(retried.reservationId).toBe(committedReservationId);
+      expect(retried.receipt).toBe(committedReceipt);
+      expect(await restartedAcceptance.acknowledgeReplay(committedReceipt!)).toEqual({
+        status: "acknowledged",
+      });
+    }
+  });
+
+  test("resumes a partial replay after memory restart without a premature receipt", async () => {
+    const harness = await createHarness({
+      replay: true,
+      limits: { replaySessionCapacity: 1 },
+    });
+    const first = createFact(
+      harness.root,
+      "memory-partial-first",
+      harness.sessionId,
+      harness.grantVersion,
+    );
+    const second = {
+      ...createFact(harness.root, "memory-partial-second", harness.sessionId, harness.grantVersion),
+      causalPredecessorIds: [first.operationId],
+    };
+    const input = {
+      mode: "replay" as const,
+      recordId: harness.root.recordId,
+      eventGameId: harness.root.eventGameId,
+      replay: {
+        sessionBearer: harness.sessionBearer,
+        originatingSessionId: "memory-partial-origin",
+        replayEvidenceId: "memory-partial-replay",
+      },
+      actions: [second, first],
+    };
+    const partial = await harness.acceptance.submitBatch(input);
+    expect(partial.results.map((result) => result.status)).toEqual(["retry-later", "accepted"]);
+    expect(partial.receipt).toBeUndefined();
+    const partialReservationId = partial.reservationId;
+    expect(partialReservationId).toEqual(expect.any(String));
+    harness.nowMs.value = 2_000;
+    const restartedAcceptance = createFoundationAcceptance(harness.storage, {
+      grant: createGrantOptions(harness.root.eventGameId),
+      externalScopeResolver: createScopeResolver(harness.root),
+      clock: () => harness.nowMs.value,
+      interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
+      limits: { replaySessionCapacity: 1 },
+      replayEligibility: () => ({ status: "eligible" as const }),
+    });
+    const resumed = await restartedAcceptance.submitBatch(input);
+    expect(resumed.results[1]).toEqual(partial.results[1]);
+    expect(resumed.results[0]).toMatchObject({ status: "accepted" });
+    expect(resumed.reservationId).toBe(partialReservationId);
+    const resumedReceipt = resumed.receipt;
+    expect(resumedReceipt).toEqual(expect.any(String));
+    expect(
+      (await harness.storage.readAuditEntries(harness.root.recordId)).filter(
+        (entry) => entry.links?.grantAuditId !== undefined,
+      ),
+    ).toHaveLength(3);
+    expect(await restartedAcceptance.acknowledgeReplay(resumedReceipt!)).toEqual({
+      status: "acknowledged",
+    });
+  });
+
+  test("persists definitive mixed replay outcomes under one reservation", async () => {
+    for (const unsupported of [true, false]) {
+      const harness = await createHarness({ replay: true });
+      const first = createFact(
+        harness.root,
+        unsupported ? "memory-mixed-valid-codec" : "memory-mixed-valid-eligibility",
+        harness.sessionId,
+        harness.grantVersion,
+      );
+      const second = createFact(
+        harness.root,
+        unsupported ? "memory-mixed-unsupported" : "memory-mixed-ineligible",
+        harness.sessionId,
+        harness.grantVersion,
+      );
+      if (unsupported) second.kind = { id: "memory-mixed-unsupported-codec", version: "1" };
+      const createReplayAcceptance = () =>
+        createFoundationAcceptance(harness.storage, {
+          grant: createGrantOptions(harness.root.eventGameId),
+          externalScopeResolver: createScopeResolver(harness.root),
+          clock: () => harness.nowMs.value,
+          interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
+          replayEligibility: ({ action }) => {
+            if (!unsupported && action.input.operationId === second.operationId)
+              throw new Error("adapter callback failure");
+            return { status: "eligible" as const };
+          },
+        });
+      const input = {
+        mode: "replay" as const,
+        recordId: harness.root.recordId,
+        eventGameId: harness.root.eventGameId,
+        replay: {
+          sessionBearer: harness.sessionBearer,
+          originatingSessionId: unsupported
+            ? "memory-mixed-unsupported-origin"
+            : "memory-mixed-ineligible-origin",
+          replayEvidenceId: "memory-mixed-replay",
+        },
+        actions: [first, second],
+      };
+      const firstDelivery = await createReplayAcceptance().submitBatch(input);
+      const reservationId = firstDelivery.reservationId;
+      const receipt = firstDelivery.receipt;
+      expect(firstDelivery.results[0]).toMatchObject({ status: "accepted" });
+      expect(firstDelivery.results[1]).toMatchObject(
+        unsupported
+          ? { status: "rejected", reason: "invalid-action" }
+          : { status: "authority-expired", reason: "replay-ineligible" },
+      );
+      expect(reservationId).toEqual(expect.any(String));
+      expect(receipt).toEqual(expect.any(String));
+      const attempts = await harness.storage.transaction((transaction) =>
+        transaction.listReplayAttempts(reservationId!),
+      );
+      expect(attempts).toHaveLength(2);
+      expect(attempts.every((attempt) => attempt.status !== "retry-later")).toBe(true);
+      expect(
+        (await harness.storage.readAuditEntries(harness.root.recordId)).filter(
+          (entry) => entry.links?.grantAuditId !== undefined,
+        ),
+      ).toHaveLength(2);
+
+      const restarted = await createReplayAcceptance().submitBatch(input);
+      expect(restarted.results).toEqual(firstDelivery.results);
+      expect(restarted.reservationId).toBe(reservationId);
+      expect(restarted.receipt).toBe(receipt);
+      expect(await createReplayAcceptance().acknowledgeReplay(receipt!)).toEqual({
+        status: "acknowledged",
+      });
+    }
+  });
+
+  test("freezes an online memory pair when fingerprints are coordinated wrongly", async () => {
+    const harness = await createHarness();
+    const outcome = await harness.acceptance.submitBatch({
+      recordId: harness.root.recordId,
+      eventGameId: harness.root.eventGameId,
+      sessionBearer: harness.sessionBearer,
+      actions: [
+        createFact(
+          harness.root,
+          "memory-online-fingerprint",
+          harness.sessionId,
+          harness.grantVersion,
+        ),
+      ],
+    });
+    expect(outcome).toMatchObject({ status: "committed" });
+    type MemoryInternals = {
+      state: {
+        controlAudits: Map<
+          string,
+          Map<string, import("@/lib/foundation-storage").StoredControlAuditEntry>
+        >;
+        grantAudits: Map<string, import("@/lib/grant-types").StoredGrantAuditEntry>;
+        grantAuditProvenance: Map<string, import("@/lib/grant-types").StoredGrantAuditEntry>;
+        grantAuditIntegrityTags: Map<string, string>;
+      };
+    };
+    const internals = harness.storage as unknown as MemoryInternals;
+    const controls = internals.state.controlAudits.get(harness.root.recordId);
+    const control = [...(controls?.values() ?? [])].find(
+      (entry) => entry.links?.grantAuditId !== undefined,
+    );
+    if (control?.links?.grantAuditId === undefined || control.links.grantAuditId === null)
+      throw new Error("Expected paired audits.");
+    const grantAuditId = control.links.grantAuditId;
+    const grant = internals.state.grantAudits.get(grantAuditId);
+    if (grant === undefined) throw new Error("Expected Grant audit.");
+    const wrongFingerprint = "f".repeat(64);
+    const mutatedControl = {
+      ...control,
+      links: { ...control.links, contentFingerprint: wrongFingerprint },
+    };
+    const mutatedGrant = { ...grant, contentFingerprint: wrongFingerprint };
+    controls!.set(control.auditId, mutatedControl);
+    internals.state.grantAudits.set(grant.auditId, mutatedGrant);
+    internals.state.grantAuditProvenance.set(grant.auditId, mutatedGrant);
+    internals.state.grantAuditIntegrityTags.set(
+      grant.auditId,
+      computeGrantAuditIntegrityTag(mutatedGrant, createKeyRing()),
+    );
+    expect(await harness.storage.readiness()).toMatchObject({
+      ok: false,
+      status: "integrity-failure",
+    });
+  });
+
+  test("fails closed when replay eligibility is omitted", async () => {
+    const harness = await createHarness({ replay: true, omitReplayEligibility: true });
+    const result = await harness.acceptance.submitBatch({
+      mode: "replay",
+      recordId: harness.root.recordId,
+      eventGameId: harness.root.eventGameId,
+      replay: {
+        sessionBearer: harness.sessionBearer,
+        originatingSessionId: harness.sessionId,
+        replayEvidenceId: "missing-eligibility",
+      },
+      actions: [
+        createFact(
+          harness.root,
+          "missing-eligibility-action",
+          harness.sessionId,
+          harness.grantVersion,
+        ),
+      ],
+    });
+    expect(result.results[0]).toMatchObject({
+      status: "authority-expired",
+      reason: "replay-ineligible",
+    });
+    expect(await harness.storage.readActions(harness.root.recordId)).toHaveLength(0);
+  });
+
+  test("normalizes adapter replay reasons before durable paired evidence", async () => {
+    const harness = await createHarness({ replay: true, replayReason: "adapter-made-up" });
+    const result = await harness.acceptance.submitBatch({
+      mode: "replay",
+      recordId: harness.root.recordId,
+      eventGameId: harness.root.eventGameId,
+      replay: {
+        sessionBearer: harness.sessionBearer,
+        originatingSessionId: harness.sessionId,
+        replayEvidenceId: "adapter-reason",
+      },
+      actions: [
+        createFact(harness.root, "adapter-reason-action", harness.sessionId, harness.grantVersion),
+      ],
+    });
+    expect(result.results[0]).toMatchObject({
+      status: "authority-expired",
+      reason: "replay-ineligible",
+    });
+    expect(await harness.storage.readiness()).toMatchObject({ ok: true });
+  });
+
+  test("reuses exact online outcomes for repeated duplicates, rejections, and conflicts", async () => {
+    const harness = await createHarness();
+    const duplicate = createFact(
+      harness.root,
+      "memory-third-duplicate",
+      harness.sessionId,
+      harness.grantVersion,
+    );
+    const duplicateResults = [];
+    for (let index = 0; index < 3; index += 1) {
+      duplicateResults.push(
+        await harness.acceptance.submitBatch({
+          recordId: harness.root.recordId,
+          eventGameId: harness.root.eventGameId,
+          sessionBearer: harness.sessionBearer,
+          actions: [duplicate],
+        }),
+      );
+    }
+    expect(duplicateResults.map((result) => result.results[0]?.status)).toEqual([
+      "accepted",
+      "duplicate-accepted",
+      "duplicate-accepted",
+    ]);
+    expect(duplicateResults[1]?.results[0]).toEqual(duplicateResults[2]?.results[0]);
+
+    const rejected = {
+      ...createFact(
+        harness.root,
+        "memory-repeated-rejection",
+        harness.sessionId,
+        harness.grantVersion,
+      ),
+      causalPredecessorIds: ["missing-memory-predecessor"],
+    };
+    const firstRejected = await harness.acceptance.submitBatch({
+      recordId: harness.root.recordId,
+      eventGameId: harness.root.eventGameId,
+      sessionBearer: harness.sessionBearer,
+      actions: [rejected],
+    });
+    const secondRejected = await harness.acceptance.submitBatch({
+      recordId: harness.root.recordId,
+      eventGameId: harness.root.eventGameId,
+      sessionBearer: harness.sessionBearer,
+      actions: [rejected],
+    });
+    expect(firstRejected.results[0]).toMatchObject({
+      status: "rejected",
+      reason: "missing-dependency",
+    });
+    expect(secondRejected.results[0]).toEqual(firstRejected.results[0]);
+
+    const conflictAccepted = createFact(
+      harness.root,
+      "memory-repeated-conflict",
+      harness.sessionId,
+      harness.grantVersion,
+    );
+    await harness.acceptance.submitBatch({
+      recordId: harness.root.recordId,
+      eventGameId: harness.root.eventGameId,
+      sessionBearer: harness.sessionBearer,
+      actions: [conflictAccepted],
+    });
+    const conflictRejected = structuredClone(conflictAccepted);
+    conflictRejected.payload = {
+      factId: "memory-repeated-conflict-other",
+      factType: "test",
+      gameSideId: harness.root.gameSides[0]?.id ?? "side-a",
+      gameTimeMs: 1,
+      data: { operationId: "memory-repeated-conflict" },
+    };
+    const firstConflict = await harness.acceptance.submitBatch({
+      recordId: harness.root.recordId,
+      eventGameId: harness.root.eventGameId,
+      sessionBearer: harness.sessionBearer,
+      actions: [conflictRejected],
+    });
+    const secondConflict = await harness.acceptance.submitBatch({
+      recordId: harness.root.recordId,
+      eventGameId: harness.root.eventGameId,
+      sessionBearer: harness.sessionBearer,
+      actions: [conflictRejected],
+    });
+    expect(firstConflict.results[0]).toMatchObject({
+      status: "rejected",
+      reason: "operation-conflict",
+    });
+    expect(secondConflict.results[0]).toEqual(firstConflict.results[0]);
+    expect(await harness.storage.readiness()).toMatchObject({ ok: true });
+    expect(
+      (await harness.storage.readAuditEntries(harness.root.recordId)).filter(
+        (entry) => entry.links?.grantAuditId !== undefined,
+      ),
+    ).toHaveLength(5);
+  });
+
+  test("retains a versioned claimed codec identity through unsupported preparation", async () => {
+    const harness = await createHarness();
+    const action = createFact(
+      harness.root,
+      "memory-unknown-codec",
+      harness.sessionId,
+      harness.grantVersion,
+    );
+    action.kind = { id: "unknown-codec", version: "7" };
+    const result = await harness.acceptance.submitBatch({
+      recordId: harness.root.recordId,
+      eventGameId: harness.root.eventGameId,
+      sessionBearer: harness.sessionBearer,
+      actions: [action],
+    });
+    expect(result.results[0]).toMatchObject({ status: "rejected", reason: "invalid-action" });
+    const audit = (await harness.storage.readAuditEntries(harness.root.recordId)).find(
+      (entry) => entry.links?.rejectedCandidate !== undefined,
+    );
+    const candidate = audit?.links?.rejectedCandidate;
+    if (candidate === undefined) throw new Error("Expected unsupported-codec evidence.");
+    const identity = JSON.parse(candidate.codecIdentity) as {
+      claimed: { id: string; version: string };
+      registered: unknown;
+    };
+    expect(identity.claimed).toEqual({ id: "unknown-codec", version: "7" });
+    expect(identity.registered).toBeNull();
+    expect(candidate.codecIdentity).not.toBe("unprepared");
+    expect(candidate.contentFingerprint).toBe(
+      sha256(`${candidate.codecFingerprint}:${candidate.canonicalContent}`),
+    );
+    expect(await harness.storage.readiness()).toMatchObject({ ok: true });
+
+    type MemoryAuditState = {
+      state: {
+        controlAudits: Map<
+          string,
+          Map<string, import("@/lib/foundation-storage").StoredControlAuditEntry>
+        >;
+      };
+    };
+    const internals = harness.storage as unknown as MemoryAuditState;
+    const controls = internals.state.controlAudits.get(harness.root.recordId);
+    const links = audit?.links;
+    if (audit === undefined || controls === undefined || links === undefined)
+      throw new Error("Expected audit state.");
+    controls.set(audit.auditId, {
+      ...audit,
+      links: {
+        ...links,
+        rejectedCandidate: { ...candidate, codecIdentity: "unprepared" },
+      },
+    });
+    expect(await harness.storage.readiness()).toMatchObject({
+      ok: false,
+      status: "integrity-failure",
+    });
+  });
+
+  test("retries a prepared action after rate refill with the same candidate evidence", async () => {
+    const harness = await createHarness({
+      limits: { onlineSessionCapacity: 1, onlineEventCapacity: 1 },
+    });
+    const first = createFact(
+      harness.root,
+      "memory-budget-first",
+      harness.sessionId,
+      harness.grantVersion,
+    );
+    const retry = createFact(
+      harness.root,
+      "memory-budget-retry",
+      harness.sessionId,
+      harness.grantVersion,
+    );
+    expect(
+      (
+        await harness.acceptance.submitBatch({
+          recordId: harness.root.recordId,
+          eventGameId: harness.root.eventGameId,
+          sessionBearer: harness.sessionBearer,
+          actions: [first],
+        })
+      ).results[0],
+    ).toMatchObject({ status: "accepted" });
+    const exhausted = await harness.acceptance.submitBatch({
+      recordId: harness.root.recordId,
+      eventGameId: harness.root.eventGameId,
+      sessionBearer: harness.sessionBearer,
+      actions: [retry],
+    });
+    expect(exhausted.results[0]).toMatchObject({ status: "retry-later", reason: "rate-budget" });
+    const retryAudit = (await harness.storage.readAuditEntries(harness.root.recordId)).find(
+      (entry) => entry.links?.reason === "rate-budget",
+    );
+    const retryCandidate = retryAudit?.links?.rejectedCandidate;
+    if (retryCandidate === undefined) throw new Error("Expected prepared rate-budget evidence.");
+    expect(retryCandidate.codecIdentity).not.toBe("unprepared");
+    expect(retryCandidate.contentFingerprint).toBe(
+      sha256(`${retryCandidate.codecFingerprint}:${retryCandidate.canonicalContent}`),
+    );
+    harness.nowMs.value = 2_000;
+    const resumed = await harness.acceptance.submitBatch({
+      recordId: harness.root.recordId,
+      eventGameId: harness.root.eventGameId,
+      sessionBearer: harness.sessionBearer,
+      actions: [retry],
+    });
+    expect(resumed.results[0]).toMatchObject({ status: "accepted" });
+    expect(resumed.results[0]).not.toMatchObject({ reason: "storage-unavailable" });
+    expect(await harness.storage.readiness()).toMatchObject({ ok: true });
+  });
+
+  test("normalizes every replay ineligibility callback outcome to bounded evidence", async () => {
+    for (const input of [
+      { replayReason: "game-locked", replayDetail: "sensitive-session-identifier" },
+      { replayReason: "x".repeat(10_000), replayDetail: "authorization bearer secret" },
+      { replayFailure: "throw" as const },
+    ]) {
+      const harness = await createHarness({ replay: true, ...input });
+      const action = createFact(
+        harness.root,
+        "bounded-ineligibility-action",
+        harness.sessionId,
+        harness.grantVersion,
+      );
+      const submit = () =>
+        harness.acceptance.submitBatch({
+          mode: "replay",
+          recordId: harness.root.recordId,
+          eventGameId: harness.root.eventGameId,
+          replay: {
+            sessionBearer: harness.sessionBearer,
+            originatingSessionId: harness.sessionId,
+            replayEvidenceId: "bounded-ineligibility",
+          },
+          actions: [action],
+        });
+      const result = await submit();
+      const repeated = await submit();
+      expect(repeated.results[0]).toEqual(result.results[0]);
+      expect(await harness.storage.readAuditEntries(harness.root.recordId)).toHaveLength(1);
+      expect(result.results[0]).toEqual({
+        status: "authority-expired",
+        reason: "replay-ineligible",
+        detail: "Replay authorization is unavailable.",
+        auditId: expect.any(String),
+        grantAuditId: expect.any(String),
+      });
+      const grants = await harness.storage.transaction((transaction) =>
+        transaction.listGrantAudit(harness.grantId),
+      );
+      const acceptanceGrants = grants.filter((grant) => grant.action === "control-action-rejected");
+      expect(acceptanceGrants).toHaveLength(1);
+      expect(acceptanceGrants[0]?.outcomeDetail ?? "").not.toContain(
+        "sensitive-session-identifier",
+      );
+      expect(acceptanceGrants[0]?.outcomeDetail ?? "").not.toContain("authorization bearer secret");
+      expect(await harness.storage.readiness()).toMatchObject({ ok: true });
+    }
+  });
+
+  test("reuses an unsupported replay outcome without a reservation", async () => {
+    const harness = await createHarness({ replay: true });
+    const action = createFact(
+      harness.root,
+      "unsupported-replay-action",
+      harness.sessionId,
+      harness.grantVersion,
+    );
+    action.kind = { id: "unsupported-replay-codec", version: "9" };
+    const submit = () =>
+      harness.acceptance.submitBatch({
+        mode: "replay",
+        recordId: harness.root.recordId,
+        eventGameId: harness.root.eventGameId,
+        replay: {
+          sessionBearer: harness.sessionBearer,
+          originatingSessionId: harness.sessionId,
+          replayEvidenceId: "unsupported-replay",
+        },
+        actions: [action],
+      });
+    const first = await submit();
+    const second = await submit();
+    expect(first.results[0]).toMatchObject({ status: "rejected", reason: "invalid-action" });
+    expect(second.results[0]).toEqual(first.results[0]);
+    expect(await harness.storage.readAuditEntries(harness.root.recordId)).toHaveLength(1);
+    const state = await harness.storage.transaction((transaction) => ({
+      reservation: transaction.findReplayReservationByOriginTuple(
+        harness.root.recordId,
+        harness.root.eventGameId,
+        harness.sessionId,
+        1,
+      ),
+    }));
+    expect(state.reservation).toBeNull();
+    expect(await harness.storage.readiness()).toMatchObject({ ok: true });
+  });
+
+  test("freezes memory when rejected canonical candidate content is tampered", async () => {
+    const harness = await createHarness();
+    const action = {
+      ...createFact(harness.root, "candidate-tamper", harness.sessionId, harness.grantVersion),
+      causalPredecessorIds: ["missing-predecessor"],
+    };
+    const result = await harness.acceptance.submitBatch({
+      recordId: harness.root.recordId,
+      eventGameId: harness.root.eventGameId,
+      sessionBearer: harness.sessionBearer,
+      actions: [action],
+    });
+    expect(result.results[0]).toMatchObject({ status: "rejected", reason: "missing-dependency" });
+    type MemoryInternals = {
+      state: {
+        controlAudits: Map<
+          string,
+          Map<string, import("@/lib/foundation-storage").StoredControlAuditEntry>
+        >;
+      };
+    };
+    const internals = harness.storage as unknown as MemoryInternals;
+    const controls = internals.state.controlAudits.get(harness.root.recordId);
+    const control = [...(controls?.values() ?? [])].find(
+      (entry) => entry.links?.rejectedCandidate !== undefined,
+    );
+    if (control?.links?.rejectedCandidate === undefined)
+      throw new Error("Expected rejection evidence.");
+    controls!.set(control.auditId, {
+      ...control,
+      links: {
+        ...control.links,
+        rejectedCandidate: { ...control.links.rejectedCandidate, canonicalContent: "{}" },
+      },
+    });
+    expect(await harness.storage.readiness()).toMatchObject({
+      ok: false,
+      status: "integrity-failure",
+    });
+  });
+});
+
+type Harness = {
+  storage: FoundationStorage;
+  root: EventGameRecordRoot;
+  acceptance: ReturnType<typeof createFoundationAcceptance>;
+  authority: GrantAuthority;
+  grant: GrantAuthorityOptions;
+  grantId: string;
+  grantVersion: string;
+  sessionId: string;
+  sessionBearer: string;
+  nowMs: { value: number };
+};
+
+async function createHarness(
+  input: {
+    locked?: boolean;
+    failureBoundary?: FailureBoundary;
+    limits?: FoundationAcceptanceOptions["limits"];
+    replay?: boolean;
+    omitReplayEligibility?: boolean;
+    replayReason?: string;
+    replayDetail?: unknown;
+    replayFailure?: "throw";
+  } = {},
+): Promise<Harness> {
+  const storage = createInMemoryFoundationStorage();
+  const root = createRoot(input.locked === true);
+  const grant = createGrantOptions(root.eventGameId);
+  const authority = createLegacyControlGrantTestAuthority(storage, grant);
+  const created = await authority.createControlGrant({
+    scope: root.externalScope,
+    actor: { kind: "fixture", id: "fixture" },
+  });
+  if (created.status !== "created") throw new Error("Expected a Grant.");
+  const admitted = await authority.admitControlGrant({
+    qrCredential: created.qrCredential,
+    browserContext: "adversarial-controller",
+  });
+  if (admitted.status !== "admitted") throw new Error("Expected a Session.");
+  const record = createEventGameRecord(storage, {
+    externalScopeResolver: createScopeResolver(root),
+    interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
+    auditAuthorityVerifier: { verify: () => true },
+  });
+  const registration = await record.registerRoot(root);
+  if (registration.status !== "registered")
+    throw new Error(`Expected a Record: ${JSON.stringify(registration)}`);
+  let lockedBatchDigest: string | undefined;
+  if (input.locked === true) {
+    const lockedAction = createFact(
+      root,
+      "locked-action",
+      admitted.grantSessionId,
+      created.grantVersion,
+    );
+    lockedBatchDigest = sha256(
+      JSON.stringify({
+        recordId: root.recordId,
+        eventGameId: root.eventGameId,
+        mode: "replay",
+        replay: {
+          originatingSessionId: "origin-session",
+          replayEvidenceId: "trusted-lock-evidence",
+        },
+        actions: [lockedAction],
+      }),
+    );
+    const reservation = {
+      reservationId: "seed-locked-reservation",
+      recordId: root.recordId,
+      eventGameId: root.eventGameId,
+      originatingSessionId: "origin-session",
+      replacementSessionId: null,
+      actionCount: 1,
+      status: "reserved" as const,
+      batchDigest: lockedBatchDigest,
+      createdAtMs: 700,
+      committedAtMs: null,
+      acknowledgedAtMs: null,
+      stateRevision: 1,
+    };
+    await storage.transaction((transaction) => {
+      transaction.insertReplayReservation(reservation);
+      transaction.insertAcceptanceIntegrityAnchor(
+        anchorFor("reservation", reservation, grant.keyRing),
+      );
+    });
+  }
+  const nowMs = { value: 1_000 };
+  const acceptance = createFoundationAcceptance(storage, {
+    grant,
+    externalScopeResolver: createScopeResolver(root),
+    clock: () => nowMs.value,
+    interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
+    limits: input.limits,
+    failureInjector:
+      input.failureBoundary === undefined
+        ? undefined
+        : (boundary) => {
+            if (boundary === input.failureBoundary)
+              throw new Error(`Injected failure at ${boundary}`);
+          },
+    verifyLockedReplay: ({ batchDigest }) =>
+      input.locked === true && batchDigest === lockedBatchDigest,
+    replayEligibility:
+      input.replay === true && input.omitReplayEligibility !== true
+        ? () =>
+            input.replayFailure === "throw"
+              ? (() => {
+                  throw new Error("adapter detail must not escape");
+                })()
+              : input.replayReason === undefined
+                ? { status: "eligible" }
+                : {
+                    status: "ineligible",
+                    reason: input.replayReason,
+                    detail: input.replayDetail ?? "Adapter supplied a replay decision.",
+                  }
+        : undefined,
+  });
+  return {
+    storage,
+    root,
+    acceptance,
+    authority,
+    grant,
+    grantId: created.grantId,
+    grantVersion: created.grantVersion,
+    sessionId: admitted.grantSessionId,
+    sessionBearer: admitted.sessionBearer,
+    nowMs,
+  };
+}
+
+function createGrantOptions(eventGameId: string): GrantAuthorityOptions {
+  let call = 0;
+  return {
+    environmentId: "acceptance-adversarial-test",
+    clock: { nowMs: () => 1_000 },
+    randomness: {
+      bytes: (length) => {
+        call += 1;
+        return Uint8Array.from({ length }, (_, index) => (index + call + length) % 256);
+      },
+    },
+    keyRing: createKeyRing(),
+    controlScopeResolver: { resolve: () => ({ status: "eligible", eventGameId }) },
+    privilegedAuthorityVerifier: createGrantTestAuthorityVerifier(),
+  };
+}
+
+function createKeyRing(): GrantKeyRing {
+  return {
+    encryption: { currentVersion: "encryption-v1", keys: new Map([["encryption-v1", bytes(1)]]) },
+    lookup: { currentVersion: "lookup-v1", keys: new Map([["lookup-v1", bytes(33)]]) },
+    audit: { currentVersion: "audit-v1", keys: new Map([["audit-v1", bytes(65)]]) },
+  };
+}
+
+function bytes(start: number): Uint8Array {
+  return Uint8Array.from({ length: 32 }, (_, index) => start + index);
+}
+
+function createRoot(locked: boolean): EventGameRecordRoot {
+  return {
+    recordId: `record-adversarial-${locked ? "locked" : "open"}`,
+    eventId: "event-adversarial",
+    eventGameId: "game-adversarial",
+    ownership: { eventId: "event-adversarial", eventGameId: "game-adversarial" },
+    externalScope: {
+      eventId: "event-adversarial",
+      gameDayId: "day-1",
+      pitchId: "pitch-1",
+      pitchSlotId: "slot-1",
+    },
+    gameSides: [
+      { id: "side-a", eventTeamId: "team-a", teamInterpretationRef: "team-a-v1" },
+      { id: "side-b", eventTeamId: "team-b", teamInterpretationRef: "team-b-v1" },
+    ],
+    lifecycle: {
+      phase: locked ? "finished" : "scheduled",
+      commencedAtMs: locked ? 100 : null,
+      finishedAtMs: locked ? 800 : null,
+      lockedAtMs: locked ? 900 : null,
+      lockReason: locked ? "administrative" : null,
+    },
+    compatibility: {
+      recordVersion: "record-v1",
+      schemaVersion: "schema-v1",
+      interpreterVersion: "rules-v1",
+    },
+    creationEvidence: {
+      operationId: "register-adversarial",
+      actorReference: "actor-test",
+      source: "event-game-registration",
+      createdAtMs: 500,
+    },
+  };
+}
+
+function createScopeResolver(root: EventGameRecordRoot) {
+  return {
+    resolve(scope: EventGameRecordRoot["externalScope"]) {
+      return JSON.stringify(scope) === JSON.stringify(root.externalScope)
+        ? { status: "resolved" as const, scope: structuredClone(scope) }
+        : { status: "mismatch" as const, detail: "scope mismatch" };
+    },
+    resolveEventTeam() {
+      return { status: "resolved" as const };
+    },
+  };
+}
+
+function createFact(
+  root: EventGameRecordRoot,
+  operationId: string,
+  sessionId: string,
+  versionId: string,
+): ControlActionInput {
+  return {
+    recordId: root.recordId,
+    eventGameId: root.eventGameId,
+    operationId,
+    kind: { id: "game-fact", version: "1" },
+    payload: {
+      factId: `fact-${operationId}`,
+      factType: "test",
+      gameSideId: "side-a",
+      gameTimeMs: 1,
+      data: { operationId },
+    },
+    causalPredecessorIds: [],
+    occurrence: { trustedAtMs: 1_000, clientOriginAtMs: 1_000, source: "online" },
+    grant: { sessionId, versionId },
+    lifecycle: structuredClone(root.lifecycle),
+  };
+}
+
+async function readAuthorityBoundaryState(harness: Harness): Promise<string> {
+  const state = await harness.storage.transaction((transaction) => ({
+    grant: transaction.findGrantById(harness.grantId),
+    sessions: transaction.listGrantSessions(harness.grantId),
+    controlAudits: transaction.listAuditEntries(harness.root.recordId),
+    grantAudits: transaction.listGrantAudit(harness.grantId),
+    budgets: [
+      transaction.findAcceptanceBudget(`budget-online-session:${harness.sessionId}`),
+      transaction.findAcceptanceBudget(`budget-online-event:${harness.root.eventGameId}`),
+      transaction.findAcceptanceBudget(`budget-replay-session:${harness.sessionId}`),
+    ],
+    metadata: transaction.readRecordMetadata(harness.root.recordId),
+  }));
+  return JSON.stringify(state);
+}
+
+function guardRootReads(
+  storage: FoundationStorage,
+  allowedRootReads = 0,
+): {
+  storage: FoundationStorage;
+  rootReads(): number;
+} {
+  let rootReadCount = 0;
+  const guardedStorage = new Proxy(storage, {
+    get(target, property, receiver) {
+      if (property !== "transaction") return Reflect.get(target, property, receiver);
+      return <T>(work: (transaction: FoundationStorageTransaction) => T) =>
+        target.transaction((transaction) =>
+          work(
+            new Proxy(transaction, {
+              get(transactionTarget, transactionProperty, transactionReceiver) {
+                if (transactionProperty === "findRootByRecordId") {
+                  const rootReader = transactionTarget.findRootByRecordId.bind(transactionTarget);
+                  return (recordId: string) => {
+                    rootReadCount += 1;
+                    if (rootReadCount <= allowedRootReads) return rootReader(recordId);
+                    throw new Error("root read must remain behind authority");
+                  };
+                }
+                return Reflect.get(transactionTarget, transactionProperty, transactionReceiver);
+              },
+            }),
+          ),
+        );
+    },
+  }) as FoundationStorage;
+  return { storage: guardedStorage, rootReads: () => rootReadCount };
+}

--- a/src/lib/foundation-acceptance-contract.ts
+++ b/src/lib/foundation-acceptance-contract.ts
@@ -1,0 +1,35 @@
+export const FOUNDATION_REJECTION_REASONS = [
+  "causal-dependency-rejected",
+  "causal-predecessor-retry",
+  "cyclic-dependency",
+  "fact-target-missing",
+  "game-locked",
+  "grant-session",
+  "invalid-action",
+  "missing-dependency",
+  "operation-conflict",
+  "rate-budget",
+  "record-not-found",
+  "replay-ineligible",
+  "replay-reservation-mismatch",
+  "replay-session-mismatch",
+  "scope-unavailable",
+  "stale-preflight",
+  "storage-unavailable",
+] as const;
+
+export type FoundationRejectionReason = (typeof FOUNDATION_REJECTION_REASONS)[number];
+
+export function isFoundationRejectionReason(value: unknown): value is FoundationRejectionReason {
+  return (
+    typeof value === "string" && (FOUNDATION_REJECTION_REASONS as readonly string[]).includes(value)
+  );
+}
+
+/**
+ * Adapter extensions cannot create a new durable reason. Unknown replay
+ * ineligibility is retained under the shared, deliberately opaque reason.
+ */
+export function normalizeFoundationRejectionReason(value: unknown): FoundationRejectionReason {
+  return isFoundationRejectionReason(value) ? value : "replay-ineligible";
+}

--- a/src/lib/foundation-acceptance-integrity.ts
+++ b/src/lib/foundation-acceptance-integrity.ts
@@ -1,0 +1,459 @@
+import { canonicalizeJson } from "@/lib/event-game-action-json";
+import { computeAcceptanceIntegrityTag } from "@/lib/grant-crypto";
+import {
+  actionIdentity,
+  parseStoredControlAction,
+  sha256,
+  type ControlAction,
+  type ControlAuditEntry,
+} from "@/lib/event-game-actions";
+import {
+  isFoundationRejectionReason,
+  type FoundationRejectionReason,
+} from "@/lib/foundation-acceptance-contract";
+import type {
+  StoredAcceptanceBudget,
+  StoredReplayAttempt,
+  StoredReplayReceipt,
+  StoredReplayReservation,
+} from "@/lib/foundation-storage";
+import type { GrantKeyRing, StoredGrantAuditEntry } from "@/lib/grant-types";
+
+export type AcceptanceIntegritySubject = "budget" | "reservation" | "attempt" | "receipt";
+
+export type AcceptanceIntegrityAnchor = {
+  anchorId: string;
+  subjectKind: AcceptanceIntegritySubject;
+  subjectId: string;
+  stateRevision: number;
+  keyVersion: string;
+  canonicalValue: string;
+  integrityTag: string;
+};
+
+/**
+ * Validate the complete, canonical result retained for a replay attempt.
+ * Status alone is deliberately insufficient: a recovered result is a durable
+ * response and must retain exactly the evidence shape that produced it.
+ */
+export function replayAttemptResultFailure(
+  attempt: StoredReplayAttempt,
+  expectedAction?: ControlAction,
+  expectedReason?: string,
+): string | null {
+  if (attempt.resultJson === null) return "Replay attempt result is missing.";
+  let value: unknown;
+  try {
+    value = JSON.parse(attempt.resultJson);
+  } catch {
+    return "Replay attempt result is invalid.";
+  }
+  if (!isRecord(value) || canonicalizeJson(value) !== attempt.resultJson)
+    return "Replay attempt result is not canonical.";
+  const keys = Object.keys(value).sort().join(",");
+  const auditIds =
+    typeof value.auditId === "string" &&
+    typeof value.grantAuditId === "string" &&
+    attempt.controlAuditId === value.auditId &&
+    attempt.grantAuditId === value.grantAuditId;
+  if (!auditIds) return "Replay attempt result audits are incomplete or altered.";
+
+  if (attempt.status === "accepted" || attempt.status === "duplicate-accepted") {
+    if (
+      value.status !== attempt.status ||
+      keys !== "action,auditId,grantAuditId,status" ||
+      !isRecord(value.action)
+    )
+      return "Replay accepted result shape is inconsistent.";
+    const parsed = parseStoredControlAction(value.action);
+    if (!parsed.ok || parsed.value.operationId !== attempt.operationId)
+      return "Replay accepted result action is invalid.";
+    if (
+      expectedAction !== undefined &&
+      canonicalizeJson(parsed.value) !== canonicalizeJson(expectedAction)
+    )
+      return "Replay accepted result action was semantically altered.";
+    return null;
+  }
+
+  if (attempt.status === "retry-later") {
+    if (value.status !== "retry-later") return "Replay retry result status is inconsistent.";
+  } else if (
+    attempt.status !== "rejected" ||
+    !["rejected", "dependency-blocked", "authority-expired"].includes(String(value.status))
+  ) {
+    return "Replay rejected result status is inconsistent.";
+  }
+  if (
+    keys !== "auditId,detail,grantAuditId,reason,status" ||
+    typeof value.reason !== "string" ||
+    typeof value.detail !== "string" ||
+    !isFoundationRejectionReason(value.reason) ||
+    (expectedReason !== undefined && value.reason !== expectedReason)
+  )
+    return "Replay rejected result shape is inconsistent.";
+  return null;
+}
+
+/** Validate the semantic contract shared by a Control/Grant acceptance pair. */
+export function acceptanceAuditPairFailure(
+  control: ControlAuditEntry,
+  grant: StoredGrantAuditEntry,
+  attempt?: StoredReplayAttempt,
+): string | null {
+  const links = control.links;
+  if (
+    links === undefined ||
+    control.operationId === null ||
+    grant.acceptanceId === null ||
+    grant.acceptanceId === undefined ||
+    links.acceptanceId !== grant.acceptanceId ||
+    links.grantAuditId !== grant.auditId ||
+    grant.controlAuditId !== control.auditId ||
+    grant.controlActionId !== links.actionId ||
+    links.actionId !== actionIdentity(control.recordId, control.operationId)
+  )
+    return "Control and Grant acceptance identities are inconsistent.";
+
+  const expected = expectedGrantOutcome(grant.action);
+  const outcomeDetail = grant.outcomeDetail;
+  const contentFingerprint = grant.contentFingerprint;
+  const linkedFingerprint = links?.contentFingerprint;
+  const linkedReason = links?.reason;
+  const rejectedCandidate = links?.rejectedCandidate;
+  const collisionCandidate = links?.collision?.rejectedAttempt;
+  const rejectedCandidateFingerprint = rejectedCandidate?.contentFingerprint;
+  if (
+    expected === null ||
+    (expected.controlKind !== null && control.kind !== expected.controlKind) ||
+    control.outcome !== expected.controlOutcome ||
+    outcomeDetail === null ||
+    outcomeDetail === undefined ||
+    contentFingerprint === null ||
+    contentFingerprint === undefined ||
+    !/^[a-f0-9]{64}$/.test(contentFingerprint) ||
+    linkedFingerprint !== contentFingerprint ||
+    !/^[a-f0-9]{64}$/.test(linkedFingerprint)
+  )
+    return "Control and Grant acceptance semantics are inconsistent.";
+  if (
+    expected.actionRequiresReason &&
+    (typeof linkedReason !== "string" ||
+      !isFoundationRejectionReason(linkedReason) ||
+      !supportedReason(grant.action, control.kind, readOutcomeStatus(outcomeDetail), linkedReason))
+  )
+    return "Control and Grant acceptance reason semantics are inconsistent.";
+  if (
+    expected.actionRequiresReason &&
+    (rejectedCandidate === undefined ||
+      rejectedCandidateFingerprint !== contentFingerprint ||
+      rejectedCandidateFailure(rejectedCandidate) !== null ||
+      (collisionCandidate !== undefined &&
+        (collisionCandidate.contentFingerprint !== contentFingerprint ||
+          rejectedCandidateFailure(collisionCandidate) !== null ||
+          collisionCandidate.canonicalContent !== rejectedCandidate.canonicalContent)))
+  )
+    return "Control and Grant rejected candidate fingerprint is inconsistent.";
+  if (
+    expected.actionRequiresReason &&
+    collisionCandidate !== undefined &&
+    !/^[a-f0-9]{64}$/.test(links?.collision?.acceptedContentFingerprint ?? "")
+  )
+    return "Control and Grant accepted collision fingerprint is inconsistent.";
+  if (
+    !expected.actionRequiresReason &&
+    (linkedReason !== undefined ||
+      rejectedCandidate !== undefined ||
+      collisionCandidate !== undefined)
+  )
+    return "Accepted Control and Grant evidence carries a rejection reason.";
+
+  const evidence = parseOutcomeEvidence(outcomeDetail);
+  if (
+    evidence === null ||
+    !expected.statuses.includes(evidence.status) ||
+    evidence.detail !== control.redactedDetail ||
+    (expected.actionRequiresReason ? evidence.reason !== linkedReason : evidence.reason !== null)
+  )
+    return "Control and Grant acceptance detail is inconsistent.";
+
+  if (attempt !== undefined) {
+    if (
+      attempt.operationId !== control.operationId ||
+      (attempt.actionFingerprint !== null && attempt.actionFingerprint !== contentFingerprint)
+    )
+      return "Replay attempt and Control/Grant content identity is inconsistent.";
+    if (replayAttemptResultFailure(attempt, undefined, linkedReason) !== null)
+      return "Replay attempt result is not paired with its Control/Grant audits.";
+    let result: unknown;
+    try {
+      result = JSON.parse(attempt.resultJson!);
+    } catch {
+      return "Replay attempt result is invalid.";
+    }
+    if (!isRecord(result) || !expected.statuses.includes(String(result.status)))
+      return "Replay attempt result status is not paired with its Control/Grant audits.";
+    if (typeof result.detail === "string" && result.detail !== control.redactedDetail)
+      return "Replay attempt result detail is not paired with its Control/Grant audits.";
+  }
+  return null;
+}
+
+function expectedGrantOutcome(action: StoredGrantAuditEntry["action"]): {
+  controlKind: ControlAuditEntry["kind"] | null;
+  controlOutcome: ControlAuditEntry["outcome"];
+  statuses: readonly string[];
+  actionRequiresReason: boolean;
+} | null {
+  switch (action) {
+    case "control-action-accepted":
+      return {
+        controlKind: "action-accepted",
+        controlOutcome: "accepted",
+        statuses: ["accepted"],
+        actionRequiresReason: false,
+      };
+    case "control-action-duplicate":
+      return {
+        controlKind: "action-duplicate",
+        controlOutcome: "accepted",
+        statuses: ["duplicate-accepted"],
+        actionRequiresReason: false,
+      };
+    case "control-action-retry-later":
+      return {
+        controlKind: "action-rejected",
+        controlOutcome: "rejected",
+        statuses: ["retry-later"],
+        actionRequiresReason: true,
+      };
+    case "control-action-dependency-blocked":
+      return {
+        controlKind: "action-rejected",
+        controlOutcome: "rejected",
+        statuses: ["dependency-blocked"],
+        actionRequiresReason: true,
+      };
+    case "control-action-rejected":
+      return {
+        controlKind: null,
+        controlOutcome: "rejected",
+        statuses: ["rejected", "authority-expired"],
+        actionRequiresReason: true,
+      };
+    default:
+      return null;
+  }
+}
+
+function supportedReason(
+  action: StoredGrantAuditEntry["action"],
+  controlKind: ControlAuditEntry["kind"],
+  status: string,
+  reason: FoundationRejectionReason,
+): boolean {
+  if (action === "control-action-retry-later")
+    return (
+      status === "retry-later" &&
+      [
+        "rate-budget",
+        "causal-predecessor-retry",
+        "replay-session-mismatch",
+        "scope-unavailable",
+        "stale-preflight",
+        "storage-unavailable",
+      ].includes(reason)
+    );
+  if (action === "control-action-dependency-blocked")
+    return status === "dependency-blocked" && reason === "causal-dependency-rejected";
+  if (action === "control-action-rejected")
+    return controlKind === "action-conflict"
+      ? status === "rejected" && reason === "operation-conflict"
+      : status === "rejected"
+        ? [
+            "cyclic-dependency",
+            "missing-dependency",
+            "fact-target-missing",
+            "invalid-action",
+          ].includes(reason)
+        : status === "authority-expired" &&
+          [
+            "game-locked",
+            "grant-session",
+            "replay-ineligible",
+            "replay-reservation-mismatch",
+          ].includes(reason);
+  return false;
+}
+
+function rejectedCandidateFailure(candidate: {
+  codecIdentity?: string;
+  codecFingerprint?: string;
+  canonicalContent: string;
+  contentFingerprint: string;
+}): string | null {
+  if (
+    typeof candidate.codecIdentity !== "string" ||
+    candidate.codecIdentity.length === 0 ||
+    typeof candidate.codecFingerprint !== "string" ||
+    candidate.codecFingerprint.length === 0 ||
+    !/^[a-f0-9]{64}$/.test(candidate.contentFingerprint)
+  )
+    return "Rejected candidate fingerprint is not a SHA-256 digest.";
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(candidate.canonicalContent);
+  } catch {
+    return "Rejected candidate canonical content is not JSON.";
+  }
+  if (canonicalizeJson(parsed) !== candidate.canonicalContent)
+    return "Rejected candidate canonical content is not canonical.";
+  if (codecIdentityFailure(candidate.codecIdentity, parsed) !== null)
+    return "Rejected candidate codec identity is inconsistent.";
+  if (
+    sha256(`${candidate.codecFingerprint}:${candidate.canonicalContent}`) !==
+    candidate.contentFingerprint
+  )
+    return "Rejected candidate fingerprint does not match canonical content.";
+  return null;
+}
+
+function codecIdentityFailure(codecIdentity: string, canonicalContent: unknown): string | null {
+  let parsedIdentity: unknown;
+  try {
+    parsedIdentity = JSON.parse(codecIdentity);
+  } catch {
+    return "Codec identity is not JSON.";
+  }
+  if (!isRecord(parsedIdentity) || canonicalizeJson(parsedIdentity) !== codecIdentity)
+    return "Codec identity is not canonical.";
+  if (
+    parsedIdentity.schema !== "control-codec-identity-v1" ||
+    !isRecord(parsedIdentity.claimed) ||
+    typeof parsedIdentity.claimed.id !== "string" ||
+    typeof parsedIdentity.claimed.version !== "string" ||
+    (parsedIdentity.registered !== null && !isRecord(parsedIdentity.registered))
+  )
+    return "Codec identity shape is invalid.";
+  if (!isRecord(canonicalContent) || !isRecord(canonicalContent.kind))
+    return "Codec identity has no claimed action kind.";
+  if (
+    parsedIdentity.claimed.id !== canonicalContent.kind.id ||
+    parsedIdentity.claimed.version !== canonicalContent.kind.version
+  )
+    return "Codec identity does not match the action kind.";
+  if (
+    parsedIdentity.registered !== null &&
+    (parsedIdentity.registered.id !== parsedIdentity.claimed.id ||
+      parsedIdentity.registered.version !== parsedIdentity.claimed.version)
+  )
+    return "Codec identity registered version is inconsistent.";
+  return null;
+}
+
+function parseOutcomeEvidence(value: string): {
+  status: string;
+  reason: FoundationRejectionReason | null;
+  detail: string;
+} | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    return null;
+  }
+  if (!isRecord(parsed) || canonicalizeJson(parsed) !== value) return null;
+  if (
+    typeof parsed.status !== "string" ||
+    (parsed.reason !== null && !isFoundationRejectionReason(parsed.reason)) ||
+    typeof parsed.detail !== "string"
+  )
+    return null;
+  return {
+    status: parsed.status,
+    reason: parsed.reason,
+    detail: parsed.detail,
+  };
+}
+
+function readOutcomeStatus(value: string): string {
+  return parseOutcomeEvidence(value)?.status ?? "";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function anchorFor(
+  subjectKind: AcceptanceIntegritySubject,
+  value:
+    | StoredAcceptanceBudget
+    | StoredReplayReservation
+    | StoredReplayAttempt
+    | StoredReplayReceipt,
+  keyRing: GrantKeyRing,
+  keyVersion = keyRing.audit.currentVersion,
+): AcceptanceIntegrityAnchor {
+  const subjectId = subjectIdFor(subjectKind, value);
+  const stateRevision = value.stateRevision;
+  const canonicalValue = canonicalizeJson(integrityValue(subjectKind, value));
+  return {
+    anchorId: `${subjectKind}:${subjectId}:${stateRevision}`,
+    subjectKind,
+    subjectId,
+    stateRevision,
+    keyVersion,
+    canonicalValue,
+    integrityTag: computeAcceptanceIntegrityTag(
+      canonicalizeJson({
+        domain: "foundation-acceptance-state-v1",
+        subjectKind,
+        subjectId,
+        stateRevision,
+        value: JSON.parse(canonicalValue),
+      }),
+      keyRing,
+      keyVersion,
+    ),
+  };
+}
+
+export function subjectIdFor(
+  subjectKind: AcceptanceIntegritySubject,
+  value:
+    | StoredAcceptanceBudget
+    | StoredReplayReservation
+    | StoredReplayAttempt
+    | StoredReplayReceipt,
+): string {
+  switch (subjectKind) {
+    case "budget":
+      return (value as StoredAcceptanceBudget).bucketId;
+    case "reservation":
+      return (value as StoredReplayReservation).reservationId;
+    case "attempt":
+      return `${(value as StoredReplayAttempt).reservationId}:${(value as StoredReplayAttempt).attemptId}`;
+    case "receipt":
+      return (value as StoredReplayReceipt).receiptId;
+  }
+}
+
+export function integrityValue(
+  subjectKind: AcceptanceIntegritySubject,
+  value:
+    | StoredAcceptanceBudget
+    | StoredReplayReservation
+    | StoredReplayAttempt
+    | StoredReplayReceipt,
+): unknown {
+  switch (subjectKind) {
+    case "budget":
+      return value;
+    case "reservation":
+      return value;
+    case "attempt":
+      return value;
+    case "receipt":
+      return value;
+  }
+}

--- a/src/lib/foundation-acceptance-sqlite.focused.ts
+++ b/src/lib/foundation-acceptance-sqlite.focused.ts
@@ -1,0 +1,1556 @@
+import { describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  createFoundationAcceptance,
+  type FoundationAcceptanceOptions,
+} from "@/lib/foundation-acceptance";
+import { anchorFor } from "@/lib/foundation-acceptance-integrity";
+import { computeGrantAuditIntegrityTag } from "@/lib/grant-crypto";
+import {
+  createDeterministicTestIqaInterpreter,
+  sha256,
+  type ControlActionInput,
+} from "@/lib/event-game-actions";
+import { createEventGameRecord } from "@/lib/event-game-record";
+import {
+  canonicalizeEventGameRecordRoot,
+  type EventGameRecordRoot,
+} from "@/lib/foundation-record-types";
+import {
+  openSqliteFoundationStorage,
+  type SqliteFoundationStorage,
+} from "@/lib/foundation-storage-sqlite";
+import type { GrantAuthorityOptions } from "@/lib/grant-authority";
+import {
+  createGrantTestAuthorityVerifier,
+  createLegacyControlGrantTestAuthority,
+} from "@/lib/grant-authority-test-support";
+import type { GrantKeyRing } from "@/lib/grant-types";
+import { readStoredGrantAuditEntry } from "@/lib/grant-storage-sqlite";
+
+describe("focused SQLite composed acceptance", () => {
+  test("commits paired evidence, survives restart, and acknowledges only a durable receipt", async () => {
+    await withDatabase(async (databasePath) => {
+      const storage = openSqliteFoundationStorage(databasePath, { grantKeyRing: createKeyRing() });
+      await storage.applyMigrations();
+      const root = createRoot("sqlite-acceptance");
+      const grantOptions = createGrantOptions(root.eventGameId);
+      const authority = createLegacyControlGrantTestAuthority(storage, grantOptions);
+      const created = await authority.createControlGrant({
+        scope: root.externalScope,
+        actor: { kind: "fixture", id: "fixture" },
+      });
+      if (created.status !== "created") throw new Error("Expected a Control Grant.");
+      const admitted = await authority.admitControlGrant({
+        qrCredential: created.qrCredential,
+        browserContext: "sqlite-controller",
+      });
+      if (admitted.status !== "admitted")
+        throw new Error(`Expected a Control Session: ${JSON.stringify(admitted)}`);
+      const record = createEventGameRecord(storage, {
+        externalScopeResolver: createScopeResolver(root),
+        interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
+        auditAuthorityVerifier: { verify: () => true },
+      });
+      expect(await record.registerRoot(root)).toMatchObject({ status: "registered" });
+      const acceptance = createAcceptance(storage, root, grantOptions);
+      const result = await acceptance.submitBatch({
+        recordId: root.recordId,
+        eventGameId: root.eventGameId,
+        sessionBearer: admitted.sessionBearer,
+        actions: [
+          createFact(root, "sqlite-operation", admitted.grantSessionId, created.grantVersion),
+        ],
+      });
+      expect(result).toMatchObject({ status: "committed" });
+      expect(result.results[0]).toMatchObject({ status: "accepted" });
+      expect(result.receipt).toBeUndefined();
+      const beforeRestart = await storage.transaction((transaction) => ({
+        actions: transaction.listActions(root.recordId),
+        controls: transaction.listAuditEntries(root.recordId),
+        grants: transaction.listGrantAudit(created.grantId),
+      }));
+      expect(beforeRestart.actions).toHaveLength(1);
+      expect(beforeRestart.controls.filter((entry) => entry.links?.grantAuditId)).toHaveLength(1);
+      expect(beforeRestart.grants.filter((entry) => entry.acceptanceId)).toHaveLength(1);
+      storage.close();
+
+      const reopened = openSqliteFoundationStorage(databasePath, { grantKeyRing: createKeyRing() });
+      expect(await reopened.readiness()).toMatchObject({ ok: true, schemaVersion: "18" });
+      expect(await reopened.readActions(root.recordId)).toHaveLength(1);
+      expect(await reopened.readAuditEntries(root.recordId)).toHaveLength(1);
+      reopened.close();
+    });
+  });
+
+  test("freezes an online pair when Control and Grant fingerprints are coordinated wrongly", async () => {
+    await withDatabase(async (databasePath) => {
+      const keyRing = createKeyRing();
+      const storage = openSqliteFoundationStorage(databasePath, { grantKeyRing: keyRing });
+      await storage.applyMigrations();
+      const root = createRoot("sqlite-online-fingerprint");
+      const grantOptions = createGrantOptions(root.eventGameId);
+      const authority = createLegacyControlGrantTestAuthority(storage, grantOptions);
+      const created = await authority.createControlGrant({
+        scope: root.externalScope,
+        actor: { kind: "fixture", id: "fixture" },
+      });
+      if (created.status !== "created") throw new Error("Expected a Control Grant.");
+      const admitted = await authority.admitControlGrant({
+        qrCredential: created.qrCredential,
+        browserContext: "sqlite-online-fingerprint-controller",
+      });
+      if (admitted.status !== "admitted") throw new Error("Expected a Control Session.");
+      const record = createEventGameRecord(storage, {
+        externalScopeResolver: createScopeResolver(root),
+      });
+      expect(await record.registerRoot(root)).toMatchObject({ status: "registered" });
+      const action = createFact(
+        root,
+        "sqlite-online-fingerprint-operation",
+        admitted.grantSessionId,
+        created.grantVersion,
+      );
+      expect(
+        await createAcceptance(storage, root, grantOptions).submitBatch({
+          recordId: root.recordId,
+          eventGameId: root.eventGameId,
+          sessionBearer: admitted.sessionBearer,
+          actions: [action],
+        }),
+      ).toMatchObject({ status: "committed" });
+      storage.close();
+
+      const raw = new Database(databasePath);
+      const wrongFingerprint = "f".repeat(64);
+      const controlRow = raw
+        .query("SELECT audit_id, audit_json FROM foundation_event_game_record_audit LIMIT 1")
+        .get() as { audit_id: string; audit_json: string };
+      const control = JSON.parse(controlRow.audit_json) as {
+        links: { contentFingerprint?: string };
+      };
+      control.links.contentFingerprint = wrongFingerprint;
+      raw
+        .query("UPDATE foundation_event_game_record_audit SET audit_json = ? WHERE audit_id = ?")
+        .run(JSON.stringify(control), controlRow.audit_id);
+      const grantRow = raw
+        .query("SELECT * FROM foundation_grant_audit WHERE content_fingerprint IS NOT NULL LIMIT 1")
+        .get() as Parameters<typeof readStoredGrantAuditEntry>[0];
+      const grantAudit = readStoredGrantAuditEntry(grantRow);
+      raw
+        .query(
+          "UPDATE foundation_grant_audit SET content_fingerprint = ?, audit_integrity_tag = ? WHERE audit_id = ?",
+        )
+        .run(
+          wrongFingerprint,
+          computeGrantAuditIntegrityTag(
+            { ...grantAudit, contentFingerprint: wrongFingerprint },
+            keyRing,
+          ),
+          grantAudit.auditId,
+        );
+      raw.close();
+
+      const reopened = openSqliteFoundationStorage(databasePath, { grantKeyRing: keyRing });
+      expect(await reopened.readiness()).toMatchObject({ ok: false, status: "integrity-failure" });
+      reopened.close();
+    });
+  });
+
+  test("uses independent SQLite writers for duplicate and conflict races", async () => {
+    await withDatabase(async (databasePath) => {
+      const bootstrap = openSqliteFoundationStorage(databasePath, {
+        grantKeyRing: createKeyRing(),
+      });
+      await bootstrap.applyMigrations();
+      const root = createRoot("sqlite-race");
+      const grantOptions = createGrantOptions(root.eventGameId);
+      const authority = createLegacyControlGrantTestAuthority(bootstrap, grantOptions);
+      const created = await authority.createControlGrant({
+        scope: root.externalScope,
+        actor: { kind: "fixture", id: "fixture" },
+      });
+      if (created.status !== "created") throw new Error("Expected a Control Grant.");
+      const admitted = await authority.admitControlGrant({
+        qrCredential: created.qrCredential,
+        browserContext: "sqlite-race-controller",
+      });
+      if (admitted.status !== "admitted")
+        throw new Error(`Expected a Control Session: ${JSON.stringify(admitted)}`);
+      const record = createEventGameRecord(bootstrap, {
+        externalScopeResolver: createScopeResolver(root),
+      });
+      expect(await record.registerRoot(root)).toMatchObject({ status: "registered" });
+      bootstrap.close();
+
+      const left = openSqliteFoundationStorage(databasePath, { grantKeyRing: createKeyRing() });
+      const right = openSqliteFoundationStorage(databasePath, { grantKeyRing: createKeyRing() });
+      const leftAcceptance = createAcceptance(left, root, grantOptions);
+      const rightAcceptance = createAcceptance(right, root, grantOptions);
+      const duplicateAction = createFact(
+        root,
+        "duplicate-race",
+        admitted.grantSessionId,
+        created.grantVersion,
+      );
+      const duplicateResults = await Promise.all([
+        leftAcceptance.submitBatch({
+          recordId: root.recordId,
+          eventGameId: root.eventGameId,
+          sessionBearer: admitted.sessionBearer,
+          actions: [duplicateAction],
+        }),
+        rightAcceptance.submitBatch({
+          recordId: root.recordId,
+          eventGameId: root.eventGameId,
+          sessionBearer: admitted.sessionBearer,
+          actions: [duplicateAction],
+        }),
+      ]);
+      expect(
+        duplicateResults
+          .map((result) => result.results[0]?.status)
+          .sort((left, right) => (left ?? "").localeCompare(right ?? "")),
+      ).toEqual(["accepted", "duplicate-accepted"]);
+
+      const conflictLeft = createFact(
+        root,
+        "conflict-race",
+        admitted.grantSessionId,
+        created.grantVersion,
+      );
+      const conflictRight = structuredClone(conflictLeft);
+      conflictRight.payload = {
+        factId: "fact-conflict-race",
+        factType: "test",
+        gameSideId: "side-a-sqlite-race",
+        gameTimeMs: 1,
+        data: { operationId: "different-content" },
+      };
+      const conflictResults = await Promise.all([
+        leftAcceptance.submitBatch({
+          recordId: root.recordId,
+          eventGameId: root.eventGameId,
+          sessionBearer: admitted.sessionBearer,
+          actions: [conflictLeft],
+        }),
+        rightAcceptance.submitBatch({
+          recordId: root.recordId,
+          eventGameId: root.eventGameId,
+          sessionBearer: admitted.sessionBearer,
+          actions: [conflictRight],
+        }),
+      ]);
+      expect(
+        conflictResults
+          .map((result) => result.results[0]?.status)
+          .sort((left, right) => (left ?? "").localeCompare(right ?? "")),
+      ).toEqual(["accepted", "rejected"]);
+      expect(
+        conflictResults.find((result) => result.results[0]?.status === "rejected")?.results[0],
+      ).toMatchObject({
+        reason: "operation-conflict",
+      });
+      left.close();
+      right.close();
+
+      const verify = openSqliteFoundationStorage(databasePath, { grantKeyRing: createKeyRing() });
+      const verifyAcceptance = createAcceptance(verify, root, grantOptions);
+      const thirdDuplicate = await verifyAcceptance.submitBatch({
+        recordId: root.recordId,
+        eventGameId: root.eventGameId,
+        sessionBearer: admitted.sessionBearer,
+        actions: [duplicateAction],
+      });
+      expect(thirdDuplicate.results[0]).toMatchObject({ status: "duplicate-accepted" });
+
+      const restartConflictAccepted = createFact(
+        root,
+        "sqlite-restart-conflict",
+        admitted.grantSessionId,
+        created.grantVersion,
+      );
+      expect(
+        await verifyAcceptance.submitBatch({
+          recordId: root.recordId,
+          eventGameId: root.eventGameId,
+          sessionBearer: admitted.sessionBearer,
+          actions: [restartConflictAccepted],
+        }),
+      ).toMatchObject({ results: [{ status: "accepted" }] });
+      const restartConflictRejected = structuredClone(restartConflictAccepted);
+      restartConflictRejected.payload = {
+        factId: "fact-sqlite-restart-conflict-other",
+        factType: "test",
+        gameSideId: root.gameSides[0]?.id ?? "side-a",
+        gameTimeMs: 1,
+        data: { operationId: "sqlite-restart-conflict" },
+      };
+      const firstRestartRejection = await verifyAcceptance.submitBatch({
+        recordId: root.recordId,
+        eventGameId: root.eventGameId,
+        sessionBearer: admitted.sessionBearer,
+        actions: [restartConflictRejected],
+      });
+      expect(firstRestartRejection.results[0]).toMatchObject({
+        status: "rejected",
+        reason: "operation-conflict",
+      });
+      verify.close();
+
+      const reopened = openSqliteFoundationStorage(databasePath, {
+        grantKeyRing: createKeyRing(),
+      });
+      const reopenedAcceptance = createAcceptance(reopened, root, grantOptions);
+      const repeatedRestartRejection = await reopenedAcceptance.submitBatch({
+        recordId: root.recordId,
+        eventGameId: root.eventGameId,
+        sessionBearer: admitted.sessionBearer,
+        actions: [restartConflictRejected],
+      });
+      expect(repeatedRestartRejection.results[0]).toEqual(firstRestartRejection.results[0]);
+      expect(await reopened.readiness()).toMatchObject({ ok: true });
+      reopened.close();
+
+      const finalVerify = openSqliteFoundationStorage(databasePath, {
+        grantKeyRing: createKeyRing(),
+      });
+      expect(await finalVerify.readiness()).toMatchObject({ ok: true });
+      expect(await finalVerify.readActions(root.recordId)).toHaveLength(3);
+      finalVerify.close();
+    });
+  });
+
+  test("persists prepared budget retries and bounded replay-ineligible outcomes", async () => {
+    await withDatabase(async (databasePath) => {
+      const storage = openSqliteFoundationStorage(databasePath, { grantKeyRing: createKeyRing() });
+      await storage.applyMigrations();
+      const root = createRoot("sqlite-correction-regressions");
+      const grantOptions = createGrantOptions(root.eventGameId);
+      const authority = createLegacyControlGrantTestAuthority(storage, grantOptions);
+      const created = await authority.createControlGrant({
+        scope: root.externalScope,
+        actor: { kind: "fixture", id: "fixture" },
+      });
+      if (created.status !== "created") throw new Error("Expected a Control Grant.");
+      const admitted = await authority.admitControlGrant({
+        qrCredential: created.qrCredential,
+        browserContext: "sqlite-correction-controller",
+      });
+      if (admitted.status !== "admitted") throw new Error("Expected a Control Session.");
+      const record = createEventGameRecord(storage, {
+        externalScopeResolver: createScopeResolver(root),
+      });
+      expect(await record.registerRoot(root)).toMatchObject({ status: "registered" });
+      const nowMs = { value: 1_000 };
+      const acceptance = createAcceptance(storage, root, grantOptions, false, undefined, {
+        clock: () => nowMs.value,
+        limits: { onlineSessionCapacity: 1, onlineEventCapacity: 1 },
+      });
+      const first = createFact(
+        root,
+        "sqlite-budget-first",
+        admitted.grantSessionId,
+        created.grantVersion,
+      );
+      const retry = createFact(
+        root,
+        "sqlite-budget-retry",
+        admitted.grantSessionId,
+        created.grantVersion,
+      );
+      expect(
+        await acceptance.submitBatch({
+          recordId: root.recordId,
+          eventGameId: root.eventGameId,
+          sessionBearer: admitted.sessionBearer,
+          actions: [first],
+        }),
+      ).toMatchObject({ results: [{ status: "accepted" }] });
+
+      const exhausted = await acceptance.submitBatch({
+        recordId: root.recordId,
+        eventGameId: root.eventGameId,
+        sessionBearer: admitted.sessionBearer,
+        actions: [retry],
+      });
+      expect(exhausted.results[0]).toMatchObject({ status: "retry-later", reason: "rate-budget" });
+      const retryAudit = (await storage.readAuditEntries(root.recordId)).find(
+        (entry) => entry.links?.reason === "rate-budget",
+      );
+      expect(retryAudit?.links?.rejectedCandidate?.codecIdentity).toEqual(expect.any(String));
+      expect(retryAudit?.links?.rejectedCandidate?.codecIdentity).not.toBe("unprepared");
+      storage.close();
+
+      nowMs.value = 2_000;
+      const reopened = openSqliteFoundationStorage(databasePath, { grantKeyRing: createKeyRing() });
+      const resumed = await createAcceptance(reopened, root, grantOptions, false, undefined, {
+        clock: () => nowMs.value,
+        limits: { onlineSessionCapacity: 1, onlineEventCapacity: 1 },
+      }).submitBatch({
+        recordId: root.recordId,
+        eventGameId: root.eventGameId,
+        sessionBearer: admitted.sessionBearer,
+        actions: [retry],
+      });
+      expect(resumed.results[0]).toMatchObject({ status: "accepted" });
+
+      const unsupported = createFact(
+        root,
+        "sqlite-unsupported-replay",
+        admitted.grantSessionId,
+        created.grantVersion,
+      );
+      unsupported.kind = { id: "sqlite-unsupported-codec", version: "9" };
+      const unsupportedFirst = await createAcceptance(reopened, root, grantOptions).submitBatch({
+        mode: "replay",
+        recordId: root.recordId,
+        eventGameId: root.eventGameId,
+        replay: {
+          sessionBearer: admitted.sessionBearer,
+          originatingSessionId: admitted.grantSessionId,
+          replayEvidenceId: "sqlite-unsupported-replay",
+        },
+        actions: [unsupported],
+      });
+      expect(unsupportedFirst.results[0]).toMatchObject({
+        status: "rejected",
+        reason: "invalid-action",
+      });
+      reopened.close();
+
+      const reopenedForReplay = openSqliteFoundationStorage(databasePath, {
+        grantKeyRing: createKeyRing(),
+      });
+      const unsupportedSecond = await createAcceptance(
+        reopenedForReplay,
+        root,
+        grantOptions,
+      ).submitBatch({
+        mode: "replay",
+        recordId: root.recordId,
+        eventGameId: root.eventGameId,
+        replay: {
+          sessionBearer: admitted.sessionBearer,
+          originatingSessionId: admitted.grantSessionId,
+          replayEvidenceId: "sqlite-unsupported-replay",
+        },
+        actions: [unsupported],
+      });
+      expect(unsupportedSecond.results[0]).toEqual(unsupportedFirst.results[0]);
+      const replayFirst = await createAcceptance(
+        reopenedForReplay,
+        root,
+        grantOptions,
+        true,
+        undefined,
+        {
+          replayDecision: "throw",
+        },
+      ).submitBatch({
+        mode: "replay",
+        recordId: root.recordId,
+        eventGameId: root.eventGameId,
+        replay: {
+          sessionBearer: admitted.sessionBearer,
+          originatingSessionId: admitted.grantSessionId,
+          replayEvidenceId: "sqlite-generic-replay-ineligible",
+        },
+        actions: [
+          createFact(
+            root,
+            "sqlite-generic-replay-ineligible",
+            admitted.grantSessionId,
+            created.grantVersion,
+          ),
+        ],
+      });
+      expect(replayFirst.results[0]).toMatchObject({
+        status: "authority-expired",
+        reason: "replay-ineligible",
+        detail: "Replay authorization is unavailable.",
+      });
+      reopenedForReplay.close();
+
+      const replayReopened = openSqliteFoundationStorage(databasePath, {
+        grantKeyRing: createKeyRing(),
+      });
+      const replaySecond = await createAcceptance(
+        replayReopened,
+        root,
+        grantOptions,
+        true,
+        undefined,
+        { replayDecision: "throw" },
+      ).submitBatch({
+        mode: "replay",
+        recordId: root.recordId,
+        eventGameId: root.eventGameId,
+        replay: {
+          sessionBearer: admitted.sessionBearer,
+          originatingSessionId: admitted.grantSessionId,
+          replayEvidenceId: "sqlite-generic-replay-ineligible",
+        },
+        actions: [
+          createFact(
+            root,
+            "sqlite-generic-replay-ineligible",
+            admitted.grantSessionId,
+            created.grantVersion,
+          ),
+        ],
+      });
+      expect(replaySecond.results[0]).toEqual(replayFirst.results[0]);
+      expect(
+        await replayReopened.transaction((transaction) =>
+          transaction.findReplayReservationByOriginTuple(
+            root.recordId,
+            root.eventGameId,
+            admitted.grantSessionId,
+            1,
+          ),
+        ),
+      ).toBeNull();
+      expect(await replayReopened.readiness()).toMatchObject({ ok: true });
+      replayReopened.close();
+    });
+  });
+
+  test("persists replay attempts and a keyed receipt without storing the bearer", async () => {
+    await withDatabase(async (databasePath) => {
+      const storage = openSqliteFoundationStorage(databasePath, { grantKeyRing: createKeyRing() });
+      await storage.applyMigrations();
+      const root = createRoot("sqlite-replay");
+      const grantOptions = createGrantOptions(root.eventGameId);
+      const authority = createLegacyControlGrantTestAuthority(storage, grantOptions);
+      const created = await authority.createControlGrant({
+        scope: root.externalScope,
+        actor: { kind: "fixture", id: "fixture" },
+      });
+      if (created.status !== "created") throw new Error("Expected a Control Grant.");
+      const admitted = await authority.admitControlGrant({
+        qrCredential: created.qrCredential,
+        browserContext: "sqlite-replay-controller",
+      });
+      if (admitted.status !== "admitted") throw new Error("Expected a Control Session.");
+      const record = createEventGameRecord(storage, {
+        externalScopeResolver: createScopeResolver(root),
+      });
+      expect(await record.registerRoot(root)).toMatchObject({ status: "registered" });
+      const acceptance = createAcceptance(storage, root, grantOptions, true);
+      const duplicateAction = createFact(
+        root,
+        "sqlite-replay-duplicate",
+        admitted.grantSessionId,
+        created.grantVersion,
+      );
+      expect(
+        await createAcceptance(storage, root, grantOptions).submitBatch({
+          recordId: root.recordId,
+          eventGameId: root.eventGameId,
+          sessionBearer: admitted.sessionBearer,
+          actions: [duplicateAction],
+        }),
+      ).toMatchObject({ results: [{ status: "accepted" }] });
+      const duplicateReplay = await acceptance.submitBatch({
+        mode: "replay",
+        recordId: root.recordId,
+        eventGameId: root.eventGameId,
+        replay: {
+          sessionBearer: admitted.sessionBearer,
+          originatingSessionId: "sqlite-duplicate-origin",
+          replayEvidenceId: "sqlite-duplicate-replay",
+        },
+        actions: [duplicateAction],
+      });
+      const duplicateReservationId = duplicateReplay.reservationId;
+      const duplicateReceipt = duplicateReplay.receipt;
+      expect(duplicateReplay.results[0]).toMatchObject({
+        status: "duplicate-accepted",
+      });
+      expect(duplicateReplay).toMatchObject({
+        status: "committed",
+        receipt: expect.any(String),
+        reservationId: expect.any(String),
+      });
+      const rejectionAction = {
+        ...createFact(
+          root,
+          "sqlite-replay-rejected",
+          admitted.grantSessionId,
+          created.grantVersion,
+        ),
+        causalPredecessorIds: ["missing-replay-predecessor"],
+      };
+      const rejectionReplay = await acceptance.submitBatch({
+        mode: "replay",
+        recordId: root.recordId,
+        eventGameId: root.eventGameId,
+        replay: {
+          sessionBearer: admitted.sessionBearer,
+          originatingSessionId: "sqlite-rejection-origin",
+          replayEvidenceId: "sqlite-rejection-replay",
+        },
+        actions: [rejectionAction],
+      });
+      const rejectionReservationId = rejectionReplay.reservationId;
+      const rejectionReceipt = rejectionReplay.receipt;
+      expect(rejectionReplay.results[0]).toMatchObject({
+        status: "rejected",
+        reason: "missing-dependency",
+      });
+      expect(rejectionReplay).toMatchObject({
+        status: "committed",
+        receipt: expect.any(String),
+        reservationId: expect.any(String),
+      });
+      const replay = await acceptance.submitBatch({
+        mode: "replay",
+        recordId: root.recordId,
+        eventGameId: root.eventGameId,
+        replay: {
+          sessionBearer: admitted.sessionBearer,
+          originatingSessionId: admitted.grantSessionId,
+          replayEvidenceId: "sqlite-replay-evidence",
+        },
+        actions: [
+          createFact(
+            root,
+            "sqlite-replay-operation",
+            admitted.grantSessionId,
+            created.grantVersion,
+          ),
+        ],
+      });
+      const replayReceipt = replay.receipt;
+      expect(replay.status).toBe("committed");
+      expect(replayReceipt).toEqual(expect.any(String));
+      storage.close();
+
+      const raw = new Database(databasePath);
+      const receiptRows = raw
+        .query("SELECT receipt_digest FROM foundation_replay_receipts")
+        .all() as Array<{ receipt_digest: string }>;
+      expect(receiptRows).toHaveLength(3);
+      expect(receiptRows[0]?.receipt_digest).toMatch(/^[a-f0-9]{64}$/);
+      expect(receiptRows[0]?.receipt_digest).not.toBe(replayReceipt);
+      raw.close();
+
+      const rotatedGrantOptions = { ...grantOptions, keyRing: rotateKeyRing() };
+      const reopened = openSqliteFoundationStorage(databasePath, {
+        grantKeyRing: rotatedGrantOptions.keyRing,
+      });
+      const reopenedAcceptance = createAcceptance(reopened, root, rotatedGrantOptions, true);
+      const duplicateRetry = await reopenedAcceptance.submitBatch({
+        mode: "replay",
+        recordId: root.recordId,
+        eventGameId: root.eventGameId,
+        replay: {
+          sessionBearer: admitted.sessionBearer,
+          originatingSessionId: "sqlite-duplicate-origin",
+          replayEvidenceId: "sqlite-duplicate-replay",
+        },
+        actions: [duplicateAction],
+      });
+      expect(duplicateRetry.results[0]).toEqual(duplicateReplay.results[0]);
+      expect(duplicateRetry.reservationId).toBe(duplicateReservationId);
+      expect(duplicateRetry.receipt).toBe(duplicateReceipt);
+      const rejectionRetry = await reopenedAcceptance.submitBatch({
+        mode: "replay",
+        recordId: root.recordId,
+        eventGameId: root.eventGameId,
+        replay: {
+          sessionBearer: admitted.sessionBearer,
+          originatingSessionId: "sqlite-rejection-origin",
+          replayEvidenceId: "sqlite-rejection-replay",
+        },
+        actions: [rejectionAction],
+      });
+      expect(rejectionRetry.results[0]).toEqual(rejectionReplay.results[0]);
+      expect(rejectionRetry.reservationId).toBe(rejectionReservationId);
+      expect(rejectionRetry.receipt).toBe(rejectionReceipt);
+      const retried = await reopenedAcceptance.submitBatch({
+        mode: "replay",
+        recordId: root.recordId,
+        eventGameId: root.eventGameId,
+        replay: {
+          sessionBearer: admitted.sessionBearer,
+          originatingSessionId: admitted.grantSessionId,
+          replayEvidenceId: "sqlite-replay-evidence",
+        },
+        actions: [
+          createFact(
+            root,
+            "sqlite-replay-operation",
+            admitted.grantSessionId,
+            created.grantVersion,
+          ),
+        ],
+      });
+      expect(retried).toMatchObject({ status: "committed", receipt: replayReceipt });
+      const rotatedAuthority = createLegacyControlGrantTestAuthority(reopened, rotatedGrantOptions);
+      expect(
+        await rotatedAuthority.revokeControlGrant(created.grantId, {
+          kind: "fixture",
+          id: "fixture",
+        }),
+      ).toMatchObject({ status: "updated" });
+      expect(await reopenedAcceptance.acknowledgeReplay(replayReceipt!)).toEqual({
+        status: "acknowledged",
+      });
+      expect(await reopenedAcceptance.acknowledgeReplay(duplicateReceipt!)).toEqual({
+        status: "acknowledged",
+      });
+      expect(await reopenedAcceptance.acknowledgeReplay(rejectionReceipt!)).toEqual({
+        status: "acknowledged",
+      });
+      expect(await reopened.readiness()).toMatchObject({ ok: true, schemaVersion: "18" });
+      reopened.close();
+    });
+  });
+
+  test("resumes a partial replay after SQLite restart without a premature receipt", async () => {
+    await withDatabase(async (databasePath) => {
+      const storage = openSqliteFoundationStorage(databasePath, { grantKeyRing: createKeyRing() });
+      await storage.applyMigrations();
+      const root = createRoot("sqlite-partial-replay");
+      const grantOptions = createGrantOptions(root.eventGameId);
+      const authority = createLegacyControlGrantTestAuthority(storage, grantOptions);
+      const created = await authority.createControlGrant({
+        scope: root.externalScope,
+        actor: { kind: "fixture", id: "fixture" },
+      });
+      if (created.status !== "created") throw new Error("Expected a Control Grant.");
+      const admitted = await authority.admitControlGrant({
+        qrCredential: created.qrCredential,
+        browserContext: "sqlite-partial-replay-controller",
+      });
+      if (admitted.status !== "admitted") throw new Error("Expected a Control Session.");
+      const record = createEventGameRecord(storage, {
+        externalScopeResolver: createScopeResolver(root),
+      });
+      expect(await record.registerRoot(root)).toMatchObject({ status: "registered" });
+      const nowMs = { value: 1_000 };
+      const limits = { replaySessionCapacity: 1 };
+      const first = createFact(
+        root,
+        "sqlite-partial-first",
+        admitted.grantSessionId,
+        created.grantVersion,
+      );
+      const second = {
+        ...createFact(root, "sqlite-partial-second", admitted.grantSessionId, created.grantVersion),
+        causalPredecessorIds: [first.operationId],
+      };
+      const input = {
+        mode: "replay" as const,
+        recordId: root.recordId,
+        eventGameId: root.eventGameId,
+        replay: {
+          sessionBearer: admitted.sessionBearer,
+          originatingSessionId: "sqlite-partial-origin",
+          replayEvidenceId: "sqlite-partial-replay",
+        },
+        actions: [second, first],
+      };
+      const partial = await createAcceptance(storage, root, grantOptions, true, undefined, {
+        clock: () => nowMs.value,
+        limits,
+      }).submitBatch(input);
+      expect(partial.results.map((result) => result.status)).toEqual(["retry-later", "accepted"]);
+      expect(partial.receipt).toBeUndefined();
+      const partialReservationId = partial.reservationId;
+      expect(partialReservationId).toEqual(expect.any(String));
+      storage.close();
+
+      nowMs.value = 2_000;
+      const reopened = openSqliteFoundationStorage(databasePath, {
+        grantKeyRing: createKeyRing(),
+      });
+      const resumed = await createAcceptance(reopened, root, grantOptions, true, undefined, {
+        clock: () => nowMs.value,
+        limits,
+      }).submitBatch(input);
+      expect(resumed.results[1]).toEqual(partial.results[1]);
+      expect(resumed.results[0]).toMatchObject({ status: "accepted" });
+      expect(resumed.reservationId).toBe(partialReservationId);
+      const resumedReceipt = resumed.receipt;
+      expect(resumedReceipt).toEqual(expect.any(String));
+      expect(await reopened.readAuditEntries(root.recordId)).toHaveLength(3);
+      expect(
+        await createAcceptance(reopened, root, grantOptions, true).acknowledgeReplay(
+          resumedReceipt!,
+        ),
+      ).toEqual({
+        status: "acknowledged",
+      });
+      expect(await reopened.readiness()).toMatchObject({ ok: true });
+      reopened.close();
+    });
+  });
+
+  test("persists definitive mixed replay outcomes under one SQLite reservation", async () => {
+    for (const unsupported of [true, false]) {
+      await withDatabase(async (databasePath) => {
+        const storage = openSqliteFoundationStorage(databasePath, {
+          grantKeyRing: createKeyRing(),
+        });
+        await storage.applyMigrations();
+        const root = createRoot(
+          unsupported ? "sqlite-mixed-unsupported" : "sqlite-mixed-ineligible",
+        );
+        const grantOptions = createGrantOptions(root.eventGameId);
+        const authority = createLegacyControlGrantTestAuthority(storage, grantOptions);
+        const created = await authority.createControlGrant({
+          scope: root.externalScope,
+          actor: { kind: "fixture", id: "fixture" },
+        });
+        if (created.status !== "created") throw new Error("Expected a Control Grant.");
+        const admitted = await authority.admitControlGrant({
+          qrCredential: created.qrCredential,
+          browserContext: "sqlite-mixed-replay-controller",
+        });
+        if (admitted.status !== "admitted") throw new Error("Expected a Control Session.");
+        const record = createEventGameRecord(storage, {
+          externalScopeResolver: createScopeResolver(root),
+        });
+        expect(await record.registerRoot(root)).toMatchObject({ status: "registered" });
+        const first = createFact(
+          root,
+          unsupported ? "sqlite-mixed-valid-codec" : "sqlite-mixed-valid-eligibility",
+          admitted.grantSessionId,
+          created.grantVersion,
+        );
+        const second = createFact(
+          root,
+          unsupported ? "sqlite-mixed-unsupported" : "sqlite-mixed-ineligible",
+          admitted.grantSessionId,
+          created.grantVersion,
+        );
+        if (unsupported) second.kind = { id: "sqlite-mixed-unsupported-codec", version: "1" };
+        const makeAcceptance = (target: SqliteFoundationStorage) =>
+          createFoundationAcceptance(target, {
+            grant: grantOptions,
+            externalScopeResolver: createScopeResolver(root),
+            clock: () => 1_000,
+            interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
+            replayEligibility: ({ action }) => {
+              if (!unsupported && action.input.operationId === second.operationId)
+                throw new Error("adapter callback failure");
+              return { status: "eligible" as const };
+            },
+          });
+        const input = {
+          mode: "replay" as const,
+          recordId: root.recordId,
+          eventGameId: root.eventGameId,
+          replay: {
+            sessionBearer: admitted.sessionBearer,
+            originatingSessionId: unsupported
+              ? "sqlite-mixed-unsupported-origin"
+              : "sqlite-mixed-ineligible-origin",
+            replayEvidenceId: "sqlite-mixed-replay",
+          },
+          actions: [first, second],
+        };
+        const firstDelivery = await makeAcceptance(storage).submitBatch(input);
+        const reservationId = firstDelivery.reservationId;
+        const receipt = firstDelivery.receipt;
+        expect(firstDelivery.results[0]).toMatchObject({ status: "accepted" });
+        expect(firstDelivery.results[1]).toMatchObject(
+          unsupported
+            ? { status: "rejected", reason: "invalid-action" }
+            : { status: "authority-expired", reason: "replay-ineligible" },
+        );
+        expect(reservationId).toEqual(expect.any(String));
+        expect(receipt).toEqual(expect.any(String));
+        const attempts = await storage.transaction((transaction) =>
+          transaction.listReplayAttempts(reservationId!),
+        );
+        expect(attempts).toHaveLength(2);
+        expect(attempts.every((attempt) => attempt.status !== "retry-later")).toBe(true);
+        expect(await storage.readAuditEntries(root.recordId)).toHaveLength(2);
+        storage.close();
+
+        const reopened = openSqliteFoundationStorage(databasePath, {
+          grantKeyRing: createKeyRing(),
+        });
+        const restarted = await makeAcceptance(reopened).submitBatch(input);
+        expect(restarted.results).toEqual(firstDelivery.results);
+        expect(restarted.reservationId).toBe(reservationId);
+        expect(restarted.receipt).toBe(receipt);
+        expect(await makeAcceptance(reopened).acknowledgeReplay(receipt!)).toEqual({
+          status: "acknowledged",
+        });
+        expect(await reopened.readAuditEntries(root.recordId)).toHaveLength(2);
+        expect(await reopened.readiness()).toMatchObject({ ok: true });
+        reopened.close();
+      });
+    }
+  });
+
+  test("recovers an exact committed replay after Game Lock and key rotation", async () => {
+    await withDatabase(async (databasePath) => {
+      const storage = openSqliteFoundationStorage(databasePath, { grantKeyRing: createKeyRing() });
+      await storage.applyMigrations();
+      const root = createRoot("sqlite-lock-recovery");
+      const grantOptions = createGrantOptions(root.eventGameId);
+      const authority = createLegacyControlGrantTestAuthority(storage, grantOptions);
+      const created = await authority.createControlGrant({
+        scope: root.externalScope,
+        actor: { kind: "fixture", id: "fixture" },
+      });
+      if (created.status !== "created") throw new Error("Expected a Control Grant.");
+      const admitted = await authority.admitControlGrant({
+        qrCredential: created.qrCredential,
+        browserContext: "sqlite-lock-recovery-controller",
+      });
+      if (admitted.status !== "admitted") throw new Error("Expected a Control Session.");
+      const record = createEventGameRecord(storage, {
+        externalScopeResolver: createScopeResolver(root),
+      });
+      expect(await record.registerRoot(root)).toMatchObject({ status: "registered" });
+      const action = createFact(
+        root,
+        "sqlite-lock-recovery-operation",
+        admitted.grantSessionId,
+        created.grantVersion,
+      );
+      const evidence = "sqlite-lock-recovery-evidence";
+      const digest = sha256(
+        JSON.stringify({
+          recordId: root.recordId,
+          eventGameId: root.eventGameId,
+          mode: "replay",
+          replay: { originatingSessionId: admitted.grantSessionId, replayEvidenceId: evidence },
+          actions: [action],
+        }),
+      );
+      const acceptance = createAcceptance(storage, root, grantOptions, true);
+      const committed = await acceptance.submitBatch({
+        mode: "replay",
+        recordId: root.recordId,
+        eventGameId: root.eventGameId,
+        replay: {
+          sessionBearer: admitted.sessionBearer,
+          originatingSessionId: admitted.grantSessionId,
+          replayEvidenceId: evidence,
+        },
+        actions: [action],
+      });
+      const receipt = committed.receipt;
+      expect(committed).toMatchObject({ status: "committed", receipt: expect.any(String) });
+      storage.close();
+
+      const locked = {
+        ...root,
+        lifecycle: {
+          phase: "finished" as const,
+          commencedAtMs: 100,
+          finishedAtMs: 800,
+          lockedAtMs: 900,
+          lockReason: "administrative" as const,
+        },
+      };
+      const raw = new Database(databasePath);
+      raw
+        .query(
+          `UPDATE foundation_event_game_record_roots
+           SET lifecycle_phase = ?, commenced_at_ms = ?, finished_at_ms = ?, locked_at_ms = ?,
+               lock_reason = ?, canonical_content = ?, root_json = ? WHERE record_id = ?`,
+        )
+        .run(
+          locked.lifecycle.phase,
+          locked.lifecycle.commencedAtMs,
+          locked.lifecycle.finishedAtMs,
+          locked.lifecycle.lockedAtMs,
+          locked.lifecycle.lockReason,
+          canonicalizeEventGameRecordRoot(locked),
+          JSON.stringify(locked),
+          root.recordId,
+        );
+      raw.close();
+
+      const rotatedGrantOptions = { ...grantOptions, keyRing: rotateKeyRing() };
+      const reopened = openSqliteFoundationStorage(databasePath, {
+        grantKeyRing: rotatedGrantOptions.keyRing,
+      });
+      const lockedAcceptance = createAcceptance(reopened, root, rotatedGrantOptions, true, digest);
+      const recovered = await lockedAcceptance.submitBatch({
+        mode: "replay",
+        recordId: root.recordId,
+        eventGameId: root.eventGameId,
+        replay: {
+          sessionBearer: "lost-response-bearer",
+          originatingSessionId: admitted.grantSessionId,
+          replayEvidenceId: evidence,
+        },
+        actions: [action],
+      });
+      expect(recovered).toMatchObject({ status: "committed", receipt });
+      expect(await lockedAcceptance.acknowledgeReplay(receipt!)).toEqual({
+        status: "acknowledged",
+      });
+      reopened.close();
+    });
+  });
+
+  test("revalidates authority and root state across a synchronized independent-writer barrier", async () => {
+    await withRaceCase(
+      "revocation",
+      async ({ right, created }) => {
+        await right.authority.revokeControlGrant(created.grantId, {
+          kind: "fixture",
+          id: "fixture",
+        });
+      },
+      (result) => {
+        expect(result.results[0]).toMatchObject({
+          status: "authority-expired",
+          reason: "grant-session",
+        });
+      },
+    );
+    await withRaceCase(
+      "grant-rotation",
+      async ({ right, created }) => {
+        await right.authority.rotateControlGrant(created.grantId, {
+          kind: "fixture",
+          id: "fixture",
+        });
+      },
+      (result) => {
+        expect(result.results[0]).toMatchObject({
+          status: "authority-expired",
+          reason: "grant-session",
+          detail: "The Grant Session is no longer current.",
+        });
+      },
+      undefined,
+      0,
+      0,
+    );
+    await withRaceCase(
+      "lifecycle-drift",
+      async (context) => {
+        context.setNow(1_500);
+        context.changeRootLifecycle();
+      },
+      (result) => {
+        expect(result.results[0]).toMatchObject({
+          status: "retry-later",
+          reason: "stale-preflight",
+        });
+      },
+      undefined,
+      0,
+      0,
+      true,
+    );
+    await withRaceCase(
+      "key-rotation",
+      async (context) => {
+        const rotatedKeyRing = rotateKeyRing();
+        const rotatedOptions = { ...context.grantOptions, keyRing: rotatedKeyRing };
+        const rotatedAuthority = createLegacyControlGrantTestAuthority(
+          context.right.storage,
+          rotatedOptions,
+        );
+        await rotatedAuthority.rotateControlGrantCredentialKeys(context.created.grantId, {
+          kind: "fixture",
+          id: "fixture",
+        });
+        context.grantOptions.keyRing = rotatedKeyRing;
+        context.left.setGrantKeyRing?.(rotatedKeyRing);
+      },
+      (result) => {
+        expect(result.results[0]).toMatchObject({ status: "accepted" });
+      },
+      undefined,
+      1,
+      1,
+    );
+    await withRaceCase(
+      "expiry",
+      async (context) => {
+        context.setNow(2_000);
+      },
+      (result) => {
+        expect(result.results[0]).toMatchObject({
+          status: "authority-expired",
+          reason: "grant-session",
+        });
+      },
+      1_500,
+    );
+    await withRaceCase(
+      "scope-change",
+      async (context) => {
+        context.setScopeAvailable(false);
+      },
+      (result) => {
+        expect(result.results[0]).toMatchObject({
+          status: "retry-later",
+          reason: "scope-unavailable",
+        });
+      },
+    );
+    await withRaceCase(
+      "game-lock",
+      async (context) => {
+        context.lockRoot();
+      },
+      (result) => {
+        expect(result.results[0]).toMatchObject({
+          status: "authority-expired",
+          reason: "game-locked",
+        });
+      },
+    );
+  });
+
+  test("freezes SQLite writes for mutated, gapped, and extra integrity history", async () => {
+    for (const corruption of ["mutated", "gapped", "extra"] as const) {
+      await withDatabase(async (databasePath) => {
+        const keyRing = createKeyRing();
+        const storage = openSqliteFoundationStorage(databasePath, { grantKeyRing: keyRing });
+        await storage.applyMigrations();
+        const first = createBudget("history-budget", 1);
+        const second = createBudget("history-budget", 2);
+        await storage.transaction((transaction) => {
+          transaction.upsertAcceptanceBudget(first);
+          transaction.insertAcceptanceIntegrityAnchor(anchorFor("budget", first, keyRing));
+          transaction.upsertAcceptanceBudget(second);
+          transaction.insertAcceptanceIntegrityAnchor(anchorFor("budget", second, keyRing));
+        });
+        const database = new Database(databasePath);
+        database.exec("DROP TRIGGER foundation_acceptance_integrity_anchors_no_update;");
+        database.exec("DROP TRIGGER foundation_acceptance_integrity_anchors_no_delete;");
+        if (corruption === "mutated") {
+          database
+            .query(
+              "UPDATE foundation_acceptance_integrity_anchors SET integrity_tag = ? WHERE subject_kind = 'budget' AND subject_id = ? AND state_revision = 1",
+            )
+            .run("hmac-sha256-v1:audit-v1:tampered", first.bucketId);
+        } else if (corruption === "gapped") {
+          database
+            .query(
+              "DELETE FROM foundation_acceptance_integrity_anchors WHERE subject_kind = 'budget' AND subject_id = ? AND state_revision = 1",
+            )
+            .run(first.bucketId);
+        } else {
+          const extra = createBudget("history-budget", 3);
+          const anchor = anchorFor("budget", extra, keyRing);
+          database
+            .query(
+              `INSERT INTO foundation_acceptance_integrity_anchors
+               (anchor_id, subject_kind, subject_id, state_revision, key_version, integrity_tag, canonical_value)
+               VALUES (?, ?, ?, ?, ?, ?, ?)`,
+            )
+            .run(
+              anchor.anchorId,
+              anchor.subjectKind,
+              anchor.subjectId,
+              anchor.stateRevision,
+              anchor.keyVersion,
+              anchor.integrityTag,
+              anchor.canonicalValue,
+            );
+        }
+        database.close();
+        expect(await storage.readiness()).toMatchObject({ ok: false, status: "integrity-failure" });
+        await storage
+          .transaction(() => "must-not-write")
+          .then(
+            () => {
+              throw new Error("Expected a frozen storage transaction to reject.");
+            },
+            (error: unknown) => {
+              expect(String(error)).toContain("not ready");
+            },
+          );
+        storage.close();
+      });
+    }
+  });
+});
+
+type RaceContext = {
+  left: SqliteFoundationStorage;
+  right: {
+    storage: SqliteFoundationStorage;
+    authority: ReturnType<typeof createLegacyControlGrantTestAuthority>;
+    close(): void;
+  };
+  root: EventGameRecordRoot;
+  created: { grantId: string; grantVersion: string };
+  admitted: { grantSessionId: string; sessionBearer: string };
+  grantOptions: GrantAuthorityOptions;
+  setNow(nowMs: number): void;
+  setScopeAvailable(available: boolean): void;
+  changeRootLifecycle(): void;
+  lockRoot(): void;
+};
+
+async function withRaceCase(
+  suffix: string,
+  mutate: (context: RaceContext) => Promise<void>,
+  assertResult: (
+    result: Awaited<ReturnType<ReturnType<typeof createAcceptance>["submitBatch"]>>,
+  ) => void,
+  expiresAtMs?: number,
+  expectedAuditCount = 0,
+  expectedActionCount = 0,
+  assertAcceptanceStateUnchanged = false,
+): Promise<void> {
+  await withDatabase(async (databasePath) => {
+    let nowMs = 1_000;
+    let scopeAvailable = true;
+    const bootstrap = openSqliteFoundationStorage(databasePath, { grantKeyRing: createKeyRing() });
+    await bootstrap.applyMigrations();
+    const root = createRoot(`race-${suffix}`);
+    const grantOptions = { ...createGrantOptions(root.eventGameId), clock: { nowMs: () => nowMs } };
+    const authority = createLegacyControlGrantTestAuthority(bootstrap, grantOptions);
+    const created = await authority.createControlGrant({
+      scope: root.externalScope,
+      actor: { kind: "fixture", id: "fixture" },
+      expiresAtMs,
+    });
+    if (created.status !== "created") throw new Error("Expected a Control Grant.");
+    const admitted = await authority.admitControlGrant({
+      qrCredential: created.qrCredential,
+      browserContext: `race-${suffix}-controller`,
+    });
+    if (admitted.status !== "admitted") throw new Error("Expected a Control Session.");
+    const record = createEventGameRecord(bootstrap, {
+      externalScopeResolver: createScopeResolver(root),
+      interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
+    });
+    expect(await record.registerRoot(root)).toMatchObject({ status: "registered" });
+    bootstrap.close();
+
+    const left = openSqliteFoundationStorage(databasePath, { grantKeyRing: createKeyRing() });
+    const rightStorage = openSqliteFoundationStorage(databasePath, {
+      grantKeyRing: createKeyRing(),
+    });
+    const rightAuthority = createLegacyControlGrantTestAuthority(rightStorage, grantOptions);
+    const scopeResolver = {
+      resolve(scope: EventGameRecordRoot["externalScope"]) {
+        return scopeAvailable
+          ? { status: "resolved" as const, scope: structuredClone(scope) }
+          : { status: "mismatch" as const, detail: "scope changed" };
+      },
+      resolveEventTeam() {
+        return { status: "resolved" as const };
+      },
+    };
+    const context = {
+      left,
+      right: {
+        storage: rightStorage,
+        authority: rightAuthority,
+        close: () => rightStorage.close(),
+      },
+      root,
+      created,
+      admitted,
+      grantOptions,
+      setNow(value: number) {
+        nowMs = value;
+      },
+      setScopeAvailable(value: boolean) {
+        scopeAvailable = value;
+      },
+      lockRoot() {
+        const database = new Database(databasePath);
+        const locked = {
+          ...root,
+          lifecycle: {
+            phase: "finished" as const,
+            commencedAtMs: 100,
+            finishedAtMs: 800,
+            lockedAtMs: 900,
+            lockReason: "administrative" as const,
+          },
+        };
+        database
+          .query(
+            `UPDATE foundation_event_game_record_roots
+             SET lifecycle_phase = ?, commenced_at_ms = ?, finished_at_ms = ?, locked_at_ms = ?,
+                 lock_reason = ?, canonical_content = ?, root_json = ? WHERE record_id = ?`,
+          )
+          .run(
+            locked.lifecycle.phase,
+            locked.lifecycle.commencedAtMs,
+            locked.lifecycle.finishedAtMs,
+            locked.lifecycle.lockedAtMs,
+            locked.lifecycle.lockReason,
+            canonicalizeEventGameRecordRoot(locked),
+            JSON.stringify(locked),
+            root.recordId,
+          );
+        database.close();
+      },
+      changeRootLifecycle() {
+        const database = new Database(databasePath);
+        const changed = {
+          ...root,
+          lifecycle: {
+            phase: "in-progress" as const,
+            commencedAtMs: 1_200,
+            finishedAtMs: null,
+            lockedAtMs: null,
+            lockReason: null,
+          },
+        };
+        database
+          .query(
+            `UPDATE foundation_event_game_record_roots
+             SET lifecycle_phase = ?, commenced_at_ms = ?, finished_at_ms = ?, locked_at_ms = ?,
+                 lock_reason = ?, canonical_content = ?, root_json = ? WHERE record_id = ?`,
+          )
+          .run(
+            changed.lifecycle.phase,
+            changed.lifecycle.commencedAtMs,
+            changed.lifecycle.finishedAtMs,
+            changed.lifecycle.lockedAtMs,
+            changed.lifecycle.lockReason,
+            canonicalizeEventGameRecordRoot(changed),
+            JSON.stringify(changed),
+            root.recordId,
+          );
+        database.close();
+      },
+    } satisfies RaceContext;
+    const acceptanceStateBefore = assertAcceptanceStateUnchanged
+      ? await left.transaction((transaction) => ({
+          actions: transaction.listActions(root.recordId),
+          audits: transaction.listAuditEntries(root.recordId),
+          metadata: transaction.readRecordMetadata(root.recordId),
+          session: transaction.listGrantSessions(created.grantId),
+          budgets: [
+            transaction.findAcceptanceBudget(`budget-online-session:${admitted.grantSessionId}`),
+            transaction.findAcceptanceBudget(`budget-online-event:${root.eventGameId}`),
+          ],
+        }))
+      : null;
+    const acceptance = createFoundationAcceptance(left, {
+      grant: grantOptions,
+      externalScopeResolver: scopeResolver,
+      clock: () => nowMs,
+      interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
+      afterReadOnlyPreflight: () => mutate(context),
+    });
+    const result = await acceptance.submitBatch({
+      recordId: root.recordId,
+      eventGameId: root.eventGameId,
+      sessionBearer: admitted.sessionBearer,
+      actions: [
+        createFact(root, `operation-${suffix}`, admitted.grantSessionId, created.grantVersion),
+      ],
+    });
+    assertResult(result);
+    expect(await left.readAuditEntries(root.recordId)).toHaveLength(expectedAuditCount);
+    expect(await left.readActions(root.recordId)).toHaveLength(expectedActionCount);
+    if (acceptanceStateBefore !== null) {
+      await left.transaction((transaction) => {
+        expect({
+          actions: transaction.listActions(root.recordId),
+          audits: transaction.listAuditEntries(root.recordId),
+          metadata: transaction.readRecordMetadata(root.recordId),
+          session: transaction.listGrantSessions(created.grantId),
+          budgets: [
+            transaction.findAcceptanceBudget(`budget-online-session:${admitted.grantSessionId}`),
+            transaction.findAcceptanceBudget(`budget-online-event:${root.eventGameId}`),
+          ],
+        }).toEqual(acceptanceStateBefore);
+      });
+    }
+    left.close();
+    rightStorage.close();
+  });
+}
+
+function createAcceptance(
+  storage: SqliteFoundationStorage,
+  root: EventGameRecordRoot,
+  grant: GrantAuthorityOptions,
+  replay = false,
+  lockedDigest?: string,
+  correctionOptions: {
+    clock?: () => number;
+    limits?: FoundationAcceptanceOptions["limits"];
+    replayDecision?: "throw" | { reason: unknown; detail: unknown };
+  } = {},
+) {
+  const replayDecision = correctionOptions.replayDecision;
+  const replayEligibility = !replay
+    ? undefined
+    : replayDecision === "throw"
+      ? () => {
+          throw new Error("adapter detail must not escape");
+        }
+      : replayDecision === undefined
+        ? () => ({ status: "eligible" as const })
+        : () => ({
+            status: "ineligible" as const,
+            reason: replayDecision.reason,
+            detail: replayDecision.detail,
+          });
+  return createFoundationAcceptance(storage, {
+    grant,
+    externalScopeResolver: createScopeResolver(root),
+    clock: correctionOptions.clock ?? (() => 1_000),
+    interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
+    limits: correctionOptions.limits,
+    replayEligibility,
+    verifyLockedReplay:
+      lockedDigest === undefined ? undefined : ({ batchDigest }) => batchDigest === lockedDigest,
+  });
+}
+
+async function withDatabase(work: (databasePath: string) => Promise<void>): Promise<void> {
+  const directory = await mkdtemp(join(tmpdir(), "quadball-timer-acceptance-sqlite-"));
+  try {
+    await work(join(directory, "foundation.sqlite"));
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+}
+
+function createGrantOptions(eventGameId: string): GrantAuthorityOptions {
+  let call = 0;
+  return {
+    environmentId: "acceptance-sqlite-test",
+    clock: { nowMs: () => 1_000 },
+    randomness: {
+      bytes: (length) => {
+        call += 1;
+        return Uint8Array.from({ length }, (_, index) => (index + call + length) % 256);
+      },
+    },
+    keyRing: createKeyRing(),
+    controlScopeResolver: { resolve: () => ({ status: "eligible", eventGameId }) },
+    privilegedAuthorityVerifier: createGrantTestAuthorityVerifier(),
+  };
+}
+
+function createKeyRing(): GrantKeyRing {
+  return {
+    encryption: { currentVersion: "encryption-v1", keys: new Map([["encryption-v1", bytes(1)]]) },
+    lookup: { currentVersion: "lookup-v1", keys: new Map([["lookup-v1", bytes(33)]]) },
+    audit: { currentVersion: "audit-v1", keys: new Map([["audit-v1", bytes(65)]]) },
+  };
+}
+
+function rotateKeyRing(): GrantKeyRing {
+  const current = createKeyRing();
+  return {
+    encryption: current.encryption,
+    lookup: {
+      currentVersion: "lookup-v2",
+      keys: new Map([...current.lookup.keys, ["lookup-v2", bytes(97)]]),
+    },
+    audit: {
+      currentVersion: "audit-v2",
+      keys: new Map([...current.audit.keys, ["audit-v2", bytes(129)]]),
+    },
+  };
+}
+
+function bytes(start: number): Uint8Array {
+  return Uint8Array.from({ length: 32 }, (_, index) => start + index);
+}
+
+function createBudget(bucketId: string, stateRevision: number) {
+  return {
+    bucketId: `budget-online-session:${bucketId}`,
+    bucketKind: "online-session" as const,
+    subjectId: bucketId,
+    capacity: 10,
+    refillPerSecond: 1,
+    tokens: 9,
+    updatedAtMs: 1_000 + stateRevision,
+    stateRevision,
+  };
+}
+
+function createRoot(suffix: string): EventGameRecordRoot {
+  return {
+    recordId: `record-${suffix}`,
+    eventId: `event-${suffix}`,
+    eventGameId: `game-${suffix}`,
+    ownership: { eventId: `event-${suffix}`, eventGameId: `game-${suffix}` },
+    externalScope: {
+      eventId: `event-${suffix}`,
+      gameDayId: "day-1",
+      pitchId: `pitch-${suffix}`,
+      pitchSlotId: `slot-${suffix}`,
+    },
+    gameSides: [
+      { id: `side-a-${suffix}`, eventTeamId: "team-a", teamInterpretationRef: "team-a-v1" },
+      { id: `side-b-${suffix}`, eventTeamId: "team-b", teamInterpretationRef: "team-b-v1" },
+    ],
+    lifecycle: {
+      phase: "scheduled",
+      commencedAtMs: null,
+      finishedAtMs: null,
+      lockedAtMs: null,
+      lockReason: null,
+    },
+    compatibility: {
+      recordVersion: "record-v1",
+      schemaVersion: "schema-v1",
+      interpreterVersion: "rules-v1",
+    },
+    creationEvidence: {
+      operationId: `register-${suffix}`,
+      actorReference: "actor-test",
+      source: "event-game-registration",
+      createdAtMs: 500,
+    },
+  };
+}
+
+function createScopeResolver(root: EventGameRecordRoot) {
+  return {
+    resolve(scope: EventGameRecordRoot["externalScope"]) {
+      return JSON.stringify(scope) === JSON.stringify(root.externalScope)
+        ? { status: "resolved" as const, scope: structuredClone(scope) }
+        : { status: "mismatch" as const, detail: "scope mismatch" };
+    },
+    resolveEventTeam() {
+      return { status: "resolved" as const };
+    },
+  };
+}
+
+function createFact(
+  root: EventGameRecordRoot,
+  operationId: string,
+  sessionId: string,
+  versionId: string,
+): ControlActionInput {
+  const sideA = root.gameSides[0];
+  if (sideA === undefined) throw new Error("Expected side A.");
+  return {
+    recordId: root.recordId,
+    eventGameId: root.eventGameId,
+    operationId,
+    kind: { id: "game-fact", version: "1" },
+    payload: {
+      factId: `fact-${operationId}`,
+      factType: "test",
+      gameSideId: sideA.id,
+      gameTimeMs: 1,
+      data: { operationId },
+    },
+    causalPredecessorIds: [],
+    occurrence: { trustedAtMs: 1_000, clientOriginAtMs: 1_000, source: "online" },
+    grant: { sessionId, versionId },
+    lifecycle: structuredClone(root.lifecycle),
+  };
+}

--- a/src/lib/foundation-acceptance.test.ts
+++ b/src/lib/foundation-acceptance.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, test } from "bun:test";
+import { createInMemoryFoundationStorage } from "@/lib/foundation-storage-memory";
+import { createFoundationAcceptance } from "@/lib/foundation-acceptance";
+import { createEventGameRecord } from "@/lib/event-game-record";
+import {
+  createDeterministicTestIqaInterpreter,
+  type ControlActionInput,
+} from "@/lib/event-game-actions";
+import type { EventGameRecordRoot } from "@/lib/foundation-record-types";
+import type { GrantAuthorityOptions } from "@/lib/grant-authority";
+import {
+  createGrantTestAuthorityVerifier,
+  createLegacyControlGrantTestAuthority,
+} from "@/lib/grant-authority-test-support";
+import type { GrantKeyRing } from "@/lib/grant-types";
+
+describe("composed Control Action acceptance", () => {
+  test("validates the batch before mutation, commits paired audits, and preserves caller order", async () => {
+    const storage = createInMemoryFoundationStorage();
+    const root = createRoot();
+    const grantOptions = createGrantOptions(root.eventGameId);
+    const authority = createLegacyControlGrantTestAuthority(storage, grantOptions);
+    const created = await authority.createControlGrant({
+      scope: root.externalScope,
+      actor: { kind: "fixture", id: "fixture" },
+    });
+    if (created.status !== "created")
+      throw new Error(`Expected a Control Grant: ${JSON.stringify(created)}`);
+    const admitted = await authority.admitControlGrant({
+      qrCredential: created.qrCredential,
+      browserContext: "controller-a",
+    });
+    if (admitted.status !== "admitted") throw new Error("Expected a Control Session.");
+
+    const record = createEventGameRecord(storage, {
+      externalScopeResolver: createScopeResolver(root),
+      interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
+      clock: () => 1_000,
+      auditAuthorityVerifier: { verify: () => true },
+    });
+    expect(await record.registerRoot(root)).toMatchObject({ status: "registered" });
+    const acceptance = createFoundationAcceptance(storage, {
+      grant: grantOptions,
+      externalScopeResolver: createScopeResolver(root),
+      clock: () => 1_000,
+      interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
+    });
+    const first = createFact(
+      root,
+      "operation-first",
+      admitted.grantSessionId,
+      created.grantVersion,
+    );
+    const second = {
+      ...createFact(root, "operation-second", admitted.grantSessionId, created.grantVersion),
+      causalPredecessorIds: [first.operationId],
+    };
+
+    const outcome = await acceptance.submitBatch({
+      recordId: root.recordId,
+      eventGameId: root.eventGameId,
+      sessionBearer: admitted.sessionBearer,
+      actions: [second, first],
+    });
+    expect(outcome.status).toBe("committed");
+    expect(outcome.results.map((result) => result.status)).toEqual(["accepted", "accepted"]);
+    expect((await record.readActions()).map((stored) => stored.action.operationId)).toEqual([
+      "operation-first",
+      "operation-second",
+    ]);
+    const grantAudit = await storage.transaction((transaction) =>
+      transaction
+        .listGrantAudit(created.grantId)
+        .filter((entry) => entry.acceptanceId !== undefined),
+    );
+    expect(grantAudit).toHaveLength(2);
+    const controlAudit = await record.readAudit({});
+    expect(controlAudit.filter((entry) => entry.links?.grantAuditId !== undefined)).toHaveLength(2);
+  });
+});
+
+function createGrantOptions(eventGameId: string): GrantAuthorityOptions {
+  let call = 0;
+  return {
+    environmentId: "acceptance-test",
+    clock: { nowMs: () => 1_000 },
+    randomness: {
+      bytes: (length) => {
+        call += 1;
+        return Uint8Array.from({ length }, (_, index) => (index + call + length) % 256);
+      },
+    },
+    keyRing: createKeyRing(),
+    controlScopeResolver: { resolve: () => ({ status: "eligible", eventGameId }) },
+    privilegedAuthorityVerifier: createGrantTestAuthorityVerifier(),
+  };
+}
+
+function createKeyRing(): GrantKeyRing {
+  return {
+    encryption: { currentVersion: "encryption-v1", keys: new Map([["encryption-v1", bytes(1)]]) },
+    lookup: { currentVersion: "lookup-v1", keys: new Map([["lookup-v1", bytes(33)]]) },
+    audit: { currentVersion: "audit-v1", keys: new Map([["audit-v1", bytes(65)]]) },
+  };
+}
+
+function bytes(start: number): Uint8Array {
+  return Uint8Array.from({ length: 32 }, (_, index) => start + index);
+}
+
+function createRoot(): EventGameRecordRoot {
+  return {
+    recordId: "record-acceptance",
+    eventId: "event-acceptance",
+    eventGameId: "game-acceptance",
+    ownership: { eventId: "event-acceptance", eventGameId: "game-acceptance" },
+    externalScope: {
+      eventId: "event-acceptance",
+      gameDayId: "day-1",
+      pitchId: "pitch-1",
+      pitchSlotId: "slot-1",
+    },
+    gameSides: [
+      { id: "side-a", eventTeamId: "team-a", teamInterpretationRef: "team-a-v1" },
+      { id: "side-b", eventTeamId: "team-b", teamInterpretationRef: "team-b-v1" },
+    ],
+    lifecycle: {
+      phase: "scheduled",
+      commencedAtMs: null,
+      finishedAtMs: null,
+      lockedAtMs: null,
+      lockReason: null,
+    },
+    compatibility: {
+      recordVersion: "record-v1",
+      schemaVersion: "schema-v1",
+      interpreterVersion: "rules-v1",
+    },
+    creationEvidence: {
+      operationId: "register-acceptance",
+      actorReference: "actor-test",
+      source: "event-game-registration",
+      createdAtMs: 500,
+    },
+  };
+}
+
+function createScopeResolver(root: EventGameRecordRoot) {
+  return {
+    resolve(scope: EventGameRecordRoot["externalScope"]) {
+      return JSON.stringify(scope) === JSON.stringify(root.externalScope)
+        ? { status: "resolved" as const, scope: structuredClone(scope) }
+        : { status: "mismatch" as const, detail: "scope mismatch" };
+    },
+    resolveEventTeam() {
+      return { status: "resolved" as const };
+    },
+  };
+}
+
+function createFact(
+  root: EventGameRecordRoot,
+  operationId: string,
+  sessionId: string,
+  versionId: string,
+): ControlActionInput {
+  return {
+    recordId: root.recordId,
+    eventGameId: root.eventGameId,
+    operationId,
+    kind: { id: "game-fact", version: "1" },
+    payload: {
+      factId: `fact-${operationId}`,
+      factType: "test",
+      gameSideId: "side-a",
+      gameTimeMs: 1,
+      data: { operationId },
+    },
+    causalPredecessorIds: [],
+    occurrence: { trustedAtMs: 1_000, clientOriginAtMs: 1_000, source: "online" },
+    grant: { sessionId, versionId },
+    lifecycle: structuredClone(root.lifecycle),
+  };
+}

--- a/src/lib/foundation-acceptance.ts
+++ b/src/lib/foundation-acceptance.ts
@@ -1,0 +1,1881 @@
+import type {
+  ControlAction,
+  ControlActionCodec,
+  ControlActionCodecRegistry,
+  ControlActionInput,
+  ControlAuditEntry,
+  ControlActionEnvelope,
+  PreparedControlAction,
+} from "@/lib/event-game-actions";
+import {
+  CONTROL_ACTION_ORDERING_VERSION,
+  actionIdentity,
+  canonicalizeJson,
+  controlActionCodecIdentity,
+  createControlActionCodecRegistry,
+  materializeControlAction,
+  prepareControlAction,
+  sha256,
+  validateControlActionEnvelope,
+} from "@/lib/event-game-actions";
+import { appendConcurrentCorrectionAudits } from "@/lib/event-game-record";
+import {
+  ACCEPTED_AUDIT_DETAIL,
+  createAuditEntry as createControlAudit,
+  findFactById,
+  validateDependencies,
+} from "@/lib/event-game-record-helpers";
+import type { EventGameRecordRoot } from "@/lib/foundation-record-types";
+import type {
+  FoundationStorage,
+  FoundationStorageSnapshot,
+  FoundationStorageTransaction,
+  StoredAcceptanceBudget,
+  StoredReplayAttempt,
+  StoredReplayReservation,
+} from "@/lib/foundation-storage";
+import { authorizeGrantInTransaction } from "@/lib/grant-management-sessions";
+import type { GrantAuthorityOptions } from "@/lib/grant-authority";
+import { auditInput } from "@/lib/grant-management-audit";
+import { createAuditEntry as createGrantAudit } from "@/lib/grant-lifecycle";
+import { GENERIC_GRANT_AUTHORIZATION_FAILURE } from "@/lib/grant-authority-types";
+import type { StoredGrant, StoredGrantSession } from "@/lib/grant-types";
+import { computeLookupDigest } from "@/lib/grant-crypto";
+import { validateOpaqueIdentifier } from "@/lib/validation-policy";
+import {
+  acceptanceAuditPairFailure,
+  anchorFor,
+  replayAttemptResultFailure,
+} from "@/lib/foundation-acceptance-integrity";
+import {
+  normalizeFoundationRejectionReason,
+  type FoundationRejectionReason,
+} from "@/lib/foundation-acceptance-contract";
+
+export const ACCEPTANCE_LIMITS = Object.freeze({
+  maxBatchActions: 100,
+  maxBatchBytes: 64 * 1024,
+  onlineSessionCapacity: 40,
+  onlineSessionRefillPerSecond: 20,
+  onlineEventCapacity: 100,
+  onlineEventRefillPerSecond: 50,
+  replaySessionCapacity: 40,
+  replaySessionRefillPerSecond: 20,
+});
+
+export type AcceptanceLimits = Partial<Record<keyof typeof ACCEPTANCE_LIMITS, number>>;
+
+export type ControlActionBatchInput = {
+  recordId: string;
+  eventGameId: string;
+  actions: readonly unknown[];
+  sessionBearer?: string;
+  mode?: "online" | "replay";
+  replay?: {
+    sessionBearer: string;
+    originatingSessionId: string;
+    replayEvidenceId: string;
+  };
+};
+
+export type FoundationActionResult =
+  | {
+      status: "accepted" | "duplicate-accepted";
+      action?: ControlAction;
+      auditId: string;
+      grantAuditId: string;
+    }
+  | {
+      status: "rejected" | "dependency-blocked" | "authority-expired" | "retry-later";
+      reason: FoundationRejectionReason;
+      detail: string;
+      auditId?: string;
+      grantAuditId?: string;
+    }
+  | { status: "locked-discarded"; count: number; eventGameId: string; rejectedAtMs: number };
+
+export type FoundationBatchOutcome = {
+  status: "committed" | "partial" | "rejected";
+  results: readonly FoundationActionResult[];
+  receipt?: string;
+  reservationId?: string;
+};
+
+export type FoundationAcceptanceOptions = {
+  grant: GrantAuthorityOptions;
+  externalScopeResolver: {
+    resolve(
+      scope: EventGameRecordRoot["externalScope"],
+      snapshot: FoundationStorageSnapshot,
+    ):
+      | { status: "resolved"; scope: EventGameRecordRoot["externalScope"] }
+      | { status: "missing" | "mismatch"; detail: string };
+    resolveEventTeam(
+      eventId: string,
+      eventTeamId: string,
+      snapshot: FoundationStorageSnapshot,
+    ): { status: "resolved" } | { status: "missing" | "mismatch"; detail: string };
+  };
+  clock?: () => number;
+  actionCodecs?: readonly ControlActionCodec[];
+  actionCodecRegistry?: ControlActionCodecRegistry;
+  interpreter: import("@/lib/event-game-actions").IqaGameRulesInterpreter;
+  verifyLockedReplay?: (input: {
+    eventGameId: string;
+    originatingSessionId: string;
+    evidence: unknown;
+    actionCount: number;
+    batchDigest: string;
+  }) => boolean;
+  replayEligibility?: (input: {
+    transaction: FoundationStorageSnapshot;
+    root: EventGameRecordRoot;
+    action: PreparedControlAction;
+    originatingSessionId: string;
+    replayEvidenceId: string;
+  }) => { status: "eligible" } | { status: "ineligible"; reason?: unknown; detail?: unknown };
+  failureInjector?: (
+    boundary:
+      | "after-action"
+      | "after-metadata"
+      | "after-control-audit"
+      | "after-grant-audit"
+      | "before-receipt",
+  ) => void;
+  /** Test-only barrier between read-only preflight and the first write transaction. */
+  afterReadOnlyPreflight?: () => void | Promise<void>;
+  limits?: AcceptanceLimits;
+};
+
+const GENERIC_REPLAY_INELIGIBILITY_DETAIL = "Replay authorization is unavailable.";
+
+type StructuralAction = { raw: unknown; envelope: ControlActionEnvelope };
+type PreparedBatch = {
+  input: ControlActionBatchInput;
+  actions: readonly StructuralAction[];
+  order: readonly number[];
+  size: number;
+  digest: string;
+};
+type BatchPreflight = {
+  authorized: boolean;
+  root: EventGameRecordRoot | null;
+  trustedLockedReplay: boolean;
+  actions: readonly { prepared: PreparedControlAction | null; error: string | null }[];
+};
+type OneOutcome = { result: FoundationActionResult; reservationId?: string; receipt?: string };
+type AuthorizedControl = {
+  grant: StoredGrant;
+  session: StoredGrantSession;
+  grantId: string;
+  grantVersion: string;
+  grantSessionId: string;
+};
+
+export type FoundationAcceptance = {
+  submitBatch(input: unknown): Promise<FoundationBatchOutcome>;
+  acknowledgeReplay(receipt: unknown): Promise<{ status: "acknowledged" | "rejected" }>;
+};
+
+export function createFoundationAcceptance(
+  storage: FoundationStorage,
+  options: FoundationAcceptanceOptions,
+): FoundationAcceptance {
+  const clock = options.clock ?? (() => Date.now());
+  const registry =
+    options.actionCodecRegistry ?? createControlActionCodecRegistry(options.actionCodecs);
+  const limits = { ...ACCEPTANCE_LIMITS, ...options.limits };
+
+  async function submitBatch(raw: unknown): Promise<FoundationBatchOutcome> {
+    const batch = structurallyValidateBatch(raw);
+    if (batch === null) return { status: "rejected", results: [] };
+    let preflight: BatchPreflight;
+    try {
+      preflight = await storage.transaction((transaction) => preflightBatch(transaction, batch));
+    } catch {
+      return {
+        status: "partial",
+        results: batch.actions.map(() => ({
+          status: "retry-later",
+          reason: "storage-unavailable",
+          detail: "Retry this action after authoritative storage recovers.",
+        })),
+      };
+    }
+    // Authorization failure is intentionally indistinguishable from an
+    // unavailable/unknown batch. In particular, do not disclose root, scope,
+    // lock, codec, payload, or reservation state to an unauthorised bearer.
+    if (!preflight.authorized)
+      return {
+        status: "rejected",
+        results: batch.actions.map(() => authorityFailure().result),
+      };
+    await options.afterReadOnlyPreflight?.();
+    // An authorized batch whose root is absent or belongs to another Event
+    // Game is a read-only structural outcome. Do not enter an accepting
+    // transaction: the normal authorization path refreshes session activity,
+    // which would make an unavailable root observable as a lifecycle write.
+    if (preflight.root === null || preflight.root.eventGameId !== batch.input.eventGameId)
+      return {
+        status: "committed",
+        results: batch.actions.map(() => ({
+          status: "rejected",
+          reason: "record-not-found",
+          detail: "The Event Game Record is unavailable.",
+        })),
+      };
+    const results: FoundationActionResult[] = Array.from({ length: batch.actions.length });
+    let reservationId: string | undefined;
+    let receipt: string | undefined;
+    for (const index of batch.order) {
+      const action = batch.actions[index];
+      if (action === undefined) continue;
+      const predecessors = predecessorResultsFor(batch, results, index);
+      let one: OneOutcome;
+      try {
+        one = await storage.transaction((transaction) =>
+          acceptOne(transaction, batch, index, predecessors, preflight.actions[index]),
+        );
+      } catch {
+        one = {
+          result: {
+            status: "retry-later",
+            reason: "storage-unavailable",
+            detail: "Retry this action after authoritative storage recovers.",
+          },
+        };
+      }
+      results[index] = one.result;
+      reservationId ??= one.reservationId;
+      receipt ??= one.receipt;
+    }
+    const hasRetry = results.some((result) => result?.status === "retry-later");
+    if (batch.input.mode === "replay" && receipt !== undefined)
+      return { status: "committed", results, receipt, reservationId };
+    return {
+      status:
+        results.every((result) => result !== undefined) && !hasRetry ? "committed" : "partial",
+      results,
+      ...(reservationId === undefined ? {} : { reservationId }),
+    };
+  }
+
+  async function acknowledgeReplay(
+    rawReceipt: unknown,
+  ): Promise<{ status: "acknowledged" | "rejected" }> {
+    if (typeof rawReceipt !== "string" || rawReceipt.length < 32) return { status: "rejected" };
+    try {
+      await storage.transaction((transaction) => {
+        const stored = transaction.findReplayReceiptByDigest(sha256(rawReceipt));
+        if (stored === null) throw new Error("Receipt unavailable.");
+        const reservation = transaction.findReplayReservation(stored.reservationId);
+        if (
+          reservation === null ||
+          (reservation.status !== "committed" && reservation.status !== "acknowledged")
+        )
+          throw new Error("Receipt reservation is not committed.");
+        if (stored.status === "acknowledged") return;
+        const acknowledgedAtMs = readNow(clock);
+        const acknowledgedReceipt = {
+          ...stored,
+          status: "acknowledged" as const,
+          acknowledgedAtMs,
+          stateRevision: stored.stateRevision + 1,
+        };
+        transaction.updateReplayReceipt(acknowledgedReceipt);
+        transaction.insertAcceptanceIntegrityAnchor(
+          anchorFor("receipt", acknowledgedReceipt, options.grant.keyRing),
+        );
+        const acknowledgedReservation = {
+          ...reservation,
+          status: "acknowledged" as const,
+          acknowledgedAtMs,
+          stateRevision: reservation.stateRevision + 1,
+        };
+        transaction.updateReplayReservation(acknowledgedReservation);
+        transaction.insertAcceptanceIntegrityAnchor(
+          anchorFor("reservation", acknowledgedReservation, options.grant.keyRing),
+        );
+      });
+      return { status: "acknowledged" };
+    } catch {
+      return { status: "rejected" };
+    }
+  }
+
+  return { submitBatch, acknowledgeReplay };
+
+  function preflightBatch(
+    transaction: FoundationStorageTransaction,
+    batch: PreparedBatch,
+  ): BatchPreflight {
+    const first = batch.actions[0];
+    if (first === undefined)
+      return { authorized: false, root: null, trustedLockedReplay: false, actions: [] };
+    const replay = batch.input.replay;
+    const trustedLockedReplay = replay !== undefined && verifyTrustedLockedReplay(batch);
+    if (trustedLockedReplay) {
+      const root = transaction.findRootByRecordId(batch.input.recordId);
+      if (
+        root === null ||
+        root.eventGameId !== batch.input.eventGameId ||
+        root.lifecycle.lockedAtMs === null
+      )
+        return { authorized: false, root: null, trustedLockedReplay: false, actions: [] };
+      return {
+        authorized: true,
+        root,
+        trustedLockedReplay: true,
+        // Locked discard validates codec/envelope/payload evidence but does
+        // not execute root-dependent sporting semantics.
+        actions: prepareBatchActions(batch, null),
+      };
+    }
+    const bearer = replay?.sessionBearer ?? batch.input.sessionBearer;
+    if (typeof bearer !== "string")
+      return { authorized: false, root: null, trustedLockedReplay: false, actions: [] };
+    const authorization = authorizeGrantInTransaction(transaction, options.grant, {
+      sessionBearer: bearer,
+      eventGameId: batch.input.eventGameId,
+      controlSessionDecision: "stay",
+      readOnly: true,
+    });
+    if (
+      authorization === GENERIC_GRANT_AUTHORIZATION_FAILURE ||
+      authorization.status !== "authorized" ||
+      authorization.grantType !== "control" ||
+      authorization.eventGameId !== batch.input.eventGameId ||
+      authorization.grantSessionId !== first.envelope.grant.sessionId ||
+      authorization.grantVersion !== first.envelope.grant.versionId
+    )
+      return { authorized: false, root: null, trustedLockedReplay: false, actions: [] };
+    if (
+      batch.actions.some(
+        ({ envelope }) =>
+          envelope.grant.sessionId !== authorization.grantSessionId ||
+          envelope.grant.versionId !== authorization.grantVersion,
+      )
+    )
+      return { authorized: false, root: null, trustedLockedReplay: false, actions: [] };
+    const root = transaction.findRootByRecordId(batch.input.recordId);
+    if (root === null || root.eventGameId !== batch.input.eventGameId)
+      return {
+        authorized: true,
+        root: null,
+        trustedLockedReplay: false,
+        actions: prepareBatchActions(batch, null),
+      };
+    return {
+      authorized: true,
+      root,
+      trustedLockedReplay: false,
+      actions: prepareBatchActions(batch, root),
+    };
+  }
+
+  function prepareBatchActions(
+    batch: PreparedBatch,
+    root: EventGameRecordRoot | null,
+  ): readonly { prepared: PreparedControlAction | null; error: string | null }[] {
+    return batch.actions.map(({ raw }) => {
+      try {
+        const prepared = prepareControlAction(raw, root, registry, readNow(clock), {
+          allowConcurrentTeamAssignment: true,
+        });
+        return prepared.ok
+          ? { prepared: prepared.value, error: null }
+          : { prepared: null, error: prepared.error };
+      } catch {
+        return { prepared: null, error: "The Control Action is invalid." };
+      }
+    });
+  }
+
+  function verifyTrustedLockedReplay(batch: PreparedBatch): boolean {
+    const replay = batch.input.replay;
+    if (replay === undefined || options.verifyLockedReplay === undefined) return false;
+    try {
+      return (
+        options.verifyLockedReplay({
+          eventGameId: batch.input.eventGameId,
+          originatingSessionId: replay.originatingSessionId,
+          evidence: replay.replayEvidenceId,
+          actionCount: batch.actions.length,
+          batchDigest: batch.digest,
+        }) === true
+      );
+    } catch {
+      return false;
+    }
+  }
+
+  function prepareCurrentAction(
+    raw: unknown,
+    root: EventGameRecordRoot | null,
+  ): { prepared: PreparedControlAction | null; error: string | null } {
+    try {
+      const prepared = prepareControlAction(raw, root, registry, readNow(clock), {
+        allowConcurrentTeamAssignment: true,
+      });
+      return prepared.ok
+        ? { prepared: prepared.value, error: null }
+        : { prepared: null, error: prepared.error };
+    } catch {
+      return { prepared: null, error: "The Control Action is invalid." };
+    }
+  }
+
+  function acceptOne(
+    transaction: FoundationStorageTransaction,
+    batch: PreparedBatch,
+    index: number,
+    predecessorResults: readonly FoundationActionResult[],
+    preflightAction: { prepared: PreparedControlAction | null; error: string | null } | undefined,
+  ): OneOutcome {
+    const structural = batch.actions[index];
+    if (structural === undefined) throw new Error("Missing structural action.");
+    const mode = batch.input.mode ?? (batch.input.replay === undefined ? "online" : "replay");
+    const replay = batch.input.replay;
+    const bearer = replay?.sessionBearer ?? batch.input.sessionBearer;
+
+    if (replay !== undefined && verifyTrustedLockedReplay(batch)) {
+      const root = transaction.findRootByRecordId(batch.input.recordId);
+      if (
+        root === null ||
+        root.eventGameId !== batch.input.eventGameId ||
+        root.lifecycle.lockedAtMs === null
+      )
+        return authorityFailure();
+      const currentPreparation = prepareCurrentAction(structural.raw, null);
+      if (
+        currentPreparation.prepared === null ||
+        !samePreparedAction(currentPreparation.prepared, preflightAction?.prepared)
+      )
+        return one({
+          status: "authority-expired",
+          reason: "game-locked",
+          detail: "The Event Game is locked.",
+        });
+      const reservation = transaction.findReplayReservationByTuple(
+        root.recordId,
+        root.eventGameId,
+        replay.originatingSessionId,
+        batch.actions.length,
+        batch.digest,
+      );
+      if (
+        reservation !== null &&
+        (reservation.status === "committed" || reservation.status === "acknowledged")
+      ) {
+        const attempt = transaction
+          .listReplayAttempts(reservation.reservationId)
+          .find((item) => item.operationId === structural.envelope.operationId);
+        if (attempt === undefined) throw new Error("Committed replay evidence is incomplete.");
+        return recoverCommittedReplay(transaction, reservation, attempt, options.grant.keyRing);
+      }
+      const otherReservation =
+        reservation === null
+          ? transaction.findReplayReservationByOriginTuple(
+              root.recordId,
+              root.eventGameId,
+              replay.originatingSessionId,
+              batch.actions.length,
+            )
+          : null;
+      if (
+        reservation === null &&
+        otherReservation !== null &&
+        ["reserved", "partial", "committing", "committed", "acknowledged"].includes(
+          otherReservation.status,
+        )
+      )
+        return one({
+          status: "authority-expired",
+          reason: "replay-reservation-mismatch",
+          detail: "The replay batch does not match the live reservation.",
+        });
+      return discardLockedReplay(
+        transaction,
+        root,
+        batch,
+        reservation ?? undefined,
+        replay.originatingSessionId,
+        readNow(clock),
+      );
+    }
+
+    // No scope, lock, catalog, codec, or payload inspection may happen before
+    // this current bearer/session check.
+    if (typeof bearer !== "string") return authorityFailure();
+    const authorization = authorizeGrantInTransaction(transaction, options.grant, {
+      sessionBearer: bearer,
+      eventGameId: batch.input.eventGameId,
+      controlSessionDecision: "stay",
+      readOnly: true,
+    });
+    if (
+      authorization === GENERIC_GRANT_AUTHORIZATION_FAILURE ||
+      authorization.status !== "authorized" ||
+      authorization.grantType !== "control" ||
+      authorization.eventGameId !== batch.input.eventGameId ||
+      authorization.grantSessionId !== structural.envelope.grant.sessionId ||
+      authorization.grantVersion !== structural.envelope.grant.versionId
+    )
+      return authorityFailure();
+    const root = transaction.findRootByRecordId(batch.input.recordId);
+    if (root === null || root.eventGameId !== batch.input.eventGameId)
+      return one({
+        status: "rejected",
+        reason: "record-not-found",
+        detail: "The Event Game Record is unavailable.",
+      });
+    const reservation =
+      mode === "replay" && replay !== undefined
+        ? replayReservation(transaction, batch, authorization.grantSessionId)
+        : undefined;
+    if (reservation?.mismatch === true)
+      return one({
+        status: "retry-later",
+        reason: "replay-session-mismatch",
+        detail: "Retry with the Grant Session that owns this replay reservation.",
+      });
+    const existingReplayReservation = reservation?.value;
+
+    if (root.lifecycle.lockedAtMs !== null) {
+      return one({
+        status: "authority-expired",
+        reason: "game-locked",
+        detail: "The Event Game is locked.",
+      });
+    }
+    const scope = options.externalScopeResolver.resolve(root.externalScope, transaction);
+    if (
+      scope.status !== "resolved" ||
+      canonicalizeJson(scope.scope) !== canonicalizeJson(root.externalScope)
+    )
+      return one({
+        status: "retry-later",
+        reason: "scope-unavailable",
+        detail: "Retry after the Event scope is available.",
+      });
+
+    const currentPreparation = prepareCurrentAction(structural.raw, root);
+    const prepared = currentPreparation.prepared;
+    if (preflightAction !== undefined && !samePreparationResult(prepared, preflightAction.prepared))
+      return one({
+        status: "retry-later",
+        reason: "stale-preflight",
+        detail: "The Event Game changed while this action was being accepted.",
+      });
+
+    const currentAuthorization = authorizeGrantInTransaction(transaction, options.grant, {
+      sessionBearer: bearer,
+      eventGameId: batch.input.eventGameId,
+      controlSessionDecision: "stay",
+    });
+    if (
+      currentAuthorization === GENERIC_GRANT_AUTHORIZATION_FAILURE ||
+      currentAuthorization.status !== "authorized" ||
+      currentAuthorization.grantType !== "control" ||
+      currentAuthorization.eventGameId !== batch.input.eventGameId ||
+      currentAuthorization.grantSessionId !== structural.envelope.grant.sessionId ||
+      currentAuthorization.grantVersion !== structural.envelope.grant.versionId
+    )
+      return authorityFailure();
+    const grant = transaction.findGrantById(currentAuthorization.grantId);
+    const session =
+      grant === null
+        ? null
+        : (transaction
+            .listGrantSessions(grant.grantId)
+            .find((candidate) => candidate.sessionId === currentAuthorization.grantSessionId) ??
+          null);
+    if (grant === null || session === null) return authorityFailure();
+    const current: AuthorizedControl = {
+      grant,
+      session,
+      grantId: currentAuthorization.grantId,
+      grantVersion: currentAuthorization.grantVersion,
+      grantSessionId: currentAuthorization.grantSessionId,
+    };
+    if (mode === "online" && replay === undefined) {
+      const recovered = recoverExistingOutcome(
+        transaction,
+        root,
+        structural,
+        prepared,
+        current,
+        false,
+      );
+      if (recovered !== null) return recovered;
+    }
+    let replayEligibility: { status: "eligible" } | { status: "ineligible" } | undefined;
+    if (mode === "replay" && replay !== undefined && prepared !== null) {
+      try {
+        const decision = options.replayEligibility?.({
+          transaction,
+          root,
+          action: prepared,
+          originatingSessionId: replay.originatingSessionId,
+          replayEvidenceId: replay.replayEvidenceId,
+        });
+        replayEligibility = decision?.status === "eligible" ? decision : { status: "ineligible" };
+      } catch {
+        replayEligibility = { status: "ineligible" };
+      }
+    }
+
+    if (mode === "replay" && replay !== undefined) {
+      const exact = recoverReplayAttempt(transaction, existingReplayReservation, structural);
+      if (exact !== null) return exact;
+      if (existingReplayReservation === undefined) {
+        const recovered = recoverExistingOutcome(
+          transaction,
+          root,
+          structural,
+          prepared,
+          current,
+          false,
+        );
+        if (recovered !== null) return recovered;
+      }
+    }
+    if (prepared === null)
+      return writeOutcome(
+        transaction,
+        root,
+        structural.envelope,
+        undefined,
+        current,
+        mode,
+        existingReplayReservation,
+        "rejected",
+        "invalid-action",
+        currentPreparation.error ?? "The Control Action is invalid.",
+      );
+    if (replayEligibility?.status === "ineligible")
+      return writeOutcome(
+        transaction,
+        root,
+        prepared.input,
+        prepared,
+        current,
+        mode,
+        existingReplayReservation,
+        "authority-expired",
+        "replay-ineligible",
+        GENERIC_REPLAY_INELIGIBILITY_DETAIL,
+      );
+
+    const ensured =
+      mode === "replay" && replay !== undefined
+        ? ensureReservation(transaction, batch, current.grantSessionId, reservation?.value)
+        : undefined;
+    if (ensured?.mismatch === true)
+      return one({
+        status: "retry-later",
+        reason: "replay-session-mismatch",
+        detail: "Retry with the Grant Session that owns this replay reservation.",
+      });
+    const replayState = ensured?.value;
+
+    const previousAttempt =
+      replayState === undefined
+        ? undefined
+        : transaction
+            .listReplayAttempts(replayState.reservationId)
+            .find((attempt) => attempt.operationId === structural.envelope.operationId);
+    if (previousAttempt !== undefined && previousAttempt.status !== "retry-later") {
+      const previousControlAudit = transaction
+        .listAuditEntries(root.recordId)
+        .find((entry) => entry.auditId === previousAttempt.controlAuditId);
+      const result = readAttemptResult(
+        previousAttempt,
+        transaction.findActionByOperationId(root.recordId, previousAttempt.operationId)?.action,
+        previousControlAudit?.links?.reason,
+      );
+      const receipt =
+        replayState === undefined
+          ? null
+          : transaction.findReplayReceiptByReservationId(replayState.reservationId);
+      return {
+        result,
+        reservationId: replayState?.reservationId,
+        ...(receipt !== null
+          ? {
+              receipt: encodeReceipt(
+                replayState!.reservationId,
+                options.grant.keyRing,
+                receipt.receiptKeyVersion,
+              ),
+            }
+          : {}),
+      };
+    }
+
+    const sessionBudget = takeBudget(
+      transaction,
+      mode === "replay" ? "replay-session" : "online-session",
+      current.grantSessionId,
+      mode === "replay" ? limits.replaySessionCapacity : limits.onlineSessionCapacity,
+      mode === "replay" ? limits.replaySessionRefillPerSecond : limits.onlineSessionRefillPerSecond,
+      readNow(clock),
+      options.grant.keyRing,
+    );
+    const eventBudget =
+      mode === "online"
+        ? takeBudget(
+            transaction,
+            "online-event",
+            root.eventGameId,
+            limits.onlineEventCapacity,
+            limits.onlineEventRefillPerSecond,
+            readNow(clock),
+            options.grant.keyRing,
+          )
+        : true;
+    if (!sessionBudget || !eventBudget) {
+      if (mode === "online" && replay === undefined) {
+        const recovered = recoverExistingOutcome(
+          transaction,
+          root,
+          structural,
+          prepared,
+          current,
+          true,
+        );
+        if (recovered !== null) return recovered;
+      }
+      return writeOutcome(
+        transaction,
+        root,
+        prepared.input,
+        prepared,
+        current,
+        mode,
+        replayState,
+        "retry-later",
+        "rate-budget",
+        "Retry after the acceptance budget resets.",
+      );
+    }
+
+    if (
+      previousAttempt !== undefined &&
+      previousAttempt.actionFingerprint !== null &&
+      previousAttempt.actionFingerprint !== prepared.contentFingerprint
+    )
+      throw new Error("Replay attempt fingerprint mismatch.");
+
+    const dependency = dependencyOutcome(predecessorResults);
+    if (dependency !== undefined)
+      return writeOutcome(
+        transaction,
+        root,
+        prepared.input,
+        prepared,
+        current,
+        mode,
+        replayState,
+        dependency.status,
+        normalizeFoundationRejectionReason(dependency.reason),
+        dependency.detail,
+      );
+    const existing = transaction.findActionByOperationId(root.recordId, prepared.input.operationId);
+    if (existing !== null && existing.contentFingerprint === prepared.contentFingerprint)
+      return writeDuplicateOutcome(
+        transaction,
+        root,
+        prepared,
+        current,
+        mode,
+        replayState,
+        existing.action,
+      );
+    if (existing !== null)
+      return writeOutcome(
+        transaction,
+        root,
+        prepared.input,
+        prepared,
+        current,
+        mode,
+        replayState,
+        "rejected",
+        "operation-conflict",
+        "The operation identity is already bound to different content.",
+        existing.action,
+        existing,
+      );
+    const validation = validateCurrentAction(transaction, root, prepared, options);
+    if (validation !== null)
+      return writeOutcome(
+        transaction,
+        root,
+        prepared.input,
+        prepared,
+        current,
+        mode,
+        replayState,
+        "rejected",
+        normalizeFoundationRejectionReason(validation.reason),
+        validation.detail,
+      );
+
+    const action = materializeControlAction(prepared, readNow(clock));
+    transaction.insertAction({
+      action,
+      canonicalContent: prepared.canonicalContent,
+      contentFingerprint: prepared.contentFingerprint,
+    });
+    options.failureInjector?.("after-action");
+    const metadata = transaction.readRecordMetadata(root.recordId);
+    transaction.upsertRecordMetadata({
+      recordId: root.recordId,
+      actionCount: (metadata?.actionCount ?? 0) + 1,
+      orderingVersion: CONTROL_ACTION_ORDERING_VERSION,
+      lastAcceptedAtMs:
+        metadata?.lastAcceptedAtMs === null || metadata?.lastAcceptedAtMs === undefined
+          ? action.acceptedAtMs
+          : Math.max(metadata.lastAcceptedAtMs, action.acceptedAtMs),
+      updatedAtMs: action.acceptedAtMs,
+    });
+    options.failureInjector?.("after-metadata");
+    const controlAudit = createControlAudit(
+      prepared.input,
+      "action-accepted",
+      ACCEPTED_AUDIT_DETAIL,
+      action.acceptedAtMs,
+      { interpretation: prepared.interpretation, relatedOperationIds: [] },
+    );
+    return writeAcceptedOutcome(
+      transaction,
+      root,
+      action,
+      prepared.contentFingerprint,
+      controlAudit,
+      current,
+      mode,
+      replayState,
+    );
+  }
+
+  function writeAcceptedOutcome(
+    transaction: FoundationStorageTransaction,
+    root: EventGameRecordRoot,
+    action: ControlAction,
+    fingerprint: string,
+    controlAudit: ControlAuditEntry,
+    current: AuthorizedControl,
+    mode: "online" | "replay",
+    reservation: StoredReplayReservation | undefined,
+  ): OneOutcome {
+    const acceptanceId = `accept-${sha256(`${root.recordId}:${action.operationId}:${action.grant.sessionId}`)}`;
+    const grantAudit = linkedGrantAudit(
+      options.grant,
+      current.grant,
+      current.session,
+      acceptanceId,
+      controlAudit.auditId,
+      actionIdentity(action.recordId, action.operationId),
+      "accepted",
+      fingerprint,
+      action.acceptedAtMs,
+      null,
+      ACCEPTED_AUDIT_DETAIL,
+    );
+    controlAudit.links = {
+      ...controlAudit.links!,
+      acceptanceId,
+      grantAuditId: grantAudit.auditId,
+      contentFingerprint: fingerprint,
+    };
+    transaction.appendAuditEntry(controlAudit);
+    options.failureInjector?.("after-control-audit");
+    transaction.appendGrantAudit(grantAudit);
+    options.failureInjector?.("after-grant-audit");
+    if (
+      action.interpretation.type === "correction" ||
+      action.interpretation.type === "team-assignment-correction"
+    )
+      appendConcurrentCorrectionAudits(transaction, root.recordId, action.acceptedAtMs);
+    return finishReplay(
+      transaction,
+      reservation,
+      action.operationId,
+      {
+        status: "accepted",
+        action,
+        auditId: controlAudit.auditId,
+        grantAuditId: grantAudit.auditId,
+      },
+      fingerprint,
+      controlAudit.auditId,
+      grantAudit.auditId,
+    );
+  }
+
+  function recoverExistingOutcome(
+    transaction: FoundationStorageTransaction,
+    root: EventGameRecordRoot,
+    structural: StructuralAction,
+    prepared: PreparedControlAction | null,
+    current: AuthorizedControl,
+    reuseRateBudget: boolean,
+  ): OneOutcome | null {
+    const candidate = rejectionCandidate(
+      prepared ?? undefined,
+      prepared?.input ?? structural.envelope,
+      registry,
+    );
+    const existingAction = transaction.findActionByOperationId(
+      root.recordId,
+      structural.envelope.operationId,
+    );
+    const grantAudits = transaction.listGrantAudit(current.grantId);
+    for (const control of transaction.listAuditEntries(root.recordId).reverse()) {
+      if (
+        control.kind !== "action-duplicate" &&
+        control.kind !== "action-rejected" &&
+        control.kind !== "action-conflict"
+      )
+        continue;
+      if (
+        control.operationId !== structural.envelope.operationId ||
+        control.links?.grantAuditId === undefined ||
+        control.links.grantAuditId === null
+      )
+        continue;
+      const grant = grantAudits.find((entry) => entry.auditId === control.links?.grantAuditId);
+      if (grant === undefined) continue;
+      const pairFailure = acceptanceAuditPairFailure(control, grant);
+      if (pairFailure !== null)
+        throw new Error(
+          `Existing Control and Grant acceptance evidence is inconsistent: ${pairFailure}`,
+        );
+      const outcome = parseGrantOutcomeDetail(grant.outcomeDetail);
+      if (outcome === null) throw new Error("Existing Grant acceptance outcome is invalid.");
+      if (
+        outcome.status === "retry-later" &&
+        (!reuseRateBudget || control.links.reason !== "rate-budget")
+      )
+        continue;
+      if (outcome.status === "duplicate-accepted") {
+        if (
+          existingAction === null ||
+          control.links.contentFingerprint !== candidate.contentFingerprint
+        )
+          continue;
+        return {
+          result: {
+            status: "duplicate-accepted",
+            action: existingAction.action,
+            auditId: control.auditId,
+            grantAuditId: grant.auditId,
+          },
+        };
+      }
+      if (
+        outcome.status !== "rejected" &&
+        outcome.status !== "dependency-blocked" &&
+        outcome.status !== "authority-expired" &&
+        outcome.status !== "retry-later"
+      )
+        continue;
+      if (!sameRejectedCandidate(control.links, candidate)) continue;
+      return {
+        result: {
+          status: outcome.status,
+          reason: normalizeFoundationRejectionReason(control.links.reason),
+          detail: control.redactedDetail,
+          auditId: control.auditId,
+          grantAuditId: grant.auditId,
+        },
+      };
+    }
+    return null;
+  }
+
+  function recoverReplayAttempt(
+    transaction: FoundationStorageTransaction,
+    reservation: StoredReplayReservation | undefined,
+    structural: StructuralAction,
+  ): OneOutcome | null {
+    if (reservation === undefined) return null;
+    const attempt = transaction
+      .listReplayAttempts(reservation.reservationId)
+      .find((item) => item.operationId === structural.envelope.operationId);
+    if (attempt === undefined || attempt.status === "retry-later") return null;
+    if (reservation.status === "committed" || reservation.status === "acknowledged")
+      return recoverCommittedReplay(transaction, reservation, attempt, options.grant.keyRing);
+    const controlAudit = transaction
+      .listAuditEntries(reservation.recordId)
+      .find((entry) => entry.auditId === attempt.controlAuditId);
+    return {
+      result: readAttemptResult(
+        attempt,
+        transaction.findActionByOperationId(reservation.recordId, attempt.operationId)?.action,
+        controlAudit?.links?.reason,
+      ),
+      reservationId: reservation.reservationId,
+    };
+  }
+
+  function writeDuplicateOutcome(
+    transaction: FoundationStorageTransaction,
+    root: EventGameRecordRoot,
+    prepared: PreparedControlAction,
+    current: AuthorizedControl,
+    mode: "online" | "replay",
+    reservation: StoredReplayReservation | undefined,
+    existing: ControlAction,
+  ): OneOutcome {
+    const nowMs = readNow(clock);
+    const controlAudit = createControlAudit(
+      prepared.input,
+      "action-duplicate",
+      "The Control Action was already committed.",
+      nowMs,
+      { interpretation: existing.interpretation },
+    );
+    controlAudit.outcome = "accepted";
+    const acceptanceId = `accept-${sha256(`${root.recordId}:${prepared.input.operationId}:duplicate`)}`;
+    const grantAudit = linkedGrantAudit(
+      options.grant,
+      current.grant,
+      current.session,
+      acceptanceId,
+      controlAudit.auditId,
+      actionIdentity(existing.recordId, existing.operationId),
+      "duplicate-accepted",
+      prepared.contentFingerprint,
+      nowMs,
+      null,
+      "The Control Action was already committed.",
+    );
+    controlAudit.links = {
+      ...controlAudit.links!,
+      acceptanceId,
+      grantAuditId: grantAudit.auditId,
+      contentFingerprint: prepared.contentFingerprint,
+    };
+    transaction.appendAuditEntry(controlAudit);
+    options.failureInjector?.("after-control-audit");
+    transaction.appendGrantAudit(grantAudit);
+    options.failureInjector?.("after-grant-audit");
+    return finishReplay(
+      transaction,
+      reservation,
+      existing.operationId,
+      {
+        status: "duplicate-accepted",
+        action: existing,
+        auditId: controlAudit.auditId,
+        grantAuditId: grantAudit.auditId,
+      },
+      prepared.contentFingerprint,
+      controlAudit.auditId,
+      grantAudit.auditId,
+    );
+  }
+
+  function writeOutcome(
+    transaction: FoundationStorageTransaction,
+    root: EventGameRecordRoot,
+    input: ControlActionEnvelope | ControlActionInput,
+    prepared: PreparedControlAction | undefined,
+    current: AuthorizedControl,
+    mode: "online" | "replay",
+    reservation: StoredReplayReservation | undefined,
+    status: Exclude<
+      FoundationActionResult["status"],
+      "accepted" | "duplicate-accepted" | "locked-discarded"
+    >,
+    reason: FoundationRejectionReason,
+    detail: string,
+    duplicateAction?: ControlAction,
+    collision?: { contentFingerprint?: string },
+  ): OneOutcome {
+    const nowMs = readNow(clock);
+    const controlInput = prepared?.input ?? input;
+    const candidate = rejectionCandidate(prepared, controlInput, registry);
+    const controlAudit = createControlAudit(
+      controlInput,
+      reason === "operation-conflict" ? "action-conflict" : "action-rejected",
+      detail,
+      nowMs,
+      duplicateAction === undefined
+        ? { interpretation: prepared?.interpretation }
+        : {
+            interpretation: prepared?.interpretation,
+            collision: {
+              acceptedAction: duplicateAction,
+              acceptedContentFingerprint: collision?.contentFingerprint ?? "",
+              rejectedAttempt: prepared!,
+            },
+          },
+    );
+    const acceptanceId = `accept-${sha256(`${root.recordId}:${controlInput.operationId}:${reason}`)}`;
+    const grantAudit = linkedGrantAudit(
+      options.grant,
+      current.grant,
+      current.session,
+      acceptanceId,
+      controlAudit.auditId,
+      actionIdentity(controlInput.recordId, controlInput.operationId),
+      status === "retry-later" ? "retry-later" : status,
+      candidate.contentFingerprint,
+      nowMs,
+      reason,
+      detail,
+    );
+    controlAudit.links = {
+      ...controlAudit.links!,
+      acceptanceId,
+      grantAuditId: grantAudit.auditId,
+      contentFingerprint: candidate.contentFingerprint,
+      reason,
+      rejectedCandidate: candidate,
+    };
+    transaction.appendAuditEntry(controlAudit);
+    options.failureInjector?.("after-control-audit");
+    transaction.appendGrantAudit(grantAudit);
+    options.failureInjector?.("after-grant-audit");
+    return finishReplay(
+      transaction,
+      reservation,
+      controlInput.operationId,
+      { status, reason, detail, auditId: controlAudit.auditId, grantAuditId: grantAudit.auditId },
+      candidate.contentFingerprint,
+      controlAudit.auditId,
+      grantAudit.auditId,
+    );
+  }
+
+  function finishReplay(
+    transaction: FoundationStorageTransaction,
+    reservation: StoredReplayReservation | undefined,
+    operationId: string,
+    result: FoundationActionResult,
+    fingerprint: string | null,
+    controlAuditId: string,
+    grantAuditId: string,
+  ): OneOutcome {
+    if (reservation === undefined) return { result };
+    const existing = transaction
+      .listReplayAttempts(reservation.reservationId)
+      .find((attempt) => attempt.operationId === operationId);
+    const status: StoredReplayAttempt["status"] =
+      result.status === "accepted" || result.status === "duplicate-accepted"
+        ? result.status
+        : result.status === "retry-later"
+          ? "retry-later"
+          : "rejected";
+    const attempt: StoredReplayAttempt = {
+      attemptId:
+        existing?.attemptId ?? `attempt-${sha256(`${reservation.reservationId}:${operationId}`)}`,
+      reservationId: reservation.reservationId,
+      operationId,
+      status,
+      actionFingerprint: fingerprint,
+      resultJson: canonicalizeJson(result),
+      controlAuditId,
+      grantAuditId,
+      createdAtMs: existing?.createdAtMs ?? readNow(clock),
+      completedAtMs: status === "retry-later" ? null : readNow(clock),
+      stateRevision: (existing?.stateRevision ?? 0) + 1,
+    };
+    if (existing === undefined) transaction.insertReplayAttempt(attempt);
+    else transaction.updateReplayAttempt(attempt);
+    transaction.insertAcceptanceIntegrityAnchor(
+      anchorFor("attempt", attempt, options.grant.keyRing),
+    );
+    if (status === "retry-later") {
+      const partial = {
+        ...reservation,
+        status: "partial" as const,
+        stateRevision: reservation.stateRevision + 1,
+      };
+      transaction.updateReplayReservation(partial);
+      transaction.insertAcceptanceIntegrityAnchor(
+        anchorFor("reservation", partial, options.grant.keyRing),
+      );
+      return { result, reservationId: reservation.reservationId };
+    }
+    const attempts = transaction.listReplayAttempts(reservation.reservationId);
+    if (
+      attempts.length !== reservation.actionCount ||
+      attempts.some((item) => item.status === "retry-later")
+    ) {
+      const partial = {
+        ...reservation,
+        status: "partial" as const,
+        stateRevision: reservation.stateRevision + 1,
+      };
+      transaction.updateReplayReservation(partial);
+      transaction.insertAcceptanceIntegrityAnchor(
+        anchorFor("reservation", partial, options.grant.keyRing),
+      );
+      return { result, reservationId: reservation.reservationId };
+    }
+    options.failureInjector?.("before-receipt");
+    const committed = {
+      ...reservation,
+      status: "committed" as const,
+      committedAtMs: readNow(clock),
+      stateRevision: reservation.stateRevision + 1,
+    };
+    transaction.updateReplayReservation(committed);
+    transaction.insertAcceptanceIntegrityAnchor(
+      anchorFor("reservation", committed, options.grant.keyRing),
+    );
+    const existingReceipt = transaction.findReplayReceiptByReservationId(reservation.reservationId);
+    const receiptKeyVersion =
+      existingReceipt?.receiptKeyVersion ?? options.grant.keyRing.lookup.currentVersion;
+    const receipt = encodeReceipt(
+      reservation.reservationId,
+      options.grant.keyRing,
+      receiptKeyVersion,
+    );
+    if (existingReceipt === null) {
+      const storedReceipt = {
+        receiptId: `receipt-${sha256(reservation.reservationId)}`,
+        reservationId: reservation.reservationId,
+        receiptDigest: sha256(receipt),
+        receiptKeyVersion,
+        status: "committed" as const,
+        actionCount: reservation.actionCount,
+        createdAtMs: readNow(clock),
+        acknowledgedAtMs: null,
+        stateRevision: 1,
+      };
+      transaction.insertReplayReceipt(storedReceipt);
+      transaction.insertAcceptanceIntegrityAnchor(
+        anchorFor("receipt", storedReceipt, options.grant.keyRing),
+      );
+    }
+    return { result, reservationId: reservation.reservationId, receipt };
+  }
+
+  function discardLockedReplay(
+    transaction: FoundationStorageTransaction,
+    root: EventGameRecordRoot,
+    batch: PreparedBatch,
+    reservation: StoredReplayReservation | undefined,
+    originatingSessionId: string,
+    rejectedAtMs: number,
+  ): OneOutcome {
+    if (reservation === undefined) {
+      const existingAudit = transaction.listAuditEntries(root.recordId).find((entry) => {
+        const locked = entry.lockedReplay;
+        return (
+          locked?.count === batch.actions.length &&
+          locked.originatingSessionId === originatingSessionId &&
+          locked.eventGameId === root.eventGameId
+        );
+      });
+      if (existingAudit?.lockedReplay !== undefined)
+        return {
+          result: {
+            status: "locked-discarded",
+            count: existingAudit.lockedReplay.count,
+            eventGameId: existingAudit.lockedReplay.eventGameId,
+            rejectedAtMs: existingAudit.lockedReplay.rejectedAtMs,
+          },
+        };
+    }
+    if (reservation === undefined || !["reserved", "partial"].includes(reservation.status))
+      return one({
+        status: "authority-expired",
+        reason: "game-locked",
+        detail: "The Event Game is locked.",
+      });
+    transaction.appendAuditEntry({
+      auditVersion: "control-audit-v1",
+      auditId: `audit-${sha256(`${root.recordId}:locked-replay:${originatingSessionId}:${rejectedAtMs}:${batch.actions.length}`)}`,
+      recordId: root.recordId,
+      eventGameId: root.eventGameId,
+      operationId: null,
+      kind: "action-rejected",
+      outcome: "rejected",
+      createdAtMs: rejectedAtMs,
+      redactedDetail: "Offline replay was discarded after the Event Game locked.",
+      links: {
+        actionId: null,
+        targetFactId: null,
+        causalPredecessorIds: [],
+        relatedOperationIds: [],
+        ordering: null,
+      },
+      provenance: {
+        occurrence: null,
+        grant: null,
+        lifecycle: null,
+        override: null,
+        recoveryProvenance: null,
+      },
+      lockedReplay: {
+        count: batch.actions.length,
+        originatingSessionId,
+        eventGameId: root.eventGameId,
+        rejectedAtMs,
+      },
+    });
+    // The trusted lock path erases the replay slot after recording only the
+    // redacted tuple above. In particular, no reservation identity or
+    // historical timestamp survives as discard evidence.
+    transaction.discardReplayReservation(reservation.reservationId);
+    return {
+      result: {
+        status: "locked-discarded",
+        count: reservation?.actionCount ?? batch.actions.length,
+        eventGameId: root.eventGameId,
+        rejectedAtMs,
+      },
+    };
+  }
+
+  function structurallyValidateBatch(raw: unknown): PreparedBatch | null {
+    if (
+      !isRecord(raw) ||
+      !Array.isArray(raw.actions) ||
+      raw.actions.length === 0 ||
+      raw.actions.length > limits.maxBatchActions
+    )
+      return null;
+    const recordId = typeof raw.recordId === "string" ? raw.recordId : "";
+    const eventGameId = typeof raw.eventGameId === "string" ? raw.eventGameId : "";
+    if (
+      !validateOpaqueIdentifier(recordId, "recordId").ok ||
+      !validateOpaqueIdentifier(eventGameId, "eventGameId").ok
+    )
+      return null;
+    const mode = raw.mode === "replay" ? "replay" : raw.mode === "online" ? "online" : undefined;
+    const replay =
+      isRecord(raw.replay) &&
+      typeof raw.replay.sessionBearer === "string" &&
+      typeof raw.replay.originatingSessionId === "string" &&
+      typeof raw.replay.replayEvidenceId === "string"
+        ? {
+            sessionBearer: raw.replay.sessionBearer,
+            originatingSessionId: raw.replay.originatingSessionId,
+            replayEvidenceId: raw.replay.replayEvidenceId,
+          }
+        : undefined;
+    if ((mode === "online" && replay !== undefined) || (mode === "replay" && replay === undefined))
+      return null;
+    const effectiveMode = mode ?? (replay === undefined ? "online" : "replay");
+    let size: number;
+    try {
+      size = Buffer.byteLength(JSON.stringify(raw), "utf8");
+    } catch {
+      return null;
+    }
+    if (size > limits.maxBatchBytes) return null;
+    const actions: StructuralAction[] = [];
+    const operationIds = new Set<string>();
+    let grantEnvelope: string | undefined;
+    let lifecycleEnvelope: string | undefined;
+    for (const value of raw.actions) {
+      const envelope = validateControlActionEnvelope(value, readNow(clock));
+      if (
+        !envelope.ok ||
+        envelope.value.recordId !== recordId ||
+        envelope.value.eventGameId !== eventGameId ||
+        operationIds.has(envelope.value.operationId)
+      )
+        return null;
+      const grant = canonicalizeJson(envelope.value.grant);
+      const lifecycle = canonicalizeJson(envelope.value.lifecycle);
+      if (
+        (grantEnvelope !== undefined && grantEnvelope !== grant) ||
+        (lifecycleEnvelope !== undefined && lifecycleEnvelope !== lifecycle)
+      )
+        return null;
+      grantEnvelope ??= grant;
+      lifecycleEnvelope ??= lifecycle;
+      if (
+        envelope.value.recoveryProvenance !== undefined &&
+        (envelope.value.recoveryProvenance.sourceRecordId !== recordId ||
+          envelope.value.recoveryProvenance.sourceEventGameId !== eventGameId ||
+          envelope.value.recoveryProvenance.sourceOperationId !== envelope.value.operationId)
+      )
+        return null;
+      operationIds.add(envelope.value.operationId);
+      actions.push({ raw: structuredClone(value), envelope: envelope.value });
+    }
+    const order = topologicalOrder(
+      actions.map((item) => ({
+        operationId: item.envelope.operationId,
+        predecessors: item.envelope.causalPredecessorIds,
+      })),
+    );
+    if (order === null) return null;
+    const normalized = {
+      recordId,
+      eventGameId,
+      mode: effectiveMode,
+      replay: replay
+        ? {
+            originatingSessionId: replay.originatingSessionId,
+            replayEvidenceId: replay.replayEvidenceId,
+          }
+        : null,
+      actions: raw.actions,
+    };
+    return {
+      input: {
+        recordId,
+        eventGameId,
+        actions: raw.actions,
+        sessionBearer: typeof raw.sessionBearer === "string" ? raw.sessionBearer : undefined,
+        mode: effectiveMode,
+        replay,
+      },
+      actions,
+      order,
+      size,
+      digest: sha256(JSON.stringify(normalized)),
+    };
+  }
+
+  function replayReservation(
+    transaction: FoundationStorageTransaction,
+    batch: PreparedBatch,
+    sessionId: string,
+  ): { value?: StoredReplayReservation; mismatch: boolean } {
+    const id = reservationIdFor(batch, sessionId);
+    const value = transaction.findReplayReservation(id);
+    if (value === null) return { mismatch: false };
+    return {
+      value:
+        value.replacementSessionId === sessionId || value.replacementSessionId === null
+          ? value
+          : undefined,
+      mismatch: value.replacementSessionId !== sessionId && value.replacementSessionId !== null,
+    };
+  }
+
+  function ensureReservation(
+    transaction: FoundationStorageTransaction,
+    batch: PreparedBatch,
+    sessionId: string,
+    existing: StoredReplayReservation | undefined,
+  ): { value?: StoredReplayReservation; mismatch: boolean } {
+    const replay = batch.input.replay;
+    if (replay === undefined) return { mismatch: false };
+    const id = reservationIdFor(batch, sessionId);
+    const value = existing ?? transaction.findReplayReservation(id);
+    if (value !== null && value !== undefined) {
+      if (
+        value.recordId !== batch.input.recordId ||
+        value.eventGameId !== batch.input.eventGameId ||
+        value.originatingSessionId !== replay.originatingSessionId ||
+        value.actionCount !== batch.actions.length ||
+        (value.batchDigest !== null && value.batchDigest !== batch.digest) ||
+        (value.replacementSessionId !== null && value.replacementSessionId !== sessionId)
+      )
+        return { mismatch: true };
+      if (value.replacementSessionId === null && value.status !== "discarded") {
+        const updated = {
+          ...value,
+          replacementSessionId: sessionId,
+          batchDigest: batch.digest,
+          stateRevision: value.stateRevision + 1,
+        };
+        transaction.updateReplayReservation(updated);
+        transaction.insertAcceptanceIntegrityAnchor(
+          anchorFor("reservation", updated, options.grant.keyRing),
+        );
+        return { value: updated, mismatch: false };
+      }
+      return { value, mismatch: false };
+    }
+    const created: StoredReplayReservation = {
+      reservationId: id,
+      recordId: batch.input.recordId,
+      eventGameId: batch.input.eventGameId,
+      originatingSessionId: replay.originatingSessionId,
+      replacementSessionId: sessionId,
+      actionCount: batch.actions.length,
+      status: "reserved",
+      batchDigest: batch.digest,
+      createdAtMs: readNow(clock),
+      committedAtMs: null,
+      acknowledgedAtMs: null,
+      stateRevision: 1,
+    };
+    transaction.insertReplayReservation(created);
+    transaction.insertAcceptanceIntegrityAnchor(
+      anchorFor("reservation", created, options.grant.keyRing),
+    );
+    return { value: created, mismatch: false };
+  }
+}
+
+function recoverCommittedReplay(
+  transaction: FoundationStorageTransaction,
+  reservation: StoredReplayReservation,
+  attempt: StoredReplayAttempt,
+  keyRing: GrantAuthorityOptions["keyRing"],
+): OneOutcome {
+  const expectedAction = transaction.findActionByOperationId(
+    reservation.recordId,
+    attempt.operationId,
+  )?.action;
+  const controlAudit = transaction
+    .listAuditEntries(reservation.recordId)
+    .find((entry) => entry.auditId === attempt.controlAuditId);
+  const result = readAttemptResult(attempt, expectedAction, controlAudit?.links?.reason);
+  const receipt = transaction.findReplayReceiptByReservationId(reservation.reservationId);
+  if (receipt === null) throw new Error("Committed replay receipt is missing.");
+  return {
+    result,
+    reservationId: reservation.reservationId,
+    receipt: encodeReceipt(reservation.reservationId, keyRing, receipt.receiptKeyVersion),
+  };
+}
+
+function authorityFailure(): OneOutcome {
+  return {
+    result: {
+      status: "authority-expired",
+      reason: "grant-session",
+      detail: "The Grant Session is no longer current.",
+    },
+  };
+}
+
+function samePreparedAction(
+  left: PreparedControlAction,
+  right: PreparedControlAction | null | undefined,
+): boolean {
+  return (
+    right !== null &&
+    right !== undefined &&
+    left.codecIdentity === right.codecIdentity &&
+    left.canonicalContent === right.canonicalContent &&
+    left.contentFingerprint === right.contentFingerprint &&
+    canonicalizeJson(left.interpretation) === canonicalizeJson(right.interpretation) &&
+    canonicalizeJson(left.input.lifecycle) === canonicalizeJson(right.input.lifecycle)
+  );
+}
+
+function samePreparationResult(
+  left: PreparedControlAction | null,
+  right: PreparedControlAction | null,
+): boolean {
+  if (left === null || right === null) return left === right;
+  return samePreparedAction(left, right);
+}
+
+function one(result: FoundationActionResult): OneOutcome {
+  return { result };
+}
+
+function validateCurrentAction(
+  transaction: FoundationStorageTransaction,
+  root: EventGameRecordRoot,
+  prepared: PreparedControlAction,
+  options: FoundationAcceptanceOptions,
+): { reason: string; detail: string } | null {
+  const dependency = validateDependencies(transaction, prepared.input);
+  if (dependency !== null) return dependency;
+  if (
+    prepared.interpretation.type === "correction" &&
+    findFactById(transaction.listActions(root.recordId), prepared.interpretation.targetFactId) ===
+      null
+  )
+    return { reason: "fact-target-missing", detail: "The Correction target is not retained." };
+  if (
+    prepared.interpretation.type === "team-assignment-correction" &&
+    options.externalScopeResolver.resolveEventTeam(
+      root.eventId,
+      prepared.interpretation.eventTeamId,
+      transaction,
+    ).status !== "resolved"
+  )
+    return { reason: "invalid-action", detail: "The Event Team is unavailable." };
+  return null;
+}
+
+function dependencyOutcome(
+  predecessorResults: readonly FoundationActionResult[],
+): { status: "dependency-blocked" | "retry-later"; reason: string; detail: string } | undefined {
+  if (
+    predecessorResults.some(
+      (result) => result.status === "retry-later" || result.status === "authority-expired",
+    )
+  )
+    return {
+      status: "retry-later",
+      reason: "causal-predecessor-retry",
+      detail: "Retry after the causal predecessor reaches a definitive outcome.",
+    };
+  if (
+    predecessorResults.some(
+      (result) => result.status !== "accepted" && result.status !== "duplicate-accepted",
+    )
+  )
+    return {
+      status: "dependency-blocked",
+      reason: "causal-dependency-rejected",
+      detail: "A causal predecessor did not commit.",
+    };
+  return undefined;
+}
+
+function readAttemptResult(
+  attempt: StoredReplayAttempt,
+  expectedAction?: ControlAction,
+  expectedReason?: string,
+): FoundationActionResult {
+  const failure = replayAttemptResultFailure(attempt, expectedAction, expectedReason);
+  if (failure !== null) throw new Error(failure);
+  return JSON.parse(attempt.resultJson!) as FoundationActionResult;
+}
+function reservationIdFor(batch: PreparedBatch, sessionId: string): string {
+  // The reservation identifies the authenticated replay slot, not its
+  // contents. The batch digest remains authenticated mutable evidence and is
+  // checked by ensureReservation, while a locked delivery can still find and
+  // discard an existing reserved/partial slot without retaining content-derived
+  // identifiers.
+  return `reservation-${sha256(`${batch.input.recordId}:${batch.input.eventGameId}:${batch.input.replay?.originatingSessionId ?? ""}:${sessionId}`)}`;
+}
+
+function rejectionCandidate(
+  prepared: PreparedControlAction | undefined,
+  input: ControlActionEnvelope | ControlActionInput,
+  registry: ControlActionCodecRegistry,
+): {
+  codecIdentity: string;
+  codecFingerprint: string;
+  canonicalContent: string;
+  contentFingerprint: string;
+} {
+  if (prepared !== undefined) {
+    return {
+      codecIdentity: prepared.codecIdentity,
+      codecFingerprint: prepared.codecFingerprint,
+      canonicalContent: prepared.canonicalContent,
+      contentFingerprint: prepared.contentFingerprint,
+    };
+  }
+  const codecIdentity = controlActionCodecIdentity(input.kind, registry);
+  const canonicalContent = canonicalizeJson(input);
+  return {
+    codecIdentity,
+    codecFingerprint: codecIdentity,
+    canonicalContent,
+    contentFingerprint: sha256(`${codecIdentity}:${canonicalContent}`),
+  };
+}
+
+function sameRejectedCandidate(
+  links: NonNullable<ControlAuditEntry["links"]>,
+  candidate: ReturnType<typeof rejectionCandidate>,
+): boolean {
+  const rejected = links.rejectedCandidate;
+  if (
+    rejected === undefined ||
+    rejected.codecIdentity !== candidate.codecIdentity ||
+    rejected.codecFingerprint !== candidate.codecFingerprint ||
+    rejected.canonicalContent !== candidate.canonicalContent ||
+    rejected.contentFingerprint !== candidate.contentFingerprint
+  )
+    return false;
+  const collision = links.collision?.rejectedAttempt;
+  return (
+    collision === undefined ||
+    (collision.codecIdentity === candidate.codecIdentity &&
+      collision.codecFingerprint === candidate.codecFingerprint &&
+      collision.canonicalContent === candidate.canonicalContent &&
+      collision.contentFingerprint === candidate.contentFingerprint)
+  );
+}
+
+function parseGrantOutcomeDetail(value: string | null | undefined): {
+  status: FoundationActionResult["status"];
+  reason: FoundationRejectionReason | null;
+} | null {
+  if (value === null || value === undefined) return null;
+  try {
+    const parsed = JSON.parse(value) as Record<string, unknown>;
+    if (
+      typeof parsed.status !== "string" ||
+      ![
+        "accepted",
+        "duplicate-accepted",
+        "rejected",
+        "dependency-blocked",
+        "authority-expired",
+        "retry-later",
+      ].includes(parsed.status) ||
+      (parsed.reason !== null && typeof parsed.reason !== "string")
+    )
+      return null;
+    return {
+      status: parsed.status as FoundationActionResult["status"],
+      reason: parsed.reason === null ? null : normalizeFoundationRejectionReason(parsed.reason),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function linkedGrantAudit(
+  options: GrantAuthorityOptions,
+  grant: StoredGrant,
+  session: StoredGrantSession,
+  acceptanceId: string,
+  controlAuditId: string,
+  controlActionId: string,
+  outcome: string,
+  contentFingerprint: string,
+  createdAtMs: number,
+  reason: FoundationRejectionReason | null,
+  detail: string | null = null,
+) {
+  const action =
+    outcome === "accepted"
+      ? "control-action-accepted"
+      : outcome === "duplicate-accepted"
+        ? "control-action-duplicate"
+        : outcome === "retry-later"
+          ? "control-action-retry-later"
+          : outcome === "dependency-blocked"
+            ? "control-action-dependency-blocked"
+            : "control-action-rejected";
+  return {
+    ...createGrantAudit(
+      options,
+      auditInput(
+        action,
+        grant,
+        {
+          kind: "session",
+          sessionId: session.sessionId,
+          pseudonymKeyVersion: session.browserContextKeyVersion,
+        },
+        grant.status,
+        session.sessionId,
+        null,
+        session.eventGameId,
+        grant.status,
+        null,
+        null,
+        null,
+        null,
+        null,
+      ),
+    ),
+    acceptanceId,
+    controlAuditId,
+    controlActionId,
+    contentFingerprint,
+    outcomeDetail: canonicalizeJson({
+      status: outcome,
+      reason,
+      detail: detail ?? "",
+    }),
+    createdAtMs,
+  };
+}
+
+function takeBudget(
+  transaction: FoundationStorageTransaction,
+  kind: StoredAcceptanceBudget["bucketKind"],
+  subjectId: string,
+  capacity: number,
+  refillPerSecond: number,
+  nowMs: number,
+  keyRing: GrantAuthorityOptions["keyRing"],
+): boolean {
+  const bucketId = `budget-${kind}:${subjectId}`;
+  const previous = transaction.findAcceptanceBudget(bucketId);
+  const elapsed = previous === null ? 0 : Math.max(0, nowMs - previous.updatedAtMs) / 1000;
+  const tokens = Math.min(capacity, (previous?.tokens ?? capacity) + elapsed * refillPerSecond);
+  const allowed = tokens >= 1;
+  transaction.upsertAcceptanceBudget({
+    bucketId,
+    bucketKind: kind,
+    subjectId,
+    capacity,
+    refillPerSecond,
+    tokens: allowed ? tokens - 1 : tokens,
+    updatedAtMs: nowMs,
+    stateRevision: (previous?.stateRevision ?? 0) + 1,
+  });
+  transaction.insertAcceptanceIntegrityAnchor(
+    anchorFor(
+      "budget",
+      {
+        bucketId,
+        bucketKind: kind,
+        subjectId,
+        capacity,
+        refillPerSecond,
+        tokens: allowed ? tokens - 1 : tokens,
+        updatedAtMs: nowMs,
+        stateRevision: (previous?.stateRevision ?? 0) + 1,
+      },
+      keyRing,
+    ),
+  );
+  return allowed;
+}
+
+function topologicalOrder(
+  actions: readonly { operationId: string; predecessors: readonly string[] }[],
+): number[] | null {
+  const byOperation = new Map(actions.map((item, index) => [item.operationId, index]));
+  const indegree = actions.map(
+    (item) => item.predecessors.filter((id) => byOperation.has(id)).length,
+  );
+  const order: number[] = [];
+  while (order.length < actions.length) {
+    const next = actions.findIndex((_, index) => indegree[index] === 0 && !order.includes(index));
+    if (next < 0) return null;
+    order.push(next);
+    const operation = actions[next]?.operationId;
+    for (const [index, item] of actions.entries())
+      if (item.predecessors.includes(operation ?? "")) indegree[index] = (indegree[index] ?? 0) - 1;
+    indegree[next] = -1;
+  }
+  return order;
+}
+function predecessorResultsFor(
+  batch: PreparedBatch,
+  results: readonly FoundationActionResult[],
+  index: number,
+): FoundationActionResult[] {
+  const predecessorResults: FoundationActionResult[] = [];
+  for (const predecessor of batch.actions[index]?.envelope.causalPredecessorIds ?? []) {
+    const predecessorIndex = batch.actions.findIndex(
+      (candidate) => candidate.envelope.operationId === predecessor,
+    );
+    if (predecessorIndex >= 0 && results[predecessorIndex] !== undefined)
+      predecessorResults.push(results[predecessorIndex]);
+  }
+  return predecessorResults;
+}
+function encodeReceipt(
+  reservationId: string,
+  keyRing: GrantAuthorityOptions["keyRing"],
+  keyVersion = keyRing.lookup.currentVersion,
+): string {
+  return `${reservationId}.${computeLookupDigest(
+    `acceptance-receipt:${reservationId}`,
+    keyRing,
+    keyVersion,
+  )}`;
+}
+function readNow(clock: () => number): number {
+  const nowMs = clock();
+  if (!Number.isSafeInteger(nowMs) || nowMs < 0)
+    throw new Error("Acceptance clock returned an invalid timestamp.");
+  return nowMs;
+}
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/lib/foundation-grant-erasure-migration.test.ts
+++ b/src/lib/foundation-grant-erasure-migration.test.ts
@@ -210,7 +210,7 @@ describe("Grant cryptographic erasure migration", () => {
 
       const current = openSqliteFoundationStorage(databasePath);
       await current.applyMigrations({ requireCandidate: false });
-      expect(await current.readiness()).toMatchObject({ ok: true, schemaVersion: "16" });
+      expect(await current.readiness()).toMatchObject({ ok: true, schemaVersion: "18" });
       current.close();
 
       const raw = new Database(databasePath);
@@ -330,7 +330,7 @@ describe("Grant cryptographic erasure migration", () => {
       raw.close();
 
       const reopened = openSqliteFoundationStorage(databasePath);
-      expect(await reopened.readiness()).toMatchObject({ ok: true, schemaVersion: "16" });
+      expect(await reopened.readiness()).toMatchObject({ ok: true, schemaVersion: "18" });
       const restartedAudit = await reopened.transaction((transaction) =>
         transaction.listGrantAudit("grant-expired"),
       );

--- a/src/lib/foundation-migrations.ts
+++ b/src/lib/foundation-migrations.ts
@@ -1084,6 +1084,154 @@ const FOUNDATION_REPLAY_PROVENANCE_MIGRATION_SQL = `
   ${FOUNDATION_GRANT_AUDIT_PROVENANCE_AFTER_INSERT_TRIGGER_V16_SQL};
 `;
 
+const FOUNDATION_COMPOSED_GRANT_AUDIT_TABLE_SQL =
+  FOUNDATION_TYPED_GRANT_AUDIT_TABLE_V16_SQL.replace(
+    "'session-terminated', 'session-switched', 'replay-authorized'))",
+    "'session-terminated', 'session-switched', 'replay-authorized', 'control-action-accepted', 'control-action-duplicate', 'control-action-rejected', 'control-action-retry-later', 'control-action-dependency-blocked'))",
+  ).replace(
+    "    created_at_ms INTEGER NOT NULL",
+    "    acceptance_id TEXT,\n    control_audit_id TEXT,\n    control_action_id TEXT,\n    content_fingerprint TEXT,\n    outcome_detail TEXT,\n    created_at_ms INTEGER NOT NULL",
+  );
+
+/** Schema-17 is the append-only durable state for the composed acceptance seam. */
+const FOUNDATION_COMPOSED_ACCEPTANCE_MIGRATION_SQL = `
+  CREATE TABLE foundation_acceptance_budgets (
+    bucket_id TEXT PRIMARY KEY,
+    bucket_kind TEXT NOT NULL CHECK (bucket_kind IN ('online-session', 'online-event', 'replay-session')),
+    subject_id TEXT NOT NULL,
+    capacity INTEGER NOT NULL CHECK (capacity > 0),
+    refill_per_second INTEGER NOT NULL CHECK (refill_per_second > 0),
+    tokens REAL NOT NULL CHECK (tokens >= 0 AND tokens <= capacity),
+    updated_at_ms INTEGER NOT NULL,
+    state_revision INTEGER NOT NULL CHECK (state_revision > 0)
+  ) STRICT;
+  CREATE TABLE foundation_replay_reservations (
+    reservation_id TEXT PRIMARY KEY,
+    record_id TEXT NOT NULL REFERENCES foundation_event_game_record_roots(record_id) ON DELETE CASCADE,
+    event_game_id TEXT NOT NULL,
+    originating_session_id TEXT NOT NULL,
+    replacement_session_id TEXT,
+    action_count INTEGER NOT NULL CHECK (action_count > 0),
+    status TEXT NOT NULL CHECK (status IN ('reserved', 'committing', 'committed', 'partial', 'discarded', 'acknowledged')),
+    batch_digest TEXT,
+    created_at_ms INTEGER NOT NULL,
+    committed_at_ms INTEGER,
+    acknowledged_at_ms INTEGER,
+    state_revision INTEGER NOT NULL CHECK (state_revision > 0)
+  ) STRICT;
+  CREATE TABLE foundation_replay_attempts (
+    attempt_id TEXT PRIMARY KEY,
+    reservation_id TEXT NOT NULL REFERENCES foundation_replay_reservations(reservation_id) ON DELETE CASCADE,
+    operation_id TEXT NOT NULL,
+    status TEXT NOT NULL CHECK (status IN ('pending', 'accepted', 'duplicate-accepted', 'rejected', 'retry-later')),
+    action_fingerprint TEXT,
+    result_json TEXT,
+    control_audit_id TEXT,
+    grant_audit_id TEXT,
+    created_at_ms INTEGER NOT NULL,
+    completed_at_ms INTEGER,
+    state_revision INTEGER NOT NULL CHECK (state_revision > 0),
+    UNIQUE (reservation_id, operation_id)
+  ) STRICT;
+  CREATE TABLE foundation_replay_receipts (
+    receipt_id TEXT PRIMARY KEY,
+    reservation_id TEXT NOT NULL REFERENCES foundation_replay_reservations(reservation_id) ON DELETE CASCADE,
+    receipt_digest TEXT NOT NULL UNIQUE,
+    receipt_key_version TEXT NOT NULL,
+    status TEXT NOT NULL CHECK (status IN ('committed', 'acknowledged')),
+    action_count INTEGER NOT NULL CHECK (action_count > 0),
+    created_at_ms INTEGER NOT NULL,
+    acknowledged_at_ms INTEGER,
+    state_revision INTEGER NOT NULL CHECK (state_revision > 0)
+  ) STRICT;
+  CREATE TABLE foundation_acceptance_integrity_anchors (
+    anchor_id TEXT PRIMARY KEY,
+    subject_kind TEXT NOT NULL CHECK (subject_kind IN ('budget', 'reservation', 'attempt', 'receipt')),
+    subject_id TEXT NOT NULL,
+    state_revision INTEGER NOT NULL CHECK (state_revision > 0),
+    key_version TEXT NOT NULL,
+    integrity_tag TEXT NOT NULL,
+    UNIQUE (subject_kind, subject_id, state_revision)
+  ) STRICT;
+  CREATE TRIGGER foundation_acceptance_integrity_anchors_no_update
+    BEFORE UPDATE ON foundation_acceptance_integrity_anchors
+    BEGIN SELECT RAISE(ABORT, 'Acceptance integrity anchors are immutable.'); END;
+  CREATE TRIGGER foundation_acceptance_integrity_anchors_no_delete
+    BEFORE DELETE ON foundation_acceptance_integrity_anchors
+    BEGIN SELECT RAISE(ABORT, 'Acceptance integrity anchors are immutable.'); END;
+  DROP TRIGGER IF EXISTS foundation_grant_audit_provenance_after_insert;
+  DROP TRIGGER IF EXISTS foundation_grant_audit_no_legacy_integrity_tag;
+  DROP INDEX IF EXISTS foundation_grant_audit_grant_id;
+  ALTER TABLE foundation_grant_audit_provenance ADD COLUMN acceptance_id TEXT;
+  ALTER TABLE foundation_grant_audit_provenance ADD COLUMN control_audit_id TEXT;
+  ALTER TABLE foundation_grant_audit_provenance ADD COLUMN control_action_id TEXT;
+  ALTER TABLE foundation_grant_audit_provenance ADD COLUMN content_fingerprint TEXT;
+  ALTER TABLE foundation_grant_audit_provenance ADD COLUMN outcome_detail TEXT;
+  ALTER TABLE foundation_grant_audit RENAME TO foundation_grant_audit_pre17;
+  ${FOUNDATION_COMPOSED_GRANT_AUDIT_TABLE_SQL};
+  INSERT INTO foundation_grant_audit (
+    audit_id, action, outcome, actor_reference, grant_id, grant_type, grant_version,
+    event_id, game_day_id, pitch_id, pitch_slot_id, session_id, replaced_session_id,
+    event_game_id, credential_kind, credential_fingerprint, before_status, after_status,
+    before_expires_at_ms, after_expires_at_ms, previous_event_game_id, replay_evidence_id,
+    terminal_reason, audit_integrity_tag, acceptance_id, control_audit_id,
+    control_action_id, content_fingerprint, outcome_detail, created_at_ms
+  ) SELECT audit_id, action, outcome, actor_reference, grant_id, grant_type, grant_version,
+    event_id, game_day_id, pitch_id, pitch_slot_id, session_id, replaced_session_id,
+    event_game_id, credential_kind, credential_fingerprint, before_status, after_status,
+    before_expires_at_ms, after_expires_at_ms, previous_event_game_id, replay_evidence_id,
+    terminal_reason, audit_integrity_tag, NULL, NULL, NULL, NULL, NULL, created_at_ms
+    FROM foundation_grant_audit_pre17;
+  DROP TABLE foundation_grant_audit_pre17;
+  CREATE INDEX foundation_grant_audit_grant_id ON foundation_grant_audit (grant_id, audit_id);
+  CREATE TRIGGER foundation_grant_audit_no_legacy_integrity_tag
+    BEFORE INSERT ON foundation_grant_audit
+    WHEN NEW.audit_integrity_tag = 'legacy-migration-v1'
+    BEGIN SELECT RAISE(ABORT, 'Legacy Grant Audit integrity tags are migration-owned.'); END;
+  CREATE TRIGGER foundation_grant_audit_provenance_after_insert
+    AFTER INSERT ON foundation_grant_audit
+    BEGIN
+      INSERT INTO foundation_grant_audit_provenance (
+        audit_id, action, outcome, actor_reference, grant_id, grant_type, grant_version,
+        event_id, game_day_id, pitch_id, pitch_slot_id, session_id, replaced_session_id,
+        event_game_id, previous_event_game_id, replay_evidence_id, credential_kind,
+        credential_fingerprint, before_status, after_status, before_expires_at_ms,
+        after_expires_at_ms, terminal_reason, audit_integrity_tag, acceptance_id,
+        control_audit_id, control_action_id, content_fingerprint, outcome_detail, created_at_ms
+      ) VALUES (
+        NEW.audit_id, NEW.action, NEW.outcome, NEW.actor_reference, NEW.grant_id,
+        NEW.grant_type, NEW.grant_version, NEW.event_id, NEW.game_day_id, NEW.pitch_id,
+        NEW.pitch_slot_id, NEW.session_id, NEW.replaced_session_id, NEW.event_game_id,
+        NEW.previous_event_game_id, NEW.replay_evidence_id, NEW.credential_kind,
+        NEW.credential_fingerprint, NEW.before_status, NEW.after_status,
+        NEW.before_expires_at_ms, NEW.after_expires_at_ms, NEW.terminal_reason,
+        NEW.audit_integrity_tag, NEW.acceptance_id, NEW.control_audit_id,
+        NEW.control_action_id, NEW.content_fingerprint, NEW.outcome_detail, NEW.created_at_ms
+      );
+    END;
+  CREATE INDEX foundation_replay_reservations_record_id
+    ON foundation_replay_reservations(record_id, created_at_ms);
+  CREATE INDEX foundation_replay_attempts_reservation_id
+    ON foundation_replay_attempts(reservation_id, attempt_id);
+`;
+
+const FOUNDATION_ACCEPTANCE_INTEGRITY_HISTORY_MIGRATION_SQL = `
+  ALTER TABLE foundation_acceptance_integrity_anchors
+    ADD COLUMN canonical_value TEXT NOT NULL DEFAULT '';
+  DROP TRIGGER foundation_acceptance_integrity_anchors_no_delete;
+  CREATE TRIGGER foundation_acceptance_integrity_anchors_no_delete
+    BEFORE DELETE ON foundation_acceptance_integrity_anchors
+    WHEN NOT EXISTS (
+      SELECT 1 FROM foundation_replay_reservations AS reservations
+      WHERE reservations.status IN ('reserved', 'partial')
+        AND (
+          (OLD.subject_kind = 'reservation' AND reservations.reservation_id = OLD.subject_id)
+          OR (OLD.subject_kind = 'attempt' AND OLD.subject_id LIKE reservations.reservation_id || ':%')
+        )
+    )
+    BEGIN SELECT RAISE(ABORT, 'Acceptance integrity anchors are immutable.'); END;
+`;
+
 export const FOUNDATION_MIGRATIONS: readonly FoundationMigration[] = Object.freeze([
   createMigration({
     id: "001-foundation-event-game-record-roots",
@@ -1180,6 +1328,18 @@ export const FOUNDATION_MIGRATIONS: readonly FoundationMigration[] = Object.free
     ordinal: 16,
     schemaVersion: 16,
     sql: FOUNDATION_REPLAY_PROVENANCE_MIGRATION_SQL,
+  }),
+  createMigration({
+    id: "017-composed-acceptance-state",
+    ordinal: 17,
+    schemaVersion: 17,
+    sql: FOUNDATION_COMPOSED_ACCEPTANCE_MIGRATION_SQL,
+  }),
+  createMigration({
+    id: "018-acceptance-integrity-history",
+    ordinal: 18,
+    schemaVersion: 18,
+    sql: FOUNDATION_ACCEPTANCE_INTEGRITY_HISTORY_MIGRATION_SQL,
   }),
 ]);
 

--- a/src/lib/foundation-schema.ts
+++ b/src/lib/foundation-schema.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import { Database } from "bun:sqlite";
+import { canonicalizeJson } from "@/lib/event-game-action-json";
 import {
   FOUNDATION_ACTION_RECORD_INDEX_SQL,
   FOUNDATION_CURRENT_ACTION_TABLE_SQL,
@@ -41,10 +42,24 @@ import {
 import {
   computeGrantAuditIntegrityTag,
   computeLegacyGrantAuditIntegrityTag,
+  computeAcceptanceIntegrityTag,
 } from "@/lib/grant-crypto";
 import { readStoredGrantAuditEntry, scanGrantState } from "@/lib/grant-storage-sqlite";
 import type { GrantStateValidationContext } from "@/lib/grant-state-validation";
 import { GRANT_AUDIT_LEGACY_INTEGRITY_TAG } from "@/lib/grant-types";
+import {
+  anchorFor,
+  acceptanceAuditPairFailure,
+  replayAttemptResultFailure,
+} from "@/lib/foundation-acceptance-integrity";
+import type { AcceptanceIntegritySubject } from "@/lib/foundation-acceptance-integrity";
+import type { GrantKeyRing, StoredGrantAuditEntry } from "@/lib/grant-types";
+import type {
+  StoredControlAuditEntry,
+  StoredReplayAttempt,
+  StoredReplayReceipt,
+  StoredReplayReservation,
+} from "@/lib/foundation-storage";
 import {
   canonicalizeEventGameRecordRoot,
   cloneEventGameRecordRoot,
@@ -682,6 +697,136 @@ export function hasExpectedFoundationSchema(database: Database): boolean {
   return foundationSchemaFingerprint(database) === FOUNDATION_SCHEMA_FINGERPRINT;
 }
 
+function hasComposedAcceptanceSchema(database: Database): boolean {
+  const requiredTables = [
+    "foundation_acceptance_budgets",
+    "foundation_replay_reservations",
+    "foundation_replay_attempts",
+    "foundation_replay_receipts",
+    "foundation_acceptance_integrity_anchors",
+  ];
+  if (
+    requiredTables.some(
+      (name) =>
+        database
+          .query("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?")
+          .get(name) === null,
+    )
+  )
+    return false;
+  const expectedColumns: Record<string, readonly string[]> = {
+    foundation_acceptance_budgets: [
+      "bucket_id",
+      "bucket_kind",
+      "subject_id",
+      "capacity",
+      "refill_per_second",
+      "tokens",
+      "updated_at_ms",
+      "state_revision",
+    ],
+    foundation_replay_reservations: [
+      "reservation_id",
+      "record_id",
+      "event_game_id",
+      "originating_session_id",
+      "replacement_session_id",
+      "action_count",
+      "status",
+      "batch_digest",
+      "created_at_ms",
+      "committed_at_ms",
+      "acknowledged_at_ms",
+      "state_revision",
+    ],
+    foundation_replay_attempts: [
+      "attempt_id",
+      "reservation_id",
+      "operation_id",
+      "status",
+      "action_fingerprint",
+      "result_json",
+      "control_audit_id",
+      "grant_audit_id",
+      "created_at_ms",
+      "completed_at_ms",
+      "state_revision",
+    ],
+    foundation_replay_receipts: [
+      "receipt_id",
+      "reservation_id",
+      "receipt_digest",
+      "receipt_key_version",
+      "status",
+      "action_count",
+      "created_at_ms",
+      "acknowledged_at_ms",
+      "state_revision",
+    ],
+    foundation_acceptance_integrity_anchors: [
+      "anchor_id",
+      "subject_kind",
+      "subject_id",
+      "state_revision",
+      "key_version",
+      "integrity_tag",
+      "canonical_value",
+    ],
+  };
+  for (const [table, columns] of Object.entries(expectedColumns)) {
+    const actual = database
+      .query(`PRAGMA table_info(${table})`)
+      .all()
+      .map((value) => String((value as Record<string, unknown>).name));
+    if (actual.length !== columns.length || actual.some((name, index) => name !== columns[index]))
+      return false;
+  }
+  const requiredIndexes = [
+    "foundation_replay_reservations_record_id",
+    "foundation_replay_attempts_reservation_id",
+  ];
+  if (
+    requiredIndexes.some(
+      (name) =>
+        database
+          .query("SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = ?")
+          .get(name) === null,
+    )
+  )
+    return false;
+  const requiredTriggers = [
+    "foundation_acceptance_integrity_anchors_no_update",
+    "foundation_acceptance_integrity_anchors_no_delete",
+    "foundation_grant_audit_no_legacy_integrity_tag",
+    "foundation_grant_audit_provenance_after_insert",
+  ];
+  if (
+    requiredTriggers.some(
+      (name) =>
+        database
+          .query("SELECT 1 FROM sqlite_master WHERE type = 'trigger' AND name = ?")
+          .get(name) === null,
+    )
+  )
+    return false;
+  const receiptColumns = database
+    .query("PRAGMA table_info(foundation_replay_receipts)")
+    .all()
+    .map((value) => String((value as Record<string, unknown>).name));
+  if (!receiptColumns.includes("receipt_key_version")) return false;
+  const columns = database
+    .query("PRAGMA table_info(foundation_grant_audit)")
+    .all()
+    .map((value) => String((value as Record<string, unknown>).name));
+  return [
+    "acceptance_id",
+    "control_audit_id",
+    "control_action_id",
+    "content_fingerprint",
+    "outcome_detail",
+  ].every((name) => columns.includes(name));
+}
+
 export function foundationSchemaFingerprint(database: Database): string {
   return fingerprint(readSchemaManifest(database));
 }
@@ -698,7 +843,8 @@ export function verifyFoundationSchema(
         detail: "The supported root table is missing.",
       };
     }
-    if (!hasExpectedFoundationSchema(database)) {
+    const composedAcceptance = hasComposedAcceptanceSchema(database);
+    if (!hasExpectedFoundationSchema(database) && !composedAcceptance) {
       return {
         ok: false,
         status: "integrity-failure",
@@ -733,6 +879,8 @@ export function verifyFoundationSchema(
     scanFoundationRoots(database);
     verifyGrantProvenance(database, grantValidationContext);
     scanFoundationGrantState(database, grantValidationContext);
+    if (composedAcceptance)
+      verifyComposedAcceptanceState(database, grantValidationContext?.keyRing);
     return { ok: true };
   } catch {
     return {
@@ -767,6 +915,637 @@ export function scanFoundationRoots(database: Database): void {
   for (const value of rows) {
     readValidatedFoundationRoot(database, asRecord(value));
   }
+}
+
+function verifyComposedAcceptanceState(database: Database, keyRing?: GrantKeyRing): void {
+  const anchors = database
+    .query("SELECT * FROM foundation_acceptance_integrity_anchors ORDER BY anchor_id")
+    .all() as unknown[];
+  if (
+    keyRing === undefined &&
+    (anchors.length !== 0 ||
+      database.query("SELECT 1 FROM foundation_acceptance_budgets LIMIT 1").get() !== null ||
+      database.query("SELECT 1 FROM foundation_replay_reservations LIMIT 1").get() !== null ||
+      database.query("SELECT 1 FROM foundation_replay_attempts LIMIT 1").get() !== null ||
+      database.query("SELECT 1 FROM foundation_replay_receipts LIMIT 1").get() !== null)
+  )
+    throw new Error("Acceptance integrity key material is unavailable.");
+  if (keyRing === undefined) return;
+  const budgets = database.query("SELECT * FROM foundation_acceptance_budgets").all() as unknown[];
+  for (const value of budgets) {
+    const row = asRecord(value);
+    const kind = readText(row.bucket_kind);
+    const subject = readText(row.subject_id);
+    const capacity = readInteger(row.capacity);
+    const refill = readInteger(row.refill_per_second);
+    const tokens = readReal(row.tokens);
+    if (
+      readText(row.bucket_id) !== `budget-${kind}:${subject}` ||
+      !["online-session", "online-event", "replay-session"].includes(kind) ||
+      capacity <= 0 ||
+      refill <= 0 ||
+      tokens < 0 ||
+      tokens > capacity ||
+      !Number.isSafeInteger(readInteger(row.updated_at_ms)) ||
+      !Number.isSafeInteger(readInteger(row.state_revision)) ||
+      !verifyAcceptanceAnchor(
+        database,
+        anchors,
+        "budget",
+        readText(row.bucket_id),
+        readInteger(row.state_revision),
+        row,
+        keyRing,
+      )
+    )
+      throw new Error("Acceptance budget state is inconsistent.");
+  }
+
+  const reservations = database
+    .query(
+      `SELECT reservations.*, roots.event_game_id AS root_event_game_id
+       FROM foundation_replay_reservations AS reservations
+       LEFT JOIN foundation_event_game_record_roots AS roots ON roots.record_id = reservations.record_id`,
+    )
+    .all() as unknown[];
+  const reservationIds = new Set<string>();
+  const reservationCounts = new Map<string, number>();
+  for (const value of reservations) {
+    const row = asRecord(value);
+    const reservationId = readText(row.reservation_id);
+    const status = readText(row.status);
+    const count = readInteger(row.action_count);
+    const digest = readNullableText(row.batch_digest);
+    if (
+      reservationIds.has(reservationId) ||
+      readText(row.root_event_game_id) !== readText(row.event_game_id) ||
+      count <= 0 ||
+      digest === null ||
+      !/^[a-f0-9]{64}$/.test(digest) ||
+      !["reserved", "committing", "committed", "partial", "discarded", "acknowledged"].includes(
+        status,
+      ) ||
+      !verifyAcceptanceAnchor(
+        database,
+        anchors,
+        "reservation",
+        reservationId,
+        readInteger(row.state_revision),
+        row,
+        keyRing,
+      )
+    )
+      throw new Error("Replay reservation state is inconsistent.");
+    const committedAt = readNullableInteger(row.committed_at_ms);
+    const acknowledgedAt = readNullableInteger(row.acknowledged_at_ms);
+    if (
+      ((status === "committed" || status === "acknowledged") && committedAt === null) ||
+      (status === "acknowledged" && acknowledgedAt === null) ||
+      (status === "discarded" && (committedAt !== null || acknowledgedAt !== null))
+    )
+      throw new Error("Replay reservation timestamps are inconsistent.");
+    if (
+      status === "discarded" &&
+      (digest !== null || readNullableText(row.replacement_session_id) !== null)
+    )
+      throw new Error("Discarded replay retained authorization provenance.");
+    reservationIds.add(reservationId);
+    reservationCounts.set(reservationId, count);
+  }
+
+  const attempts = database.query("SELECT * FROM foundation_replay_attempts").all() as unknown[];
+  const attemptsByReservation = new Map<string, number>();
+  for (const value of attempts) {
+    const row = asRecord(value);
+    const fingerprint = readNullableText(row.action_fingerprint);
+    const resultJson = readNullableText(row.result_json);
+    if (
+      !reservationIds.has(readText(row.reservation_id)) ||
+      readText(row.operation_id).length === 0 ||
+      (fingerprint !== null && !/^[a-f0-9]{64}$/.test(fingerprint)) ||
+      (resultJson !== null && !isValidJsonObject(resultJson)) ||
+      (readNullableText(row.control_audit_id) === null) !== (resultJson === null) ||
+      (readNullableText(row.grant_audit_id) === null) !== (resultJson === null) ||
+      !verifyAcceptanceAnchor(
+        database,
+        anchors,
+        "attempt",
+        readText(row.attempt_id),
+        readInteger(row.state_revision),
+        row,
+        keyRing,
+      )
+    )
+      throw new Error("Replay attempt state is inconsistent.");
+    if (resultJson === null || !isValidJsonObject(resultJson))
+      throw new Error("Replay attempt result evidence is missing.");
+    if (canonicalizeJson(JSON.parse(resultJson)) !== resultJson)
+      throw new Error("Replay attempt result JSON is not canonical.");
+    const result = JSON.parse(resultJson) as { status?: string };
+    const status = readText(row.status);
+    if (
+      typeof result.status !== "string" ||
+      (status === "accepted" && result.status !== "accepted") ||
+      (status === "duplicate-accepted" && result.status !== "duplicate-accepted") ||
+      (status === "retry-later" && result.status !== "retry-later") ||
+      (status === "rejected" &&
+        !["rejected", "dependency-blocked", "authority-expired"].includes(result.status))
+    )
+      throw new Error("Replay attempt result status is inconsistent.");
+    const createdAt = readInteger(row.created_at_ms);
+    const completedAt = readNullableInteger(row.completed_at_ms);
+    if (
+      (status === "retry-later") !== (completedAt === null) ||
+      createdAt < 0 ||
+      (completedAt !== null && completedAt < 0)
+    )
+      throw new Error("Replay attempt timestamps are inconsistent.");
+    const reservationId = readText(row.reservation_id);
+    attemptsByReservation.set(reservationId, (attemptsByReservation.get(reservationId) ?? 0) + 1);
+  }
+  for (const value of reservations) {
+    const row = asRecord(value);
+    const status = readText(row.status);
+    const attemptsCount = attemptsByReservation.get(readText(row.reservation_id)) ?? 0;
+    const receiptsCount = database
+      .query("SELECT COUNT(*) AS count FROM foundation_replay_receipts WHERE reservation_id = ?")
+      .get(readText(row.reservation_id));
+    const receiptCount = readInteger(asRecord(receiptsCount).count);
+    if (
+      (status === "reserved" && (attemptsCount !== 0 || receiptCount !== 0)) ||
+      (status === "partial" &&
+        (attemptsCount === 0 ||
+          attemptsCount > readInteger(row.action_count) ||
+          receiptCount !== 0)) ||
+      ((status === "committed" || status === "acknowledged") &&
+        (attemptsCount !== readInteger(row.action_count) || receiptCount !== 1)) ||
+      (status === "discarded" && (attemptsCount !== 0 || receiptCount !== 0))
+    )
+      throw new Error("Replay evidence cardinality is inconsistent.");
+  }
+
+  const receipts = database.query("SELECT * FROM foundation_replay_receipts").all() as unknown[];
+  for (const value of receipts) {
+    const row = asRecord(value);
+    const reservationId = readText(row.reservation_id);
+    if (
+      !reservationIds.has(reservationId) ||
+      readInteger(row.action_count) !== reservationCounts.get(reservationId) ||
+      !/^[a-f0-9]{64}$/.test(readText(row.receipt_digest)) ||
+      readText(row.receipt_key_version).length === 0 ||
+      !["committed", "acknowledged"].includes(readText(row.status)) ||
+      !verifyAcceptanceAnchor(
+        database,
+        anchors,
+        "receipt",
+        readText(row.receipt_id),
+        readInteger(row.state_revision),
+        row,
+        keyRing,
+      )
+    )
+      throw new Error("Replay receipt state is inconsistent.");
+    const receiptStatus = readText(row.status);
+    const acknowledgedAt = readNullableInteger(row.acknowledged_at_ms);
+    if (
+      (receiptStatus === "acknowledged") !== (acknowledgedAt !== null) ||
+      readInteger(row.created_at_ms) < 0
+    )
+      throw new Error("Replay receipt timestamps are inconsistent.");
+  }
+
+  const currentRevisions = new Map<string, number>();
+  for (const value of budgets) {
+    const row = asRecord(value);
+    currentRevisions.set(`budget:${readText(row.bucket_id)}`, readInteger(row.state_revision));
+  }
+  for (const value of reservations) {
+    const row = asRecord(value);
+    currentRevisions.set(
+      `reservation:${readText(row.reservation_id)}`,
+      readInteger(row.state_revision),
+    );
+  }
+  for (const value of attempts) {
+    const row = asRecord(value);
+    currentRevisions.set(
+      `attempt:${readText(row.reservation_id)}:${readText(row.attempt_id)}`,
+      readInteger(row.state_revision),
+    );
+  }
+  for (const value of receipts) {
+    const row = asRecord(value);
+    currentRevisions.set(`receipt:${readText(row.receipt_id)}`, readInteger(row.state_revision));
+  }
+  const anchorGroups = new Map<string, Record<string, unknown>[]>();
+  for (const value of anchors) {
+    const row = asRecord(value);
+    const subjectKind = readText(row.subject_kind) as AcceptanceIntegritySubject;
+    const subjectId = readText(row.subject_id);
+    const revision = readInteger(row.state_revision);
+    const canonicalValue = readText(row.canonical_value);
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(canonicalValue) as unknown;
+    } catch {
+      throw new Error("Acceptance integrity anchor evidence is not valid JSON.");
+    }
+    if (
+      !["budget", "reservation", "attempt", "receipt"].includes(subjectKind) ||
+      canonicalizeJson(parsed) !== canonicalValue ||
+      readText(row.anchor_id) !== `${subjectKind}:${subjectId}:${revision}`
+    )
+      throw new Error("Acceptance integrity anchor identity is inconsistent.");
+    let expectedTag: string;
+    try {
+      expectedTag = computeAcceptanceIntegrityTag(
+        canonicalizeJson({
+          domain: "foundation-acceptance-state-v1",
+          subjectKind,
+          subjectId,
+          stateRevision: revision,
+          value: parsed,
+        }),
+        keyRing,
+        readText(row.key_version),
+      );
+    } catch {
+      throw new Error("Acceptance integrity anchor key material is unavailable.");
+    }
+    if (readText(row.integrity_tag) !== expectedTag)
+      throw new Error("Acceptance integrity anchor authentication failed.");
+    const key = `${subjectKind}:${subjectId}`;
+    const group = anchorGroups.get(key) ?? [];
+    group.push(row);
+    anchorGroups.set(key, group);
+  }
+  for (const [key, group] of anchorGroups) {
+    const current = currentRevisions.get(key);
+    if (current === undefined || group.length !== current) {
+      throw new Error("Acceptance integrity anchor history is missing or orphaned.");
+    }
+    const revisions = group.map((row) => readInteger(row.state_revision)).sort((a, b) => a - b);
+    if (revisions.some((revision, index) => revision !== index + 1))
+      throw new Error("Acceptance integrity anchor history is not contiguous.");
+  }
+  if (anchorGroups.size !== currentRevisions.size)
+    throw new Error("Acceptance integrity anchor history has an extra or missing subject.");
+  for (const value of anchors) {
+    const row = asRecord(value);
+    const key = `${readText(row.subject_kind)}:${readText(row.subject_id)}`;
+    const currentRevision = currentRevisions.get(key);
+    if (currentRevision === undefined) {
+      const subject = readText(row.subject_id);
+      const separator = subject.lastIndexOf(":");
+      const reservationId = separator > 0 ? subject.slice(0, separator) : "";
+      const discarded = database
+        .query(
+          "SELECT 1 FROM foundation_replay_reservations WHERE reservation_id = ? AND status = 'discarded'",
+        )
+        .get(reservationId);
+      if (readText(row.subject_kind) !== "attempt" || discarded === null)
+        throw new Error("Acceptance integrity anchor is orphaned.");
+      continue;
+    }
+    if (readInteger(row.state_revision) > currentRevision)
+      throw new Error("Acceptance integrity anchor is orphaned.");
+  }
+  const maximumAnchorRevision = new Map<string, number>();
+  for (const value of anchors) {
+    const row = asRecord(value);
+    const key = `${readText(row.subject_kind)}:${readText(row.subject_id)}`;
+    maximumAnchorRevision.set(
+      key,
+      Math.max(maximumAnchorRevision.get(key) ?? 0, readInteger(row.state_revision)),
+    );
+  }
+  for (const value of budgets) {
+    const row = asRecord(value);
+    if (
+      maximumAnchorRevision.get(`budget:${readText(row.bucket_id)}`) !==
+      readInteger(row.state_revision)
+    )
+      throw new Error("Acceptance integrity history is not monotonic.");
+  }
+  for (const value of reservations) {
+    const row = asRecord(value);
+    if (
+      maximumAnchorRevision.get(`reservation:${readText(row.reservation_id)}`) !==
+      readInteger(row.state_revision)
+    )
+      throw new Error("Acceptance integrity history is not monotonic.");
+  }
+  for (const value of attempts) {
+    const row = asRecord(value);
+    if (
+      maximumAnchorRevision.get(
+        `attempt:${readText(row.reservation_id)}:${readText(row.attempt_id)}`,
+      ) !== readInteger(row.state_revision)
+    )
+      throw new Error("Acceptance integrity history is not monotonic.");
+  }
+  for (const value of receipts) {
+    const row = asRecord(value);
+    if (
+      maximumAnchorRevision.get(`receipt:${readText(row.receipt_id)}`) !==
+      readInteger(row.state_revision)
+    )
+      throw new Error("Acceptance integrity history is not monotonic.");
+  }
+
+  const controlAudits = database
+    .query("SELECT * FROM foundation_event_game_record_audit ORDER BY audit_id")
+    .all()
+    .map((value) => JSON.parse(readText(asRecord(value).audit_json)) as StoredControlAuditEntry);
+  const grantAudits = database
+    .query("SELECT * FROM foundation_grant_audit ORDER BY audit_id")
+    .all()
+    .map((value) => readStoredGrantAuditEntry(asRecord(value)));
+  const controlsById = new Map(controlAudits.map((audit) => [audit.auditId, audit]));
+  const grantsById = new Map(grantAudits.map((audit) => [audit.auditId, audit]));
+  const actionEvidence = new Map<
+    string,
+    { contentFingerprint: string; canonicalContent: string; actionJson: string }
+  >();
+  for (const value of database
+    .query(
+      "SELECT record_id, operation_id, content_fingerprint, canonical_content, action_json FROM foundation_event_game_record_actions",
+    )
+    .all()) {
+    const row = asRecord(value);
+    actionEvidence.set(`${readText(row.record_id)}:${readText(row.operation_id)}`, {
+      contentFingerprint: readText(row.content_fingerprint),
+      canonicalContent: readText(row.canonical_content),
+      actionJson: readText(row.action_json),
+    });
+  }
+  const idempotencyEvidence = new Map<string, string>();
+  for (const value of database
+    .query(
+      "SELECT record_id, operation_id, content_fingerprint FROM foundation_event_game_record_idempotency",
+    )
+    .all()) {
+    const row = asRecord(value);
+    idempotencyEvidence.set(
+      `${readText(row.record_id)}:${readText(row.operation_id)}`,
+      readText(row.content_fingerprint),
+    );
+  }
+  for (const control of controlAudits) {
+    const linkedGrantId = control.links?.grantAuditId;
+    if (linkedGrantId !== undefined && linkedGrantId !== null) {
+      const grant = grantsById.get(linkedGrantId);
+      if (
+        grant === undefined ||
+        acceptanceAuditPairFailure(control, grant) !== null ||
+        sqliteAcceptanceFingerprintFailure(control, grant, actionEvidence, idempotencyEvidence) !==
+          null
+      )
+        throw new Error("Control and Grant acceptance semantics are inconsistent.");
+    } else if (control.links?.acceptanceId !== undefined && control.links.acceptanceId !== null) {
+      throw new Error("Control acceptance evidence has no paired Grant audit.");
+    }
+  }
+  for (const grant of grantAudits) {
+    const hasAcceptanceFields =
+      grant.acceptanceId !== null ||
+      grant.controlAuditId !== null ||
+      grant.controlActionId !== null ||
+      grant.contentFingerprint !== null ||
+      grant.outcomeDetail !== null;
+    if (!hasAcceptanceFields) continue;
+    const control =
+      typeof grant.controlAuditId !== "string" ? undefined : controlsById.get(grant.controlAuditId);
+    if (
+      control === undefined ||
+      acceptanceAuditPairFailure(control, grant) !== null ||
+      sqliteAcceptanceFingerprintFailure(control, grant, actionEvidence, idempotencyEvidence) !==
+        null
+    )
+      throw new Error("Grant acceptance evidence has no exact paired Control audit.");
+  }
+
+  const linkedGrantAudits = database
+    .query(
+      `SELECT grants.audit_id, grants.acceptance_id, grants.control_audit_id,
+              grants.control_action_id,
+              json_extract(controls.audit_json, '$.auditId') AS control_id,
+              json_extract(controls.audit_json, '$.links.grantAuditId') AS linked_grant_id,
+              json_extract(controls.audit_json, '$.links.acceptanceId') AS linked_acceptance_id
+       FROM foundation_grant_audit AS grants
+       LEFT JOIN foundation_event_game_record_audit AS controls
+         ON json_extract(controls.audit_json, '$.auditId') = grants.control_audit_id
+       WHERE grants.acceptance_id IS NOT NULL`,
+    )
+    .all() as unknown[];
+  for (const value of linkedGrantAudits) {
+    const row = asRecord(value);
+    if (
+      readText(row.control_id) !== readText(row.control_audit_id) ||
+      readText(row.linked_grant_id) !== readText(row.audit_id) ||
+      readText(row.linked_acceptance_id) !== readText(row.acceptance_id) ||
+      readText(row.control_action_id).length === 0
+    )
+      throw new Error("Control and Grant acceptance evidence is not bidirectionally linked.");
+  }
+  const orphanedControlLinks = database
+    .query(
+      `SELECT controls.audit_id, json_extract(controls.audit_json, '$.links.grantAuditId') AS grant_id
+       FROM foundation_event_game_record_audit AS controls
+       LEFT JOIN foundation_grant_audit AS grants
+         ON grants.audit_id = json_extract(controls.audit_json, '$.links.grantAuditId')
+       WHERE json_extract(controls.audit_json, '$.links.grantAuditId') IS NOT NULL
+         AND (grants.audit_id IS NULL OR grants.control_audit_id <> controls.audit_id)`,
+    )
+    .all() as unknown[];
+  if (orphanedControlLinks.length !== 0)
+    throw new Error("Control acceptance evidence points to an orphan Grant audit.");
+  const orphanedAttempts = database
+    .query(
+      `SELECT attempts.attempt_id
+       FROM foundation_replay_attempts AS attempts
+       LEFT JOIN foundation_event_game_record_audit AS controls
+         ON controls.audit_id = attempts.control_audit_id
+       LEFT JOIN foundation_grant_audit AS grants
+         ON grants.audit_id = attempts.grant_audit_id
+       WHERE controls.audit_id IS NULL
+          OR grants.audit_id IS NULL
+          OR grants.control_audit_id <> controls.audit_id
+          OR json_extract(controls.audit_json, '$.links.grantAuditId') <> grants.audit_id
+          OR json_extract(controls.audit_json, '$.links.acceptanceId') <> grants.acceptance_id
+          OR grants.acceptance_id IS NULL
+          OR grants.content_fingerprint IS NULL
+          OR (attempts.action_fingerprint IS NOT NULL AND attempts.action_fingerprint <> grants.content_fingerprint)`,
+    )
+    .all() as unknown[];
+  if (orphanedAttempts.length !== 0)
+    throw new Error("Replay attempt evidence is not paired with its durable audits.");
+
+  for (const value of attempts) {
+    const row = asRecord(value);
+    const control = controlsById.get(readText(row.control_audit_id));
+    const grant = grantsById.get(readText(row.grant_audit_id));
+    if (control === undefined || grant === undefined) continue;
+    const attempt: StoredReplayAttempt = {
+      attemptId: readText(row.attempt_id),
+      reservationId: readText(row.reservation_id),
+      operationId: readText(row.operation_id),
+      status: readText(row.status) as StoredReplayAttempt["status"],
+      actionFingerprint: readNullableText(row.action_fingerprint),
+      resultJson: readNullableText(row.result_json),
+      controlAuditId: readNullableText(row.control_audit_id),
+      grantAuditId: readNullableText(row.grant_audit_id),
+      createdAtMs: readInteger(row.created_at_ms),
+      completedAtMs: readNullableInteger(row.completed_at_ms),
+      stateRevision: readInteger(row.state_revision),
+    };
+    const evidence = actionEvidence.get(`${control.recordId}:${control.operationId}`);
+    let result: unknown = null;
+    try {
+      result = JSON.parse(attempt.resultJson ?? "null");
+    } catch {
+      result = null;
+    }
+    const accepted = control.kind === "action-accepted" || control.kind === "action-duplicate";
+    const collisionFingerprint = control.links?.collision?.rejectedAttempt?.contentFingerprint;
+    const candidateFingerprint =
+      collisionFingerprint ?? control.links?.rejectedCandidate?.contentFingerprint;
+    const expectedFingerprint = accepted ? evidence?.contentFingerprint : candidateFingerprint;
+    if (
+      acceptanceAuditPairFailure(control, grant, attempt) !== null ||
+      sqliteAcceptanceFingerprintFailure(control, grant, actionEvidence, idempotencyEvidence) !==
+        null ||
+      (accepted &&
+        (evidence === undefined ||
+          grant.contentFingerprint !== evidence.contentFingerprint ||
+          attempt.actionFingerprint !== evidence.contentFingerprint ||
+          idempotencyEvidence.get(`${control.recordId}:${control.operationId}`) !==
+            evidence.contentFingerprint ||
+          !isRecord(result) ||
+          canonicalizeJson(result.action) !== canonicalizeJson(JSON.parse(evidence.actionJson)))) ||
+      (expectedFingerprint !== undefined &&
+        (grant.contentFingerprint !== expectedFingerprint ||
+          attempt.actionFingerprint !== expectedFingerprint)) ||
+      replayAttemptResultFailure(attempt) !== null
+    )
+      throw new Error("Replay attempt semantics are not paired with its Control/Grant audits.");
+  }
+}
+
+function sqliteAcceptanceFingerprintFailure(
+  control: StoredControlAuditEntry,
+  grant: StoredGrantAuditEntry,
+  actionEvidence: ReadonlyMap<
+    string,
+    { contentFingerprint: string; canonicalContent: string; actionJson: string }
+  >,
+  idempotencyEvidence: ReadonlyMap<string, string>,
+): string | null {
+  if (control.operationId === null || grant.contentFingerprint === null) return "missing";
+  const key = `${control.recordId}:${control.operationId}`;
+  const accepted = control.kind === "action-accepted" || control.kind === "action-duplicate";
+  const action = actionEvidence.get(key);
+  const collisionFingerprint = control.links?.collision?.rejectedAttempt?.contentFingerprint;
+  const candidateFingerprint =
+    collisionFingerprint ?? control.links?.rejectedCandidate?.contentFingerprint;
+  const expectedFingerprint = accepted ? action?.contentFingerprint : candidateFingerprint;
+  if (
+    expectedFingerprint === undefined ||
+    control.links?.contentFingerprint !== expectedFingerprint ||
+    grant.contentFingerprint !== expectedFingerprint
+  )
+    return "fingerprint";
+  if (accepted && (action === undefined || idempotencyEvidence.get(key) !== expectedFingerprint))
+    return "fingerprint";
+  return null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function verifyAcceptanceAnchor(
+  _database: Database,
+  anchors: unknown[],
+  subjectKind: AcceptanceIntegritySubject,
+  subjectId: string,
+  stateRevision: number,
+  row: Record<string, unknown>,
+  keyRing: GrantKeyRing,
+): boolean {
+  const anchorSubjectId =
+    subjectKind === "attempt" ? `${readText(row.reservation_id)}:${subjectId}` : subjectId;
+  const anchorRow = anchors
+    .map(asRecord)
+    .find(
+      (candidate) =>
+        readText(candidate.subject_kind) === subjectKind &&
+        readText(candidate.subject_id) === anchorSubjectId &&
+        readInteger(candidate.state_revision) === stateRevision,
+    );
+  if (anchorRow === undefined) return false;
+  const value =
+    subjectKind === "budget"
+      ? {
+          bucketId: readText(row.bucket_id),
+          bucketKind: readText(row.bucket_kind) as
+            | "online-session"
+            | "online-event"
+            | "replay-session",
+          subjectId: readText(row.subject_id),
+          capacity: readInteger(row.capacity),
+          refillPerSecond: readInteger(row.refill_per_second),
+          tokens: readReal(row.tokens),
+          updatedAtMs: readInteger(row.updated_at_ms),
+          stateRevision,
+        }
+      : subjectKind === "reservation"
+        ? {
+            reservationId: readText(row.reservation_id),
+            recordId: readText(row.record_id),
+            eventGameId: readText(row.event_game_id),
+            originatingSessionId: readText(row.originating_session_id),
+            replacementSessionId: readNullableText(row.replacement_session_id),
+            actionCount: readInteger(row.action_count),
+            status: readText(row.status) as StoredReplayReservation["status"],
+            batchDigest: readNullableText(row.batch_digest),
+            createdAtMs: readInteger(row.created_at_ms),
+            committedAtMs: readNullableInteger(row.committed_at_ms),
+            acknowledgedAtMs: readNullableInteger(row.acknowledged_at_ms),
+            stateRevision,
+          }
+        : subjectKind === "attempt"
+          ? {
+              attemptId: readText(row.attempt_id),
+              reservationId: readText(row.reservation_id),
+              operationId: readText(row.operation_id),
+              status: readText(row.status) as StoredReplayAttempt["status"],
+              actionFingerprint: readNullableText(row.action_fingerprint),
+              resultJson: readNullableText(row.result_json),
+              controlAuditId: readNullableText(row.control_audit_id),
+              grantAuditId: readNullableText(row.grant_audit_id),
+              createdAtMs: readInteger(row.created_at_ms),
+              completedAtMs: readNullableInteger(row.completed_at_ms),
+              stateRevision,
+            }
+          : {
+              receiptId: readText(row.receipt_id),
+              reservationId: readText(row.reservation_id),
+              receiptDigest: readText(row.receipt_digest),
+              receiptKeyVersion: readText(row.receipt_key_version),
+              status: readText(row.status) as StoredReplayReceipt["status"],
+              actionCount: readInteger(row.action_count),
+              createdAtMs: readInteger(row.created_at_ms),
+              acknowledgedAtMs: readNullableInteger(row.acknowledged_at_ms),
+              stateRevision,
+            };
+  const expected = anchorFor(subjectKind, value, keyRing, readText(anchorRow.key_version));
+  return (
+    readText(anchorRow.anchor_id) === expected.anchorId &&
+    readText(anchorRow.key_version) === expected.keyVersion &&
+    readText(anchorRow.canonical_value) === expected.canonicalValue &&
+    readText(anchorRow.integrity_tag) === expected.integrityTag
+  );
 }
 
 function scanFoundationGrantState(
@@ -884,9 +1663,19 @@ function verifyGrantProvenance(
     "audit_integrity_tag",
     "created_at_ms",
   ] as const;
+  const currentColumns = [
+    ...columns.slice(0, -1),
+    "acceptance_id",
+    "control_audit_id",
+    "control_action_id",
+    "content_fingerprint",
+    "outcome_detail",
+    "created_at_ms",
+  ] as const;
   const select = columns.join(", ");
+  const currentSelect = currentColumns.join(", ");
   const current = database
-    .query(`SELECT ${select} FROM foundation_grant_audit ORDER BY audit_id`)
+    .query(`SELECT ${currentSelect} FROM foundation_grant_audit ORDER BY audit_id`)
     .all() as unknown[];
   const durable = database
     .query(`SELECT ${select} FROM foundation_grant_audit_provenance ORDER BY audit_id`)
@@ -1236,10 +2025,25 @@ function readInteger(value: unknown): number {
   return parsed;
 }
 
+function readReal(value: unknown): number {
+  const parsed = Number(readText(value));
+  if (!Number.isFinite(parsed)) throw new Error("SQLite returned an invalid schema real.");
+  return parsed;
+}
+
 function readNullableInteger(value: unknown): number | null {
   return value === null ? null : readInteger(value);
 }
 
 function readNullableText(value: unknown): string | null {
   return value === null ? null : readText(value);
+}
+
+function isValidJsonObject(value: string): boolean {
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed);
+  } catch {
+    return false;
+  }
 }

--- a/src/lib/foundation-storage-memory.ts
+++ b/src/lib/foundation-storage-memory.ts
@@ -4,7 +4,7 @@ import {
   validateEventGameRecordRoot,
   type EventGameRecordRoot,
 } from "@/lib/foundation-record-types";
-import { computeGrantAuditIntegrityTag } from "@/lib/grant-crypto";
+import { computeAcceptanceIntegrityTag, computeGrantAuditIntegrityTag } from "@/lib/grant-crypto";
 import {
   cloneStoredGrant,
   cloneStoredGrantAuditEntry,
@@ -26,17 +26,31 @@ import {
   type StoredControlAction,
   type StoredControlAuditEntry,
   type StoredControlIdempotencyEntry,
+  type StoredAcceptanceBudget,
+  type StoredReplayAttempt,
+  type StoredReplayReceipt,
+  type StoredReplayReservation,
   type StoredEventGameRecordMetadata,
   type StoredEventGameRecordRoot,
   isThenable,
   DURABLE_EVIDENCE_PROVENANCE,
 } from "@/lib/foundation-storage";
+import type {
+  AcceptanceIntegrityAnchor,
+  AcceptanceIntegritySubject,
+} from "@/lib/foundation-acceptance-integrity";
+import {
+  anchorFor,
+  acceptanceAuditPairFailure,
+  replayAttemptResultFailure,
+} from "@/lib/foundation-acceptance-integrity";
 import {
   CONTROL_AUDIT_VERSION,
   CONTROL_ACTION_VERSION,
   LEGACY_CONTROL_AUDIT_VERSION,
   LEGACY_CONTROL_ACTION_VERSION,
   actionIdentity,
+  canonicalizeJson,
   parseStoredControlAction,
 } from "@/lib/event-game-actions";
 import { validateGrantState, type GrantStateValidationContext } from "@/lib/grant-state-validation";
@@ -54,6 +68,11 @@ type MemoryState = {
   grantAudits: Map<string, StoredGrantAuditEntry>;
   grantAuditProvenance: Map<string, StoredGrantAuditEntry>;
   grantAuditIntegrityTags: Map<string, string>;
+  acceptanceBudgets: Map<string, StoredAcceptanceBudget>;
+  replayReservations: Map<string, StoredReplayReservation>;
+  replayAttempts: Map<string, StoredReplayAttempt>;
+  replayReceipts: Map<string, StoredReplayReceipt>;
+  integrityAnchors: Map<string, AcceptanceIntegrityAnchor>;
 };
 
 export function createInMemoryFoundationStorage(): FoundationStorage {
@@ -74,6 +93,11 @@ class InMemoryFoundationStorage implements FoundationStorage {
     grantAudits: new Map(),
     grantAuditProvenance: new Map(),
     grantAuditIntegrityTags: new Map(),
+    acceptanceBudgets: new Map(),
+    replayReservations: new Map(),
+    replayAttempts: new Map(),
+    replayReceipts: new Map(),
+    integrityAnchors: new Map(),
   };
   private writerTail: Promise<void> = Promise.resolve();
   private closed = false;
@@ -83,6 +107,18 @@ class InMemoryFoundationStorage implements FoundationStorage {
   transaction<T>(work: FoundationStorageTransactionWork<T>): Promise<T> {
     const operation = this.writerTail.then(() => {
       this.assertOpen();
+      const acceptanceFailure = acceptanceStateFailure(
+        this.state,
+        this.grantValidationContext.keyRing,
+      );
+      if (acceptanceFailure !== null) {
+        throw new FoundationStorageNotReadyError({
+          ok: false,
+          status: "integrity-failure",
+          detail: acceptanceFailure,
+          storage: "memory",
+        });
+      }
       const grantFailure = this.grantStateFailure();
       if (grantFailure !== null) {
         throw new FoundationStorageNotReadyError({
@@ -293,6 +329,18 @@ class InMemoryFoundationStorage implements FoundationStorage {
           storage: "memory",
         } satisfies FoundationStorageReadiness;
       }
+      const acceptanceFailure = acceptanceStateFailure(
+        this.state,
+        this.grantValidationContext.keyRing,
+      );
+      if (acceptanceFailure !== null) {
+        return {
+          ok: false,
+          status: "integrity-failure",
+          detail: acceptanceFailure,
+          storage: "memory",
+        } satisfies FoundationStorageReadiness;
+      }
       return {
         ok: true,
         schemaVersion: "memory",
@@ -335,6 +383,367 @@ class InMemoryFoundationStorage implements FoundationStorage {
       },
     );
   }
+}
+
+function acceptanceStateFailure(
+  state: MemoryState,
+  keyRing: GrantKeyRing | undefined,
+): string | null {
+  if (
+    keyRing === undefined &&
+    (state.integrityAnchors.size > 0 ||
+      state.acceptanceBudgets.size > 0 ||
+      state.replayReservations.size > 0 ||
+      state.replayAttempts.size > 0 ||
+      state.replayReceipts.size > 0)
+  )
+    return "Acceptance integrity key material is unavailable.";
+  if (keyRing === undefined) return null;
+  for (const budget of state.acceptanceBudgets.values()) {
+    if (
+      budget.bucketId !== `budget-${budget.bucketKind}:${budget.subjectId}` ||
+      !Number.isFinite(budget.tokens) ||
+      budget.capacity <= 0 ||
+      budget.refillPerSecond <= 0 ||
+      budget.tokens < 0 ||
+      budget.tokens > budget.capacity ||
+      !Number.isSafeInteger(budget.updatedAtMs) ||
+      !Number.isSafeInteger(budget.stateRevision) ||
+      !hasCurrentIntegrityAnchor(state, "budget", budget.bucketId, budget, keyRing)
+    )
+      return "In-memory acceptance budget state is inconsistent.";
+  }
+  const attemptsByReservation = new Map<string, StoredReplayAttempt[]>();
+  for (const attempt of state.replayAttempts.values()) {
+    const list = attemptsByReservation.get(attempt.reservationId) ?? [];
+    list.push(attempt);
+    attemptsByReservation.set(attempt.reservationId, list);
+  }
+  const receiptsByReservation = new Map<string, StoredReplayReceipt[]>();
+  for (const receipt of state.replayReceipts.values()) {
+    const list = receiptsByReservation.get(receipt.reservationId) ?? [];
+    list.push(receipt);
+    receiptsByReservation.set(receipt.reservationId, list);
+  }
+  for (const reservation of state.replayReservations.values()) {
+    const root = state.roots.get(reservation.recordId);
+    if (
+      root === undefined ||
+      root.root.eventGameId !== reservation.eventGameId ||
+      reservation.actionCount <= 0 ||
+      !Number.isSafeInteger(reservation.createdAtMs) ||
+      (reservation.committedAtMs !== null && !Number.isSafeInteger(reservation.committedAtMs)) ||
+      (reservation.acknowledgedAtMs !== null &&
+        !Number.isSafeInteger(reservation.acknowledgedAtMs)) ||
+      reservation.batchDigest === null ||
+      !/^[a-f0-9]{64}$/.test(reservation.batchDigest) ||
+      !Number.isSafeInteger(reservation.stateRevision) ||
+      !hasCurrentIntegrityAnchor(
+        state,
+        "reservation",
+        reservation.reservationId,
+        reservation,
+        keyRing,
+      ) ||
+      !["reserved", "committing", "committed", "partial", "discarded", "acknowledged"].includes(
+        reservation.status,
+      )
+    )
+      return "In-memory replay reservation state is inconsistent.";
+    if (
+      reservation.status === "discarded" &&
+      (reservation.batchDigest !== null || reservation.replacementSessionId !== null)
+    )
+      return "In-memory discarded replay retained authorization provenance.";
+    if (
+      (reservation.status === "committed" || reservation.status === "acknowledged") &&
+      reservation.committedAtMs === null
+    )
+      return "In-memory committed replay lacks a commit timestamp.";
+    if (reservation.status === "acknowledged" && reservation.acknowledgedAtMs === null)
+      return "In-memory acknowledged replay lacks an acknowledgement timestamp.";
+    const attempts = attemptsByReservation.get(reservation.reservationId) ?? [];
+    const receipts = receiptsByReservation.get(reservation.reservationId) ?? [];
+    if (
+      (reservation.status === "reserved" && (attempts.length !== 0 || receipts.length !== 0)) ||
+      (reservation.status === "partial" &&
+        (attempts.length === 0 ||
+          attempts.length > reservation.actionCount ||
+          receipts.length !== 0)) ||
+      ((reservation.status === "committed" || reservation.status === "acknowledged") &&
+        (attempts.length !== reservation.actionCount ||
+          attempts.some((attempt) => attempt.status === "retry-later") ||
+          receipts.length !== 1)) ||
+      (reservation.status === "discarded" && (attempts.length !== 0 || receipts.length !== 0))
+    )
+      return "In-memory replay evidence cardinality is inconsistent.";
+  }
+  const grantsByAudit = state.grantAudits;
+  for (const attempt of state.replayAttempts.values()) {
+    const controlAudit = [...state.controlAudits.values()]
+      .flatMap((audits) => [...audits.values()])
+      .find((audit) => audit.auditId === attempt.controlAuditId);
+    const grantAudit = grantsByAudit.get(attempt.grantAuditId ?? "");
+    const pairFailure =
+      controlAudit === undefined || grantAudit === undefined
+        ? "missing"
+        : acceptanceAuditPairFailure(controlAudit, grantAudit, attempt);
+    const expectedAction =
+      controlAudit === undefined ||
+      (controlAudit.kind !== "action-accepted" && controlAudit.kind !== "action-duplicate")
+        ? undefined
+        : state.actions.get(controlAudit.recordId)?.get(controlAudit.operationId ?? "")?.action;
+    const durableFingerprint =
+      controlAudit === undefined || grantAudit === undefined
+        ? null
+        : acceptanceFingerprintFailure(state, controlAudit, grantAudit, attempt);
+    if (
+      !state.replayReservations.has(attempt.reservationId) ||
+      attempt.operationId.length === 0 ||
+      (attempt.actionFingerprint !== null && !/^[a-f0-9]{64}$/.test(attempt.actionFingerprint)) ||
+      attempt.resultJson === null ||
+      replayAttemptResultFailure(attempt, expectedAction, controlAudit?.links?.reason) !== null ||
+      attempt.controlAuditId === null ||
+      attempt.grantAuditId === null ||
+      controlAudit === undefined ||
+      grantAudit === undefined ||
+      grantAudit.controlAuditId !== controlAudit.auditId ||
+      controlAudit.links?.grantAuditId !== grantAudit.auditId ||
+      grantAudit.acceptanceId !== controlAudit.links?.acceptanceId ||
+      grantAudit.contentFingerprint === null ||
+      (attempt.actionFingerprint !== null &&
+        attempt.actionFingerprint !== grantAudit.contentFingerprint) ||
+      pairFailure !== null ||
+      durableFingerprint !== null
+    )
+      return "In-memory replay attempt state is inconsistent.";
+    if (
+      !Number.isSafeInteger(attempt.createdAtMs) ||
+      (attempt.completedAtMs !== null && !Number.isSafeInteger(attempt.completedAtMs)) ||
+      !Number.isSafeInteger(attempt.stateRevision) ||
+      !hasCurrentIntegrityAnchor(state, "attempt", attempt.attemptId, attempt, keyRing) ||
+      (attempt.status === "retry-later") !== (attempt.completedAtMs === null)
+    )
+      return "In-memory replay attempt timestamps are inconsistent.";
+  }
+  for (const receipt of state.replayReceipts.values()) {
+    const reservation = state.replayReservations.get(receipt.reservationId);
+    if (
+      reservation === undefined ||
+      receipt.actionCount !== reservation.actionCount ||
+      !/^[a-f0-9]{64}$/.test(receipt.receiptDigest) ||
+      !["committed", "acknowledged"].includes(receipt.status) ||
+      !Number.isSafeInteger(receipt.stateRevision) ||
+      !hasCurrentIntegrityAnchor(state, "receipt", receipt.receiptId, receipt, keyRing)
+    )
+      return "In-memory replay receipt state is inconsistent.";
+    if (
+      !Number.isSafeInteger(receipt.createdAtMs) ||
+      (receipt.acknowledgedAtMs !== null && !Number.isSafeInteger(receipt.acknowledgedAtMs)) ||
+      (receipt.status === "acknowledged") !== (receipt.acknowledgedAtMs !== null)
+    )
+      return "In-memory replay receipt timestamps are inconsistent.";
+    if (reservation.status !== "committed" && reservation.status !== "acknowledged")
+      return "In-memory replay receipt points to an uncommitted reservation.";
+  }
+  for (const audits of state.controlAudits.values()) {
+    for (const audit of audits.values()) {
+      const grantAuditId = audit.links?.grantAuditId;
+      if (typeof grantAuditId === "string") {
+        const grantAudit = grantsByAudit.get(grantAuditId);
+        if (
+          grantAudit === undefined ||
+          acceptanceAuditPairFailure(audit, grantAudit) !== null ||
+          acceptanceFingerprintFailure(state, audit, grantAudit) !== null
+        )
+          return "In-memory Control and Grant audit linkage is inconsistent.";
+      }
+    }
+  }
+  for (const grantAudit of grantsByAudit.values()) {
+    const hasAcceptanceFields =
+      (grantAudit.acceptanceId !== null && grantAudit.acceptanceId !== undefined) ||
+      (grantAudit.controlAuditId !== null && grantAudit.controlAuditId !== undefined) ||
+      (grantAudit.controlActionId !== null && grantAudit.controlActionId !== undefined) ||
+      (grantAudit.contentFingerprint !== null && grantAudit.contentFingerprint !== undefined) ||
+      (grantAudit.outcomeDetail !== null && grantAudit.outcomeDetail !== undefined);
+    if (hasAcceptanceFields) {
+      const control = [...state.controlAudits.values()]
+        .flatMap((audits) => [...audits.values()])
+        .find((audit) => audit.auditId === grantAudit.controlAuditId);
+      if (
+        control === undefined ||
+        acceptanceAuditPairFailure(control, grantAudit) !== null ||
+        acceptanceFingerprintFailure(state, control, grantAudit) !== null
+      )
+        return "In-memory Grant acceptance evidence has no paired Control audit.";
+    }
+  }
+  const currentRevisions = new Map<string, number>();
+  for (const budget of state.acceptanceBudgets.values())
+    currentRevisions.set(`budget:${budget.bucketId}`, budget.stateRevision);
+  for (const reservation of state.replayReservations.values())
+    currentRevisions.set(`reservation:${reservation.reservationId}`, reservation.stateRevision);
+  for (const attempt of state.replayAttempts.values())
+    currentRevisions.set(
+      `attempt:${attempt.reservationId}:${attempt.attemptId}`,
+      attempt.stateRevision,
+    );
+  for (const receipt of state.replayReceipts.values())
+    currentRevisions.set(`receipt:${receipt.receiptId}`, receipt.stateRevision);
+
+  const anchorGroups = new Map<string, AcceptanceIntegrityAnchor[]>();
+  for (const anchor of state.integrityAnchors.values()) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(anchor.canonicalValue) as unknown;
+    } catch {
+      return "In-memory acceptance integrity anchor evidence is not valid JSON.";
+    }
+    if (
+      canonicalizeJson(parsed) !== anchor.canonicalValue ||
+      anchor.anchorId !== `${anchor.subjectKind}:${anchor.subjectId}:${anchor.stateRevision}`
+    )
+      return "In-memory acceptance integrity anchor identity is inconsistent.";
+    let expectedTag: string;
+    try {
+      expectedTag = computeAcceptanceIntegrityTag(
+        canonicalizeJson({
+          domain: "foundation-acceptance-state-v1",
+          subjectKind: anchor.subjectKind,
+          subjectId: anchor.subjectId,
+          stateRevision: anchor.stateRevision,
+          value: parsed,
+        }),
+        keyRing,
+        anchor.keyVersion,
+      );
+    } catch {
+      return "In-memory acceptance integrity anchor key material is unavailable.";
+    }
+    if (anchor.integrityTag !== expectedTag)
+      return "In-memory acceptance integrity anchor authentication failed.";
+    const key = `${anchor.subjectKind}:${anchor.subjectId}`;
+    const group = anchorGroups.get(key) ?? [];
+    group.push(anchor);
+    anchorGroups.set(key, group);
+  }
+  for (const [key, group] of anchorGroups) {
+    const currentRevision = currentRevisions.get(key);
+    if (currentRevision === undefined || group.length !== currentRevision)
+      return "In-memory acceptance integrity anchor history is missing or orphaned.";
+    const revisions = group.map((anchor) => anchor.stateRevision).sort((a, b) => a - b);
+    if (revisions.some((revision, index) => revision !== index + 1))
+      return "In-memory acceptance integrity anchor history is not contiguous.";
+  }
+  if (anchorGroups.size !== currentRevisions.size)
+    return "In-memory acceptance integrity anchor history has an extra or missing subject.";
+
+  const maximumAnchorRevision = new Map<string, number>();
+  for (const anchor of state.integrityAnchors.values()) {
+    const key = `${anchor.subjectKind}:${anchor.subjectId}`;
+    maximumAnchorRevision.set(
+      key,
+      Math.max(maximumAnchorRevision.get(key) ?? 0, anchor.stateRevision),
+    );
+  }
+  for (const [subjectId, budget] of state.acceptanceBudgets) {
+    if (maximumAnchorRevision.get(`budget:${subjectId}`) !== budget.stateRevision)
+      return "In-memory acceptance integrity history is not monotonic.";
+  }
+  for (const [subjectId, reservation] of state.replayReservations) {
+    if (maximumAnchorRevision.get(`reservation:${subjectId}`) !== reservation.stateRevision)
+      return "In-memory acceptance integrity history is not monotonic.";
+  }
+  for (const attempt of state.replayAttempts.values()) {
+    const anchorSubjectId = anchorFor("attempt", attempt, keyRing).subjectId;
+    if (maximumAnchorRevision.get(`attempt:${anchorSubjectId}`) !== attempt.stateRevision)
+      return "In-memory acceptance integrity history is not monotonic.";
+  }
+  for (const [subjectId, receipt] of state.replayReceipts) {
+    if (maximumAnchorRevision.get(`receipt:${subjectId}`) !== receipt.stateRevision)
+      return "In-memory acceptance integrity history is not monotonic.";
+  }
+  for (const anchor of state.integrityAnchors.values()) {
+    const currentRevision =
+      anchor.subjectKind === "budget"
+        ? state.acceptanceBudgets.get(anchor.subjectId)?.stateRevision
+        : anchor.subjectKind === "reservation"
+          ? state.replayReservations.get(anchor.subjectId)?.stateRevision
+          : anchor.subjectKind === "attempt"
+            ? state.replayAttempts.get(
+                anchor.subjectId.slice(anchor.subjectId.lastIndexOf(":") + 1),
+              )?.stateRevision
+            : state.replayReceipts.get(anchor.subjectId)?.stateRevision;
+    if (currentRevision === undefined) return "In-memory acceptance integrity anchor is orphaned.";
+    if (anchor.stateRevision > currentRevision)
+      return "In-memory acceptance integrity anchor is orphaned.";
+  }
+  return null;
+}
+
+function acceptanceFingerprintFailure(
+  state: MemoryState,
+  control: StoredControlAuditEntry,
+  grant: StoredGrantAuditEntry,
+  attempt?: StoredReplayAttempt,
+): string | null {
+  const operationId = control.operationId;
+  if (operationId === null || grant.contentFingerprint === null) return "missing";
+  const accepted = control.kind === "action-accepted" || control.kind === "action-duplicate";
+  const durableAction = state.actions.get(control.recordId)?.get(operationId);
+  const collisionFingerprint = control.links?.collision?.rejectedAttempt?.contentFingerprint;
+  const candidateFingerprint =
+    collisionFingerprint ?? control.links?.rejectedCandidate?.contentFingerprint;
+  const expectedFingerprint = accepted ? durableAction?.contentFingerprint : candidateFingerprint;
+  if (
+    expectedFingerprint === undefined ||
+    control.links?.contentFingerprint !== expectedFingerprint ||
+    expectedFingerprint !== grant.contentFingerprint
+  )
+    return "fingerprint";
+  if (attempt !== undefined && attempt.actionFingerprint !== expectedFingerprint)
+    return "fingerprint";
+  if (accepted) {
+    const idempotency = [...(state.idempotency.get(control.recordId)?.values() ?? [])].find(
+      (entry) => entry.operationId === operationId,
+    );
+    if (
+      durableAction === undefined ||
+      idempotency === undefined ||
+      idempotency.contentFingerprint !== expectedFingerprint ||
+      idempotency.contentFingerprint !== grant.contentFingerprint
+    )
+      return "fingerprint";
+  }
+  return null;
+}
+
+function hasCurrentIntegrityAnchor(
+  state: MemoryState,
+  subjectKind: AcceptanceIntegritySubject,
+  subjectId: string,
+  value:
+    | StoredAcceptanceBudget
+    | StoredReplayReservation
+    | StoredReplayAttempt
+    | StoredReplayReceipt,
+  keyRing: GrantKeyRing | undefined,
+): boolean {
+  if (keyRing === undefined) return false;
+  const expected = anchorFor(subjectKind, value, keyRing);
+  const anchor = state.integrityAnchors.get(
+    `${subjectKind}:${expected.subjectId}:${value.stateRevision}`,
+  );
+  if (anchor === undefined) return false;
+  const keyedExpected = anchorFor(subjectKind, value, keyRing, anchor.keyVersion);
+  return (
+    anchor.subjectId === keyedExpected.subjectId &&
+    anchor.stateRevision === keyedExpected.stateRevision &&
+    anchor.keyVersion === keyedExpected.keyVersion &&
+    anchor.canonicalValue === keyedExpected.canonicalValue &&
+    anchor.integrityTag === keyedExpected.integrityTag
+  );
 }
 
 function createTransaction(
@@ -535,6 +944,73 @@ function createTransaction(
         .sort((left, right) => left.auditId.localeCompare(right.auditId))
         .map(cloneStoredGrantAuditEntry);
     },
+    findAcceptanceBudget(bucketId) {
+      const budget = state.acceptanceBudgets.get(bucketId);
+      return budget === undefined ? null : structuredClone(budget);
+    },
+    findReplayReservation(reservationId) {
+      const reservation = state.replayReservations.get(reservationId);
+      return reservation === undefined ? null : structuredClone(reservation);
+    },
+    findReplayReservationByTuple(
+      recordId,
+      eventGameId,
+      originatingSessionId,
+      actionCount,
+      batchDigest,
+    ) {
+      let match: StoredReplayReservation | undefined;
+      for (const reservation of state.replayReservations.values()) {
+        if (
+          reservation.recordId === recordId &&
+          reservation.eventGameId === eventGameId &&
+          reservation.originatingSessionId === originatingSessionId &&
+          reservation.actionCount === actionCount &&
+          reservation.batchDigest === batchDigest
+        )
+          if (match !== undefined) return null;
+          else match = reservation;
+      }
+      return match === undefined ? null : structuredClone(match);
+    },
+    findReplayReservationByOriginTuple(recordId, eventGameId, originatingSessionId, actionCount) {
+      return (
+        [...state.replayReservations.values()]
+          .filter(
+            (reservation) =>
+              reservation.recordId === recordId &&
+              reservation.eventGameId === eventGameId &&
+              reservation.originatingSessionId === originatingSessionId &&
+              reservation.actionCount === actionCount,
+          )
+          .sort((left, right) => right.stateRevision - left.stateRevision)
+          .map((reservation) => structuredClone(reservation))[0] ?? null
+      );
+    },
+    listReplayAttempts(reservationId) {
+      return [...state.replayAttempts.values()]
+        .filter((attempt) => attempt.reservationId === reservationId)
+        .sort((left, right) => left.attemptId.localeCompare(right.attemptId))
+        .map((attempt) => structuredClone(attempt));
+    },
+    findReplayReceiptByDigest(receiptDigest) {
+      for (const receipt of state.replayReceipts.values()) {
+        if (receipt.receiptDigest === receiptDigest) return structuredClone(receipt);
+      }
+      return null;
+    },
+    findReplayReceiptByReservationId(reservationId) {
+      for (const receipt of state.replayReceipts.values()) {
+        if (receipt.reservationId === reservationId) return structuredClone(receipt);
+      }
+      return null;
+    },
+    listAcceptanceIntegrityAnchors(subjectKind: AcceptanceIntegritySubject, subjectId: string) {
+      return [...state.integrityAnchors.values()]
+        .filter((anchor) => anchor.subjectKind === subjectKind && anchor.subjectId === subjectId)
+        .sort((left, right) => left.stateRevision - right.stateRevision)
+        .map((anchor) => structuredClone(anchor));
+    },
     insertGrant(grant) {
       if (state.grants.has(grant.grantId)) {
         throw new FoundationStorageConstraintError("grant-id");
@@ -696,6 +1172,117 @@ function createTransaction(
         computeGrantAuditIntegrityTag(entry, keyRing),
       );
       undo.push(() => state.grantAuditIntegrityTags.delete(entry.auditId));
+    },
+    upsertAcceptanceBudget(budget) {
+      const previous = state.acceptanceBudgets.get(budget.bucketId);
+      state.acceptanceBudgets.set(budget.bucketId, structuredClone(budget));
+      undo.push(() => {
+        if (previous === undefined) state.acceptanceBudgets.delete(budget.bucketId);
+        else state.acceptanceBudgets.set(budget.bucketId, previous);
+      });
+    },
+    insertReplayReservation(reservation) {
+      if (state.replayReservations.has(reservation.reservationId))
+        throw new FoundationStorageConstraintError("replay-reservation-id");
+      state.replayReservations.set(reservation.reservationId, structuredClone(reservation));
+      undo.push(() => state.replayReservations.delete(reservation.reservationId));
+    },
+    updateReplayReservation(reservation) {
+      if (!state.replayReservations.has(reservation.reservationId))
+        throw new FoundationStorageConstraintError("replay-reservation-id");
+      const previous = state.replayReservations.get(reservation.reservationId);
+      state.replayReservations.set(reservation.reservationId, structuredClone(reservation));
+      undo.push(() => {
+        if (previous !== undefined)
+          state.replayReservations.set(reservation.reservationId, previous);
+      });
+    },
+    insertReplayAttempt(attempt) {
+      if (state.replayAttempts.has(attempt.attemptId))
+        throw new FoundationStorageConstraintError("integrity-anchor-id");
+      state.replayAttempts.set(attempt.attemptId, structuredClone(attempt));
+      undo.push(() => state.replayAttempts.delete(attempt.attemptId));
+    },
+    updateReplayAttempt(attempt) {
+      if (!state.replayAttempts.has(attempt.attemptId))
+        throw new FoundationStorageConstraintError("replay-attempt-id");
+      const previous = state.replayAttempts.get(attempt.attemptId);
+      state.replayAttempts.set(attempt.attemptId, structuredClone(attempt));
+      undo.push(() => {
+        if (previous !== undefined) state.replayAttempts.set(attempt.attemptId, previous);
+      });
+    },
+    discardReplayAttempts(reservationId) {
+      const previous = [...state.replayAttempts.entries()].filter(
+        ([, attempt]) => attempt.reservationId === reservationId,
+      );
+      for (const [attemptId] of previous) state.replayAttempts.delete(attemptId);
+      const previousAnchors = [...state.integrityAnchors.entries()].filter(
+        ([, anchor]) =>
+          anchor.subjectKind === "attempt" && anchor.subjectId.startsWith(`${reservationId}:`),
+      );
+      for (const [anchorId] of previousAnchors) state.integrityAnchors.delete(anchorId);
+      undo.push(() => {
+        for (const [attemptId, attempt] of previous) state.replayAttempts.set(attemptId, attempt);
+        for (const [anchorId, anchor] of previousAnchors)
+          state.integrityAnchors.set(anchorId, anchor);
+      });
+    },
+    discardReplayReservation(reservationId) {
+      const reservation = state.replayReservations.get(reservationId);
+      if (reservation === undefined) return;
+      const attempts = [...state.replayAttempts.entries()].filter(
+        ([, attempt]) => attempt.reservationId === reservationId,
+      );
+      const receipts = [...state.replayReceipts.entries()].filter(
+        ([, receipt]) => receipt.reservationId === reservationId,
+      );
+      const anchors = [...state.integrityAnchors.entries()].filter(([, anchor]) =>
+        anchor.subjectKind === "reservation"
+          ? anchor.subjectId === reservationId
+          : anchor.subjectKind === "attempt"
+            ? anchor.subjectId.startsWith(`${reservationId}:`)
+            : anchor.subjectKind === "receipt"
+              ? receipts.some(([, receipt]) => receipt.receiptId === anchor.subjectId)
+              : false,
+      );
+      state.replayReservations.delete(reservationId);
+      for (const [attemptId] of attempts) state.replayAttempts.delete(attemptId);
+      for (const [receiptId] of receipts) state.replayReceipts.delete(receiptId);
+      for (const [anchorId] of anchors) state.integrityAnchors.delete(anchorId);
+      undo.push(() => {
+        state.replayReservations.set(reservationId, reservation);
+        for (const [attemptId, attempt] of attempts) state.replayAttempts.set(attemptId, attempt);
+        for (const [receiptId, receipt] of receipts) state.replayReceipts.set(receiptId, receipt);
+        for (const [anchorId, anchor] of anchors) state.integrityAnchors.set(anchorId, anchor);
+      });
+    },
+    insertReplayReceipt(receipt) {
+      if (state.replayReceipts.has(receipt.receiptId))
+        throw new FoundationStorageConstraintError("replay-receipt-id");
+      if (
+        [...state.replayReceipts.values()].some(
+          (candidate) => candidate.receiptDigest === receipt.receiptDigest,
+        )
+      )
+        throw new FoundationStorageConstraintError("replay-receipt-digest");
+      state.replayReceipts.set(receipt.receiptId, structuredClone(receipt));
+      undo.push(() => state.replayReceipts.delete(receipt.receiptId));
+    },
+    updateReplayReceipt(receipt) {
+      if (!state.replayReceipts.has(receipt.receiptId))
+        throw new FoundationStorageConstraintError("replay-receipt-id");
+      const previous = state.replayReceipts.get(receipt.receiptId);
+      state.replayReceipts.set(receipt.receiptId, structuredClone(receipt));
+      undo.push(() => {
+        if (previous !== undefined) state.replayReceipts.set(receipt.receiptId, previous);
+      });
+    },
+    insertAcceptanceIntegrityAnchor(anchor: AcceptanceIntegrityAnchor) {
+      if (state.integrityAnchors.has(anchor.anchorId))
+        throw new FoundationStorageConstraintError("replay-attempt-id");
+      state.integrityAnchors.set(anchor.anchorId, structuredClone(anchor));
+      undo.push(() => state.integrityAnchors.delete(anchor.anchorId));
     },
   };
 }

--- a/src/lib/foundation-storage-sqlite-helpers.ts
+++ b/src/lib/foundation-storage-sqlite-helpers.ts
@@ -52,6 +52,21 @@ export function translateSqliteConstraint(error: unknown): unknown {
   if (message.includes("audit_id")) {
     return new FoundationStorageConstraintError("audit-id");
   }
+  if (message.includes("bucket_id")) {
+    return new FoundationStorageConstraintError("acceptance-budget-id");
+  }
+  if (message.includes("reservation_id")) {
+    return new FoundationStorageConstraintError("replay-reservation-id");
+  }
+  if (message.includes("attempt_id")) {
+    return new FoundationStorageConstraintError("replay-attempt-id");
+  }
+  if (message.includes("receipt_digest")) {
+    return new FoundationStorageConstraintError("replay-receipt-digest");
+  }
+  if (message.includes("receipt_id")) {
+    return new FoundationStorageConstraintError("replay-receipt-id");
+  }
   return error;
 }
 
@@ -171,6 +186,9 @@ export function readAudit(row: RootRow): StoredControlAuditEntry {
     ...(entry.provenance === undefined
       ? {}
       : { provenance: readAuditProvenance(entry.provenance) }),
+    ...(entry.lockedReplay === undefined
+      ? {}
+      : { lockedReplay: readLockedReplay(entry.lockedReplay) }),
   };
   if (
     result.auditId !== readText(row.audit_id) ||
@@ -204,14 +222,53 @@ function readAuditLinks(value: unknown): ControlAuditLinkage {
   if (!causalPredecessorIds.ok)
     throw new Error("Stored Control Audit causal predecessors are invalid.");
   const collision = value.collision === undefined ? undefined : readAuditCollision(value.collision);
+  const rejectedCandidate =
+    value.rejectedCandidate === undefined
+      ? undefined
+      : readRejectedCandidate(value.rejectedCandidate);
   return {
     actionId,
     targetFactId,
     causalPredecessorIds: causalPredecessorIds.value,
     relatedOperationIds,
     ordering: readAuditOrdering(value.ordering),
+    ...(value.grantAuditId === undefined
+      ? {}
+      : { grantAuditId: readValidatedNullableId(value.grantAuditId, "grantAuditId") }),
+    ...(value.acceptanceId === undefined
+      ? {}
+      : { acceptanceId: readValidatedNullableId(value.acceptanceId, "acceptanceId") }),
+    ...(value.contentFingerprint === undefined
+      ? {}
+      : { contentFingerprint: readFingerprint(value.contentFingerprint, "contentFingerprint") }),
+    ...(value.reason === undefined ? {} : { reason: readNonEmptyText(value.reason, "reason") }),
+    ...(rejectedCandidate === undefined ? {} : { rejectedCandidate }),
     ...(collision === undefined ? {} : { collision }),
   };
+}
+
+function readRejectedCandidate(
+  value: unknown,
+): NonNullable<ControlAuditLinkage["rejectedCandidate"]> {
+  if (!isObject(value)) throw new Error("Stored Control Audit rejected candidate is invalid.");
+  return {
+    codecIdentity: readNonEmptyText(value.codecIdentity, "rejectedCodecIdentity"),
+    codecFingerprint: readNonEmptyText(value.codecFingerprint, "rejectedCodecFingerprint"),
+    canonicalContent: readText(value.canonicalContent),
+    contentFingerprint: readFingerprint(value.contentFingerprint, "rejectedContentFingerprint"),
+  };
+}
+
+function readLockedReplay(value: unknown): NonNullable<StoredControlAuditEntry["lockedReplay"]> {
+  if (!isObject(value)) throw new Error("Stored locked replay evidence is invalid.");
+  const count = typeof value.count === "number" ? value.count : NaN;
+  const originatingSessionId = readRequiredId(value.originatingSessionId, "originatingSessionId");
+  const eventGameId = readRequiredId(value.eventGameId, "eventGameId");
+  const rejectedAtMs = validateTimestamp(value.rejectedAtMs, "rejectedAtMs");
+  if (!Number.isSafeInteger(count) || count <= 0 || !rejectedAtMs.ok) {
+    throw new Error("Stored locked replay evidence is invalid.");
+  }
+  return { count, originatingSessionId, eventGameId, rejectedAtMs: rejectedAtMs.value };
 }
 
 function readAuditCollision(value: unknown): ControlAuditLinkage["collision"] {
@@ -240,6 +297,14 @@ function readAuditCollision(value: unknown): ControlAuditLinkage["collision"] {
     acceptedContentFingerprint,
     rejectedAttempt: {
       input: input.value,
+      codecIdentity:
+        rejectedAttempt.codecIdentity === undefined
+          ? undefined
+          : readNonEmptyText(rejectedAttempt.codecIdentity, "rejectedCodecIdentity"),
+      codecFingerprint:
+        rejectedAttempt.codecFingerprint === undefined
+          ? undefined
+          : readNonEmptyText(rejectedAttempt.codecFingerprint, "rejectedCodecFingerprint"),
       canonicalContent: readText(rejectedAttempt.canonicalContent),
       contentFingerprint: readFingerprint(
         rejectedAttempt.contentFingerprint,
@@ -255,6 +320,12 @@ function readFingerprint(value: unknown, field: string): string {
     throw new Error(`Stored Control Audit ${field} is invalid.`);
   }
   return value;
+}
+
+function readNonEmptyText(value: unknown, field: string): string {
+  const text = readText(value);
+  if (text.length === 0) throw new Error(`Stored Control Audit ${field} is invalid.`);
+  return text;
 }
 
 function readAuditOrdering(value: unknown): ControlAuditLinkage["ordering"] {

--- a/src/lib/foundation-storage-sqlite.test.ts
+++ b/src/lib/foundation-storage-sqlite.test.ts
@@ -56,7 +56,7 @@ describe("SQLite foundation storage", () => {
       first.close();
 
       const reopened = openSqliteFoundationStorage(databasePath);
-      expect(await reopened.readiness()).toMatchObject({ ok: true, schemaVersion: "16" });
+      expect(await reopened.readiness()).toMatchObject({ ok: true, schemaVersion: "18" });
       const reopenedRecord = createEventGameRecord(reopened, {
         externalScopeResolver: createScopeResolver(root),
       });
@@ -74,12 +74,12 @@ describe("SQLite foundation storage", () => {
       const storage = openSqliteFoundationStorage(databasePath);
       const candidate = await storage.validateCandidate();
       expect(candidate.ready).toBe(true);
-      expect(candidate.readiness).toMatchObject({ ok: true, schemaVersion: "16" });
+      expect(candidate.readiness).toMatchObject({ ok: true, schemaVersion: "18" });
       expect(existsSync(candidate.candidatePath)).toBe(false);
       expect(await storage.readiness()).toMatchObject({ ok: false, status: "pending" });
 
       const migration = await storage.applyMigrations({ requireCandidate: true });
-      expect(migration.schemaVersion).toBe(16);
+      expect(migration.schemaVersion).toBe(18);
       expect(await storage.readiness()).toMatchObject({ ok: true });
       storage.close();
     });
@@ -103,6 +103,7 @@ describe("SQLite foundation storage", () => {
       const provenanceMigration = FOUNDATION_MIGRATIONS[13];
       const bindingMigration = FOUNDATION_MIGRATIONS[14];
       const replayProvenanceMigration = FOUNDATION_MIGRATIONS[15];
+      const composedAcceptanceMigration = FOUNDATION_MIGRATIONS[16];
       if (
         initialMigration === undefined ||
         repairMigration === undefined ||
@@ -119,7 +120,8 @@ describe("SQLite foundation storage", () => {
         auditEvidenceMigration === undefined ||
         provenanceMigration === undefined ||
         bindingMigration === undefined ||
-        replayProvenanceMigration === undefined
+        replayProvenanceMigration === undefined ||
+        composedAcceptanceMigration === undefined
       ) {
         throw new Error("Expected the foundation migrations.");
       }
@@ -148,8 +150,10 @@ describe("SQLite foundation storage", () => {
         provenanceMigration.id,
         bindingMigration.id,
         replayProvenanceMigration.id,
+        composedAcceptanceMigration.id,
+        "018-acceptance-integrity-history",
       ]);
-      expect(await current.readiness()).toMatchObject({ ok: true, schemaVersion: "16" });
+      expect(await current.readiness()).toMatchObject({ ok: true, schemaVersion: "18" });
       current.close();
     });
   });
@@ -158,9 +162,9 @@ describe("SQLite foundation storage", () => {
     await withDatabase(async (databasePath) => {
       const baseMigrations = FOUNDATION_MIGRATIONS;
       const failingMigration = createMigration(
-        "017-failing-test-migration",
-        17,
-        17,
+        "019-failing-test-migration",
+        19,
+        19,
         "CREATE TABLE migration_failure_probe (id TEXT) STRICT; THIS IS NOT SQL;",
       );
       const store = openSqliteFoundationStorage(databasePath, {
@@ -180,7 +184,7 @@ describe("SQLite foundation storage", () => {
       });
       expect(await priorBinary.readiness()).toMatchObject({
         ok: true,
-        schemaVersion: "16",
+        schemaVersion: "18",
       });
       priorBinary.close();
 
@@ -252,7 +256,7 @@ describe("SQLite foundation storage", () => {
         .query(
           "INSERT INTO foundation_migration_ledger (migration_id, ordinal, schema_version, checksum, status, applied_at_ms) VALUES (?, ?, ?, ?, ?, ?)",
         )
-        .run("future-999", 17, 17, "future-checksum", "complete", 2_000);
+        .run("future-999", 19, 19, "future-checksum", "complete", 2_000);
       futureDatabase.close();
       const future = openSqliteFoundationStorage(databasePath);
       expect(await future.readiness()).toMatchObject({ ok: false });

--- a/src/lib/foundation-storage-sqlite.ts
+++ b/src/lib/foundation-storage-sqlite.ts
@@ -40,9 +40,17 @@ import {
   type StoredControlAction,
   type StoredControlAuditEntry,
   type StoredControlIdempotencyEntry,
+  type StoredAcceptanceBudget,
+  type StoredReplayAttempt,
+  type StoredReplayReceipt,
+  type StoredReplayReservation,
   type StoredEventGameRecordMetadata,
   type StoredEventGameRecordRoot,
 } from "@/lib/foundation-storage";
+import type {
+  AcceptanceIntegrityAnchor,
+  AcceptanceIntegritySubject,
+} from "@/lib/foundation-acceptance-integrity";
 import {
   actionIdentity,
   asRecord,
@@ -96,6 +104,87 @@ export class FoundationMigrationError extends Error {
   }
 }
 
+function readBudget(value: unknown): StoredAcceptanceBudget | null {
+  if (value === null || value === undefined) return null;
+  const row = value as Record<string, unknown>;
+  return {
+    bucketId: String(row.bucket_id),
+    bucketKind: String(row.bucket_kind) as StoredAcceptanceBudget["bucketKind"],
+    subjectId: String(row.subject_id),
+    capacity: Number(row.capacity),
+    refillPerSecond: Number(row.refill_per_second),
+    tokens: Number(row.tokens),
+    updatedAtMs: Number(row.updated_at_ms),
+    stateRevision: Number(row.state_revision),
+  };
+}
+
+function readReservation(value: unknown): StoredReplayReservation | null {
+  if (value === null || value === undefined) return null;
+  const row = value as Record<string, unknown>;
+  return {
+    reservationId: String(row.reservation_id),
+    recordId: String(row.record_id),
+    eventGameId: String(row.event_game_id),
+    originatingSessionId: String(row.originating_session_id),
+    replacementSessionId:
+      row.replacement_session_id === null ? null : readText(row.replacement_session_id),
+    actionCount: Number(row.action_count),
+    status: String(row.status) as StoredReplayReservation["status"],
+    batchDigest: row.batch_digest === null ? null : readText(row.batch_digest),
+    createdAtMs: Number(row.created_at_ms),
+    committedAtMs: row.committed_at_ms === null ? null : Number(row.committed_at_ms),
+    acknowledgedAtMs: row.acknowledged_at_ms === null ? null : Number(row.acknowledged_at_ms),
+    stateRevision: Number(row.state_revision),
+  };
+}
+
+function readAttempt(value: unknown): StoredReplayAttempt {
+  const row = value as Record<string, unknown>;
+  return {
+    attemptId: String(row.attempt_id),
+    reservationId: String(row.reservation_id),
+    operationId: String(row.operation_id),
+    status: String(row.status) as StoredReplayAttempt["status"],
+    actionFingerprint: row.action_fingerprint === null ? null : readText(row.action_fingerprint),
+    resultJson: row.result_json === null ? null : readText(row.result_json),
+    controlAuditId: row.control_audit_id === null ? null : readText(row.control_audit_id),
+    grantAuditId: row.grant_audit_id === null ? null : readText(row.grant_audit_id),
+    createdAtMs: Number(row.created_at_ms),
+    completedAtMs: row.completed_at_ms === null ? null : Number(row.completed_at_ms),
+    stateRevision: Number(row.state_revision),
+  };
+}
+
+function readReceipt(value: unknown): StoredReplayReceipt | null {
+  if (value === null || value === undefined) return null;
+  const row = value as Record<string, unknown>;
+  return {
+    receiptId: String(row.receipt_id),
+    reservationId: String(row.reservation_id),
+    receiptDigest: String(row.receipt_digest),
+    receiptKeyVersion: String(row.receipt_key_version),
+    status: String(row.status) as StoredReplayReceipt["status"],
+    actionCount: Number(row.action_count),
+    createdAtMs: Number(row.created_at_ms),
+    acknowledgedAtMs: row.acknowledged_at_ms === null ? null : Number(row.acknowledged_at_ms),
+    stateRevision: Number(row.state_revision),
+  };
+}
+
+function readIntegrityAnchor(value: unknown): AcceptanceIntegrityAnchor {
+  const row = value as Record<string, unknown>;
+  return {
+    anchorId: String(row.anchor_id),
+    subjectKind: String(row.subject_kind) as AcceptanceIntegritySubject,
+    subjectId: String(row.subject_id),
+    stateRevision: Number(row.state_revision),
+    keyVersion: String(row.key_version),
+    canonicalValue: String(row.canonical_value),
+    integrityTag: String(row.integrity_tag),
+  };
+}
+
 type SqlStatement = ReturnType<Database["query"]>;
 
 type RootStatements = {
@@ -115,6 +204,25 @@ type RootStatements = {
   idempotencyByRecordId: SqlStatement;
   insertAudit: SqlStatement;
   insertEvidenceProvenance: SqlStatement;
+  budgetById: SqlStatement;
+  upsertBudget: SqlStatement;
+  reservationById: SqlStatement;
+  reservationByTuple: SqlStatement;
+  reservationByOriginTuple: SqlStatement;
+  insertReservation: SqlStatement;
+  updateReservation: SqlStatement;
+  attemptsByReservation: SqlStatement;
+  insertAttempt: SqlStatement;
+  updateAttempt: SqlStatement;
+  discardAttempts: SqlStatement;
+  discardAnchors: SqlStatement;
+  discardReservation: SqlStatement;
+  receiptByDigest: SqlStatement;
+  receiptByReservationId: SqlStatement;
+  anchorsBySubject: SqlStatement;
+  insertReceipt: SqlStatement;
+  updateReceipt: SqlStatement;
+  insertAnchor: SqlStatement;
 };
 
 const ROOT_SELECT_COLUMNS = `
@@ -423,12 +531,163 @@ export class SqliteFoundationStorage implements FoundationStorage {
       listGrantSessions: (grantId) =>
         listGrantSessions(this.getGrantStatements().sessionsByGrant, grantId),
       listGrantAudit: (grantId) => listGrantAudit(this.getGrantStatements().auditByGrant, grantId),
+      findAcceptanceBudget: (bucketId) => readBudget(statements.budgetById.get(bucketId)),
+      findReplayReservation: (reservationId) =>
+        readReservation(statements.reservationById.get(reservationId)),
+      findReplayReservationByTuple: (
+        recordId,
+        eventGameId,
+        originatingSessionId,
+        actionCount,
+        batchDigest,
+      ) =>
+        (() => {
+          const matches = statements.reservationByTuple.all(
+            recordId,
+            eventGameId,
+            originatingSessionId,
+            actionCount,
+            batchDigest,
+          ) as unknown[];
+          return matches.length === 1 ? readReservation(matches[0]) : null;
+        })(),
+      findReplayReservationByOriginTuple: (
+        recordId,
+        eventGameId,
+        originatingSessionId,
+        actionCount,
+      ) =>
+        readReservation(
+          statements.reservationByOriginTuple.get(
+            recordId,
+            eventGameId,
+            originatingSessionId,
+            actionCount,
+          ),
+        ),
+      listReplayAttempts: (reservationId) =>
+        statements.attemptsByReservation.all(reservationId).map(readAttempt),
+      findReplayReceiptByDigest: (receiptDigest) =>
+        readReceipt(statements.receiptByDigest.get(receiptDigest)),
+      findReplayReceiptByReservationId: (reservationId) =>
+        readReceipt(statements.receiptByReservationId.get(reservationId)),
+      listAcceptanceIntegrityAnchors: (subjectKind, subjectId) =>
+        statements.anchorsBySubject.all(subjectKind, subjectId).map(readIntegrityAnchor),
       insertGrant: (grant) => insertGrant(this.getGrantStatements(), grant),
       updateGrant: (grant) => updateGrant(this.getGrantStatements(), grant),
       insertGrantSession: (session) => insertGrantSession(this.getGrantStatements(), session),
       updateGrantSession: (session) => updateGrantSession(this.getGrantStatements(), session),
       appendGrantAudit: (entry) =>
         appendGrantAudit(this.getGrantStatements(), entry, this.grantValidationContext.keyRing),
+      upsertAcceptanceBudget: (budget) =>
+        statements.upsertBudget.run(
+          budget.bucketId,
+          budget.bucketKind,
+          budget.subjectId,
+          budget.capacity,
+          budget.refillPerSecond,
+          budget.tokens,
+          budget.updatedAtMs,
+          budget.stateRevision,
+        ),
+      insertReplayReservation: (reservation) =>
+        statements.insertReservation.run(
+          reservation.reservationId,
+          reservation.recordId,
+          reservation.eventGameId,
+          reservation.originatingSessionId,
+          reservation.replacementSessionId,
+          reservation.actionCount,
+          reservation.status,
+          reservation.batchDigest,
+          reservation.createdAtMs,
+          reservation.committedAtMs,
+          reservation.acknowledgedAtMs,
+          reservation.stateRevision,
+        ),
+      updateReplayReservation: (reservation) =>
+        statements.updateReservation.run(
+          reservation.recordId,
+          reservation.eventGameId,
+          reservation.originatingSessionId,
+          reservation.replacementSessionId,
+          reservation.actionCount,
+          reservation.status,
+          reservation.batchDigest,
+          reservation.createdAtMs,
+          reservation.committedAtMs,
+          reservation.acknowledgedAtMs,
+          reservation.stateRevision,
+          reservation.reservationId,
+        ),
+      insertReplayAttempt: (attempt) =>
+        statements.insertAttempt.run(
+          attempt.attemptId,
+          attempt.reservationId,
+          attempt.operationId,
+          attempt.status,
+          attempt.actionFingerprint,
+          attempt.resultJson,
+          attempt.controlAuditId,
+          attempt.grantAuditId,
+          attempt.createdAtMs,
+          attempt.completedAtMs,
+          attempt.stateRevision,
+        ),
+      updateReplayAttempt: (attempt) =>
+        statements.updateAttempt.run(
+          attempt.reservationId,
+          attempt.operationId,
+          attempt.status,
+          attempt.actionFingerprint,
+          attempt.resultJson,
+          attempt.controlAuditId,
+          attempt.grantAuditId,
+          attempt.createdAtMs,
+          attempt.completedAtMs,
+          attempt.stateRevision,
+          attempt.attemptId,
+        ),
+      discardReplayAttempts: (reservationId) => statements.discardAttempts.run(reservationId),
+      discardReplayReservation: (reservationId) => {
+        statements.discardAnchors.run(reservationId, `${reservationId}:%`);
+        statements.discardAttempts.run(reservationId);
+        statements.discardReservation.run(reservationId);
+      },
+      insertReplayReceipt: (receipt) =>
+        statements.insertReceipt.run(
+          receipt.receiptId,
+          receipt.reservationId,
+          receipt.receiptDigest,
+          receipt.receiptKeyVersion,
+          receipt.status,
+          receipt.actionCount,
+          receipt.createdAtMs,
+          receipt.acknowledgedAtMs,
+          receipt.stateRevision,
+        ),
+      updateReplayReceipt: (receipt) =>
+        statements.updateReceipt.run(
+          receipt.reservationId,
+          receipt.receiptDigest,
+          receipt.receiptKeyVersion,
+          receipt.status,
+          receipt.actionCount,
+          receipt.createdAtMs,
+          receipt.acknowledgedAtMs,
+          receipt.stateRevision,
+          receipt.receiptId,
+        ),
+      insertAcceptanceIntegrityAnchor: (anchor) =>
+        statements.insertAnchor.run(
+          anchor.anchorId,
+          anchor.subjectKind,
+          anchor.subjectId,
+          anchor.stateRevision,
+          anchor.keyVersion,
+          anchor.canonicalValue,
+          anchor.integrityTag,
+        ),
     };
   }
 
@@ -679,6 +938,94 @@ export class SqliteFoundationStorage implements FoundationStorage {
         INSERT INTO foundation_control_evidence_provenance
           (evidence_kind, evidence_id, evidence_format, origin)
         VALUES (?, ?, 'current', 'post-75-current')
+      `),
+      budgetById: this.database.query(
+        `SELECT * FROM foundation_acceptance_budgets WHERE bucket_id = ?`,
+      ),
+      upsertBudget: this.database.query(`
+        INSERT INTO foundation_acceptance_budgets
+          (bucket_id, bucket_kind, subject_id, capacity, refill_per_second, tokens, updated_at_ms, state_revision)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(bucket_id) DO UPDATE SET
+          bucket_kind = excluded.bucket_kind, subject_id = excluded.subject_id,
+          capacity = excluded.capacity, refill_per_second = excluded.refill_per_second,
+          tokens = excluded.tokens, updated_at_ms = excluded.updated_at_ms,
+          state_revision = excluded.state_revision
+      `),
+      reservationById: this.database.query(
+        `SELECT * FROM foundation_replay_reservations WHERE reservation_id = ?`,
+      ),
+      reservationByTuple: this.database.query(
+        `SELECT * FROM foundation_replay_reservations
+         WHERE record_id = ? AND event_game_id = ? AND originating_session_id = ? AND action_count = ?
+           AND batch_digest = ?
+         ORDER BY state_revision DESC LIMIT 2`,
+      ),
+      reservationByOriginTuple: this.database.query(
+        `SELECT * FROM foundation_replay_reservations
+         WHERE record_id = ? AND event_game_id = ? AND originating_session_id = ? AND action_count = ?
+         ORDER BY state_revision DESC LIMIT 1`,
+      ),
+      insertReservation: this.database.query(`
+        INSERT INTO foundation_replay_reservations
+          (reservation_id, record_id, event_game_id, originating_session_id, replacement_session_id,
+           action_count, status, batch_digest, created_at_ms, committed_at_ms, acknowledged_at_ms, state_revision)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `),
+      updateReservation: this.database.query(`
+        UPDATE foundation_replay_reservations SET record_id = ?, event_game_id = ?,
+          originating_session_id = ?, replacement_session_id = ?, action_count = ?, status = ?,
+          batch_digest = ?, created_at_ms = ?, committed_at_ms = ?, acknowledged_at_ms = ?, state_revision = ?
+        WHERE reservation_id = ?
+      `),
+      attemptsByReservation: this.database.query(
+        `SELECT * FROM foundation_replay_attempts WHERE reservation_id = ? ORDER BY attempt_id`,
+      ),
+      insertAttempt: this.database.query(`
+        INSERT INTO foundation_replay_attempts
+          (attempt_id, reservation_id, operation_id, status, action_fingerprint, result_json,
+           control_audit_id, grant_audit_id, created_at_ms, completed_at_ms, state_revision)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `),
+      updateAttempt: this.database.query(`
+        UPDATE foundation_replay_attempts SET reservation_id = ?, operation_id = ?, status = ?,
+          action_fingerprint = ?, result_json = ?, control_audit_id = ?, grant_audit_id = ?,
+          created_at_ms = ?, completed_at_ms = ?, state_revision = ? WHERE attempt_id = ?
+      `),
+      discardAttempts: this.database.query(
+        `DELETE FROM foundation_replay_attempts WHERE reservation_id = ?`,
+      ),
+      discardAnchors: this.database.query(
+        `DELETE FROM foundation_acceptance_integrity_anchors
+         WHERE (subject_kind = 'reservation' AND subject_id = ?)
+            OR (subject_kind = 'attempt' AND subject_id LIKE ?)`,
+      ),
+      discardReservation: this.database.query(
+        `DELETE FROM foundation_replay_reservations WHERE reservation_id = ?`,
+      ),
+      receiptByDigest: this.database.query(
+        `SELECT * FROM foundation_replay_receipts WHERE receipt_digest = ?`,
+      ),
+      receiptByReservationId: this.database.query(
+        `SELECT * FROM foundation_replay_receipts WHERE reservation_id = ?`,
+      ),
+      anchorsBySubject: this.database.query(
+        `SELECT * FROM foundation_acceptance_integrity_anchors
+         WHERE subject_kind = ? AND subject_id = ? ORDER BY state_revision`,
+      ),
+      insertReceipt: this.database.query(`
+        INSERT INTO foundation_replay_receipts
+          (receipt_id, reservation_id, receipt_digest, receipt_key_version, status, action_count, created_at_ms, acknowledged_at_ms, state_revision)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `),
+      updateReceipt: this.database.query(`
+        UPDATE foundation_replay_receipts SET reservation_id = ?, receipt_digest = ?, receipt_key_version = ?, status = ?,
+          action_count = ?, created_at_ms = ?, acknowledged_at_ms = ?, state_revision = ? WHERE receipt_id = ?
+      `),
+      insertAnchor: this.database.query(`
+        INSERT INTO foundation_acceptance_integrity_anchors
+          (anchor_id, subject_kind, subject_id, state_revision, key_version, canonical_value, integrity_tag)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
       `),
     };
     return this.statements;

--- a/src/lib/foundation-storage.ts
+++ b/src/lib/foundation-storage.ts
@@ -46,6 +46,58 @@ export type StoredControlAuditEntry = ControlAuditEntry & {
 
 export type StoredEventGameRecordMetadata = EventGameRecordMetadata;
 
+export type StoredAcceptanceBudget = {
+  bucketId: string;
+  bucketKind: "online-session" | "online-event" | "replay-session";
+  subjectId: string;
+  capacity: number;
+  refillPerSecond: number;
+  tokens: number;
+  updatedAtMs: number;
+  stateRevision: number;
+};
+
+export type StoredReplayReservation = {
+  reservationId: string;
+  recordId: string;
+  eventGameId: string;
+  originatingSessionId: string;
+  replacementSessionId: string | null;
+  actionCount: number;
+  status: "reserved" | "committing" | "committed" | "partial" | "discarded" | "acknowledged";
+  batchDigest: string | null;
+  createdAtMs: number;
+  committedAtMs: number | null;
+  acknowledgedAtMs: number | null;
+  stateRevision: number;
+};
+
+export type StoredReplayAttempt = {
+  attemptId: string;
+  reservationId: string;
+  operationId: string;
+  status: "pending" | "accepted" | "duplicate-accepted" | "rejected" | "retry-later";
+  actionFingerprint: string | null;
+  resultJson: string | null;
+  controlAuditId: string | null;
+  grantAuditId: string | null;
+  createdAtMs: number;
+  completedAtMs: number | null;
+  stateRevision: number;
+};
+
+export type StoredReplayReceipt = {
+  receiptId: string;
+  reservationId: string;
+  receiptDigest: string;
+  receiptKeyVersion: string;
+  status: "committed" | "acknowledged";
+  actionCount: number;
+  createdAtMs: number;
+  acknowledgedAtMs: number | null;
+  stateRevision: number;
+};
+
 export type FoundationStorageReadiness =
   | {
       ok: true;
@@ -93,6 +145,28 @@ export type FoundationStorageSnapshot = {
   ): StoredGrantSession | null;
   listGrantSessions(grantId: string): StoredGrantSession[];
   listGrantAudit(grantId: string): StoredGrantAuditEntry[];
+  findAcceptanceBudget(bucketId: string): StoredAcceptanceBudget | null;
+  findReplayReservation(reservationId: string): StoredReplayReservation | null;
+  findReplayReservationByTuple(
+    recordId: string,
+    eventGameId: string,
+    originatingSessionId: string,
+    actionCount: number,
+    batchDigest: string,
+  ): StoredReplayReservation | null;
+  findReplayReservationByOriginTuple(
+    recordId: string,
+    eventGameId: string,
+    originatingSessionId: string,
+    actionCount: number,
+  ): StoredReplayReservation | null;
+  listReplayAttempts(reservationId: string): StoredReplayAttempt[];
+  findReplayReceiptByDigest(receiptDigest: string): StoredReplayReceipt | null;
+  findReplayReceiptByReservationId(reservationId: string): StoredReplayReceipt | null;
+  listAcceptanceIntegrityAnchors(
+    subjectKind: import("@/lib/foundation-acceptance-integrity").AcceptanceIntegritySubject,
+    subjectId: string,
+  ): import("@/lib/foundation-acceptance-integrity").AcceptanceIntegrityAnchor[];
 };
 
 export type FoundationStorageTransaction = FoundationStorageSnapshot & {
@@ -105,6 +179,18 @@ export type FoundationStorageTransaction = FoundationStorageSnapshot & {
   insertGrantSession(session: StoredGrantSession): void;
   updateGrantSession(session: StoredGrantSession): void;
   appendGrantAudit(entry: StoredGrantAuditEntry): void;
+  upsertAcceptanceBudget(budget: StoredAcceptanceBudget): void;
+  insertReplayReservation(reservation: StoredReplayReservation): void;
+  updateReplayReservation(reservation: StoredReplayReservation): void;
+  insertReplayAttempt(attempt: StoredReplayAttempt): void;
+  updateReplayAttempt(attempt: StoredReplayAttempt): void;
+  discardReplayAttempts(reservationId: string): void;
+  discardReplayReservation(reservationId: string): void;
+  insertReplayReceipt(receipt: StoredReplayReceipt): void;
+  updateReplayReceipt(receipt: StoredReplayReceipt): void;
+  insertAcceptanceIntegrityAnchor(
+    anchor: import("@/lib/foundation-acceptance-integrity").AcceptanceIntegrityAnchor,
+  ): void;
 };
 
 export type FoundationStorageTransactionWork<T> = (transaction: FoundationStorageTransaction) => T;
@@ -138,7 +224,13 @@ export type FoundationStorageConstraint =
   | "grant-session-id"
   | "grant-session-verifier"
   | "grant-session-context"
-  | "grant-audit-id";
+  | "grant-audit-id"
+  | "acceptance-budget-id"
+  | "replay-reservation-id"
+  | "replay-attempt-id"
+  | "replay-receipt-id"
+  | "replay-receipt-digest"
+  | "integrity-anchor-id";
 
 export class FoundationStorageConstraintError extends Error {
   readonly constraint: FoundationStorageConstraint;

--- a/src/lib/grant-authority.focused.ts
+++ b/src/lib/grant-authority.focused.ts
@@ -141,7 +141,7 @@ describe("focused SQLite Grant authority boundary", () => {
           /^opaque-migration-reference-v1:[a-f0-9]{64}$/,
         );
         expect(beforeRotation.audit[0]?.credentialFingerprint).toBeNull();
-        expect(await current.readiness()).toMatchObject({ ok: true, schemaVersion: "16" });
+        expect(await current.readiness()).toMatchObject({ ok: true, schemaVersion: "18" });
 
         const forged = new Database(databasePath);
         expect(() =>
@@ -263,7 +263,7 @@ describe("focused SQLite Grant authority boundary", () => {
       const restarted = openSqliteFoundationStorage(handle.databasePath, {
         grantKeyRing: createGrantTestKeyRing(),
       });
-      expect(await restarted.readiness()).toMatchObject({ ok: true, schemaVersion: "16" });
+      expect(await restarted.readiness()).toMatchObject({ ok: true, schemaVersion: "18" });
       restarted.close();
       const database = new Database(handle.databasePath);
       database
@@ -380,7 +380,7 @@ describe("focused SQLite Grant authority boundary", () => {
       const readyRestart = openSqliteFoundationStorage(handle.databasePath, {
         grantKeyRing: keyRing,
       });
-      expect(await readyRestart.readiness()).toMatchObject({ ok: true, schemaVersion: "16" });
+      expect(await readyRestart.readiness()).toMatchObject({ ok: true, schemaVersion: "18" });
       readyRestart.close();
 
       const selfLinkDatabase = new Database(handle.databasePath);
@@ -409,7 +409,7 @@ describe("focused SQLite Grant authority boundary", () => {
       const repairedRestart = openSqliteFoundationStorage(handle.databasePath, {
         grantKeyRing: keyRing,
       });
-      expect(await repairedRestart.readiness()).toMatchObject({ ok: true, schemaVersion: "16" });
+      expect(await repairedRestart.readiness()).toMatchObject({ ok: true, schemaVersion: "18" });
       repairedRestart.close();
 
       const activeOriginDatabase = new Database(handle.databasePath);
@@ -619,7 +619,7 @@ describe("focused SQLite Grant authority boundary", () => {
       let currentClosed = false;
       try {
         const report = await current.applyMigrations({ requireCandidate: false });
-        expect(report.schemaVersion).toBe(16);
+        expect(report.schemaVersion).toBe(18);
         expect(report.appliedMigrationIds).toEqual([
           "007-anchor-control-action-audit-versions",
           "008-anchor-current-evidence-format",
@@ -631,10 +631,12 @@ describe("focused SQLite Grant authority boundary", () => {
           "014-grant-provenance-integrity",
           "015-control-session-binding",
           "016-replay-content-provenance",
+          "017-composed-acceptance-state",
+          "018-acceptance-integrity-history",
         ]);
         expect(await current.readiness()).toMatchObject({
           ok: true,
-          schemaVersion: "16",
+          schemaVersion: "18",
         });
         const migrated = await current.transaction((transaction) => ({
           grant: transaction.findGrantById(grantId),
@@ -683,7 +685,7 @@ describe("focused SQLite Grant authority boundary", () => {
 
         const restarted = openSqliteFoundationStorage(databasePath, { grantKeyRing: keyRing });
         try {
-          expect(await restarted.readiness()).toMatchObject({ ok: true, schemaVersion: "16" });
+          expect(await restarted.readiness()).toMatchObject({ ok: true, schemaVersion: "18" });
           const restartedAudit = await restarted.transaction((transaction) =>
             transaction.listGrantAudit(grantId),
           );
@@ -1080,7 +1082,7 @@ describe("focused SQLite Grant authority boundary", () => {
         grantKeyRing: options.keyRing,
       });
       try {
-        expect(await reopened.readiness()).toMatchObject({ ok: true, schemaVersion: "16" });
+        expect(await reopened.readiness()).toMatchObject({ ok: true, schemaVersion: "18" });
         const rotated = createTypedGrantAuthority(reopened, {
           ...options,
           keyRing: createGrantTestRotatedKeyRing(keyRing),
@@ -1208,7 +1210,7 @@ describe("focused SQLite Grant authority boundary", () => {
         grantKeyRing: options.keyRing,
       });
       try {
-        expect(await reopened.readiness()).toMatchObject({ ok: true, schemaVersion: "16" });
+        expect(await reopened.readiness()).toMatchObject({ ok: true, schemaVersion: "18" });
         const reopenedAuthority = createTypedGrantAuthority(reopened, options);
         const reopenedAudit = await reopenedAuthority.listGrantAudit(control.grantId, {
           kind: "technical-admin",

--- a/src/lib/grant-crypto.ts
+++ b/src/lib/grant-crypto.ts
@@ -220,6 +220,20 @@ export function computeLookupDigest(
   return encodeBase64Url(hmac(key, token));
 }
 
+/** Keyed, domain-separated integrity for composed acceptance evidence. */
+export function computeAcceptanceIntegrityTag(
+  value: string,
+  keyRing: GrantKeyRing,
+  keyVersion = keyRing.audit.currentVersion,
+): string {
+  return `hmac-sha256-v1:${keyVersion}:${encodeBase64Url(
+    hmac(
+      getKey(keyRing.audit.keys, keyVersion, HMAC_KEY_MIN_BYTES),
+      `acceptance-integrity:${value}`,
+    ),
+  )}`;
+}
+
 export function computeSessionVerifier(
   bearer: string,
   keyRing: GrantKeyRing,
@@ -277,6 +291,19 @@ function computeGrantAuditIntegrityTagWithPreviousEventGameId(
     beforeExpiresAtMs: entry.beforeExpiresAtMs,
     afterExpiresAtMs: entry.afterExpiresAtMs,
     terminalReason: entry.terminalReason,
+    ...(entry.acceptanceId == null &&
+    entry.controlAuditId == null &&
+    entry.controlActionId == null &&
+    entry.contentFingerprint == null &&
+    entry.outcomeDetail == null
+      ? {}
+      : {
+          acceptanceId: entry.acceptanceId ?? null,
+          controlAuditId: entry.controlAuditId ?? null,
+          controlActionId: entry.controlActionId ?? null,
+          contentFingerprint: entry.contentFingerprint ?? null,
+          outcomeDetail: entry.outcomeDetail ?? null,
+        }),
     createdAtMs: entry.createdAtMs,
   });
   return `hmac-sha256-v1:${keyVersion}:${encodeBase64Url(

--- a/src/lib/grant-management-sessions.ts
+++ b/src/lib/grant-management-sessions.ts
@@ -3,7 +3,7 @@ import {
   computeSessionVerifier,
   createRandomIdentifier,
 } from "@/lib/grant-crypto";
-import type { FoundationStorage } from "@/lib/foundation-storage";
+import type { FoundationStorage, FoundationStorageTransaction } from "@/lib/foundation-storage";
 import type { GrantAuthorityOptions } from "@/lib/grant-authority";
 import {
   EVENT_ADMIN_GRANT_TYPE,
@@ -168,99 +168,111 @@ export async function authorizeGrant(
   )
     return GENERIC_GRANT_AUTHORIZATION_FAILURE;
   try {
-    return await storage.transaction((transaction) => {
-      const session = findSessionByBearer(transaction, options, input.sessionBearer);
-      if (session === null) return GENERIC_GRANT_AUTHORIZATION_FAILURE;
-      const stored = transaction.findGrantById(session.grantId);
-      if (stored === null) return GENERIC_GRANT_AUTHORIZATION_FAILURE;
-      const grant = expireGrantIfDue(transaction, options, stored);
-      if (
-        grant.status !== "active" ||
-        session.status !== "active" ||
-        session.grantVersion !== grant.grantVersion
-      )
-        return GENERIC_GRANT_AUTHORIZATION_FAILURE;
-      const nowMs = readGrantNow(options);
-      if (
-        grant.grantType === EVENT_ADMIN_GRANT_TYPE &&
-        nowMs >=
-          Math.min(
-            grant.expiresAtMs ?? Number.MAX_SAFE_INTEGER,
-            session.lastActiveAtMs + 30 * DAY_MS,
-          )
-      ) {
-        expireSession(transaction, options, grant, session);
-        return GENERIC_GRANT_AUTHORIZATION_FAILURE;
-      }
-      let eventGameId: string | null = null;
-      if (grant.grantType === GRANT_TYPE) {
-        if (input.eventGameId === undefined) return GENERIC_GRANT_AUTHORIZATION_FAILURE;
-        const relationship = resolveControlSession(
-          options,
-          grant.scope as ControlGrantScope,
-          session.eventGameId,
-        );
-        if (relationship.status === "game-locked") {
-          terminateControlSessionForEventGame(
-            transaction,
-            options,
-            grant,
-            "game-locked",
-            relationship.eventGameId,
-          );
-          return GENERIC_GRANT_AUTHORIZATION_FAILURE;
-        }
-        if (relationship.status === "switchable") {
-          if (
-            input.controlSessionDecision === "stay" &&
-            input.eventGameId === relationship.previousEventGameId
-          ) {
-            eventGameId = relationship.previousEventGameId;
-          } else if (
-            input.eventGameId === relationship.currentEventGameId ||
-            (input.controlSessionDecision === undefined &&
-              input.eventGameId === relationship.previousEventGameId)
-          ) {
-            return {
-              status: "switch-required",
-              grantId: grant.grantId,
-              grantVersion: grant.grantVersion,
-              grantType: GRANT_TYPE,
-              scope: structuredClone(grant.scope as ControlGrantScope),
-              grantSessionId: session.sessionId,
-              previousEventGameId: relationship.previousEventGameId,
-              currentEventGameId: relationship.currentEventGameId,
-            } satisfies TypedGrantAuthorization;
-          } else {
-            return GENERIC_GRANT_AUTHORIZATION_FAILURE;
-          }
-        }
-        if (relationship.status === "pinned") {
-          if (input.eventGameId !== relationship.sessionEventGameId)
-            return GENERIC_GRANT_AUTHORIZATION_FAILURE;
-          eventGameId = relationship.sessionEventGameId;
-        } else if (relationship.status === "current") {
-          if (input.eventGameId !== relationship.eventGameId)
-            return GENERIC_GRANT_AUTHORIZATION_FAILURE;
-          eventGameId = relationship.eventGameId;
-        } else if (relationship.status !== "switchable") {
-          return GENERIC_GRANT_AUTHORIZATION_FAILURE;
-        }
-      }
-      transaction.updateGrantSession({ ...session, lastActiveAtMs: nowMs });
-      return {
-        status: "authorized",
-        grantId: grant.grantId,
-        grantVersion: grant.grantVersion,
-        grantType: grant.grantType,
-        scope: structuredClone(grant.scope),
-        eventGameId,
-        grantSessionId: session.sessionId,
-      };
-    });
+    return await storage.transaction((transaction) =>
+      authorizeGrantInTransaction(transaction, options, input),
+    );
   } catch {
     return GENERIC_GRANT_AUTHORIZATION_FAILURE;
   }
+}
+
+/** Transaction-local authorization used by the composed acceptance seam. */
+export function authorizeGrantInTransaction(
+  transaction: FoundationStorageTransaction,
+  options: GrantAuthorityOptions,
+  input: {
+    sessionBearer: string;
+    eventGameId?: string;
+    controlSessionDecision?: "stay";
+    readOnly?: boolean;
+  },
+): TypedGrantAuthorization {
+  const session = findSessionByBearer(transaction, options, input.sessionBearer);
+  if (session === null) return GENERIC_GRANT_AUTHORIZATION_FAILURE;
+  const stored = transaction.findGrantById(session.grantId);
+  if (stored === null) return GENERIC_GRANT_AUTHORIZATION_FAILURE;
+  // Batch preflight must not refresh sessions, expire grants, or emit lifecycle
+  // evidence. The accepting transaction repeats this check with the default
+  // mutating behavior before it commits any action evidence.
+  const grant = input.readOnly ? stored : expireGrantIfDue(transaction, options, stored);
+  if (
+    grant.status !== "active" ||
+    session.status !== "active" ||
+    session.grantVersion !== grant.grantVersion
+  )
+    return GENERIC_GRANT_AUTHORIZATION_FAILURE;
+  const nowMs = readGrantNow(options);
+  if (
+    grant.grantType === EVENT_ADMIN_GRANT_TYPE &&
+    nowMs >=
+      Math.min(grant.expiresAtMs ?? Number.MAX_SAFE_INTEGER, session.lastActiveAtMs + 30 * DAY_MS)
+  ) {
+    if (input.readOnly) return GENERIC_GRANT_AUTHORIZATION_FAILURE;
+    expireSession(transaction, options, grant, session);
+    return GENERIC_GRANT_AUTHORIZATION_FAILURE;
+  }
+  let eventGameId: string | null = null;
+  if (grant.grantType === GRANT_TYPE) {
+    if (input.eventGameId === undefined) return GENERIC_GRANT_AUTHORIZATION_FAILURE;
+    const relationship = resolveControlSession(
+      options,
+      grant.scope as ControlGrantScope,
+      session.eventGameId,
+    );
+    if (relationship.status === "game-locked") {
+      if (input.readOnly) return GENERIC_GRANT_AUTHORIZATION_FAILURE;
+      terminateControlSessionForEventGame(
+        transaction,
+        options,
+        grant,
+        "game-locked",
+        relationship.eventGameId,
+      );
+      return GENERIC_GRANT_AUTHORIZATION_FAILURE;
+    }
+    if (relationship.status === "switchable") {
+      if (
+        input.controlSessionDecision === "stay" &&
+        input.eventGameId === relationship.previousEventGameId
+      ) {
+        eventGameId = relationship.previousEventGameId;
+      } else if (
+        input.eventGameId === relationship.currentEventGameId ||
+        (input.controlSessionDecision === undefined &&
+          input.eventGameId === relationship.previousEventGameId)
+      ) {
+        return {
+          status: "switch-required",
+          grantId: grant.grantId,
+          grantVersion: grant.grantVersion,
+          grantType: GRANT_TYPE,
+          scope: structuredClone(grant.scope as ControlGrantScope),
+          grantSessionId: session.sessionId,
+          previousEventGameId: relationship.previousEventGameId,
+          currentEventGameId: relationship.currentEventGameId,
+        } satisfies TypedGrantAuthorization;
+      } else return GENERIC_GRANT_AUTHORIZATION_FAILURE;
+    }
+    if (relationship.status === "pinned") {
+      if (input.eventGameId !== relationship.sessionEventGameId)
+        return GENERIC_GRANT_AUTHORIZATION_FAILURE;
+      eventGameId = relationship.sessionEventGameId;
+    } else if (relationship.status === "current") {
+      if (input.eventGameId !== relationship.eventGameId)
+        return GENERIC_GRANT_AUTHORIZATION_FAILURE;
+      eventGameId = relationship.eventGameId;
+    } else if (relationship.status !== "switchable") return GENERIC_GRANT_AUTHORIZATION_FAILURE;
+  }
+  if (!input.readOnly) transaction.updateGrantSession({ ...session, lastActiveAtMs: nowMs });
+  return {
+    status: "authorized",
+    grantId: grant.grantId,
+    grantVersion: grant.grantVersion,
+    grantType: grant.grantType,
+    scope: structuredClone(grant.scope),
+    eventGameId,
+    grantSessionId: session.sessionId,
+  };
 }
 
 export async function acceptControlGrantSessionSwitch(

--- a/src/lib/grant-state-validation.ts
+++ b/src/lib/grant-state-validation.ts
@@ -484,6 +484,11 @@ function validateAudit(
     "session-terminated",
     "session-switched",
     "replay-authorized",
+    "control-action-accepted",
+    "control-action-duplicate",
+    "control-action-rejected",
+    "control-action-retry-later",
+    "control-action-dependency-blocked",
   ];
   const allowedTerminalReasons: readonly TerminalGrantSessionReason[] = [
     "game-locked",

--- a/src/lib/grant-storage-sqlite.ts
+++ b/src/lib/grant-storage-sqlite.ts
@@ -83,6 +83,11 @@ const AUDIT_SELECT_COLUMNS = `
   audit.previous_event_game_id AS previous_event_game_id,
   audit.replay_evidence_id AS replay_evidence_id,
   audit.terminal_reason AS terminal_reason,
+  audit.acceptance_id AS acceptance_id,
+  audit.control_audit_id AS control_audit_id,
+  audit.control_action_id AS control_action_id,
+  audit.content_fingerprint AS content_fingerprint,
+  audit.outcome_detail AS outcome_detail,
   audit.created_at_ms AS created_at_ms
 `;
 
@@ -155,9 +160,14 @@ export function createGrantSqliteStatements(database: Database): GrantSqliteStat
         event_id, game_day_id, pitch_id, pitch_slot_id, session_id, replaced_session_id,
         event_game_id, credential_kind, credential_fingerprint, before_status, after_status,
         before_expires_at_ms, after_expires_at_ms, previous_event_game_id, replay_evidence_id,
-        terminal_reason,
+        terminal_reason, acceptance_id, control_audit_id, control_action_id, content_fingerprint,
+        outcome_detail,
         audit_integrity_tag, created_at_ms
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ) VALUES (
+        ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+        ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+        ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+      )
     `),
   };
 }
@@ -352,6 +362,11 @@ export function appendGrantAudit(
     entry.previousEventGameId ?? null,
     entry.replayEvidenceId ?? null,
     entry.terminalReason,
+    entry.acceptanceId ?? null,
+    entry.controlAuditId ?? null,
+    entry.controlActionId ?? null,
+    entry.contentFingerprint ?? null,
+    entry.outcomeDetail ?? null,
     integrityTag,
     entry.createdAtMs,
   );
@@ -586,6 +601,11 @@ export function readStoredGrantAuditEntry(row: GrantRow): StoredGrantAuditEntry 
     "session-terminated",
     "session-switched",
     "replay-authorized",
+    "control-action-accepted",
+    "control-action-duplicate",
+    "control-action-rejected",
+    "control-action-retry-later",
+    "control-action-dependency-blocked",
   ];
   if (!allowedActions.includes(action)) {
     throw new Error("Stored Grant Audit Trail action is invalid.");
@@ -647,6 +667,11 @@ export function readStoredGrantAuditEntry(row: GrantRow): StoredGrantAuditEntry 
     previousEventGameId: readNullableText(row.previous_event_game_id),
     replayEvidenceId: readNullableText(row.replay_evidence_id),
     terminalReason: terminalReason as StoredGrantAuditEntry["terminalReason"],
+    acceptanceId: readNullableText(row.acceptance_id),
+    controlAuditId: readNullableText(row.control_audit_id),
+    controlActionId: readNullableText(row.control_action_id),
+    contentFingerprint: readNullableText(row.content_fingerprint),
+    outcomeDetail: readNullableText(row.outcome_detail),
     createdAtMs: readInteger(row.created_at_ms),
   };
 }

--- a/src/lib/grant-types.ts
+++ b/src/lib/grant-types.ts
@@ -175,7 +175,12 @@ export type GrantAuditAction =
   | "session-admitted"
   | "session-replaced"
   | "session-switched"
-  | "replay-authorized";
+  | "replay-authorized"
+  | "control-action-accepted"
+  | "control-action-duplicate"
+  | "control-action-rejected"
+  | "control-action-retry-later"
+  | "control-action-dependency-blocked";
 
 export type StoredGrantAuditEntry = {
   auditId: string;
@@ -198,6 +203,11 @@ export type StoredGrantAuditEntry = {
   beforeExpiresAtMs: number | null;
   afterExpiresAtMs: number | null;
   terminalReason: TerminalGrantSessionReason | null;
+  acceptanceId?: string | null;
+  controlAuditId?: string | null;
+  controlActionId?: string | null;
+  contentFingerprint?: string | null;
+  outcomeDetail?: string | null;
   createdAtMs: number;
 };
 


### PR DESCRIPTION
## What changed

This adds the composed Control Action acceptance boundary required by specification #70. Authorized online and replay batches are structurally validated before mutation, processed in causal order, and committed through transaction-local Event Game and Grant authority checks. Every definitive action outcome is paired with durable Control and Grant audit evidence.

Replay delivery now has durable reservations, attempts, keyed acknowledgement receipts, retry budgets, and exact restart recovery. Partial batches resume without premature acknowledgement, committed batches recover the same receipt, and Game Lock records only the permitted redacted discard tuple. Memory and SQLite adapters enforce the same readiness and rollback rules.

## Why

Controllers need to submit queued actions without acknowledging sporting state that was not authorized and durably committed. Earlier layers exposed Event Game and Grant primitives separately, which left race windows around revocation, rotation, expiry, scope changes, Game Lock, duplicate delivery, and lost responses.

The root cause was the absence of one fail-closed transaction boundary that owned both sporting acceptance and capability provenance. This layer provides that boundary and binds replay recovery to permanent, content-specific evidence.

## Impact

- Valid actions are acknowledged only after the Event Game mutation and linked Grant evidence commit together.
- Invalid authority and stale state fail generically without leaking record or scope details.
- Offline retries survive restart and return the same durable outcomes and receipt without duplicating audits.
- Revocation, full Grant rotation, expiry, scope drift, and Game Lock cannot race a stale action into accepted sporting state.
- Corrupt or incomplete acceptance evidence freezes further authoritative writes.

## Validation

- `bun install --frozen-lockfile`
- `bun audit` — no vulnerabilities
- `bun run check`
- `bun test --isolate` — 327 tests passed on the integrated result
- `bun run test:focused:acceptance` — 10 tests, 137 expectations
- `bun run test:focused:grant` — 36 tests, 388 expectations
- `bun run test:focused:sqlite` — 21 tests, 191 expectations
- `bun run build`
- `bun run build:executable`
- `git diff --check`

No Qualification Test and no `bun run check:sqlite-runtime` workload was run.

## Stack

This is the first open layer after the already merged #70 foundation stack and targets `main`. The forthcoming #78 Grant Code layer will be stacked on this branch after its independent acceptance and integration.

Closes #79.
