### PR TITLE
Fail closed when durable authority is unsafe (#80)

### DIFF
--- a/src/lib/event-game-actions-sqlite.focused.ts
+++ b/src/lib/event-game-actions-sqlite.focused.ts
@@ -691,21 +691,16 @@ describe("SQLite immutable Event Game actions", () => {
 
       const reopened = openSqliteFoundationStorage(databasePath);
       const reopenedRecord = createRecord(reopened, root);
-      expect(await reopenedRecord.registerRoot(root)).toMatchObject({ status: "idempotent" });
-      expect(await reopenedRecord.readiness()).toMatchObject({
-        ok: false,
-        status: "rebuild-failure",
+      expect(await reopenedRecord.registerRoot(root)).toMatchObject({
+        status: "rejected",
+        reason: "storage-not-ready",
       });
-      expect(
-        await reopenedRecord.acceptAction(
-          createFact(root, "operation-after-unknown-version", 2_000),
-        ),
-      ).toMatchObject({ status: "rejected", reason: "storage-not-ready" });
-      expect(
-        (await reopenedRecord.readAudit(createAuditAuthority())).filter(
-          (entry) => entry.operationId === "operation-after-unknown-version",
-        ),
-      ).toHaveLength(0);
+      const failedReadiness = await reopenedRecord.readiness();
+      expect(failedReadiness).toMatchObject({ ok: false, status: "storage-not-ready" });
+      expect(failedReadiness.storage.evidence?.replay).toMatchObject({
+        result: "failed",
+        durationMs: expect.any(Number),
+      });
       reopened.close();
     });
   });
@@ -773,11 +768,24 @@ describe("SQLite immutable Event Game actions", () => {
 
         const reopened = openSqliteFoundationStorage(databasePath);
         const reopenedRecord = createRecord(reopened, root);
-        expect(await reopenedRecord.registerRoot(root)).toMatchObject({ status: "idempotent" });
-        expect(await reopenedRecord.readiness(), label).toMatchObject({
-          ok: false,
-          status: "rebuild-failure",
-        });
+        if (label === "action") {
+          expect(await reopenedRecord.registerRoot(root)).toMatchObject({
+            status: "rejected",
+            reason: "storage-not-ready",
+          });
+          const failedReadiness = await reopenedRecord.readiness();
+          expect(failedReadiness).toMatchObject({ ok: false, status: "storage-not-ready" });
+          expect(failedReadiness.storage.evidence?.replay).toMatchObject({
+            result: "failed",
+            durationMs: expect.any(Number),
+          });
+        } else {
+          expect(await reopenedRecord.registerRoot(root)).toMatchObject({ status: "idempotent" });
+          expect(await reopenedRecord.readiness(), label).toMatchObject({
+            ok: false,
+            status: "rebuild-failure",
+          });
+        }
         reopened.close();
       });
     }
@@ -1206,7 +1214,14 @@ describe("SQLite immutable Event Game actions", () => {
         database.close();
         const reopened = openSqliteFoundationStorage(databasePath);
         const reopenedRecord = createRecord(reopened, root);
-        expect(await reopenedRecord.registerRoot(root)).toMatchObject({ status: "idempotent" });
+        if (label === "missing-version") {
+          expect(await reopenedRecord.registerRoot(root)).toMatchObject({
+            status: "rejected",
+            reason: "storage-not-ready",
+          });
+        } else {
+          expect(await reopenedRecord.registerRoot(root)).toMatchObject({ status: "idempotent" });
+        }
         expect(await reopenedRecord.readiness()).toMatchObject({ ok: false });
         expect(
           await reopenedRecord.acceptAction(createFact(root, "operation-after-corruption", 3_000)),
@@ -1238,14 +1253,15 @@ describe("SQLite immutable Event Game actions", () => {
         },
         auditAuthorityVerifier: testAuditAuthorityVerifier,
       });
-      expect(await nondeterministic.registerRoot(root)).toMatchObject({ status: "idempotent" });
+      expect(await nondeterministic.registerRoot(root)).toMatchObject({
+        status: "rejected",
+        reason: "storage-not-ready",
+      });
       expect(
         await nondeterministic.acceptAction(
           createFact(root, "operation-after-nondeterministic", 2_000),
         ),
       ).toMatchObject({ status: "rejected", reason: "storage-not-ready" });
-      expect(await seeded.readActions()).toHaveLength(1);
-      expect(await nondeterministic.readAudit(createAuditAuthority())).toHaveLength(1);
       storage.close();
     });
   });
@@ -1289,8 +1305,14 @@ describe("SQLite immutable Event Game actions", () => {
       expect(
         await record.acceptAction(createFact(root, "operation-after-cache-race", 2_000)),
       ).toMatchObject({ status: "rejected", reason: "storage-not-ready" });
-      expect(await record.readActions()).toHaveLength(1);
-      expect(await record.readAudit(createAuditAuthority())).toHaveLength(1);
+      const retained = new Database(databasePath);
+      expect(
+        retained.query("SELECT COUNT(*) AS count FROM foundation_event_game_record_actions").get(),
+      ).toEqual({ count: 1 });
+      expect(
+        retained.query("SELECT COUNT(*) AS count FROM foundation_event_game_record_audit").get(),
+      ).toEqual({ count: 1 });
+      retained.close();
       storage.close();
     });
   });

--- a/src/lib/event-game-actions.test.ts
+++ b/src/lib/event-game-actions.test.ts
@@ -155,20 +155,20 @@ describe("immutable Event Game actions", () => {
       externalScopeResolver: createScopeResolver(versionRoot),
       interpreter: createDeterministicTestIqaInterpreter("rules-v2"),
     });
-    expect(await versionRecord.registerRoot(versionRoot)).toMatchObject({ status: "registered" });
+    expect(await versionRecord.registerRoot(versionRoot)).toMatchObject({
+      status: "rejected",
+      reason: "storage-not-ready",
+    });
     expect(await versionRecord.rebuild()).toMatchObject({
       status: "failed",
-      reason: "unknown-interpreter-version",
+      reason: "invalid-history",
     });
-    expect(await versionRecord.readiness()).toMatchObject({
-      ok: false,
-      status: "rebuild-failure",
-    });
+    expect(await versionRecord.readiness()).toMatchObject({ ok: false, status: "record-missing" });
     expect(
       await versionRecord.acceptAction(
         createFact(versionRoot, "operation-after-version-failure", 2_000),
       ),
-    ).toMatchObject({ status: "rejected", reason: "storage-not-ready" });
+    ).toMatchObject({ status: "rejected", reason: "record-not-found" });
 
     const nondeterministicRoot = createRoot("record-interpreter-nondeterministic");
     let rebuildCount = 0;
