### PR TITLE
Apply Controller session and Game Commencement boundaries

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -305,6 +305,31 @@ async function startServer() {
             return liveEventControlTransport.submitControllerIntent(req);
           },
         },
+        "/api/event-control/refresh": {
+          POST(req: Request) {
+            return liveEventControlTransport.refreshController(req);
+          },
+        },
+        "/api/event-control/switch": {
+          POST(req: Request) {
+            return liveEventControlTransport.switchController(req);
+          },
+        },
+        "/api/event-control/stay": {
+          POST(req: Request) {
+            return liveEventControlTransport.stayController(req);
+          },
+        },
+        "/api/event-control/reveal-qr": {
+          POST(req: Request) {
+            return liveEventControlTransport.revealControllerQr(req);
+          },
+        },
+        "/api/event-control/leave": {
+          POST(req: Request) {
+            return liveEventControlTransport.leaveController(req);
+          },
+        },
         "/api/admin/enrollment/options": {
           async POST(req: Request) {
             const body = await readJsonRecord(req);

--- a/src/lib/controller-intent-retry.test.ts
+++ b/src/lib/controller-intent-retry.test.ts
@@ -1,13 +1,55 @@
 import { describe, expect, test } from "bun:test";
-import { retainControllerGoalIntent } from "@/lib/controller-intent-retry";
+import {
+  retainControllerIntent,
+  type PendingControllerIntent,
+} from "@/lib/controller-intent-retry";
+import type { LiveEventControllerIntent } from "@/lib/live-event-game-control";
 
 describe("Controller tap retry identity", () => {
   test("reuses the pending operation and fact identity after an uncertain response", () => {
-    const first = retainControllerGoalIntent(null, "side-a", 1234);
-    const retry = retainControllerGoalIntent(first, "side-a", 9876);
+    const first = intent("record-goal", { gameSideId: "side-a" });
+    const retry = retainControllerIntent(first, intent("record-goal", { gameSideId: "side-a" }));
 
     expect(retry).toEqual(first);
     expect(JSON.stringify(retry)).toBe(JSON.stringify(first));
-    expect(retainControllerGoalIntent(first, "side-b")).not.toEqual(first);
+    expect(
+      retainControllerIntent(first, intent("record-goal", { gameSideId: "side-b" })),
+    ).not.toEqual(first);
+  });
+
+  test("uses one immutable pending seam for every controller intent", () => {
+    const cases: LiveEventControllerIntent[] = [
+      intent("record-goal", { gameSideId: "side-a" }),
+      intent("clock", { running: true }),
+      intent("substantive", { trigger: "card" }),
+      intent("substantive", { trigger: "timeout" }),
+      intent("substantive", { trigger: "suspension" }),
+      intent("substantive", { trigger: "result" }),
+      intent("reset"),
+      intent("undo"),
+    ];
+    for (const first of cases) {
+      const retry = retainControllerIntent(first as PendingControllerIntent, {
+        ...first,
+        operationId: `${first.operationId}-new`,
+        factId: `${first.factId}-new`,
+      });
+      expect(retry).toBe(first);
+    }
   });
 });
+
+function intent(
+  type: LiveEventControllerIntent["type"],
+  extra: Record<string, unknown> = {},
+): LiveEventControllerIntent {
+  return {
+    version: "live-event-control-intent-v1",
+    type,
+    operationId: crypto.randomUUID(),
+    factId: crypto.randomUUID(),
+    gameTimeMs: 0,
+    occurrence: { clientOriginAtMs: Date.now() },
+    ...extra,
+  } as LiveEventControllerIntent;
+}

--- a/src/lib/controller-intent-retry.ts
+++ b/src/lib/controller-intent-retry.ts
@@ -3,15 +3,45 @@ import {
   type LiveEventControllerIntent,
 } from "@/lib/live-event-game-control";
 
-export type PendingControllerGoalIntent = LiveEventControllerIntent;
+export type PendingControllerIntent = LiveEventControllerIntent;
+export type PendingControllerGoalIntent = Extract<
+  LiveEventControllerIntent,
+  { type: "record-goal" }
+>;
 
+/** Reuses one immutable intent while a response is uncertain, for every control. */
+export function retainControllerIntent(
+  pending: PendingControllerIntent | null,
+  candidate: PendingControllerIntent,
+): PendingControllerIntent {
+  return pending !== null &&
+    controllerIntentRetryKey(pending) === controllerIntentRetryKey(candidate)
+    ? pending
+    : candidate;
+}
+
+export function controllerIntentRetryKey(intent: LiveEventControllerIntent): string {
+  switch (intent.type) {
+    case "record-goal":
+      return JSON.stringify([intent.type, intent.gameSideId, intent.gameTimeMs]);
+    case "clock":
+    case "set-running":
+      return JSON.stringify([intent.type, intent.running, intent.gameTimeMs]);
+    case "substantive":
+      return JSON.stringify([intent.type, intent.trigger, intent.gameTimeMs]);
+    case "reset":
+    case "undo":
+      return JSON.stringify([intent.type, intent.gameTimeMs]);
+  }
+}
+
+/** Compatibility wrapper for callers that only construct goal intents. */
 export function retainControllerGoalIntent(
   pending: PendingControllerGoalIntent | null,
   gameSideId: string,
   clientOriginAtMs = Date.now(),
 ): PendingControllerGoalIntent {
-  if (pending?.gameSideId === gameSideId) return pending;
-  return {
+  const candidate: PendingControllerGoalIntent = {
     version: LIVE_EVENT_CONTROL_INTENT_VERSION,
     type: "record-goal",
     operationId: crypto.randomUUID(),
@@ -20,4 +50,5 @@ export function retainControllerGoalIntent(
     gameTimeMs: 0,
     occurrence: { clientOriginAtMs },
   };
+  return retainControllerIntent(pending, candidate) as PendingControllerGoalIntent;
 }

--- a/src/lib/event-game-actions.ts
+++ b/src/lib/event-game-actions.ts
@@ -550,9 +550,13 @@ export function validateStoredControlAction(
   root: EventGameRecordRoot,
   registry: ControlActionCodecRegistry,
 ): ActionHistoryReadiness {
-  const prepared = prepareControlAction(action, root, registry, action.occurrence.trustedAtMs, {
-    allowConcurrentTeamAssignment: true,
-  });
+  const prepared = prepareControlAction(
+    action,
+    { ...root, lifecycle: action.lifecycle },
+    registry,
+    action.occurrence.trustedAtMs,
+    { allowConcurrentTeamAssignment: true },
+  );
   if (!prepared.ok) return { ok: false, detail: prepared.error };
   if (prepared.value.canonicalContent !== canonicalContent) {
     return { ok: false, detail: "Stored Control Action canonical content is inconsistent." };

--- a/src/lib/event-game-record-helpers.ts
+++ b/src/lib/event-game-record-helpers.ts
@@ -378,7 +378,7 @@ function validateAuditLinkage(
     const rejected = collision.rejectedAttempt;
     const preparedRejected = prepareControlAction(
       rejected.input,
-      root,
+      { ...root, lifecycle: rejected.input.lifecycle },
       registry,
       rejected.input.occurrence.trustedAtMs,
     );

--- a/src/lib/event-game-record.ts
+++ b/src/lib/event-game-record.ts
@@ -88,6 +88,43 @@ export type ExternalScopeResolver = {
   ): ExternalEventTeamResolution;
 };
 
+function sameLifecycleContext(
+  left: EventGameRecordRoot["lifecycle"],
+  right: EventGameRecordRoot["lifecycle"],
+): boolean {
+  return (
+    left.phase === right.phase &&
+    left.commencedAtMs === right.commencedAtMs &&
+    left.finishedAtMs === right.finishedAtMs &&
+    left.lockedAtMs === right.lockedAtMs &&
+    left.lockReason === right.lockReason
+  );
+}
+
+function isAllowedLifecycleTransition(
+  current: EventGameRecordRoot["lifecycle"],
+  next: EventGameRecordRoot["lifecycle"],
+): boolean {
+  if (current.lockedAtMs !== null || current.finishedAtMs !== null) return false;
+  if (
+    current.commencedAtMs !== null &&
+    (next.commencedAtMs === null || next.commencedAtMs !== current.commencedAtMs)
+  )
+    return false;
+  if (next.phase === "scheduled" && next.commencedAtMs !== null) return false;
+  if (current.phase === "scheduled") {
+    return (
+      next.commencedAtMs !== null && (next.phase === "in-progress" || next.phase === "finished")
+    );
+  }
+  if (current.phase === "in-progress" || current.phase === "suspended") {
+    return (
+      next.phase === current.phase || (next.phase === "finished" && next.finishedAtMs !== null)
+    );
+  }
+  return false;
+}
+
 export type EventGameRecordOptions = {
   externalScopeResolver: ExternalScopeResolver;
   clock?: () => number;
@@ -117,6 +154,9 @@ export type RootRegistrationOutcome =
 export type EventGameRecord = {
   registerRoot(root: unknown): Promise<RootRegistrationOutcome>;
   readRoot(recordId: string): Promise<EventGameRecordRoot | null>;
+  transitionLifecycle(
+    lifecycle: EventGameRecordRoot["lifecycle"],
+  ): Promise<LifecycleTransitionOutcome>;
   acceptAction(input: unknown): Promise<ControlActionAcceptanceOutcome>;
   readActions(): Promise<StoredControlAction[]>;
   readRecoveryProvenance(): Promise<ControlActionRecoveryProvenance[]>;
@@ -125,6 +165,10 @@ export type EventGameRecord = {
   rebuild(): Promise<ActionRebuildResult>;
   readiness(): Promise<EventGameRecordReadiness>;
 };
+
+export type LifecycleTransitionOutcome =
+  | { status: "updated" | "idempotent"; root: EventGameRecordRoot }
+  | { status: "rejected"; detail: string };
 
 export type ControlActionAcceptanceOutcome =
   | {
@@ -458,6 +502,54 @@ export function createEventGameRecord(
 
     readRoot(recordId) {
       return storage.readRoot(recordId);
+    },
+
+    async transitionLifecycle(lifecycle) {
+      try {
+        return await storage.transaction((transaction) => {
+          const current = transaction.findRootByRecordId(currentRecordId());
+          if (current === null) {
+            return {
+              status: "rejected",
+              detail: "The Event Game Record is not registered.",
+            } satisfies LifecycleTransitionOutcome;
+          }
+          if (sameLifecycleContext(current.lifecycle, lifecycle)) {
+            return {
+              status: "idempotent",
+              root: cloneEventGameRecordRoot(current),
+            } satisfies LifecycleTransitionOutcome;
+          }
+          const candidate = { ...current, lifecycle: structuredClone(lifecycle) };
+          const validated = validateEventGameRecordRoot(candidate);
+          if (!validated.ok) {
+            return {
+              status: "rejected",
+              detail: validated.error,
+            } satisfies LifecycleTransitionOutcome;
+          }
+          if (!isAllowedLifecycleTransition(current.lifecycle, validated.value.lifecycle)) {
+            return {
+              status: "rejected",
+              detail: "Event Game lifecycle transitions are monotonic.",
+            } satisfies LifecycleTransitionOutcome;
+          }
+          const storedRoot = {
+            root: validated.value,
+            canonicalContent: canonicalizeEventGameRecordRoot(validated.value),
+          };
+          transaction.updateRoot(storedRoot);
+          return {
+            status: "updated",
+            root: cloneEventGameRecordRoot(validated.value),
+          } satisfies LifecycleTransitionOutcome;
+        });
+      } catch {
+        return {
+          status: "rejected",
+          detail: "The Event Game lifecycle could not be durably updated.",
+        } satisfies LifecycleTransitionOutcome;
+      }
     },
 
     async acceptAction(input) {

--- a/src/lib/foundation-acceptance.ts
+++ b/src/lib/foundation-acceptance.ts
@@ -25,12 +25,17 @@ import {
   findFactById,
   validateDependencies,
 } from "@/lib/event-game-record-helpers";
-import type { EventGameRecordRoot } from "@/lib/foundation-record-types";
+import {
+  canonicalizeEventGameRecordRoot,
+  validateEventGameRecordRoot,
+  type EventGameRecordRoot,
+} from "@/lib/foundation-record-types";
 import type {
   FoundationStorage,
   FoundationStorageSnapshot,
   FoundationStorageTransaction,
   StoredAcceptanceBudget,
+  StoredControlAction,
   StoredReplayAttempt,
   StoredReplayReservation,
 } from "@/lib/foundation-storage";
@@ -81,6 +86,7 @@ export type ControlActionBatchInput = {
     originatingSessionId: string;
     replayEvidenceId: string;
   };
+  lifecycleTransition?: EventGameRecordRoot["lifecycle"];
 };
 
 export type FoundationActionResult =
@@ -145,6 +151,7 @@ export type FoundationAcceptanceOptions = {
       | "after-metadata"
       | "after-control-audit"
       | "after-grant-audit"
+      | "after-lifecycle"
       | "before-receipt",
   ) => void;
   /** Test-only barrier between read-only preflight and the first write transaction. */
@@ -341,7 +348,7 @@ export function createFoundationAcceptance(
         trustedLockedReplay: true,
         // Locked discard validates codec/envelope/payload evidence but does
         // not execute root-dependent sporting semantics.
-        actions: prepareBatchActions(batch, null),
+        actions: prepareBatchActions(batch, null, transaction),
       };
     }
     const bearer = replay?.sessionBearer ?? batch.input.sessionBearer;
@@ -350,7 +357,7 @@ export function createFoundationAcceptance(
     const authorization = authorizeGrantInTransaction(transaction, options.grant, {
       sessionBearer: bearer,
       eventGameId: batch.input.eventGameId,
-      controlSessionDecision: batch.input.controlSessionDecision ?? "stay",
+      controlSessionDecision: batch.input.controlSessionDecision,
       readOnly: true,
     });
     if (
@@ -376,23 +383,36 @@ export function createFoundationAcceptance(
         authorized: true,
         root: null,
         trustedLockedReplay: false,
-        actions: prepareBatchActions(batch, null),
+        actions: prepareBatchActions(batch, null, transaction),
       };
     return {
       authorized: true,
       root,
       trustedLockedReplay: false,
-      actions: prepareBatchActions(batch, root),
+      actions: prepareBatchActions(batch, root, transaction),
     };
   }
 
   function prepareBatchActions(
     batch: PreparedBatch,
     root: EventGameRecordRoot | null,
+    snapshot: FoundationStorageSnapshot,
   ): readonly { prepared: PreparedControlAction | null; error: string | null }[] {
     return batch.actions.map(({ raw }) => {
       try {
-        const prepared = prepareControlAction(raw, root, registry, readNow(clock), {
+        const operationId =
+          typeof raw === "object" && raw !== null && !Array.isArray(raw)
+            ? (raw as Record<string, unknown>).operationId
+            : undefined;
+        const existing =
+          root !== null && typeof operationId === "string"
+            ? snapshot.findActionByOperationId(root.recordId, operationId)
+            : null;
+        const preparationRoot =
+          root !== null && existing !== null
+            ? { ...root, lifecycle: existing.action.lifecycle }
+            : root;
+        const prepared = prepareControlAction(raw, preparationRoot, registry, readNow(clock), {
           allowConcurrentTeamAssignment: true,
         });
         return prepared.ok
@@ -425,9 +445,14 @@ export function createFoundationAcceptance(
   function prepareCurrentAction(
     raw: unknown,
     root: EventGameRecordRoot | null,
+    existing?: StoredControlAction | null,
   ): { prepared: PreparedControlAction | null; error: string | null } {
     try {
-      const prepared = prepareControlAction(raw, root, registry, readNow(clock), {
+      const preparationRoot =
+        root !== null && existing !== null && existing !== undefined
+          ? { ...root, lifecycle: existing.action.lifecycle }
+          : root;
+      const prepared = prepareControlAction(raw, preparationRoot, registry, readNow(clock), {
         allowConcurrentTeamAssignment: true,
       });
       return prepared.ok
@@ -523,7 +548,7 @@ export function createFoundationAcceptance(
     const authorization = authorizeGrantInTransaction(transaction, options.grant, {
       sessionBearer: bearer,
       eventGameId: batch.input.eventGameId,
-      controlSessionDecision: batch.input.controlSessionDecision ?? "stay",
+      controlSessionDecision: batch.input.controlSessionDecision,
       readOnly: true,
     });
     if (
@@ -576,7 +601,7 @@ export function createFoundationAcceptance(
       root.recordId,
       structural.envelope.operationId,
     );
-    let currentPreparation = prepareCurrentAction(structural.raw, root);
+    let currentPreparation = prepareCurrentAction(structural.raw, root, existing);
     if (
       existing !== null &&
       currentPreparation.prepared !== null &&
@@ -585,12 +610,14 @@ export function createFoundationAcceptance(
       currentPreparation = prepareCurrentAction(
         withTrustedOccurrence(structural.raw, existing.action.occurrence.trustedAtMs),
         root,
+        existing,
       );
     }
     const prepared = currentPreparation.prepared;
     if (
       preflightAction !== undefined &&
-      !samePreparationResultIgnoringTrustedOccurrence(prepared, preflightAction.prepared)
+      !samePreparationResultIgnoringTrustedOccurrence(prepared, preflightAction.prepared) &&
+      transaction.findActionByOperationId(root.recordId, structural.envelope.operationId) === null
     )
       return one({
         status: "retry-later",
@@ -601,7 +628,7 @@ export function createFoundationAcceptance(
     const currentAuthorization = authorizeGrantInTransaction(transaction, options.grant, {
       sessionBearer: bearer,
       eventGameId: batch.input.eventGameId,
-      controlSessionDecision: batch.input.controlSessionDecision ?? "stay",
+      controlSessionDecision: batch.input.controlSessionDecision,
     });
     if (
       currentAuthorization === GENERIC_GRANT_AUTHORIZATION_FAILURE ||
@@ -820,6 +847,7 @@ export function createFoundationAcceptance(
         mode,
         replayState,
         existing.action,
+        batch.input.lifecycleTransition,
       );
     if (existing !== null)
       return writeOutcome(
@@ -886,6 +914,7 @@ export function createFoundationAcceptance(
       current,
       mode,
       replayState,
+      batch.input.lifecycleTransition,
     );
   }
 
@@ -898,6 +927,7 @@ export function createFoundationAcceptance(
     current: AuthorizedControl,
     mode: "online" | "replay",
     reservation: StoredReplayReservation | undefined,
+    lifecycleTransition: EventGameRecordRoot["lifecycle"] | undefined,
   ): OneOutcome {
     const acceptanceId = `accept-${sha256(`${root.recordId}:${action.operationId}:${action.grant.sessionId}`)}`;
     const grantAudit = linkedGrantAudit(
@@ -928,6 +958,7 @@ export function createFoundationAcceptance(
       action.interpretation.type === "team-assignment-correction"
     )
       appendConcurrentCorrectionAudits(transaction, root.recordId, action.acceptedAtMs);
+    applyLifecycleTransition(transaction, root.recordId, lifecycleTransition);
     return finishReplay(
       transaction,
       reservation,
@@ -1058,6 +1089,7 @@ export function createFoundationAcceptance(
     mode: "online" | "replay",
     reservation: StoredReplayReservation | undefined,
     existing: ControlAction,
+    lifecycleTransition: EventGameRecordRoot["lifecycle"] | undefined,
   ): OneOutcome {
     const nowMs = readNow(clock);
     const controlAudit = createControlAudit(
@@ -1092,6 +1124,7 @@ export function createFoundationAcceptance(
     options.failureInjector?.("after-control-audit");
     transaction.appendGrantAudit(grantAudit);
     options.failureInjector?.("after-grant-audit");
+    applyLifecycleTransition(transaction, root.recordId, lifecycleTransition);
     return finishReplay(
       transaction,
       reservation,
@@ -1451,6 +1484,9 @@ export function createFoundationAcceptance(
           }
         : null,
       actions: raw.actions,
+      ...(isRecord(raw.lifecycleTransition)
+        ? { lifecycleTransition: raw.lifecycleTransition }
+        : {}),
     };
     return {
       input: {
@@ -1460,12 +1496,70 @@ export function createFoundationAcceptance(
         sessionBearer: typeof raw.sessionBearer === "string" ? raw.sessionBearer : undefined,
         mode: effectiveMode,
         replay,
+        lifecycleTransition: isRecord(raw.lifecycleTransition)
+          ? (structuredClone(raw.lifecycleTransition) as EventGameRecordRoot["lifecycle"])
+          : undefined,
       },
       actions,
       order,
       size,
       digest: sha256(JSON.stringify(normalized)),
     };
+  }
+
+  function applyLifecycleTransition(
+    transaction: FoundationStorageTransaction,
+    recordId: string,
+    lifecycle: EventGameRecordRoot["lifecycle"] | undefined,
+  ): void {
+    if (lifecycle === undefined) return;
+    const current = transaction.findRootByRecordId(recordId);
+    if (current === null) throw new Error("The Event Game Record is unavailable.");
+    if (JSON.stringify(current.lifecycle) === JSON.stringify(lifecycle)) return;
+    if (current.lifecycle.phase === "finished" && lifecycle.phase === "finished") return;
+    if (
+      current.lifecycle.commencedAtMs !== null &&
+      lifecycle.commencedAtMs !== current.lifecycle.commencedAtMs &&
+      lifecycle.phase === "in-progress"
+    )
+      return;
+    const validated = validateEventGameRecordRoot({
+      ...current,
+      lifecycle: structuredClone(lifecycle),
+    });
+    if (
+      !validated.ok ||
+      !allowedLifecycleTransition(current.lifecycle, validated.value.lifecycle)
+    ) {
+      throw new Error("Event Game lifecycle transitions are monotonic.");
+    }
+    transaction.updateRoot({
+      root: validated.value,
+      canonicalContent: canonicalizeEventGameRecordRoot(validated.value),
+    });
+    options.failureInjector?.("after-lifecycle");
+  }
+
+  function allowedLifecycleTransition(
+    current: EventGameRecordRoot["lifecycle"],
+    next: EventGameRecordRoot["lifecycle"],
+  ): boolean {
+    if (current.lockedAtMs !== null || current.finishedAtMs !== null) return false;
+    if (
+      current.commencedAtMs !== null &&
+      (next.commencedAtMs === null || next.commencedAtMs !== current.commencedAtMs)
+    )
+      return false;
+    if (next.phase === "scheduled" && next.commencedAtMs !== null) return false;
+    if (current.phase === "scheduled")
+      return (
+        next.commencedAtMs !== null && (next.phase === "in-progress" || next.phase === "finished")
+      );
+    if (current.phase === "in-progress" || current.phase === "suspended")
+      return (
+        next.phase === current.phase || (next.phase === "finished" && next.finishedAtMs !== null)
+      );
+    return false;
   }
 
   function replayReservation(

--- a/src/lib/foundation-grant-erasure-migration.test.ts
+++ b/src/lib/foundation-grant-erasure-migration.test.ts
@@ -210,7 +210,7 @@ describe("Grant cryptographic erasure migration", () => {
 
       const current = openSqliteFoundationStorage(databasePath);
       await current.applyMigrations({ requireCandidate: false });
-      expect(await current.readiness()).toMatchObject({ ok: true, schemaVersion: "21" });
+      expect(await current.readiness()).toMatchObject({ ok: true, schemaVersion: "22" });
       current.close();
 
       const raw = new Database(databasePath);
@@ -330,7 +330,7 @@ describe("Grant cryptographic erasure migration", () => {
       raw.close();
 
       const reopened = openSqliteFoundationStorage(databasePath);
-      expect(await reopened.readiness()).toMatchObject({ ok: true, schemaVersion: "21" });
+      expect(await reopened.readiness()).toMatchObject({ ok: true, schemaVersion: "22" });
       const restartedAudit = await reopened.transaction((transaction) =>
         transaction.listGrantAudit("grant-expired"),
       );

--- a/src/lib/foundation-migrations.test.ts
+++ b/src/lib/foundation-migrations.test.ts
@@ -13,7 +13,7 @@ const migrations: readonly FoundationMigration[] = [
 ];
 
 describe("foundation migration ledger compatibility", () => {
-  test("keeps accepted migrations 001 through 019 byte-for-byte immutable and pins 020/021", () => {
+  test("keeps accepted migrations 001 through 021 byte-for-byte immutable and pins 022", () => {
     expect(FOUNDATION_MIGRATIONS.map(({ id, checksum }) => ({ id, checksum }))).toEqual([
       {
         id: "001-foundation-event-game-record-roots",
@@ -98,6 +98,10 @@ describe("foundation migration ledger compatibility", () => {
       {
         id: "021-grant-code-game-lock-erasure-evidence",
         checksum: "d91853426ecc62a0b5a6341536fc788753604b75aef6d515de770624d403fec0",
+      },
+      {
+        id: "022-control-session-stay-binding",
+        checksum: "88c2b77d65542cc3310c268389e9ad5693a7f87bc0815cb1209be7db49e2cf6e",
       },
     ]);
   });

--- a/src/lib/foundation-migrations.ts
+++ b/src/lib/foundation-migrations.ts
@@ -1552,6 +1552,11 @@ const FOUNDATION_EVENT_CATALOG_MIGRATION_SQL = `
   ${FOUNDATION_EVENT_CATALOG_AUDIT_EVENT_INDEX_SQL};
 `;
 
+const FOUNDATION_CONTROL_SESSION_STAY_MIGRATION_SQL = `
+  ALTER TABLE foundation_grant_sessions
+    ADD COLUMN stayed_on_event_game_id TEXT;
+`;
+
 export const FOUNDATION_MIGRATIONS: readonly FoundationMigration[] = Object.freeze([
   createMigration({
     id: "001-foundation-event-game-record-roots",
@@ -1678,6 +1683,12 @@ export const FOUNDATION_MIGRATIONS: readonly FoundationMigration[] = Object.free
     ordinal: 21,
     schemaVersion: 21,
     sql: FOUNDATION_GRANT_CODE_LOCK_MIGRATION_SQL,
+  }),
+  createMigration({
+    id: "022-control-session-stay-binding",
+    ordinal: 22,
+    schemaVersion: 22,
+    sql: FOUNDATION_CONTROL_SESSION_STAY_MIGRATION_SQL,
   }),
 ]);
 

--- a/src/lib/foundation-storage-memory.ts
+++ b/src/lib/foundation-storage-memory.ts
@@ -1140,6 +1140,17 @@ function createTransaction(
       });
       undo.push(() => state.roots.delete(storedRoot.root.recordId));
     },
+    updateRoot(storedRoot) {
+      const previous = state.roots.get(storedRoot.root.recordId);
+      if (previous === undefined) {
+        throw new FoundationStorageConstraintError("record-id");
+      }
+      state.roots.set(storedRoot.root.recordId, {
+        root: cloneEventGameRecordRoot(storedRoot.root),
+        canonicalContent: storedRoot.canonicalContent,
+      });
+      undo.push(() => state.roots.set(storedRoot.root.recordId, previous));
+    },
     insertAction(storedAction) {
       const { action } = storedAction;
       if (!state.roots.has(action.recordId)) {

--- a/src/lib/foundation-storage-sqlite.test.ts
+++ b/src/lib/foundation-storage-sqlite.test.ts
@@ -546,7 +546,7 @@ describe("SQLite foundation storage", () => {
       expect(await reopenedRecord.registerRoot(root)).toMatchObject({ status: "idempotent" });
       expect(await reopened.readiness()).toMatchObject({
         ok: true,
-        schemaVersion: "21",
+        schemaVersion: "22",
         evidence: { replay: { result: "passed", rootCount: 1, durationMs: expect.any(Number) } },
       });
       reopened.close();
@@ -594,12 +594,12 @@ describe("SQLite foundation storage", () => {
       const storage = openSqliteFoundationStorage(databasePath);
       const candidate = await storage.validateCandidate();
       expect(candidate.ready).toBe(true);
-      expect(candidate.readiness).toMatchObject({ ok: true, schemaVersion: "21" });
+      expect(candidate.readiness).toMatchObject({ ok: true, schemaVersion: "22" });
       expect(existsSync(candidate.candidatePath)).toBe(false);
       expect(await storage.readiness()).toMatchObject({ ok: false, status: "pending" });
 
       const migration = await storage.applyMigrations({ requireCandidate: true });
-      expect(migration.schemaVersion).toBe(21);
+      expect(migration.schemaVersion).toBe(22);
       expect(await storage.readiness()).toMatchObject({ ok: true });
       storage.close();
     });
@@ -628,6 +628,7 @@ describe("SQLite foundation storage", () => {
       const eventCatalogMigration = FOUNDATION_MIGRATIONS[18];
       const grantCodeMigration = FOUNDATION_MIGRATIONS[19];
       const grantCodeLockMigration = FOUNDATION_MIGRATIONS[20];
+      const controlSessionStayMigration = FOUNDATION_MIGRATIONS[21];
       if (
         initialMigration === undefined ||
         repairMigration === undefined ||
@@ -649,7 +650,8 @@ describe("SQLite foundation storage", () => {
         acceptanceIntegrityHistoryMigration === undefined ||
         eventCatalogMigration === undefined ||
         grantCodeMigration === undefined ||
-        grantCodeLockMigration === undefined
+        grantCodeLockMigration === undefined ||
+        controlSessionStayMigration === undefined
       ) {
         throw new Error("Expected the foundation migrations.");
       }
@@ -683,8 +685,9 @@ describe("SQLite foundation storage", () => {
         eventCatalogMigration.id,
         grantCodeMigration.id,
         grantCodeLockMigration.id,
+        controlSessionStayMigration.id,
       ]);
-      expect(await current.readiness()).toMatchObject({ ok: true, schemaVersion: "21" });
+      expect(await current.readiness()).toMatchObject({ ok: true, schemaVersion: "22" });
       current.close();
     });
   });
@@ -693,9 +696,9 @@ describe("SQLite foundation storage", () => {
     await withDatabase(async (databasePath) => {
       const baseMigrations = FOUNDATION_MIGRATIONS;
       const failingMigration = createMigration(
-        "022-failing-test-migration",
-        22,
-        22,
+        "023-failing-test-migration",
+        23,
+        23,
         "CREATE TABLE migration_failure_probe (id TEXT) STRICT; THIS IS NOT SQL;",
       );
       const store = openSqliteFoundationStorage(databasePath, {
@@ -715,7 +718,7 @@ describe("SQLite foundation storage", () => {
       });
       expect(await priorBinary.readiness()).toMatchObject({
         ok: true,
-        schemaVersion: "21",
+        schemaVersion: "22",
       });
       priorBinary.close();
 
@@ -787,7 +790,7 @@ describe("SQLite foundation storage", () => {
         .query(
           "INSERT INTO foundation_migration_ledger (migration_id, ordinal, schema_version, checksum, status, applied_at_ms) VALUES (?, ?, ?, ?, ?, ?)",
         )
-        .run("future-999", 22, 22, "future-checksum", "complete", 2_000);
+        .run("future-999", 23, 23, "future-checksum", "complete", 2_000);
       futureDatabase.close();
       const future = openSqliteFoundationStorage(databasePath);
       expect(await future.readiness()).toMatchObject({ ok: false });

--- a/src/lib/foundation-storage-sqlite.ts
+++ b/src/lib/foundation-storage-sqlite.ts
@@ -301,6 +301,7 @@ type RootStatements = {
   byGameSideId: SqlStatement;
   insertRoot: SqlStatement;
   allRoots: SqlStatement;
+  updateRoot: SqlStatement;
   insertSide: SqlStatement;
   actionByOperationId: SqlStatement;
   actionsByRecordId: SqlStatement;
@@ -841,6 +842,7 @@ export class SqliteFoundationStorage implements FoundationStorage {
       findRootByGameSideId: (gameSideId) =>
         this.readRootByStatement(statements.byGameSideId, gameSideId),
       insertRoot: (storedRoot) => this.insertRoot(statements, storedRoot),
+      updateRoot: (storedRoot) => this.updateRoot(statements, storedRoot),
       findActionByOperationId: (recordId, operationId) =>
         this.readActionByStatement(statements.actionByOperationId, recordId, operationId),
       listActions: (recordId) => this.readActionsByRecordId(statements.actionsByRecordId, recordId),
@@ -1171,6 +1173,23 @@ export class SqliteFoundationStorage implements FoundationStorage {
     );
   }
 
+  private updateRoot(statements: RootStatements, storedRoot: StoredEventGameRecordRoot): void {
+    const { root } = storedRoot;
+    const result = statements.updateRoot.run(
+      root.lifecycle.phase,
+      root.lifecycle.commencedAtMs,
+      root.lifecycle.finishedAtMs,
+      root.lifecycle.lockedAtMs,
+      root.lifecycle.lockReason,
+      storedRoot.canonicalContent,
+      JSON.stringify(root),
+      root.recordId,
+    );
+    if (result.changes !== 1) {
+      throw new FoundationStorageConstraintError("record-id");
+    }
+  }
+
   private insertAction(statements: RootStatements, storedAction: StoredControlAction): void {
     const { action } = storedAction;
     const actionId = actionIdentity(action.recordId, action.operationId);
@@ -1298,6 +1317,12 @@ export class SqliteFoundationStorage implements FoundationStorage {
           creation_operation_id, creation_actor_reference, creation_source,
           creation_created_at_ms, canonical_content, root_json
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `),
+      updateRoot: this.database.query(`
+        UPDATE foundation_event_game_record_roots
+        SET lifecycle_phase = ?, commenced_at_ms = ?, finished_at_ms = ?,
+            locked_at_ms = ?, lock_reason = ?, canonical_content = ?, root_json = ?
+        WHERE record_id = ?
       `),
       insertSide: this.database.query(`
         INSERT INTO foundation_event_game_record_sides (

--- a/src/lib/foundation-storage.ts
+++ b/src/lib/foundation-storage.ts
@@ -320,6 +320,7 @@ export type FoundationStorageSnapshot = {
 
 export type FoundationStorageTransaction = FoundationStorageSnapshot & {
   insertRoot(root: StoredEventGameRecordRoot): void;
+  updateRoot(root: StoredEventGameRecordRoot): void;
   insertAction(action: StoredControlAction): void;
   upsertRecordMetadata(metadata: StoredEventGameRecordMetadata): void;
   appendAuditEntry(entry: StoredControlAuditEntry): void;

--- a/src/lib/grant-management-sessions.ts
+++ b/src/lib/grant-management-sessions.ts
@@ -128,6 +128,7 @@ export async function admitGrant(
         grantId: current.grantId,
         grantVersion: current.grantVersion,
         eventGameId: eventGameId ?? "grant-management",
+        stayedOnEventGameId: null,
         browserContextDigest: contextDigest,
         browserContextKeyVersion: lookupVersion,
         bearerMaterialState: "present",
@@ -217,7 +218,7 @@ export function authorizeGrantInTransaction(
     readOnly?: boolean;
   },
 ): TypedGrantAuthorization {
-  const session = findSessionByBearer(transaction, options, input.sessionBearer);
+  let session = findSessionByBearer(transaction, options, input.sessionBearer);
   if (session === null) return GENERIC_GRANT_AUTHORIZATION_FAILURE;
   const stored = transaction.findGrantById(session.grantId);
   if (stored === null) return GENERIC_GRANT_AUTHORIZATION_FAILURE;
@@ -264,6 +265,19 @@ export function authorizeGrantInTransaction(
     if (relationship.status === "switchable") {
       if (
         input.controlSessionDecision === "stay" &&
+        input.eventGameId === relationship.previousEventGameId &&
+        !input.readOnly
+      ) {
+        session = {
+          ...session,
+          stayedOnEventGameId: relationship.currentEventGameId,
+        };
+        transaction.updateGrantSession({
+          ...session,
+        });
+        eventGameId = relationship.previousEventGameId;
+      } else if (
+        session.stayedOnEventGameId === relationship.currentEventGameId &&
         input.eventGameId === relationship.previousEventGameId
       ) {
         eventGameId = relationship.previousEventGameId;
@@ -341,6 +355,7 @@ export async function acceptControlGrantSessionSwitch(
       transaction.updateGrantSession({
         ...session,
         eventGameId: relationship.currentEventGameId,
+        stayedOnEventGameId: null,
         lastActiveAtMs: nowMs,
       });
       transaction.appendGrantAudit(
@@ -597,7 +612,11 @@ function resolveControlSession(
   sessionEventGameId: string,
 ): ControlGrantSessionResolution {
   if (options.controlScopeResolver.resolveSession !== undefined) {
-    const resolved = options.controlScopeResolver.resolveSession(scope, sessionEventGameId);
+    const resolved = options.controlScopeResolver.resolveSession(
+      scope,
+      sessionEventGameId,
+      transaction,
+    );
     if (resolved.status === "current")
       return resolved.eventGameId === sessionEventGameId &&
         validateOpaqueIdentifier(resolved.eventGameId, "eventGameId").ok

--- a/src/lib/grant-state-validation.ts
+++ b/src/lib/grant-state-validation.ts
@@ -991,6 +991,9 @@ function validateSession(
     !validateOpaqueIdentifier(session.grantId, "session.grantId").ok ||
     !validateOpaqueIdentifier(session.grantVersion, "session.grantVersion").ok ||
     !validateOpaqueIdentifier(session.eventGameId, "session.eventGameId").ok ||
+    (session.stayedOnEventGameId !== undefined &&
+      session.stayedOnEventGameId !== null &&
+      !validateOpaqueIdentifier(session.stayedOnEventGameId, "session.stayedOnEventGameId").ok) ||
     session.browserContextKeyVersion.length === 0 ||
     !isStoredGrantSessionStatus(session.status) ||
     !Number.isSafeInteger(session.createdAtMs) ||

--- a/src/lib/grant-storage-sqlite.ts
+++ b/src/lib/grant-storage-sqlite.ts
@@ -97,6 +97,7 @@ const GRANT_SELECT_COLUMNS = `
 const SESSION_SELECT_COLUMNS = `
   sessions.session_id AS session_id, sessions.grant_id AS grant_id,
   sessions.grant_version AS grant_version, sessions.event_game_id AS event_game_id,
+  sessions.stayed_on_event_game_id AS stayed_on_event_game_id,
   sessions.browser_context_digest AS browser_context_digest,
   sessions.browser_context_key_version AS browser_context_key_version,
   sessions.bearer_material_state AS bearer_material_state,
@@ -193,13 +194,13 @@ export function createGrantSqliteStatements(database: Database): GrantSqliteStat
     insertSession: database.query(`
       INSERT INTO foundation_grant_sessions (
         session_id, grant_id, grant_version, event_game_id, browser_context_digest,
-        browser_context_key_version, bearer_material_state, bearer_lookup_verifier, bearer_lookup_key_version,
+        stayed_on_event_game_id, browser_context_key_version, bearer_material_state, bearer_lookup_verifier, bearer_lookup_key_version,
         status, created_at_ms, last_active_at_ms, revoked_at_ms, device_class, browser_class
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `),
     updateSession: database.query(`
       UPDATE foundation_grant_sessions SET
-        grant_id = ?, grant_version = ?, event_game_id = ?, browser_context_digest = ?,
+        grant_id = ?, grant_version = ?, event_game_id = ?, stayed_on_event_game_id = ?, browser_context_digest = ?,
         browser_context_key_version = ?, bearer_material_state = ?, bearer_lookup_verifier = ?,
         bearer_lookup_key_version = ?, status = ?, created_at_ms = ?,
         last_active_at_ms = ?, revoked_at_ms = ?, device_class = ?, browser_class = ?
@@ -575,6 +576,7 @@ export function insertGrantSession(
     session.grantVersion,
     session.eventGameId,
     session.browserContextDigest,
+    session.stayedOnEventGameId ?? null,
     session.browserContextKeyVersion,
     session.bearerMaterialState,
     session.bearerLookupVerifier,
@@ -596,6 +598,7 @@ export function updateGrantSession(
     session.grantId,
     session.grantVersion,
     session.eventGameId,
+    session.stayedOnEventGameId ?? null,
     session.browserContextDigest,
     session.browserContextKeyVersion,
     session.bearerMaterialState,
@@ -1073,6 +1076,7 @@ function readStoredGrantSession(row: GrantRow): StoredGrantSession {
     grantId: readText(row.grant_id),
     grantVersion: readText(row.grant_version),
     eventGameId: readText(row.event_game_id),
+    stayedOnEventGameId: readNullableText(row.stayed_on_event_game_id),
     browserContextDigest: readText(row.browser_context_digest),
     browserContextKeyVersion: readText(row.browser_context_key_version),
     bearerMaterialState: bearerMaterialState as "present" | "erased",

--- a/src/lib/grant-types.ts
+++ b/src/lib/grant-types.ts
@@ -147,6 +147,7 @@ export type ControlGrantScopeResolver = {
   resolveSession?: (
     scope: ControlGrantScope,
     sessionEventGameId: string,
+    snapshot?: FoundationStorageSnapshot,
   ) => ControlGrantSessionResolution;
   /** Optional lifecycle-aware seam used by explicit offline replay authorization. */
   resolveReplay?: (
@@ -197,6 +198,7 @@ export type StoredGrantSession = {
   grantId: string;
   grantVersion: string;
   eventGameId: string;
+  stayedOnEventGameId?: string | null;
   browserContextDigest: string;
   browserContextKeyVersion: string;
   bearerMaterialState: "present" | "erased";

--- a/src/lib/live-event-game-control.test.ts
+++ b/src/lib/live-event-game-control.test.ts
@@ -6,7 +6,7 @@ import { createEventGameRecord } from "@/lib/event-game-record";
 import { createGrantTestAuthorityVerifier } from "@/lib/grant-authority-test-support";
 import { createTypedGrantAuthority } from "@/lib/grant-management";
 import type { GrantAuthorityOptions } from "@/lib/grant-authority";
-import type { GrantKeyRing } from "@/lib/grant-types";
+import type { ControlGrantSessionResolution, GrantKeyRing } from "@/lib/grant-types";
 import type { EventGameRecordRoot } from "@/lib/foundation-record-types";
 import {
   createLiveEventGameControl,
@@ -129,6 +129,243 @@ describe("Live Event Game control", () => {
         browserContext: "controller-phone",
       }),
     ).toEqual({ status: "rejected", message: "Unable to open Controller experience." });
+  });
+
+  test("keeps a short clock test provisional, then commences after ten active seconds", async () => {
+    const harness = await createHarness();
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "clock-boundary",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+
+    const start = await harness.control.submitControllerIntent({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      intent: clockIntent("clock-start", true),
+    });
+    expect(start).toMatchObject({
+      status: "accepted",
+      projection: { commencement: { status: "provisional" } },
+    });
+
+    harness.setNow(19_000);
+    const shortRunningUpdate = await harness.control.submitControllerIntent({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      intent: clockIntent("clock-short-update", true),
+    });
+    expect(shortRunningUpdate).toMatchObject({
+      projection: { commencement: { status: "provisional" } },
+    });
+    expect(
+      (await harness.record.readRoot(harness.root.recordId))?.lifecycle.commencedAtMs,
+    ).toBeNull();
+
+    harness.setNow(20_000);
+    const longPause = await harness.control.submitControllerIntent({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      intent: clockIntent("clock-long-pause", false),
+    });
+    expect(longPause).toMatchObject({ projection: { commencement: { status: "commenced" } } });
+    expect((await harness.record.readRoot(harness.root.recordId))?.lifecycle).toMatchObject({
+      phase: "in-progress",
+      commencedAtMs: 20_000,
+    });
+  });
+
+  test("persists passive clock commencement at the ten-second boundary during refresh", async () => {
+    const harness = await createHarness();
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "passive-commencement",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+
+    await harness.control.submitControllerIntent({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      intent: clockIntent("passive-clock-start", true),
+    });
+    harness.setNow(20_000);
+    expect(
+      await harness.control.refreshController({
+        sessionBearer: opened.session.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+      }),
+    ).toMatchObject({
+      status: "authorized",
+      projection: { commencement: { status: "commenced", commencedAtMs: 20_000 } },
+    });
+    expect((await harness.record.readRoot(harness.root.recordId))?.lifecycle).toMatchObject({
+      phase: "in-progress",
+      commencedAtMs: 20_000,
+    });
+
+    harness.setNow(25_000);
+    await harness.control.submitControllerIntent({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      intent: substantiveIntent("passive-card", "card"),
+    });
+    expect((await harness.record.readRoot(harness.root.recordId))?.lifecycle.commencedAtMs).toBe(
+      20_000,
+    );
+  });
+
+  test.each(["card", "timeout", "suspension", "result"] as const)(
+    "commences irreversibly on the first %s trigger",
+    async (trigger) => {
+      const harness = await createHarness();
+      const opened = await harness.control.openController({
+        qrCredential: harness.qrCredential,
+        browserContext: `trigger-${trigger}`,
+      });
+      if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+      const result = await harness.control.submitControllerIntent({
+        sessionBearer: opened.session.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+        intent: substantiveIntent(`trigger-${trigger}`, trigger),
+      });
+      expect(result.status).toBe("accepted");
+      expect((await harness.record.readRoot(harness.root.recordId))?.lifecycle.commencedAtMs).toBe(
+        10_000,
+      );
+      if (trigger === "result") {
+        expect((await harness.record.readRoot(harness.root.recordId))?.lifecycle.phase).toBe(
+          "finished",
+        );
+      }
+    },
+  );
+
+  test("reset and undo do not reverse commencement, and QR reveal stops after finish", async () => {
+    const harness = await createHarness();
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "qr-and-leave",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+    expect(
+      await harness.control.revealControllerQr({
+        sessionBearer: opened.session.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+      }),
+    ).toMatchObject({ status: "revealed", qrCredential: harness.qrCredential });
+    await harness.control.submitControllerIntent({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      intent: goalIntent(),
+    });
+    await harness.control.submitControllerIntent({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      intent: simpleIntent("reset-1", "reset"),
+    });
+    await harness.control.submitControllerIntent({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      intent: simpleIntent("undo-1", "undo"),
+    });
+    expect(
+      (await harness.record.readRoot(harness.root.recordId))?.lifecycle.commencedAtMs,
+    ).not.toBeNull();
+    const finishIntent = substantiveIntent("finish-1", "result");
+    expect(
+      await harness.control.submitControllerIntent({
+        sessionBearer: opened.session.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+        intent: finishIntent,
+      }),
+    ).toMatchObject({ status: "accepted" });
+    expect(
+      await harness.control.submitControllerIntent({
+        sessionBearer: opened.session.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+        intent: finishIntent,
+      }),
+    ).toMatchObject({ status: "duplicate-accepted" });
+    expect(
+      await harness.control.submitControllerIntent({
+        sessionBearer: opened.session.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+        intent: substantiveIntent("post-finish", "card"),
+      }),
+    ).toMatchObject({ status: "rejected" });
+    expect(
+      (await ownerState(harness)).grantSessions.find(
+        (session) => session.sessionId === opened.session.grantSessionId,
+      )?.stayedOnEventGameId,
+    ).toBeNull();
+    expect(
+      await harness.control.revealControllerQr({
+        sessionBearer: opened.session.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+      }),
+    ).toEqual({ status: "rejected", message: "Unable to reveal the active Control Grant QR." });
+    expect(
+      await harness.control.leaveController({ sessionBearer: opened.session.sessionBearer }),
+    ).toEqual({
+      status: "left",
+    });
+    expect(
+      await harness.control.submitControllerIntent({
+        sessionBearer: opened.session.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+        intent: simpleIntent("after-leave", "undo"),
+      }),
+    ).toMatchObject({ status: "rejected" });
+  });
+
+  test("returns a pre-commencement switch prompt and pins a commenced session", async () => {
+    const harness = await createHarness();
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "switch-boundary",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+
+    harness.setSessionResolution({
+      status: "switchable",
+      previousEventGameId: harness.root.eventGameId,
+      currentEventGameId: "game-reassigned",
+    });
+    const prompt = await harness.control.refreshController({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+    });
+    expect(prompt).toMatchObject({
+      status: "switch-required",
+      previousEventGameId: harness.root.eventGameId,
+      currentEventGameId: "game-reassigned",
+    });
+    expect(
+      await harness.control.revealControllerQr({
+        sessionBearer: opened.session.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+      }),
+    ).toMatchObject({ status: "rejected" });
+    expect(
+      (await ownerState(harness)).grantSessions.find(
+        (session) => session.sessionId === opened.session.grantSessionId,
+      )?.stayedOnEventGameId,
+    ).toBeNull();
+    expect(
+      await harness.control.stayController({
+        sessionBearer: opened.session.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+      }),
+    ).toMatchObject({ status: "authorized", session: { eventGameId: harness.root.eventGameId } });
+    expect(
+      await harness.control.refreshController({
+        sessionBearer: opened.session.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+      }),
+    ).toMatchObject({ status: "authorized", session: { eventGameId: harness.root.eventGameId } });
+    expect(
+      await harness.control.switchController({ sessionBearer: opened.session.sessionBearer }),
+    ).toMatchObject({ status: "authorized" });
   });
 
   test("authorizes the Controller session before inspecting untrusted intent content", async () => {
@@ -361,6 +598,28 @@ describe("Live Event Game control", () => {
     });
   });
 
+  test("atomically rolls back the action and commencement at the lifecycle boundary", async () => {
+    const harness = await createHarness({ failureBoundary: "after-lifecycle" });
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "controller-phone",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+
+    expect(
+      await harness.control.submitControllerIntent({
+        sessionBearer: opened.session.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+        intent: substantiveIntent("atomic-card", "card"),
+      }),
+    ).toMatchObject({ status: "retryable" });
+    expect(await harness.record.readActions()).toHaveLength(0);
+    expect((await harness.record.readRoot(harness.root.recordId))?.lifecycle).toMatchObject({
+      phase: "scheduled",
+      commencedAtMs: null,
+    });
+  });
+
   test("assigns trusted occurrence time at the server seam and leaves Ad Hoc commands separate", async () => {
     expect(
       parseLiveEventControllerIntent({
@@ -484,6 +743,35 @@ describe("Live Event Game control", () => {
     };
     expect(opened.session.sessionBearer).toBeString();
 
+    const refreshResponse = await transport.refreshController(
+      new Request("https://timer.quadball.app/api/event-control/refresh", {
+        method: "POST",
+        headers: { origin: allowedOrigin, host: "timer.quadball.app" },
+        body: JSON.stringify({
+          sessionBearer: opened.session.sessionBearer,
+          eventGameId: opened.eventGameId,
+        }),
+      }),
+    );
+    expect(refreshResponse.status).toBe(200);
+    expect(await refreshResponse.json()).toMatchObject({ status: "authorized" });
+
+    const revealResponse = await transport.revealControllerQr(
+      new Request("https://timer.quadball.app/api/event-control/reveal-qr", {
+        method: "POST",
+        headers: { origin: allowedOrigin, host: "timer.quadball.app" },
+        body: JSON.stringify({
+          sessionBearer: opened.session.sessionBearer,
+          eventGameId: opened.eventGameId,
+        }),
+      }),
+    );
+    expect(revealResponse.status).toBe(200);
+    expect(await revealResponse.json()).toMatchObject({
+      status: "revealed",
+      qrCredential: harness.qrCredential,
+    });
+
     const actionResponse = await transport.submitControllerIntent(
       new Request("https://timer.quadball.app/api/event-control/intent", {
         method: "POST",
@@ -510,6 +798,16 @@ describe("Live Event Game control", () => {
       }),
     );
     expect(rejectedAction.status).toBe(404);
+
+    const leaveResponse = await transport.leaveController(
+      new Request("https://timer.quadball.app/api/event-control/leave", {
+        method: "POST",
+        headers: { origin: allowedOrigin, host: "timer.quadball.app" },
+        body: JSON.stringify({ sessionBearer: opened.session.sessionBearer }),
+      }),
+    );
+    expect(leaveResponse.status).toBe(200);
+    expect(await leaveResponse.json()).toEqual({ status: "left" });
   });
 });
 
@@ -518,13 +816,15 @@ async function createHarness(
     eventGameId?: string;
     grantEventGameId?: string;
     grantExpiresAtMs?: number | null;
-    failureBoundary?: "after-action";
+    failureBoundary?: "after-action" | "after-lifecycle";
     projectionFailure?: () => boolean;
     scopeStatus?: "empty" | "conflict";
     controlClock?: () => number;
+    sessionResolution?: ControlGrantSessionResolution;
   } = {},
 ) {
   const root = createRoot(overrides.eventGameId ?? "game-live-control");
+  const reassignedRoot = createRoot("game-reassigned", "reassigned");
   const storage = createInMemoryFoundationStorage();
   const grantOptions = createGrantOptions(overrides.grantEventGameId ?? root.eventGameId);
   const authority = createTypedGrantAuthority(storage, grantOptions);
@@ -540,6 +840,8 @@ async function createHarness(
   });
   if (admitted.status !== "admitted") throw new Error("Expected a Grant Session.");
   if (overrides.scopeStatus !== undefined) grantOptions.setScopeStatus(overrides.scopeStatus);
+  if (overrides.sessionResolution !== undefined)
+    grantOptions.setSessionResolution(overrides.sessionResolution);
 
   let failureBoundary = overrides.failureBoundary;
   const record = createEventGameRecord(storage, {
@@ -550,6 +852,15 @@ async function createHarness(
   });
   if ((await record.registerRoot(root)).status !== "registered") {
     throw new Error("Expected the Event Game Record root to register.");
+  }
+  const reassignedRecord = createEventGameRecord(storage, {
+    externalScopeResolver: createScopeResolver(reassignedRoot),
+    interpreter: createLiveEventGameIqaInterpreter(),
+    clock: () => grantOptions.clock.nowMs(),
+    auditAuthorityVerifier: { verify: () => true },
+  });
+  if ((await reassignedRecord.registerRoot(reassignedRoot)).status !== "registered") {
+    throw new Error("Expected the reassigned Event Game Record root to register.");
   }
   const acceptance = createFoundationAcceptance(storage, {
     grant: grantOptions,
@@ -562,7 +873,11 @@ async function createHarness(
   });
   const control = createLiveEventGameControl({
     resolveEventGameRecord: async (eventGameId) =>
-      eventGameId === root.eventGameId ? { recordId: root.recordId, record } : null,
+      eventGameId === root.eventGameId
+        ? { recordId: root.recordId, record }
+        : eventGameId === reassignedRoot.eventGameId
+          ? { recordId: reassignedRoot.recordId, record: reassignedRecord }
+          : null,
     acceptance,
     grantAuthority: authority,
     clock: overrides.controlClock ?? (() => grantOptions.clock.nowMs()),
@@ -586,6 +901,9 @@ async function createHarness(
     setScopeEventGameId(value: string) {
       grantOptions.setScopeEventGameId(value);
     },
+    setSessionResolution(value: ControlGrantSessionResolution | undefined) {
+      grantOptions.setSessionResolution(value);
+    },
   };
 }
 
@@ -601,10 +919,49 @@ function goalIntent(overrides: { gameSideId?: string } = {}) {
   };
 }
 
+function clockIntent(operationId: string, running: boolean) {
+  return {
+    version: LIVE_EVENT_CONTROL_INTENT_VERSION,
+    type: "clock" as const,
+    operationId,
+    factId: `fact-${operationId}`,
+    running,
+    gameTimeMs: 0,
+    occurrence: { clientOriginAtMs: null },
+  };
+}
+
+function substantiveIntent(
+  operationId: string,
+  trigger: "card" | "timeout" | "suspension" | "result",
+) {
+  return {
+    version: LIVE_EVENT_CONTROL_INTENT_VERSION,
+    type: "substantive" as const,
+    trigger,
+    operationId,
+    factId: `fact-${operationId}`,
+    gameTimeMs: 0,
+    occurrence: { clientOriginAtMs: null },
+  };
+}
+
+function simpleIntent(operationId: string, type: "reset" | "undo") {
+  return {
+    version: LIVE_EVENT_CONTROL_INTENT_VERSION,
+    type,
+    operationId,
+    factId: `fact-${operationId}`,
+    gameTimeMs: 0,
+    occurrence: { clientOriginAtMs: null },
+  } as const;
+}
+
 type TestGrantOptions = GrantAuthorityOptions & {
   setNow: (value: number) => void;
   setScopeStatus: (value: "empty" | "conflict" | undefined) => void;
   setScopeEventGameId: (value: string) => void;
+  setSessionResolution: (value: ControlGrantSessionResolution | undefined) => void;
 };
 
 function createGrantOptions(eventGameId: string): TestGrantOptions {
@@ -612,6 +969,7 @@ function createGrantOptions(eventGameId: string): TestGrantOptions {
   let nowMs = 10_000;
   let scopeStatus: "empty" | "conflict" | undefined;
   let resolvedEventGameId = eventGameId;
+  let sessionResolution: ControlGrantSessionResolution | undefined;
   return {
     environmentId: "live-control-test",
     clock: { nowMs: () => nowMs },
@@ -627,6 +985,11 @@ function createGrantOptions(eventGameId: string): TestGrantOptions {
         scopeStatus === undefined
           ? { status: "eligible", eventGameId: resolvedEventGameId }
           : { status: scopeStatus },
+      resolveSession: (_scope, sessionEventGameId) =>
+        sessionResolution ??
+        (sessionEventGameId === resolvedEventGameId
+          ? { status: "current", eventGameId: resolvedEventGameId }
+          : { status: "mismatch" }),
     },
     privilegedAuthorityVerifier: createGrantTestAuthorityVerifier(),
     setNow(value: number) {
@@ -637,6 +1000,9 @@ function createGrantOptions(eventGameId: string): TestGrantOptions {
     },
     setScopeEventGameId(value) {
       resolvedEventGameId = value;
+    },
+    setSessionResolution(value) {
+      sessionResolution = value;
     },
   };
 }
@@ -663,7 +1029,7 @@ function bytes(start: number): Uint8Array {
   return Uint8Array.from({ length: 32 }, (_, index) => start + index);
 }
 
-function createRoot(eventGameId: string): EventGameRecordRoot {
+function createRoot(eventGameId: string, sideSuffix = ""): EventGameRecordRoot {
   return {
     recordId: `record-${eventGameId}`,
     eventId: "event-live-control",
@@ -676,8 +1042,16 @@ function createRoot(eventGameId: string): EventGameRecordRoot {
       pitchSlotId: `slot-${eventGameId}`,
     },
     gameSides: [
-      { id: "side-a", eventTeamId: "team-a", teamInterpretationRef: "team-a-v1" },
-      { id: "side-b", eventTeamId: "team-b", teamInterpretationRef: "team-b-v1" },
+      {
+        id: `side-a${sideSuffix}`,
+        eventTeamId: `team-a${sideSuffix}`,
+        teamInterpretationRef: `team-a${sideSuffix}-v1`,
+      },
+      {
+        id: `side-b${sideSuffix}`,
+        eventTeamId: `team-b${sideSuffix}`,
+        teamInterpretationRef: `team-b${sideSuffix}-v1`,
+      },
     ],
     lifecycle: {
       phase: "scheduled",

--- a/src/lib/live-event-game-control.ts
+++ b/src/lib/live-event-game-control.ts
@@ -13,17 +13,74 @@ import {
 export const LIVE_EVENT_CONTROL_INTENT_VERSION = "live-event-control-intent-v1" as const;
 export const LIVE_EVENT_IQA_INTERPRETER_VERSION = "live-event-iqa-v1" as const;
 
-export type LiveEventControllerIntent = {
+type ControllerIntentBase = {
   version: typeof LIVE_EVENT_CONTROL_INTENT_VERSION;
-  type: "record-goal";
   operationId: string;
   factId: string;
-  gameSideId: string;
   gameTimeMs: number;
   occurrence: {
     clientOriginAtMs: number | null;
   };
 };
+
+export type LiveEventControllerIntent =
+  | (ControllerIntentBase & {
+      type: "record-goal";
+      gameSideId: string;
+    })
+  | (ControllerIntentBase & {
+      type: "clock" | "set-running";
+      running: boolean;
+    })
+  | (ControllerIntentBase & {
+      type: "substantive";
+      trigger: "card" | "timeout" | "suspension" | "result";
+    })
+  | (ControllerIntentBase & {
+      type: "reset" | "undo";
+    });
+
+export type ControllerCommencement = {
+  status: "provisional" | "commenced";
+  commencedAtMs: number | null;
+  provisionalRunningSinceMs: number | null;
+  provisionalElapsedMs: number;
+};
+
+export type ControllerSessionAttachment = {
+  eventGameId: string;
+  grantSessionId: string;
+  grantVersion: string;
+};
+
+export type ControllerSwitchRequired = {
+  status: "switch-required";
+  previousEventGameId: string;
+  currentEventGameId: string;
+  session: ControllerSessionAttachment;
+};
+
+export type ControllerRefreshResult =
+  | {
+      status: "authorized";
+      session: ControllerSessionAttachment;
+      projection: ControllerProjection | null;
+      projectionStatus: "available" | "unavailable";
+    }
+  | ControllerSwitchRequired
+  | { status: "rejected"; message: "Unable to refresh Controller session." };
+
+export type ControllerQrResult =
+  | {
+      status: "revealed";
+      eventGameId: string;
+      qrCredential: string;
+    }
+  | { status: "rejected"; message: "Unable to reveal the active Control Grant QR." };
+
+export type ControllerLeaveResult =
+  | { status: "left" }
+  | { status: "rejected"; message: "Unable to leave Controller session." };
 
 export type LiveEventGameDerivedState = {
   interpreterVersion: string;
@@ -37,6 +94,7 @@ export type ControllerProjection = {
   phase: EventGameLifecyclePhase;
   scoreByGameSide: Readonly<Record<string, number>>;
   goalCount: number;
+  commencement: ControllerCommencement;
 };
 
 export type ControllerSynchronization = {
@@ -93,7 +151,14 @@ export type LiveEventGameControlOptions = {
     eventGameId: string,
   ) => Promise<{ recordId: string; record: EventGameRecord } | null>;
   acceptance: FoundationAcceptance;
-  grantAuthority: Pick<TypedGrantAuthority, "admitGrant" | "authorizeGrant">;
+  grantAuthority: Pick<
+    TypedGrantAuthority,
+    | "admitGrant"
+    | "authorizeGrant"
+    | "acceptControlGrantSessionSwitch"
+    | "revealGrant"
+    | "leaveGrantSession"
+  >;
   clock?: () => number;
   /** Test-only seam for proving the post-commit projection response. */
   projectionFailure?: () => boolean;
@@ -117,11 +182,18 @@ export function parseLiveEventControllerIntent(
   if (value.version !== LIVE_EVENT_CONTROL_INTENT_VERSION) {
     return invalid("Controller intent version is unsupported.");
   }
-  if (value.type !== "record-goal") return invalid("Controller intent type is unsupported.");
+  if (
+    value.type !== "record-goal" &&
+    value.type !== "clock" &&
+    value.type !== "set-running" &&
+    value.type !== "substantive" &&
+    value.type !== "reset" &&
+    value.type !== "undo"
+  )
+    return invalid("Controller intent type is unsupported.");
 
   const operationId = validateOpaqueIdentifier(value.operationId, "operationId");
   const factId = validateOpaqueIdentifier(value.factId, "factId");
-  const gameSideId = validateOpaqueIdentifier(value.gameSideId, "gameSideId");
   const gameTimeMs = validateIntegerInRange(
     value.gameTimeMs,
     0,
@@ -130,8 +202,30 @@ export function parseLiveEventControllerIntent(
   );
   if (!operationId.ok) return invalid(operationId.error);
   if (!factId.ok) return invalid(factId.error);
-  if (!gameSideId.ok) return invalid(gameSideId.error);
   if (!gameTimeMs.ok) return invalid(gameTimeMs.error);
+
+  let gameSideId: string | undefined;
+  if (value.type === "record-goal") {
+    const parsedSide = validateOpaqueIdentifier(value.gameSideId, "gameSideId");
+    if (!parsedSide.ok) return invalid(parsedSide.error);
+    gameSideId = parsedSide.value;
+  }
+  let running: boolean | undefined;
+  if (value.type === "clock" || value.type === "set-running") {
+    if (typeof value.running !== "boolean") return invalid("running must be a boolean.");
+    running = value.running;
+  }
+  let trigger: "card" | "timeout" | "suspension" | "result" | undefined;
+  if (value.type === "substantive") {
+    if (
+      value.trigger !== "card" &&
+      value.trigger !== "timeout" &&
+      value.trigger !== "suspension" &&
+      value.trigger !== "result"
+    )
+      return invalid("substantive trigger is unsupported.");
+    trigger = value.trigger;
+  }
 
   if (!isRecord(value.occurrence)) return invalid("occurrence must be an object.");
   let clientOriginAtMs: number | null = null;
@@ -152,13 +246,15 @@ export function parseLiveEventControllerIntent(
     ok: true,
     value: {
       version: LIVE_EVENT_CONTROL_INTENT_VERSION,
-      type: "record-goal",
+      type: value.type,
       operationId: operationId.value,
       factId: factId.value,
-      gameSideId: gameSideId.value,
       gameTimeMs: gameTimeMs.value,
       occurrence: { clientOriginAtMs },
-    },
+      ...(gameSideId === undefined ? {} : { gameSideId }),
+      ...(running === undefined ? {} : { running }),
+      ...(trigger === undefined ? {} : { trigger }),
+    } as LiveEventControllerIntent,
   };
 }
 
@@ -186,7 +282,6 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
     const authorized = await options.grantAuthority.authorizeGrant({
       sessionBearer: admitted.sessionBearer,
       eventGameId: admitted.eventGameId,
-      controlSessionDecision: "stay",
       readOnly: true,
     });
     if (
@@ -199,14 +294,22 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
     }
 
     const owner = await options.resolveEventGameRecord(authorized.eventGameId);
-    if (owner === null) return rejectedOpen();
+    if (owner === null) {
+      return rejectedOpen();
+    }
     const root = await owner.record.readRoot(owner.recordId);
-    if (root === null || root.eventGameId !== authorized.eventGameId) return rejectedOpen();
+    if (root === null || root.eventGameId !== authorized.eventGameId) {
+      return rejectedOpen();
+    }
+    const commenced = await ensureClockCommencement(owner, root, clock());
+    if (commenced.status === "rejected") {
+      return rejectedOpen();
+    }
 
-    const projection = await readProjection(owner.record, root);
+    const projection = await readProjection(owner.record, commenced.root);
     return {
       status: "opened",
-      eventGameId: root.eventGameId,
+      eventGameId: commenced.root.eventGameId,
       session: {
         sessionBearer: admitted.sessionBearer,
         grantSessionId: authorized.grantSessionId,
@@ -218,6 +321,197 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
     };
   }
 
+  async function refreshController(input: {
+    sessionBearer: string;
+    eventGameId: string;
+  }): Promise<ControllerRefreshResult> {
+    const authorized = await options.grantAuthority.authorizeGrant({
+      sessionBearer: input.sessionBearer,
+      eventGameId: input.eventGameId,
+      readOnly: true,
+    });
+    if (authorized.status === "switch-required") {
+      const previousOwner = await options.resolveEventGameRecord(authorized.previousEventGameId);
+      const previousRoot =
+        previousOwner === null ? null : await previousOwner.record.readRoot(previousOwner.recordId);
+      if (previousOwner !== null && previousRoot !== null) {
+        const commenced = await ensureClockCommencement(previousOwner, previousRoot, clock());
+        if (commenced.status === "rejected") {
+          return { status: "rejected", message: "Unable to refresh Controller session." };
+        }
+        if (commenced.root.lifecycle.commencedAtMs !== null) {
+          const pinned = await options.grantAuthority.authorizeGrant({
+            sessionBearer: input.sessionBearer,
+            eventGameId: input.eventGameId,
+            readOnly: true,
+          });
+          if (
+            pinned.status === "authorized" &&
+            pinned.grantType === "control" &&
+            pinned.eventGameId !== null
+          ) {
+            const owner = await options.resolveEventGameRecord(pinned.eventGameId);
+            const root = owner === null ? null : await owner.record.readRoot(owner.recordId);
+            if (owner !== null && root !== null) {
+              const projection = await readProjection(owner.record, root);
+              return {
+                status: "authorized",
+                session: {
+                  eventGameId: root.eventGameId,
+                  grantSessionId: pinned.grantSessionId,
+                  grantVersion: pinned.grantVersion,
+                },
+                projection,
+                projectionStatus: projection === null ? "unavailable" : "available",
+              };
+            }
+          }
+        }
+      }
+      return {
+        status: "switch-required",
+        previousEventGameId: authorized.previousEventGameId,
+        currentEventGameId: authorized.currentEventGameId,
+        session: {
+          eventGameId: authorized.previousEventGameId,
+          grantSessionId: authorized.grantSessionId,
+          grantVersion: authorized.grantVersion,
+        },
+      };
+    }
+    if (
+      authorized.status !== "authorized" ||
+      authorized.grantType !== "control" ||
+      authorized.eventGameId === null
+    )
+      return { status: "rejected", message: "Unable to refresh Controller session." };
+    const owner = await options.resolveEventGameRecord(authorized.eventGameId);
+    const root = owner === null ? null : await owner.record.readRoot(owner.recordId);
+    if (owner === null || root === null) {
+      return { status: "rejected", message: "Unable to refresh Controller session." };
+    }
+    const commenced = await ensureClockCommencement(owner, root, clock());
+    if (commenced.status === "rejected") {
+      return { status: "rejected", message: "Unable to refresh Controller session." };
+    }
+    const projection = await readProjection(owner.record, commenced.root);
+    return {
+      status: "authorized",
+      session: {
+        eventGameId: commenced.root.eventGameId,
+        grantSessionId: authorized.grantSessionId,
+        grantVersion: authorized.grantVersion,
+      },
+      projection,
+      projectionStatus: projection === null ? "unavailable" : "available",
+    };
+  }
+
+  async function switchController(input: {
+    sessionBearer: string;
+  }): Promise<ControllerRefreshResult> {
+    const switched = await options.grantAuthority.acceptControlGrantSessionSwitch({
+      sessionBearer: input.sessionBearer,
+    });
+    if (switched.status !== "switched") {
+      return { status: "rejected", message: "Unable to refresh Controller session." };
+    }
+    const owner = await options.resolveEventGameRecord(switched.eventGameId);
+    const root = owner === null ? null : await owner.record.readRoot(owner.recordId);
+    if (owner === null || root === null || root.eventGameId !== switched.eventGameId) {
+      return { status: "rejected", message: "Unable to refresh Controller session." };
+    }
+    const commenced = await ensureClockCommencement(owner, root, clock());
+    if (commenced.status === "rejected") {
+      return { status: "rejected", message: "Unable to refresh Controller session." };
+    }
+    const projection = await readProjection(owner.record, commenced.root);
+    return {
+      status: "authorized",
+      session: {
+        eventGameId: commenced.root.eventGameId,
+        grantSessionId: switched.grantSessionId,
+        grantVersion: switched.grantVersion,
+      },
+      projection,
+      projectionStatus: projection === null ? "unavailable" : "available",
+    };
+  }
+
+  async function stayController(input: {
+    sessionBearer: string;
+    eventGameId: string;
+  }): Promise<ControllerRefreshResult> {
+    const authorized = await options.grantAuthority.authorizeGrant({
+      sessionBearer: input.sessionBearer,
+      eventGameId: input.eventGameId,
+      controlSessionDecision: "stay",
+      readOnly: false,
+    });
+    if (
+      authorized.status !== "authorized" ||
+      authorized.grantType !== "control" ||
+      authorized.eventGameId === null
+    )
+      return { status: "rejected", message: "Unable to refresh Controller session." };
+    const owner = await options.resolveEventGameRecord(authorized.eventGameId);
+    const root = owner === null ? null : await owner.record.readRoot(owner.recordId);
+    if (owner === null || root === null) {
+      return { status: "rejected", message: "Unable to refresh Controller session." };
+    }
+    const commenced = await ensureClockCommencement(owner, root, clock());
+    if (commenced.status === "rejected") {
+      return { status: "rejected", message: "Unable to refresh Controller session." };
+    }
+    const projection = await readProjection(owner.record, commenced.root);
+    return {
+      status: "authorized",
+      session: {
+        eventGameId: commenced.root.eventGameId,
+        grantSessionId: authorized.grantSessionId,
+        grantVersion: authorized.grantVersion,
+      },
+      projection,
+      projectionStatus: projection === null ? "unavailable" : "available",
+    };
+  }
+
+  async function revealControllerQr(input: {
+    sessionBearer: string;
+    eventGameId: string;
+  }): Promise<ControllerQrResult> {
+    const authorized = await options.grantAuthority.authorizeGrant({
+      sessionBearer: input.sessionBearer,
+      eventGameId: input.eventGameId,
+      readOnly: true,
+    });
+    if (
+      authorized.status !== "authorized" ||
+      authorized.grantType !== "control" ||
+      authorized.eventGameId === null
+    )
+      return { status: "rejected", message: "Unable to reveal the active Control Grant QR." };
+    const owner = await options.resolveEventGameRecord(authorized.eventGameId);
+    const root = owner === null ? null : await owner.record.readRoot(owner.recordId);
+    if (owner === null || root === null || root.lifecycle.phase === "finished") {
+      return { status: "rejected", message: "Unable to reveal the active Control Grant QR." };
+    }
+    const revealed = await options.grantAuthority.revealGrant(authorized.grantId, {
+      kind: "grant-session",
+      sessionBearer: input.sessionBearer,
+    });
+    return revealed.status === "revealed"
+      ? { status: "revealed", eventGameId: root.eventGameId, qrCredential: revealed.qrCredential }
+      : { status: "rejected", message: "Unable to reveal the active Control Grant QR." };
+  }
+
+  async function leaveController(input: { sessionBearer: string }): Promise<ControllerLeaveResult> {
+    const left = await options.grantAuthority.leaveGrantSession(input.sessionBearer);
+    return left.status === "updated"
+      ? { status: "left" }
+      : { status: "rejected", message: "Unable to leave Controller session." };
+  }
+
   async function submitControllerIntent(input: {
     sessionBearer: string;
     eventGameId: string;
@@ -226,7 +520,6 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
     const authorized = await options.grantAuthority.authorizeGrant({
       sessionBearer: input.sessionBearer,
       eventGameId: input.eventGameId,
-      controlSessionDecision: "stay",
       readOnly: true,
     });
     if (
@@ -243,29 +536,60 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
 
     const owner = await options.resolveEventGameRecord(authorized.eventGameId);
     const root = owner === null ? null : await owner.record.readRoot(owner.recordId);
-    if (
-      owner === null ||
-      root === null ||
-      !root.gameSides.some((side) => side.id === parsed.value.gameSideId)
-    ) {
+    if (owner === null || root === null) {
       return rejectedAction(parsed.value.operationId);
     }
+    const commenced = await ensureClockCommencement(owner, root, clock());
+    if (commenced.status === "rejected") return retryableAction(parsed.value.operationId);
+    const activeRoot = commenced.root;
+
+    if (parsed.value.type === "record-goal") {
+      const gameSideId = parsed.value.gameSideId;
+      if (!activeRoot.gameSides.some((side) => side.id === gameSideId)) {
+        return rejectedAction(parsed.value.operationId);
+      }
+    }
+
+    const actionsBefore = await owner.record.readActions();
+    const existingAction = actionsBefore.find(
+      (stored) => stored.action.operationId === parsed.value.operationId,
+    );
+    if (activeRoot.lifecycle.phase === "finished" && existingAction === undefined) {
+      return rejectedAction(parsed.value.operationId);
+    }
+    const nowMs = clock();
+    const previousClockStartMs = latestRunningClockStart(actionsBefore);
+    const clockStartMs =
+      parsed.value.type === "clock" || parsed.value.type === "set-running"
+        ? parsed.value.running
+          ? (previousClockStartMs ?? nowMs)
+          : previousClockStartMs
+        : null;
+    const factType = controllerFactType(parsed.value);
+    const gameSideId = parsed.value.type === "record-goal" ? parsed.value.gameSideId : null;
 
     const action = {
       recordId: owner.recordId,
-      eventGameId: root.eventGameId,
+      eventGameId: activeRoot.eventGameId,
       operationId: parsed.value.operationId,
       kind: { id: goalCodec.kind, version: goalCodec.version },
       payload: {
         factId: parsed.value.factId,
-        factType: "goal",
-        gameSideId: parsed.value.gameSideId,
+        factType,
+        gameSideId,
         gameTimeMs: parsed.value.gameTimeMs,
-        data: { points: 10 },
+        data:
+          parsed.value.type === "record-goal"
+            ? { points: 10 }
+            : parsed.value.type === "clock" || parsed.value.type === "set-running"
+              ? { running: parsed.value.running, startedAtMs: clockStartMs }
+              : parsed.value.type === "substantive"
+                ? { trigger: parsed.value.trigger }
+                : null,
       },
       causalPredecessorIds: [],
       occurrence: {
-        trustedAtMs: clock(),
+        trustedAtMs: nowMs,
         clientOriginAtMs: parsed.value.occurrence.clientOriginAtMs,
         source: "online",
       },
@@ -273,16 +597,37 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
         sessionId: authorized.grantSessionId,
         versionId: authorized.grantVersion,
       },
-      lifecycle: structuredClone(root.lifecycle),
+      lifecycle: structuredClone(existingAction?.action.lifecycle ?? activeRoot.lifecycle),
     };
+
+    const shouldCommence = shouldRecordCommencement(parsed.value, activeRoot, nowMs, clockStartMs);
+    const shouldFinish =
+      parsed.value.type === "substantive" &&
+      parsed.value.trigger === "result" &&
+      activeRoot.lifecycle.finishedAtMs === null;
+    const lifecycleTransition: EventGameRecordRoot["lifecycle"] | undefined =
+      shouldCommence !== null || shouldFinish
+        ? {
+            ...activeRoot.lifecycle,
+            phase:
+              parsed.value.type === "substantive" && parsed.value.trigger === "result"
+                ? "finished"
+                : "in-progress",
+            commencedAtMs: activeRoot.lifecycle.commencedAtMs ?? shouldCommence?.atMs ?? nowMs,
+            finishedAtMs:
+              parsed.value.type === "substantive" && parsed.value.trigger === "result"
+                ? nowMs
+                : activeRoot.lifecycle.finishedAtMs,
+          }
+        : undefined;
 
     let accepted;
     try {
       accepted = await options.acceptance.submitBatch({
-        recordId: root.recordId,
-        eventGameId: root.eventGameId,
+        recordId: activeRoot.recordId,
+        eventGameId: activeRoot.eventGameId,
         sessionBearer: input.sessionBearer,
-        controlSessionDecision: "stay",
+        lifecycleTransition,
         actions: [action],
       });
     } catch {
@@ -298,7 +643,9 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
       return rejectedAction(parsed.value.operationId);
     }
 
-    const projection = await readProjection(owner.record, root);
+    const currentRoot = await owner.record.readRoot(owner.recordId);
+    const projection =
+      currentRoot === null ? null : await readProjection(owner.record, currentRoot);
     return {
       status: result.status,
       acknowledgement: {
@@ -325,18 +672,35 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
       if (rebuild.status !== "ready") return null;
       const derived = readDerivedState(rebuild.derivedGameState);
       if (derived === null) return null;
+      const actions = await record.readActions();
+      const runningSinceMs =
+        root.lifecycle.commencedAtMs === null ? latestRunningClockStart(actions) : null;
       return {
         eventGameId: root.eventGameId,
         phase: derived.phase,
         scoreByGameSide: structuredClone(derived.scoreByGameSide),
         goalCount: derived.goalCount,
+        commencement: {
+          status: root.lifecycle.commencedAtMs === null ? "provisional" : "commenced",
+          commencedAtMs: root.lifecycle.commencedAtMs,
+          provisionalRunningSinceMs: runningSinceMs,
+          provisionalElapsedMs: runningSinceMs === null ? 0 : Math.max(0, clock() - runningSinceMs),
+        },
       };
     } catch {
       return null;
     }
   }
 
-  return { openController, submitControllerIntent };
+  return {
+    openController,
+    refreshController,
+    switchController,
+    stayController,
+    revealControllerQr,
+    leaveController,
+    submitControllerIntent,
+  };
 }
 
 function deriveLiveEventGameState(
@@ -362,6 +726,74 @@ function deriveLiveEventGameState(
     scoreByGameSide,
     goalCount,
   };
+}
+
+function controllerFactType(intent: LiveEventControllerIntent): string {
+  if (intent.type === "record-goal") return "goal";
+  if (intent.type === "clock" || intent.type === "set-running") return "clock";
+  if (intent.type === "substantive") return intent.trigger;
+  return intent.type;
+}
+
+async function ensureClockCommencement(
+  owner: { recordId: string; record: EventGameRecord },
+  root: EventGameRecordRoot,
+  nowMs: number,
+): Promise<{ status: "ready"; root: EventGameRecordRoot } | { status: "rejected" }> {
+  if (root.lifecycle.commencedAtMs !== null || root.lifecycle.phase !== "scheduled") {
+    return { status: "ready", root };
+  }
+  const actions = await owner.record.readActions();
+  const runningSinceMs = latestRunningClockStart(actions);
+  if (runningSinceMs === null || nowMs - runningSinceMs < 10_000) {
+    return { status: "ready", root };
+  }
+  const transition = await owner.record.transitionLifecycle({
+    ...root.lifecycle,
+    phase: "in-progress",
+    commencedAtMs: runningSinceMs + 10_000,
+  });
+  if (transition.status === "rejected") return { status: "rejected" };
+  return { status: "ready", root: transition.root };
+}
+
+function latestRunningClockStart(
+  actions: readonly { action: { interpretation: unknown } }[],
+): number | null {
+  for (const stored of [...actions].reverse()) {
+    const interpretation = stored.action.interpretation;
+    if (
+      !isRecord(interpretation) ||
+      interpretation.type !== "fact" ||
+      interpretation.factType !== "clock"
+    )
+      continue;
+    const payload = interpretation.payload;
+    if (!isRecord(payload) || !isRecord(payload.data)) return null;
+    if (payload.data.running !== true) return null;
+    return typeof payload.data.startedAtMs === "number" ? payload.data.startedAtMs : null;
+  }
+  return null;
+}
+
+function shouldRecordCommencement(
+  intent: LiveEventControllerIntent,
+  root: EventGameRecordRoot,
+  nowMs: number,
+  clockStartMs: number | null,
+): { atMs: number } | null {
+  if (root.lifecycle.commencedAtMs !== null) return null;
+  if (intent.type === "record-goal" || intent.type === "substantive") {
+    return { atMs: nowMs };
+  }
+  if (
+    (intent.type === "clock" || intent.type === "set-running") &&
+    clockStartMs !== null &&
+    nowMs - clockStartMs >= 10_000
+  ) {
+    return { atMs: clockStartMs + 10_000 };
+  }
+  return null;
 }
 
 function readDerivedState(value: unknown): LiveEventGameDerivedState | null {

--- a/src/lib/live-event-game-runtime.test.ts
+++ b/src/lib/live-event-game-runtime.test.ts
@@ -6,13 +6,18 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createEventGameRecord } from "@/lib/event-game-record";
 import type { EventGameRecordRoot } from "@/lib/foundation-record-types";
+import type { FoundationStorageSnapshot } from "@/lib/foundation-storage";
 import { FOUNDATION_MIGRATIONS } from "@/lib/foundation-migrations";
 import { openSqliteFoundationStorage } from "@/lib/foundation-storage-sqlite";
 import { createGrantTestAuthorityVerifier } from "@/lib/grant-authority-test-support";
 import { createTypedGrantAuthority } from "@/lib/grant-management";
 import type { GrantAuthorityOptions } from "@/lib/grant-authority";
 import type { GrantKeyRing } from "@/lib/grant-types";
-import { openLiveEventGameRuntime, readLiveEventGrantKeyRing } from "@/lib/live-event-game-runtime";
+import {
+  createControlScopeResolver,
+  openLiveEventGameRuntime,
+  readLiveEventGrantKeyRing,
+} from "@/lib/live-event-game-runtime";
 import {
   createLiveEventGameIqaInterpreter,
   LIVE_EVENT_CONTROL_INTENT_VERSION,
@@ -201,7 +206,11 @@ describe("Live Event Game SQLite runtime", () => {
       expect(accepted).toMatchObject({
         status: "accepted",
         projectionStatus: "available",
-        projection: { scoreByGameSide: { "side-a": 10, "side-b": 0 }, goalCount: 1 },
+        projection: {
+          scoreByGameSide: { "side-a": 10, "side-b": 0 },
+          goalCount: 1,
+          commencement: { status: "commenced", commencedAtMs: 10_000 },
+        },
       });
 
       const duplicate = await runtime.control.submitControllerIntent({
@@ -243,6 +252,151 @@ describe("Live Event Game SQLite runtime", () => {
         projectionStatus: "available",
         projection: { scoreByGameSide: { "side-a": 10, "side-b": 0 }, goalCount: 1 },
       });
+    } finally {
+      runtime.close();
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("production scope resolver switches before commencement and pins after it", () => {
+    const previous = createRoot();
+    const current: EventGameRecordRoot = {
+      ...previous,
+      recordId: "runtime-record-current",
+      eventGameId: "runtime-game-current",
+      ownership: { eventId: previous.eventId, eventGameId: "runtime-game-current" },
+      lifecycle: { ...previous.lifecycle },
+    };
+    const previousCommenced: EventGameRecordRoot = {
+      ...previous,
+      recordId: "runtime-record-previous-commenced",
+      eventGameId: "runtime-game-previous-commenced",
+      ownership: { eventId: previous.eventId, eventGameId: "runtime-game-previous-commenced" },
+      lifecycle: { ...previous.lifecycle, phase: "in-progress", commencedAtMs: 10_000 },
+    };
+    const snapshot = {
+      findRootByPitchSlotId: () => current,
+      findRootByEventGameId: (eventGameId: string) =>
+        eventGameId === previous.eventGameId
+          ? previous
+          : eventGameId === previousCommenced.eventGameId
+            ? previousCommenced
+            : current,
+    } as unknown as FoundationStorageSnapshot;
+    const resolver = createControlScopeResolver();
+
+    expect(
+      resolver.resolveSession?.(current.externalScope, previous.eventGameId, snapshot),
+    ).toEqual({
+      status: "switchable",
+      previousEventGameId: previous.eventGameId,
+      currentEventGameId: current.eventGameId,
+    });
+    expect(
+      resolver.resolveSession?.(current.externalScope, previousCommenced.eventGameId, snapshot),
+    ).toEqual({
+      status: "pinned",
+      sessionEventGameId: previousCommenced.eventGameId,
+      currentEventGameId: current.eventGameId,
+    });
+  });
+
+  test("production reassignment resolution persists passive commencement without refresh", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "quadball-event-game-runtime-"));
+    const databasePath = join(directory, "event-game.sqlite");
+    const keyRing = createKeyRing();
+    let nowMs = 0;
+    const previous = createRoot();
+    const current: EventGameRecordRoot = {
+      ...previous,
+      recordId: "runtime-record-reassigned",
+      eventGameId: "runtime-game-reassigned",
+      ownership: { eventId: previous.eventId, eventGameId: "runtime-game-reassigned" },
+      externalScope: { ...previous.externalScope, pitchSlotId: "runtime-slot-2" },
+      gameSides: [
+        { id: "side-c", eventTeamId: "team-c", teamInterpretationRef: "team-c-v1" },
+        { id: "side-d", eventTeamId: "team-d", teamInterpretationRef: "team-d-v1" },
+      ],
+      creationEvidence: { ...previous.creationEvidence, operationId: "runtime-register-2" },
+    };
+    const setupStorage = openSqliteFoundationStorage(databasePath, { grantKeyRing: keyRing });
+    let qrCredential: string;
+    try {
+      await setupStorage.applyMigrations({ requireCandidate: false });
+      for (const root of [previous, current]) {
+        const record = createEventGameRecord(setupStorage, {
+          externalScopeResolver: createExternalScopeResolver(root),
+          interpreter: createLiveEventGameIqaInterpreter(),
+          auditAuthorityVerifier: { verify: () => true },
+        });
+        expect(await record.registerRoot(root)).toMatchObject({ status: "registered" });
+      }
+      const authority = createTypedGrantAuthority(
+        setupStorage,
+        createGrantOptions("runtime-test", keyRing),
+      );
+      const created = await authority.createControlGrant({
+        scope: previous.externalScope,
+        authority: { kind: "fixture", id: "runtime-fixture" },
+      });
+      if (created.status !== "created") throw new Error("Expected a runtime Control Grant.");
+      qrCredential = created.qrCredential;
+    } finally {
+      setupStorage.close();
+    }
+
+    const runtime = await openLiveEventGameRuntime({
+      databasePath,
+      environmentId: "runtime-test",
+      keyRing,
+      clock: () => nowMs,
+    });
+    try {
+      const opened = await runtime.control.openController({
+        qrCredential,
+        browserContext: "runtime-reassignment-device",
+      });
+      if (opened.status !== "opened") throw new Error("Expected the runtime Controller to open.");
+      const clock = await runtime.control.submitControllerIntent({
+        sessionBearer: opened.session.sessionBearer,
+        eventGameId: previous.eventGameId,
+        intent: {
+          version: LIVE_EVENT_CONTROL_INTENT_VERSION,
+          type: "clock",
+          operationId: "runtime-clock-start",
+          factId: "runtime-clock-fact",
+          running: true,
+          gameTimeMs: 0,
+          occurrence: { clientOriginAtMs: 0 },
+        },
+      });
+      expect(clock).toMatchObject({ status: "accepted" });
+      nowMs = 10_001;
+
+      const storage = openSqliteFoundationStorage(databasePath, { grantKeyRing: keyRing });
+      try {
+        createEventGameRecord(storage, {
+          externalScopeResolver: createExternalScopeResolver(previous),
+          interpreter: createLiveEventGameIqaInterpreter(),
+        });
+        const result = await storage.transaction((transaction) =>
+          createControlScopeResolver(() => nowMs).resolveSession?.(
+            current.externalScope,
+            previous.eventGameId,
+            transaction,
+          ),
+        );
+        expect(result).toEqual({
+          status: "pinned",
+          sessionEventGameId: previous.eventGameId,
+          currentEventGameId: current.eventGameId,
+        });
+        expect(await storage.readRoot(previous.recordId)).toMatchObject({
+          lifecycle: { phase: "in-progress", commencedAtMs: 10_000 },
+        });
+      } finally {
+        storage.close();
+      }
     } finally {
       runtime.close();
       await rm(directory, { recursive: true, force: true });

--- a/src/lib/live-event-game-runtime.ts
+++ b/src/lib/live-event-game-runtime.ts
@@ -14,6 +14,14 @@ import { createTypedGrantAuthority } from "@/lib/grant-management";
 import type { GrantAuthorityOptions } from "@/lib/grant-authority";
 import type { GrantKeyRing } from "@/lib/grant-types";
 import type { EventGameRecordRoot } from "@/lib/foundation-record-types";
+import {
+  canonicalizeEventGameRecordRoot,
+  validateEventGameRecordRoot,
+} from "@/lib/foundation-record-types";
+import type {
+  FoundationStorageSnapshot,
+  FoundationStorageTransaction,
+} from "@/lib/foundation-storage";
 
 export type LiveEventGameRuntime = {
   control: ReturnType<typeof createLiveEventGameControl>;
@@ -106,16 +114,20 @@ function createGrantOptions(
     clock: { nowMs: clock },
     randomness: { bytes: (length) => new Uint8Array(randomBytes(length)) },
     keyRing,
-    controlScopeResolver: createControlScopeResolver(),
+    controlScopeResolver: createControlScopeResolver(clock),
     privilegedAuthorityVerifier: { verify: () => null },
   };
 }
 
-function createControlScopeResolver(): GrantAuthorityOptions["controlScopeResolver"] {
+export function createControlScopeResolver(
+  clock: () => number = () => Date.now(),
+): GrantAuthorityOptions["controlScopeResolver"] {
   return {
     resolve(scope, snapshot) {
       if (snapshot === undefined) return { status: "unavailable" };
-      const root = snapshot.findRootByPitchSlotId(scope.pitchSlotId);
+      const storedRoot = snapshot.findRootByPitchSlotId(scope.pitchSlotId);
+      const root =
+        storedRoot === null ? null : materializeCommencement(storedRoot, snapshot, clock());
       if (root === null) return { status: "empty" };
       if (
         root.externalScope.eventId !== scope.eventId ||
@@ -128,7 +140,94 @@ function createControlScopeResolver(): GrantAuthorityOptions["controlScopeResolv
       }
       return { status: "eligible", eventGameId: root.eventGameId };
     },
+    resolveSession(scope, sessionEventGameId, snapshot) {
+      if (snapshot === undefined) return { status: "unavailable" };
+      const storedCurrent = snapshot.findRootByPitchSlotId(scope.pitchSlotId);
+      const current =
+        storedCurrent === null ? null : materializeCommencement(storedCurrent, snapshot, clock());
+      if (current === null) return { status: "empty" };
+      if (
+        current.externalScope.eventId !== scope.eventId ||
+        current.externalScope.gameDayId !== scope.gameDayId ||
+        current.externalScope.pitchId !== scope.pitchId
+      )
+        return { status: "conflict" };
+      if (current.lifecycle.lockedAtMs !== null) {
+        return { status: "game-locked", eventGameId: current.eventGameId };
+      }
+      if (current.eventGameId === sessionEventGameId) {
+        return { status: "current", eventGameId: current.eventGameId };
+      }
+      const sessionRootValue = snapshot.findRootByEventGameId(sessionEventGameId);
+      const sessionRoot =
+        sessionRootValue === null
+          ? null
+          : materializeCommencement(sessionRootValue, snapshot, clock());
+      return sessionRoot !== null && sessionRoot.lifecycle.commencedAtMs !== null
+        ? {
+            status: "pinned",
+            sessionEventGameId,
+            currentEventGameId: current.eventGameId,
+          }
+        : {
+            status: "switchable",
+            previousEventGameId: sessionEventGameId,
+            currentEventGameId: current.eventGameId,
+          };
+    },
   };
+}
+
+function materializeCommencement(
+  root: EventGameRecordRoot,
+  snapshot: FoundationStorageSnapshot,
+  nowMs: number,
+): EventGameRecordRoot {
+  if (root.lifecycle.phase !== "scheduled" || root.lifecycle.commencedAtMs !== null) return root;
+  if (typeof snapshot.listActions !== "function") return root;
+  const runningSinceMs = latestRunningClockStart(snapshot.listActions(root.recordId));
+  if (runningSinceMs === null || nowMs < runningSinceMs + 10_000) return root;
+  const candidate = {
+    ...root,
+    lifecycle: {
+      ...root.lifecycle,
+      phase: "in-progress" as const,
+      commencedAtMs: runningSinceMs + 10_000,
+    },
+  };
+  const validated = validateEventGameRecordRoot(candidate);
+  if (!validated.ok) return root;
+  const transaction = snapshot as FoundationStorageTransaction;
+  if (typeof transaction.updateRoot === "function") {
+    transaction.updateRoot({
+      root: validated.value,
+      canonicalContent: canonicalizeEventGameRecordRoot(validated.value),
+    });
+  }
+  return validated.value;
+}
+
+function latestRunningClockStart(
+  actions: readonly { action: { interpretation: unknown } }[],
+): number | null {
+  for (const stored of [...actions].reverse()) {
+    const interpretation = stored.action.interpretation;
+    if (
+      !isRecord(interpretation) ||
+      interpretation.type !== "fact" ||
+      interpretation.factType !== "clock"
+    )
+      continue;
+    const payload = interpretation.payload;
+    if (!isRecord(payload) || !isRecord(payload.data)) return null;
+    if (payload.data.running !== true) return null;
+    return typeof payload.data.startedAtMs === "number" ? payload.data.startedAtMs : null;
+  }
+  return null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function createExternalScopeResolver(): ExternalScopeResolver {

--- a/src/lib/live-event-game-transport.ts
+++ b/src/lib/live-event-game-transport.ts
@@ -1,5 +1,8 @@
 import { readJsonBodyWithinLimit } from "@/lib/http-body";
 import type {
+  ControllerLeaveResult,
+  ControllerQrResult,
+  ControllerRefreshResult,
   LiveEventGameControlResult,
   OpenControllerResult,
 } from "@/lib/live-event-game-control";
@@ -7,6 +10,11 @@ import { SHARED_LIMITS } from "@/lib/validation-policy";
 
 export type LiveEventGameControlTransport = {
   openController(request: Request): Promise<Response>;
+  refreshController(request: Request): Promise<Response>;
+  switchController(request: Request): Promise<Response>;
+  stayController(request: Request): Promise<Response>;
+  revealControllerQr(request: Request): Promise<Response>;
+  leaveController(request: Request): Promise<Response>;
   submitControllerIntent(request: Request): Promise<Response>;
 };
 
@@ -15,6 +23,20 @@ export type LiveEventGameControlTransportTarget = {
     qrCredential: string;
     browserContext: string;
   }): Promise<OpenControllerResult>;
+  refreshController(input: {
+    sessionBearer: string;
+    eventGameId: string;
+  }): Promise<ControllerRefreshResult>;
+  switchController(input: { sessionBearer: string }): Promise<ControllerRefreshResult>;
+  stayController(input: {
+    sessionBearer: string;
+    eventGameId: string;
+  }): Promise<ControllerRefreshResult>;
+  revealControllerQr(input: {
+    sessionBearer: string;
+    eventGameId: string;
+  }): Promise<ControllerQrResult>;
+  leaveController(input: { sessionBearer: string }): Promise<ControllerLeaveResult>;
   submitControllerIntent(input: {
     sessionBearer: string;
     eventGameId: string;
@@ -72,12 +94,88 @@ export function createLiveEventGameControlTransport(
       });
       return noStoreJson(result, resultStatus(result));
     },
+    async refreshController(request) {
+      const input = await readSessionInput(request, isAllowedRequest);
+      if (input === null || input.eventGameId === undefined) return unavailable();
+      const control = resolve();
+      if (control === null) return unavailable();
+      const result = await control.refreshController({
+        sessionBearer: input.sessionBearer,
+        eventGameId: input.eventGameId,
+      });
+      return noStoreJson(result, controllerResultStatus(result));
+    },
+    async switchController(request) {
+      const input = await readSessionInput(request, isAllowedRequest);
+      if (input === null) return unavailable();
+      const control = resolve();
+      if (control === null) return unavailable();
+      const result = await control.switchController({ sessionBearer: input.sessionBearer });
+      return noStoreJson(result, controllerResultStatus(result));
+    },
+    async stayController(request) {
+      const input = await readSessionInput(request, isAllowedRequest);
+      if (input === null || input.eventGameId === undefined) return unavailable();
+      const control = resolve();
+      if (control === null) return unavailable();
+      const result = await control.stayController({
+        sessionBearer: input.sessionBearer,
+        eventGameId: input.eventGameId,
+      });
+      return noStoreJson(result, controllerResultStatus(result));
+    },
+    async revealControllerQr(request) {
+      const input = await readSessionInput(request, isAllowedRequest);
+      if (input === null || input.eventGameId === undefined) return unavailable();
+      const control = resolve();
+      if (control === null) return unavailable();
+      const result = await control.revealControllerQr({
+        sessionBearer: input.sessionBearer,
+        eventGameId: input.eventGameId,
+      });
+      return noStoreJson(result, controllerResultStatus(result));
+    },
+    async leaveController(request) {
+      if (!isAllowedRequest(request)) return unavailable();
+      const control = resolve();
+      if (control === null) return unavailable();
+      const body = await readJsonBodyWithinLimit(
+        request,
+        SHARED_LIMITS.transport.httpJsonBodyBytes,
+      );
+      if (!body.ok || !isRecord(body.body) || typeof body.body.sessionBearer !== "string") {
+        return unavailable();
+      }
+      const result = await control.leaveController({ sessionBearer: body.body.sessionBearer });
+      return noStoreJson(result, controllerResultStatus(result));
+    },
   };
+}
+
+async function readSessionInput(
+  request: Request,
+  isAllowedRequest: (request: Request) => boolean,
+): Promise<{ sessionBearer: string; eventGameId?: string } | null> {
+  if (!isAllowedRequest(request)) return null;
+  const body = await readJsonBodyWithinLimit(request, SHARED_LIMITS.transport.httpJsonBodyBytes);
+  if (!body.ok || !isRecord(body.body) || typeof body.body.sessionBearer !== "string") return null;
+  if (typeof body.body.eventGameId === "string") {
+    return { sessionBearer: body.body.sessionBearer, eventGameId: body.body.eventGameId };
+  }
+  return { sessionBearer: body.body.sessionBearer };
 }
 
 function resultStatus(result: LiveEventGameControlResult): number {
   if (result.status === "retryable") return 503;
   if (result.status === "rejected") return 403;
+  return 200;
+}
+
+function controllerResultStatus(
+  result: ControllerRefreshResult | ControllerQrResult | ControllerLeaveResult,
+): number {
+  if (result.status === "rejected") return 403;
+  if (result.status === "switch-required") return 409;
   return 200;
 }
 

--- a/src/pages/event-game-controller-page.tsx
+++ b/src/pages/event-game-controller-page.tsx
@@ -1,102 +1,288 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import type { ControllerProjection } from "@/lib/live-event-game-control";
+import type {
+  ControllerProjection,
+  LiveEventControllerIntent,
+} from "@/lib/live-event-game-control";
 import {
-  retainControllerGoalIntent,
-  type PendingControllerGoalIntent,
-} from "@/lib/controller-intent-retry";
+  LIVE_EVENT_CONTROL_INTENT_VERSION,
+  parseLiveEventControllerIntent,
+} from "@/lib/live-event-game-control";
 import { readControllerDeviceContext } from "@/lib/controller-device-context";
+import {
+  retainControllerIntent,
+  type PendingControllerIntent,
+} from "@/lib/controller-intent-retry";
 
-type OpenResponse = {
+type PersistedControllerSession = { sessionBearer: string; eventGameId: string };
+type ControllerOpenResponse = {
   status: "opened";
   eventGameId: string;
   session: { sessionBearer: string };
   projection: ControllerProjection | null;
   projectionStatus: "available" | "unavailable";
 };
-
-type ActionResponse = {
-  status: "accepted" | "duplicate-accepted";
-  acknowledgement: { status: "acknowledged"; operationId: string };
-  projection: ControllerProjection | null;
-  projectionStatus: "available" | "unavailable";
-};
+type ControllerRefreshResponse =
+  | {
+      status: "authorized";
+      session: { eventGameId: string };
+      projection: ControllerProjection | null;
+      projectionStatus: "available" | "unavailable";
+    }
+  | { status: "switch-required"; previousEventGameId: string; currentEventGameId: string }
+  | { status: "rejected"; message: string };
 
 export function EventGameControllerPage() {
+  const persisted = readPersistedControllerSession();
   const [qrCredential, setQrCredential] = useState("");
-  const [sessionBearer, setSessionBearer] = useState<string | null>(null);
-  const [eventGameId, setEventGameId] = useState<string | null>(null);
+  const [sessionBearer, setSessionBearer] = useState<string | null>(
+    persisted?.sessionBearer ?? null,
+  );
+  const [eventGameId, setEventGameId] = useState<string | null>(persisted?.eventGameId ?? null);
   const [projection, setProjection] = useState<ControllerProjection | null>(null);
   const [projectionStatus, setProjectionStatus] = useState<"available" | "unavailable">(
     "unavailable",
   );
+  const [revealedQr, setRevealedQr] = useState<string | null>(null);
+  const [switchTarget, setSwitchTarget] = useState<string | null>(null);
+  const [stayedOnAssignment, setStayedOnAssignment] = useState<string | null>(null);
+  const [clockRunning, setClockRunning] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
-  const [pendingIntent, setPendingIntent] = useState<PendingControllerGoalIntent | null>(null);
+  const [pendingIntent, setPendingIntent] = useState<PendingControllerIntent | null>(() =>
+    readPersistedPendingIntent(),
+  );
   const [browserContext] = useState(() => readControllerDeviceContext());
+
+  useEffect(() => {
+    if (sessionBearer === null || eventGameId === null) {
+      sessionStorage.removeItem("quadball:event-controller-session");
+      return;
+    }
+    sessionStorage.setItem(
+      "quadball:event-controller-session",
+      JSON.stringify({ sessionBearer, eventGameId } satisfies PersistedControllerSession),
+    );
+  }, [eventGameId, sessionBearer]);
+
+  useEffect(() => {
+    if (pendingIntent === null) {
+      sessionStorage.removeItem("quadball:event-controller-pending-intent");
+      return;
+    }
+    sessionStorage.setItem(
+      "quadball:event-controller-pending-intent",
+      JSON.stringify(pendingIntent),
+    );
+  }, [pendingIntent]);
+
+  useEffect(() => {
+    if (persisted !== null) void refreshController(true);
+    // Persisted authority is deliberately revalidated after browser restore.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   async function openController() {
     setBusy(true);
     setMessage(null);
     try {
-      const response = await fetch("/api/event-control/open", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ qrCredential, browserContext }),
+      const response = await postJson<ControllerOpenResponse>("/api/event-control/open", {
+        qrCredential,
+        browserContext,
       });
-      if (!response.ok) throw new Error("Unable to open Controller experience.");
-      const result = (await response.json()) as OpenResponse;
-      setSessionBearer(result.session.sessionBearer);
-      setEventGameId(result.eventGameId);
-      setProjection(result.projection);
-      setProjectionStatus(result.projectionStatus);
+      if (response.status !== "opened") throw new Error("open failed");
+      setSessionBearer(response.session.sessionBearer);
+      setEventGameId(response.eventGameId);
+      setProjection(response.projection);
+      setProjectionStatus(response.projectionStatus);
     } catch {
-      setSessionBearer(null);
-      setEventGameId(null);
-      setProjection(null);
-      setProjectionStatus("unavailable");
+      clearSession();
       setMessage("Unable to open Controller experience.");
     } finally {
       setBusy(false);
     }
   }
 
-  async function recordGoal(gameSideId: string) {
+  async function refreshController(silent = false) {
     if (sessionBearer === null || eventGameId === null) return;
-    setBusy(true);
-    setMessage(null);
-    const intent: PendingControllerGoalIntent = retainControllerGoalIntent(
-      pendingIntent,
-      gameSideId,
-    );
-    setPendingIntent(intent);
+    if (!silent) setBusy(true);
     try {
-      const response = await fetch("/api/event-control/intent", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({
-          sessionBearer,
-          eventGameId,
-          intent,
-        }),
+      const response = await postJson<ControllerRefreshResponse>("/api/event-control/refresh", {
+        sessionBearer,
+        eventGameId,
       });
-      const result = (await response.json()) as ActionResponse | { error?: string };
-      if (!response.ok || !("acknowledgement" in result)) {
-        setMessage("The tap was not acknowledged. Retry the same pending tap.");
+      if (response.status === "switch-required") {
+        setSwitchTarget(
+          stayedOnAssignment === response.currentEventGameId ? null : response.currentEventGameId,
+        );
         return;
       }
-      setPendingIntent(null);
-      setProjection(result.projection);
-      setProjectionStatus(result.projectionStatus);
-      setMessage("Goal acknowledged by the durable Event Game record.");
+      if (response.status === "rejected") throw new Error("refresh failed");
+      setSwitchTarget(null);
+      setEventGameId(response.session.eventGameId);
+      setProjection(response.projection);
+      setProjectionStatus(response.projectionStatus);
     } catch {
-      setMessage("The tap may still be pending. Retry the same pending tap.");
+      if (!silent) setMessage("Unable to refresh Controller session.");
+    } finally {
+      if (!silent) setBusy(false);
+    }
+  }
+
+  async function switchController() {
+    if (sessionBearer === null) return;
+    setBusy(true);
+    try {
+      const response = await postJson<ControllerRefreshResponse>("/api/event-control/switch", {
+        sessionBearer,
+      });
+      if (response.status !== "authorized") throw new Error("switch failed");
+      setEventGameId(response.session.eventGameId);
+      setProjection(response.projection);
+      setProjectionStatus(response.projectionStatus);
+      setSwitchTarget(null);
+      setStayedOnAssignment(null);
+      setMessage("Controller Device switched to the newly assigned Event Game.");
+    } catch {
+      setMessage("Unable to switch Controller Device.");
     } finally {
       setBusy(false);
     }
+  }
+
+  async function stayOnCurrentAssignment() {
+    if (sessionBearer === null || eventGameId === null || switchTarget === null) return;
+    setBusy(true);
+    try {
+      const response = await postJson<ControllerRefreshResponse>("/api/event-control/stay", {
+        sessionBearer,
+        eventGameId,
+      });
+      if (response.status !== "authorized") throw new Error("stay failed");
+      setStayedOnAssignment(switchTarget);
+      setSwitchTarget(null);
+      setEventGameId(response.session.eventGameId);
+      setProjection(response.projection);
+      setProjectionStatus(response.projectionStatus);
+      setMessage("Staying on the current Event Game until the assignment changes again.");
+    } catch {
+      setMessage("Unable to retain the current Event Game assignment.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function revealQr() {
+    if (sessionBearer === null || eventGameId === null) return;
+    setBusy(true);
+    try {
+      const response = await postJson<{ status: "revealed"; qrCredential: string }>(
+        "/api/event-control/reveal-qr",
+        { sessionBearer, eventGameId },
+      );
+      if (response.status !== "revealed") throw new Error("reveal failed");
+      setRevealedQr(response.qrCredential);
+    } catch {
+      setMessage("The active Control Grant QR is no longer revealable.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function leaveController() {
+    if (sessionBearer === null) return;
+    setBusy(true);
+    try {
+      const response = await postJson<{ status: "left" }>("/api/event-control/leave", {
+        sessionBearer,
+      });
+      if (response.status !== "left") throw new Error("leave failed");
+      clearSession();
+      setMessage("Controller Session left. Pending evidence remains on the Event Game Record.");
+    } catch {
+      setMessage("Unable to leave Controller session.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function submitIntent(intent: LiveEventControllerIntent) {
+    if (sessionBearer === null || eventGameId === null) return;
+    setBusy(true);
+    try {
+      const response = await postJson<
+        | { status: "accepted" | "duplicate-accepted"; projection: ControllerProjection | null }
+        | { status: "rejected" | "retryable" }
+      >("/api/event-control/intent", { sessionBearer, eventGameId, intent });
+      if (response.status !== "accepted" && response.status !== "duplicate-accepted") {
+        if (response.status === "rejected") setPendingIntent(null);
+        setMessage("The Controller action was not committed; retry is safe.");
+        return;
+      }
+      setPendingIntent(null);
+      setProjection(response.projection);
+      setProjectionStatus(response.projection === null ? "unavailable" : "available");
+      if (intent.type === "clock" || intent.type === "set-running") setClockRunning(intent.running);
+    } catch {
+      setMessage("The Controller action may still be pending. Retry the same action.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function recordGoal(gameSideId: string) {
+    queueIntent({
+      version: LIVE_EVENT_CONTROL_INTENT_VERSION,
+      type: "record-goal",
+      operationId: crypto.randomUUID(),
+      factId: crypto.randomUUID(),
+      gameSideId,
+      gameTimeMs: 0,
+      occurrence: { clientOriginAtMs: Date.now() },
+    });
+  }
+
+  function trigger(type: "card" | "timeout" | "suspension" | "result") {
+    queueIntent({
+      version: LIVE_EVENT_CONTROL_INTENT_VERSION,
+      type: "substantive",
+      trigger: type,
+      operationId: crypto.randomUUID(),
+      factId: crypto.randomUUID(),
+      gameTimeMs: 0,
+      occurrence: { clientOriginAtMs: Date.now() },
+    });
+  }
+
+  function toggleClock() {
+    queueIntent({
+      version: LIVE_EVENT_CONTROL_INTENT_VERSION,
+      type: "clock",
+      running: !clockRunning,
+      operationId: crypto.randomUUID(),
+      factId: crypto.randomUUID(),
+      gameTimeMs: 0,
+      occurrence: { clientOriginAtMs: Date.now() },
+    });
+  }
+
+  function queueIntent(candidate: LiveEventControllerIntent) {
+    const intent = retainControllerIntent(pendingIntent, candidate);
+    setPendingIntent(intent);
+    void submitIntent(intent);
+  }
+
+  function clearSession() {
+    setSessionBearer(null);
+    setEventGameId(null);
+    setProjection(null);
+    setProjectionStatus("unavailable");
+    setRevealedQr(null);
+    setSwitchTarget(null);
+    setStayedOnAssignment(null);
   }
 
   return (
@@ -104,33 +290,90 @@ export function EventGameControllerPage() {
       <Card>
         <CardHeader>
           <CardTitle>Event Game Controller</CardTitle>
-          <CardDescription>Open this Controller Device with a valid Control Grant.</CardDescription>
+          <CardDescription>
+            A Grant Session survives refresh and connectivity loss until you explicitly leave.
+          </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
-          <div className="space-y-2">
-            <Label htmlFor="control-grant">Control Grant credential</Label>
-            <Input
-              id="control-grant"
-              value={qrCredential}
-              onChange={(event) => setQrCredential(event.target.value)}
-              autoComplete="off"
-              placeholder="Scan or paste the QR credential"
-              disabled={sessionBearer !== null || busy}
-            />
-          </div>
           {sessionBearer === null ? (
-            <Button className="w-full" onClick={() => void openController()} disabled={busy}>
-              Open Controller Device
-            </Button>
+            <>
+              <div className="space-y-2">
+                <Label htmlFor="control-grant">Active Pitch Slot Control Grant QR</Label>
+                <Input
+                  id="control-grant"
+                  value={qrCredential}
+                  onChange={(event) => setQrCredential(event.target.value)}
+                  autoComplete="off"
+                  placeholder="Scan or paste the QR credential"
+                  disabled={busy}
+                />
+              </div>
+              <Button className="w-full" onClick={() => void openController()} disabled={busy}>
+                Open Controller Device
+              </Button>
+            </>
           ) : (
             <>
               <div className="rounded-lg border bg-muted/30 p-3 text-sm">
-                <p className="font-medium">Controller Device is active.</p>
+                <p className="font-medium">Controller Device: {eventGameId}</p>
+                <p className="mt-1 text-muted-foreground">
+                  {projection?.commencement.status === "commenced"
+                    ? "Game Commencement is irreversible."
+                    : "Game remains provisional until genuine play is recognized."}
+                </p>
                 {projectionStatus === "unavailable" ? (
-                  <p className="mt-1 text-muted-foreground">
-                    The durable action is available, but its projection is temporarily unavailable.
-                  </p>
+                  <p className="mt-1 text-muted-foreground">Projection temporarily unavailable.</p>
                 ) : null}
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <Button variant="outline" onClick={() => void revealQr()} disabled={busy}>
+                  Reveal active Grant QR
+                </Button>
+                <Button variant="outline" onClick={() => void refreshController()} disabled={busy}>
+                  Refresh assignment
+                </Button>
+                <Button variant="outline" onClick={() => void leaveController()} disabled={busy}>
+                  Leave Controller Session
+                </Button>
+              </div>
+              {switchTarget === null ? null : (
+                <div className="rounded-lg border border-amber-500/50 bg-amber-50 p-3 text-sm">
+                  <p className="font-medium">Pitch Slot assignment changed.</p>
+                  <p className="mt-1">
+                    Switch to {switchTarget}, or stay on {eventGameId}.
+                  </p>
+                  <div className="mt-3 flex gap-2">
+                    <Button onClick={() => void switchController()} disabled={busy}>
+                      Switch Event Game
+                    </Button>
+                    <Button variant="outline" onClick={stayOnCurrentAssignment} disabled={busy}>
+                      Stay here
+                    </Button>
+                  </div>
+                </div>
+              )}
+              {revealedQr === null ? null : (
+                <div className="rounded-lg border p-3 text-sm">
+                  <p className="font-medium">Share this active Pitch Slot QR</p>
+                  <code className="mt-2 block break-all text-xs">{revealedQr}</code>
+                </div>
+              )}
+              <div className="flex flex-wrap gap-2">
+                <Button onClick={toggleClock} disabled={busy}>
+                  {clockRunning ? "Pause clock" : "Start clock"}
+                </Button>
+                <Button variant="outline" onClick={() => trigger("card")} disabled={busy}>
+                  Record card
+                </Button>
+                <Button variant="outline" onClick={() => trigger("timeout")} disabled={busy}>
+                  Start timeout
+                </Button>
+                <Button variant="outline" onClick={() => trigger("suspension")} disabled={busy}>
+                  Suspend game
+                </Button>
+                <Button variant="outline" onClick={() => trigger("result")} disabled={busy}>
+                  Record result
+                </Button>
               </div>
               {projection === null ? null : (
                 <div className="space-y-3">
@@ -142,13 +385,18 @@ export function EventGameControllerPage() {
                       <span className="font-medium">Game Side {gameSideId}</span>
                       <div className="flex items-center gap-3">
                         <span className="text-2xl font-semibold tabular-nums">{score}</span>
-                        <Button onClick={() => void recordGoal(gameSideId)} disabled={busy}>
+                        <Button onClick={() => recordGoal(gameSideId)} disabled={busy}>
                           Record 10-point goal
                         </Button>
                       </div>
                     </div>
                   ))}
                 </div>
+              )}
+              {pendingIntent === null ? null : (
+                <p className="text-sm text-amber-700">
+                  An uncertain Controller action is retained for safe retry.
+                </p>
               )}
             </>
           )}
@@ -157,4 +405,39 @@ export function EventGameControllerPage() {
       </Card>
     </main>
   );
+}
+
+async function postJson<T>(path: string, body: unknown): Promise<T> {
+  const response = await fetch(path, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const result = (await response.json()) as T;
+  if (!response.ok) throw new Error("request failed");
+  return result;
+}
+
+function readPersistedControllerSession(): PersistedControllerSession | null {
+  try {
+    const raw = sessionStorage.getItem("quadball:event-controller-session");
+    if (raw === null) return null;
+    const value = JSON.parse(raw) as Partial<PersistedControllerSession>;
+    return typeof value.sessionBearer === "string" && typeof value.eventGameId === "string"
+      ? { sessionBearer: value.sessionBearer, eventGameId: value.eventGameId }
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function readPersistedPendingIntent(): PendingControllerIntent | null {
+  try {
+    const raw = sessionStorage.getItem("quadball:event-controller-pending-intent");
+    if (raw === null) return null;
+    const parsed = parseLiveEventControllerIntent(JSON.parse(raw));
+    return parsed.ok ? parsed.value : null;
+  } catch {
+    return null;
+  }
 }


### PR DESCRIPTION
## What changed

- Adds Controller QR reveal, explicit leave, refresh, switch, and durable stay flows for active Grant Sessions.
- Records provisional clock starts and makes Game Commencement irreversible after ten active seconds or the first substantive score, card, timeout, suspension, or result.
- Atomically commits substantive actions with their lifecycle transition and preserves exact intent identity across uncertain browser retries.
- Persists Controller attachment and lifecycle state in SQLite, including production reassignment pinning after commencement.

## Why

Controllers need to survive refreshes, network uncertainty, and Pitch Slot reassignment without duplicating actions or controlling the wrong Event Game. Game Commencement must become a durable authority boundary so a commenced Game remains pinned while pre-commencement reassignment still offers an explicit switch-or-stay choice.

## Impact

The Event Controller can now reveal the active QR, explicitly leave, recover its nonpersistent session, choose whether to follow a reassignment before commencement, and remain attached to the commenced Event Game afterward. Ad Hoc games remain separate and unchanged.

## Stack

- Depends on #145, which activates durable Event Game control.
- Implements #85 from spec #83.

## Validation

- `bun run check`
- `bun run test` — 433 passed, 0 failed
- `bun run build`
- Independent acceptance review: 0 Standards findings, 0 Intent findings

No qualification, soak, load, crash, recovery, or exact-production-artifact workload was run.

Closes #85
