### PR TITLE
Activate durable Event Game control

### DIFF
--- a/docs/agents/event-game-runtime.md
+++ b/docs/agents/event-game-runtime.md
@@ -1,0 +1,20 @@
+# Durable Event Game runtime
+
+The live Event Game Controller runtime is enabled only when all three required
+key-ring variables are configured. Each value is exactly 32 bytes encoded as
+unpadded base64url:
+
+- `EVENT_GAME_ENCRYPTION_KEY`
+- `EVENT_GAME_LOOKUP_KEY`
+- `EVENT_GAME_AUDIT_KEY`
+
+If any value is missing or malformed, the server keeps the durable Controller
+routes unavailable and does not invent a production secret. `EVENT_GAME_DATABASE`
+is optional; when omitted, the runtime database is
+`data/<technical-admin-environment>/event-game.sqlite`. Secret provisioning and
+deployment scope are owned by deployment operations, not by the application.
+Before startup, deployment operations must apply the currently approved
+Foundation migrations to this database. Runtime startup only checks schema
+readiness and compatibility; it never migrates or upgrades the production
+database. Migration remains an explicit operational step with its backup,
+quiescence, readiness, and rollback procedure.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { DEFAULT_AWAY_TEAM_COLOR, DEFAULT_HOME_TEAM_COLOR } from "@/lib/team-col
 import { ColorTestPage } from "@/pages/color-test-page";
 import { EventOperationsPrototypePage } from "@/pages/event-operations-prototype-page";
 import { EventAdminPage } from "@/pages/event-admin-page";
+import { EventGameControllerPage } from "@/pages/event-game-controller-page";
 import { GamePage } from "@/pages/game-page";
 import { TechnicalAdminPage } from "@/pages/technical-admin-page";
 import "./index.css";