@@ -207,14 +207,19 @@ describe("immutable Event Game actions", () => {
     const record = createEventGameRecord(storage, {
       externalScopeResolver: createScopeResolver(root),
     });
-    expect(await record.registerRoot(root)).toMatchObject({ status: "registered" });
+    expect(await record.registerRoot(root)).toMatchObject({
+      status: "rejected",
+      reason: "storage-not-ready",
+    });
     expect(
       await record.acceptAction(createFact(root, "operation-no-interpreter", 1_000)),
     ).toMatchObject({
       status: "rejected",
-      reason: "storage-not-ready",
+      reason: "record-not-found",
     });
-    expect(await record.readActions()).toHaveLength(0);
+    expect(
+      await storage.transaction((transaction) => transaction.listActions(root.recordId)),
+    ).toHaveLength(0);
     expect(record.readAudit(createTestAuditAuthority("event-admin").credential)).rejects.toThrow(
       "trusted",
     );
@@ -227,7 +232,7 @@ describe("immutable Event Game actions", () => {
       auditAuthorityVerifier: trusted.verifier,
       interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
     });
-    expect(await authorizedRecord.registerRoot(root)).toMatchObject({ status: "idempotent" });
+    expect(await authorizedRecord.registerRoot(root)).toMatchObject({ status: "registered" });
     expect(await authorizedRecord.readAudit(trusted.credential)).toHaveLength(0);
     expect(
       authorizedRecord.readAudit(createTestAuditAuthority("technical-admin").credential),

--- a/src/lib/event-game-record.test.ts
+++ b/src/lib/event-game-record.test.ts
@@ -3,6 +3,7 @@ import {
   canonicalizeEventGameRecordRoot,
   type EventGameRecordRoot,
 } from "@/lib/foundation-record-types";
+import { createDeterministicTestIqaInterpreter } from "@/lib/event-game-actions";
 import { createEventGameRecord, type ExternalScopeResolver } from "@/lib/event-game-record";
 import { createInMemoryFoundationStorage } from "@/lib/foundation-storage-memory";
 
@@ -60,6 +61,7 @@ describe("Event Game Record contract", () => {
     const root = createRoot();
     const record = createEventGameRecord(createInMemoryFoundationStorage(), {
       externalScopeResolver: createScopeResolver(root),
+      interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
     });
 
     expect(await record.registerRoot(root)).toMatchObject({ status: "registered" });
@@ -83,6 +85,7 @@ describe("Event Game Record contract", () => {
     const root = createRoot();
     const record = createEventGameRecord(createInMemoryFoundationStorage(), {
       externalScopeResolver: createScopeResolver(root),
+      interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
     });
     const reordered = JSON.parse(
       JSON.stringify({

--- a/src/lib/event-game-record.ts
+++ b/src/lib/event-game-record.ts
@@ -226,6 +226,18 @@ function rebuildRecordSnapshot(
   return rebuildControlActionHistory(root, storedActions, registry, interpreter);
 }
 
+function hasCompatibleReplayContext(
+  root: EventGameRecordRoot,
+  interpreter: IqaGameRulesInterpreter | undefined,
+): boolean {
+  return (
+    interpreter !== undefined &&
+    typeof interpreter.version === "string" &&
+    interpreter.version === root.compatibility.interpreterVersion &&
+    typeof interpreter.rebuild === "function"
+  );
+}
+
 export function createEventGameRecord(
   storage: FoundationStorage,
   options: EventGameRecordOptions,
@@ -233,6 +245,12 @@ export function createEventGameRecord(
   const clock = options.clock ?? (() => Date.now());
   const codecRegistry =
     options.actionCodecRegistry ?? createControlActionCodecRegistry(options.actionCodecs);
+  if (options.interpreter !== undefined) {
+    storage.setReadinessContext?.({
+      actionCodecRegistry: codecRegistry,
+      interpreter: options.interpreter,
+    });
+  }
   let activeRecordId: string | undefined;
   let verifiedRevision: number | undefined;
   let stableIdentityRevision: number | undefined;
@@ -324,6 +342,14 @@ export function createEventGameRecord(
 
       const root = validated.value;
       const canonicalContent = canonicalizeEventGameRecordRoot(root);
+
+      if (!hasCompatibleReplayContext(root, options.interpreter)) {
+        return {
+          status: "rejected",
+          reason: "storage-not-ready",
+          detail: "The Event Game Record could not be durably registered.",
+        };
+      }
 
       try {
         const outcome = await storage.transaction((transaction) => {

--- a/src/lib/foundation-acceptance-sqlite.focused.ts
+++ b/src/lib/foundation-acceptance-sqlite.focused.ts
@@ -79,6 +79,17 @@ describe("focused SQLite composed acceptance", () => {
       storage.close();
 
       const reopened = openSqliteFoundationStorage(databasePath, { grantKeyRing: createKeyRing() });
+      expect(await reopened.readiness()).toMatchObject({
+        ok: false,
+        status: "integrity-failure",
+        evidence: { replay: { result: "not-configured", rootCount: 1 } },
+      });
+      const reopenedRecord = createEventGameRecord(reopened, {
+        externalScopeResolver: createScopeResolver(root),
+        interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
+        auditAuthorityVerifier: { verify: () => true },
+      });
+      expect(await reopenedRecord.registerRoot(root)).toMatchObject({ status: "idempotent" });
       expect(await reopened.readiness()).toMatchObject({ ok: true, schemaVersion: "21" });
       expect(await reopened.readActions(root.recordId)).toHaveLength(1);
       expect(await reopened.readAuditEntries(root.recordId)).toHaveLength(1);
@@ -106,6 +117,7 @@ describe("focused SQLite composed acceptance", () => {
       if (admitted.status !== "admitted") throw new Error("Expected a Control Session.");
       const record = createEventGameRecord(storage, {
         externalScopeResolver: createScopeResolver(root),
+        interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
       });
       expect(await record.registerRoot(root)).toMatchObject({ status: "registered" });
       const action = createFact(
@@ -182,6 +194,7 @@ describe("focused SQLite composed acceptance", () => {
         throw new Error(`Expected a Control Session: ${JSON.stringify(admitted)}`);
       const record = createEventGameRecord(bootstrap, {
         externalScopeResolver: createScopeResolver(root),
+        interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
       });
       expect(await record.registerRoot(root)).toMatchObject({ status: "registered" });
       bootstrap.close();
@@ -318,8 +331,13 @@ describe("focused SQLite composed acceptance", () => {
       const finalVerify = openSqliteFoundationStorage(databasePath, {
         grantKeyRing: createKeyRing(),
       });
+      const finalRecord = createEventGameRecord(finalVerify, {
+        externalScopeResolver: createScopeResolver(root),
+        interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
+      });
+      expect(await finalRecord.registerRoot(root)).toMatchObject({ status: "idempotent" });
       expect(await finalVerify.readiness()).toMatchObject({ ok: true });
-      expect(await finalVerify.readActions(root.recordId)).toHaveLength(3);
+      expect(await finalRecord.readActions()).toHaveLength(3);
       finalVerify.close();
     });
   });
@@ -343,6 +361,7 @@ describe("focused SQLite composed acceptance", () => {
       if (admitted.status !== "admitted") throw new Error("Expected a Control Session.");
       const record = createEventGameRecord(storage, {
         externalScopeResolver: createScopeResolver(root),
+        interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
       });
       expect(await record.registerRoot(root)).toMatchObject({ status: "registered" });
       const nowMs = { value: 1_000 };
@@ -538,6 +557,7 @@ describe("focused SQLite composed acceptance", () => {
       if (admitted.status !== "admitted") throw new Error("Expected a Control Session.");
       const record = createEventGameRecord(storage, {
         externalScopeResolver: createScopeResolver(root),
+        interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
       });
       expect(await record.registerRoot(root)).toMatchObject({ status: "registered" });
       const acceptance = createAcceptance(storage, root, grantOptions, true);
@@ -731,6 +751,7 @@ describe("focused SQLite composed acceptance", () => {
       if (admitted.status !== "admitted") throw new Error("Expected a Control Session.");
       const record = createEventGameRecord(storage, {
         externalScopeResolver: createScopeResolver(root),
+        interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
       });
       expect(await record.registerRoot(root)).toMatchObject({ status: "registered" });
       const nowMs = { value: 1_000 };
@@ -816,6 +837,7 @@ describe("focused SQLite composed acceptance", () => {
         if (admitted.status !== "admitted") throw new Error("Expected a Control Session.");
         const record = createEventGameRecord(storage, {
           externalScopeResolver: createScopeResolver(root),
+          interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
         });
         expect(await record.registerRoot(root)).toMatchObject({ status: "registered" });
         const first = createFact(
@@ -911,6 +933,7 @@ describe("focused SQLite composed acceptance", () => {
       if (admitted.status !== "admitted") throw new Error("Expected a Control Session.");
       const record = createEventGameRecord(storage, {
         externalScopeResolver: createScopeResolver(root),
+        interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
       });
       expect(await record.registerRoot(root)).toMatchObject({ status: "registered" });
       const action = createFact(
@@ -1233,8 +1256,16 @@ async function withRaceCase(
     bootstrap.close();
 
     const left = openSqliteFoundationStorage(databasePath, { grantKeyRing: createKeyRing() });
+    createEventGameRecord(left, {
+      externalScopeResolver: createScopeResolver(root),
+      interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
+    });
     const rightStorage = openSqliteFoundationStorage(databasePath, {
       grantKeyRing: createKeyRing(),
+    });
+    createEventGameRecord(rightStorage, {
+      externalScopeResolver: createScopeResolver(root),
+      interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
     });
     const rightAuthority = createLegacyControlGrantTestAuthority(rightStorage, grantOptions);
     const scopeResolver = {

--- a/src/lib/foundation-acceptance.ts
+++ b/src/lib/foundation-acceptance.ts
@@ -184,6 +184,10 @@ export function createFoundationAcceptance(
   const clock = options.clock ?? (() => Date.now());
   const registry =
     options.actionCodecRegistry ?? createControlActionCodecRegistry(options.actionCodecs);
+  storage.setReadinessContext?.({
+    actionCodecRegistry: registry,
+    interpreter: options.interpreter,
+  });
   const limits = { ...ACCEPTANCE_LIMITS, ...options.limits };
   storage.setGrantValidationContext?.({
     environmentId: options.grant.environmentId,

--- a/src/lib/foundation-storage-contract.test.ts
+++ b/src/lib/foundation-storage-contract.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createEventGameRecord, type ExternalScopeResolver } from "@/lib/event-game-record";
+import { createDeterministicTestIqaInterpreter } from "@/lib/event-game-actions";
 import {
   canonicalizeEventGameRecordRoot,
   type EventGameRecordRoot,
@@ -97,6 +98,7 @@ function runStorageContract(name: string, factory: StorageFactory): void {
         const root = createRoot();
         const record = createEventGameRecord(harness.storage, {
           externalScopeResolver: createScopeResolver(root),
+          interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
         });
         expect(await record.registerRoot(root)).toMatchObject({ status: "registered" });
         expect(await record.readRoot(root.recordId)).toEqual(root);
@@ -111,6 +113,7 @@ function runStorageContract(name: string, factory: StorageFactory): void {
         const root = createRoot();
         const record = createEventGameRecord(harness.storage, {
           externalScopeResolver: createScopeResolver(root),
+          interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
         });
         expect(await record.registerRoot(root)).toMatchObject({ status: "registered" });
         expect(await record.registerRoot(structuredClone(root))).toMatchObject({
@@ -163,6 +166,7 @@ function runStorageContract(name: string, factory: StorageFactory): void {
         };
         const record = createEventGameRecord(harness.storage, {
           externalScopeResolver: resolver,
+          interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
         });
 
         expect(await record.registerRoot(root)).toMatchObject({ status: "registered" });
@@ -183,6 +187,7 @@ function runStorageContract(name: string, factory: StorageFactory): void {
         const root = createRoot();
         const record = createEventGameRecord(harness.storage, {
           externalScopeResolver: createScopeResolver(root),
+          interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
         });
         const outcomes = await Promise.all([record.registerRoot(root), record.registerRoot(root)]);
         expect(outcomes.filter((outcome) => outcome.status === "registered")).toHaveLength(1);
@@ -249,6 +254,7 @@ function runStorageContract(name: string, factory: StorageFactory): void {
           const caseEventGameId = `event-game-${label.replaceAll(" ", "-").toLowerCase()}`;
           const record = createEventGameRecord(harness.storage, {
             externalScopeResolver: resolver,
+            interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
           });
           const outcome = await record.registerRoot(
             createRoot({
@@ -275,6 +281,7 @@ function runStorageContract(name: string, factory: StorageFactory): void {
       try {
         const record = createEventGameRecord(harness.storage, {
           externalScopeResolver: resolver,
+          interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
         });
         expect(await record.registerRoot(root)).toMatchObject({ status: "registered" });
       } finally {
@@ -318,6 +325,7 @@ function runStorageContract(name: string, factory: StorageFactory): void {
           });
           const record = createEventGameRecord(harness.storage, {
             externalScopeResolver: createScopeResolver(root),
+            interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
           });
           const outcome = await record.registerRoot(root);
           expect(outcome).toMatchObject({ status: "rejected", reason: "invalid-root" });

--- a/src/lib/foundation-storage-sqlite.test.ts
+++ b/src/lib/foundation-storage-sqlite.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { Database } from "bun:sqlite";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -10,12 +10,21 @@ import {
   type FoundationMigration,
 } from "@/lib/foundation-migrations";
 import type { EventGameRecordRoot } from "@/lib/foundation-record-types";
+import { createDeterministicTestIqaInterpreter } from "@/lib/event-game-actions";
+import { createFoundationAcceptance } from "@/lib/foundation-acceptance";
+import type { ControlActionInput } from "@/lib/event-game-actions";
 import { createEventGameRecord, type ExternalScopeResolver } from "@/lib/event-game-record";
 import {
   FoundationMigrationError,
   openSqliteFoundationStorage,
+  SqliteFoundationFault,
 } from "@/lib/foundation-storage-sqlite";
 import { createGrantTestKeyRing } from "@/lib/grant-authority-contract";
+import type { GrantAuthorityOptions } from "@/lib/grant-authority";
+import {
+  createGrantTestAuthorityVerifier,
+  createLegacyControlGrantTestAuthority,
+} from "@/lib/grant-authority-test-support";
 
 async function withDatabase<T>(work: (databasePath: string) => Promise<T>): Promise<T> {
   const directory = await mkdtemp(join(tmpdir(), "quadball-timer-sqlite-"));
@@ -27,6 +36,403 @@ async function withDatabase<T>(work: (databasePath: string) => Promise<T>): Prom
 }
 
 describe("SQLite foundation storage", () => {
+  test("latches an after-COMMIT boundary failure without claiming readiness", async () => {
+    await withDatabase(async (databasePath) => {
+      let injected = true;
+      const storage = openSqliteFoundationStorage(databasePath, {
+        faultInjector(phase) {
+          if (injected && phase === "after-commit")
+            throw new SqliteFoundationFault("commit-failure");
+        },
+      });
+      await storage.applyMigrations();
+      expect(await storage.readiness()).toMatchObject({
+        ok: false,
+        status: "not-writeable",
+        evidence: { sqlite: { failureCategory: "commit-failure" } },
+      });
+      injected = false;
+      expect(await storage.readiness()).toMatchObject({
+        ok: true,
+        evidence: { sqlite: { failureCategory: null }, transaction: { writePressure: "normal" } },
+      });
+      storage.close();
+    });
+  });
+
+  test("treats corruption as terminal and never probes or changes the database after restart", async () => {
+    await withDatabase(async (databasePath) => {
+      let injectCorruption = true;
+      let probeCalls = 0;
+      const storage = openSqliteFoundationStorage(databasePath, {
+        faultInjector(phase) {
+          if (phase === "readiness-write-probe") {
+            probeCalls += 1;
+            if (injectCorruption) throw new SqliteFoundationFault("corruption");
+          }
+        },
+      });
+      await storage.applyMigrations();
+      const markerPath = storage.quarantineMarkerPath;
+      expect(markerPath).toBe(`${databasePath}.quarantine`);
+      const before = new Database(databasePath);
+      const beforeUserVersion = before.query("PRAGMA user_version").get();
+      before.close();
+
+      expect(await storage.readiness()).toMatchObject({
+        ok: false,
+        status: "integrity-failure",
+        evidence: { sqlite: { failureCategory: "corruption" } },
+      });
+      expect(markerPath === null ? null : readFileSync(markerPath, "utf8")).toBe(
+        "quadball-timer-foundation-quarantine-v1\ncategory=corruption\n",
+      );
+      expect(markerPath === null ? null : statSync(markerPath).size).toBeLessThanOrEqual(128);
+      expect(markerPath === null ? null : statSync(markerPath).mode & 0o777).toBe(0o600);
+      expect(await storage.readiness()).toMatchObject({
+        ok: false,
+        status: "integrity-failure",
+        evidence: { sqlite: { failureCategory: "corruption" } },
+      });
+      expect(probeCalls).toBe(1);
+      injectCorruption = false;
+      expect(await storage.readiness()).toMatchObject({ ok: false, status: "integrity-failure" });
+      expect(probeCalls).toBe(1);
+
+      const frozenRecord = createEventGameRecord(storage, {
+        externalScopeResolver: createScopeResolver(createRoot("corruption-frozen")),
+        interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
+      });
+      expect(await frozenRecord.registerRoot(createRoot("corruption-frozen"))).toMatchObject({
+        status: "rejected",
+        reason: "storage-not-ready",
+      });
+      const after = new Database(databasePath);
+      expect(after.query("PRAGMA user_version").get()).toEqual(beforeUserVersion);
+      expect(
+        after.query("SELECT COUNT(*) AS count FROM foundation_event_game_record_roots").get(),
+      ).toEqual({
+        count: 0,
+      });
+      after.close();
+      storage.close();
+
+      let restartedProbeCalls = 0;
+      const restarted = openSqliteFoundationStorage(databasePath, {
+        faultInjector(phase) {
+          if (phase === "readiness-write-probe") restartedProbeCalls += 1;
+        },
+      });
+      expect(await restarted.readiness()).toMatchObject({
+        ok: false,
+        status: "integrity-failure",
+        evidence: { sqlite: { failureCategory: "corruption" } },
+      });
+      expect(restartedProbeCalls).toBe(0);
+      const frozenAfterRestart = createEventGameRecord(restarted, {
+        externalScopeResolver: createScopeResolver(createRoot("corruption-restart-frozen")),
+        interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
+      });
+      expect(
+        await frozenAfterRestart.registerRoot(createRoot("corruption-restart-frozen")),
+      ).toMatchObject({ status: "rejected", reason: "storage-not-ready" });
+      const afterRestart = new Database(databasePath);
+      expect(afterRestart.query("PRAGMA user_version").get()).toEqual(beforeUserVersion);
+      expect(
+        afterRestart
+          .query("SELECT COUNT(*) AS count FROM foundation_event_game_record_roots")
+          .get(),
+      ).toEqual({ count: 0 });
+      afterRestart.close();
+      restarted.close();
+    });
+  });
+
+  test.each([
+    "quarantine-write",
+    "quarantine-rename",
+    "quarantine-sync",
+    "quarantine-verify",
+  ] as const)("does not acknowledge a quarantine marker %s failure", async (failedPhase) => {
+    await withDatabase(async (databasePath) => {
+      let probeCalls = 0;
+      const storage = openSqliteFoundationStorage(databasePath, {
+        faultInjector(phase) {
+          if (phase === "readiness-write-probe") {
+            probeCalls += 1;
+            throw new SqliteFoundationFault("corruption");
+          }
+          if (phase === failedPhase) throw new Error("Injected quarantine persistence failure.");
+        },
+      });
+      await storage.applyMigrations();
+
+      expect(await storage.readiness()).toMatchObject({
+        ok: false,
+        status: "quarantine-failure",
+        detail: "SQLite corruption quarantine could not be durably persisted.",
+        evidence: { sqlite: { failureCategory: "corruption" } },
+      });
+      expect(probeCalls).toBe(1);
+      expect(await storage.readiness()).toMatchObject({
+        ok: false,
+        status: "quarantine-failure",
+        evidence: { sqlite: { failureCategory: "corruption" } },
+      });
+      expect(probeCalls).toBe(1);
+
+      const root = createRoot(`quarantine-${failedPhase}`);
+      const record = createEventGameRecord(storage, {
+        externalScopeResolver: createScopeResolver(root),
+        interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
+      });
+      expect(await record.registerRoot(root)).toMatchObject({
+        status: "rejected",
+        reason: "storage-not-ready",
+      });
+      const raw = new Database(databasePath);
+      expect(
+        raw.query("SELECT COUNT(*) AS count FROM foundation_event_game_record_roots").get(),
+      ).toEqual({ count: 0 });
+      raw.close();
+      storage.close();
+    });
+  });
+
+  test("reports persisted key requirements without a ring and distinguishes missing audit keys", async () => {
+    await withDatabase(async (databasePath) => {
+      const empty = openSqliteFoundationStorage(databasePath);
+      await empty.applyMigrations();
+      const emptyReadiness = await empty.readiness();
+      expect(emptyReadiness).toMatchObject({
+        ok: true,
+        evidence: {
+          keys: {
+            requiredCount: 0,
+            availableCount: 0,
+            missingCount: 0,
+            requiredCategories: { encryption: 0, lookup: 0, audit: 0 },
+            missingCategories: { encryption: 0, lookup: 0, audit: 0 },
+          },
+        },
+      });
+      empty.close();
+
+      const keyRing = createGrantTestKeyRing();
+      const keyed = openSqliteFoundationStorage(databasePath, { grantKeyRing: keyRing });
+      const authority = createLegacyControlGrantTestAuthority(
+        keyed,
+        createGrantOptions("event-game-key-evidence", keyRing),
+      );
+      const created = await authority.createControlGrant({
+        scope: {
+          eventId: "event-key-evidence",
+          gameDayId: "day-key-evidence",
+          pitchId: "pitch-key-evidence",
+          pitchSlotId: "slot-key-evidence",
+        },
+        actor: { kind: "fixture", id: "key-evidence" },
+      });
+      expect(created.status).toBe("created");
+      keyed.close();
+
+      const noRing = openSqliteFoundationStorage(databasePath);
+      const noRingReadiness = await noRing.readiness();
+      expect(noRingReadiness).toMatchObject({ ok: false });
+      const noRingKeys = noRingReadiness.evidence?.keys;
+      expect(noRingKeys?.requiredCount).toBeGreaterThan(0);
+      expect(noRingKeys?.availableCount).toBe(0);
+      expect(noRingKeys?.missingCount).toBe(noRingKeys?.requiredCount);
+      expect(noRingKeys?.requiredCategories.audit).toBeGreaterThan(0);
+      expect(noRingKeys?.missingCategories.audit).toBe(noRingKeys?.requiredCategories.audit);
+      noRing.close();
+
+      const missingAuditRing = {
+        ...keyRing,
+        audit: { ...keyRing.audit, keys: new Map() },
+      };
+      const missingAudit = openSqliteFoundationStorage(databasePath, {
+        grantKeyRing: missingAuditRing,
+      });
+      const missingAuditReadiness = await missingAudit.readiness();
+      expect(missingAuditReadiness).toMatchObject({ ok: false });
+      expect(missingAuditReadiness.evidence?.keys.missingCategories.audit).toBeGreaterThan(0);
+      expect(missingAuditReadiness.evidence?.keys.availableCategories.encryption).toBeGreaterThan(
+        0,
+      );
+      expect(missingAuditReadiness.evidence?.keys.availableCategories.lookup).toBeGreaterThan(0);
+      missingAudit.close();
+    });
+  });
+
+  test("does not acknowledge Control Action or Grant revocation across a failed COMMIT", async () => {
+    await withDatabase(async (databasePath) => {
+      const keyRing = createGrantTestKeyRing();
+      let injectCommitFailure = false;
+      const storage = openSqliteFoundationStorage(databasePath, {
+        grantKeyRing: keyRing,
+        faultInjector(phase) {
+          if (injectCommitFailure && phase === "before-commit")
+            throw new SqliteFoundationFault("commit-failure");
+        },
+      });
+      await storage.applyMigrations();
+      const root = createRoot("sqlite-acceptance-rpo");
+      const grantOptions = createGrantOptions(root.eventGameId, keyRing);
+      const authority = createLegacyControlGrantTestAuthority(storage, grantOptions);
+      const created = await authority.createControlGrant({
+        scope: root.externalScope,
+        actor: { kind: "fixture", id: "fixture" },
+      });
+      if (created.status !== "created") throw new Error("Expected a Control Grant.");
+      const admitted = await authority.admitControlGrant({
+        qrCredential: created.qrCredential,
+        browserContext: "sqlite-controller",
+      });
+      if (admitted.status !== "admitted") throw new Error("Expected a Control Session.");
+      const record = createEventGameRecord(storage, {
+        externalScopeResolver: createScopeResolver(root),
+        interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
+      });
+      expect(await record.registerRoot(root)).toMatchObject({ status: "registered" });
+      const acceptance = createFoundationAcceptance(storage, {
+        grant: grantOptions,
+        externalScopeResolver: createScopeResolver(root),
+        interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
+      });
+      const action = createAcceptanceFact(root, admitted.grantSessionId, created.grantVersion);
+
+      injectCommitFailure = true;
+      const failedAction = await acceptance.submitBatch({
+        recordId: root.recordId,
+        eventGameId: root.eventGameId,
+        sessionBearer: admitted.sessionBearer,
+        actions: [action],
+      });
+      expect(failedAction).toMatchObject({
+        status: "partial",
+        results: [{ status: "retry-later", reason: "storage-unavailable" }],
+      });
+      expect(await storage.readiness()).toMatchObject({ ok: false, status: "not-writeable" });
+      injectCommitFailure = false;
+      expect(await storage.readiness()).toMatchObject({
+        ok: true,
+        evidence: { sqlite: { failureCategory: null }, replay: { result: "passed" } },
+      });
+      expect(await record.readActions()).toHaveLength(0);
+
+      const restarted = openSqliteFoundationStorage(databasePath, { grantKeyRing: keyRing });
+      const restartedRecord = createEventGameRecord(restarted, {
+        externalScopeResolver: createScopeResolver(root),
+        interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
+      });
+      expect(await restartedRecord.registerRoot(root)).toMatchObject({ status: "idempotent" });
+      expect(await restartedRecord.readActions()).toHaveLength(0);
+      const restartedAcceptance = createFoundationAcceptance(restarted, {
+        grant: grantOptions,
+        externalScopeResolver: createScopeResolver(root),
+        interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
+      });
+      expect(
+        await restartedAcceptance.submitBatch({
+          recordId: root.recordId,
+          eventGameId: root.eventGameId,
+          sessionBearer: admitted.sessionBearer,
+          actions: [action],
+        }),
+      ).toMatchObject({ status: "committed", results: [{ status: "accepted" }] });
+
+      restarted.close();
+      injectCommitFailure = true;
+      const failedRevocation = await authority.revokeControlGrant(created.grantId, {
+        kind: "fixture",
+        id: "fixture",
+      });
+      expect(failedRevocation).toMatchObject({ status: "rejected", reason: "unavailable" });
+      expect(await storage.readiness()).toMatchObject({ ok: false, status: "not-writeable" });
+      injectCommitFailure = false;
+      expect(await storage.readiness()).toMatchObject({ ok: true });
+      expect(
+        await authority.revokeControlGrant(created.grantId, {
+          kind: "fixture",
+          id: "fixture",
+        }),
+      ).toMatchObject({ status: "updated" });
+      const final = openSqliteFoundationStorage(databasePath, { grantKeyRing: keyRing });
+      const finalRecord = createEventGameRecord(final, {
+        externalScopeResolver: createScopeResolver(root),
+        interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
+      });
+      expect(await finalRecord.registerRoot(root)).toMatchObject({ status: "idempotent" });
+      expect(await final.readiness()).toMatchObject({ ok: true });
+      expect(
+        await final.transaction((transaction) => transaction.findGrantById(created.grantId)),
+      ).toMatchObject({
+        status: "revoked",
+      });
+      final.close();
+      storage.close();
+    });
+  });
+
+  test.each([
+    ["busy", "begin"],
+    ["readonly", "readiness-write-probe"],
+    ["full", "begin"],
+    ["io-error", "begin"],
+    ["commit-failure", "commit"],
+  ] as const)("fails closed and recovers after a %s failure", async (category, phase) => {
+    await withDatabase(async (databasePath) => {
+      let injected = true;
+      const storage = openSqliteFoundationStorage(databasePath, {
+        faultInjector(actualPhase) {
+          if (injected && actualPhase === phase) {
+            throw new SqliteFoundationFault(category);
+          }
+        },
+      });
+      await storage.applyMigrations();
+      expect(storage.liveness?.()).toEqual({ ok: true, process: "available" });
+      if (phase === "readiness-write-probe")
+        expect(await storage.readiness()).toMatchObject({ ok: false, status: "not-writeable" });
+      const record = createEventGameRecord(storage, {
+        externalScopeResolver: createScopeResolver(createRoot(`fault-${category}`)),
+        interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
+      });
+      const root = createRoot(`fault-${category}`);
+      const failed = await record.registerRoot(root);
+      expect(failed).toMatchObject({ status: "rejected", reason: "storage-not-ready" });
+
+      const raw = new Database(databasePath);
+      expect(
+        raw.query("SELECT COUNT(*) AS count FROM foundation_event_game_record_roots").get(),
+      ).toEqual({ count: 0 });
+      raw.close();
+      const evidence = await storage.readiness();
+      expect(evidence).toMatchObject({ ok: false, status: "not-writeable" });
+      expect(evidence.evidence?.sqlite.failureCategory).toBe(category);
+      expect(evidence.evidence?.transaction.rejectionCategories[category]).toBeGreaterThan(0);
+      const evidenceJson = JSON.stringify(evidence);
+      expect(evidenceJson).not.toContain("Injected");
+      expect(evidenceJson.length).toBeLessThan(4_096);
+      expect(Object.keys(evidence.evidence?.transaction.rejectionCategories ?? {}).sort()).toEqual([
+        "busy",
+        "commit-failure",
+        "corruption",
+        "full",
+        "io-error",
+        "readonly",
+      ]);
+      injected = false;
+      const recovered = await storage.readiness();
+      expect(recovered).toMatchObject({ ok: true });
+      expect(recovered.evidence?.sqlite.failureCategory).toBeNull();
+      expect(recovered.evidence?.transaction.writePressure).toBe("normal");
+      expect(await record.registerRoot(root)).toMatchObject({ status: "registered" });
+      storage.close();
+    });
+  });
+
   test("configures production settings without migrating on open", async () => {
     await withDatabase(async (databasePath) => {
       const storage = openSqliteFoundationStorage(databasePath);
@@ -44,6 +450,71 @@ describe("SQLite foundation storage", () => {
     });
   });
 
+  test("rejects the first root without compatible replay context before any durable mutation", async () => {
+    await withDatabase(async (databasePath) => {
+      const storage = openSqliteFoundationStorage(databasePath);
+      await storage.applyMigrations();
+      const root = createRoot("first-root-context");
+      const absent = createEventGameRecord(storage, {
+        externalScopeResolver: createScopeResolver(root),
+      });
+      expect(await absent.registerRoot(root)).toMatchObject({
+        status: "rejected",
+        reason: "storage-not-ready",
+      });
+
+      const unknown = createEventGameRecord(storage, {
+        externalScopeResolver: createScopeResolver(root),
+        interpreter: createDeterministicTestIqaInterpreter("rules-unknown"),
+      });
+      expect(await unknown.registerRoot(root)).toMatchObject({
+        status: "rejected",
+        reason: "storage-not-ready",
+      });
+      const raw = new Database(databasePath);
+      expect(
+        raw.query("SELECT COUNT(*) AS count FROM foundation_event_game_record_roots").get(),
+      ).toEqual({
+        count: 0,
+      });
+      expect(
+        raw.query("SELECT COUNT(*) AS count FROM foundation_event_game_record_idempotency").get(),
+      ).toEqual({
+        count: 0,
+      });
+      expect(
+        raw.query("SELECT COUNT(*) AS count FROM foundation_event_game_record_audit").get(),
+      ).toEqual({
+        count: 0,
+      });
+      raw.close();
+      expect(await storage.readiness()).toMatchObject({ ok: true });
+
+      const valid = createEventGameRecord(storage, {
+        externalScopeResolver: createScopeResolver(root),
+        interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
+      });
+      expect(await valid.registerRoot(root)).toMatchObject({ status: "registered" });
+      storage.close();
+
+      const restarted = openSqliteFoundationStorage(databasePath);
+      expect(await restarted.readiness()).toMatchObject({
+        ok: false,
+        status: "integrity-failure",
+        evidence: { replay: { result: "not-configured", rootCount: 1 } },
+      });
+      createEventGameRecord(restarted, {
+        externalScopeResolver: createScopeResolver(root),
+        interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
+      });
+      expect(await restarted.readiness()).toMatchObject({
+        ok: true,
+        evidence: { replay: { result: "passed", rootCount: 1 } },
+      });
+      restarted.close();
+    });
+  });
+
   test("applies explicit migrations, persists a root, and reopens it", async () => {
     await withDatabase(async (databasePath) => {
       const first = openSqliteFoundationStorage(databasePath);
@@ -52,20 +523,32 @@ describe("SQLite foundation storage", () => {
       const root = createRoot(recordId);
       const firstRecord = createEventGameRecord(first, {
         externalScopeResolver: createScopeResolver(root),
+        interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
       });
       expect(await firstRecord.registerRoot(root)).toMatchObject({ status: "registered" });
       first.close();
 
       const reopened = openSqliteFoundationStorage(databasePath);
-      expect(await reopened.readiness()).toMatchObject({ ok: true, schemaVersion: "21" });
+      const beforeContext = await reopened.readiness();
+      expect(beforeContext).toMatchObject({
+        ok: false,
+        status: "integrity-failure",
+        evidence: { replay: { result: "not-configured", rootCount: 1 } },
+      });
       const reopenedRecord = createEventGameRecord(reopened, {
         externalScopeResolver: createScopeResolver(root),
+        interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
       });
       expect(await reopenedRecord.readRoot(recordId)).toMatchObject({
         recordId,
         eventGameId: "event-game-reopen",
       });
       expect(await reopenedRecord.registerRoot(root)).toMatchObject({ status: "idempotent" });
+      expect(await reopened.readiness()).toMatchObject({
+        ok: true,
+        schemaVersion: "21",
+        evidence: { replay: { result: "passed", rootCount: 1, durationMs: expect.any(Number) } },
+      });
       reopened.close();
     });
   });
@@ -319,6 +802,7 @@ describe("SQLite foundation storage", () => {
       const root = createRoot("corrupt-root");
       const record = createEventGameRecord(initial, {
         externalScopeResolver: createScopeResolver(root),
+        interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
       });
       expect(await record.registerRoot(root)).toMatchObject({ status: "registered" });
       initial.close();
@@ -461,5 +945,49 @@ function createScopeResolver(root: EventGameRecordRoot): ExternalScopeResolver {
         ? { status: "resolved" }
         : { status: "mismatch", detail: "The Event Team is outside the Event scope." };
     },
+  };
+}
+
+function createGrantOptions(
+  eventGameId: string,
+  keyRing: ReturnType<typeof createGrantTestKeyRing>,
+): GrantAuthorityOptions {
+  let call = 0;
+  return {
+    environmentId: "sqlite-acceptance-test",
+    clock: { nowMs: () => 1_000 },
+    randomness: {
+      bytes(length) {
+        call += 1;
+        return Uint8Array.from({ length }, (_, index) => (index + call + length) % 256);
+      },
+    },
+    keyRing,
+    controlScopeResolver: { resolve: () => ({ status: "eligible", eventGameId }) },
+    privilegedAuthorityVerifier: createGrantTestAuthorityVerifier(),
+  };
+}
+
+function createAcceptanceFact(
+  root: EventGameRecordRoot,
+  sessionId: string,
+  versionId: string,
+): ControlActionInput {
+  return {
+    recordId: root.recordId,
+    eventGameId: root.eventGameId,
+    operationId: "sqlite-acceptance-operation",
+    kind: { id: "game-fact", version: "1" },
+    payload: {
+      factId: "sqlite-acceptance-fact",
+      factType: "test",
+      gameSideId: root.gameSides[0]!.id,
+      gameTimeMs: 1_000,
+      data: { source: "sqlite-acceptance-test" },
+    },
+    causalPredecessorIds: [],
+    occurrence: { trustedAtMs: 1_000, clientOriginAtMs: 1_000, source: "online" },
+    grant: { sessionId, versionId },
+    lifecycle: structuredClone(root.lifecycle),
   };
 }

--- a/src/lib/foundation-storage-sqlite.ts
+++ b/src/lib/foundation-storage-sqlite.ts
@@ -1,7 +1,19 @@
 import { Database } from "bun:sqlite";
+import {
+  closeSync,
+  fsyncSync,
+  lstatSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  statfsSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import type { EventGameRecordRoot } from "@/lib/foundation-record-types";
 import {
   appendGrantAudit,
@@ -26,6 +38,11 @@ import {
 import type { GrantKeyRing } from "@/lib/grant-types";
 import type { GrantStateValidationContext } from "@/lib/grant-state-validation";
 import {
+  CONTROL_ACTION_ORDERING_VERSION,
+  rebuildControlActionHistory,
+} from "@/lib/event-game-actions";
+import { validateIdempotencyHistory } from "@/lib/event-game-record-helpers";
+import {
   assessMigrationReadiness,
   FOUNDATION_MIGRATION_LEDGER_SQL,
   FOUNDATION_MIGRATIONS,
@@ -38,6 +55,11 @@ import {
   FoundationStorageClosedError,
   FoundationStorageConstraintError,
   FoundationStorageNotReadyError,
+  type FoundationStorageEvidence,
+  type FoundationStorageFailureCategory,
+  type FoundationStorageKeyCategory,
+  type FoundationStorageKeyCounts,
+  type FoundationStorageReadinessContext,
   isThenable,
   type FoundationStorage,
   type FoundationStorageReadiness,
@@ -82,7 +104,25 @@ export type SqliteFoundationStorageOptions = {
   beforeWriteTransactionLock?: () => void;
   grantKeyRing?: GrantKeyRing;
   grantValidationContext?: GrantStateValidationContext;
+  /** Test-only fault injection at a durable transaction phase. */
+  faultInjector?: (
+    phase:
+      | "begin"
+      | "commit"
+      | "before-commit"
+      | "after-commit"
+      | "readiness-write-probe"
+      | "quarantine-write"
+      | "quarantine-rename"
+      | "quarantine-sync"
+      | "quarantine-verify",
+  ) => void;
+  /** Migration candidates are not authoritative runtime composition boundaries. */
+  requireReplayContext?: boolean;
 };
+
+const QUARANTINE_MARKER_CONTENT = "quadball-timer-foundation-quarantine-v1\ncategory=corruption\n";
+const QUARANTINE_MARKER_MAX_BYTES = 128;
 
 export type SqliteFoundationSettings = {
   journalMode: string;
@@ -110,6 +150,23 @@ export class FoundationMigrationError extends Error {
     super(message);
     this.name = "FoundationMigrationError";
     this.readiness = readiness;
+  }
+}
+
+export class SqliteFoundationFault extends Error {
+  readonly category: FoundationStorageFailureCategory;
+
+  constructor(category: FoundationStorageFailureCategory) {
+    super("Injected SQLite foundation fault.");
+    this.name = "SqliteFoundationFault";
+    this.category = category;
+  }
+}
+
+export class FoundationQuarantinePersistenceError extends Error {
+  constructor() {
+    super("SQLite corruption quarantine could not be durably persisted.");
+    this.name = "FoundationQuarantinePersistenceError";
   }
 }
 
@@ -241,6 +298,7 @@ type RootStatements = {
   byPitchSlotId: SqlStatement;
   byGameSideId: SqlStatement;
   insertRoot: SqlStatement;
+  allRoots: SqlStatement;
   insertSide: SqlStatement;
   actionByOperationId: SqlStatement;
   actionsByRecordId: SqlStatement;
@@ -301,13 +359,36 @@ const ROOT_SELECT_COLUMNS = `
 
 const OPAQUE_MIGRATION_REFERENCE_PATTERN = /^opaque-migration-reference-v1:[a-f0-9]{64}$/;
 
+const KEY_CATEGORIES: readonly FoundationStorageKeyCategory[] = ["encryption", "lookup", "audit"];
+
+function emptyKeyCounts(): FoundationStorageKeyCounts {
+  return { encryption: 0, lookup: 0, audit: 0 };
+}
+
+function keyCategory(kind: "e" | "l" | "a"): FoundationStorageKeyCategory {
+  return kind === "e" ? "encryption" : kind === "l" ? "lookup" : "audit";
+}
+
+function extractIntegrityKeyVersion(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const match = /^hmac-sha256-v1:([^:]{1,64}):[^:]{1,256}$/.exec(value);
+  return match?.[1] ?? null;
+}
+
+function readNullableTextValue(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
 export class SqliteFoundationStorage implements FoundationStorage {
   readonly databasePath: string;
+  readonly quarantineMarkerPath: string | null;
 
   private readonly database: Database;
   private readonly migrations: readonly FoundationMigration[];
   private readonly busyTimeoutMs: number;
   private readonly beforeWriteTransactionLock: (() => void) | undefined;
+  private readonly faultInjector: SqliteFoundationStorageOptions["faultInjector"];
+  private readonly requireReplayContext: boolean;
   private grantValidationContext: GrantStateValidationContext;
   private writerTail: Promise<void> = Promise.resolve();
   private statements: RootStatements | undefined;
@@ -315,25 +396,50 @@ export class SqliteFoundationStorage implements FoundationStorage {
   private closed = false;
   private revision = 0;
   private dataVersion: number;
+  private readinessContext: FoundationStorageReadinessContext | undefined;
+  private unsafeFailure: FoundationStorageFailureCategory | undefined;
+  private quarantinePersistenceFailure = false;
+  private lastTransactionLatencyMs: number | null = null;
+  private rejectionCount = 0;
+  private readonly rejectionCategories: Record<FoundationStorageFailureCategory, number> = {
+    busy: 0,
+    readonly: 0,
+    full: 0,
+    "io-error": 0,
+    "commit-failure": 0,
+    corruption: 0,
+  };
 
   constructor(databasePath: string, options: SqliteFoundationStorageOptions = {}) {
     this.databasePath = databasePath;
+    this.quarantineMarkerPath = databasePath === ":memory:" ? null : `${databasePath}.quarantine`;
     this.migrations = options.migrations ?? FOUNDATION_MIGRATIONS;
     this.busyTimeoutMs = options.busyTimeoutMs ?? 5_000;
     this.beforeWriteTransactionLock = options.beforeWriteTransactionLock;
+    this.faultInjector = options.faultInjector;
+    this.requireReplayContext = options.requireReplayContext ?? true;
     this.grantValidationContext = options.grantValidationContext ?? {
       keyRing: options.grantKeyRing,
     };
+    this.unsafeFailure = readQuarantineMarker(this.quarantineMarkerPath) ? "corruption" : undefined;
     this.database = new Database(databasePath);
-    this.configureDatabase();
+    if (this.unsafeFailure !== "corruption") this.configureDatabase();
     this.dataVersion = this.readDataVersion();
   }
 
   transaction<T>(work: FoundationStorageTransactionWork<T>): Promise<T> {
     return this.enqueue(() => {
       this.beforeWriteTransactionLock?.();
-      this.database.exec("BEGIN IMMEDIATE;");
+      const startedAt = Date.now();
+      let transactionStarted = false;
+      let commitBoundary = false;
       try {
+        if (this.unsafeFailure === "corruption") {
+          throw new FoundationStorageNotReadyError(this.readinessSync());
+        }
+        this.faultInjector?.("begin");
+        this.database.exec("BEGIN IMMEDIATE;");
+        transactionStarted = true;
         // The write lock fixes the snapshot before both the external revision
         // token and semantic readiness are derived. A commit from another
         // connection cannot land between these operations and be hidden by
@@ -358,12 +464,32 @@ export class SqliteFoundationStorage implements FoundationStorage {
           }
           writeGrantAdmissionStateAnchor(grantStatements, keyRing);
         }
+        commitBoundary = true;
+        this.faultInjector?.("before-commit");
+        this.faultInjector?.("commit");
         this.database.exec("COMMIT;");
+        transactionStarted = false;
+        this.faultInjector?.("after-commit");
+        this.lastTransactionLatencyMs = boundedMetric(Date.now() - startedAt);
+        this.unsafeFailure = undefined;
         this.revision += 1;
         this.dataVersion = this.readDataVersion();
         return result;
       } catch (error) {
-        this.rollbackQuietly();
+        if (transactionStarted) this.rollbackQuietly();
+        this.lastTransactionLatencyMs = boundedMetric(Date.now() - startedAt);
+        const category = classifySqliteFailure(
+          error,
+          commitBoundary ? "commit" : transactionStarted ? "transaction" : "commit",
+        );
+        if (category !== null) {
+          if (category === "corruption") this.latchCorruption();
+          else this.unsafeFailure = category;
+          this.rejectionCount = boundedMetric(this.rejectionCount + 1);
+          this.rejectionCategories[category] = boundedMetric(
+            this.rejectionCategories[category] + 1,
+          );
+        }
         throw translateSqliteConstraint(error);
       }
     });
@@ -413,7 +539,15 @@ export class SqliteFoundationStorage implements FoundationStorage {
   }
 
   readiness(): Promise<FoundationStorageReadiness> {
-    return this.enqueue(() => this.readinessSync());
+    return this.enqueue(() => this.readinessSync(true));
+  }
+
+  liveness() {
+    return { ok: true as const, process: "available" as const };
+  }
+
+  setReadinessContext(context: FoundationStorageReadinessContext): void {
+    this.readinessContext = context;
   }
 
   getSettings(): SqliteFoundationSettings {
@@ -424,6 +558,11 @@ export class SqliteFoundationStorage implements FoundationStorage {
   async applyMigrations(
     options: { requireCandidate?: boolean } = {},
   ): Promise<FoundationMigrationReport> {
+    if (this.unsafeFailure === "corruption") {
+      throw new FoundationMigrationError(
+        "The SQLite foundation database is quarantined after suspected corruption.",
+      );
+    }
     if (options.requireCandidate !== false) {
       const candidate = await this.validateCandidate();
       if (!candidate.ready) {
@@ -459,6 +598,7 @@ export class SqliteFoundationStorage implements FoundationStorage {
         migrations: this.migrations,
         busyTimeoutMs: this.busyTimeoutMs,
         grantValidationContext: this.grantValidationContext,
+        requireReplayContext: false,
       });
       const migration = await candidate.applyMigrations({ requireCandidate: false });
       const readiness = await candidate.readiness();
@@ -484,6 +624,9 @@ export class SqliteFoundationStorage implements FoundationStorage {
   }
 
   setGrantKeyRing(keyRing: GrantKeyRing): void {
+    if (this.unsafeFailure === "corruption") {
+      throw new FoundationStorageNotReadyError(this.readinessSync());
+    }
     if (
       !this.hasInstalledGrantAdmissionAnchor() &&
       (this.countRows("foundation_grant_admission_telemetry") > 0 ||
@@ -1121,6 +1264,9 @@ export class SqliteFoundationStorage implements FoundationStorage {
   private getStatements(): RootStatements {
     if (this.statements !== undefined) return this.statements;
     this.statements = {
+      allRoots: this.database.query(
+        `SELECT ${ROOT_SELECT_COLUMNS} FROM foundation_event_game_record_roots AS roots ORDER BY roots.record_id`,
+      ),
       byRecordId: this.database.query(
         `SELECT ${ROOT_SELECT_COLUMNS} FROM foundation_event_game_record_roots AS roots WHERE roots.record_id = ?`,
       ),
@@ -1406,20 +1552,51 @@ export class SqliteFoundationStorage implements FoundationStorage {
     };
   }
 
-  private readinessSync(): FoundationStorageReadiness {
+  private readinessSync(probeWriteability = false): FoundationStorageReadiness {
+    const evidence = this.baseEvidence();
     try {
       this.assertOpen();
+      if (this.unsafeFailure === "corruption") {
+        evidence.transaction.writePressure = "unsafe";
+        evidence.sqlite.failureCategory = "corruption";
+        return {
+          ok: false,
+          status: this.quarantinePersistenceFailure ? "quarantine-failure" : "integrity-failure",
+          detail: this.quarantinePersistenceFailure
+            ? "SQLite corruption quarantine could not be durably persisted."
+            : "SQLite durable authority is frozen after suspected corruption.",
+          storage: "sqlite",
+          evidence,
+        };
+      }
+      if (this.unsafeFailure !== undefined && !probeWriteability) {
+        evidence.transaction.writePressure = "unsafe";
+        evidence.sqlite.failureCategory = this.unsafeFailure;
+        return {
+          ok: false,
+          status: "not-writeable",
+          detail: "SQLite durable authority is paused until a writeability proof succeeds.",
+          storage: "sqlite",
+          evidence,
+        };
+      }
       const settings = this.readSettings();
+      evidence.sqlite.journalMode =
+        settings.journalMode.toLowerCase() === "wal" ? "wal" : "unknown";
+      evidence.sqlite.synchronous = settings.synchronous;
+      evidence.sqlite.foreignKeys = settings.foreignKeys === 1;
       if (
-        settings.journalMode.toLowerCase() !== "wal" ||
+        evidence.sqlite.journalMode !== "wal" ||
         settings.synchronous !== 2 ||
         settings.foreignKeys !== 1
       ) {
+        evidence.transaction.writePressure = "unsafe";
         return {
           ok: false,
           status: "unsafe-settings",
           detail: "SQLite did not report the required WAL, FULL, and foreign-key settings.",
           storage: "sqlite",
+          evidence,
         };
       }
 
@@ -1429,12 +1606,16 @@ export class SqliteFoundationStorage implements FoundationStorage {
         migrationState.entries,
         this.migrations,
       );
+      evidence.migration.state = migrationReadiness.status === "ready" ? "ready" : "unsafe";
+      evidence.migration.schemaVersion = String(migrationReadiness.schemaVersion);
+      evidence.migration.appliedCount = boundedMetric(migrationState.entries.length);
       if (migrationReadiness.status !== "ready") {
         return {
           ok: false,
           status: migrationReadiness.status,
           detail: migrationReadiness.detail,
           storage: "sqlite",
+          evidence,
         };
       }
       if (
@@ -1442,9 +1623,10 @@ export class SqliteFoundationStorage implements FoundationStorage {
         this.migrations.some((migration) => migration.id === "006-grant-cryptographic-erasure")
       )
         this.refreshGrantMigrationProvenance();
+      this.updateKeyEvidence(evidence);
       const schemaVerification = verifyFoundationSchema(this.database, this.grantValidationContext);
       if (!schemaVerification.ok) {
-        return { ...schemaVerification, storage: "sqlite" };
+        return { ...schemaVerification, storage: "sqlite", evidence };
       }
       const idempotencyFailure = this.verifyIdempotencyParity();
       if (idempotencyFailure !== null) {
@@ -1453,28 +1635,94 @@ export class SqliteFoundationStorage implements FoundationStorage {
           status: "integrity-failure",
           detail: idempotencyFailure,
           storage: "sqlite",
+          evidence,
         };
       }
-
+      const rootCount = this.countRows("foundation_event_game_record_roots");
+      const actionCount = this.countRows("foundation_event_game_record_actions");
+      if (
+        this.requireReplayContext &&
+        this.readinessContext === undefined &&
+        (rootCount > 0 || actionCount > 0)
+      ) {
+        evidence.replay.rootCount = boundedMetric(rootCount);
+        evidence.replay.actionCount = boundedMetric(actionCount);
+        evidence.replay.result = "not-configured";
+        evidence.transaction.writePressure = "unsafe";
+        return {
+          ok: false,
+          status: "integrity-failure",
+          detail: "Event Game replay context is not installed at the authoritative boundary.",
+          storage: "sqlite",
+          evidence,
+        };
+      }
+      if (this.readinessContext !== undefined) {
+        const replayFailure = this.verifyRegisteredReplay(evidence, this.readinessContext);
+        if (replayFailure !== null)
+          return {
+            ok: false,
+            status: "integrity-failure",
+            detail: replayFailure,
+            storage: "sqlite",
+            evidence,
+          };
+      }
+      if (probeWriteability) {
+        this.probeWriteability(evidence);
+        this.unsafeFailure = undefined;
+        evidence.sqlite.failureCategory = null;
+      }
+      evidence.transaction.writePressure = "normal";
       return {
         ok: true,
         schemaVersion: String(migrationReadiness.schemaVersion),
         storage: "sqlite",
+        evidence,
       };
     } catch (error) {
+      const category = classifySqliteFailure(error, "readiness");
+      if (category !== null) {
+        if (category === "corruption") this.latchCorruption();
+        else this.unsafeFailure = category;
+        this.rejectionCount = boundedMetric(this.rejectionCount + 1);
+        this.rejectionCategories[category] = boundedMetric(this.rejectionCategories[category] + 1);
+        evidence.transaction.rejectionCount = this.rejectionCount;
+        evidence.transaction.rejectionCategories = { ...this.rejectionCategories };
+        evidence.transaction.writePressure = "unsafe";
+        evidence.sqlite.failureCategory = category;
+        return {
+          ok: false,
+          status:
+            category === "corruption"
+              ? this.quarantinePersistenceFailure
+                ? "quarantine-failure"
+                : "integrity-failure"
+              : "not-writeable",
+          detail:
+            category === "corruption" && this.quarantinePersistenceFailure
+              ? "SQLite corruption quarantine could not be durably persisted."
+              : "SQLite durable authority is paused after a storage failure.",
+          storage: "sqlite",
+          evidence,
+        };
+      }
       if (error instanceof FoundationStorageClosedError) {
         return {
           ok: false,
           status: "closed",
           detail: "SQLite foundation storage is closed.",
           storage: "sqlite",
+          evidence,
         };
       }
+      evidence.transaction.writePressure = "unsafe";
       return {
         ok: false,
         status: "integrity-failure",
         detail: "SQLite readiness verification failed.",
         storage: "sqlite",
+        evidence,
       };
     }
   }
@@ -1486,6 +1734,237 @@ export class SqliteFoundationStorage implements FoundationStorage {
       foreignKeys: readInteger(this.database.query("PRAGMA foreign_keys").get()),
       busyTimeoutMs: readInteger(this.database.query("PRAGMA busy_timeout").get()),
     };
+  }
+
+  private baseEvidence(): FoundationStorageEvidence {
+    const databaseBytes = safeFileSize(this.databasePath);
+    const walBytes = safeFileSize(`${this.databasePath}-wal`);
+    return {
+      runtime: {
+        engine: "bun",
+        version: boundedText(Bun.version),
+        sqliteVersion: safeSqliteVersion(this.database),
+      },
+      transaction: {
+        lastLatencyMs: this.lastTransactionLatencyMs,
+        rejectionCount: this.rejectionCount,
+        rejectionCategories: { ...this.rejectionCategories },
+        writePressure: "unknown",
+      },
+      sqlite: {
+        journalMode: "unknown",
+        synchronous: null,
+        foreignKeys: null,
+        walBytes,
+        checkpoint: "not-attempted",
+        diskBytes: databaseBytes,
+        diskFreeBytes: safeFreeBytes(this.databasePath),
+        failureCategory: this.unsafeFailure ?? null,
+      },
+      migration: { state: "unknown", schemaVersion: null, appliedCount: null },
+      keys: {
+        requiredCount: 0,
+        availableCount: 0,
+        missingCount: 0,
+        requiredCategories: emptyKeyCounts(),
+        availableCategories: emptyKeyCounts(),
+        missingCategories: emptyKeyCounts(),
+      },
+      replay: {
+        result: this.readinessContext === undefined ? "not-configured" : "failed",
+        rootCount: 0,
+        actionCount: 0,
+        durationMs: null,
+      },
+    };
+  }
+
+  private probeWriteability(evidence: FoundationStorageEvidence): void {
+    const startedAt = Date.now();
+    const originalUserVersion = readInteger(
+      (this.database.query("PRAGMA user_version").get() as RootRow).user_version,
+    );
+    let transactionStarted = false;
+    try {
+      this.faultInjector?.("begin");
+      this.database.exec("BEGIN IMMEDIATE;");
+      transactionStarted = true;
+      this.faultInjector?.("readiness-write-probe");
+      this.database.exec(`PRAGMA user_version = ${originalUserVersion + 1};`);
+      this.database.exec(`PRAGMA user_version = ${originalUserVersion};`);
+      this.faultInjector?.("before-commit");
+      this.faultInjector?.("commit");
+      this.database.exec("COMMIT;");
+      transactionStarted = false;
+      this.faultInjector?.("after-commit");
+      const verifiedUserVersion = readInteger(
+        (this.database.query("PRAGMA user_version").get() as RootRow).user_version,
+      );
+      if (verifiedUserVersion !== originalUserVersion)
+        throw new SqliteFoundationFault("corruption");
+    } catch (error) {
+      if (transactionStarted) this.rollbackQuietly();
+      throw error;
+    }
+    evidence.transaction.lastLatencyMs = boundedMetric(Date.now() - startedAt);
+    try {
+      const row = this.database.query("PRAGMA wal_checkpoint(PASSIVE)").get() as Record<
+        string,
+        unknown
+      > | null;
+      const busy = readInteger(row?.busy ?? 0);
+      evidence.sqlite.checkpoint = busy === 0 ? "ok" : "busy";
+      if (busy !== 0) throw new SqliteFoundationFault("busy");
+    } catch (error) {
+      if (error instanceof SqliteFoundationFault) throw error;
+      evidence.sqlite.checkpoint = "failed";
+      throw new SqliteFoundationFault("io-error");
+    }
+  }
+
+  private updateKeyEvidence(evidence: FoundationStorageEvidence): void {
+    const keyRing = this.grantValidationContext.keyRing;
+    const required = new Set<string>();
+    const requiredCategories = emptyKeyCounts();
+    const addRequired = (kind: "e" | "l" | "a", version: string | null): void => {
+      if (
+        typeof version !== "string" ||
+        version.length === 0 ||
+        version.length > 64 ||
+        !/^[A-Za-z0-9._-]+$/.test(version)
+      )
+        return;
+      const key = `${kind}:${version}`;
+      if (required.has(key)) return;
+      required.add(key);
+      requiredCategories[keyCategory(kind)] += 1;
+    };
+    for (const grant of listGrants(this.getGrantStatements().allGrants)) {
+      if (grant.credential.materialState === "present") {
+        addRequired("e", grant.credential.encryptionKeyVersion);
+        addRequired("l", grant.credential.lookupKeyVersion);
+      }
+      if (grant.code !== null && grant.code !== undefined && grant.code.state !== "erased") {
+        addRequired("e", grant.code.encryptionKeyVersion);
+        addRequired("a", grant.code.lookupKeyVersion);
+      }
+      for (const session of listGrantSessions(
+        this.getGrantStatements().sessionsByGrant,
+        grant.grantId,
+      )) {
+        addRequired("l", session.browserContextKeyVersion);
+        if (session.bearerMaterialState === "present")
+          addRequired("l", session.bearerLookupKeyVersion);
+      }
+    }
+    for (const row of this.database
+      .query("SELECT audit_integrity_tag FROM foundation_grant_audit")
+      .all() as unknown[]) {
+      addRequired("a", extractIntegrityKeyVersion(asRecord(row).audit_integrity_tag));
+    }
+    for (const row of this.database
+      .query("SELECT integrity_tag FROM foundation_grant_state_anchors")
+      .all() as unknown[]) {
+      addRequired("a", extractIntegrityKeyVersion(asRecord(row).integrity_tag));
+    }
+    for (const row of this.database
+      .query("SELECT integrity_tag FROM foundation_grant_admission_state_anchors")
+      .all() as unknown[]) {
+      addRequired("a", extractIntegrityKeyVersion(asRecord(row).integrity_tag));
+    }
+    for (const row of this.database
+      .query("SELECT key_version FROM foundation_acceptance_integrity_anchors")
+      .all() as unknown[]) {
+      addRequired("a", readNullableTextValue(asRecord(row).key_version));
+    }
+    for (const row of this.database
+      .query("SELECT receipt_key_version FROM foundation_replay_receipts")
+      .all() as unknown[]) {
+      addRequired("a", readNullableTextValue(asRecord(row).receipt_key_version));
+    }
+    const availableCategories = emptyKeyCounts();
+    const available = [...required].filter((key) => {
+      const [kind, version] = key.split(":");
+      if (version === undefined) return false;
+      const available =
+        keyRing !== undefined &&
+        (kind === "e"
+          ? keyRing.encryption.keys.has(version)
+          : kind === "a"
+            ? keyRing.audit.keys.has(version)
+            : keyRing.lookup.keys.has(version));
+      if (available) availableCategories[keyCategory(kind as "e" | "l" | "a")] += 1;
+      return available;
+    }).length;
+    const missingCategories = emptyKeyCounts();
+    for (const category of KEY_CATEGORIES) {
+      missingCategories[category] = requiredCategories[category] - availableCategories[category];
+    }
+    evidence.keys = {
+      requiredCount: boundedMetric(required.size),
+      availableCount: boundedMetric(available),
+      missingCount: boundedMetric(required.size - available),
+      requiredCategories,
+      availableCategories,
+      missingCategories,
+    };
+  }
+
+  private verifyRegisteredReplay(
+    evidence: FoundationStorageEvidence,
+    context: FoundationStorageReadinessContext,
+  ): string | null {
+    const startedAt = Date.now();
+    try {
+      const rows = this.getStatements().allRoots.all() as unknown[];
+      evidence.replay.rootCount = boundedMetric(rows.length);
+      for (const value of rows) {
+        const row = asRecord(value);
+        const root = readValidatedFoundationRoot(this.database, row);
+        const actions = this.readActionsByRecordId(
+          this.getStatements().actionsByRecordId,
+          root.recordId,
+        );
+        const idempotency = this.readIdempotencyByRecordId(
+          this.getStatements().idempotencyByRecordId,
+          root.recordId,
+        );
+        const metadataRow = this.getStatements().metadataByRecordId.get(
+          root.recordId,
+        ) as RootRow | null;
+        const metadata = metadataRow === null ? null : readMetadata(metadataRow);
+        evidence.replay.actionCount = boundedMetric(evidence.replay.actionCount + actions.length);
+        if (
+          metadata === null ||
+          metadata.actionCount !== actions.length ||
+          metadata.orderingVersion !== CONTROL_ACTION_ORDERING_VERSION
+        )
+          return "Event Game Record replay metadata is incomplete.";
+        const idempotencyFailure = validateIdempotencyHistory(root, actions, idempotency);
+        if (idempotencyFailure !== null) return idempotencyFailure;
+        const historicalRoot =
+          actions[0] === undefined
+            ? root
+            : {
+                ...root,
+                lifecycle: structuredClone(actions[0].action.lifecycle),
+              };
+        const replay = rebuildControlActionHistory(
+          historicalRoot,
+          actions,
+          context.actionCodecRegistry,
+          context.interpreter,
+        );
+        if (replay.status !== "ready") return replay.detail;
+      }
+      evidence.replay.result = "passed";
+      return null;
+    } catch {
+      return "Event Game Record replay verification failed.";
+    } finally {
+      evidence.replay.durationMs = boundedMetric(Date.now() - startedAt);
+      if (evidence.replay.result !== "passed") evidence.replay.result = "failed";
+    }
   }
 
   private refreshGrantMigrationProvenance(): void {
@@ -1613,6 +2092,16 @@ export class SqliteFoundationStorage implements FoundationStorage {
     );
   }
 
+  private latchCorruption(): void {
+    this.unsafeFailure = "corruption";
+    try {
+      persistQuarantineMarker(this.quarantineMarkerPath, this.faultInjector);
+    } catch (error) {
+      if (!(error instanceof FoundationQuarantinePersistenceError)) throw error;
+      this.quarantinePersistenceFailure = true;
+    }
+  }
+
   private rollbackQuietly(): void {
     try {
       this.database.exec("ROLLBACK;");
@@ -1684,4 +2173,148 @@ function translateSqliteConstraint(error: unknown): unknown {
     return new FoundationStorageConstraintError("grant-audit-id");
   }
   return translateControlSqliteConstraint(error);
+}
+
+function boundedMetric(value: number): number {
+  return Number.isSafeInteger(value) ? Math.max(0, Math.min(value, 1_000_000_000)) : 0;
+}
+
+function boundedText(value: string): string {
+  return value.length <= 32 ? value : value.slice(0, 32);
+}
+
+function readQuarantineMarker(path: string | null): boolean {
+  if (path === null) return false;
+  try {
+    const stats = statSync(path);
+    if (!stats.isFile() || stats.size > QUARANTINE_MARKER_MAX_BYTES) return true;
+  } catch (error) {
+    return error instanceof Error && (error as NodeJS.ErrnoException).code !== "ENOENT";
+  }
+  return true;
+}
+
+function persistQuarantineMarker(
+  path: string | null,
+  faultInjector: SqliteFoundationStorageOptions["faultInjector"],
+): void {
+  if (path === null) throw new FoundationQuarantinePersistenceError();
+  try {
+    if (statSync(path).isFile()) {
+      verifyQuarantineMarker(path);
+      return;
+    }
+  } catch (error) {
+    if (!(error instanceof Error) || (error as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw new FoundationQuarantinePersistenceError();
+    }
+  }
+
+  const temporaryPath = `${path}.tmp-${process.pid}-${Date.now()}`;
+  try {
+    faultInjector?.("quarantine-write");
+    writeFileSync(temporaryPath, QUARANTINE_MARKER_CONTENT, {
+      encoding: "utf8",
+      flag: "wx",
+      mode: 0o600,
+    });
+    const markerFd = openSync(temporaryPath, "r");
+    try {
+      faultInjector?.("quarantine-sync");
+      fsyncSync(markerFd);
+    } finally {
+      closeSync(markerFd);
+    }
+    faultInjector?.("quarantine-rename");
+    renameSync(temporaryPath, path);
+    const parentFd = openSync(dirname(path), "r");
+    try {
+      faultInjector?.("quarantine-sync");
+      fsyncSync(parentFd);
+    } catch {
+      closeSync(parentFd);
+      throw new FoundationQuarantinePersistenceError();
+    }
+    closeSync(parentFd);
+    faultInjector?.("quarantine-verify");
+    verifyQuarantineMarker(path);
+  } catch {
+    try {
+      unlinkSync(temporaryPath);
+    } catch {
+      // Preserve the bounded quarantine failure even if cleanup is unavailable.
+    }
+    throw new FoundationQuarantinePersistenceError();
+  }
+}
+
+function verifyQuarantineMarker(path: string): void {
+  const stats = lstatSync(path);
+  if (
+    !stats.isFile() ||
+    stats.size > QUARANTINE_MARKER_MAX_BYTES ||
+    (stats.mode & 0o777) !== 0o600
+  ) {
+    throw new FoundationQuarantinePersistenceError();
+  }
+  if (readFileSync(path, "utf8") !== QUARANTINE_MARKER_CONTENT) {
+    throw new FoundationQuarantinePersistenceError();
+  }
+}
+
+function safeFileSize(path: string): number | null {
+  try {
+    return boundedMetric(statSync(path).size);
+  } catch {
+    return null;
+  }
+}
+
+function safeFreeBytes(path: string): number | null {
+  try {
+    const stats = statfsSync(path);
+    return boundedMetric(stats.bavail * stats.bsize);
+  } catch {
+    return null;
+  }
+}
+
+function safeSqliteVersion(database: Database): string | null {
+  try {
+    const row = database.query("SELECT sqlite_version() AS version").get() as Record<
+      string,
+      unknown
+    >;
+    const version = row.version;
+    return typeof version === "string" ? boundedText(version) : null;
+  } catch {
+    return null;
+  }
+}
+
+function classifySqliteFailure(
+  error: unknown,
+  phase: "transaction" | "commit" | "readiness",
+): FoundationStorageFailureCategory | null {
+  if (error instanceof SqliteFoundationFault) return error.category;
+  if (!(error instanceof Error)) return null;
+  const message = error.message.toLowerCase();
+  if (message.includes("busy") || message.includes("locked")) return "busy";
+  if (
+    message.includes("readonly") ||
+    message.includes("read-only") ||
+    message.includes("permission denied")
+  )
+    return "readonly";
+  if (message.includes("full") || message.includes("quota")) return "full";
+  if (message.includes("ioerr") || message.includes("i/o") || message.includes("disk i/o"))
+    return "io-error";
+  if (phase === "commit" && message.includes("commit")) return "commit-failure";
+  if (
+    message.includes("malformed") ||
+    message.includes("corrupt") ||
+    message.includes("not a database")
+  )
+    return "corruption";
+  return null;
 }

--- a/src/lib/foundation-storage.ts
+++ b/src/lib/foundation-storage.ts
@@ -3,6 +3,8 @@ import type {
   ControlAction,
   ControlAuditEntry,
   EventGameRecordMetadata,
+  ControlActionCodecRegistry,
+  IqaGameRulesInterpreter,
 } from "@/lib/event-game-actions";
 import type {
   GrantKeyRing,
@@ -178,6 +180,7 @@ export type FoundationStorageReadiness =
       ok: true;
       schemaVersion: string;
       storage: "memory" | "sqlite";
+      evidence?: FoundationStorageEvidence;
     }
   | {
       ok: false;
@@ -191,10 +194,70 @@ export type FoundationStorageReadiness =
         | "future"
         | "unsafe-settings"
         | "integrity-failure"
+        | "quarantine-failure"
         | "not-writeable";
       detail: string;
       storage: "memory" | "sqlite";
+      evidence?: FoundationStorageEvidence;
     };
+
+export type FoundationStorageFailureCategory =
+  | "busy"
+  | "readonly"
+  | "full"
+  | "io-error"
+  | "commit-failure"
+  | "corruption";
+
+export type FoundationStorageKeyCategory = "encryption" | "lookup" | "audit";
+
+export type FoundationStorageKeyCounts = Record<FoundationStorageKeyCategory, number>;
+
+export type FoundationStorageEvidence = {
+  runtime: { engine: "bun"; version: string; sqliteVersion: string | null };
+  transaction: {
+    lastLatencyMs: number | null;
+    rejectionCount: number;
+    rejectionCategories: Record<FoundationStorageFailureCategory, number>;
+    writePressure: "unknown" | "normal" | "unsafe";
+  };
+  sqlite: {
+    journalMode: "wal" | "unknown";
+    synchronous: number | null;
+    foreignKeys: boolean | null;
+    walBytes: number | null;
+    checkpoint: "not-attempted" | "ok" | "busy" | "failed";
+    diskBytes: number | null;
+    diskFreeBytes: number | null;
+    failureCategory: FoundationStorageFailureCategory | null;
+  };
+  migration: {
+    state: "unknown" | "ready" | "unsafe";
+    schemaVersion: string | null;
+    appliedCount: number | null;
+  };
+  keys: {
+    requiredCount: number;
+    availableCount: number;
+    missingCount: number;
+    requiredCategories: FoundationStorageKeyCounts;
+    availableCategories: FoundationStorageKeyCounts;
+    missingCategories: FoundationStorageKeyCounts;
+  };
+  replay: {
+    result: "not-configured" | "passed" | "failed";
+    rootCount: number;
+    actionCount: number;
+    durationMs: number | null;
+  };
+};
+
+export type FoundationStorageReadinessContext = {
+  actionCodecRegistry: ControlActionCodecRegistry;
+  interpreter: IqaGameRulesInterpreter;
+};
+
+export type FoundationStorageLiveness = { ok: true; process: "available" };
 
 export type FoundationStorageSnapshot = {
   revision: number;
@@ -374,6 +437,8 @@ export interface FoundationStorage {
   readRecordMetadata(recordId: string): Promise<StoredEventGameRecordMetadata | null>;
   readAuditEntries(recordId: string): Promise<StoredControlAuditEntry[]>;
   readiness(): Promise<FoundationStorageReadiness>;
+  liveness?(): FoundationStorageLiveness;
+  setReadinessContext?(context: FoundationStorageReadinessContext): void;
   /** Configure the key material required to validate persisted Grant state. */
   setGrantKeyRing?(keyRing: GrantKeyRing): void;
   /** Configure the environment and key material required for deep Grant validation. */

--- a/src/lib/grant-authority-contract.ts
+++ b/src/lib/grant-authority-contract.ts
@@ -311,13 +311,27 @@ export function registerGrantAuthorityContract(
             });
           }),
         ).rejects.toThrow();
-        expect(await storage.readiness()).toMatchObject({ ok: true });
-        expect(
-          await authority.createControlGrant({
-            scope: { ...createScope(), pitchSlotId: "slot-after-active-downgrade" },
-            actor: createActor(),
-          }),
-        ).toMatchObject({ status: "created" });
+        const readinessAfterActiveDowngrade = await storage.readiness();
+        if (!readinessAfterActiveDowngrade.ok) {
+          expect(readinessAfterActiveDowngrade).toMatchObject({
+            ok: false,
+            status: "integrity-failure",
+          });
+          expect(
+            await authority.createControlGrant({
+              scope: { ...createScope(), pitchSlotId: "slot-after-active-downgrade" },
+              actor: createActor(),
+            }),
+          ).toMatchObject({ status: "rejected", reason: "unavailable" });
+        } else {
+          expect(readinessAfterActiveDowngrade).toMatchObject({ ok: true });
+          expect(
+            await authority.createControlGrant({
+              scope: { ...createScope(), pitchSlotId: "slot-after-active-downgrade" },
+              actor: createActor(),
+            }),
+          ).toMatchObject({ status: "created" });
+        }
       });
 
       await withStorage(createStorage, async (storage) => {
@@ -344,13 +358,27 @@ export function registerGrantAuthorityContract(
             });
           }),
         ).rejects.toThrow();
-        expect(await storage.readiness()).toMatchObject({ ok: true });
-        expect(
-          await authority.createControlGrant({
-            scope: { ...createScope(), pitchSlotId: "slot-after-erased-downgrade" },
-            actor: createActor(),
-          }),
-        ).toMatchObject({ status: "created" });
+        const readinessAfterErasedDowngrade = await storage.readiness();
+        if (!readinessAfterErasedDowngrade.ok) {
+          expect(readinessAfterErasedDowngrade).toMatchObject({
+            ok: false,
+            status: "integrity-failure",
+          });
+          expect(
+            await authority.createControlGrant({
+              scope: { ...createScope(), pitchSlotId: "slot-after-erased-downgrade" },
+              actor: createActor(),
+            }),
+          ).toMatchObject({ status: "rejected", reason: "unavailable" });
+        } else {
+          expect(readinessAfterErasedDowngrade).toMatchObject({ ok: true });
+          expect(
+            await authority.createControlGrant({
+              scope: { ...createScope(), pitchSlotId: "slot-after-erased-downgrade" },
+              actor: createActor(),
+            }),
+          ).toMatchObject({ status: "created" });
+        }
       });
     },
   );


### PR DESCRIPTION
## What changed

- Latch SQLite busy, read-only, full, I/O, commit-boundary, and suspected-corruption failures so authoritative writes remain unavailable until the correct recovery boundary is proven.
- Prove transient recovery with a committed main-database write/restore probe, checkpoint and foreign-key verification before clearing the unsafe state.
- Keep suspected corruption terminal across restart with a bounded, non-secret, mode-`0600` sibling quarantine marker that is synced and verified before the database can be reopened authoritatively.
- Require compatible action codecs and an Event Game interpreter before the first authoritative root write, and replay stored Event Game state deterministically during readiness.
- Report bounded, redacted readiness evidence for SQLite pressure/failures, replay, persisted key requirements, rejection categories, and transaction closure.
- Add fault-focused Fast coverage for failed commits, rollback/no-false-acknowledgement, restart recovery, Control Action acceptance, Grant revocation, interpreter compatibility, and quarantine persistence failures.

## Why

The durable Event foundation must never acknowledge sporting or authority mutations when SQLite cannot safely commit them. Process liveness is not sufficient evidence that authoritative storage is writable, compatible, or replayable.

## Impact

- Authoritative Event Game and Grant operations now fail closed with generic typed outcomes while storage is unsafe.
- Transient storage failures can recover only after a real durable commit-path probe succeeds.
- Suspected corruption preserves the affected database for the explicit recovery workflow in #81; #80 does not silently repair or clear quarantine.
- Health and process liveness remain available independently of authoritative readiness.
- Migrations `001`–`021` are unchanged.

## Root cause

Readiness previously lacked a durable failure latch and did not consistently prove the SQLite write/commit path, required key availability, interpreter/codec compatibility, or deterministic replay before accepting mutations. Some commit and recovery paths could therefore report readiness or acknowledgement without enough durable evidence.

## Checks

- `bun install --frozen-lockfile`
- `bun audit` — no vulnerabilities
- `bun run check` — passed with seven pre-existing `await-thenable` warnings
- `bun test --isolate` — 393 passed, 0 failed, 16,357 assertions
- Focused SQLite Event Game — 21 passed
- Focused composed acceptance — 10 passed
- Focused Grant authority — 36 passed
- Focused Grant Code — 15 passed
- Focused SQLite foundation storage — 24 passed
- Migration ledger — 4 passed
- `bun run build`
- `bun run build:executable`
- `git diff --check`

No Qualification Test was run. `bun run check:sqlite-runtime` was not run.

## Stack

- Base: `main` at `ab5a344d7d8bed88d9b7e5727b1916b54183dce5`, including merged #78 / PR #142.
- This is the #80 durable-authority safety layer for Spec #70.
- #81 recovery work will build on this layer.

Closes #80.
