### PR TITLE
Keep production state outside release directories

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -52,9 +52,10 @@ jobs:
       - name: Prepare release bundle
         run: |
           set -euo pipefail
-          install -d release/deploy
+          install -d release/deploy/systemd
           install -m 755 dist/quadball-timer release/quadball-timer
           install -m 755 deploy/activate-release.sh release/deploy/activate-release.sh
+          install -m 644 deploy/systemd/quadball-timer.service release/deploy/systemd/quadball-timer.service
 
       - name: Upload release artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a

--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ deploy-quadball-timer ALL=NOPASSWD: /bin/systemctl restart quadball-timer
 The app itself binds to `127.0.0.1:3000`; public HTTPS and WebSocket traffic is
 terminated by Caddy and proxied to that localhost backend.
 
+Production state is separate from immutable releases. The systemd unit owns the
+private `/var/lib/quadball-timer` state directory. Technical Admin authority is
+stored in `technical-admin.sqlite`, while Event administration foundation data
+uses the separate `foundation.sqlite` file. Activation fails before switching a
+release when the installed unit does not provide this state contract.
+
 Pushes to `main` skip CI and deployment when every changed path is limited to
 `AGENTS.md`, `CONTEXT.md`, `README.md`, `docs/`, or `.github/dependabot.yml`.
 Files under `docs/` are also excluded from formatting, linting, and type-aware

--- a/deploy/activate-release.sh
+++ b/deploy/activate-release.sh
@@ -91,10 +91,42 @@ if [[ "$actual_exec_start" != *"$expected_exec_start"* ]]; then
   exit 1
 fi
 