@@ -24,6 +25,9 @@ type Route =
     }
   | {
       type: "event-admin";
+    }
+  | {
+      type: "event-game-controller";
     }
   | {
       type: "technical-admin";
@@ -54,6 +58,10 @@ export function App() {
 
   if (route.type === "event-admin") {
     return <EventAdminPage />;
+  }
+
+  if (route.type === "event-game-controller") {
+    return <EventGameControllerPage />;
   }
 
   if (route.type === "technical-admin") {
@@ -348,6 +356,10 @@ function parseRoute(pathname: string, search: string): Route {
 
   if (pathname === "/event-admin" || pathname === "/event-admin/") {
     return { type: "event-admin" };
+  }
+
+  if (pathname === "/event-control" || pathname === "/event-control/") {
+    return { type: "event-game-controller" };
   }
 
   const match = pathname.match(/^\/game\/([a-zA-Z0-9-]+)$/);

--- a/src/index-ad-hoc.test.ts
+++ b/src/index-ad-hoc.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import { applyAdHocCommand, createGame, readAdHocGame } from "./index";
+
+describe("Ad Hoc HTTP route persistence", () => {
+  test("keeps the existing create, command, and read path working", async () => {
+    const createdResponse = await createGame(
+      new Request("http://localhost/api/games", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ homeName: "A", awayName: "B" }),
+      }),
+    );
+    expect(createdResponse.status).toBe(201);
+    const created = (await createdResponse.json()) as { gameId: string };
+
+    expect(
+      applyAdHocCommand({
+        gameId: created.gameId,
+        id: "ad-hoc-command-1",
+        clientSentAtMs: Date.now(),
+        command: { type: "set-running", running: true },
+      }),
+    ).toBe(true);
+    expect(readAdHocGame(created.gameId)).toMatchObject({
+      state: { isRunning: true },
+    });
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,12 @@ import {
 } from "@/lib/sqlite-foundation-probe";
 import { isAllowedWebSocketOrigin } from "@/lib/ws-origin";
 import { parseClientWsMessage, type ServerWsMessage } from "@/lib/ws-protocol";
+import { createLiveEventGameControlTransport } from "@/lib/live-event-game-transport";
+import {
+  openLiveEventGameRuntime,
+  readLiveEventGrantKeyRing,
+  type LiveEventGameRuntime,
+} from "@/lib/live-event-game-runtime";
 import {
   clearTechnicalAdminCookie,
   clearTechnicalAdminCsrfCookie,
@@ -180,6 +186,26 @@ async function startServer() {
         eventAdministration = null;
       }
     }
+    let liveEventRuntime: LiveEventGameRuntime | null = null;
+    const liveEventDatabasePath =
+      process.env.EVENT_GAME_DATABASE ?? `data/${environment}/event-game.sqlite`;
+    const liveEventKeyRing = readLiveEventGrantKeyRing();
+    if (liveEventKeyRing !== null) {
+      try {
+        liveEventRuntime = await openLiveEventGameRuntime({
+          databasePath: liveEventDatabasePath,
+          environmentId: environment,
+          keyRing: liveEventKeyRing,
+        });
+        startupCleanup.add(() => liveEventRuntime?.close());
+      } catch (error) {
+        console.warn("Durable Event Game Controller is unavailable.", error);
+      }
+    }
+    const liveEventControlTransport = createLiveEventGameControlTransport(
+      () => liveEventRuntime?.control ?? null,
+      (request) => technicalAdminAuth.isExpectedBinding(requestBinding(request)),
+    );
     const adminGrantMutationRoute =
       (
         operation:
@@ -261,12 +287,22 @@ async function startServer() {
         "/api/games/:gameId": {
           GET(req: Request) {
             const gameId = new URL(req.url).pathname.replace("/api/games/", "");
-            const game = games.get(gameId);
-            if (game === undefined) {
+            const game = readAdHocGame(gameId);
+            if (game === null) {
               return json({ error: "Game not found." }, 404);
             }
 
-            return json({ game: projectGameView(game.state, Date.now()) });
+            return json({ game });
+          },
+        },
+        "/api/event-control/open": {
+          POST(req: Request) {
+            return liveEventControlTransport.openController(req);
+          },
+        },
+        "/api/event-control/intent": {
+          POST(req: Request) {
+            return liveEventControlTransport.submitControllerIntent(req);
           },
         },
         "/api/admin/enrollment/options": {
@@ -843,7 +879,7 @@ async function runProbeMode(
   }
 }
 
-async function createGame(req: Request) {
+export async function createGame(req: Request) {
   const body = await readJsonBodyWithinLimit(req, SHARED_LIMITS.transport.httpJsonBodyBytes);
   if (!body.ok) {
     return json({ error: body.error }, body.status);
@@ -911,6 +947,23 @@ async function createGame(req: Request) {
     },
     201,
   );
+}
+
+export function readAdHocGame(gameId: string) {
+  const game = games.get(gameId);
+  return game === undefined ? null : projectGameView(game.state, Date.now());
+}
+
+export function applyAdHocCommand(input: {
+  gameId: string;
+  id: string;
+  clientSentAtMs: number;
+  command: GameCommand;
+}) {
+  const managedGame = games.get(input.gameId);
+  if (managedGame === undefined) return false;
+  applyCommandsToGame({ managedGame, commands: [input] });
+  return true;
 }
 
 function createGameId() {

--- a/src/lib/controller-device-context.test.ts
+++ b/src/lib/controller-device-context.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import {
+  readControllerDeviceContext,
+  type ControllerDeviceStorage,
+} from "@/lib/controller-device-context";
+
+function createStorage(): ControllerDeviceStorage {
+  const values = new Map<string, string>();
+  return {
+    getItem(key) {
+      return values.get(key) ?? null;
+    },
+    setItem(key, value) {
+      values.set(key, value);
+    },
+  };
+}
+
+describe("Controller Device context", () => {
+  test("keeps one pseudonymous context per browser storage and separates devices", () => {
+    const firstDevice = createStorage();
+    const secondDevice = createStorage();
+
+    const firstContext = readControllerDeviceContext(firstDevice);
+    expect(readControllerDeviceContext(firstDevice)).toBe(firstContext);
+    expect(readControllerDeviceContext(secondDevice)).not.toBe(firstContext);
+  });
+});

--- a/src/lib/controller-device-context.ts
+++ b/src/lib/controller-device-context.ts
@@ -1,0 +1,35 @@
+const CONTROLLER_DEVICE_CONTEXT_STORAGE_KEY = "quadball-timer.controller-device-context.v1";
+
+export type ControllerDeviceStorage = Pick<Storage, "getItem" | "setItem">;
+
+export function readControllerDeviceContext(
+  storage: ControllerDeviceStorage | null = readBrowserStorage(),
+): string {
+  if (storage !== null) {
+    try {
+      const existing = storage.getItem(CONTROLLER_DEVICE_CONTEXT_STORAGE_KEY);
+      if (existing !== null && existing.length > 0) return existing;
+    } catch {
+      // Private browsing and disabled storage are still valid Controller states.
+    }
+  }
+
+  const context = `controller-device-${crypto.randomUUID()}`;
+  if (storage !== null) {
+    try {
+      storage.setItem(CONTROLLER_DEVICE_CONTEXT_STORAGE_KEY, context);
+    } catch {
+      // The page keeps this generated context for its current lifetime.
+    }
+  }
+  return context;
+}
+
+function readBrowserStorage(): ControllerDeviceStorage | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/controller-intent-retry.test.ts
+++ b/src/lib/controller-intent-retry.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test";
+import { retainControllerGoalIntent } from "@/lib/controller-intent-retry";
+
+describe("Controller tap retry identity", () => {
+  test("reuses the pending operation and fact identity after an uncertain response", () => {
+    const first = retainControllerGoalIntent(null, "side-a", 1234);
+    const retry = retainControllerGoalIntent(first, "side-a", 9876);
+
+    expect(retry).toEqual(first);
+    expect(JSON.stringify(retry)).toBe(JSON.stringify(first));
+    expect(retainControllerGoalIntent(first, "side-b")).not.toEqual(first);
+  });
+});

--- a/src/lib/controller-intent-retry.ts
+++ b/src/lib/controller-intent-retry.ts
@@ -1,0 +1,23 @@
+import {
+  LIVE_EVENT_CONTROL_INTENT_VERSION,
+  type LiveEventControllerIntent,
+} from "@/lib/live-event-game-control";
+
+export type PendingControllerGoalIntent = LiveEventControllerIntent;
+
+export function retainControllerGoalIntent(
+  pending: PendingControllerGoalIntent | null,
+  gameSideId: string,
+  clientOriginAtMs = Date.now(),
+): PendingControllerGoalIntent {
+  if (pending?.gameSideId === gameSideId) return pending;
+  return {
+    version: LIVE_EVENT_CONTROL_INTENT_VERSION,
+    type: "record-goal",
+    operationId: crypto.randomUUID(),
+    factId: crypto.randomUUID(),
+    gameSideId,
+    gameTimeMs: 0,
+    occurrence: { clientOriginAtMs },
+  };
+}

--- a/src/lib/foundation-acceptance.ts
+++ b/src/lib/foundation-acceptance.ts
@@ -39,7 +39,11 @@ import type { GrantAuthorityOptions } from "@/lib/grant-authority";
 import { auditInput } from "@/lib/grant-management-audit";
 import { createAuditEntry as createGrantAudit } from "@/lib/grant-lifecycle";
 import { GENERIC_GRANT_AUTHORIZATION_FAILURE } from "@/lib/grant-authority-types";
-import type { StoredGrant, StoredGrantSession } from "@/lib/grant-types";
+import type {
+  ControlGrantSessionDecision,
+  StoredGrant,
+  StoredGrantSession,
+} from "@/lib/grant-types";
 import { computeLookupDigest } from "@/lib/grant-crypto";
 import { validateOpaqueIdentifier } from "@/lib/validation-policy";
 import {
@@ -70,6 +74,7 @@ export type ControlActionBatchInput = {
   eventGameId: string;
   actions: readonly unknown[];
   sessionBearer?: string;
+  controlSessionDecision?: ControlGrantSessionDecision;
   mode?: "online" | "replay";
   replay?: {
     sessionBearer: string;
@@ -345,7 +350,7 @@ export function createFoundationAcceptance(
     const authorization = authorizeGrantInTransaction(transaction, options.grant, {
       sessionBearer: bearer,
       eventGameId: batch.input.eventGameId,
-      controlSessionDecision: "stay",
+      controlSessionDecision: batch.input.controlSessionDecision ?? "stay",
       readOnly: true,
     });
     if (
@@ -518,7 +523,7 @@ export function createFoundationAcceptance(
     const authorization = authorizeGrantInTransaction(transaction, options.grant, {
       sessionBearer: bearer,
       eventGameId: batch.input.eventGameId,
-      controlSessionDecision: "stay",
+      controlSessionDecision: batch.input.controlSessionDecision ?? "stay",
       readOnly: true,
     });
     if (
@@ -567,9 +572,26 @@ export function createFoundationAcceptance(
         detail: "Retry after the Event scope is available.",
       });
 
-    const currentPreparation = prepareCurrentAction(structural.raw, root);
+    const existing = transaction.findActionByOperationId(
+      root.recordId,
+      structural.envelope.operationId,
+    );
+    let currentPreparation = prepareCurrentAction(structural.raw, root);
+    if (
+      existing !== null &&
+      currentPreparation.prepared !== null &&
+      sameImmutableActionContent(existing.action, currentPreparation.prepared.input)
+    ) {
+      currentPreparation = prepareCurrentAction(
+        withTrustedOccurrence(structural.raw, existing.action.occurrence.trustedAtMs),
+        root,
+      );
+    }
     const prepared = currentPreparation.prepared;
-    if (preflightAction !== undefined && !samePreparationResult(prepared, preflightAction.prepared))
+    if (
+      preflightAction !== undefined &&
+      !samePreparationResultIgnoringTrustedOccurrence(prepared, preflightAction.prepared)
+    )
       return one({
         status: "retry-later",
         reason: "stale-preflight",
@@ -579,7 +601,7 @@ export function createFoundationAcceptance(
     const currentAuthorization = authorizeGrantInTransaction(transaction, options.grant, {
       sessionBearer: bearer,
       eventGameId: batch.input.eventGameId,
-      controlSessionDecision: "stay",
+      controlSessionDecision: batch.input.controlSessionDecision ?? "stay",
     });
     if (
       currentAuthorization === GENERIC_GRANT_AUTHORIZATION_FAILURE ||
@@ -789,7 +811,6 @@ export function createFoundationAcceptance(
         normalizeFoundationRejectionReason(dependency.reason),
         dependency.detail,
       );
-    const existing = transaction.findActionByOperationId(root.recordId, prepared.input.operationId);
     if (existing !== null && existing.contentFingerprint === prepared.contentFingerprint)
       return writeDuplicateOutcome(
         transaction,
@@ -1569,12 +1590,60 @@ function samePreparedAction(
   );
 }
 
-function samePreparationResult(
+function samePreparationResultIgnoringTrustedOccurrence(
   left: PreparedControlAction | null,
   right: PreparedControlAction | null,
 ): boolean {
   if (left === null || right === null) return left === right;
-  return samePreparedAction(left, right);
+  return (
+    left.codecIdentity === right.codecIdentity &&
+    canonicalizeJson(actionContentWithoutTrustedOccurrence(left.input)) ===
+      canonicalizeJson(actionContentWithoutTrustedOccurrence(right.input)) &&
+    canonicalizeJson(left.interpretation) === canonicalizeJson(right.interpretation) &&
+    canonicalizeJson(left.input.lifecycle) === canonicalizeJson(right.input.lifecycle)
+  );
+}
+
+function sameImmutableActionContent(
+  existing: ControlAction,
+  candidate: ControlActionInput,
+): boolean {
+  return (
+    canonicalizeJson(actionContentWithoutTrustedOccurrence(existing)) ===
+    canonicalizeJson(actionContentWithoutTrustedOccurrence(candidate))
+  );
+}
+
+function actionContentWithoutTrustedOccurrence(
+  action: ControlActionInput,
+): Record<string, unknown> {
+  return {
+    recordId: action.recordId,
+    eventGameId: action.eventGameId,
+    operationId: action.operationId,
+    kind: action.kind,
+    payload: action.payload,
+    causalPredecessorIds: action.causalPredecessorIds,
+    occurrence: {
+      clientOriginAtMs: action.occurrence.clientOriginAtMs,
+      source: action.occurrence.source,
+    },
+    grant: action.grant,
+    lifecycle: action.lifecycle,
+    override: action.override ?? null,
+    recoveryProvenance: action.recoveryProvenance ?? null,
+  };
+}
+
+function withTrustedOccurrence(raw: unknown, trustedAtMs: number): unknown {
+  if (!isRecord(raw) || !isRecord(raw.occurrence)) return raw;
+  return {
+    ...structuredClone(raw),
+    occurrence: {
+      ...structuredClone(raw.occurrence),
+      trustedAtMs,
+    },
+  };
 }
 
 function one(result: FoundationActionResult): OneOutcome {

--- a/src/lib/foundation-storage-sqlite.ts
+++ b/src/lib/foundation-storage-sqlite.ts
@@ -100,6 +100,8 @@ import {
 export type SqliteFoundationStorageOptions = {
   migrations?: readonly FoundationMigration[];
   busyTimeoutMs?: number;
+  /** Read-only existing-database mode used by startup readiness preflight. */
+  readOnly?: boolean;
   /** Test-only synchronization seam immediately before acquiring the writer lock. */
   beforeWriteTransactionLock?: () => void;
   grantKeyRing?: GrantKeyRing;
@@ -386,6 +388,7 @@ export class SqliteFoundationStorage implements FoundationStorage {
   private readonly database: Database;
   private readonly migrations: readonly FoundationMigration[];
   private readonly busyTimeoutMs: number;
+  private readonly readOnly: boolean;
   private readonly beforeWriteTransactionLock: (() => void) | undefined;
   private readonly faultInjector: SqliteFoundationStorageOptions["faultInjector"];
   private readonly requireReplayContext: boolean;
@@ -415,6 +418,7 @@ export class SqliteFoundationStorage implements FoundationStorage {
     this.quarantineMarkerPath = databasePath === ":memory:" ? null : `${databasePath}.quarantine`;
     this.migrations = options.migrations ?? FOUNDATION_MIGRATIONS;
     this.busyTimeoutMs = options.busyTimeoutMs ?? 5_000;
+    this.readOnly = options.readOnly === true;
     this.beforeWriteTransactionLock = options.beforeWriteTransactionLock;
     this.faultInjector = options.faultInjector;
     this.requireReplayContext = options.requireReplayContext ?? true;
@@ -422,8 +426,10 @@ export class SqliteFoundationStorage implements FoundationStorage {
       keyRing: options.grantKeyRing,
     };
     this.unsafeFailure = readQuarantineMarker(this.quarantineMarkerPath) ? "corruption" : undefined;
-    this.database = new Database(databasePath);
-    if (this.unsafeFailure !== "corruption") this.configureDatabase();
+    this.database = this.readOnly
+      ? new Database(databasePath, { readonly: true })
+      : new Database(databasePath, { create: true, readwrite: true });
+    if (!this.readOnly && this.unsafeFailure !== "corruption") this.configureDatabase();
     this.dataVersion = this.readDataVersion();
   }
 
@@ -539,7 +545,7 @@ export class SqliteFoundationStorage implements FoundationStorage {
   }
 
   readiness(): Promise<FoundationStorageReadiness> {
-    return this.enqueue(() => this.readinessSync(true));
+    return this.enqueue(() => this.readinessSync(!this.readOnly));
   }
 
   liveness() {
@@ -1586,9 +1592,8 @@ export class SqliteFoundationStorage implements FoundationStorage {
       evidence.sqlite.synchronous = settings.synchronous;
       evidence.sqlite.foreignKeys = settings.foreignKeys === 1;
       if (
-        evidence.sqlite.journalMode !== "wal" ||
-        settings.synchronous !== 2 ||
-        settings.foreignKeys !== 1
+        settings.journalMode.toLowerCase() !== "wal" ||
+        (!this.readOnly && (settings.synchronous !== 2 || settings.foreignKeys !== 1))
       ) {
         evidence.transaction.writePressure = "unsafe";
         return {
@@ -2132,6 +2137,30 @@ export function openSqliteFoundationStorage(
   options: SqliteFoundationStorageOptions = {},
 ): SqliteFoundationStorage {
   return new SqliteFoundationStorage(databasePath, options);
+}
+
+export async function readSqliteFoundationStorageReadiness(
+  databasePath: string,
+  options: Omit<SqliteFoundationStorageOptions, "readOnly"> = {},
+): Promise<FoundationStorageReadiness> {
+  let storage: SqliteFoundationStorage | undefined;
+  try {
+    storage = new SqliteFoundationStorage(databasePath, {
+      ...options,
+      readOnly: true,
+      requireReplayContext: false,
+    });
+    return await storage.readiness();
+  } catch {
+    return {
+      ok: false,
+      status: "missing",
+      detail: "SQLite foundation database is unavailable.",
+      storage: "sqlite",
+    };
+  } finally {
+    storage?.close();
+  }
 }
 
 export async function validateFoundationMigrationCandidate(

--- a/src/lib/grant-management-policy.ts
+++ b/src/lib/grant-management-policy.ts
@@ -167,7 +167,10 @@ export function canManageInTransaction(
     return false;
   }
   if (caller.grantType === "control") {
-    const resolved = options.controlScopeResolver.resolve(caller.scope as ControlGrantScope);
+    const resolved = options.controlScopeResolver.resolve(
+      caller.scope as ControlGrantScope,
+      transaction,
+    );
     if (resolved.status === "terminal") {
       if (resolved.reason === "game-locked")
         terminateControlSessionForEventGame(
@@ -225,7 +228,10 @@ export function canCreateInTransaction(
     return false;
   }
   if (caller.grantType === "control") {
-    const resolved = options.controlScopeResolver.resolve(caller.scope as ControlGrantScope);
+    const resolved = options.controlScopeResolver.resolve(
+      caller.scope as ControlGrantScope,
+      transaction,
+    );
     if (resolved.status === "terminal") {
       if (resolved.reason === "game-locked")
         terminateControlSessionForEventGame(

--- a/src/lib/grant-management-sessions.ts
+++ b/src/lib/grant-management-sessions.ts
@@ -11,6 +11,7 @@ import {
   GRANT_TYPE,
   type ControlGrantScope,
   type ControlGrantScopeResolution,
+  type ControlGrantSessionDecision,
   type ControlGrantSessionResolution,
   type StoredGrant,
   type StoredGrantSession,
@@ -99,7 +100,10 @@ export async function admitGrant(
       }
       let eventGameId: string | null = null;
       if (current.grantType === GRANT_TYPE) {
-        const resolved = options.controlScopeResolver.resolve(current.scope as ControlGrantScope);
+        const resolved = options.controlScopeResolver.resolve(
+          current.scope as ControlGrantScope,
+          transaction,
+        );
         if (
           resolved.status !== "eligible" ||
           !validateOpaqueIdentifier(resolved.eventGameId, "eventGameId").ok
@@ -182,7 +186,8 @@ export async function authorizeGrant(
   input: {
     sessionBearer: string;
     eventGameId?: string;
-    controlSessionDecision?: "stay";
+    controlSessionDecision?: ControlGrantSessionDecision;
+    readOnly?: boolean;
   },
 ): Promise<TypedGrantAuthorization> {
   if (
@@ -208,7 +213,7 @@ export function authorizeGrantInTransaction(
   input: {
     sessionBearer: string;
     eventGameId?: string;
-    controlSessionDecision?: "stay";
+    controlSessionDecision?: ControlGrantSessionDecision;
     readOnly?: boolean;
   },
 ): TypedGrantAuthorization {
@@ -240,6 +245,7 @@ export function authorizeGrantInTransaction(
   if (grant.grantType === GRANT_TYPE) {
     if (input.eventGameId === undefined) return GENERIC_GRANT_AUTHORIZATION_FAILURE;
     const relationship = resolveControlSession(
+      transaction,
       options,
       grant.scope as ControlGrantScope,
       session.eventGameId,
@@ -262,9 +268,10 @@ export function authorizeGrantInTransaction(
       ) {
         eventGameId = relationship.previousEventGameId;
       } else if (
-        input.eventGameId === relationship.currentEventGameId ||
-        (input.controlSessionDecision === undefined &&
-          input.eventGameId === relationship.previousEventGameId)
+        input.eventGameId !== undefined &&
+        (input.eventGameId === relationship.currentEventGameId ||
+          (input.controlSessionDecision === undefined &&
+            input.eventGameId === relationship.previousEventGameId))
       ) {
         return {
           status: "switch-required",
@@ -288,7 +295,9 @@ export function authorizeGrantInTransaction(
       eventGameId = relationship.eventGameId;
     } else if (relationship.status !== "switchable") return GENERIC_GRANT_AUTHORIZATION_FAILURE;
   }
-  if (!input.readOnly) transaction.updateGrantSession({ ...session, lastActiveAtMs: nowMs });
+  if (!input.readOnly) {
+    transaction.updateGrantSession({ ...session, lastActiveAtMs: nowMs });
+  }
   return {
     status: "authorized",
     grantId: grant.grantId,
@@ -322,6 +331,7 @@ export async function acceptControlGrantSessionSwitch(
       if (grant.status !== "active" || grant.grantVersion !== session.grantVersion)
         return GENERIC_GRANT_AUTHORIZATION_FAILURE;
       const relationship = resolveControlSession(
+        transaction,
         options,
         grant.scope as ControlGrantScope,
         session.eventGameId,
@@ -581,6 +591,7 @@ export async function authorizeControlGrantReplay(
 }
 
 function resolveControlSession(
+  transaction: FoundationStorageTransaction,
   options: GrantAuthorityOptions,
   scope: ControlGrantScope,
   sessionEventGameId: string,
@@ -612,13 +623,14 @@ function resolveControlSession(
         : { status: "mismatch" };
     return resolved;
   }
-  const current = options.controlScopeResolver.resolve(scope);
+  const current = options.controlScopeResolver.resolve(scope, transaction);
   if (
     current.status === "eligible" &&
-    current.eventGameId === sessionEventGameId &&
     validateOpaqueIdentifier(current.eventGameId, "eventGameId").ok
   )
-    return { status: "current", eventGameId: current.eventGameId };
+    return current.eventGameId === sessionEventGameId
+      ? { status: "current", eventGameId: current.eventGameId }
+      : { status: "mismatch" };
   if (
     current.status === "terminal" &&
     current.reason === "game-locked" &&

--- a/src/lib/grant-management-types.ts
+++ b/src/lib/grant-management-types.ts
@@ -202,6 +202,7 @@ export type TypedGrantAuthority = {
     sessionBearer: string;
     eventGameId?: string;
     controlSessionDecision?: ControlGrantSessionDecision;
+    readOnly?: boolean;
   }): Promise<TypedGrantAuthorization>;
   /** Revalidates and refreshes a Grant Session on the caller's existing transaction. */
   authorizeGrantInTransaction(

--- a/src/lib/grant-types.ts
+++ b/src/lib/grant-types.ts
@@ -1,4 +1,5 @@
 import { validateOpaqueIdentifier, type ValidationResult } from "@/lib/validation-policy";
+import type { FoundationStorageSnapshot } from "@/lib/foundation-storage";
 
 export const GRANT_CREDENTIAL_FORMAT_VERSION = 1 as const;
 export const GRANT_CREDENTIAL_KIND = "qr" as const;
@@ -138,7 +139,10 @@ export type ControlGrantReplayResolution =
 export type ControlGrantSessionDecision = "stay";
 
 export type ControlGrantScopeResolver = {
-  resolve(scope: ControlGrantScope): ControlGrantScopeResolution;
+  resolve(
+    scope: ControlGrantScope,
+    snapshot?: FoundationStorageSnapshot,
+  ): ControlGrantScopeResolution;
   /** Optional lifecycle-aware seam used after a session has already been admitted. */
   resolveSession?: (
     scope: ControlGrantScope,

--- a/src/lib/live-event-game-control.test.ts
+++ b/src/lib/live-event-game-control.test.ts
@@ -1,0 +1,714 @@
+import { describe, expect, test } from "bun:test";
+import { applyGameCommand, createInitialGameState } from "@/lib/game-engine";
+import { createFoundationAcceptance } from "@/lib/foundation-acceptance";
+import { createInMemoryFoundationStorage } from "@/lib/foundation-storage-memory";
+import { createEventGameRecord } from "@/lib/event-game-record";
+import { createGrantTestAuthorityVerifier } from "@/lib/grant-authority-test-support";
+import { createTypedGrantAuthority } from "@/lib/grant-management";
+import type { GrantAuthorityOptions } from "@/lib/grant-authority";
+import type { GrantKeyRing } from "@/lib/grant-types";
+import type { EventGameRecordRoot } from "@/lib/foundation-record-types";
+import {
+  createLiveEventGameControl,
+  createLiveEventGameIqaInterpreter,
+  LIVE_EVENT_CONTROL_INTENT_VERSION,
+  parseLiveEventControllerIntent,
+} from "@/lib/live-event-game-control";
+import { createLiveEventGameControlTransport } from "@/lib/live-event-game-transport";
+
+describe("Live Event Game control", () => {
+  test("opens from a Control Grant and durably acknowledges a ten-point goal with a rebuilt projection", async () => {
+    const harness = await createHarness();
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "controller-phone",
+    });
+
+    expect(opened).toMatchObject({
+      status: "opened",
+      eventGameId: harness.root.eventGameId,
+      projection: {
+        eventGameId: harness.root.eventGameId,
+        scoreByGameSide: { "side-a": 0, "side-b": 0 },
+      },
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+
+    const result = await harness.control.submitControllerIntent({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      intent: goalIntent(),
+    });
+
+    expect(result).toMatchObject({
+      status: "accepted",
+      acknowledgement: { status: "acknowledged", operationId: "operation-goal" },
+      projection: {
+        eventGameId: harness.root.eventGameId,
+        scoreByGameSide: { "side-a": 10, "side-b": 0 },
+        goalCount: 1,
+      },
+      synchronization: { status: "synchronized", pendingCount: 0 },
+    });
+    expect(JSON.stringify(result)).not.toContain(harness.sessionBearer);
+    expect(await harness.record.readActions()).toHaveLength(1);
+
+    const secondDevice = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "controller-device-b",
+    });
+    expect(secondDevice).toMatchObject({
+      status: "opened",
+      eventGameId: harness.root.eventGameId,
+      projection: {
+        eventGameId: harness.root.eventGameId,
+        scoreByGameSide: { "side-a": 10, "side-b": 0 },
+        goalCount: 1,
+      },
+    });
+  });
+
+  test("keeps invalid, empty, conflicted, expired, revoked, rotated, and wrong-scope authority generic", async () => {
+    const harness = await createHarness();
+    const invalid = await harness.control.openController({
+      qrCredential: "not-a-grant",
+      browserContext: "controller-phone",
+    });
+    expect(invalid).toEqual({
+      status: "rejected",
+      message: "Unable to open Controller experience.",
+    });
+
+    const wrongScope = await createHarness({ grantEventGameId: "different-game" });
+    const wrong = await wrongScope.control.openController({
+      qrCredential: wrongScope.qrCredential,
+      browserContext: "controller-phone",
+    });
+    expect(wrong).toEqual({
+      status: "rejected",
+      message: "Unable to open Controller experience.",
+    });
+
+    const expired = await createHarness({ grantExpiresAtMs: 20_000 });
+    expired.setNow(20_000);
+    expect(
+      await expired.control.openController({
+        qrCredential: expired.qrCredential,
+        browserContext: "controller-phone",
+      }),
+    ).toEqual({
+      status: "rejected",
+      message: "Unable to open Controller experience.",
+    });
+    expect(await harness.record.readActions()).toHaveLength(0);
+
+    for (const scopeStatus of ["empty", "conflict"] as const) {
+      const unresolved = await createHarness({ scopeStatus });
+      expect(
+        await unresolved.control.openController({
+          qrCredential: unresolved.qrCredential,
+          browserContext: "controller-phone",
+        }),
+      ).toEqual({ status: "rejected", message: "Unable to open Controller experience." });
+    }
+
+    const revoked = await createHarness();
+    await revoked.authority.revokeGrant(revoked.grantId, { kind: "fixture", id: "fixture" });
+    expect(
+      await revoked.control.openController({
+        qrCredential: revoked.qrCredential,
+        browserContext: "controller-phone",
+      }),
+    ).toEqual({ status: "rejected", message: "Unable to open Controller experience." });
+
+    const rotated = await createHarness();
+    await rotated.authority.rotateGrant(rotated.grantId, { kind: "fixture", id: "fixture" });
+    expect(
+      await rotated.control.openController({
+        qrCredential: rotated.qrCredential,
+        browserContext: "controller-phone",
+      }),
+    ).toEqual({ status: "rejected", message: "Unable to open Controller experience." });
+  });
+
+  test("authorizes the Controller session before inspecting untrusted intent content", async () => {
+    const harness = await createHarness();
+    expect(
+      await harness.control.submitControllerIntent({
+        sessionBearer: "invalid-session-bearer",
+        eventGameId: harness.root.eventGameId,
+        intent: {
+          operationId: "untrusted-operation-id",
+          version: "unsupported-version",
+          payload: { gameSideId: "untrusted-side" },
+        },
+      }),
+    ).toEqual({
+      status: "rejected",
+      message: "Unable to perform that Controller action.",
+      operationId: null,
+    });
+
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "controller-phone",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+    expect(
+      await harness.control.submitControllerIntent({
+        sessionBearer: opened.session.sessionBearer,
+        eventGameId: "wrong-event-game",
+        intent: {
+          operationId: "untrusted-operation-id",
+          version: "unsupported-version",
+          payload: { gameSideId: "untrusted-side" },
+        },
+      }),
+    ).toEqual({
+      status: "rejected",
+      message: "Unable to perform that Controller action.",
+      operationId: null,
+    });
+  });
+
+  test("rejects a changed Pitch Slot target without synthesizing a session switch", async () => {
+    const harness = await createHarness();
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "controller-phone",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+    const before = await ownerState(harness);
+
+    harness.setScopeEventGameId("reassigned-game");
+    expect(
+      await harness.authority.authorizeGrant({
+        sessionBearer: opened.session.sessionBearer,
+        eventGameId: "reassigned-game",
+        controlSessionDecision: "stay",
+      }),
+    ).toEqual({
+      status: "rejected",
+      code: "grant-authorization-failed",
+      message: "Unable to authorize this Grant Session.",
+    });
+    expect(await ownerState(harness)).toEqual(before);
+  });
+
+  test("idempotently acknowledges a resend and rejects conflicting content under one identity", async () => {
+    const harness = await createHarness();
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "controller-phone",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+
+    const first = await harness.control.submitControllerIntent({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      intent: goalIntent(),
+    });
+    const duplicate = await harness.control.submitControllerIntent({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      intent: goalIntent(),
+    });
+    const conflict = await harness.control.submitControllerIntent({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      intent: goalIntent({ gameSideId: "side-b" }),
+    });
+
+    expect(first.status).toBe("accepted");
+    expect(duplicate).toMatchObject({
+      status: "duplicate-accepted",
+      acknowledgement: { status: "acknowledged", operationId: "operation-goal" },
+      projection: { scoreByGameSide: { "side-a": 10, "side-b": 0 } },
+    });
+    expect(conflict).toEqual({
+      status: "rejected",
+      message: "Unable to perform that Controller action.",
+      operationId: "operation-goal",
+    });
+    expect(await harness.record.readActions()).toHaveLength(1);
+  });
+
+  test("duplicate-acknowledges an identical retry after the server clock advances", async () => {
+    const harness = await createHarness();
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "controller-phone",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+
+    const accepted = await harness.control.submitControllerIntent({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      intent: goalIntent(),
+    });
+    expect(accepted.status).toBe("accepted");
+
+    harness.setNow(20_000);
+    const duplicate = await harness.control.submitControllerIntent({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      intent: goalIntent(),
+    });
+
+    expect(duplicate).toMatchObject({
+      status: "duplicate-accepted",
+      acknowledgement: { status: "acknowledged", operationId: "operation-goal" },
+    });
+    expect((await harness.record.readActions())[0]?.action.occurrence.trustedAtMs).toBe(10_000);
+  });
+
+  test("concurrent identical submissions share one trusted occurrence and one action", async () => {
+    let nowMs = 10_000;
+    const harness = await createHarness({
+      controlClock: () => {
+        nowMs += 1_000;
+        return nowMs;
+      },
+    });
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "controller-phone",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+
+    const results = await Promise.all(
+      [0, 1].map(() =>
+        harness.control.submitControllerIntent({
+          sessionBearer: opened.session.sessionBearer,
+          eventGameId: harness.root.eventGameId,
+          intent: goalIntent(),
+        }),
+      ),
+    );
+
+    expect(results.map((result) => result.status).sort()).toEqual([
+      "accepted",
+      "duplicate-accepted",
+    ]);
+    const actions = await harness.record.readActions();
+    expect(actions).toHaveLength(1);
+    expect(actions[0]?.action.occurrence.trustedAtMs).toBeGreaterThan(10_000);
+  });
+
+  test("keeps distinct Controller Devices active while reopening one device replaces only itself", async () => {
+    const harness = await createHarness();
+    const first = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "controller-device-a",
+    });
+    const second = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "controller-device-b",
+    });
+    if (first.status !== "opened" || second.status !== "opened") {
+      throw new Error("Expected both Controller Devices to open.");
+    }
+
+    const reopened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "controller-device-a",
+    });
+    if (reopened.status !== "opened")
+      throw new Error("Expected the first Controller Device to reopen.");
+
+    const sessions = (await ownerState(harness)).grantSessions;
+    expect(
+      sessions.find((session) => session.sessionId === first.session.grantSessionId)?.status,
+    ).toBe("revoked");
+    expect(
+      sessions.find((session) => session.sessionId === second.session.grantSessionId)?.status,
+    ).toBe("active");
+    expect(
+      sessions.find((session) => session.sessionId === reopened.session.grantSessionId)?.status,
+    ).toBe("active");
+  });
+
+  test("does not acknowledge or project an action when the durable transaction fails", async () => {
+    const harness = await createHarness({ failureBoundary: "after-action" });
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "controller-phone",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+
+    const failed = await harness.control.submitControllerIntent({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      intent: goalIntent(),
+    });
+
+    expect(failed).toEqual({
+      status: "retryable",
+      message: "Controller action was not committed; retry is safe.",
+      operationId: "operation-goal",
+    });
+    expect(await harness.record.readActions()).toHaveLength(0);
+
+    harness.failureBoundary = undefined;
+    const recovered = await harness.control.submitControllerIntent({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      intent: goalIntent(),
+    });
+    expect(recovered).toMatchObject({
+      status: "accepted",
+      projection: { scoreByGameSide: { "side-a": 10 } },
+    });
+  });
+
+  test("assigns trusted occurrence time at the server seam and leaves Ad Hoc commands separate", async () => {
+    expect(
+      parseLiveEventControllerIntent({
+        version: LIVE_EVENT_CONTROL_INTENT_VERSION,
+        type: "record-goal",
+        operationId: "operation-goal",
+        factId: "fact-goal",
+        gameSideId: "side-a",
+        gameTimeMs: 12_000,
+        occurrence: { trustedAtMs: 1, clientOriginAtMs: 10_000, source: "offline" },
+      }),
+    ).toMatchObject({ ok: true });
+    expect(
+      parseLiveEventControllerIntent({
+        version: LIVE_EVENT_CONTROL_INTENT_VERSION,
+        type: "record-goal",
+      }),
+    ).toMatchObject({ ok: false });
+
+    const adHoc = createInitialGameState({ id: "ad-hoc-regression", nowMs: 10_000 });
+    const running = applyGameCommand({
+      state: adHoc,
+      command: { type: "set-running", running: true },
+      nowMs: 10_001,
+    });
+    expect(running.isRunning).toBe(true);
+
+    const harness = await createHarness();
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "controller-phone",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+    await harness.control.submitControllerIntent({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      intent: goalIntent(),
+    });
+    const action = (await harness.record.readActions())[0];
+    expect(action?.action.occurrence).toMatchObject({
+      trustedAtMs: 10_000,
+      clientOriginAtMs: 10_000,
+      source: "online",
+    });
+  });
+
+  test("acknowledges a committed goal when projection rebuild is unavailable", async () => {
+    let projectionUnavailable = false;
+    const harness = await createHarness({ projectionFailure: () => projectionUnavailable });
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "controller-phone",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+    projectionUnavailable = true;
+
+    const result = await harness.control.submitControllerIntent({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      intent: goalIntent(),
+    });
+
+    expect(result).toMatchObject({
+      status: "accepted",
+      acknowledgement: { status: "acknowledged" },
+      projection: null,
+      projectionStatus: "unavailable",
+    });
+    expect(JSON.stringify(result)).not.toContain("not committed");
+    expect(await harness.record.readActions()).toHaveLength(1);
+  });
+
+  test("keeps every owning module unchanged when durable acceptance fails", async () => {
+    const harness = await createHarness({ failureBoundary: "after-action" });
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "controller-phone",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+    const before = await ownerState(harness);
+
+    const result = await harness.control.submitControllerIntent({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      intent: goalIntent(),
+    });
+
+    expect(result.status).toBe("retryable");
+    expect(await ownerState(harness)).toEqual(before);
+  });
+
+  test("exposes the Controller through its HTTP transport without changing Ad Hoc routes", async () => {
+    const harness = await createHarness();
+    const allowedOrigin = "https://timer.quadball.app";
+    const transport = createLiveEventGameControlTransport(
+      () => harness.control,
+      (request) =>
+        request.headers.get("origin") === allowedOrigin &&
+        request.headers.get("host") === "timer.quadball.app",
+    );
+    const rejectedOpen = await transport.openController(
+      new Request("https://timer.quadball.app/api/event-control/open", {
+        method: "POST",
+        headers: { origin: "https://attacker.invalid", host: "timer.quadball.app" },
+        body: JSON.stringify({ qrCredential: harness.qrCredential, browserContext: "phone" }),
+      }),
+    );
+    expect(rejectedOpen.status).toBe(404);
+
+    const openedResponse = await transport.openController(
+      new Request("https://timer.quadball.app/api/event-control/open", {
+        method: "POST",
+        headers: { origin: allowedOrigin, host: "timer.quadball.app" },
+        body: JSON.stringify({ qrCredential: harness.qrCredential, browserContext: "phone" }),
+      }),
+    );
+    expect(openedResponse.status).toBe(200);
+    const opened = (await openedResponse.json()) as {
+      eventGameId: string;
+      session: { sessionBearer: string };
+    };
+    expect(opened.session.sessionBearer).toBeString();
+
+    const actionResponse = await transport.submitControllerIntent(
+      new Request("https://timer.quadball.app/api/event-control/intent", {
+        method: "POST",
+        headers: { origin: allowedOrigin, host: "timer.quadball.app" },
+        body: JSON.stringify({
+          sessionBearer: opened.session.sessionBearer,
+          eventGameId: opened.eventGameId,
+          intent: goalIntent(),
+        }),
+      }),
+    );
+    expect(actionResponse.status).toBe(200);
+    expect(await actionResponse.json()).toMatchObject({ status: "accepted" });
+
+    const rejectedAction = await transport.submitControllerIntent(
+      new Request("https://timer.quadball.app/api/event-control/intent", {
+        method: "POST",
+        headers: { origin: "https://attacker.invalid", host: "timer.quadball.app" },
+        body: JSON.stringify({
+          sessionBearer: opened.session.sessionBearer,
+          eventGameId: opened.eventGameId,
+          intent: goalIntent(),
+        }),
+      }),
+    );
+    expect(rejectedAction.status).toBe(404);
+  });
+});
+
+async function createHarness(
+  overrides: {
+    eventGameId?: string;
+    grantEventGameId?: string;
+    grantExpiresAtMs?: number | null;
+    failureBoundary?: "after-action";
+    projectionFailure?: () => boolean;
+    scopeStatus?: "empty" | "conflict";
+    controlClock?: () => number;
+  } = {},
+) {
+  const root = createRoot(overrides.eventGameId ?? "game-live-control");
+  const storage = createInMemoryFoundationStorage();
+  const grantOptions = createGrantOptions(overrides.grantEventGameId ?? root.eventGameId);
+  const authority = createTypedGrantAuthority(storage, grantOptions);
+  const created = await authority.createControlGrant({
+    scope: root.externalScope,
+    authority: { kind: "fixture", id: "fixture" },
+    expiresAtMs: overrides.grantExpiresAtMs,
+  });
+  if (created.status !== "created") throw new Error("Expected a Control Grant.");
+  const admitted = await authority.admitGrant({
+    qrCredential: created.qrCredential,
+    browserContext: "controller-phone",
+  });
+  if (admitted.status !== "admitted") throw new Error("Expected a Grant Session.");
+  if (overrides.scopeStatus !== undefined) grantOptions.setScopeStatus(overrides.scopeStatus);
+
+  let failureBoundary = overrides.failureBoundary;
+  const record = createEventGameRecord(storage, {
+    externalScopeResolver: createScopeResolver(root),
+    interpreter: createLiveEventGameIqaInterpreter(),
+    clock: () => grantOptions.clock.nowMs(),
+    auditAuthorityVerifier: { verify: () => true },
+  });
+  if ((await record.registerRoot(root)).status !== "registered") {
+    throw new Error("Expected the Event Game Record root to register.");
+  }
+  const acceptance = createFoundationAcceptance(storage, {
+    grant: grantOptions,
+    externalScopeResolver: createScopeResolver(root),
+    clock: () => grantOptions.clock.nowMs(),
+    interpreter: createLiveEventGameIqaInterpreter(),
+    failureInjector: (boundary) => {
+      if (boundary === failureBoundary) throw new Error("simulated durable failure");
+    },
+  });
+  const control = createLiveEventGameControl({
+    resolveEventGameRecord: async (eventGameId) =>
+      eventGameId === root.eventGameId ? { recordId: root.recordId, record } : null,
+    acceptance,
+    grantAuthority: authority,
+    clock: overrides.controlClock ?? (() => grantOptions.clock.nowMs()),
+    projectionFailure: overrides.projectionFailure,
+  });
+  return {
+    root,
+    storage,
+    record,
+    control,
+    authority,
+    grantId: created.grantId,
+    qrCredential: created.qrCredential,
+    sessionBearer: admitted.sessionBearer,
+    set failureBoundary(value: typeof failureBoundary) {
+      failureBoundary = value;
+    },
+    setNow(value: number) {
+      grantOptions.setNow(value);
+    },
+    setScopeEventGameId(value: string) {
+      grantOptions.setScopeEventGameId(value);
+    },
+  };
+}
+
+function goalIntent(overrides: { gameSideId?: string } = {}) {
+  return {
+    version: LIVE_EVENT_CONTROL_INTENT_VERSION,
+    type: "record-goal",
+    operationId: "operation-goal",
+    factId: "fact-goal",
+    gameSideId: overrides.gameSideId ?? "side-a",
+    gameTimeMs: 12_000,
+    occurrence: { clientOriginAtMs: 10_000 },
+  };
+}
+
+type TestGrantOptions = GrantAuthorityOptions & {
+  setNow: (value: number) => void;
+  setScopeStatus: (value: "empty" | "conflict" | undefined) => void;
+  setScopeEventGameId: (value: string) => void;
+};
+
+function createGrantOptions(eventGameId: string): TestGrantOptions {
+  let call = 0;
+  let nowMs = 10_000;
+  let scopeStatus: "empty" | "conflict" | undefined;
+  let resolvedEventGameId = eventGameId;
+  return {
+    environmentId: "live-control-test",
+    clock: { nowMs: () => nowMs },
+    randomness: {
+      bytes: (length) => {
+        call += 1;
+        return Uint8Array.from({ length }, (_, index) => (index + call + length) % 256);
+      },
+    },
+    keyRing: createKeyRing(),
+    controlScopeResolver: {
+      resolve: () =>
+        scopeStatus === undefined
+          ? { status: "eligible", eventGameId: resolvedEventGameId }
+          : { status: scopeStatus },
+    },
+    privilegedAuthorityVerifier: createGrantTestAuthorityVerifier(),
+    setNow(value: number) {
+      nowMs = value;
+    },
+    setScopeStatus(value) {
+      scopeStatus = value;
+    },
+    setScopeEventGameId(value) {
+      resolvedEventGameId = value;
+    },
+  };
+}
+
+async function ownerState(harness: Awaited<ReturnType<typeof createHarness>>) {
+  return harness.storage.transaction((transaction) => ({
+    actions: transaction.listActions(harness.root.recordId),
+    metadata: transaction.readRecordMetadata(harness.root.recordId),
+    recordAudits: transaction.listAuditEntries(harness.root.recordId),
+    grantAudits: transaction.listGrantAudit(harness.grantId),
+    grantSessions: transaction.listGrantSessions(harness.grantId),
+  }));
+}
+
+function createKeyRing(): GrantKeyRing {
+  return {
+    encryption: { currentVersion: "encryption-v1", keys: new Map([["encryption-v1", bytes(1)]]) },
+    lookup: { currentVersion: "lookup-v1", keys: new Map([["lookup-v1", bytes(33)]]) },
+    audit: { currentVersion: "audit-v1", keys: new Map([["audit-v1", bytes(65)]]) },
+  };
+}
+
+function bytes(start: number): Uint8Array {
+  return Uint8Array.from({ length: 32 }, (_, index) => start + index);
+}
+
+function createRoot(eventGameId: string): EventGameRecordRoot {
+  return {
+    recordId: `record-${eventGameId}`,
+    eventId: "event-live-control",
+    eventGameId,
+    ownership: { eventId: "event-live-control", eventGameId },
+    externalScope: {
+      eventId: "event-live-control",
+      gameDayId: "day-1",
+      pitchId: "pitch-1",
+      pitchSlotId: `slot-${eventGameId}`,
+    },
+    gameSides: [
+      { id: "side-a", eventTeamId: "team-a", teamInterpretationRef: "team-a-v1" },
+      { id: "side-b", eventTeamId: "team-b", teamInterpretationRef: "team-b-v1" },
+    ],
+    lifecycle: {
+      phase: "scheduled",
+      commencedAtMs: null,
+      finishedAtMs: null,
+      lockedAtMs: null,
+      lockReason: null,
+    },
+    compatibility: {
+      recordVersion: "record-v1",
+      schemaVersion: "schema-v1",
+      interpreterVersion: "live-event-iqa-v1",
+    },
+    creationEvidence: {
+      operationId: `register-${eventGameId}`,
+      actorReference: "actor-test",
+      source: "event-game-registration",
+      createdAtMs: 500,
+    },
+  };
+}
+
+function createScopeResolver(root: EventGameRecordRoot) {
+  return {
+    resolve(scope: EventGameRecordRoot["externalScope"]) {
+      return JSON.stringify(scope) === JSON.stringify(root.externalScope)
+        ? { status: "resolved" as const, scope: structuredClone(scope) }
+        : { status: "mismatch" as const, detail: "scope mismatch" };
+    },
+    resolveEventTeam() {
+      return { status: "resolved" as const };
+    },
+  };
+}

--- a/src/lib/live-event-game-control.ts
+++ b/src/lib/live-event-game-control.ts
@@ -1,0 +1,436 @@
+import type { EffectiveGameFact, IqaGameRulesInterpreter } from "@/lib/event-game-actions";
+import { createDefaultControlActionCodecs } from "@/lib/event-game-actions";
+import type { EventGameLifecyclePhase, EventGameRecordRoot } from "@/lib/foundation-record-types";
+import type { EventGameRecord } from "@/lib/event-game-record";
+import type { FoundationAcceptance } from "@/lib/foundation-acceptance";
+import type { TypedGrantAuthority } from "@/lib/grant-management-types";
+import {
+  SHARED_LIMITS,
+  validateIntegerInRange,
+  validateOpaqueIdentifier,
+} from "@/lib/validation-policy";
+
+export const LIVE_EVENT_CONTROL_INTENT_VERSION = "live-event-control-intent-v1" as const;
+export const LIVE_EVENT_IQA_INTERPRETER_VERSION = "live-event-iqa-v1" as const;
+
+export type LiveEventControllerIntent = {
+  version: typeof LIVE_EVENT_CONTROL_INTENT_VERSION;
+  type: "record-goal";
+  operationId: string;
+  factId: string;
+  gameSideId: string;
+  gameTimeMs: number;
+  occurrence: {
+    clientOriginAtMs: number | null;
+  };
+};
+
+export type LiveEventGameDerivedState = {
+  interpreterVersion: string;
+  phase: EventGameLifecyclePhase;
+  scoreByGameSide: Readonly<Record<string, number>>;
+  goalCount: number;
+};
+
+export type ControllerProjection = {
+  eventGameId: string;
+  phase: EventGameLifecyclePhase;
+  scoreByGameSide: Readonly<Record<string, number>>;
+  goalCount: number;
+};
+
+export type ControllerSynchronization = {
+  status: "synchronized";
+  pendingCount: 0;
+};
+
+export type OpenControllerResult =
+  | {
+      status: "opened";
+      eventGameId: string;
+      session: {
+        sessionBearer: string;
+        grantSessionId: string;
+        grantVersion: string;
+      };
+      projection: ControllerProjection | null;
+      projectionStatus: "available" | "unavailable";
+      synchronization: ControllerSynchronization;
+    }
+  | {
+      status: "rejected";
+      message: "Unable to open Controller experience.";
+    };
+
+export type LiveEventGameControlResult =
+  | {
+      status: "accepted" | "duplicate-accepted";
+      acknowledgement: {
+        status: "acknowledged";
+        operationId: string;
+      };
+      projection: ControllerProjection | null;
+      projectionStatus: "available" | "unavailable";
+      synchronization: ControllerSynchronization;
+      auditReference: {
+        kind: "control";
+        id: string;
+      };
+    }
+  | {
+      status: "retryable";
+      message: "Controller action was not committed; retry is safe.";
+      operationId: string | null;
+    }
+  | {
+      status: "rejected";
+      message: "Unable to perform that Controller action.";
+      operationId: string | null;
+    };
+
+export type LiveEventGameControlOptions = {
+  resolveEventGameRecord: (
+    eventGameId: string,
+  ) => Promise<{ recordId: string; record: EventGameRecord } | null>;
+  acceptance: FoundationAcceptance;
+  grantAuthority: Pick<TypedGrantAuthority, "admitGrant" | "authorizeGrant">;
+  clock?: () => number;
+  /** Test-only seam for proving the post-commit projection response. */
+  projectionFailure?: () => boolean;
+};
+
+export function createLiveEventGameIqaInterpreter(
+  version = LIVE_EVENT_IQA_INTERPRETER_VERSION,
+): IqaGameRulesInterpreter {
+  return {
+    version,
+    rebuild({ root, effectiveFacts }) {
+      return deriveLiveEventGameState(root, effectiveFacts, version);
+    },
+  };
+}
+
+export function parseLiveEventControllerIntent(
+  value: unknown,
+): { ok: true; value: LiveEventControllerIntent } | { ok: false; error: string } {
+  if (!isRecord(value)) return invalid("Controller intent must be an object.");
+  if (value.version !== LIVE_EVENT_CONTROL_INTENT_VERSION) {
+    return invalid("Controller intent version is unsupported.");
+  }
+  if (value.type !== "record-goal") return invalid("Controller intent type is unsupported.");
+
+  const operationId = validateOpaqueIdentifier(value.operationId, "operationId");
+  const factId = validateOpaqueIdentifier(value.factId, "factId");
+  const gameSideId = validateOpaqueIdentifier(value.gameSideId, "gameSideId");
+  const gameTimeMs = validateIntegerInRange(
+    value.gameTimeMs,
+    0,
+    SHARED_LIMITS.clock.maxMs,
+    "gameTimeMs",
+  );
+  if (!operationId.ok) return invalid(operationId.error);
+  if (!factId.ok) return invalid(factId.error);
+  if (!gameSideId.ok) return invalid(gameSideId.error);
+  if (!gameTimeMs.ok) return invalid(gameTimeMs.error);
+
+  if (!isRecord(value.occurrence)) return invalid("occurrence must be an object.");
+  let clientOriginAtMs: number | null = null;
+  if (
+    value.occurrence.clientOriginAtMs !== undefined &&
+    value.occurrence.clientOriginAtMs !== null
+  ) {
+    const clientOrigin = validateIntegerInRange(
+      value.occurrence.clientOriginAtMs,
+      0,
+      Number.MAX_SAFE_INTEGER,
+      "occurrence.clientOriginAtMs",
+    );
+    if (!clientOrigin.ok) return invalid(clientOrigin.error);
+    clientOriginAtMs = clientOrigin.value;
+  }
+  return {
+    ok: true,
+    value: {
+      version: LIVE_EVENT_CONTROL_INTENT_VERSION,
+      type: "record-goal",
+      operationId: operationId.value,
+      factId: factId.value,
+      gameSideId: gameSideId.value,
+      gameTimeMs: gameTimeMs.value,
+      occurrence: { clientOriginAtMs },
+    },
+  };
+}
+
+export function createLiveEventGameControl(options: LiveEventGameControlOptions) {
+  const clock = options.clock ?? (() => Date.now());
+  const gameFactCodec = createDefaultControlActionCodecs().find(
+    (codec) => codec.kind === "game-fact" && codec.version === "1",
+  );
+  if (gameFactCodec === undefined) {
+    throw new Error("The game-fact runtime codec is unavailable.");
+  }
+  const goalCodec = gameFactCodec;
+
+  async function openController(input: {
+    qrCredential: string;
+    browserContext: string;
+    deviceClass?: string;
+    browserClass?: string;
+  }): Promise<OpenControllerResult> {
+    const admitted = await options.grantAuthority.admitGrant(input);
+    if (admitted.status !== "admitted" || admitted.eventGameId === null) {
+      return rejectedOpen();
+    }
+
+    const authorized = await options.grantAuthority.authorizeGrant({
+      sessionBearer: admitted.sessionBearer,
+      eventGameId: admitted.eventGameId,
+      controlSessionDecision: "stay",
+      readOnly: true,
+    });
+    if (
+      authorized.status !== "authorized" ||
+      authorized.grantType !== "control" ||
+      authorized.eventGameId === null ||
+      authorized.grantSessionId !== admitted.grantSessionId
+    ) {
+      return rejectedOpen();
+    }
+
+    const owner = await options.resolveEventGameRecord(authorized.eventGameId);
+    if (owner === null) return rejectedOpen();
+    const root = await owner.record.readRoot(owner.recordId);
+    if (root === null || root.eventGameId !== authorized.eventGameId) return rejectedOpen();
+
+    const projection = await readProjection(owner.record, root);
+    return {
+      status: "opened",
+      eventGameId: root.eventGameId,
+      session: {
+        sessionBearer: admitted.sessionBearer,
+        grantSessionId: authorized.grantSessionId,
+        grantVersion: authorized.grantVersion,
+      },
+      projection,
+      projectionStatus: projection === null ? "unavailable" : "available",
+      synchronization: synchronized(),
+    };
+  }
+
+  async function submitControllerIntent(input: {
+    sessionBearer: string;
+    eventGameId: string;
+    intent: unknown;
+  }): Promise<LiveEventGameControlResult> {
+    const authorized = await options.grantAuthority.authorizeGrant({
+      sessionBearer: input.sessionBearer,
+      eventGameId: input.eventGameId,
+      controlSessionDecision: "stay",
+      readOnly: true,
+    });
+    if (
+      authorized.status !== "authorized" ||
+      authorized.grantType !== "control" ||
+      authorized.eventGameId === null
+    ) {
+      return rejectedAction(null);
+    }
+
+    const operationId = readOperationId(input.intent);
+    const parsed = parseLiveEventControllerIntent(input.intent);
+    if (!parsed.ok) return rejectedAction(operationId);
+
+    const owner = await options.resolveEventGameRecord(authorized.eventGameId);
+    const root = owner === null ? null : await owner.record.readRoot(owner.recordId);
+    if (
+      owner === null ||
+      root === null ||
+      !root.gameSides.some((side) => side.id === parsed.value.gameSideId)
+    ) {
+      return rejectedAction(parsed.value.operationId);
+    }
+
+    const action = {
+      recordId: owner.recordId,
+      eventGameId: root.eventGameId,
+      operationId: parsed.value.operationId,
+      kind: { id: goalCodec.kind, version: goalCodec.version },
+      payload: {
+        factId: parsed.value.factId,
+        factType: "goal",
+        gameSideId: parsed.value.gameSideId,
+        gameTimeMs: parsed.value.gameTimeMs,
+        data: { points: 10 },
+      },
+      causalPredecessorIds: [],
+      occurrence: {
+        trustedAtMs: clock(),
+        clientOriginAtMs: parsed.value.occurrence.clientOriginAtMs,
+        source: "online",
+      },
+      grant: {
+        sessionId: authorized.grantSessionId,
+        versionId: authorized.grantVersion,
+      },
+      lifecycle: structuredClone(root.lifecycle),
+    };
+
+    let accepted;
+    try {
+      accepted = await options.acceptance.submitBatch({
+        recordId: root.recordId,
+        eventGameId: root.eventGameId,
+        sessionBearer: input.sessionBearer,
+        controlSessionDecision: "stay",
+        actions: [action],
+      });
+    } catch {
+      return retryableAction(parsed.value.operationId);
+    }
+
+    const result = accepted.results[0];
+    if (accepted.status === "partial" || result?.status === "retry-later") {
+      return retryableAction(parsed.value.operationId);
+    }
+    if (result === undefined) return rejectedAction(parsed.value.operationId);
+    if (result.status !== "accepted" && result.status !== "duplicate-accepted") {
+      return rejectedAction(parsed.value.operationId);
+    }
+
+    const projection = await readProjection(owner.record, root);
+    return {
+      status: result.status,
+      acknowledgement: {
+        status: "acknowledged",
+        operationId: parsed.value.operationId,
+      },
+      projection,
+      projectionStatus: projection === null ? "unavailable" : "available",
+      synchronization: synchronized(),
+      auditReference: {
+        kind: "control",
+        id: result.auditId,
+      },
+    };
+  }
+
+  async function readProjection(
+    record: EventGameRecord,
+    root: EventGameRecordRoot,
+  ): Promise<ControllerProjection | null> {
+    try {
+      if (options.projectionFailure?.() === true) return null;
+      const rebuild = await record.rebuild();
+      if (rebuild.status !== "ready") return null;
+      const derived = readDerivedState(rebuild.derivedGameState);
+      if (derived === null) return null;
+      return {
+        eventGameId: root.eventGameId,
+        phase: derived.phase,
+        scoreByGameSide: structuredClone(derived.scoreByGameSide),
+        goalCount: derived.goalCount,
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  return { openController, submitControllerIntent };
+}
+
+function deriveLiveEventGameState(
+  root: EventGameRecordRoot,
+  effectiveFacts: readonly EffectiveGameFact[],
+  version: string,
+): LiveEventGameDerivedState {
+  const scoreByGameSide: Record<string, number> = Object.fromEntries(
+    root.gameSides.map((side) => [side.id, 0]),
+  );
+  let goalCount = 0;
+  for (const fact of effectiveFacts) {
+    if (fact.interpretation.factType !== "goal") continue;
+    const gameSideId = fact.interpretation.gameSideId;
+    if (gameSideId !== null && gameSideId in scoreByGameSide) {
+      scoreByGameSide[gameSideId] = (scoreByGameSide[gameSideId] ?? 0) + 10;
+    }
+    goalCount += 1;
+  }
+  return {
+    interpreterVersion: version,
+    phase: root.lifecycle.phase,
+    scoreByGameSide,
+    goalCount,
+  };
+}
+
+function readDerivedState(value: unknown): LiveEventGameDerivedState | null {
+  if (!isRecord(value) || typeof value.interpreterVersion !== "string") return null;
+  if (
+    value.phase !== "scheduled" &&
+    value.phase !== "in-progress" &&
+    value.phase !== "suspended" &&
+    value.phase !== "finished"
+  )
+    return null;
+  if (!isRecord(value.scoreByGameSide)) return null;
+  const scoreByGameSide: Record<string, number> = {};
+  for (const [gameSideId, score] of Object.entries(value.scoreByGameSide)) {
+    if (
+      !validateOpaqueIdentifier(gameSideId, "scoreByGameSide.gameSideId").ok ||
+      typeof score !== "number" ||
+      !Number.isSafeInteger(score) ||
+      score < 0
+    )
+      return null;
+    scoreByGameSide[gameSideId] = score;
+  }
+  if (
+    typeof value.goalCount !== "number" ||
+    !Number.isSafeInteger(value.goalCount) ||
+    value.goalCount < 0
+  )
+    return null;
+  return {
+    interpreterVersion: value.interpreterVersion,
+    phase: value.phase,
+    scoreByGameSide,
+    goalCount: value.goalCount,
+  };
+}
+
+function synchronized(): ControllerSynchronization {
+  return { status: "synchronized", pendingCount: 0 };
+}
+
+function rejectedOpen(): OpenControllerResult {
+  return { status: "rejected", message: "Unable to open Controller experience." };
+}
+
+function rejectedAction(operationId: string | null): LiveEventGameControlResult {
+  return {
+    status: "rejected",
+    message: "Unable to perform that Controller action.",
+    operationId,
+  };
+}
+
+function retryableAction(operationId: string | null): LiveEventGameControlResult {
+  return {
+    status: "retryable",
+    message: "Controller action was not committed; retry is safe.",
+    operationId,
+  };
+}
+
+function readOperationId(value: unknown): string | null {
+  return isRecord(value) && typeof value.operationId === "string" ? value.operationId : null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function invalid(error: string): { ok: false; error: string } {
+  return { ok: false, error };
+}

--- a/src/lib/live-event-game-runtime.test.ts
+++ b/src/lib/live-event-game-runtime.test.ts
@@ -1,0 +1,349 @@
+import { describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { existsSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createEventGameRecord } from "@/lib/event-game-record";
+import type { EventGameRecordRoot } from "@/lib/foundation-record-types";
+import { FOUNDATION_MIGRATIONS } from "@/lib/foundation-migrations";
+import { openSqliteFoundationStorage } from "@/lib/foundation-storage-sqlite";
+import { createGrantTestAuthorityVerifier } from "@/lib/grant-authority-test-support";
+import { createTypedGrantAuthority } from "@/lib/grant-management";
+import type { GrantAuthorityOptions } from "@/lib/grant-authority";
+import type { GrantKeyRing } from "@/lib/grant-types";
+import { openLiveEventGameRuntime, readLiveEventGrantKeyRing } from "@/lib/live-event-game-runtime";
+import {
+  createLiveEventGameIqaInterpreter,
+  LIVE_EVENT_CONTROL_INTENT_VERSION,
+} from "@/lib/live-event-game-control";
+
+describe("Live Event Game SQLite runtime", () => {
+  test("fails closed when any required runtime secret is absent", () => {
+    expect(
+      readLiveEventGrantKeyRing({
+        EVENT_GAME_ENCRYPTION_KEY: "missing-lookup-and-audit",
+      }),
+    ).toBeNull();
+  });
+
+  test("fails closed without creating a missing database", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "quadball-event-game-runtime-"));
+    const databasePath = join(directory, "event-game.sqlite");
+    try {
+      expect(existsSync(databasePath)).toBe(false);
+      expect(
+        openLiveEventGameRuntime({
+          databasePath,
+          environmentId: "runtime-test",
+          keyRing: createKeyRing(),
+        }),
+      ).rejects.toThrow("Durable Event Game storage is not ready.");
+      expect(existsSync(databasePath)).toBe(false);
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("fails closed without migrating an unprepared database", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "quadball-event-game-runtime-"));
+    const databasePath = join(directory, "event-game.sqlite");
+    const keyRing = createKeyRing();
+    const initialStorage = openSqliteFoundationStorage(databasePath, { grantKeyRing: keyRing });
+    const journalMode = initialStorage.getSettings().journalMode;
+    initialStorage.close();
+    try {
+      expect(
+        openLiveEventGameRuntime({
+          databasePath,
+          environmentId: "runtime-test",
+          keyRing,
+        }),
+      ).rejects.toThrow("Durable Event Game storage is not ready.");
+
+      expect(existsSync(databasePath)).toBe(true);
+      const database = new Database(databasePath, { readonly: true });
+      try {
+        expect(
+          database
+            .query("SELECT name FROM sqlite_master WHERE name = 'foundation_migration_ledger'")
+            .get(),
+        ).toBeNull();
+        expect(database.query("PRAGMA journal_mode").get()).toEqual({ journal_mode: journalMode });
+      } finally {
+        database.close();
+      }
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("fails closed without migrating an incompatible database", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "quadball-event-game-runtime-"));
+    const databasePath = join(directory, "event-game.sqlite");
+    const keyRing = createKeyRing();
+    const migration = FOUNDATION_MIGRATIONS[0];
+    if (migration === undefined) throw new Error("Expected the foundation migrations.");
+    const setupStorage = openSqliteFoundationStorage(databasePath, { grantKeyRing: keyRing });
+    try {
+      await setupStorage.applyMigrations({ requireCandidate: false });
+    } finally {
+      setupStorage.close();
+    }
+    const database = new Database(databasePath);
+    database
+      .query("UPDATE foundation_migration_ledger SET checksum = ? WHERE migration_id = ?")
+      .run("incompatible", migration.id);
+    const ledgerBefore = database
+      .query(
+        "SELECT migration_id, ordinal, schema_version, checksum, status FROM foundation_migration_ledger ORDER BY ordinal",
+      )
+      .all();
+    const journalMode = database.query("PRAGMA journal_mode").get();
+    database.close();
+
+    try {
+      expect(
+        openLiveEventGameRuntime({
+          databasePath,
+          environmentId: "runtime-test",
+          keyRing,
+        }),
+      ).rejects.toThrow("Durable Event Game storage is not ready.");
+
+      const database = new Database(databasePath, { readonly: true });
+      try {
+        expect(
+          database
+            .query(
+              "SELECT migration_id, ordinal, schema_version, checksum, status FROM foundation_migration_ledger ORDER BY ordinal",
+            )
+            .all(),
+        ).toEqual(ledgerBefore);
+        expect(database.query("PRAGMA journal_mode").get()).toEqual(journalMode);
+      } finally {
+        database.close();
+      }
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("activates a configured persisted Game and accepts a goal through the runtime", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "quadball-event-game-runtime-"));
+    const databasePath = join(directory, "event-game.sqlite");
+    const environmentId = "runtime-test";
+    const keyRing = createKeyRing();
+    const configured = readLiveEventGrantKeyRing({
+      EVENT_GAME_ENCRYPTION_KEY: encodeKey(keyRing.encryption.keys.get("encryption-v1")),
+      EVENT_GAME_LOOKUP_KEY: encodeKey(keyRing.lookup.keys.get("lookup-v1")),
+      EVENT_GAME_AUDIT_KEY: encodeKey(keyRing.audit.keys.get("audit-v1")),
+    });
+    expect(configured).not.toBeNull();
+
+    const root = createRoot();
+    const setupStorage = openSqliteFoundationStorage(databasePath, { grantKeyRing: keyRing });
+    let qrCredential: string;
+    try {
+      await setupStorage.applyMigrations({ requireCandidate: false });
+      const setupRecord = createEventGameRecord(setupStorage, {
+        externalScopeResolver: createExternalScopeResolver(root),
+        interpreter: createLiveEventGameIqaInterpreter(),
+        auditAuthorityVerifier: { verify: () => true },
+      });
+      expect(await setupRecord.registerRoot(root)).toMatchObject({ status: "registered" });
+      const authority = createTypedGrantAuthority(
+        setupStorage,
+        createGrantOptions(environmentId, keyRing),
+      );
+      const created = await authority.createControlGrant({
+        scope: root.externalScope,
+        authority: { kind: "fixture", id: "runtime-fixture" },
+      });
+      if (created.status !== "created") throw new Error("Expected a runtime Control Grant.");
+      qrCredential = created.qrCredential;
+    } finally {
+      setupStorage.close();
+    }
+
+    const runtime = await openLiveEventGameRuntime({
+      databasePath,
+      environmentId,
+      keyRing: configured ?? keyRing,
+      clock: () => 10_000,
+    });
+    try {
+      const opened = await runtime.control.openController({
+        qrCredential,
+        browserContext: "runtime-test-device",
+      });
+      expect(opened).toMatchObject({
+        status: "opened",
+        eventGameId: root.eventGameId,
+        projectionStatus: "available",
+        projection: { scoreByGameSide: { "side-a": 0, "side-b": 0 } },
+      });
+      if (opened.status !== "opened") throw new Error("Expected the runtime Controller to open.");
+
+      const accepted = await runtime.control.submitControllerIntent({
+        sessionBearer: opened.session.sessionBearer,
+        eventGameId: opened.eventGameId,
+        intent: {
+          version: LIVE_EVENT_CONTROL_INTENT_VERSION,
+          type: "record-goal",
+          operationId: "runtime-operation-1",
+          factId: "runtime-fact-1",
+          gameSideId: "side-a",
+          gameTimeMs: 0,
+          occurrence: { clientOriginAtMs: 1234 },
+        },
+      });
+      expect(accepted).toMatchObject({
+        status: "accepted",
+        projectionStatus: "available",
+        projection: { scoreByGameSide: { "side-a": 10, "side-b": 0 }, goalCount: 1 },
+      });
+
+      const duplicate = await runtime.control.submitControllerIntent({
+        sessionBearer: opened.session.sessionBearer,
+        eventGameId: opened.eventGameId,
+        intent: {
+          version: LIVE_EVENT_CONTROL_INTENT_VERSION,
+          type: "record-goal",
+          operationId: "runtime-operation-1",
+          factId: "runtime-fact-1",
+          gameSideId: "side-a",
+          gameTimeMs: 0,
+          occurrence: { clientOriginAtMs: 1234 },
+        },
+      });
+      expect(duplicate).toMatchObject({
+        status: "duplicate-accepted",
+        projection: { scoreByGameSide: { "side-a": 10, "side-b": 0 }, goalCount: 1 },
+      });
+
+      const mismatchedSelector = await runtime.control.submitControllerIntent({
+        sessionBearer: opened.session.sessionBearer,
+        eventGameId: "wrong-runtime-game",
+        intent: { version: "untrusted", operationId: "untrusted-operation" },
+      });
+      expect(mismatchedSelector).toEqual({
+        status: "rejected",
+        message: "Unable to perform that Controller action.",
+        operationId: null,
+      });
+
+      const secondDevice = await runtime.control.openController({
+        qrCredential,
+        browserContext: "runtime-test-device-2",
+      });
+      expect(secondDevice).toMatchObject({
+        status: "opened",
+        eventGameId: root.eventGameId,
+        projectionStatus: "available",
+        projection: { scoreByGameSide: { "side-a": 10, "side-b": 0 }, goalCount: 1 },
+      });
+    } finally {
+      runtime.close();
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+});
+
+function createGrantOptions(environmentId: string, keyRing: GrantKeyRing): GrantAuthorityOptions {
+  return {
+    environmentId,
+    clock: { nowMs: () => 10_000 },
+    randomness: { bytes: (length) => crypto.getRandomValues(new Uint8Array(length)) },
+    keyRing,
+    controlScopeResolver: {
+      resolve(scope, snapshot) {
+        if (snapshot === undefined) return { status: "unavailable" };
+        const candidate = snapshot.findRootByPitchSlotId(scope.pitchSlotId);
+        return candidate !== null && sameScope(candidate.externalScope, scope)
+          ? { status: "eligible", eventGameId: candidate.eventGameId }
+          : { status: "empty" };
+      },
+    },
+    privilegedAuthorityVerifier: createGrantTestAuthorityVerifier(),
+  };
+}
+
+function createExternalScopeResolver(root: EventGameRecordRoot) {
+  return {
+    resolve(scope: EventGameRecordRoot["externalScope"]) {
+      return sameScope(scope, root.externalScope)
+        ? { status: "resolved" as const, scope: structuredClone(scope) }
+        : { status: "mismatch" as const, detail: "scope mismatch" };
+    },
+    resolveEventTeam() {
+      return { status: "resolved" as const };
+    },
+  };
+}
+
+function createRoot(): EventGameRecordRoot {
+  return {
+    recordId: "runtime-record-1",
+    eventId: "runtime-event-1",
+    eventGameId: "runtime-game-1",
+    ownership: { eventId: "runtime-event-1", eventGameId: "runtime-game-1" },
+    externalScope: {
+      eventId: "runtime-event-1",
+      gameDayId: "runtime-day-1",
+      pitchId: "runtime-pitch-1",
+      pitchSlotId: "runtime-slot-1",
+    },
+    gameSides: [
+      { id: "side-a", eventTeamId: "team-a", teamInterpretationRef: "team-a-v1" },
+      { id: "side-b", eventTeamId: "team-b", teamInterpretationRef: "team-b-v1" },
+    ],
+    lifecycle: {
+      phase: "scheduled",
+      commencedAtMs: null,
+      finishedAtMs: null,
+      lockedAtMs: null,
+      lockReason: null,
+    },
+    compatibility: {
+      recordVersion: "record-v1",
+      schemaVersion: "schema-v1",
+      interpreterVersion: "live-event-iqa-v1",
+    },
+    creationEvidence: {
+      operationId: "runtime-register-1",
+      actorReference: "runtime-test",
+      source: "event-game-registration",
+      createdAtMs: 1_000,
+    },
+  };
+}
+
+function createKeyRing(): GrantKeyRing {
+  return {
+    encryption: { currentVersion: "encryption-v1", keys: new Map([["encryption-v1", bytes(1)]]) },
+    lookup: { currentVersion: "lookup-v1", keys: new Map([["lookup-v1", bytes(33)]]) },
+    audit: { currentVersion: "audit-v1", keys: new Map([["audit-v1", bytes(65)]]) },
+  };
+}
+
+function bytes(start: number): Uint8Array {
+  return Uint8Array.from({ length: 32 }, (_, index) => start + index);
+}
+
+function encodeKey(value: Uint8Array | undefined): string {
+  if (value === undefined) throw new Error("Expected a test key.");
+  return Buffer.from(value).toString("base64url");
+}
+
+function sameScope(
+  left: EventGameRecordRoot["externalScope"],
+  right: EventGameRecordRoot["externalScope"],
+): boolean {
+  return (
+    left.eventId === right.eventId &&
+    left.gameDayId === right.gameDayId &&
+    left.pitchId === right.pitchId &&
+    left.pitchSlotId === right.pitchSlotId
+  );
+}

--- a/src/lib/live-event-game-runtime.ts
+++ b/src/lib/live-event-game-runtime.ts
@@ -1,0 +1,172 @@
+import { randomBytes } from "node:crypto";
+import { createFoundationAcceptance } from "@/lib/foundation-acceptance";
+import { createEventGameRecord, type ExternalScopeResolver } from "@/lib/event-game-record";
+import type { EventGameRecord } from "@/lib/event-game-record";
+import {
+  openSqliteFoundationStorage,
+  readSqliteFoundationStorageReadiness,
+} from "@/lib/foundation-storage-sqlite";
+import {
+  createLiveEventGameControl,
+  createLiveEventGameIqaInterpreter,
+} from "@/lib/live-event-game-control";
+import { createTypedGrantAuthority } from "@/lib/grant-management";
+import type { GrantAuthorityOptions } from "@/lib/grant-authority";
+import type { GrantKeyRing } from "@/lib/grant-types";
+import type { EventGameRecordRoot } from "@/lib/foundation-record-types";
+
+export type LiveEventGameRuntime = {
+  control: ReturnType<typeof createLiveEventGameControl>;
+  close(): void;
+};
+
+export async function openLiveEventGameRuntime(input: {
+  databasePath: string;
+  environmentId: string;
+  keyRing: GrantKeyRing;
+  clock?: () => number;
+}): Promise<LiveEventGameRuntime> {
+  const readiness = await readSqliteFoundationStorageReadiness(input.databasePath, {
+    grantKeyRing: input.keyRing,
+  });
+  if (!readiness.ok) {
+    throw new Error("Durable Event Game storage is not ready.");
+  }
+
+  const storage = openSqliteFoundationStorage(input.databasePath, { grantKeyRing: input.keyRing });
+  try {
+    const clock = input.clock ?? (() => Date.now());
+    const grantOptions = createGrantOptions(input.environmentId, input.keyRing, clock);
+    const authority = createTypedGrantAuthority(storage, grantOptions);
+    const scopeResolver = createExternalScopeResolver();
+    const acceptance = createFoundationAcceptance(storage, {
+      grant: grantOptions,
+      externalScopeResolver: scopeResolver,
+      interpreter: createLiveEventGameIqaInterpreter(),
+      clock,
+    });
+    const records = new Map<string, EventGameRecord>();
+    const resolveEventGameRecord = async (eventGameId: string) => {
+      const root = await storage.transaction((transaction) =>
+        transaction.findRootByEventGameId(eventGameId),
+      );
+      if (root === null) return null;
+      let record = records.get(root.recordId);
+      if (record === undefined) {
+        record = createEventGameRecord(storage, {
+          externalScopeResolver: scopeResolver,
+          interpreter: createLiveEventGameIqaInterpreter(),
+        });
+        records.set(root.recordId, record);
+      }
+      const activation = await record.registerRoot(root);
+      if (activation.status !== "registered" && activation.status !== "idempotent") {
+        return null;
+      }
+      return { recordId: root.recordId, record };
+    };
+    return {
+      control: createLiveEventGameControl({
+        resolveEventGameRecord,
+        acceptance,
+        grantAuthority: authority,
+        clock,
+      }),
+      close() {
+        storage.close();
+      },
+    };
+  } catch (error) {
+    storage.close();
+    throw error;
+  }
+}
+
+export function readLiveEventGrantKeyRing(
+  environmentVariables: Record<string, string | undefined> = process.env,
+): GrantKeyRing | null {
+  const encryption = readKey(environmentVariables.EVENT_GAME_ENCRYPTION_KEY, 32);
+  const lookup = readKey(environmentVariables.EVENT_GAME_LOOKUP_KEY, 32);
+  const audit = readKey(environmentVariables.EVENT_GAME_AUDIT_KEY, 32);
+  if (encryption === null || lookup === null || audit === null) return null;
+  return {
+    encryption: { currentVersion: "encryption-v1", keys: new Map([["encryption-v1", encryption]]) },
+    lookup: { currentVersion: "lookup-v1", keys: new Map([["lookup-v1", lookup]]) },
+    audit: { currentVersion: "audit-v1", keys: new Map([["audit-v1", audit]]) },
+  };
+}
+
+function createGrantOptions(
+  environmentId: string,
+  keyRing: GrantKeyRing,
+  clock: () => number,
+): GrantAuthorityOptions {
+  return {
+    environmentId,
+    clock: { nowMs: clock },
+    randomness: { bytes: (length) => new Uint8Array(randomBytes(length)) },
+    keyRing,
+    controlScopeResolver: createControlScopeResolver(),
+    privilegedAuthorityVerifier: { verify: () => null },
+  };
+}
+
+function createControlScopeResolver(): GrantAuthorityOptions["controlScopeResolver"] {
+  return {
+    resolve(scope, snapshot) {
+      if (snapshot === undefined) return { status: "unavailable" };
+      const root = snapshot.findRootByPitchSlotId(scope.pitchSlotId);
+      if (root === null) return { status: "empty" };
+      if (
+        root.externalScope.eventId !== scope.eventId ||
+        root.externalScope.gameDayId !== scope.gameDayId ||
+        root.externalScope.pitchId !== scope.pitchId
+      )
+        return { status: "conflict" };
+      if (root.lifecycle.lockedAtMs !== null) {
+        return { status: "terminal", reason: "game-locked", eventGameId: root.eventGameId };
+      }
+      return { status: "eligible", eventGameId: root.eventGameId };
+    },
+  };
+}
+
+function createExternalScopeResolver(): ExternalScopeResolver {
+  return {
+    resolve(scope, snapshot) {
+      const root = snapshot.findRootByPitchSlotId(scope.pitchSlotId);
+      return root !== null && sameScope(root.externalScope, scope)
+        ? { status: "resolved", scope: structuredClone(scope) }
+        : { status: "mismatch", detail: "Event Game Pitch Slot is unavailable." };
+    },
+    resolveEventTeam(eventId, eventTeamId, _snapshot) {
+      return eventId.length > 0 && eventTeamId.length > 0
+        ? { status: "resolved" }
+        : { status: "missing", detail: "Event Team is unavailable." };
+    },
+  };
+}
+
+function readKey(value: string | undefined, bytes: number): Uint8Array | null {
+  if (value === undefined) return null;
+  try {
+    const decoded = new Uint8Array(Buffer.from(value, "base64url"));
+    return decoded.byteLength === bytes && Buffer.from(decoded).toString("base64url") === value
+      ? decoded
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function sameScope(
+  left: EventGameRecordRoot["externalScope"],
+  right: EventGameRecordRoot["externalScope"],
+) {
+  return (
+    left.eventId === right.eventId &&
+    left.gameDayId === right.gameDayId &&
+    left.pitchId === right.pitchId &&
+    left.pitchSlotId === right.pitchSlotId
+  );
+}

--- a/src/lib/live-event-game-transport.ts
+++ b/src/lib/live-event-game-transport.ts
@@ -1,0 +1,101 @@
+import { readJsonBodyWithinLimit } from "@/lib/http-body";
+import type {
+  LiveEventGameControlResult,
+  OpenControllerResult,
+} from "@/lib/live-event-game-control";
+import { SHARED_LIMITS } from "@/lib/validation-policy";
+
+export type LiveEventGameControlTransport = {
+  openController(request: Request): Promise<Response>;
+  submitControllerIntent(request: Request): Promise<Response>;
+};
+
+export type LiveEventGameControlTransportTarget = {
+  openController(input: {
+    qrCredential: string;
+    browserContext: string;
+  }): Promise<OpenControllerResult>;
+  submitControllerIntent(input: {
+    sessionBearer: string;
+    eventGameId: string;
+    intent: unknown;
+  }): Promise<LiveEventGameControlResult>;
+};
+
+export function createLiveEventGameControlTransport(
+  resolve: () => LiveEventGameControlTransportTarget | null,
+  isAllowedRequest: (request: Request) => boolean,
+): LiveEventGameControlTransport {
+  return {
+    async openController(request) {
+      if (!isAllowedRequest(request)) return unavailable();
+      const control = resolve();
+      if (control === null) return unavailable();
+
+      const body = await readJsonBodyWithinLimit(
+        request,
+        SHARED_LIMITS.transport.httpJsonBodyBytes,
+      );
+      if (!body.ok || !isRecord(body.body)) return unavailable();
+      if (typeof body.body.qrCredential !== "string") return unavailable();
+
+      const result = await control.openController({
+        qrCredential: body.body.qrCredential,
+        browserContext:
+          typeof body.body.browserContext === "string" ? body.body.browserContext : "phone",
+      });
+      return result.status === "opened" ? noStoreJson(result) : unavailable();
+    },
+
+    async submitControllerIntent(request) {
+      if (!isAllowedRequest(request)) return unavailable();
+      const control = resolve();
+      if (control === null) return unavailable();
+
+      const body = await readJsonBodyWithinLimit(
+        request,
+        SHARED_LIMITS.transport.httpJsonBodyBytes,
+      );
+      if (!body.ok || !isRecord(body.body)) return unavailable();
+      if (
+        typeof body.body.sessionBearer !== "string" ||
+        typeof body.body.eventGameId !== "string" ||
+        body.body.intent === undefined
+      ) {
+        return unavailable();
+      }
+
+      const result = await control.submitControllerIntent({
+        sessionBearer: body.body.sessionBearer,
+        eventGameId: body.body.eventGameId,
+        intent: body.body.intent,
+      });
+      return noStoreJson(result, resultStatus(result));
+    },
+  };
+}
+
+function resultStatus(result: LiveEventGameControlResult): number {
+  if (result.status === "retryable") return 503;
+  if (result.status === "rejected") return 403;
+  return 200;
+}
+
+function unavailable() {
+  return noStoreJson({ error: "Event Game Controller is unavailable." }, 404);
+}
+
+function noStoreJson(payload: unknown, status = 200) {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: {
+      "cache-control": "no-store",
+      "content-type": "application/json",
+      "referrer-policy": "no-referrer",
+    },
+  });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/pages/event-game-controller-page.tsx
+++ b/src/pages/event-game-controller-page.tsx
@@ -1,0 +1,160 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import type { ControllerProjection } from "@/lib/live-event-game-control";
+import {
+  retainControllerGoalIntent,
+  type PendingControllerGoalIntent,
+} from "@/lib/controller-intent-retry";
+import { readControllerDeviceContext } from "@/lib/controller-device-context";
+
+type OpenResponse = {
+  status: "opened";
+  eventGameId: string;
+  session: { sessionBearer: string };
+  projection: ControllerProjection | null;
+  projectionStatus: "available" | "unavailable";
+};
+
+type ActionResponse = {
+  status: "accepted" | "duplicate-accepted";
+  acknowledgement: { status: "acknowledged"; operationId: string };
+  projection: ControllerProjection | null;
+  projectionStatus: "available" | "unavailable";
+};
+
+export function EventGameControllerPage() {
+  const [qrCredential, setQrCredential] = useState("");
+  const [sessionBearer, setSessionBearer] = useState<string | null>(null);
+  const [eventGameId, setEventGameId] = useState<string | null>(null);
+  const [projection, setProjection] = useState<ControllerProjection | null>(null);
+  const [projectionStatus, setProjectionStatus] = useState<"available" | "unavailable">(
+    "unavailable",
+  );
+  const [message, setMessage] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [pendingIntent, setPendingIntent] = useState<PendingControllerGoalIntent | null>(null);
+  const [browserContext] = useState(() => readControllerDeviceContext());
+
+  async function openController() {
+    setBusy(true);
+    setMessage(null);
+    try {
+      const response = await fetch("/api/event-control/open", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ qrCredential, browserContext }),
+      });
+      if (!response.ok) throw new Error("Unable to open Controller experience.");
+      const result = (await response.json()) as OpenResponse;
+      setSessionBearer(result.session.sessionBearer);
+      setEventGameId(result.eventGameId);
+      setProjection(result.projection);
+      setProjectionStatus(result.projectionStatus);
+    } catch {
+      setSessionBearer(null);
+      setEventGameId(null);
+      setProjection(null);
+      setProjectionStatus("unavailable");
+      setMessage("Unable to open Controller experience.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function recordGoal(gameSideId: string) {
+    if (sessionBearer === null || eventGameId === null) return;
+    setBusy(true);
+    setMessage(null);
+    const intent: PendingControllerGoalIntent = retainControllerGoalIntent(
+      pendingIntent,
+      gameSideId,
+    );
+    setPendingIntent(intent);
+    try {
+      const response = await fetch("/api/event-control/intent", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          sessionBearer,
+          eventGameId,
+          intent,
+        }),
+      });
+      const result = (await response.json()) as ActionResponse | { error?: string };
+      if (!response.ok || !("acknowledgement" in result)) {
+        setMessage("The tap was not acknowledged. Retry the same pending tap.");
+        return;
+      }
+      setPendingIntent(null);
+      setProjection(result.projection);
+      setProjectionStatus(result.projectionStatus);
+      setMessage("Goal acknowledged by the durable Event Game record.");
+    } catch {
+      setMessage("The tap may still be pending. Retry the same pending tap.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <main className="mx-auto w-full max-w-xl p-4 pb-12 sm:p-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Event Game Controller</CardTitle>
+          <CardDescription>Open this Controller Device with a valid Control Grant.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="control-grant">Control Grant credential</Label>
+            <Input
+              id="control-grant"
+              value={qrCredential}
+              onChange={(event) => setQrCredential(event.target.value)}
+              autoComplete="off"
+              placeholder="Scan or paste the QR credential"
+              disabled={sessionBearer !== null || busy}
+            />
+          </div>
+          {sessionBearer === null ? (
+            <Button className="w-full" onClick={() => void openController()} disabled={busy}>
+              Open Controller Device
+            </Button>
+          ) : (
+            <>
+              <div className="rounded-lg border bg-muted/30 p-3 text-sm">
+                <p className="font-medium">Controller Device is active.</p>
+                {projectionStatus === "unavailable" ? (
+                  <p className="mt-1 text-muted-foreground">
+                    The durable action is available, but its projection is temporarily unavailable.
+                  </p>
+                ) : null}
+              </div>
+              {projection === null ? null : (
+                <div className="space-y-3">
+                  <p className="text-sm text-muted-foreground">
+                    Phase: {projection.phase} · Goals: {projection.goalCount}
+                  </p>
+                  {Object.entries(projection.scoreByGameSide).map(([gameSideId, score]) => (
+                    <div key={gameSideId} className="flex items-center justify-between gap-3">
+                      <span className="font-medium">Game Side {gameSideId}</span>
+                      <div className="flex items-center gap-3">
+                        <span className="text-2xl font-semibold tabular-nums">{score}</span>
+                        <Button onClick={() => void recordGoal(gameSideId)} disabled={busy}>
+                          Record 10-point goal
+                        </Button>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </>
+          )}
+          {message === null ? null : <p className="text-sm text-muted-foreground">{message}</p>}
+        </CardContent>
+      </Card>
+    </main>
+  );
+}


### PR DESCRIPTION
## What changed

Implements #84 as the bottom layer of the Spec #83 stack.

- activates a production-shaped phone Controller path from Control Grant admission through explicit Event Game authorization, atomic Foundation Acceptance, durable Event Game Record storage, IQA interpretation, acknowledgement, and rebuilt projection
- keeps Ad Hoc Games on their existing authority and persistence path
- preserves server-owned occurrence time and idempotent sequential or concurrent resends while rejecting conflicting content under the same operation identity
- composes the runtime against an already-prepared SQLite foundation database, with read-only readiness preflight and fail-closed key, schema, scope, and authority handling
- adds focused evidence for rollback atomicity, generic authority failures, exact-Origin admission, distinct Controller Devices, durable second-device projection, and real SQLite activation

## Why

Live Event Games need their first usable vertical control tracer without relying on self-declared Controller mode or mutable in-memory Game State. This layer establishes the narrow durable seam that later Spec #83 tickets extend with commencement, synchronization, clock, rules, and mobile interaction behavior.

## Impact

A valid Control Grant can open its uniquely assigned Event Game and record a ten-point goal that is acknowledged only after durable commit. Invalid or stale authority fails generically before sporting mutation, and missing or incompatible runtime storage remains unavailable rather than being created or migrated during startup.

## Validation

- focused #84 Controller, runtime, Foundation Acceptance, and Grant suites: 29 passed
- `bun run check`
- `bun run test`: 348 passed
- `bun run build`
- `git diff --check`

No qualification, load, soak, crash, recovery, or exact-production-artifact workload was run.
