### PR TITLE
Hand off Event Admin authority

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,12 +12,14 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^1.14.0",
+        "qrcode": "^1.5.4",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
         "tailwind-merge": "^3.5.0",
       },
       "devDependencies": {
         "@types/bun": "1.3.14",
+        "@types/qrcode": "^1.5.6",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "happy-dom": "20.11.2",
@@ -217,6 +219,8 @@
 
     "@types/node": ["@types/node@25.3.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A=="],
 
+    "@types/qrcode": ["@types/qrcode@1.5.6", "", { "dependencies": { "@types/node": "*" } }, "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw=="],
+
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
@@ -224,6 +228,10 @@
     "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "aria-hidden": ["aria-hidden@1.2.6", "", { "dependencies": { "tslib": "^2.0.0" } }, "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA=="],
 
@@ -235,21 +243,43 @@
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
+    "camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
+
     "class-variance-authority": ["class-variance-authority@0.7.1", "", { "dependencies": { "clsx": "^2.1.1" } }, "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg=="],
+
+    "cliui": ["cliui@6.0.0", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^6.2.0" } }, "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ=="],
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
+    "decamelize": ["decamelize@1.2.0", "", {}, "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="],
 
     "detect-node-es": ["detect-node-es@1.1.0", "", {}, "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="],
 
+    "dijkstrajs": ["dijkstrajs@1.0.3", "", {}, "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA=="],
+
+    "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
     "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
+    "find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
+
     "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+
+    "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
 
     "get-nonce": ["get-nonce@1.0.1", "", {}, "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q=="],
 
     "happy-dom": ["happy-dom@20.11.2", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "buffer-image-size": "^0.6.4", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.21.0" } }, "sha512-7MB+bJLkxu3SowAfBJbjW+c55kNz5tkR45gu2qzrxznezhLeN5YIlJbwUgSzlGc+qWoZ8Ykg71H5ezz69xixrw=="],
+
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 
     "lucide-react": ["lucide-react@1.14.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-+1mdWcfSJVUsaTIjN9zoezmUhfXo5l0vP7ekBMPo3jcS/aIkxHnXqAPsByszMZx/Y8oQBRJxJx5xg+RH3urzxA=="],
 
@@ -259,9 +289,21 @@
 
     "oxlint-tsgolint": ["oxlint-tsgolint@7.0.2001", "", { "optionalDependencies": { "@oxlint-tsgolint/darwin-arm64": "7.0.2001", "@oxlint-tsgolint/darwin-x64": "7.0.2001", "@oxlint-tsgolint/linux-arm64": "7.0.2001", "@oxlint-tsgolint/linux-x64": "7.0.2001", "@oxlint-tsgolint/win32-arm64": "7.0.2001", "@oxlint-tsgolint/win32-x64": "7.0.2001" }, "bin": { "tsgolint": "./bin/tsgolint.js" } }, "sha512-KjK/XLcXr1DSyonKhsuFqJRiuKqcyG9j3LJ8nkOsrLzGvodBPqzHOKauy10asLMDI0sUpvb+1sxlzff3udZvfg=="],
 
+    "p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
+
+    "p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
+
+    "p-try": ["p-try@2.2.0", "", {}, "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="],
+
+    "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
+
     "playwright": ["playwright@1.62.1", "", { "dependencies": { "playwright-core": "1.62.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg=="],
 
     "playwright-core": ["playwright-core@1.62.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw=="],
+
+    "pngjs": ["pngjs@5.0.0", "", {}, "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw=="],
+
+    "qrcode": ["qrcode@1.5.4", "", { "dependencies": { "dijkstrajs": "^1.0.1", "pngjs": "^5.0.0", "yargs": "^15.3.1" }, "bin": { "qrcode": "bin/qrcode" } }, "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg=="],
 
     "react": ["react@19.2.6", "", {}, "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q=="],
 
@@ -273,7 +315,17 @@
 
     "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
 
+    "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
+
+    "require-main-filename": ["require-main-filename@2.0.0", "", {}, "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="],
+
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
+    "set-blocking": ["set-blocking@2.0.0", "", {}, "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="],
+
+    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "tailwind-merge": ["tailwind-merge@3.5.0", "", {}, "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A=="],
 
@@ -293,7 +345,17 @@
 
     "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
 
+    "which-module": ["which-module@2.0.1", "", {}, "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ=="],
+
+    "wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
+
     "ws": ["ws@8.21.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw=="],
+
+    "y18n": ["y18n@4.0.3", "", {}, "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="],
+
+    "yargs": ["yargs@15.4.1", "", { "dependencies": { "cliui": "^6.0.0", "decamelize": "^1.2.0", "find-up": "^4.1.0", "get-caller-file": "^2.0.1", "require-directory": "^2.1.1", "require-main-filename": "^2.0.0", "set-blocking": "^2.0.0", "string-width": "^4.2.0", "which-module": "^2.0.0", "y18n": "^4.0.0", "yargs-parser": "^18.1.2" } }, "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A=="],
+
+    "yargs-parser": ["yargs-parser@18.1.3", "", { "dependencies": { "camelcase": "^5.0.0", "decamelize": "^1.2.0" } }, "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ=="],
 
     "@radix-ui/react-arrow/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "admin:enroll": "bun scripts/enroll-technical-admin.ts",
     "admin:reset": "bun scripts/reset-technical-admin.ts",
     "event:catalog": "bun scripts/event-catalog.ts",
+    "event:admin": "bun scripts/event-admin.ts",
     "test:focused:technical-admin-browser": "bun scripts/test-technical-admin-browser.ts",
     "test:focused:technical-admin": "bun test --isolate ./src/lib/technical-admin-auth-sqlite.focused.ts",
     "test:focused:startup": "bun test --isolate ./src/index-startup.focused.ts",
@@ -40,12 +41,14 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.14.0",
+    "qrcode": "^1.5.4",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "tailwind-merge": "^3.5.0"
   },
   "devDependencies": {
     "@types/bun": "1.3.14",
+    "@types/qrcode": "^1.5.6",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "happy-dom": "20.11.2",

--- a/scripts/event-admin-cli.focused.ts
+++ b/scripts/event-admin-cli.focused.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createEventCatalog, createFoundationEventCatalogStorage } from "@/lib/event-catalog";
+import { openSqliteFoundationStorage } from "@/lib/foundation-storage-sqlite";
+import {
+  MemoryTechnicalAdminAuthRepository,
+  createTechnicalAdminAuth,
+} from "@/lib/technical-admin-auth";
+
+describe("Event Admin CLI", () => {
+  test("manages a Grant without accepting or exposing its raw credential", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "quadball-event-admin-cli-"));
+    const databasePath = join(directory, "foundation.sqlite");
+    try {
+      const foundation = openSqliteFoundationStorage(databasePath);
+      await foundation.applyMigrations();
+      const technical = createTechnicalAdminAuth(
+        { environment: "test", origin: "https://timer.example", rpId: "timer.example" },
+        new MemoryTechnicalAdminAuthRepository(),
+      ).resolveHostLocalAuthority();
+      const catalog = createEventCatalog(createFoundationEventCatalogStorage(foundation), {});
+      const event = await catalog.createEvent({ name: "CLI Event", timeZone: "UTC" }, technical);
+      if (event.status !== "accepted") throw new Error("Expected Event.");
+      await catalog.addGameDay(event.value.eventId, { date: "2026-08-14" }, technical);
+      foundation.close();
+
+      const created = await runCli(databasePath, "create", "--event-id", event.value.eventId);
+      expect(created.exitCode).toBe(0);
+      expect(created.output).toMatchObject({ status: "accepted", value: { status: "active" } });
+      expect(JSON.stringify(created.output)).not.toContain("qrCredential");
+
+      const status = await runCli(databasePath, "status", "--event-id", event.value.eventId);
+      expect(status).toMatchObject({
+        exitCode: 0,
+        output: { status: "accepted", value: { status: "active" } },
+      });
+
+      const reveal = await runCli(databasePath, "reveal", "--event-id", event.value.eventId);
+      expect(reveal.exitCode).not.toBe(0);
+      expect(reveal.output).toMatchObject({ status: "rejected", reason: "invalid-input" });
+      expect(JSON.stringify(reveal.output)).not.toContain("qrCredential");
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+});
+
+async function runCli(databasePath: string, ...args: string[]) {
+  const child = Bun.spawn(["bun", "run", "event:admin", "--", "--db", databasePath, ...args], {
+    cwd: process.cwd(),
+    env: { ...process.env, NODE_ENV: "test", QUADBALL_ENVIRONMENT: "test" },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const stdout = await new Response(child.stdout as unknown as BodyInit).text();
+  const stderr = await new Response(child.stderr as unknown as BodyInit).text();
+  const exitCode = await child.exited;
+  return { exitCode, stderr, output: JSON.parse(stdout.trim()) as Record<string, unknown> };
+}

--- a/scripts/event-admin.ts
+++ b/scripts/event-admin.ts
@@ -1,0 +1,109 @@
+import {
+  createEventAdministration,
+  type EventAdministration,
+  type EventAdministrationOutcome,
+} from "@/lib/event-administration";
+import { openSqliteFoundationStorage } from "@/lib/foundation-storage-sqlite";
+import { FoundationStorageNotReadyError } from "@/lib/foundation-storage";
+import {
+  MemoryTechnicalAdminAuthRepository,
+  createTechnicalAdminAuth,
+  type TechnicalAdminAuthority,
+} from "@/lib/technical-admin-auth";
+import { readTechnicalAdminConfig } from "@/lib/technical-admin-config";
+import { createGrantAuthority } from "@/lib/grant-authority";
+import { readGrantAuthorityOptions } from "@/lib/grant-runtime";
+
+const args = process.argv.slice(2);
+const databasePath = option("--db") ?? process.env.EVENT_CATALOG_DATABASE?.trim() ?? null;
+const command = args.find((arg) =>
+  ["status", "create", "rotate", "disable", "revoke", "reactivate", "reveal", "admit"].includes(
+    arg,
+  ),
+);
+let foundationStorage: ReturnType<typeof openSqliteFoundationStorage> | null = null;
+let hostAuth: ReturnType<typeof createTechnicalAdminAuth> | null = null;
+
+class InvalidCliInput extends Error {}
+
+try {
+  if (databasePath === null || databasePath.length === 0)
+    throw new InvalidCliInput(
+      "A foundation database path is required via --db or EVENT_CATALOG_DATABASE.",
+    );
+  if (command === "reveal" || command === "admit")
+    throw new InvalidCliInput(
+      "This machine-readable CLI never accepts or reveals a raw Grant credential; use the browser handoff.",
+    );
+  if (command === undefined) throw new InvalidCliInput(usage());
+
+  foundationStorage = openSqliteFoundationStorage(databasePath);
+  const config = readTechnicalAdminConfig();
+  const grants = createGrantAuthority(
+    foundationStorage,
+    readGrantAuthorityOptions(config.environment),
+  );
+  const readiness = await foundationStorage.readiness();
+  if (!readiness.ok) throw new FoundationStorageNotReadyError(readiness);
+  hostAuth = createTechnicalAdminAuth(config, new MemoryTechnicalAdminAuthRepository());
+  const administration = createEventAdministration({
+    storage: foundationStorage,
+    grants,
+  });
+  const result = await run(administration, command, hostAuth.resolveHostLocalAuthority());
+  console.log(JSON.stringify(result));
+  if (result.status !== "accepted") process.exitCode = 1;
+} catch (error) {
+  const result =
+    error instanceof InvalidCliInput
+      ? { status: "rejected", reason: "invalid-input", detail: error.message }
+      : {
+          status: "retryable-failure",
+          detail: error instanceof Error ? error.message : "Event Admin CLI failed.",
+        };
+  console.log(JSON.stringify(result));
+  process.exitCode = 1;
+} finally {
+  hostAuth?.close();
+  foundationStorage?.close();
+}
+
+async function run(
+  administration: EventAdministration,
+  name: string,
+  authority: TechnicalAdminAuthority,
+): Promise<EventAdministrationOutcome<unknown>> {
+  const eventId = required("event-id");
+  switch (name) {
+    case "status":
+      return administration.inspectEventAdminGrant(eventId, authority);
+    case "create":
+      return administration.createEventAdminGrant(eventId, authority);
+    case "rotate":
+      return administration.rotateEventAdminGrant(eventId, authority);
+    case "disable":
+      return administration.disableEventAdminGrant(eventId, authority);
+    case "revoke":
+      return administration.revokeEventAdminGrant(eventId, authority);
+    case "reactivate":
+      return administration.reactivateEventAdminGrant(eventId, authority);
+    default:
+      return { status: "rejected", reason: "invalid-input", detail: usage() };
+  }
+}
+
+function option(name: string): string | undefined {
+  const index = args.indexOf(name);
+  const value = index === -1 ? undefined : args[index + 1];
+  return value !== undefined && !value.startsWith("--") ? value : undefined;
+}
+
+function required(name: string): string {
+  const value = option(`--${name}`);
+  if (value === undefined) throw new InvalidCliInput(`Missing --${name}.`);
+  return value;
+}
+
+function usage(): string {
+  return "Usage: status|create|rotate|disable|revoke|reactivate --event-id ID; reveal/admit require the browser handoff.";
+}

--- a/scripts/test-technical-admin-browser.ts
+++ b/scripts/test-technical-admin-browser.ts
@@ -174,18 +174,166 @@ try {
   await page.getByRole("button", { name: "Add", exact: true }).click();
   const gameDayDate = page.locator('input[id^="game-day-date-"]');
   await expectValue(gameDayDate, "2026-08-14");
-  await page.getByText("current", { exact: true }).waitFor();
-  await gameDayDate.fill("2026-08-15");
-  await page.getByRole("button", { name: "Save Game Day" }).click();
-  await expectValue(gameDayDate, "2026-08-15");
-  await page.getByText("future", { exact: true }).waitFor();
+  await page.getByLabel("Add Game Day").fill("2026-08-15");
+  await page.getByRole("button", { name: "Add", exact: true }).click();
+  await page.locator('input[id^="game-day-date-"]').nth(1).waitFor();
+  assert(
+    (await page.locator('input[id^="game-day-date-"]').count()) === 2,
+    "browser flow did not create two Game Days",
+  );
+  await expectValue(page.locator('input[id^="game-day-date-"]').nth(0), "2026-08-14");
+  await expectValue(page.locator('input[id^="game-day-date-"]').nth(1), "2026-08-15");
   await page.locator("#selected-event-name").fill("Browser Event Updated");
   await page.getByRole("button", { name: "Save Event" }).click();
   await page.getByRole("heading", { name: "Browser Event Updated" }).waitFor();
-  await page.getByRole("button", { name: "Remove", exact: true }).click();
+  const eventsPayload = (await (
+    await context.request.get(`${origin}/api/admin/events`)
+  ).json()) as {
+    status: string;
+    value: Array<{ eventId: string; name: string }>;
+  };
+  const eventId = eventsPayload.value.find(
+    (event) => event.name === "Browser Event Updated",
+  )?.eventId;
+  if (!eventId) throw new Error("Browser Event was not returned by the catalog.");
+  await page.getByRole("button", { name: /Browser Event Updated/ }).click();
+  await page.getByRole("button", { name: "Create Grant" }).click();
+  const revealResponsePromise = page.waitForResponse(
+    (response) =>
+      response.url().includes(`/api/admin/events/${eventId}/event-admin-grant/reveal`) &&
+      response.request().method() === "POST",
+  );
+  await page.getByRole("button", { name: "Reveal QR credential" }).click();
+  const revealResponse = await revealResponsePromise;
+  const revealPayload = (await revealResponse.json()) as {
+    status: string;
+    value?: { qrCredential?: string };
+  };
+  const revealedCredential = revealPayload.value?.qrCredential ?? "";
+  assert(revealResponse.status() === 200 && revealedCredential.length > 0, "QR reveal succeeded");
+  const qrCode = page.getByAltText("Event Admin Grant QR code");
+  await qrCode.waitFor();
+  const qrSource = await qrCode.getAttribute("src");
+  assert(
+    qrSource?.startsWith("data:image/png;base64,") === true,
+    "browser reveal rendered a PNG QR code",
+  );
+  await page.getByRole("button", { name: "Open Event Hub" }).click();
+  await page.getByText("Event Hub", { exact: true }).waitFor();
+  await page.getByLabel("Game Day").selectOption({ index: 1 });
+  const eventAdminContext = await browser.newContext({ ignoreHTTPSErrors: true });
+  const eventAdminPage = await eventAdminContext.newPage();
+  eventAdminPage.setDefaultTimeout(5_000);
+  await eventAdminPage.goto(`${origin}/event-admin?eventId=${eventId}`);
+  await eventAdminPage.getByLabel("Scanned Event Admin QR value").fill(revealedCredential);
+  await eventAdminPage.getByRole("button", { name: "Admit Event Admin" }).click();
+  await eventAdminPage.getByText(/event-admin/u).waitFor();
+  const eventAdminGameDaySelector = eventAdminPage.getByLabel("Game Day");
+  await eventAdminGameDaySelector.selectOption({ index: 1 });
+  const firstSelectedGameDay = await expectSelectValue(eventAdminGameDaySelector, 1);
+  await eventAdminGameDaySelector.selectOption({ index: 2 });
+  const secondSelectedGameDay = await expectSelectValue(eventAdminGameDaySelector, 2);
+  assert(firstSelectedGameDay !== secondSelectedGameDay, "Game Day selector reused one option");
+  const sessionCookieBeforeRefresh = (await eventAdminContext.cookies()).find(
+    (cookie) => cookie.name === "__Host-event-admin-session",
+  );
+  await eventAdminPage.reload();
+  await eventAdminPage.getByText(/event-admin/u).waitFor();
+  const sessionCookieAfterRefresh = (await eventAdminContext.cookies()).find(
+    (cookie) => cookie.name === "__Host-event-admin-session",
+  );
+  assert(
+    sessionCookieBeforeRefresh !== undefined &&
+      sessionCookieAfterRefresh !== undefined &&
+      sessionCookieAfterRefresh.expires >= sessionCookieBeforeRefresh.expires,
+    "Event Admin Hub did not refresh the rolling session cookie",
+  );
+  const wrongEventResponse = await fetchFromPage(
+    eventAdminPage,
+    `${origin}/api/event-admin/hub?eventId=wrong-event`,
+  );
+  assert(wrongEventResponse.status === 401, "wrong-Event Event Admin authority was accepted");
+  await page.goto(`${origin}/admin`);
+  await page.getByRole("button", { name: /Browser Event Updated/ }).click();
+  const rotateResponsePromise = page.waitForResponse(
+    (response) =>
+      response.url().includes(`/api/admin/events/${eventId}/event-admin-grant/rotate`) &&
+      response.request().method() === "POST",
+  );
+  await page.getByRole("button", { name: "Rotate Grant" }).click();
+  assert((await rotateResponsePromise).status() === 200, "Grant rotation failed");
+  const staleAfterRotation = await fetchFromPage(
+    eventAdminPage,
+    `${origin}/api/event-admin/hub?eventId=${eventId}`,
+  );
+  assert(staleAfterRotation.status === 401, "rotated Event Admin session remained live");
+  const freshRevealResponsePromise = page.waitForResponse(
+    (response) =>
+      response.url().includes(`/api/admin/events/${eventId}/event-admin-grant/reveal`) &&
+      response.request().method() === "POST",
+  );
+  await page.getByRole("button", { name: "Reveal QR credential" }).click();
+  const freshRevealResponse = await freshRevealResponsePromise;
+  const freshRevealPayload = (await freshRevealResponse.json()) as {
+    status: string;
+    value?: { qrCredential?: string };
+  };
+  const freshCredential = freshRevealPayload.value?.qrCredential ?? "";
+  assert(
+    freshRevealResponse.status() === 200 && freshCredential.length > 0,
+    "fresh QR reveal failed",
+  );
+  const revokedEventAdminContext = await browser.newContext({ ignoreHTTPSErrors: true });
+  const revokedEventAdminPage = await revokedEventAdminContext.newPage();
+  revokedEventAdminPage.setDefaultTimeout(5_000);
+  await revokedEventAdminPage.goto(`${origin}/event-admin?eventId=${eventId}`);
+  await revokedEventAdminPage.getByLabel("Scanned Event Admin QR value").fill(freshCredential);
+  await revokedEventAdminPage.getByRole("button", { name: "Admit Event Admin" }).click();
+  await revokedEventAdminPage.getByText(/event-admin/u).waitFor();
+  const validFreshSession = await fetchFromPage(
+    revokedEventAdminPage,
+    `${origin}/api/event-admin/hub?eventId=${eventId}`,
+  );
+  assert(validFreshSession.status === 200, "newly admitted Event Admin session was not live");
+  assert(validFreshSession.cacheControl === "no-store", "private Event Hub response was cacheable");
+  const revokeResponsePromise = page.waitForResponse(
+    (response) =>
+      response.url().includes(`/api/admin/events/${eventId}/event-admin-grant/revoke`) &&
+      response.request().method() === "POST",
+  );
+  await page.getByRole("button", { name: "Revoke Grant" }).click();
+  assert((await revokeResponsePromise).status() === 200, "Grant revocation failed");
+  const revokedFreshSession = await fetchFromPage(
+    revokedEventAdminPage,
+    `${origin}/api/event-admin/hub?eventId=${eventId}`,
+  );
+  assert(
+    revokedFreshSession.status === 401,
+    "explicitly revoked live Event Admin session remained live",
+  );
+  await eventAdminContext.close();
+  await revokedEventAdminContext.close();
+  const removeButtons = page.getByRole("button", { name: "Remove", exact: true });
+  await removeButtons.nth(0).click();
+  await removeButtons.nth(0).click();
   await page.getByText("No Game Days.").waitFor();
-  await page.getByRole("button", { name: "Remove empty Event" }).click();
-  await page.getByText("No Events yet.").waitFor();
+  const attachedGrantRemoval = await page.evaluate(async (url) => {
+    const csrf = document.cookie
+      .split(";")
+      .map((part) => part.trim())
+      .find((part) => part.startsWith("__Host-technical-admin-csrf="))
+      ?.slice("__Host-technical-admin-csrf=".length);
+    return (
+      await fetch(url, {
+        method: "DELETE",
+        headers: { "x-technical-admin-csrf": csrf ?? "" },
+      })
+    ).status;
+  }, `${origin}/api/admin/events/${eventId}`);
+  assert(
+    attachedGrantRemoval === 409,
+    `attached Event Admin Grant removal returned ${attachedGrantRemoval}`,
+  );
   const staleCookies = await context.cookies();
   const staleCookieHeader = staleCookies
     .map((cookie) => `${cookie.name}=${cookie.value}`)
@@ -226,6 +374,10 @@ try {
       sessionRevocation: true,
       replacement: true,
       eventCatalog: true,
+      eventAdminGrantHandoff: true,
+      qrRender: true,
+      eventHubDelegation: true,
+      eventAdminRotationRevocationIsolation: true,
       forgedAuthorityRejected: true,
       revocationRevalidated: true,
     }),
@@ -233,7 +385,9 @@ try {
 } catch (error) {
   console.error(
     redactDiagnosticText(
-      error instanceof Error ? error.message : "Technical Admin browser test failed.",
+      error instanceof Error
+        ? (error.stack ?? error.message)
+        : JSON.stringify(error) || "Technical Admin browser test failed.",
     ),
   );
   if (browserPage) {
@@ -273,6 +427,19 @@ function assert(condition: boolean, message: string): asserts condition {
 async function expectValue(locator: ReturnType<Page["locator"]>, expected: string) {
   const actual = await locator.inputValue();
   assert(actual === expected, `Expected input value ${expected}, got ${actual}.`);
+}
+
+async function expectSelectValue(locator: ReturnType<Page["getByLabel"]>, index: number) {
+  const value = await locator.inputValue();
+  assert(value.length > 0, `Game Day selector option ${index} was not selected.`);
+  return value;
+}
+
+async function fetchFromPage(page: Page, url: string) {
+  return page.evaluate(async (requestUrl) => {
+    const response = await fetch(requestUrl);
+    return { status: response.status, cacheControl: response.headers.get("cache-control") };
+  }, url);
 }
 
 function redactBrowserUrl(value: string) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import type { ControllerRole, GameSummary } from "@/lib/game-types";
 import { DEFAULT_AWAY_TEAM_COLOR, DEFAULT_HOME_TEAM_COLOR } from "@/lib/team-colors";
 import { ColorTestPage } from "@/pages/color-test-page";
 import { EventOperationsPrototypePage } from "@/pages/event-operations-prototype-page";
+import { EventAdminPage } from "@/pages/event-admin-page";
 import { GamePage } from "@/pages/game-page";
 import { TechnicalAdminPage } from "@/pages/technical-admin-page";
 import "./index.css";
@@ -20,6 +21,9 @@ type Route =
     }
   | {
       type: "event-operations-prototype";
+    }
+  | {
+      type: "event-admin";
     }
   | {
       type: "technical-admin";
@@ -46,6 +50,10 @@ export function App() {
 
   if (route.type === "event-operations-prototype") {
     return <EventOperationsPrototypePage />;
+  }
+
+  if (route.type === "event-admin") {
+    return <EventAdminPage />;
   }
 
   if (route.type === "technical-admin") {
@@ -336,6 +344,10 @@ function parseRoute(pathname: string, search: string): Route {
 
   if (pathname === "/prototype/event-operations") {
     return { type: "event-operations-prototype" };
+  }
+
+  if (pathname === "/event-admin" || pathname === "/event-admin/") {
+    return { type: "event-admin" };
   }
 
   const match = pathname.match(/^\/game\/([a-zA-Z0-9-]+)$/);

--- a/src/index-event-admin-headers.focused.ts
+++ b/src/index-event-admin-headers.focused.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+describe("Event Hub early response headers", () => {
+  test("marks unauthenticated and unavailable early responses as sensitive", async () => {
+    await withServer({}, async (serverUrl) => {
+      const response = await fetch(new URL("/api/event-admin/hub?eventId=event", serverUrl));
+      expect(response.status).toBe(401);
+      expect(response.headers.get("cache-control")).toBe("no-store");
+      expect(response.headers.get("referrer-policy")).toBe("no-referrer");
+      expect(await response.json()).toEqual({ error: "Authentication failed." });
+    });
+
+    await withServer({ incompleteGrantKeys: true }, async (serverUrl) => {
+      const response = await fetch(new URL("/api/event-admin/hub?eventId=event", serverUrl));
+      expect(response.status).toBe(503);
+      expect(response.headers.get("cache-control")).toBe("no-store");
+      expect(response.headers.get("referrer-policy")).toBe("no-referrer");
+      expect(await response.json()).toEqual({ error: "Authentication failed." });
+    });
+  });
+});
+
+async function withServer(
+  options: { incompleteGrantKeys?: boolean },
+  work: (serverUrl: URL) => Promise<void>,
+): Promise<void> {
+  const directory = mkdtempSync(join(tmpdir(), "quadball-event-admin-headers-"));
+  const environment = Object.fromEntries(
+    Object.entries(process.env).filter(
+      (entry): entry is [string, string] => entry[1] !== undefined,
+    ),
+  );
+  Object.assign(environment, {
+    NODE_ENV: "test",
+    QUADBALL_ENVIRONMENT: "test",
+    PUBLIC_ORIGIN: "https://localhost",
+    WEBAUTHN_RP_ID: "localhost",
+    PORT: "0",
+    TECHNICAL_ADMIN_DATABASE: join(directory, "technical-admin.sqlite"),
+  });
+  delete environment.FOUNDATION_DATABASE;
+  delete environment.GRANT_LOOKUP_KEY;
+  delete environment.GRANT_AUDIT_KEY;
+  delete environment.GRANT_ENCRYPTION_KEY;
+  if (options.incompleteGrantKeys) environment.GRANT_ENCRYPTION_KEY = "00".repeat(32);
+
+  const server = Bun.spawn([process.execPath, "run", "src/index.ts"], {
+    cwd: process.cwd(),
+    env: environment,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  try {
+    const serverUrl = await readServerUrl(server.stdout);
+    await work(serverUrl);
+  } finally {
+    server.kill();
+    await server.exited;
+    rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+async function readServerUrl(stdout: ReadableStream<Uint8Array>): Promise<URL> {
+  const reader = stdout.getReader();
+  const decoder = new TextDecoder();
+  let output = "";
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) throw new Error("Server exited before reporting its bound URL.");
+      output += decoder.decode(value, { stream: true });
+      const match = output.match(/Server running at (http:\/\/[^\s]+)/u);
+      if (match?.[1]) return new URL(match[1]);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,14 @@ import {
   createUnavailableEventCatalogStorage,
   type CatalogOutcome,
 } from "@/lib/event-catalog";
+import {
+  createEventAdministration,
+  type EventAdministration,
+  type EventAdministrationAuthority,
+  type EventAdministrationOutcome,
+} from "@/lib/event-administration";
+import { createGrantAuthority } from "@/lib/grant-authority";
+import { readGrantAuthorityOptions } from "@/lib/grant-runtime";
 import { createInMemoryFoundationStorage } from "@/lib/foundation-storage-memory";
 import { openSqliteFoundationStorage } from "@/lib/foundation-storage-sqlite";
 import type { FoundationStorage } from "@/lib/foundation-storage";
@@ -155,6 +163,38 @@ async function startServer() {
     }
 
     const eventCatalog = createEventCatalog(eventCatalogStorage, {});
+    let eventAdministration: EventAdministration | null = null;
+    if (foundationStorage !== undefined) {
+      try {
+        const grantAuthority = createGrantAuthority(
+          foundationStorage,
+          readGrantAuthorityOptions(environment),
+        );
+        eventAdministration = createEventAdministration({
+          storage: foundationStorage,
+          grants: grantAuthority,
+        });
+      } catch {
+        // Grant keys are an Event Administration dependency, not a server-wide dependency.
+        // Keep the foundation-backed Technical Admin and Event Catalog routes available.
+        eventAdministration = null;
+      }
+    }
+    const adminGrantMutationRoute =
+      (
+        operation:
+          | "rotateEventAdminGrant"
+          | "disableEventAdminGrant"
+          | "revokeEventAdminGrant"
+          | "reactivateEventAdminGrant",
+      ) =>
+      async (req: Request) => {
+        const token = requireTechnicalAdminMutationToken(req, technicalAdminAuth);
+        if (token === null) return genericAuthFailure(401);
+        if (eventAdministration === null) return genericAuthFailure(503);
+        const eventId = new URL(req.url).pathname.split("/").at(-3) ?? "";
+        return eventAdministrationResponse(await eventAdministration[operation](eventId, token));
+      };
     const tls =
       process.env.TLS_CERT_FILE && process.env.TLS_KEY_FILE
         ? { cert: Bun.file(process.env.TLS_CERT_FILE), key: Bun.file(process.env.TLS_KEY_FILE) }
@@ -495,6 +535,123 @@ async function startServer() {
             const eventId = path.at(-3) ?? "";
             const gameDayId = path.at(-1) ?? "";
             return catalogResponse(await eventCatalog.removeGameDay(eventId, gameDayId, token));
+          },
+        },
+        "/api/admin/events/:eventId/event-admin-grant": {
+          async GET(req: Request) {
+            const token = requireTechnicalAdminToken(req, technicalAdminAuth);
+            if (token === null) return genericAuthFailure(401);
+            if (eventAdministration === null) return genericAuthFailure(503);
+            const eventId = new URL(req.url).pathname.split("/").at(-2) ?? "";
+            return eventAdministrationResponse(
+              await eventAdministration.inspectEventAdminGrant(eventId, token),
+            );
+          },
+          async POST(req: Request) {
+            const token = requireTechnicalAdminMutationToken(req, technicalAdminAuth);
+            if (token === null) return genericAuthFailure(401);
+            if (eventAdministration === null) return genericAuthFailure(503);
+            const eventId = new URL(req.url).pathname.split("/").at(-2) ?? "";
+            return eventAdministrationResponse(
+              await eventAdministration.createEventAdminGrant(eventId, token),
+              201,
+            );
+          },
+        },
+        "/api/admin/events/:eventId/event-admin-grant/reveal": {
+          async POST(req: Request) {
+            const token = requireTechnicalAdminMutationToken(req, technicalAdminAuth);
+            if (token === null) return genericAuthFailure(401);
+            if (eventAdministration === null) return genericAuthFailure(503);
+            const eventId = new URL(req.url).pathname.split("/").at(-3) ?? "";
+            return sensitiveEventAdministrationResponse(
+              await eventAdministration.revealEventAdminGrant(eventId, token),
+            );
+          },
+        },
+        "/api/admin/events/:eventId/event-admin-grant/rotate": {
+          POST: adminGrantMutationRoute("rotateEventAdminGrant"),
+        },
+        "/api/admin/events/:eventId/event-admin-grant/disable": {
+          POST: adminGrantMutationRoute("disableEventAdminGrant"),
+        },
+        "/api/admin/events/:eventId/event-admin-grant/revoke": {
+          POST: adminGrantMutationRoute("revokeEventAdminGrant"),
+        },
+        "/api/admin/events/:eventId/event-admin-grant/reactivate": {
+          POST: adminGrantMutationRoute("reactivateEventAdminGrant"),
+        },
+        "/api/event-admin/admit": {
+          async POST(req: Request) {
+            if (eventAdministration === null) return genericAuthFailure(503);
+            const body = await readJsonRecord(req);
+            if (body === null || typeof body.qrCredential !== "string")
+              return json({ error: "Unable to admit this Grant." }, 400);
+            const context = readEventAdminContext(req.headers.get("cookie")) ?? crypto.randomUUID();
+            const result = await eventAdministration.admitEventAdmin({
+              qrCredential: body.qrCredential,
+              browserContext: context,
+              deviceClass: body.deviceClass,
+              browserClass: body.browserClass,
+            });
+            if (result.status !== "admitted") return sensitiveJson(result, 401);
+            return sensitiveJson(
+              {
+                status: "admitted",
+                grantId: result.grantId,
+                grantVersion: result.grantVersion,
+                grantType: result.grantType,
+                scope: result.scope,
+                grantSessionId: result.grantSessionId,
+              },
+              200,
+              [
+                ["set-cookie", eventAdminContextCookie(context)],
+                [
+                  "set-cookie",
+                  eventAdminSessionCookie(result.sessionBearer, result.sessionExpiresAtMs),
+                ],
+              ],
+            );
+          },
+        },
+        "/api/event-admin/hub": {
+          async GET(req: Request) {
+            if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
+            const url = new URL(req.url);
+            const eventId = url.searchParams.get("eventId") ?? "";
+            const gameDayId = url.searchParams.get("gameDayId") ?? undefined;
+            const authority = resolveEventAdministrationAuthority(req, technicalAdminAuth);
+            if (authority === null) return sensitiveGenericAuthFailure(401);
+            const result = await eventAdministration.openEventHub({
+              eventId,
+              gameDayId,
+              authority,
+            });
+            const refreshHeaders: Array<[string, string]> =
+              authority.kind === "grant-session" && result.status === "accepted"
+                ? [
+                    [
+                      "set-cookie",
+                      eventAdminSessionCookie(
+                        authority.sessionBearer,
+                        result.value.grantSessionExpiresAtMs,
+                      ),
+                    ],
+                  ]
+                : [];
+            return sensitiveEventAdministrationResponse(result, 200, refreshHeaders);
+          },
+        },
+        "/api/event-admin/leave": {
+          async POST(req: Request) {
+            if (eventAdministration === null) return genericAuthFailure(503);
+            const sessionBearer = readEventAdminSession(req.headers.get("cookie"));
+            if (sessionBearer === null) return genericAuthFailure(401);
+            const result = await eventAdministration.leaveEventAdminSession(sessionBearer);
+            return sensitiveJson(result, result.status === "updated" ? 200 : 401, [
+              ["set-cookie", clearEventAdminSessionCookie()],
+            ]);
           },
         },
         "/internal/healthz": {
@@ -937,6 +1094,10 @@ function genericAuthFailure(status: number) {
   return json({ error: "Authentication failed." }, status);
 }
 
+function sensitiveGenericAuthFailure(status: number) {
+  return sensitiveJson({ error: "Authentication failed." }, status);
+}
+
 function authFailureResponse(result: AuthResult<unknown>) {
   if (result.ok) return sensitiveJson(result.value);
   const headers: Array<[string, string]> = [];
@@ -962,13 +1123,13 @@ function requireTechnicalAdminMutationToken(
   req: Request,
   technicalAdminAuth: ReturnType<typeof createTechnicalAdminAuth>,
 ): TechnicalAdminAuthority | null {
-  if (
-    req.headers.get("x-technical-admin-csrf") !== "1" ||
-    !technicalAdminAuth.isExpectedBinding(requestBinding(req))
-  ) {
-    return null;
-  }
-  return requireTechnicalAdminToken(req, technicalAdminAuth);
+  if (!technicalAdminAuth.isExpectedBinding(requestBinding(req))) return null;
+  const token = readTechnicalAdminCookie(req.headers.get("cookie"));
+  const csrfToken = req.headers.get("x-technical-admin-csrf");
+  if (token === null || csrfToken === null) return null;
+  if (!technicalAdminAuth.authenticateSession(token)) return null;
+  if (!technicalAdminAuth.verifyCsrf(token, csrfToken)) return null;
+  return technicalAdminAuth.resolveCurrentAuthority(token);
 }
 
 function catalogResponse<T>(result: CatalogOutcome<T>, acceptedStatus = 200) {
@@ -985,6 +1146,31 @@ function catalogResponse<T>(result: CatalogOutcome<T>, acceptedStatus = 200) {
   return json(result, status);
 }
 
+function eventAdministrationResponse<T>(
+  result: EventAdministrationOutcome<T>,
+  acceptedStatus = 200,
+  extraHeaders: Iterable<[string, string]> = [],
+) {
+  if (result.status === "accepted") return json(result, acceptedStatus, extraHeaders);
+  if (result.status === "retryable-failure") return json(result, 503, extraHeaders);
+  const status = result.reason === "unauthorized" ? 401 : result.reason === "not-found" ? 404 : 400;
+  return json(result, status, extraHeaders);
+}
+
+function sensitiveEventAdministrationResponse<T>(
+  result: EventAdministrationOutcome<T>,
+  acceptedStatus = 200,
+  extraHeaders: Iterable<[string, string]> = [],
+) {
+  if (result.status === "accepted") return sensitiveJson(result, acceptedStatus, extraHeaders);
+  if (result.status === "retryable-failure") return sensitiveJson(result, 503, extraHeaders);
+  return sensitiveJson(
+    result,
+    result.reason === "unauthorized" ? 401 : result.reason === "not-found" ? 404 : 400,
+    extraHeaders,
+  );
+}
+
 function readTechnicalAdminCookie(header: string | null): string | null {
   if (header === null) return null;
   for (const part of header.split(";")) {
@@ -992,6 +1178,51 @@ function readTechnicalAdminCookie(header: string | null): string | null {
     if (name === "__Host-technical-admin" && value.length > 0) return value.join("=");
   }
   return null;
+}
+
+function resolveEventAdministrationAuthority(
+  req: Request,
+  technicalAdminAuth: ReturnType<typeof createTechnicalAdminAuth>,
+): EventAdministrationAuthority | null {
+  const technicalToken = readTechnicalAdminCookie(req.headers.get("cookie"));
+  const technical =
+    technicalToken === null ? null : technicalAdminAuth.resolveCurrentAuthority(technicalToken);
+  if (technical !== null) return technical;
+  const sessionBearer = readEventAdminSession(req.headers.get("cookie"));
+  return sessionBearer === null ? null : { kind: "grant-session", sessionBearer };
+}
+
+function readEventAdminContext(header: string | null): string | null {
+  return readCookieValue(header, "__Host-event-admin-context");
+}
+
+function readEventAdminSession(header: string | null): string | null {
+  return readCookieValue(header, "__Host-event-admin-session");
+}
+
+function readCookieValue(header: string | null, cookieName: string): string | null {
+  if (header === null) return null;
+  for (const part of header.split(";")) {
+    const [name, ...value] = part.trim().split("=");
+    if (name === cookieName && value.length > 0) return value.join("=");
+  }
+  return null;
+}
+
+function eventAdminContextCookie(value: string): string {
+  return `__Host-event-admin-context=${encodeURIComponent(value)}; Path=/; HttpOnly; Secure; SameSite=Strict`;
+}
+
+function eventAdminSessionCookie(value: string, expiresAtMs: number | null | undefined): string {
+  const maxAgeSeconds =
+    expiresAtMs === null || expiresAtMs === undefined
+      ? 2_592_000
+      : Math.max(0, Math.min(2_592_000, Math.ceil((expiresAtMs - Date.now()) / 1_000)));
+  return `__Host-event-admin-session=${encodeURIComponent(value)}; Path=/; Max-Age=${maxAgeSeconds}; HttpOnly; Secure; SameSite=Strict`;
+}
+
+function clearEventAdminSessionCookie(): string {
+  return "__Host-event-admin-session=; Path=/; Max-Age=0; HttpOnly; Secure; SameSite=Strict";
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/lib/event-administration.test.ts
+++ b/src/lib/event-administration.test.ts
@@ -1,0 +1,447 @@
+import { describe, expect, test } from "bun:test";
+import { createEventAdministration } from "@/lib/event-administration";
+import { createEventCatalog, createFoundationEventCatalogStorage } from "@/lib/event-catalog";
+import type { FoundationStorage } from "@/lib/foundation-storage";
+import { createInMemoryFoundationStorage } from "@/lib/foundation-storage-memory";
+import { createGrantAuthority, createGrantAuthorityVerifier } from "@/lib/grant-authority";
+import type { GrantKeyRing } from "@/lib/grant-types";
+import {
+  MemoryTechnicalAdminAuthRepository,
+  createTechnicalAdminAuth,
+  isTechnicalAdminAuthority,
+} from "@/lib/technical-admin-auth";
+
+const keyRing: GrantKeyRing = {
+  encryption: { currentVersion: "v1", keys: new Map([["v1", bytes(1)]]) },
+  lookup: { currentVersion: "v1", keys: new Map([["v1", bytes(2)]]) },
+  audit: { currentVersion: "v1", keys: new Map([["v1", bytes(3)]]) },
+};
+
+describe("Event Administration handoff", () => {
+  test("creates a secret-free handoff, admits a pseudonymous session, and opens the same Hub", async () => {
+    const fixture = createFixture();
+    const event = await fixture.catalog.createEvent(
+      { name: "Two Day Event", timeZone: "Europe/Zurich" },
+      fixture.technical,
+    );
+    if (event.status !== "accepted") throw new Error("Expected Event.");
+    await fixture.catalog.addGameDay(
+      event.value.eventId,
+      { date: "2026-08-14" },
+      fixture.technical,
+    );
+    await fixture.catalog.addGameDay(
+      event.value.eventId,
+      { date: "2026-08-15" },
+      fixture.technical,
+    );
+
+    const created = await fixture.administration.createEventAdminGrant(
+      event.value.eventId,
+      fixture.technical,
+    );
+    expect(created).toMatchObject({ status: "accepted", value: { status: "active" } });
+    expect(JSON.stringify(created)).not.toContain("qrCredential");
+    if (created.status !== "accepted") throw new Error("Expected Grant.");
+
+    const grant = await fixture.grants.revealGrant(created.value.grantId, fixture.technical);
+    if (grant.status !== "revealed") throw new Error("Expected Grant reveal.");
+    const admission = await fixture.administration.admitEventAdmin({
+      qrCredential: grant.qrCredential,
+      browserContext: "browser-a",
+      deviceClass: "mobile",
+      browserClass: "safari",
+    });
+    expect(admission).toMatchObject({ status: "admitted", eventGameId: null });
+    if (admission.status !== "admitted") return;
+
+    const eventAdminHub = await fixture.administration.openEventHub({
+      eventId: event.value.eventId,
+      authority: { kind: "grant-session", sessionBearer: admission.sessionBearer },
+    });
+    expect(eventAdminHub).toMatchObject({
+      status: "accepted",
+      value: { authority: "event-admin", event: { eventId: event.value.eventId } },
+    });
+    const technicalHub = await fixture.administration.openEventHub({
+      eventId: event.value.eventId,
+      authority: fixture.technical,
+    });
+    expect(technicalHub).toMatchObject({
+      status: "accepted",
+      value: { authority: "technical-admin", event: { eventId: event.value.eventId } },
+    });
+  });
+
+  test("rejects duplicate Event Admin creation without creating another authority", async () => {
+    const fixture = createFixture();
+    const event = await fixture.catalog.createEvent(
+      { name: "Singular Event", timeZone: "UTC" },
+      fixture.technical,
+    );
+    if (event.status !== "accepted") throw new Error("Expected Event.");
+    await fixture.catalog.addGameDay(
+      event.value.eventId,
+      { date: "2026-08-14" },
+      fixture.technical,
+    );
+
+    const first = await fixture.administration.createEventAdminGrant(
+      event.value.eventId,
+      fixture.technical,
+    );
+    const duplicate = await fixture.administration.createEventAdminGrant(
+      event.value.eventId,
+      fixture.technical,
+    );
+    expect(first).toMatchObject({ status: "accepted", value: { status: "active" } });
+    expect(duplicate).toMatchObject({
+      status: "rejected",
+      reason: "invalid-input",
+      detail: "An Event Admin Grant already exists for this Event.",
+    });
+    expect(
+      await fixture.storage.transaction((transaction) =>
+        transaction
+          .listGrants()
+          .filter(
+            (grant) =>
+              grant.grantType === "event-admin" && grant.scope.eventId === event.value.eventId,
+          ),
+      ),
+    ).toHaveLength(1);
+  });
+
+  test("revokes stale sessions across disable/reactivate and expiry", async () => {
+    const fixture = createFixture();
+    const event = await fixture.catalog.createEvent(
+      { name: "Lifecycle Event", timeZone: "UTC" },
+      fixture.technical,
+    );
+    if (event.status !== "accepted") throw new Error("Expected Event.");
+    await fixture.catalog.addGameDay(
+      event.value.eventId,
+      { date: "2026-08-14" },
+      fixture.technical,
+    );
+    const created = await fixture.administration.createEventAdminGrant(
+      event.value.eventId,
+      fixture.technical,
+    );
+    if (created.status !== "accepted") throw new Error("Expected Grant.");
+    const firstCredential = await fixture.grants.revealGrant(
+      created.value.grantId,
+      fixture.technical,
+    );
+    if (firstCredential.status !== "revealed") throw new Error("Expected reveal.");
+    const firstAdmission = await fixture.administration.admitEventAdmin({
+      qrCredential: firstCredential.qrCredential,
+      browserContext: "lifecycle-browser",
+    });
+    if (firstAdmission.status !== "admitted") throw new Error("Expected admission.");
+
+    expect(
+      await fixture.administration.disableEventAdminGrant(event.value.eventId, fixture.technical),
+    ).toMatchObject({ status: "accepted", value: { status: "updated" } });
+    expect(
+      await fixture.administration.openEventHub({
+        eventId: event.value.eventId,
+        authority: { kind: "grant-session", sessionBearer: firstAdmission.sessionBearer },
+      }),
+    ).toMatchObject({ status: "rejected", reason: "unauthorized" });
+
+    expect(
+      await fixture.administration.reactivateEventAdminGrant(
+        event.value.eventId,
+        fixture.technical,
+      ),
+    ).toMatchObject({ status: "accepted", value: { status: "updated" } });
+    expect(
+      await fixture.administration.openEventHub({
+        eventId: event.value.eventId,
+        authority: { kind: "grant-session", sessionBearer: firstAdmission.sessionBearer },
+      }),
+    ).toMatchObject({ status: "rejected", reason: "unauthorized" });
+
+    const freshCredential = await fixture.grants.revealGrant(
+      created.value.grantId,
+      fixture.technical,
+    );
+    if (freshCredential.status !== "revealed") throw new Error("Expected fresh reveal.");
+    const freshAdmission = await fixture.administration.admitEventAdmin({
+      qrCredential: freshCredential.qrCredential,
+      browserContext: "fresh-lifecycle-browser",
+    });
+    if (freshAdmission.status !== "admitted") throw new Error("Expected fresh admission.");
+    expect(
+      await fixture.administration.openEventHub({
+        eventId: event.value.eventId,
+        authority: { kind: "grant-session", sessionBearer: freshAdmission.sessionBearer },
+      }),
+    ).toMatchObject({ status: "accepted" });
+    fixture.setNow(Date.parse("2026-09-20T12:00:00Z"));
+    expect(
+      await fixture.administration.openEventHub({
+        eventId: event.value.eventId,
+        authority: { kind: "grant-session", sessionBearer: freshAdmission.sessionBearer },
+      }),
+    ).toMatchObject({ status: "rejected", reason: "unauthorized" });
+  });
+
+  test("rejects wrong-Event sessions and invalidates a rotated Grant before projection", async () => {
+    const fixture = createFixture();
+    const first = await fixture.catalog.createEvent(
+      { name: "First", timeZone: "UTC" },
+      fixture.technical,
+    );
+    const second = await fixture.catalog.createEvent(
+      { name: "Second", timeZone: "UTC" },
+      fixture.technical,
+    );
+    if (first.status !== "accepted" || second.status !== "accepted")
+      throw new Error("Expected Events.");
+    await fixture.catalog.addGameDay(
+      first.value.eventId,
+      { date: "2026-08-14" },
+      fixture.technical,
+    );
+    await fixture.catalog.addGameDay(
+      second.value.eventId,
+      { date: "2026-08-14" },
+      fixture.technical,
+    );
+    const grant = await fixture.grants.createEventAdminGrant({
+      authority: fixture.technical,
+      scope: { eventId: first.value.eventId, eventTimeZone: "UTC", finalGameDayDate: "2026-08-14" },
+    });
+    if (grant.status !== "created") throw new Error("Expected Grant.");
+    const admission = await fixture.administration.admitEventAdmin({
+      qrCredential: grant.qrCredential,
+      browserContext: "browser-b",
+    });
+    if (admission.status !== "admitted") throw new Error("Expected admission.");
+
+    expect(
+      await fixture.administration.openEventHub({
+        eventId: second.value.eventId,
+        authority: { kind: "grant-session", sessionBearer: admission.sessionBearer },
+      }),
+    ).toMatchObject({ status: "rejected", reason: "unauthorized" });
+    expect(
+      await fixture.administration.rotateEventAdminGrant(first.value.eventId, fixture.technical),
+    ).toMatchObject({
+      status: "accepted",
+      value: { status: "updated" },
+    });
+    expect(
+      await fixture.administration.openEventHub({
+        eventId: first.value.eventId,
+        authority: { kind: "grant-session", sessionBearer: admission.sessionBearer },
+      }),
+    ).toMatchObject({ status: "rejected", reason: "unauthorized" });
+  });
+
+  test("explicitly revokes a newly admitted currently valid session", async () => {
+    const fixture = createFixture();
+    const event = await fixture.catalog.createEvent(
+      { name: "Revoke Event", timeZone: "UTC" },
+      fixture.technical,
+    );
+    if (event.status !== "accepted") throw new Error("Expected Event.");
+    await fixture.catalog.addGameDay(
+      event.value.eventId,
+      { date: "2026-08-14" },
+      fixture.technical,
+    );
+    const grant = await fixture.administration.createEventAdminGrant(
+      event.value.eventId,
+      fixture.technical,
+    );
+    if (grant.status !== "accepted") throw new Error("Expected Grant.");
+    const reveal = await fixture.grants.revealGrant(grant.value.grantId, fixture.technical);
+    if (reveal.status !== "revealed") throw new Error("Expected reveal.");
+    const admission = await fixture.administration.admitEventAdmin({
+      qrCredential: reveal.qrCredential,
+      browserContext: "revoke-browser",
+    });
+    if (admission.status !== "admitted") throw new Error("Expected admission.");
+    expect(
+      await fixture.administration.openEventHub({
+        eventId: event.value.eventId,
+        authority: { kind: "grant-session", sessionBearer: admission.sessionBearer },
+      }),
+    ).toMatchObject({ status: "accepted" });
+    expect(
+      await fixture.administration.revokeEventAdminGrant(event.value.eventId, fixture.technical),
+    ).toMatchObject({ status: "accepted", value: { status: "updated" } });
+    expect(
+      await fixture.administration.openEventHub({
+        eventId: event.value.eventId,
+        authority: { kind: "grant-session", sessionBearer: admission.sessionBearer },
+      }),
+    ).toMatchObject({ status: "rejected", reason: "unauthorized" });
+  });
+
+  test("keeps Grant, session, audit, and catalog state unchanged on an injected transaction failure", async () => {
+    const baseStorage = createInMemoryFoundationStorage();
+    let failNext = false;
+    const storage = new Proxy(baseStorage, {
+      get(target, property, receiver) {
+        if (property === "transaction") {
+          return (work: Parameters<FoundationStorage["transaction"]>[0]) =>
+            target.transaction((transaction) => {
+              const result = work(transaction);
+              if (failNext) {
+                failNext = false;
+                throw new Error("injected transaction failure");
+              }
+              return result;
+            });
+        }
+        const value = Reflect.get(target, property, receiver);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    }) as FoundationStorage;
+    const fixture = createFixture(storage);
+    const event = await fixture.catalog.createEvent(
+      { name: "Failure Event", timeZone: "UTC" },
+      fixture.technical,
+    );
+    if (event.status !== "accepted") throw new Error("Expected Event.");
+    await fixture.catalog.addGameDay(
+      event.value.eventId,
+      { date: "2026-08-14" },
+      fixture.technical,
+    );
+    const grant = await fixture.administration.createEventAdminGrant(
+      event.value.eventId,
+      fixture.technical,
+    );
+    if (grant.status !== "accepted") throw new Error("Expected Grant.");
+    const reveal = await fixture.grants.revealGrant(grant.value.grantId, fixture.technical);
+    if (reveal.status !== "revealed") throw new Error("Expected reveal.");
+    const admission = await fixture.administration.admitEventAdmin({
+      qrCredential: reveal.qrCredential,
+      browserContext: "failure-browser",
+    });
+    if (admission.status !== "admitted") throw new Error("Expected admission.");
+    const readState = () =>
+      baseStorage.transaction((transaction) => ({
+        grants: transaction.listGrants(),
+        sessions: transaction.listGrantSessions(grant.value.grantId),
+        grantAudit: transaction.listGrantAudit(grant.value.grantId),
+        event: transaction.findEvent(event.value.eventId),
+        gameDays: transaction.listGameDays(event.value.eventId),
+        eventAudit: transaction.listEventAuditTrail(event.value.eventId),
+      }));
+    const before = await readState();
+    failNext = true;
+    expect(
+      await fixture.administration.openEventHub({
+        eventId: event.value.eventId,
+        authority: { kind: "grant-session", sessionBearer: admission.sessionBearer },
+      }),
+    ).toMatchObject({ status: "retryable-failure" });
+    expect(await readState()).toEqual(before);
+  });
+
+  test("preserves empty Event removal while rejecting removal of an attached Grant", async () => {
+    const fixture = createFixture();
+    const event = await fixture.catalog.createEvent(
+      { name: "Attached Grant Event", timeZone: "UTC" },
+      fixture.technical,
+    );
+    if (event.status !== "accepted") throw new Error("Expected Event.");
+    const day = await fixture.catalog.addGameDay(
+      event.value.eventId,
+      { date: "2026-08-14" },
+      fixture.technical,
+    );
+    if (day.status !== "accepted") throw new Error("Expected Game Day.");
+    const grant = await fixture.administration.createEventAdminGrant(
+      event.value.eventId,
+      fixture.technical,
+    );
+    if (grant.status !== "accepted") throw new Error("Expected Grant.");
+    expect(
+      await fixture.catalog.removeGameDay(
+        event.value.eventId,
+        day.value.gameDayId,
+        fixture.technical,
+      ),
+    ).toMatchObject({ status: "accepted" });
+    expect(await fixture.catalog.removeEvent(event.value.eventId, fixture.technical)).toMatchObject(
+      {
+        status: "rejected",
+        reason: "in-use",
+        detail: "Event has an attached Event Admin Grant.",
+      },
+    );
+    const empty = await fixture.catalog.createEvent(
+      { name: "No Grant Event", timeZone: "UTC" },
+      fixture.technical,
+    );
+    if (empty.status !== "accepted") throw new Error("Expected empty Event.");
+    expect(await fixture.catalog.removeEvent(empty.value.eventId, fixture.technical)).toMatchObject(
+      {
+        status: "accepted",
+      },
+    );
+  });
+});
+
+function createFixture(storage: FoundationStorage = createInMemoryFoundationStorage()) {
+  let nowMs = Date.parse("2026-08-14T12:00:00Z");
+  let entropy = 7;
+  const technical = createTechnicalAdminAuth(
+    { environment: "test", origin: "https://timer.example", rpId: "timer.example" },
+    new MemoryTechnicalAdminAuthRepository(),
+  ).resolveHostLocalAuthority();
+  const catalog = createEventCatalog(createFoundationEventCatalogStorage(storage), {
+    clock: { nowMs: () => nowMs },
+  });
+  const options = {
+    environmentId: "test",
+    clock: { nowMs: () => nowMs },
+    randomness: {
+      bytes: (length: number) => {
+        const seed = entropy++;
+        return Uint8Array.from({ length }, (_, index) => ((seed + index * 37) % 240) + 1);
+      },
+    },
+    keyRing,
+    controlScopeResolver: { resolve: () => ({ status: "unavailable" as const }) },
+    privilegedAuthorityVerifier: createGrantAuthorityVerifier((input) => {
+      if (isTechnicalAdminAuthority(input)) return { kind: "technical-admin", id: input.sessionId };
+      if (
+        isRecord(input) &&
+        input.kind === "grant-session" &&
+        typeof input.sessionBearer === "string"
+      )
+        return { kind: "grant-session", sessionBearer: input.sessionBearer, sessionId: "session" };
+      return null;
+    }),
+  };
+  const grants = createGrantAuthority(storage, options);
+  const administration = createEventAdministration({
+    storage,
+    grants,
+    nowMs: () => nowMs,
+  });
+  return {
+    storage,
+    technical,
+    catalog,
+    grants,
+    administration,
+    setNow: (value: number) => (nowMs = value),
+  };
+}
+
+function bytes(value: number): Uint8Array {
+  return new Uint8Array(32).fill(value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/lib/event-administration.ts
+++ b/src/lib/event-administration.ts
@@ -1,0 +1,385 @@
+import type { FoundationStorage, FoundationStorageTransaction } from "@/lib/foundation-storage";
+import { projectEventProjection, type EventProjection } from "@/lib/event-catalog";
+import type { TechnicalAdminAuthority } from "@/lib/technical-admin-auth";
+import type {
+  TypedGrantAdmission,
+  TypedGrantAdmissionThrottled,
+  TypedGrantAuthority,
+  TypedGrantMutation,
+  TypedGrantReveal,
+} from "@/lib/grant-management";
+import { EVENT_ADMIN_GRANT_TYPE, type StoredGrant } from "@/lib/grant-types";
+import { isTechnicalAdminAuthority } from "@/lib/technical-admin-auth";
+import { validateOpaqueIdentifier } from "@/lib/validation-policy";
+
+export const GENERIC_EVENT_HUB_AUTHORIZATION_FAILURE = Object.freeze({
+  status: "rejected",
+  code: "event-hub-authorization-failed",
+  message: "Unable to authorize the Event Hub.",
+} as const);
+
+export type EventAdministrationAuthority =
+  | TechnicalAdminAuthority
+  | { kind: "grant-session"; sessionBearer: string };
+
+export type EventAdminGrantProjection = {
+  grantId: string;
+  grantVersion: string;
+  grantType: typeof EVENT_ADMIN_GRANT_TYPE;
+  eventId: string;
+  status: StoredGrant["status"];
+  createdAtMs: number;
+  expiresAtMs: number | null;
+};
+
+export type EventHubProjection = {
+  event: EventProjection;
+  selectedGameDayId: string | null;
+  authority: "technical-admin" | "event-admin";
+  grantSessionId: string | null;
+  grantSessionExpiresAtMs: number | null;
+};
+
+export type EventAdministrationOutcome<T> =
+  | { status: "accepted"; value: T }
+  | { status: "rejected"; reason: "invalid-input" | "unauthorized" | "not-found"; detail: string }
+  | { status: "retryable-failure"; detail: string };
+
+export type EventAdministrationOptions = {
+  storage: FoundationStorage;
+  grants: TypedGrantAuthority;
+  nowMs?: () => number;
+};
+
+export type EventAdministration = {
+  createEventAdminGrant(
+    eventId: unknown,
+    authority: TechnicalAdminAuthority,
+  ): Promise<EventAdministrationOutcome<EventAdminGrantProjection>>;
+  inspectEventAdminGrant(
+    eventId: unknown,
+    authority: EventAdministrationAuthority,
+  ): Promise<EventAdministrationOutcome<EventAdminGrantProjection | null>>;
+  revealEventAdminGrant(
+    eventId: unknown,
+    authority: TechnicalAdminAuthority,
+  ): Promise<EventAdministrationOutcome<TypedGrantReveal>>;
+  rotateEventAdminGrant(
+    eventId: unknown,
+    authority: TechnicalAdminAuthority,
+  ): Promise<EventAdministrationOutcome<TypedGrantMutation>>;
+  disableEventAdminGrant(
+    eventId: unknown,
+    authority: TechnicalAdminAuthority,
+  ): Promise<EventAdministrationOutcome<TypedGrantMutation>>;
+  revokeEventAdminGrant(
+    eventId: unknown,
+    authority: TechnicalAdminAuthority,
+  ): Promise<EventAdministrationOutcome<TypedGrantMutation>>;
+  reactivateEventAdminGrant(
+    eventId: unknown,
+    authority: TechnicalAdminAuthority,
+  ): Promise<EventAdministrationOutcome<TypedGrantMutation>>;
+  admitEventAdmin(input: {
+    qrCredential: unknown;
+    browserContext: unknown;
+    deviceClass?: unknown;
+    browserClass?: unknown;
+  }): Promise<TypedGrantAdmission | TypedGrantAdmissionThrottled>;
+  leaveEventAdminSession(sessionBearer: unknown): Promise<TypedGrantMutation>;
+  openEventHub(input: {
+    eventId: unknown;
+    gameDayId?: unknown;
+    authority: EventAdministrationAuthority;
+  }): Promise<EventAdministrationOutcome<EventHubProjection>>;
+};
+
+export function createEventAdministration(
+  options: EventAdministrationOptions,
+): EventAdministration {
+  const nowMs = options.nowMs ?? (() => Date.now());
+
+  return {
+    async createEventAdminGrant(eventIdInput, authority) {
+      if (!isTechnicalAdminAuthority(authority)) return unauthorized();
+      const eventId = validateEventId(eventIdInput);
+      if (!eventId.ok) return invalid(eventId.error);
+      try {
+        return await options.storage.transaction((transaction) => {
+          const event = transaction.findEvent(eventId.value);
+          if (event === null) return notFound("Event was not found.");
+          const finalGameDay = transaction
+            .listGameDays(event.eventId)
+            .sort((left, right) => left.date.localeCompare(right.date))
+            .at(-1);
+          if (finalGameDay === undefined) return invalid("The Event needs a Game Day first.");
+          const result = options.grants.createEventAdminGrantInTransaction(transaction, {
+            authority,
+            scope: {
+              eventId: event.eventId,
+              eventTimeZone: event.timeZone,
+              finalGameDayDate: finalGameDay.date,
+            },
+          });
+          if (result.status !== "created") return grantMutationRejection(result);
+          const stored = transaction.findGrantById(result.grantId);
+          if (stored === null) return unavailable();
+          return accepted(projectGrant(stored));
+        });
+      } catch {
+        return unavailable();
+      }
+    },
+
+    async inspectEventAdminGrant(eventIdInput, authority) {
+      const eventId = validateEventId(eventIdInput);
+      if (!eventId.ok) return invalid(eventId.error);
+      try {
+        return await options.storage.transaction((transaction) => {
+          if (
+            authorizeEventScopeInTransaction(options, transaction, eventId.value, authority) ===
+            null
+          )
+            return unauthorized();
+          const grant =
+            transaction
+              .listGrants()
+              .filter(
+                (candidate) =>
+                  candidate.grantType === EVENT_ADMIN_GRANT_TYPE &&
+                  candidate.scope.eventId === eventId.value,
+              )
+              .sort((left, right) => right.createdAtMs - left.createdAtMs)[0] ?? null;
+          return accepted(grant === null ? null : projectGrant(grant));
+        });
+      } catch {
+        return unavailable();
+      }
+    },
+
+    async revealEventAdminGrant(eventIdInput, authority) {
+      if (!isTechnicalAdminAuthority(authority)) return unauthorized();
+      const grant = await findEventAdminGrant(options, eventIdInput);
+      if (grant.status !== "accepted") return grant;
+      if (grant.value === null) return notFound("Event Admin Grant was not found.");
+      const result = await options.grants.revealGrant(grant.value.grantId, authority);
+      if (result.status === "revealed") return accepted(result);
+      if (result.reason === "unauthorized") return unauthorized();
+      if (result.reason === "not-found") return notFound(result.detail);
+      return unavailable();
+    },
+
+    async rotateEventAdminGrant(eventIdInput, authority) {
+      return manageEventAdminGrant(options, eventIdInput, authority, "rotateGrant");
+    },
+    async disableEventAdminGrant(eventIdInput, authority) {
+      return manageEventAdminGrant(options, eventIdInput, authority, "disableGrant");
+    },
+    async revokeEventAdminGrant(eventIdInput, authority) {
+      return manageEventAdminGrant(options, eventIdInput, authority, "revokeGrant");
+    },
+    async reactivateEventAdminGrant(eventIdInput, authority) {
+      return manageEventAdminGrant(options, eventIdInput, authority, "reactivateGrant");
+    },
+
+    async admitEventAdmin(input) {
+      if (
+        typeof input.qrCredential !== "string" ||
+        typeof input.browserContext !== "string" ||
+        input.qrCredential.length === 0 ||
+        input.browserContext.length === 0
+      )
+        return options.grants.admitGrant({ qrCredential: "", browserContext: "" });
+      return options.grants.admitGrant({
+        qrCredential: input.qrCredential,
+        browserContext: input.browserContext,
+        deviceClass: typeof input.deviceClass === "string" ? input.deviceClass : undefined,
+        browserClass: typeof input.browserClass === "string" ? input.browserClass : undefined,
+      });
+    },
+
+    async leaveEventAdminSession(sessionBearer) {
+      if (typeof sessionBearer !== "string")
+        return { status: "rejected", reason: "invalid-input", detail: "Grant Session is invalid." };
+      return options.grants.leaveGrantSession(sessionBearer);
+    },
+
+    async openEventHub(input) {
+      const eventId = validateEventId(input.eventId);
+      if (!eventId.ok) return unauthorized();
+      let gameDayId: string | null = null;
+      if (input.gameDayId !== undefined) {
+        const validatedGameDayId = validateEventId(input.gameDayId);
+        if (!validatedGameDayId.ok) return unauthorized();
+        gameDayId = validatedGameDayId.value;
+      }
+      try {
+        return await options.storage.transaction((transaction) => {
+          const authorized = authorizeEventScopeInTransaction(
+            options,
+            transaction,
+            eventId.value,
+            input.authority,
+          );
+          if (authorized === null) return unauthorized();
+          const stored = transaction.findEvent(eventId.value);
+          if (stored === null) return unauthorized();
+          const event = projectEventProjection(
+            stored,
+            transaction.listGameDays(eventId.value),
+            transaction.listEventAuditTrail(eventId.value),
+            validNow(nowMs),
+          );
+          if (gameDayId !== null && !event.gameDays.some((day) => day.gameDayId === gameDayId))
+            return unauthorized();
+          return accepted({
+            event,
+            selectedGameDayId: gameDayId,
+            authority: authorized.kind,
+            grantSessionId: authorized.sessionId,
+            grantSessionExpiresAtMs: authorized.sessionExpiresAtMs,
+          });
+        });
+      } catch {
+        return unavailable();
+      }
+    },
+  };
+}
+
+function authorizeEventScopeInTransaction(
+  options: EventAdministrationOptions,
+  transaction: FoundationStorageTransaction,
+  eventId: string,
+  authority: EventAdministrationAuthority,
+): {
+  kind: "technical-admin" | "event-admin";
+  sessionId: string | null;
+  sessionExpiresAtMs: number | null;
+} | null {
+  if (isTechnicalAdminAuthority(authority))
+    return { kind: "technical-admin", sessionId: null, sessionExpiresAtMs: null };
+  if (
+    !isRecord(authority) ||
+    authority.kind !== "grant-session" ||
+    typeof authority.sessionBearer !== "string" ||
+    authority.sessionBearer.length === 0
+  )
+    return null;
+  const result = options.grants.authorizeGrantInTransaction(transaction, {
+    sessionBearer: authority.sessionBearer,
+  });
+  if (
+    result.status !== "authorized" ||
+    result.grantType !== EVENT_ADMIN_GRANT_TYPE ||
+    result.scope.eventId !== eventId
+  )
+    return null;
+  return {
+    kind: "event-admin",
+    sessionId: result.grantSessionId,
+    sessionExpiresAtMs: result.sessionExpiresAtMs ?? null,
+  };
+}
+
+async function findEventAdminGrant(
+  options: EventAdministrationOptions,
+  eventIdInput: unknown,
+): Promise<EventAdministrationOutcome<StoredGrant | null>> {
+  const eventId = validateEventId(eventIdInput);
+  if (!eventId.ok) return invalid(eventId.error);
+  try {
+    return accepted(
+      await options.storage.transaction(
+        (transaction) =>
+          transaction
+            .listGrants()
+            .filter(
+              (candidate) =>
+                candidate.grantType === EVENT_ADMIN_GRANT_TYPE &&
+                candidate.scope.eventId === eventId.value,
+            )
+            .sort((left, right) => right.createdAtMs - left.createdAtMs)[0] ?? null,
+      ),
+    );
+  } catch {
+    return unavailable();
+  }
+}
+
+function grantMutationRejection(result: TypedGrantMutation): EventAdministrationOutcome<never> {
+  if (result.status === "updated") return invalid("Grant creation returned an invalid outcome.");
+  if (result.reason === "unauthorized") return unauthorized();
+  if (result.reason === "not-found") return notFound(result.detail ?? "Grant was not found.");
+  if (result.reason === "unavailable") return unavailable();
+  return invalid(result.detail ?? "Grant operation was rejected.");
+}
+
+async function manageEventAdminGrant(
+  options: EventAdministrationOptions,
+  eventIdInput: unknown,
+  authority: TechnicalAdminAuthority,
+  operation: "rotateGrant" | "disableGrant" | "revokeGrant" | "reactivateGrant",
+): Promise<EventAdministrationOutcome<TypedGrantMutation>> {
+  if (!isTechnicalAdminAuthority(authority)) return unauthorized();
+  const grant = await findEventAdminGrant(options, eventIdInput);
+  if (grant.status !== "accepted") return grant;
+  if (grant.value === null) return notFound("Event Admin Grant was not found.");
+  const result = await options.grants[operation](grant.value.grantId, authority);
+  return result.status === "updated" ? accepted(result) : grantMutationRejection(result);
+}
+
+function projectGrant(grant: StoredGrant): EventAdminGrantProjection {
+  return {
+    grantId: grant.grantId,
+    grantVersion: grant.grantVersion,
+    grantType: EVENT_ADMIN_GRANT_TYPE,
+    eventId: grant.scope.eventId,
+    status: grant.status,
+    createdAtMs: grant.createdAtMs,
+    expiresAtMs: grant.expiresAtMs,
+  };
+}
+
+function validateEventId(
+  value: unknown,
+): { ok: true; value: string } | { ok: false; error: string } {
+  return validateOpaqueIdentifier(value, "eventId");
+}
+
+function validNow(read: () => number): number {
+  const value = read();
+  if (!Number.isSafeInteger(value) || value < 0) throw new Error("Event clock is invalid.");
+  return value;
+}
+
+function accepted<T>(value: T): EventAdministrationOutcome<T> {
+  return { status: "accepted", value };
+}
+
+function invalid(detail: string): EventAdministrationOutcome<never> {
+  return { status: "rejected", reason: "invalid-input", detail };
+}
+
+function unauthorized(): EventAdministrationOutcome<never> {
+  return {
+    status: "rejected",
+    reason: "unauthorized",
+    detail: "Unable to authorize Event Administration.",
+  };
+}
+
+function notFound(detail: string): EventAdministrationOutcome<never> {
+  return { status: "rejected", reason: "not-found", detail };
+}
+
+function unavailable(): EventAdministrationOutcome<never> {
+  return {
+    status: "retryable-failure",
+    detail: "Event Administration is temporarily unavailable.",
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/lib/event-catalog.ts
+++ b/src/lib/event-catalog.ts
@@ -35,6 +35,16 @@ export type EventProjection = StoredEvent & {
   auditTrail: readonly EventAdministrationAuditEntry[];
 };
 
+/** Shared projection seam for composed Event Administration workflows. */
+export function projectEventProjection(
+  event: StoredEvent,
+  gameDays: readonly StoredGameDay[],
+  auditTrail: readonly EventAdministrationAuditEntry[],
+  nowMs: number,
+): EventProjection {
+  return project(event, gameDays, auditTrail, nowMs);
+}
+
 export type CatalogRejectedReason =
   | "invalid-input"
   | "unauthorized"
@@ -70,6 +80,7 @@ export type EventCatalogStorageSnapshot = {
 };
 
 export type EventCatalogStorageTransaction = EventCatalogStorageSnapshot & {
+  hasAttachedEventAdminGrant(eventId: string): boolean;
   insertEvent(event: StoredEvent): void;
   updateEvent(event: StoredEvent): void;
   deleteEvent(eventId: string): void;
@@ -427,6 +438,9 @@ export function createEventCatalog(
         if (transaction.listGameDays(event.eventId).length > 0) {
           return inUse("Event still contains Game Days.");
         }
+        if (transaction.hasAttachedEventAdminGrant(event.eventId)) {
+          return inUse("Event has an attached Event Admin Grant.");
+        }
         const audit = createAudit(
           ids,
           "event-removed",
@@ -712,6 +726,10 @@ function eventCatalogTransaction(
 ): EventCatalogStorageTransaction {
   return {
     ...eventCatalogSnapshot(transaction),
+    hasAttachedEventAdminGrant: (eventId) =>
+      transaction
+        .listGrants()
+        .some((grant) => grant.grantType === "event-admin" && grant.scope.eventId === eventId),
     insertEvent: (event) => transaction.insertEvent(event),
     updateEvent: (event) => transaction.updateEvent(event),
     deleteEvent: (eventId) => transaction.deleteEvent(eventId),

--- a/src/lib/grant-authority-trust.ts
+++ b/src/lib/grant-authority-trust.ts
@@ -1,10 +1,12 @@
 import { validateOpaqueIdentifier } from "@/lib/validation-policy";
 import type { GrantAuthorityActor } from "@/lib/grant-types";
+import type { TechnicalAdminAuthority } from "@/lib/technical-admin-auth";
 
 const TRUSTED_AUTHORITY = Symbol("trusted-grant-authority");
 
 export type GrantAuthorityInput =
   | { kind: "technical-admin"; id: string }
+  | TechnicalAdminAuthority
   | { kind: "grant-session"; sessionBearer: string }
   | GrantAuthorityActor;
 

--- a/src/lib/grant-management-commands.ts
+++ b/src/lib/grant-management-commands.ts
@@ -3,7 +3,7 @@ import {
   createRandomIdentifier,
   encryptCredential,
 } from "@/lib/grant-crypto";
-import type { FoundationStorage } from "@/lib/foundation-storage";
+import type { FoundationStorage, FoundationStorageTransaction } from "@/lib/foundation-storage";
 import type { GrantAuthorityOptions } from "@/lib/grant-authority";
 import {
   GRANT_CREDENTIAL_FORMAT_VERSION,
@@ -44,6 +44,21 @@ export async function createGrant(
   options: GrantAuthorityOptions,
   input: CreateTypedGrantInput,
 ): Promise<TypedGrantCreated | TypedGrantMutation> {
+  try {
+    return await storage.transaction((transaction) =>
+      createGrantInTransaction(transaction, options, input),
+    );
+  } catch (error) {
+    if (error instanceof GrantUnauthorizedError) return unauthorizedGrant();
+    return unavailableGrant();
+  }
+}
+
+export function createGrantInTransaction(
+  transaction: FoundationStorageTransaction,
+  options: GrantAuthorityOptions,
+  input: CreateTypedGrantInput,
+): TypedGrantCreated | TypedGrantMutation {
   if (!isGrantRecord(input) || !isGrantType(input.grantType))
     return invalidGrant("Grant type is invalid.");
   const scope = validateGrantScope(input.grantType, input.scope);
@@ -80,24 +95,31 @@ export async function createGrant(
     expiresAtMs,
     credential: encryptCredential(qrCredential, binding, options.randomness, options.keyRing),
   };
-  try {
-    await storage.transaction((transaction) => {
-      const resolvedAuthority = resolveManagementAuthority(transaction, options, trustedAuthority);
-      if (
-        resolvedAuthority === null ||
-        !canCreateInTransaction(transaction, options, grant, resolvedAuthority)
+  const resolvedAuthority = resolveManagementAuthority(transaction, options, trustedAuthority);
+  if (
+    resolvedAuthority === null ||
+    !canCreateInTransaction(transaction, options, grant, resolvedAuthority)
+  )
+    throw new GrantUnauthorizedError();
+  if (
+    grant.grantType === "event-admin" &&
+    transaction
+      .listGrants()
+      .some(
+        (candidate) =>
+          candidate.grantType === "event-admin" && candidate.scope.eventId === grant.scope.eventId,
       )
-        throw new GrantUnauthorizedError();
-      transaction.insertGrant(grant);
-      transaction.appendGrantAudit(
-        createAuditEntry(options, auditInput("grant-created", grant, resolvedAuthority, "active")),
-      );
-      refreshEventAdminSession(transaction, options, resolvedAuthority);
-    });
-  } catch (error) {
-    if (error instanceof GrantUnauthorizedError) return unauthorizedGrant();
-    return unavailableGrant();
-  }
+  )
+    return {
+      status: "rejected",
+      reason: "invalid-state",
+      detail: "An Event Admin Grant already exists for this Event.",
+    };
+  transaction.insertGrant(grant);
+  transaction.appendGrantAudit(
+    createAuditEntry(options, auditInput("grant-created", grant, resolvedAuthority, "active")),
+  );
+  refreshEventAdminSession(transaction, options, resolvedAuthority);
   return {
     status: "created",
     grantId,

--- a/src/lib/grant-management-sessions.ts
+++ b/src/lib/grant-management-sessions.ts
@@ -165,6 +165,10 @@ export async function admitGrant(
         eventGameId,
         grantSessionId: session.sessionId,
         sessionBearer: bearer,
+        sessionExpiresAtMs:
+          current.grantType === EVENT_ADMIN_GRANT_TYPE
+            ? Math.min(current.expiresAtMs ?? Number.MAX_SAFE_INTEGER, nowMs + 30 * DAY_MS)
+            : null,
       };
     });
   } catch {
@@ -293,6 +297,10 @@ export function authorizeGrantInTransaction(
     scope: structuredClone(grant.scope),
     eventGameId,
     grantSessionId: session.sessionId,
+    sessionExpiresAtMs:
+      grant.grantType === EVENT_ADMIN_GRANT_TYPE
+        ? Math.min(grant.expiresAtMs ?? Number.MAX_SAFE_INTEGER, nowMs + 30 * DAY_MS)
+        : null,
   };
 }
 

--- a/src/lib/grant-management-types.ts
+++ b/src/lib/grant-management-types.ts
@@ -15,6 +15,7 @@ import {
   GENERIC_GRANT_STORAGE_FAILURE,
 } from "@/lib/grant-authority-types";
 import type { GrantAuthorityInput } from "@/lib/grant-authority-trust";
+import type { FoundationStorageTransaction } from "@/lib/foundation-storage";
 import type { GrantLifecycleMetadataCorrection } from "@/lib/grant-management-lifecycle";
 
 export type GrantManagementAuthority = GrantAuthorityInput;
@@ -47,6 +48,7 @@ export type TypedGrantAdmission =
       eventGameId: string | null;
       grantSessionId: string;
       sessionBearer: string;
+      sessionExpiresAtMs?: number | null;
     }
   | typeof GENERIC_GRANT_ADMISSION_FAILURE;
 
@@ -87,6 +89,7 @@ export type TypedGrantAuthorization =
       scope: GrantScope;
       eventGameId: string | null;
       grantSessionId: string;
+      sessionExpiresAtMs?: number | null;
     }
   | {
       status: "switch-required";
@@ -157,6 +160,14 @@ export type TypedGrantAuthority = {
   createEventAdminGrant(
     input: Omit<CreateTypedGrantInput, "grantType"> & { scope: EventAdminGrantScope },
   ): Promise<TypedGrantCreated | TypedGrantMutation>;
+  /**
+   * The composed Event Administration seam. Callers must invoke this inside the Foundation
+   * transaction that revalidates Event membership and Game Day state.
+   */
+  createEventAdminGrantInTransaction(
+    transaction: FoundationStorageTransaction,
+    input: Omit<CreateTypedGrantInput, "grantType"> & { scope: EventAdminGrantScope },
+  ): TypedGrantCreated | TypedGrantMutation;
   createPitchManagerGrant(
     input: Omit<CreateTypedGrantInput, "grantType"> & { scope: PitchManagerGrantScope },
   ): Promise<TypedGrantCreated | TypedGrantMutation>;
@@ -192,6 +203,11 @@ export type TypedGrantAuthority = {
     eventGameId?: string;
     controlSessionDecision?: ControlGrantSessionDecision;
   }): Promise<TypedGrantAuthorization>;
+  /** Revalidates and refreshes a Grant Session on the caller's existing transaction. */
+  authorizeGrantInTransaction(
+    transaction: FoundationStorageTransaction,
+    input: { sessionBearer: string },
+  ): TypedGrantAuthorization;
   acceptControlGrantSessionSwitch(input: {
     sessionBearer: string;
   }): Promise<TypedControlGrantSwitch>;

--- a/src/lib/grant-management.ts
+++ b/src/lib/grant-management.ts
@@ -1,7 +1,12 @@
 import { requireGrantStorageCapabilities, type FoundationStorage } from "@/lib/foundation-storage";
 import type { GrantAuthorityOptions } from "@/lib/grant-authority";
 import { EVENT_ADMIN_GRANT_TYPE, GRANT_TYPE, PITCH_MANAGER_GRANT_TYPE } from "@/lib/grant-types";
-import { createGrant, reactivateGrant, updateGrantStatus } from "@/lib/grant-management-commands";
+import {
+  createGrant,
+  createGrantInTransaction,
+  reactivateGrant,
+  updateGrantStatus,
+} from "@/lib/grant-management-commands";
 import {
   revealGrant,
   rotateGrant,
@@ -14,6 +19,7 @@ import {
   admitGrant,
   acceptControlGrantSessionSwitch,
   authorizeGrant,
+  authorizeGrantInTransaction,
   authorizeControlGrantReplay,
   leaveGrantSession,
   revokeGrantSession,
@@ -53,6 +59,11 @@ export function createTypedGrantAuthority(
     createGrant: (input) => createGrant(storage, options, input),
     createEventAdminGrant: (input) =>
       createGrant(storage, options, { ...input, grantType: EVENT_ADMIN_GRANT_TYPE }),
+    createEventAdminGrantInTransaction: (transaction, input) =>
+      createGrantInTransaction(transaction, options, {
+        ...input,
+        grantType: EVENT_ADMIN_GRANT_TYPE,
+      }),
     createPitchManagerGrant: (input) =>
       createGrant(storage, options, { ...input, grantType: PITCH_MANAGER_GRANT_TYPE }),
     createControlGrant: (input) =>
@@ -66,6 +77,8 @@ export function createTypedGrantAuthority(
     admitGrantCode: (input) => admitGrantCode(storage, options, input),
     admitGrant: (input) => admitGrant(storage, options, input),
     authorizeGrant: (input) => authorizeGrant(storage, options, input),
+    authorizeGrantInTransaction: (transaction, input) =>
+      authorizeGrantInTransaction(transaction, options, input),
     acceptControlGrantSessionSwitch: (input) =>
       acceptControlGrantSessionSwitch(storage, options, input.sessionBearer),
     authorizeControlGrantReplay: (input) => authorizeControlGrantReplay(storage, options, input),

--- a/src/lib/grant-runtime.ts
+++ b/src/lib/grant-runtime.ts
@@ -1,0 +1,83 @@
+import { createHash, randomBytes } from "node:crypto";
+import { createGrantAuthorityVerifier, type GrantAuthorityOptions } from "@/lib/grant-authority";
+import { isTechnicalAdminAuthority } from "@/lib/technical-admin-auth";
+import type { GrantKeyRing } from "@/lib/grant-types";
+
+const KEY_BYTES = 32;
+
+/** Runtime-only wiring for the published Grant authority module. */
+export function readGrantAuthorityOptions(
+  environment: "production" | "test",
+  variables: Record<string, string | undefined> = process.env,
+): GrantAuthorityOptions {
+  const keyRing = readKeyRing(environment, variables);
+  return {
+    environmentId: environment,
+    clock: { nowMs: () => Date.now() },
+    randomness: { bytes: (length) => randomBytes(length) },
+    keyRing,
+    controlScopeResolver: {
+      resolve: () => ({ status: "unavailable", detail: "Control scope is not available." }),
+    },
+    privilegedAuthorityVerifier: createGrantAuthorityVerifier((input) => {
+      if (isTechnicalAdminAuthority(input)) {
+        return { kind: "technical-admin", id: input.sessionId };
+      }
+      if (isRecord(input) && input.kind === "grant-session") {
+        return typeof input.sessionBearer === "string"
+          ? {
+              kind: "grant-session",
+              sessionBearer: input.sessionBearer,
+              sessionId: "runtime-session",
+            }
+          : null;
+      }
+      return null;
+    }),
+  };
+}
+
+function readKeyRing(
+  environment: "production" | "test",
+  variables: Record<string, string | undefined>,
+): GrantKeyRing {
+  const names = {
+    encryption: "GRANT_ENCRYPTION_KEY",
+    lookup: "GRANT_LOOKUP_KEY",
+    audit: "GRANT_AUDIT_KEY",
+  } as const;
+  const configured = Object.values(names).map((name) => variables[name]?.trim() ?? "");
+  if (configured.some(Boolean)) {
+    if (configured.some((value) => value.length === 0))
+      throw new Error("All Grant key environment variables must be configured together.");
+    return {
+      encryption: { currentVersion: "v1", keys: new Map([["v1", decodeKey(configured[0]!)]]) },
+      lookup: { currentVersion: "v1", keys: new Map([["v1", decodeKey(configured[1]!)]]) },
+      audit: { currentVersion: "v1", keys: new Map([["v1", decodeKey(configured[2]!)]]) },
+    };
+  }
+  if (environment === "production")
+    throw new Error("Grant keys are required in the Production Environment.");
+  return {
+    encryption: { currentVersion: "v1", keys: new Map([["v1", testKey("encryption")]]) },
+    lookup: { currentVersion: "v1", keys: new Map([["v1", testKey("lookup")]]) },
+    audit: { currentVersion: "v1", keys: new Map([["v1", testKey("audit")]]) },
+  };
+}
+
+function testKey(name: string): Uint8Array {
+  return new Uint8Array(createHash("sha256").update(`quadball-test-grant-v1:${name}`).digest());
+}
+
+function decodeKey(value: string): Uint8Array {
+  const decoded = /^[0-9a-f]{64}$/u.test(value)
+    ? Buffer.from(value, "hex")
+    : Buffer.from(value, "base64url");
+  if (decoded.byteLength !== KEY_BYTES)
+    throw new Error("Grant keys must contain exactly 32 bytes.");
+  return new Uint8Array(decoded);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/pages/event-admin-page.tsx
+++ b/src/pages/event-admin-page.tsx
@@ -1,0 +1,157 @@
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+type HubResponse = {
+  status: "accepted";
+  value: {
+    event: {
+      eventId: string;
+      name: string;
+      timeZone: string;
+      lifecycle: string;
+      gameDays: Array<{ gameDayId: string; date: string; classification: string }>;
+    };
+    selectedGameDayId: string | null;
+    authority: "technical-admin" | "event-admin";
+  };
+};
+
+export function EventAdminPage() {
+  const queryEventId = new URLSearchParams(window.location.search).get("eventId") ?? "";
+  const [eventId, setEventId] = useState(queryEventId);
+  const [credential, setCredential] = useState("");
+  const [hub, setHub] = useState<HubResponse["value"] | null>(null);
+  const [selectedGameDayId, setSelectedGameDayId] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const loadHub = async (nextGameDayId = selectedGameDayId) => {
+    if (eventId.trim().length === 0) return;
+    const params = new URLSearchParams({ eventId: eventId.trim() });
+    if (nextGameDayId !== null) params.set("gameDayId", nextGameDayId);
+    const response = await fetch(`/api/event-admin/hub?${params}`);
+    const payload = (await response.json()) as
+      | HubResponse
+      | { status: "rejected" | "retryable-failure"; message?: string };
+    if (!response.ok || payload.status !== "accepted")
+      throw new Error("Unable to open the Event Hub.");
+    setHub(payload.value);
+    setSelectedGameDayId(payload.value.selectedGameDayId);
+  };
+
+  useEffect(() => {
+    if (eventId.length > 0) void loadHub().catch(() => undefined);
+  }, []);
+
+  const run = async (action: () => Promise<void>) => {
+    setBusy(true);
+    setMessage(null);
+    try {
+      await action();
+    } catch {
+      setMessage("Unable to authorize the Event Hub.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <main className="mx-auto flex min-h-screen w-full max-w-xl items-center justify-center p-4">
+      <Card className="w-full">
+        <CardHeader>
+          <CardTitle>Event Hub</CardTitle>
+          <CardDescription>Choose the Event and Game Day before operating it.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="event-id">Event ID</Label>
+            <Input
+              id="event-id"
+              value={eventId}
+              onChange={(event) => setEventId(event.target.value)}
+            />
+          </div>
+          {hub === null ? (
+            <div className="space-y-3">
+              <div className="space-y-2">
+                <Label htmlFor="event-admin-credential">Scanned Event Admin QR value</Label>
+                <Input
+                  id="event-admin-credential"
+                  type="password"
+                  value={credential}
+                  onChange={(event) => setCredential(event.target.value)}
+                  autoComplete="off"
+                />
+                <p className="text-xs text-muted-foreground">
+                  Use a trusted QR scanner and submit its value here.
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  disabled={busy || eventId.trim().length === 0 || credential.length === 0}
+                  onClick={() =>
+                    void run(async () => {
+                      const response = await fetch("/api/event-admin/admit", {
+                        method: "POST",
+                        headers: { "content-type": "application/json" },
+                        body: JSON.stringify({ qrCredential: credential }),
+                      });
+                      if (!response.ok) throw new Error("Admission failed.");
+                      setCredential("");
+                      await loadHub(null);
+                    })
+                  }
+                >
+                  Admit Event Admin
+                </Button>
+                <Button
+                  variant="outline"
+                  disabled={busy || eventId.trim().length === 0}
+                  onClick={() => void run(() => loadHub(null))}
+                >
+                  Open as Technical Admin
+                </Button>
+              </div>
+            </div>
+          ) : (
+            <div className="space-y-4 rounded-lg border p-4">
+              <div>
+                <p className="font-semibold">{hub.event.name}</p>
+                <p className="text-sm text-muted-foreground">
+                  {hub.event.timeZone} · {hub.authority}
+                </p>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="game-day-selector">Game Day</Label>
+                <select
+                  className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+                  id="game-day-selector"
+                  value={selectedGameDayId ?? ""}
+                  onChange={(event) => {
+                    const next = event.target.value || null;
+                    setSelectedGameDayId(next);
+                    void run(() => loadHub(next));
+                  }}
+                >
+                  <option value="">Choose a Game Day</option>
+                  {hub.event.gameDays.map((day) => (
+                    <option key={day.gameDayId} value={day.gameDayId}>
+                      {day.date} · {day.classification}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <Button variant="outline" onClick={() => setHub(null)}>
+                Change authority
+              </Button>
+            </div>
+          )}
+          {message ? <p className="text-sm text-destructive">{message}</p> : null}
+        </CardContent>
+      </Card>
+    </main>
+  );
+}

--- a/src/pages/technical-admin-page.tsx
+++ b/src/pages/technical-admin-page.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, type ReactNode } from "react";
+import QRCode from "qrcode/lib/browser";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -234,6 +235,14 @@ type EventProjection = {
   }>;
 };
 
+type EventAdminGrantProjection = {
+  grantId: string;
+  grantVersion: string;
+  eventId: string;
+  status: "active" | "disabled" | "revoked" | "expired";
+  expiresAtMs: number | null;
+};
+
 function EventCatalogPanel() {
   const [events, setEvents] = useState<EventProjection[]>([]);
   const [selected, setSelected] = useState<EventProjection | null>(null);
@@ -244,10 +253,31 @@ function EventCatalogPanel() {
   const [timeZone, setTimeZone] = useState("Europe/Zurich");
   const [gameDayDate, setGameDayDate] = useState("");
   const [message, setMessage] = useState<string | null>(null);
+  const [eventAdminGrant, setEventAdminGrant] = useState<EventAdminGrantProjection | null>(null);
+  const [revealedCredential, setRevealedCredential] = useState<string | null>(null);
+  const [qrDataUrl, setQrDataUrl] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
 
+  useEffect(() => {
+    if (revealedCredential === null) {
+      setQrDataUrl(null);
+      return;
+    }
+    let cancelled = false;
+    void QRCode.toDataURL(revealedCredential, {
+      errorCorrectionLevel: "M",
+      margin: 2,
+      width: 320,
+    }).then((dataUrl) => {
+      if (!cancelled) setQrDataUrl(dataUrl);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [revealedCredential]);
+
   const request = async <T,>(url: string, init?: RequestInit) => {
-    const response = await fetch(url, init);
+    const response = await adminFetch(url, init);
     const payload = (await response.json()) as EventCatalogResponse<T>;
     if (!response.ok || payload.status !== "accepted") {
       throw new Error("detail" in payload ? payload.detail : "Event catalog operation failed.");
@@ -266,6 +296,10 @@ function EventCatalogPanel() {
       setEditedGameDays(
         Object.fromEntries(current.gameDays.map((day) => [day.gameDayId, day.date])),
       );
+      const grant = await request<EventAdminGrantProjection | null>(
+        `/api/admin/events/${current.eventId}/event-admin-grant`,
+      );
+      setEventAdminGrant(grant);
     }
   };
 
@@ -275,6 +309,12 @@ function EventCatalogPanel() {
     setEditedName(current.name);
     setEditedTimeZone(current.timeZone);
     setEditedGameDays(Object.fromEntries(current.gameDays.map((day) => [day.gameDayId, day.date])));
+    setEventAdminGrant(
+      await request<EventAdminGrantProjection | null>(
+        `/api/admin/events/${current.eventId}/event-admin-grant`,
+      ),
+    );
+    setRevealedCredential(null);
   };
 
   useEffect(() => {
@@ -430,6 +470,146 @@ function EventCatalogPanel() {
                 >
                   Remove empty Event
                 </Button>
+                <Button
+                  variant="outline"
+                  onClick={() => window.location.assign(`/event-admin?eventId=${selected.eventId}`)}
+                >
+                  Open Event Hub
+                </Button>
+              </div>
+              <div className="space-y-3 rounded-lg border p-3">
+                <div>
+                  <h3 className="font-semibold">Event Admin Grant</h3>
+                  <p className="text-xs text-muted-foreground">
+                    Shared Event-scoped handoff; the QR credential is shown only after an explicit
+                    reveal.
+                  </p>
+                </div>
+                {eventAdminGrant ? (
+                  <p className="text-sm">
+                    {eventAdminGrant.status} · {eventAdminGrant.grantId}
+                  </p>
+                ) : (
+                  <p className="text-sm text-muted-foreground">No Event Admin Grant yet.</p>
+                )}
+                <div className="flex flex-wrap gap-2">
+                  <Button
+                    disabled={busy || eventAdminGrant !== null}
+                    onClick={() =>
+                      void run(async () => {
+                        setEventAdminGrant(
+                          await request<EventAdminGrantProjection>(
+                            `/api/admin/events/${selected.eventId}/event-admin-grant`,
+                            {
+                              method: "POST",
+                              headers: { "content-type": "application/json" },
+                            },
+                          ),
+                        );
+                      })
+                    }
+                  >
+                    Create Grant
+                  </Button>
+                  <Button
+                    disabled={busy || eventAdminGrant === null}
+                    onClick={() =>
+                      void run(async () => {
+                        const response = await adminFetch(
+                          `/api/admin/events/${selected.eventId}/event-admin-grant/reveal`,
+                          { method: "POST", headers: { "content-type": "application/json" } },
+                        );
+                        const payload = (await response.json()) as EventCatalogResponse<{
+                          qrCredential: string;
+                        }>;
+                        if (!response.ok || payload.status !== "accepted")
+                          throw new Error("Grant reveal failed.");
+                        setRevealedCredential(payload.value.qrCredential);
+                      })
+                    }
+                  >
+                    Reveal QR credential
+                  </Button>
+                  <Button
+                    variant="outline"
+                    disabled={busy || eventAdminGrant?.status !== "active"}
+                    onClick={() =>
+                      void run(async () => {
+                        await request(
+                          `/api/admin/events/${selected.eventId}/event-admin-grant/rotate`,
+                          {
+                            method: "POST",
+                            headers: { "content-type": "application/json" },
+                          },
+                        );
+                        setRevealedCredential(null);
+                        await refresh();
+                      })
+                    }
+                  >
+                    Rotate Grant
+                  </Button>
+                  <Button
+                    variant="outline"
+                    disabled={busy || eventAdminGrant?.status !== "active"}
+                    onClick={() =>
+                      void run(async () => {
+                        await request(
+                          `/api/admin/events/${selected.eventId}/event-admin-grant/disable`,
+                          { method: "POST", headers: { "content-type": "application/json" } },
+                        );
+                        await refresh();
+                      })
+                    }
+                  >
+                    Disable Grant
+                  </Button>
+                  <Button
+                    variant="outline"
+                    disabled={busy || eventAdminGrant?.status !== "active"}
+                    onClick={() =>
+                      void run(async () => {
+                        await request(
+                          `/api/admin/events/${selected.eventId}/event-admin-grant/revoke`,
+                          { method: "POST", headers: { "content-type": "application/json" } },
+                        );
+                        await refresh();
+                      })
+                    }
+                  >
+                    Revoke Grant
+                  </Button>
+                  <Button
+                    variant="outline"
+                    disabled={
+                      busy || eventAdminGrant?.status === "active" || eventAdminGrant === null
+                    }
+                    onClick={() =>
+                      void run(async () => {
+                        await request(
+                          `/api/admin/events/${selected.eventId}/event-admin-grant/reactivate`,
+                          { method: "POST", headers: { "content-type": "application/json" } },
+                        );
+                        setRevealedCredential(null);
+                        await refresh();
+                      })
+                    }
+                  >
+                    Reactivate Grant
+                  </Button>
+                </div>
+                {qrDataUrl ? (
+                  <div className="space-y-2 rounded-md border bg-white p-3">
+                    <img
+                      alt="Event Admin Grant QR code"
+                      className="mx-auto size-80 max-w-full"
+                      src={qrDataUrl}
+                    />
+                    <p className="text-center text-xs text-muted-foreground">
+                      Scan this protected QR code on the Event Admin device.
+                    </p>
+                  </div>
+                ) : null}
               </div>
               <div className="space-y-2">
                 <Label htmlFor="game-day-date">Add Game Day</Label>

--- a/src/qrcode-browser.d.ts
+++ b/src/qrcode-browser.d.ts
@@ -1,0 +1,9 @@
+declare module "qrcode/lib/browser" {
+  import type { QRCodeOptions, QRCodeToDataURLOptions } from "qrcode";
+
+  const QRCode: {
+    toDataURL(text: string, options?: QRCodeOptions & QRCodeToDataURLOptions): Promise<string>;
+  };
+
+  export default QRCode;
+}


### PR DESCRIPTION
## What changed

Implements the minimum reliable two-day Event Admin handoff for parent spec #105 and implementation issue #109:

- Technical Admins can create, reveal, rotate, revoke, and inspect the singular Event Admin Grant through the protected browser flow and focused host-local CLI.
- QR admission creates a pseudonymous Event-scoped Grant Session, with shared Event Hub/Game Day projection for valid Event Admin and Technical Admin authority.
- Grant/session authorization, projection, cookie refresh, audit, and catalog state use the deep Foundation transaction seams and fail closed for stale, expired, revoked, rotated, malformed, or wrong-Event authority.
- The browser reveal presents a real scannable QR credential while keeping the raw credential out of CLI output, URLs, logs, and ordinary diagnostics.

## Why

Event staff need a short-lived, revocable handoff from Technical Admin to a second human device without introducing accounts or claimed identities. The implementation keeps authority pseudonymous and Event-scoped while making the two-day Event Hub flow operationally recoverable.

## User and developer impact

Event Admins can enter the Event Hub by scanning the protected QR handoff and selecting the correct Game Day. Technical Admins retain delegation and lifecycle control. Developers get typed grant-authority and transaction seams for deterministic composition tests; unrelated public, Ad Hoc, and Technical Admin routes retain their existing behavior.

## Validation

- `bun test --isolate`: 386 passed, 0 failed, 16,237 expectations.
- Focused Event Administration, Event Catalog, and private Hub header tests: 18 passed, 0 failed, 80 expectations.
- `bun run check` passed (with existing non-failing `await-thenable` warnings in Grant modules).
- `bun run build` passed.
- `bun run scripts/test-technical-admin-browser.ts` passed, including QR handoff, delegation, rotation, isolation, and revocation evidence.
- `git diff --check` passed.

No qualification tests, deployment changes, merges, or issue closures are included.