+check_service_state_contract() {
+  local installed_unit
+  local required_directive
+  installed_unit="$(systemctl cat "$service_name" --no-pager 2>/dev/null || true)"
+  for required_directive in \
+    "StateDirectory=quadball-timer" \
+    "StateDirectoryMode=0750" \
+    "Environment=TECHNICAL_ADMIN_DATABASE=/var/lib/quadball-timer/technical-admin.sqlite" \
+    "Environment=FOUNDATION_DATABASE=/var/lib/quadball-timer/foundation.sqlite"
+  do
+    if ! grep -Fqx "$required_directive" <<<"$installed_unit"; then
+      echo "Systemd service ${service_name} is missing required Production state configuration: ${required_directive}" >&2
+      echo "Install ${release_dir}/deploy/systemd/quadball-timer.service and run systemctl daemon-reload before activation." >&2
+      return 1
+    fi
+  done
+}
+
+if ! check_service_state_contract; then
+  exit 1
+fi
+
 ln -sfn "$release_dir" "$current_link"
 
 restart_service() {
   sudo systemctl restart "$service_name"
+}
+
+report_service_state() {
+  local property
+  local value
+  echo "Service state after failed activation:" >&2
+  for property in ActiveState SubState Result ExecMainStatus; do
+    value="$(systemctl show "$service_name" --property="$property" --value 2>/dev/null || true)"
+    echo "  ${property}=${value:-<unavailable>}" >&2
+  done
 }
 
 check_health() {
@@ -132,6 +164,7 @@ if restart_service && check_health; then
   activate_release
 fi
 
+report_service_state
 echo "Deploy failed; attempting rollback." >&2
 if [[ -n "$previous_release" && -d "$previous_release" ]]; then
   ln -sfn "$previous_release" "$current_link"

--- a/deploy/activate-release.sh
+++ b/deploy/activate-release.sh
@@ -92,21 +92,22 @@ if [[ "$actual_exec_start" != *"$expected_exec_start"* ]]; then
 fi
 
 check_service_state_contract() {
-  local installed_unit
-  local required_directive
-  installed_unit="$(systemctl cat "$service_name" --no-pager 2>/dev/null || true)"
-  for required_directive in \
-    "StateDirectory=quadball-timer" \
-    "StateDirectoryMode=0750" \
-    "Environment=TECHNICAL_ADMIN_DATABASE=/var/lib/quadball-timer/technical-admin.sqlite" \
-    "Environment=FOUNDATION_DATABASE=/var/lib/quadball-timer/foundation.sqlite"
-  do
-    if ! grep -Fqx "$required_directive" <<<"$installed_unit"; then
-      echo "Systemd service ${service_name} is missing required Production state configuration: ${required_directive}" >&2
-      echo "Install ${release_dir}/deploy/systemd/quadball-timer.service and run systemctl daemon-reload before activation." >&2
-      return 1
-    fi
-  done
+  local effective_environment
+  local effective_state_directory
+  local effective_state_directory_mode
+  effective_state_directory="$(systemctl show "$service_name" --property=StateDirectory --value 2>/dev/null || true)"
+  effective_state_directory_mode="$(systemctl show "$service_name" --property=StateDirectoryMode --value 2>/dev/null || true)"
+  effective_environment="$(systemctl show "$service_name" --property=Environment --value 2>/dev/null || true)"
+
+  if [[ "$effective_state_directory" != "quadball-timer" ]] ||
+    [[ "$effective_state_directory_mode" != "0750" ]] ||
+    [[ " $effective_environment " != *" TECHNICAL_ADMIN_DATABASE=/var/lib/quadball-timer/technical-admin.sqlite "* ]] ||
+    [[ " $effective_environment " != *" FOUNDATION_DATABASE=/var/lib/quadball-timer/foundation.sqlite "* ]]
+  then
+    echo "Systemd service ${service_name} does not provide the required Production state contract." >&2
+    echo "Install ${release_dir}/deploy/systemd/quadball-timer.service and run systemctl daemon-reload before activation." >&2
+    return 1
+  fi
 }
 
 if ! check_service_state_contract; then

--- a/deploy/systemd/quadball-timer.service
+++ b/deploy/systemd/quadball-timer.service
@@ -10,6 +10,10 @@ WorkingDirectory=/srv/quadball-timer/current
 Environment=NODE_ENV=production
 Environment=HOST=127.0.0.1
 Environment=PORT=3000
+Environment=TECHNICAL_ADMIN_DATABASE=/var/lib/quadball-timer/technical-admin.sqlite
+Environment=FOUNDATION_DATABASE=/var/lib/quadball-timer/foundation.sqlite
+StateDirectory=quadball-timer
+StateDirectoryMode=0750
 ExecStart=/srv/quadball-timer/current/quadball-timer
 Restart=always
 RestartSec=3

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "event:catalog": "bun scripts/event-catalog.ts",
     "test:focused:technical-admin-browser": "bun scripts/test-technical-admin-browser.ts",
     "test:focused:technical-admin": "bun test --isolate ./src/lib/technical-admin-auth-sqlite.focused.ts",
+    "test:focused:startup": "bun test --isolate ./src/index-startup.focused.ts",
     "build": "bun run build.ts",
     "build:executable": "bun run build.ts --compile --compile-target=bun-linux-x64-modern --outfile=dist/quadball-timer",
     "check:sqlite-runtime": "bun scripts/check-sqlite-runtime.ts",

--- a/scripts/enroll-technical-admin.ts
+++ b/scripts/enroll-technical-admin.ts
@@ -3,11 +3,11 @@ import {
   createSqliteTechnicalAdminAuthRepository,
   createTechnicalAdminAuth,
 } from "@/lib/technical-admin-auth";
-import { readTechnicalAdminConfig } from "@/lib/technical-admin-config";
+import { readRuntimeConfig } from "@/lib/runtime-config";
 
-const config = readTechnicalAdminConfig();
+const { technicalAdmin: config, storagePaths } = readRuntimeConfig();
 const { environment } = config;
-const databasePath = config.databasePath ?? `data/${environment}/technical-admin.sqlite`;
+const databasePath = storagePaths.technicalAdminDatabase;
 
 const repository = createSqliteTechnicalAdminAuthRepository(databasePath, {
   environment,

--- a/scripts/event-catalog.ts
+++ b/scripts/event-catalog.ts
@@ -11,7 +11,7 @@ import {
   createTechnicalAdminAuth,
   type TechnicalAdminAuthority,
 } from "@/lib/technical-admin-auth";
-import { readTechnicalAdminConfig } from "@/lib/technical-admin-config";
+import { readRuntimeConfig } from "@/lib/runtime-config";
 
 const args = process.argv.slice(2);
 const databasePath = option("--db") ?? process.env.EVENT_CATALOG_DATABASE?.trim() ?? null;
@@ -43,7 +43,7 @@ try {
   if (!readiness.ok) throw new FoundationStorageNotReadyError(readiness);
   const catalog = createEventCatalog(createFoundationEventCatalogStorage(foundationStorage), {});
   hostAuth = createTechnicalAdminAuth(
-    readTechnicalAdminConfig(),
+    readRuntimeConfig().technicalAdmin,
     new MemoryTechnicalAdminAuthRepository(),
   );
   const result = await run(catalog, command, hostAuth);

--- a/scripts/reset-technical-admin.ts
+++ b/scripts/reset-technical-admin.ts
@@ -6,10 +6,10 @@ import {
   createTechnicalAdminAuth,
   type TechnicalAdminAuthRepository,
 } from "@/lib/technical-admin-auth";
-import { readTechnicalAdminConfig } from "@/lib/technical-admin-config";
+import { readRuntimeConfig } from "@/lib/runtime-config";
 
-const config = readTechnicalAdminConfig();
-const databasePath = config.databasePath ?? `data/${config.environment}/technical-admin.sqlite`;
+const { technicalAdmin: config, storagePaths } = readRuntimeConfig();
+const databasePath = storagePaths.technicalAdminDatabase;
 let repository: TechnicalAdminAuthRepository | undefined;
 let statusPrinted = false;
 

--- a/src/index-startup.focused.ts
+++ b/src/index-startup.focused.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 describe("server startup", () => {
-  test("starts a Production server from a read-only release with explicit writable state", async () => {
+  test("starts the production runtime from a read-only release with explicit Test state", async () => {
     const root = await mkdtemp(join(tmpdir(), "quadball-timer-startup-"));
     const releaseDirectory = join(root, "release");
     const stateDirectory = join(root, "state");
@@ -17,8 +17,8 @@ describe("server startup", () => {
       env: {
         ...process.env,
         NODE_ENV: "production",
-        QUADBALL_ENVIRONMENT: "production",
-        PUBLIC_ORIGIN: "https://timer.quadball.app",
+        QUADBALL_ENVIRONMENT: "test",
+        PUBLIC_ORIGIN: "https://localhost.test",
         TECHNICAL_ADMIN_DATABASE: join(stateDirectory, "technical-admin.sqlite"),
         FOUNDATION_DATABASE: join(stateDirectory, "foundation.sqlite"),
         HOST: "127.0.0.1",

--- a/src/index-startup.focused.ts
+++ b/src/index-startup.focused.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 describe("server startup", () => {
-  test("starts the production runtime from a read-only release with explicit Test state", async () => {
+  test("starts from a read-only release while an unready Foundation leaves health available", async () => {
     const root = await mkdtemp(join(tmpdir(), "quadball-timer-startup-"));
     const releaseDirectory = join(root, "release");
     const stateDirectory = join(root, "state");
@@ -41,6 +41,40 @@ describe("server startup", () => {
       server.kill();
       await server.exited;
       await chmod(releaseDirectory, 0o750);
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("keeps unrelated routes available when Foundation storage cannot be opened", async () => {
+    const root = await mkdtemp(join(tmpdir(), "quadball-timer-startup-"));
+    const stateDirectory = join(root, "state");
+    await mkdir(stateDirectory, { mode: 0o750 });
+    const server = Bun.spawn([process.execPath, "run", join(process.cwd(), "src/index.ts")], {
+      cwd: root,
+      env: {
+        NODE_ENV: "production",
+        QUADBALL_ENVIRONMENT: "test",
+        PUBLIC_ORIGIN: "https://localhost.test",
+        TECHNICAL_ADMIN_DATABASE: join(stateDirectory, "technical-admin.sqlite"),
+        FOUNDATION_DATABASE: join(root, "absent", "foundation.sqlite"),
+        HOST: "127.0.0.1",
+        PORT: "0",
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    try {
+      const serverUrl = await readServerUrl(server.stdout);
+      const health = await fetch(new URL("/internal/healthz", serverUrl), {
+        headers: { host: serverUrl.host },
+      });
+      const games = await fetch(new URL("/api/games", serverUrl));
+      expect(health.status).toBe(200);
+      expect(games.status).toBe(200);
+    } finally {
+      server.kill();
+      await server.exited;
       await rm(root, { recursive: true, force: true });
     }
   });

--- a/src/index-startup.focused.ts
+++ b/src/index-startup.focused.ts
@@ -11,29 +11,28 @@ describe("server startup", () => {
     await mkdir(releaseDirectory, { mode: 0o750 });
     await mkdir(stateDirectory, { mode: 0o750 });
     await chmod(releaseDirectory, 0o550);
-    const port = 39_000 + Math.floor(Math.random() * 500);
-    const server = Bun.spawn(["bun", "run", join(process.cwd(), "src/index.ts")], {
+    const server = Bun.spawn([process.execPath, "run", join(process.cwd(), "src/index.ts")], {
       cwd: releaseDirectory,
       env: {
-        ...process.env,
         NODE_ENV: "production",
         QUADBALL_ENVIRONMENT: "test",
         PUBLIC_ORIGIN: "https://localhost.test",
         TECHNICAL_ADMIN_DATABASE: join(stateDirectory, "technical-admin.sqlite"),
         FOUNDATION_DATABASE: join(stateDirectory, "foundation.sqlite"),
         HOST: "127.0.0.1",
-        PORT: String(port),
+        PORT: "0",
       },
       stdout: "pipe",
       stderr: "pipe",
     });
 
     try {
+      const serverUrl = await readServerUrl(server.stdout);
       let response: Response | null = null;
       for (let attempt = 0; attempt < 100; attempt += 1) {
         await Bun.sleep(25);
-        response = await fetch(`http://127.0.0.1:${port}/internal/healthz`, {
-          headers: { host: `127.0.0.1:${port}` },
+        response = await fetch(new URL("/internal/healthz", serverUrl), {
+          headers: { host: serverUrl.host },
         }).catch(() => null);
         if (response?.status === 200) break;
       }
@@ -46,3 +45,29 @@ describe("server startup", () => {
     }
   });
 });
+
+async function readServerUrl(stdout: ReadableStream<Uint8Array>): Promise<URL> {
+  const reader = stdout.getReader();
+  const decoder = new TextDecoder();
+  const readUrl = (async () => {
+    let output = "";
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) throw new Error("Server exited before reporting its bound URL.");
+      output += decoder.decode(value, { stream: true });
+      const match = output.match(/Server running at (http:\/\/[^\s]+)/);
+      if (match?.[1]) return new URL(match[1]);
+    }
+  })();
+
+  try {
+    return await Promise.race([
+      readUrl,
+      Bun.sleep(2_500).then(() => {
+        throw new Error("Server did not report its bound URL within 2.5 seconds.");
+      }),
+    ]);
+  } finally {
+    reader.releaseLock();
+  }
+}

--- a/src/index-startup.test.ts
+++ b/src/index-startup.test.ts
@@ -1,20 +1,26 @@
 import { describe, expect, test } from "bun:test";
-import { mkdtemp, rm } from "node:fs/promises";
-import { join } from "node:path";
+import { chmod, mkdir, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 describe("server startup", () => {
-  test("keeps shipped configuration available when the default catalog is not ready", async () => {
-    const directory = await mkdtemp(join(tmpdir(), "quadball-timer-startup-"));
+  test("starts a Production server from a read-only release with explicit writable state", async () => {
+    const root = await mkdtemp(join(tmpdir(), "quadball-timer-startup-"));
+    const releaseDirectory = join(root, "release");
+    const stateDirectory = join(root, "state");
+    await mkdir(releaseDirectory, { mode: 0o750 });
+    await mkdir(stateDirectory, { mode: 0o750 });
+    await chmod(releaseDirectory, 0o550);
     const port = 39_000 + Math.floor(Math.random() * 500);
     const server = Bun.spawn(["bun", "run", join(process.cwd(), "src/index.ts")], {
-      cwd: directory,
+      cwd: releaseDirectory,
       env: {
         ...process.env,
         NODE_ENV: "production",
         QUADBALL_ENVIRONMENT: "production",
         PUBLIC_ORIGIN: "https://timer.quadball.app",
-        TECHNICAL_ADMIN_DATABASE: join(directory, "technical-admin.sqlite"),
+        TECHNICAL_ADMIN_DATABASE: join(stateDirectory, "technical-admin.sqlite"),
+        FOUNDATION_DATABASE: join(stateDirectory, "foundation.sqlite"),
         HOST: "127.0.0.1",
         PORT: String(port),
       },
@@ -25,7 +31,7 @@ describe("server startup", () => {
     try {
       let response: Response | null = null;
       for (let attempt = 0; attempt < 100; attempt += 1) {
-        await Bun.sleep(50);
+        await Bun.sleep(25);
         response = await fetch(`http://127.0.0.1:${port}/internal/healthz`, {
           headers: { host: `127.0.0.1:${port}` },
         }).catch(() => null);
@@ -35,7 +41,8 @@ describe("server startup", () => {
     } finally {
       server.kill();
       await server.exited;
-      await rm(directory, { recursive: true, force: true });
+      await chmod(releaseDirectory, 0o750);
+      await rm(root, { recursive: true, force: true });
     }
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ import {
   type TechnicalAdminAuth,
   type TechnicalAdminAuthority,
 } from "@/lib/technical-admin-auth";
-import { readTechnicalAdminConfig } from "@/lib/technical-admin-config";
+import { readRuntimeConfig } from "@/lib/runtime-config";
 import {
   createEventCatalog,
   createFoundationEventCatalogStorage,
@@ -103,8 +103,8 @@ async function startServer() {
 
   try {
     const port = Number(process.env.PORT ?? 3000);
-    const technicalAdminConfig = readTechnicalAdminConfig();
-    const { environment, storagePaths } = technicalAdminConfig;
+    const { technicalAdmin: technicalAdminConfig, storagePaths } = readRuntimeConfig();
+    const { environment } = technicalAdminConfig;
     assertProductionStateBoundary(environment, storagePaths);
     const databasePath = storagePaths.technicalAdminDatabase;
     technicalAdminRepository = createSqliteTechnicalAdminAuthRepository(databasePath, {

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,10 @@ import {
 import { createInMemoryFoundationStorage } from "@/lib/foundation-storage-memory";
 import { openSqliteFoundationStorage } from "@/lib/foundation-storage-sqlite";
 import type { FoundationStorage } from "@/lib/foundation-storage";
+import {
+  assertProductionStateBoundary,
+  readRuntimeStoragePaths,
+} from "@/lib/runtime-storage-config";
 import { createStartupCleanup } from "@/lib/startup-resources";
 
 type ManagedGame = {
@@ -104,8 +108,9 @@ async function startServer() {
     const port = Number(process.env.PORT ?? 3000);
     const technicalAdminConfig = readTechnicalAdminConfig();
     const { environment } = technicalAdminConfig;
-    const databasePath =
-      technicalAdminConfig.databasePath ?? `data/${environment}/technical-admin.sqlite`;
+    const storagePaths = readRuntimeStoragePaths(environment);
+    assertProductionStateBoundary(environment, storagePaths);
+    const databasePath = technicalAdminConfig.databasePath ?? storagePaths.technicalAdminDatabase;
     technicalAdminRepository = createSqliteTechnicalAdminAuthRepository(databasePath, {
       environment: technicalAdminConfig.environment,
       origin: technicalAdminConfig.origin,
@@ -120,8 +125,7 @@ async function startServer() {
     technicalAdminAuth.storageStatus();
     technicalAdminAuth.startRetentionMaintenance(createTechnicalAdminRetentionScheduler());
 
-    const foundationDatabasePath =
-      process.env.FOUNDATION_DATABASE?.trim() || `data/${environment}/foundation.sqlite`;
+    const foundationDatabasePath = storagePaths.foundationDatabase;
     let eventCatalogStorage;
     let candidateFoundation: FoundationStorage | undefined;
     try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,10 +41,7 @@ import {
 import { createInMemoryFoundationStorage } from "@/lib/foundation-storage-memory";
 import { openSqliteFoundationStorage } from "@/lib/foundation-storage-sqlite";
 import type { FoundationStorage } from "@/lib/foundation-storage";
-import {
-  assertProductionStateBoundary,
-  readRuntimeStoragePaths,
-} from "@/lib/runtime-storage-config";
+import { assertProductionStateBoundary } from "@/lib/runtime-storage-config";
 import { createStartupCleanup } from "@/lib/startup-resources";
 
 type ManagedGame = {
@@ -107,10 +104,9 @@ async function startServer() {
   try {
     const port = Number(process.env.PORT ?? 3000);
     const technicalAdminConfig = readTechnicalAdminConfig();
-    const { environment } = technicalAdminConfig;
-    const storagePaths = readRuntimeStoragePaths(environment);
+    const { environment, storagePaths } = technicalAdminConfig;
     assertProductionStateBoundary(environment, storagePaths);
-    const databasePath = technicalAdminConfig.databasePath ?? storagePaths.technicalAdminDatabase;
+    const databasePath = storagePaths.technicalAdminDatabase;
     technicalAdminRepository = createSqliteTechnicalAdminAuthRepository(databasePath, {
       environment: technicalAdminConfig.environment,
       origin: technicalAdminConfig.origin,

--- a/src/lib/runtime-config.ts
+++ b/src/lib/runtime-config.ts
@@ -1,0 +1,16 @@
+import type { TechnicalAdminAuthConfig } from "@/lib/technical-admin-auth";
+import { readTechnicalAdminConfig } from "@/lib/technical-admin-config";
+import { readRuntimeStoragePaths, type RuntimeStoragePaths } from "@/lib/runtime-storage-config";
+
+export type RuntimeConfig = {
+  technicalAdmin: TechnicalAdminAuthConfig;
+  storagePaths: RuntimeStoragePaths;
+};
+
+export function readRuntimeConfig(
+  environmentVariables: Record<string, string | undefined> = process.env,
+): RuntimeConfig {
+  const technicalAdmin = readTechnicalAdminConfig(environmentVariables);
+  const storagePaths = readRuntimeStoragePaths(technicalAdmin.environment, environmentVariables);
+  return { technicalAdmin, storagePaths };
+}

--- a/src/lib/runtime-storage-config.test.ts
+++ b/src/lib/runtime-storage-config.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test";
+import { chmodSync, mkdtempSync, mkdirSync, rmSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  assertProductionStateBoundary,
+  readRuntimeStoragePaths,
+} from "@/lib/runtime-storage-config";
+
+describe("runtime storage configuration", () => {
+  test("keeps both Production databases in the canonical systemd state directory", () => {
+    expect(readRuntimeStoragePaths("production", {})).toEqual({
+      technicalAdminDatabase: "/var/lib/quadball-timer/technical-admin.sqlite",
+      foundationDatabase: "/var/lib/quadball-timer/foundation.sqlite",
+    });
+  });
+
+  test("keeps Test defaults isolated from Production state", () => {
+    expect(readRuntimeStoragePaths("test", {})).toEqual({
+      technicalAdminDatabase: "data/test/technical-admin.sqlite",
+      foundationDatabase: "data/test/foundation.sqlite",
+    });
+  });
+
+  test("honors explicit storage paths for disposable startup environments", () => {
+    expect(
+      readRuntimeStoragePaths("production", {
+        TECHNICAL_ADMIN_DATABASE: "/tmp/timer-test/technical-admin.sqlite",
+        FOUNDATION_DATABASE: "/tmp/timer-test/foundation.sqlite",
+      }),
+    ).toEqual({
+      technicalAdminDatabase: "/tmp/timer-test/technical-admin.sqlite",
+      foundationDatabase: "/tmp/timer-test/foundation.sqlite",
+    });
+  });
+
+  test("accepts one private writable Production state directory", () => {
+    const directory = mkdtempSync(join(tmpdir(), "quadball-timer-state-"));
+    chmodSync(directory, 0o750);
+
+    try {
+      expect(() =>
+        assertProductionStateBoundary("production", {
+          technicalAdminDatabase: join(directory, "technical-admin.sqlite"),
+          foundationDatabase: join(directory, "foundation.sqlite"),
+        }),
+      ).not.toThrow();
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects absent, shared, or symlinked Production state directories", () => {
+    const root = mkdtempSync(join(tmpdir(), "quadball-timer-state-"));
+    const missing = join(root, "missing");
+    const shared = join(root, "shared");
+    const privateDirectory = join(root, "private");
+    const linked = join(root, "linked");
+    mkdirSync(shared, { mode: 0o770 });
+    chmodSync(shared, 0o770);
+    mkdirSync(privateDirectory, { mode: 0o750 });
+    symlinkSync(privateDirectory, linked);
+
+    try {
+      for (const directory of [missing, shared, linked]) {
+        expect(() =>
+          assertProductionStateBoundary("production", {
+            technicalAdminDatabase: join(directory, "technical-admin.sqlite"),
+            foundationDatabase: join(directory, "foundation.sqlite"),
+          }),
+        ).toThrow("Production state directory");
+      }
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("requires both Production databases to share one absolute state directory", () => {
+    expect(() =>
+      assertProductionStateBoundary("production", {
+        technicalAdminDatabase: "/var/lib/quadball-timer/technical-admin.sqlite",
+        foundationDatabase: "/srv/quadball-timer/foundation.sqlite",
+      }),
+    ).toThrow("one state directory");
+  });
+});

--- a/src/lib/runtime-storage-config.test.ts
+++ b/src/lib/runtime-storage-config.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { chmodSync, mkdtempSync, mkdirSync, rmSync, symlinkSync } from "node:fs";
+import { chmodSync, mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -22,9 +22,18 @@ describe("runtime storage configuration", () => {
     });
   });
 
-  test("honors explicit storage paths for disposable startup environments", () => {
-    expect(
+  test("rejects Production storage overrides outside the canonical state directory", () => {
+    expect(() =>
       readRuntimeStoragePaths("production", {
+        TECHNICAL_ADMIN_DATABASE: "/tmp/timer-test/technical-admin.sqlite",
+        FOUNDATION_DATABASE: "/tmp/timer-test/foundation.sqlite",
+      }),
+    ).toThrow("canonical path");
+  });
+
+  test("honors explicit storage paths for disposable Test environments", () => {
+    expect(
+      readRuntimeStoragePaths("test", {
         TECHNICAL_ADMIN_DATABASE: "/tmp/timer-test/technical-admin.sqlite",
         FOUNDATION_DATABASE: "/tmp/timer-test/foundation.sqlite",
       }),
@@ -82,5 +91,31 @@ describe("runtime storage configuration", () => {
         foundationDatabase: "/srv/quadball-timer/foundation.sqlite",
       }),
     ).toThrow("one state directory");
+  });
+
+  test("rejects an unsafe existing Technical Admin database before startup", () => {
+    const root = mkdtempSync(join(tmpdir(), "quadball-timer-state-"));
+    const unsafeDatabase = join(root, "unsafe.sqlite");
+    const linkedDatabase = join(root, "linked.sqlite");
+    const linkTarget = join(root, "target.sqlite");
+    chmodSync(root, 0o750);
+    writeFileSync(unsafeDatabase, "");
+    chmodSync(unsafeDatabase, 0o660);
+    writeFileSync(linkTarget, "");
+    chmodSync(linkTarget, 0o640);
+    symlinkSync(linkTarget, linkedDatabase);
+
+    try {
+      for (const technicalAdminDatabase of [unsafeDatabase, linkedDatabase]) {
+        expect(() =>
+          assertProductionStateBoundary("production", {
+            technicalAdminDatabase,
+            foundationDatabase: join(root, "foundation.sqlite"),
+          }),
+        ).toThrow("Technical Admin database");
+      }
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });

--- a/src/lib/runtime-storage-config.ts
+++ b/src/lib/runtime-storage-config.ts
@@ -1,0 +1,69 @@
+import { accessSync, constants, lstatSync } from "node:fs";
+import { dirname, isAbsolute } from "node:path";
+import type { TechnicalAdminEnvironment } from "@/lib/technical-admin-auth";
+
+export const PRODUCTION_STATE_DIRECTORY = "/var/lib/quadball-timer";
+
+export type RuntimeStoragePaths = {
+  technicalAdminDatabase: string;
+  foundationDatabase: string;
+};
+
+export function readRuntimeStoragePaths(
+  environment: TechnicalAdminEnvironment,
+  environmentVariables: Record<string, string | undefined> = process.env,
+): RuntimeStoragePaths {
+  const defaultDirectory =
+    environment === "production" ? PRODUCTION_STATE_DIRECTORY : `data/${environment}`;
+
+  return {
+    technicalAdminDatabase:
+      environmentVariables.TECHNICAL_ADMIN_DATABASE?.trim() ||
+      `${defaultDirectory}/technical-admin.sqlite`,
+    foundationDatabase:
+      environmentVariables.FOUNDATION_DATABASE?.trim() || `${defaultDirectory}/foundation.sqlite`,
+  };
+}
+
+export function assertProductionStateBoundary(
+  environment: TechnicalAdminEnvironment,
+  paths: RuntimeStoragePaths,
+): void {
+  if (environment !== "production") return;
+
+  if (!isAbsolute(paths.technicalAdminDatabase) || !isAbsolute(paths.foundationDatabase)) {
+    throw new Error("Production database paths must be absolute.");
+  }
+
+  const technicalAdminDirectory = dirname(paths.technicalAdminDatabase);
+  const foundationDirectory = dirname(paths.foundationDatabase);
+  if (technicalAdminDirectory !== foundationDirectory) {
+    throw new Error("Production databases must use one state directory.");
+  }
+
+  let stateDirectory;
+  try {
+    stateDirectory = lstatSync(technicalAdminDirectory);
+  } catch {
+    throw new Error("Production state directory is absent or inaccessible.");
+  }
+
+  if (!stateDirectory.isDirectory() || stateDirectory.isSymbolicLink()) {
+    throw new Error("Production state directory must be a real directory.");
+  }
+
+  if ((stateDirectory.mode & 0o022) !== 0) {
+    throw new Error("Production state directory permissions are unsafe.");
+  }
+
+  const currentUserId = process.getuid?.();
+  if (currentUserId !== undefined && stateDirectory.uid !== currentUserId) {
+    throw new Error("Production state directory has the wrong owner.");
+  }
+
+  try {
+    accessSync(technicalAdminDirectory, constants.R_OK | constants.W_OK | constants.X_OK);
+  } catch {
+    throw new Error("Production state directory is not readable and writable by the service.");
+  }
+}

--- a/src/lib/runtime-storage-config.ts
+++ b/src/lib/runtime-storage-config.ts
@@ -13,8 +13,25 @@ export function readRuntimeStoragePaths(
   environment: TechnicalAdminEnvironment,
   environmentVariables: Record<string, string | undefined> = process.env,
 ): RuntimeStoragePaths {
-  const defaultDirectory =
-    environment === "production" ? PRODUCTION_STATE_DIRECTORY : `data/${environment}`;
+  if (environment === "production") {
+    const canonicalPaths = {
+      technicalAdminDatabase: `${PRODUCTION_STATE_DIRECTORY}/technical-admin.sqlite`,
+      foundationDatabase: `${PRODUCTION_STATE_DIRECTORY}/foundation.sqlite`,
+    };
+    requireCanonicalProductionPath(
+      "TECHNICAL_ADMIN_DATABASE",
+      environmentVariables.TECHNICAL_ADMIN_DATABASE,
+      canonicalPaths.technicalAdminDatabase,
+    );
+    requireCanonicalProductionPath(
+      "FOUNDATION_DATABASE",
+      environmentVariables.FOUNDATION_DATABASE,
+      canonicalPaths.foundationDatabase,
+    );
+    return canonicalPaths;
+  }
+
+  const defaultDirectory = `data/${environment}`;
 
   return {
     technicalAdminDatabase:
@@ -66,4 +83,54 @@ export function assertProductionStateBoundary(
   } catch {
     throw new Error("Production state directory is not readable and writable by the service.");
   }
+
+  assertTechnicalAdminDatabaseFile(paths.technicalAdminDatabase, currentUserId);
+}
+
+function requireCanonicalProductionPath(
+  variableName: string,
+  configuredPath: string | undefined,
+  canonicalPath: string,
+): void {
+  const normalizedPath = configuredPath?.trim();
+  if (normalizedPath !== undefined && normalizedPath !== "" && normalizedPath !== canonicalPath) {
+    throw new Error(`${variableName} must use its canonical path ${canonicalPath}.`);
+  }
+}
+
+function assertTechnicalAdminDatabaseFile(
+  databasePath: string,
+  currentUserId: number | undefined,
+): void {
+  let databaseFile;
+  try {
+    databaseFile = lstatSync(databasePath);
+  } catch (error) {
+    if (isMissingPath(error)) return;
+    throw new Error("Technical Admin database is inaccessible.");
+  }
+
+  if (!databaseFile.isFile() || databaseFile.isSymbolicLink()) {
+    throw new Error("Technical Admin database must be a regular file.");
+  }
+  if ((databaseFile.mode & 0o022) !== 0) {
+    throw new Error("Technical Admin database permissions are unsafe.");
+  }
+  if (currentUserId !== undefined && databaseFile.uid !== currentUserId) {
+    throw new Error("Technical Admin database has the wrong owner.");
+  }
+  try {
+    accessSync(databasePath, constants.R_OK | constants.W_OK);
+  } catch {
+    throw new Error("Technical Admin database is not readable and writable by the service.");
+  }
+}
+
+function isMissingPath(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { code?: unknown }).code === "ENOENT"
+  );
 }

--- a/src/lib/technical-admin-config.ts
+++ b/src/lib/technical-admin-config.ts
@@ -2,6 +2,7 @@ import type {
   TechnicalAdminAuthConfig,
   TechnicalAdminEnvironment,
 } from "@/lib/technical-admin-auth";
+import { readRuntimeStoragePaths } from "@/lib/runtime-storage-config";
 
 export function readTechnicalAdminConfig(
   environmentVariables: Record<string, string | undefined> = process.env,
@@ -18,8 +19,10 @@ export function readTechnicalAdminConfig(
     environmentVariables.PUBLIC_ORIGIN ??
     (environment === "test" ? `https://localhost:${port}` : "https://timer.quadball.app");
   const rpId = environmentVariables.WEBAUTHN_RP_ID ?? new URL(origin).hostname;
-  const databasePath =
-    environmentVariables.TECHNICAL_ADMIN_DATABASE ?? `data/${environment}/technical-admin.sqlite`;
+  const databasePath = readRuntimeStoragePaths(
+    environment,
+    environmentVariables,
+  ).technicalAdminDatabase;
   const logKey = environmentVariables.TECHNICAL_ADMIN_LOG_KEY;
   const trustProxyHeaders = environmentVariables.TRUSTED_PROXY_HEADERS === "true";
   return { environment, origin, rpId, databasePath, logKey, trustProxyHeaders };

--- a/src/lib/technical-admin-config.ts
+++ b/src/lib/technical-admin-config.ts
@@ -3,10 +3,15 @@ import type {
   TechnicalAdminEnvironment,
 } from "@/lib/technical-admin-auth";
 import { readRuntimeStoragePaths } from "@/lib/runtime-storage-config";
+import type { RuntimeStoragePaths } from "@/lib/runtime-storage-config";
+
+export type TechnicalAdminRuntimeConfig = TechnicalAdminAuthConfig & {
+  storagePaths: RuntimeStoragePaths;
+};
 
 export function readTechnicalAdminConfig(
   environmentVariables: Record<string, string | undefined> = process.env,
-): TechnicalAdminAuthConfig {
+): TechnicalAdminRuntimeConfig {
   const port = Number(environmentVariables.PORT ?? 3000);
   const environment: TechnicalAdminEnvironment =
     environmentVariables.QUADBALL_ENVIRONMENT === "production"
@@ -19,11 +24,9 @@ export function readTechnicalAdminConfig(
     environmentVariables.PUBLIC_ORIGIN ??
     (environment === "test" ? `https://localhost:${port}` : "https://timer.quadball.app");
   const rpId = environmentVariables.WEBAUTHN_RP_ID ?? new URL(origin).hostname;
-  const databasePath = readRuntimeStoragePaths(
-    environment,
-    environmentVariables,
-  ).technicalAdminDatabase;
+  const storagePaths = readRuntimeStoragePaths(environment, environmentVariables);
+  const databasePath = storagePaths.technicalAdminDatabase;
   const logKey = environmentVariables.TECHNICAL_ADMIN_LOG_KEY;
   const trustProxyHeaders = environmentVariables.TRUSTED_PROXY_HEADERS === "true";
-  return { environment, origin, rpId, databasePath, logKey, trustProxyHeaders };
+  return { environment, origin, rpId, databasePath, logKey, trustProxyHeaders, storagePaths };
 }

--- a/src/lib/technical-admin-config.ts
+++ b/src/lib/technical-admin-config.ts
@@ -2,16 +2,10 @@ import type {
   TechnicalAdminAuthConfig,
   TechnicalAdminEnvironment,
 } from "@/lib/technical-admin-auth";
-import { readRuntimeStoragePaths } from "@/lib/runtime-storage-config";
-import type { RuntimeStoragePaths } from "@/lib/runtime-storage-config";
-
-export type TechnicalAdminRuntimeConfig = TechnicalAdminAuthConfig & {
-  storagePaths: RuntimeStoragePaths;
-};
 
 export function readTechnicalAdminConfig(
   environmentVariables: Record<string, string | undefined> = process.env,
-): TechnicalAdminRuntimeConfig {
+): TechnicalAdminAuthConfig {
   const port = Number(environmentVariables.PORT ?? 3000);
   const environment: TechnicalAdminEnvironment =
     environmentVariables.QUADBALL_ENVIRONMENT === "production"
@@ -24,9 +18,7 @@ export function readTechnicalAdminConfig(
     environmentVariables.PUBLIC_ORIGIN ??
     (environment === "test" ? `https://localhost:${port}` : "https://timer.quadball.app");
   const rpId = environmentVariables.WEBAUTHN_RP_ID ?? new URL(origin).hostname;
-  const storagePaths = readRuntimeStoragePaths(environment, environmentVariables);
-  const databasePath = storagePaths.technicalAdminDatabase;
   const logKey = environmentVariables.TECHNICAL_ADMIN_LOG_KEY;
   const trustProxyHeaders = environmentVariables.TRUSTED_PROXY_HEADERS === "true";
-  return { environment, origin, rpId, databasePath, logKey, trustProxyHeaders, storagePaths };
+  return { environment, origin, rpId, logKey, trustProxyHeaders };
 }

--- a/src/production-deployment.test.ts
+++ b/src/production-deployment.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const repositoryRoot = process.cwd();
+
+describe("Production deployment contract", () => {
+  test("gives the service one private persistent state directory", () => {
+    const unit = readFileSync(
+      join(repositoryRoot, "deploy/systemd/quadball-timer.service"),
+      "utf8",
+    );
+
+    expect(unit).toContain("StateDirectory=quadball-timer");
+    expect(unit).toContain("StateDirectoryMode=0750");
+    expect(unit).toContain(
+      "Environment=TECHNICAL_ADMIN_DATABASE=/var/lib/quadball-timer/technical-admin.sqlite",
+    );
+    expect(unit).toContain(
+      "Environment=FOUNDATION_DATABASE=/var/lib/quadball-timer/foundation.sqlite",
+    );
+  });
+
+  test("ships the canonical unit with every release", () => {
+    const workflow = readFileSync(
+      join(repositoryRoot, ".github/workflows/deploy-production.yml"),
+      "utf8",
+    );
+
+    expect(workflow).toContain(
+      "install -m 644 deploy/systemd/quadball-timer.service release/deploy/systemd/quadball-timer.service",
+    );
+  });
+
+  test("reports bounded non-secret service state when activation fails", () => {
+    const activation = readFileSync(join(repositoryRoot, "deploy/activate-release.sh"), "utf8");
+
+    expect(activation).toContain("for property in ActiveState SubState Result ExecMainStatus");
+    expect(activation).toContain('--property="$property"');
+    expect(activation).not.toContain("journalctl");
+  });
+
+  test("refuses activation until the installed unit owns Production state", () => {
+    const activation = readFileSync(join(repositoryRoot, "deploy/activate-release.sh"), "utf8");
+
+    expect(activation).toContain("check_service_state_contract");
+    expect(activation).toContain("missing required Production state configuration");
+    expect(activation).toContain(
+      "Install ${release_dir}/deploy/systemd/quadball-timer.service and run systemctl daemon-reload before activation.",
+    );
+  });
+});

--- a/src/production-deployment.test.ts
+++ b/src/production-deployment.test.ts
@@ -44,7 +44,15 @@ describe("Production deployment contract", () => {
     const activation = readFileSync(join(repositoryRoot, "deploy/activate-release.sh"), "utf8");
 
     expect(activation).toContain("check_service_state_contract");
-    expect(activation).toContain("missing required Production state configuration");
+    expect(activation).toContain(
+      'systemctl show "$service_name" --property=StateDirectory --value',
+    );
+    expect(activation).toContain(
+      'systemctl show "$service_name" --property=StateDirectoryMode --value',
+    );
+    expect(activation).toContain('systemctl show "$service_name" --property=Environment --value');
+    expect(activation).not.toContain('systemctl cat "$service_name"');
+    expect(activation).toContain("does not provide the required Production state contract");
     expect(activation).toContain(
       "Install ${release_dir}/deploy/systemd/quadball-timer.service and run systemctl daemon-reload before activation.",
     );


### PR DESCRIPTION
## Outcome

Keeps Production SQLite state outside immutable release directories so the systemd service can start after Technical Admin authentication was merged, while preserving #108 bounded Event Catalog unavailability.

## Root cause

Implementation #106 introduced a default `data/production/technical-admin.sqlite` path relative to `/srv/quadball-timer/current`. Releases are owned by the deploy user while the service runs as `quadball-timer`, so startup exited with `EACCES: permission denied, mkdir data` before binding port 3000. PR #129 was the first merge that carried the stacked change to `main`.

## What changed

- Defines one systemd-managed `/var/lib/quadball-timer` state directory with mode `0750`.
- Requires the exact separate `technical-admin.sqlite` and `foundation.sqlite` Production paths and rejects overrides.
- Rejects absent, shared-writable, symlinked, split, wrong-owner, or inaccessible Production state before binding, including unsafe existing Technical Admin database files.
- Preserves #108 behavior: unready or unopenable Foundation storage fails the Event Catalog closed while health and unrelated routes remain available.
- Resolves cross-subsystem storage through a neutral runtime configuration aggregate.
- Ships the canonical systemd unit in every release artifact.
- Refuses activation unless effective loaded systemd properties expose the persistent-state contract, including drop-in overrides.
- Emits bounded systemd state diagnostics without journal or secret output when activation fails.
- Adds deterministic Fast configuration tests plus a separately routed Focused Integration Test for read-only-release startup and bounded Foundation failures.

## Operational evidence

The privileged unit gate passed before readiness:

- staged unit checksum verified
- `StateDirectory=quadball-timer` and `StateDirectoryMode=0750`
- exact Technical Admin and Foundation environment paths
- `/var/lib/quadball-timer` owned by `quadball-timer:quadball-timer` with mode `0750`
- restart persistence check passed
- service active/running with zero restarts and successful main process
- port 3000 bound on loopback
- internal and public health passed after the immediate restart readiness race

The exact hotfix artifact still requires the normal merge-triggered deployment and post-deploy verification.

## Validation

- `bun run check`
- `bun run test` — 351 passed, 0 failed, 14,405 assertions
- `bun run test:focused:startup` — 2 passed, 0 failed
- `bun run build`
- `bun run build:executable`
- `git diff --check`
- Standards and Spec review: PASS at `bf4a0fb13ea8ab4e9ec576ab96a954759b69ec23` against `origin/main` `07b3d8ffaeb61b06422a468365748b9c286c8aa6`

No Qualification Test was run.
