### PR TITLE
Restore Event records and Grant continuity (#81)

### DIFF
--- a/docs/agents/issue-81-design-gate.md
+++ b/docs/agents/issue-81-design-gate.md
@@ -1,0 +1,143 @@
+# Issue #81 recovery design gate
+
+## Delivery boundary
+
+Issue #81 adds one deep `FoundationRecovery` module. Its interface has four operations:
+
+- create one verified pre-deployment snapshot;
+- independently verify a retained snapshot;
+- stage and replace the live Event foundation database while preserving the failed image;
+- import Controller-held Control Actions through the existing composed-acceptance interface.
+
+The module does not schedule backups, deploy releases, cut over Production, enroll/reset a Technical
+Admin Passkey, or provide periodic, Event-handoff, or off-host backup machinery. Published
+migrations 001–021 remain byte-for-byte unchanged; recovery points, restore evidence, and Recovery
+Gaps are durable 0600 sidecars rather than a new application relation.
+
+## Backup policy and integrity
+
+`foundation-backup-policy-v1` is a closed relation allowlist. It includes all Event Game Record,
+Control Action, idempotency, replay, Event catalog, non-Technical-Admin Grant, Grant Session,
+credential/verifier, audit, integrity-anchor, admission, and migration-ledger relations. It excludes
+the exact Technical Admin credential, enrollment, challenge, browser-session, identity/state, log,
+and alert relations. A new or otherwise unclassified table/view fails the backup before retention can
+change.
+
+The live writer queue drains and remains held while `VACUUM INTO` creates a consistent raw snapshot
+outside the live database directory. Explicitly excluded relations are removed only from that raw
+snapshot. A second `VACUUM INTO` creates the compact retained image, so deleted Technical Admin
+payload is absent from free pages as well as logical rows.
+
+The backup workspace is a physically separate, caller-owned, non-symlink `0700` directory. Raw,
+staged, retained, manifest, evidence, and failed-image destinations fail closed on pre-existing or
+symlink paths. The raw unsanitized image is tightened to `0600` before the SQLite writer queue yields;
+all other files are `0600`. Verification and restore copy from no-follow file handles whose inode,
+size, and modification identity remain stable, into exclusively created private files. Published
+files are rechecked against the opened inode; failed/live image moves use exclusive same-filesystem
+links before unlinking the source. Every owned Event, Technical Admin, WAL/SHM, and quarantine source
+is tightened and verified as a non-symlink `0600` regular file before preservation; the linked
+destination is verified at the same private mode. Rollback repeats that identity and mode check.
+Cleanup unlinks only the inode recovery created. Existing,
+wrong-owner, permissive, symlinked, or replaced paths are never repaired or overwritten.
+
+Verification uses a separate database handle and disposable copy. It requires:
+
+- exact retained-file SHA-256 and deterministic included-relation equality with the quiesced point;
+- `integrity_check`, `foreign_key_check`, exact schema, ordered migration IDs/checksums, immutable
+  provenance, action/idempotency parity, Grant/audit/session/reference integrity, and complete Event
+  Game replay through the existing readiness verifier;
+- every encryption, lookup, and audit key version represented in retained rows to exist in the
+  separately supplied key ring;
+- no Technical Admin relation after compaction.
+
+Grant credential/session lookup versions are lookup-key requirements. The accepted Grant Code format
+derives its stored lookup/fingerprint material from the audit ring, so its represented lookup-version
+column is truthfully an audit-key requirement; integrity anchors and audit tags are audit requirements
+as well. Recovery reports the persisted contract without changing it, and a neighboring lookup key
+cannot satisfy a missing represented audit key.
+
+Keys are never written to the SQLite image, manifest, or evidence. A verified backup uses unique
+versioned filenames. Existing verified snapshots remain untouched until the new database and
+manifest have both passed verification and their directory entry is synced.
+
+## Restore and authority policy
+
+Restore verifies the retained snapshot before touching the live database and copies it to an
+exclusive staging path beside the live file. Technical Admin and Event authoritative writers then
+stop, drain, and close before the one final current-authority evaluation immediately preceding
+replacement. Expired Grants are cryptographically erased through the existing lifecycle
+implementation; stale Event Admin sessions are expired. Every active Control Session is resolved
+through `resolveSession(scope, session.eventGameId)`: exact current, pinned, and switchable sessions
+remain usable; only the exact session reported terminal for Game Lock or past Game Day is terminated.
+One reused Control Grant may therefore terminate exact active sessions for multiple historical Game
+identities without conflict. Its present Grant Code is erased once only when the Grant's independently
+resolved current scope is Game-locked, with that exact current Game recorded as evidence. Missing,
+unavailable, conflicted, malformed, or identity-mismatched resolution aborts restore.
+
+The staging database passes readiness again, is sealed into a portable checkpointed image, and is
+confirmed free of Technical Admin state. The injected Technical Admin auth adapter then stops new
+auth writes and drains/closes its separate database before authoritative Event writes are drained.
+The live Event image, Technical Admin auth image, and any sidecars/quarantine marker move exclusively
+to unique failed-image paths; only the staged Event image moves exclusively into active use. On next startup the
+auth repository therefore creates empty auth state rather than reviving the former passkey, sessions,
+challenges, or enrollment authorization. A replacement failure removes only the installed inode and
+moves both failed images back without overwriting a competing path. The caller must reopen storage
+after either outcome.
+
+Before cutover, recovery writes and syncs one immutable private pending record. After successful live
+replacement it atomically adds a separate synced `0600` completion record. A completion-record I/O
+failure cannot turn the already completed restore into a reported failure: the return value states
+`completed: true` and `completionEvidenceStatus: write-failed`, while the immutable pending record
+retains the cutover identity for reconciliation and prevents an unsafe blind retry.
+
+Redacted restore evidence records snapshot time, snapshot/current action counts, whether potentially
+newer work existed, the preserved failed-image path, and restored Grant type/version tuples with
+Grant IDs hashed. This is the accepted older-snapshot resurrection-risk evidence for later Technical
+Admin review. It never claims that restored authority was current at snapshot time; current lifecycle
+reevaluation remains decisive.
+
+## Recovery import and Recovery Gaps
+
+Controller-held actions are treated as untrusted inputs. The recovery operation:
+
+- rejects cross-Event-Game input before submission;
+- preserves each original operation identity, causal/occurrence evidence, and payload; original
+  server acceptance time is nullable and retained only when surviving evidence establishes it;
+- replaces historical authority claims with a supplied current Grant Session/version and submits the
+  batch through the `FoundationAcceptance` instance composed once from this recovery's storage,
+  Grant environment, codecs, scope resolver, and interpreter using a fresh current session bearer;
+- therefore receives normal codec validation, content-bound idempotency, current authorization,
+  cross-Game checks, deterministic ordering/rebuild, and paired Control/Grant audit behavior;
+- bounds action and supplied-gap counts before pending evidence, writes explicit bounded redacted
+  Recovery Gaps before submission, and adds one gap for every supplied action not accepted, including
+  whole-batch rejection or a result list shorter than the action list, without inventing
+  acknowledgement or other server-only evidence.
+
+## Corruption and fatal quarantine failure
+
+The #80 fatal case remains intentionally narrow. If corruption is latched and the sibling quarantine
+marker itself cannot be durably persisted, the running storage still reports `quarantine-failure` and
+must remain frozen. Operators must not attempt a fresh snapshot or silent SQLite repair from that
+instance. Preserve the database, WAL/SHM files, and any marker as the failed image; restore only an
+already independently verified snapshot through the staged path; then reopen with the separately
+supplied key ring and require readiness before authoritative traffic. If no verified snapshot exists,
+keep authoritative writes stopped and use current-authority Controller recovery plus the Official
+Score Sheet, recording Recovery Gaps. This is not an automatic failover or a second writer.
+
+## Fast-test evidence
+
+Ordinary hermetic tests cover SQLite snapshot/compaction, synthetic Technical Admin rows and physical
+canaries, unclassified relations, independent verification, retained predecessor backups, staged
+replacement, failed replacement rollback, failed-image preservation, restart, current lifecycle
+reevaluation, redacted evidence, explicit gaps, and real composed-acceptance import with durable
+SQLite mutation. They do not run Qualification, soak, load, crash, or exact-production-artifact
+workloads.
+
+The corrected suite additionally covers the synchronized final-evaluation/cutover race; a pinned old
+Game beside multiple exact locked and past-Game-Day sessions on one reused Grant; one truthful current
+Game Code erasure across memory, SQLite, and restart; rejected/malformed per-session
+resolution; private/no-follow filesystem behavior including synchronized backup-final replacement,
+valid-database substitution before reevaluation, and verified restore-stage pathname and in-place
+mutation races; `0644` failed-image inputs and rollback; post-cutover completion-evidence I/O failure;
+base-contract present/disabled Grant Codes and represented-key category neighbors; whole-batch
+gap completeness and bounds; and real composed acceptance with restart-observed SQLite mutation.

--- a/docs/agents/issue-81-handoff.md
+++ b/docs/agents/issue-81-handoff.md
@@ -1,0 +1,86 @@
+# Issue #81 implementation handoff
+
+## Result
+
+`FoundationRecovery` implements the minimum Event recovery operation required by #81/#70:
+verified sanitized `VACUUM INTO` snapshots, independent replay/key/schema verification, conservative
+retention, staged reversible restore, current Grant lifecycle reevaluation, redacted resurrection-risk
+evidence, and current-authority Controller recovery with explicit Recovery Gaps. The correction from
+candidate `1be460d6749aa98d96189fce88356a83d854ee37` closes the cutover-authority race, resolves every
+active Control Session by its own Event Game identity, binds real composed acceptance at construction,
+hardens the local filesystem boundary, completes rejected-batch gaps, and corrects Grant Code lookup
+key reporting without changing the accepted persisted Grant Code format. The localized final-review
+correction additionally supports multiple exact terminal Games on one reused Control Grant, enforces
+private failed-image modes, and separates immutable pending from atomic completion evidence.
+
+## Review seams
+
+- `src/lib/foundation-recovery.ts` — the single public recovery interface and orchestration.
+- `src/lib/foundation-recovery-sqlite.ts` — closed policy, deterministic snapshot facts, key-version
+  discovery, sanitization, and SQLite quoting.
+- `src/lib/foundation-storage-sqlite.ts` — only two recovery primitives: queued `VACUUM INTO` and
+  drained/checkpointed close before replacement.
+- `src/lib/foundation-recovery.test.ts` — SQLite, restart, sanitization, retention, lifecycle,
+  composed-acceptance, filesystem, and failure-injection Fast coverage.
+- `src/lib/grant-code.ts` and `src/lib/foundation-storage-sqlite.ts` — the accepted Grant Code format
+  remains audit-ring-backed while readiness/recovery report that represented category truthfully.
+- `docs/agents/issue-81-design-gate.md` — invariants and proportional operator handling for #80's
+  fatal quarantine-marker failure.
+
+The deterministic cutover test moves lock, Game Day, and Event Admin idle-expiry facts at the
+post-quiescence barrier, then synchronously attempts a second lock, Game Day transition, expiry, and
+Grant Session revocation after final evaluation and before live replacement. Final evaluation observes
+the drained facts; all four late writers are rejected because Event storage is already closed. The
+restored result preserves the pinned old-Game session while terminating exact sessions for multiple
+locked historical Games and a past Game Day. The Grant Code is erased once using only the separately
+resolved current Game Lock as truthful evidence.
+
+## Explicit boundaries
+
+- Migrations 001–021 are unchanged; no migration 022 was necessary.
+- Technical Admin authentication state is never restored from this backup set.
+- Restore requires a Technical Admin auth adapter that stops/drains auth writes and preserves the
+  separate auth database as a failed image while leaving no active auth database to revive.
+- Encryption/lookup/audit keys stay outside database, manifests, and evidence.
+- There is no backup schedule, Event-handoff/off-host backup, production cutover, deployment change,
+  Technical Admin enrollment/reset, distributed failover, or automatic corruption repair.
+- Recovery evidence is private 0600 operator material and contains hashes/versions/counts rather than
+  raw Grant IDs, credentials, session bearers, action payloads, or sporting evidence.
+- The owned backup workspace is physically outside the live database directory, non-symlink `0700`;
+  all file material is `0600`, exclusive/no-follow sources and destinations reject unsafe paths, and
+  verification/copy/publication/cleanup bind to stable file identity without overwriting competing
+  replacements. Failed Event/Technical Admin databases, sidecars, and quarantine images are tightened
+  and verified before preservation and again on rollback.
+- Restore evidence uses one immutable synced pending record plus an atomic separate completion record.
+  Completion-record I/O failure is returned as a completed cutover with explicit evidence status, not
+  as a failed restore that could invite an unsafe retry.
+- Recovery import has no per-call acceptance adapter. Construction composes acceptance from this
+  storage and Grant environment, and tests prove current bearer authorization plus SQLite mutation
+  visible after reopen.
+
+## Gate record
+
+Base: `066365aa070018f858e4a067191bedd5726a0124` (accepted #80 integration). Candidate:
+`1be460d6749aa98d96189fce88356a83d854ee37`. The correction commit is the commit containing this
+handoff.
+
+- `bun install --frozen-lockfile` — passed without lockfile changes.
+- `bun audit` — passed; no vulnerabilities found.
+- `bun run check` — passed; only the seven pre-existing `await-thenable` warnings in Grant files.
+- `bun run test` — passed: 404 tests, 0 failures, 16,470 expectations in 12.61 seconds.
+- Timing investigation: Darwin 25.5.0 arm64, Bun 1.3.14; `/usr/bin/time -l` measured 12.64 seconds
+  real, 12.37 user, 1.56 system, and 843,857,920 bytes maximum RSS. The recovery file measured 1.64
+  seconds, below its two-second file target. The principal ordinary-suite files remained the required
+  1,000-sequence generated convergence coverage (~3.08 seconds) and 10,000-action retention coverage
+  (~1.67 seconds). Decision: retain all required deterministic Fast coverage and record the aggregate
+  overrun; no test was weakened, removed, reclassified, or moved merely for timing.
+- `bun test --isolate ./src/lib/foundation-recovery.test.ts` — passed: 10 tests, 0 failures.
+- `bun run test:focused:sqlite` — passed: 21 tests, 0 failures.
+- `bun run test:focused:acceptance` — passed: 10 tests, 0 failures.
+- `bun run test:focused:grant` — passed: 36 tests, 0 failures.
+- `bun run test:focused:grant-code` — passed: 15 tests, 0 failures.
+- `bun run build` and `bun run build:executable` — passed.
+- migration diff check — passed; migrations 001–021 remain byte-for-byte unchanged from base.
+- `git diff --check` — passed.
+
+No Qualification Test and no `bun run check:sqlite-runtime` were run or added for this issue.

--- a/docs/research/planned-control-recovery-security-design-audit.md
+++ b/docs/research/planned-control-recovery-security-design-audit.md
@@ -1,5 +1,11 @@
 # Planned control and recovery security design audit
 
+> **Superseded restore-policy note (issue #81):** PDS-3 below records an earlier planning
+> decision. The accepted implementation contract now excludes all Technical Admin authentication
+> state from Event foundation backups, retains eligible non-Technical-Admin Grants and Grant
+> Sessions, and re-evaluates their current expiry, Game Day, and Game Lock facts during staged
+> restore. PDS-3 remains here only as historical research context.
+
 Audit date: 11 August 2026
 
 Planning ticket: [Audit planned control and recovery security design](https://github.com/netzhuffle/quadball-timer/issues/39)

--- a/src/lib/event-game-actions-sqlite.focused.ts
+++ b/src/lib/event-game-actions-sqlite.focused.ts
@@ -25,6 +25,8 @@ import type { EventGameRecordRoot } from "@/lib/foundation-record-types";
 import { canonicalizeEventGameRecordRoot } from "@/lib/foundation-record-types";
 import { FOUNDATION_MIGRATIONS } from "@/lib/foundation-migrations";
 
+const CURRENT_SCHEMA_VERSION = FOUNDATION_MIGRATIONS.at(-1)?.schemaVersion ?? 0;
+
 describe("SQLite immutable Event Game actions", () => {
   test("persists the action, idempotency, metadata, and audit across restart", async () => {
     await withDatabase(async (databasePath) => {
@@ -930,7 +932,7 @@ describe("SQLite immutable Event Game actions", () => {
       database.close();
 
       const current = openSqliteFoundationStorage(databasePath);
-      expect((await current.applyMigrations()).schemaVersion).toBe(21);
+      expect((await current.applyMigrations()).schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
       const currentRecord = createRecord(current, root);
       expect(await currentRecord.registerRoot(root)).toMatchObject({ status: "idempotent" });
       expect(await currentRecord.readiness()).toMatchObject({ ok: true, actionCount: 1 });
@@ -945,7 +947,7 @@ describe("SQLite immutable Event Game actions", () => {
       await seedLegacyConflictHistory(databasePath, root);
 
       const storage = openSqliteFoundationStorage(databasePath);
-      expect((await storage.applyMigrations()).schemaVersion).toBe(21);
+      expect((await storage.applyMigrations()).schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
       const record = createRecord(storage, root);
       expect(await record.registerRoot(root)).toMatchObject({ status: "idempotent" });
       expect(await record.readiness()).toMatchObject({ ok: true, actionCount: 3 });
@@ -966,7 +968,7 @@ describe("SQLite immutable Event Game actions", () => {
       await seedLegacyConflictHistory(databasePath, root);
 
       const storage = openSqliteFoundationStorage(databasePath);
-      expect((await storage.applyMigrations()).schemaVersion).toBe(21);
+      expect((await storage.applyMigrations()).schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
       const record = createRecord(storage, root);
       expect(await record.registerRoot(root)).toMatchObject({ status: "idempotent" });
       expect(

--- a/src/lib/foundation-acceptance-sqlite.focused.ts
+++ b/src/lib/foundation-acceptance-sqlite.focused.ts
@@ -30,6 +30,9 @@ import {
 } from "@/lib/grant-authority-test-support";
 import type { GrantKeyRing } from "@/lib/grant-types";
 import { readStoredGrantAuditEntry } from "@/lib/grant-storage-sqlite";
+import { FOUNDATION_MIGRATIONS } from "@/lib/foundation-migrations";
+
+const CURRENT_SCHEMA_VERSION = String(FOUNDATION_MIGRATIONS.at(-1)?.schemaVersion ?? 0);
 
 describe("focused SQLite composed acceptance", () => {
   test("commits paired evidence, survives restart, and acknowledges only a durable receipt", async () => {
@@ -90,7 +93,10 @@ describe("focused SQLite composed acceptance", () => {
         auditAuthorityVerifier: { verify: () => true },
       });
       expect(await reopenedRecord.registerRoot(root)).toMatchObject({ status: "idempotent" });
-      expect(await reopened.readiness()).toMatchObject({ ok: true, schemaVersion: "21" });
+      expect(await reopened.readiness()).toMatchObject({
+        ok: true,
+        schemaVersion: CURRENT_SCHEMA_VERSION,
+      });
       expect(await reopened.readActions(root.recordId)).toHaveLength(1);
       expect(await reopened.readAuditEntries(root.recordId)).toHaveLength(1);
       reopened.close();
@@ -727,7 +733,10 @@ describe("focused SQLite composed acceptance", () => {
       expect(await reopenedAcceptance.acknowledgeReplay(rejectionReceipt!)).toEqual({
         status: "acknowledged",
       });
-      expect(await reopened.readiness()).toMatchObject({ ok: true, schemaVersion: "21" });
+      expect(await reopened.readiness()).toMatchObject({
+        ok: true,
+        schemaVersion: CURRENT_SCHEMA_VERSION,
+      });
       reopened.close();
     });
   });

--- a/src/lib/foundation-recovery-sqlite.ts
+++ b/src/lib/foundation-recovery-sqlite.ts
@@ -1,0 +1,270 @@
+import { createHash } from "node:crypto";
+import { Database } from "bun:sqlite";
+
+export const FOUNDATION_BACKUP_POLICY_VERSION = "foundation-backup-policy-v1" as const;
+
+export type FoundationBackupPolicy = {
+  version: typeof FOUNDATION_BACKUP_POLICY_VERSION;
+  includedRelations: readonly string[];
+  excludedRelations: readonly string[];
+};
+
+const INCLUDED_RELATIONS = Object.freeze([
+  "foundation_acceptance_budgets",
+  "foundation_acceptance_integrity_anchors",
+  "foundation_control_evidence_provenance",
+  "foundation_event_catalog_audit",
+  "foundation_event_catalog_events",
+  "foundation_event_catalog_game_days",
+  "foundation_event_game_record_actions",
+  "foundation_event_game_record_audit",
+  "foundation_event_game_record_idempotency",
+  "foundation_event_game_record_metadata",
+  "foundation_event_game_record_roots",
+  "foundation_event_game_record_sides",
+  "foundation_grant_admission_global_windows",
+  "foundation_grant_admission_state_anchors",
+  "foundation_grant_admission_telemetry",
+  "foundation_grant_audit",
+  "foundation_grant_audit_provenance",
+  "foundation_grant_codes",
+  "foundation_grant_migration_provenance",
+  "foundation_grant_migration_provenance_state",
+  "foundation_grant_roots",
+  "foundation_grant_sessions",
+  "foundation_grant_state_anchors",
+  "foundation_migration_ledger",
+  "foundation_replay_attempts",
+  "foundation_replay_receipts",
+  "foundation_replay_reservations",
+] as const);
+
+const EXCLUDED_RELATIONS = Object.freeze([
+  "technical_admin_alerts",
+  "technical_admin_challenges",
+  "technical_admin_credentials",
+  "technical_admin_enrollment",
+  "technical_admin_operational_logs",
+  "technical_admin_sessions",
+  "technical_admin_state",
+  "technical_admin_storage_identity",
+] as const);
+
+export const FOUNDATION_BACKUP_POLICY: FoundationBackupPolicy = Object.freeze({
+  version: FOUNDATION_BACKUP_POLICY_VERSION,
+  includedRelations: INCLUDED_RELATIONS,
+  excludedRelations: EXCLUDED_RELATIONS,
+});
+
+export type RecoverySnapshotFacts = {
+  logicalDigest: string;
+  actionCount: number;
+  grantVersions: readonly { grantId: string; grantType: string; grantVersion: string }[];
+  excludedRelations: readonly string[];
+};
+
+export type RepresentedKeyVersions = {
+  encryption: readonly string[];
+  lookup: readonly string[];
+  audit: readonly string[];
+};
+
+export class FoundationBackupPolicyError extends Error {
+  readonly relation: string;
+
+  constructor(relation: string) {
+    super("SQLite backup policy rejected an unclassified authority relation.");
+    this.name = "FoundationBackupPolicyError";
+    this.relation = relation;
+  }
+}
+
+export function inspectRecoveryDatabase(
+  database: Database,
+  policy: FoundationBackupPolicy = FOUNDATION_BACKUP_POLICY,
+): RecoverySnapshotFacts {
+  if (policy.version !== FOUNDATION_BACKUP_POLICY_VERSION) {
+    throw new Error("Unsupported SQLite backup inclusion policy.");
+  }
+  const included = new Set(policy.includedRelations);
+  const excluded = new Set(policy.excludedRelations);
+  const relations = listRelations(database);
+  for (const relation of relations) {
+    if (!included.has(relation) && !excluded.has(relation)) {
+      throw new FoundationBackupPolicyError(relation);
+    }
+  }
+  const representedIncluded = relations.filter((relation) => included.has(relation));
+  const logicalDigest = createHash("sha256");
+  for (const relation of representedIncluded) {
+    logicalDigest.update(relation);
+    logicalDigest.update("\0");
+    for (const row of canonicalRows(database, relation)) {
+      logicalDigest.update(row);
+      logicalDigest.update("\n");
+    }
+  }
+  const actionCount = included.has("foundation_event_game_record_actions")
+    ? countRows(database, "foundation_event_game_record_actions")
+    : 0;
+  const grantVersions = relations.includes("foundation_grant_roots")
+    ? (
+        database
+          .query(
+            "SELECT grant_id, grant_type, grant_version FROM foundation_grant_roots ORDER BY grant_id",
+          )
+          .all() as Array<{ grant_id: string; grant_type: string; grant_version: string }>
+      ).map((row) => ({
+        grantId: row.grant_id,
+        grantType: row.grant_type,
+        grantVersion: row.grant_version,
+      }))
+    : [];
+  return {
+    logicalDigest: logicalDigest.digest("hex"),
+    actionCount,
+    grantVersions,
+    excludedRelations: relations.filter((relation) => excluded.has(relation)),
+  };
+}
+
+export function removeExcludedRelations(
+  database: Database,
+  policy: FoundationBackupPolicy = FOUNDATION_BACKUP_POLICY,
+): void {
+  const facts = inspectRecoveryDatabase(database, policy);
+  database.exec("PRAGMA foreign_keys = OFF; BEGIN IMMEDIATE;");
+  try {
+    for (const relation of facts.excludedRelations) {
+      database.exec(`DROP TABLE ${quoteIdentifier(relation)};`);
+    }
+    database.exec("COMMIT; PRAGMA foreign_keys = ON;");
+  } catch (error) {
+    try {
+      database.exec("ROLLBACK; PRAGMA foreign_keys = ON;");
+    } catch {
+      // The original sanitization failure is the useful boundary.
+    }
+    throw error;
+  }
+}
+
+export function readRepresentedKeyVersions(database: Database): RepresentedKeyVersions {
+  const relations = new Set(listRelations(database));
+  const encryption = new Set<string>();
+  const lookup = new Set<string>();
+  const audit = new Set<string>();
+  const add = (target: Set<string>, value: unknown): void => {
+    if (typeof value === "string" && /^[A-Za-z0-9._-]{1,64}$/.test(value)) target.add(value);
+  };
+  if (relations.has("foundation_grant_roots")) {
+    for (const row of database
+      .query(
+        "SELECT encryption_key_version AS encryption_version, lookup_key_version AS lookup_version FROM foundation_grant_roots",
+      )
+      .all() as Array<{ encryption_version: unknown; lookup_version: unknown }>) {
+      add(encryption, row.encryption_version);
+      add(lookup, row.lookup_version);
+    }
+  }
+  if (relations.has("foundation_grant_codes")) {
+    for (const row of database
+      .query(
+        "SELECT encryption_key_version AS encryption_version, lookup_key_version AS lookup_version FROM foundation_grant_codes",
+      )
+      .all() as Array<{ encryption_version: unknown; lookup_version: unknown }>) {
+      add(encryption, row.encryption_version);
+      add(audit, row.lookup_version);
+    }
+  }
+  if (relations.has("foundation_grant_sessions")) {
+    for (const row of database
+      .query(
+        "SELECT browser_context_key_version AS context_version, bearer_lookup_key_version AS bearer_version FROM foundation_grant_sessions",
+      )
+      .all() as Array<{ context_version: unknown; bearer_version: unknown }>) {
+      add(lookup, row.context_version);
+      add(lookup, row.bearer_version);
+    }
+  }
+  for (const [relation, column] of [
+    ["foundation_grant_audit", "audit_integrity_tag"],
+    ["foundation_grant_state_anchors", "integrity_tag"],
+    ["foundation_grant_admission_state_anchors", "integrity_tag"],
+  ] as const) {
+    if (!relations.has(relation)) continue;
+    for (const row of database
+      .query(`SELECT ${quoteIdentifier(column)} AS value FROM ${quoteIdentifier(relation)}`)
+      .all() as Array<{ value: unknown }>) {
+      if (typeof row.value !== "string") continue;
+      add(audit, /^hmac-sha256-v1:([^:]+):/.exec(row.value)?.[1]);
+    }
+  }
+  if (relations.has("foundation_acceptance_integrity_anchors")) {
+    for (const row of database
+      .query("SELECT key_version AS value FROM foundation_acceptance_integrity_anchors")
+      .all() as Array<{ value: unknown }>)
+      add(audit, row.value);
+  }
+  if (relations.has("foundation_replay_receipts")) {
+    for (const row of database
+      .query("SELECT receipt_key_version AS value FROM foundation_replay_receipts")
+      .all() as Array<{ value: unknown }>)
+      add(audit, row.value);
+  }
+  return {
+    encryption: [...encryption].sort(),
+    lookup: [...lookup].sort(),
+    audit: [...audit].sort(),
+  };
+}
+
+function listRelations(database: Database): string[] {
+  return (
+    database
+      .query(
+        "SELECT name FROM sqlite_master WHERE type IN ('table', 'view') AND name NOT LIKE 'sqlite_%' ORDER BY name",
+      )
+      .all() as Array<{ name: string }>
+  ).map((row) => row.name);
+}
+
+function canonicalRows(database: Database, relation: string): string[] {
+  const columns = (
+    database.query(`PRAGMA table_info(${quoteIdentifier(relation)})`).all() as Array<{
+      name: string;
+    }>
+  ).map((row) => row.name);
+  if (columns.length === 0) return [];
+  const order = columns.map(quoteIdentifier).join(", ");
+  const rows = database
+    .query(`SELECT * FROM ${quoteIdentifier(relation)} ORDER BY ${order}`)
+    .all() as Record<string, unknown>[];
+  return rows.map((row) =>
+    JSON.stringify(columns.map((column) => canonicalSqliteValue(row[column]))),
+  );
+}
+
+function canonicalSqliteValue(value: unknown): unknown {
+  if (value instanceof Uint8Array) return { blob: Buffer.from(value).toString("base64") };
+  if (typeof value === "bigint") return value.toString();
+  return value;
+}
+
+function countRows(database: Database, relation: string): number {
+  const row = database
+    .query(`SELECT COUNT(*) AS count FROM ${quoteIdentifier(relation)}`)
+    .get() as {
+    count: number | bigint;
+  };
+  return Number(row.count);
+}
+
+export function quoteRecoverySqliteString(value: string): string {
+  if (value.includes("\0")) throw new Error("SQLite path contains a null byte.");
+  return `'${value.replaceAll("'", "''")}'`;
+}
+
+function quoteIdentifier(value: string): string {
+  return `"${value.replaceAll('"', '""')}"`;
+}

--- a/src/lib/foundation-recovery.test.ts
+++ b/src/lib/foundation-recovery.test.ts
@@ -1,0 +1,1229 @@
+import { describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import {
+  chmodSync,
+  copyFileSync,
+  existsSync,
+  lstatSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs";
+import { chmod, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { createDeterministicTestIqaInterpreter } from "@/lib/event-game-actions";
+import type { ControlAction } from "@/lib/event-game-actions";
+import type { GrantAuthorityOptions } from "@/lib/grant-authority";
+import { createGrantAuthority } from "@/lib/grant-authority";
+import { createGrantTestKeyRing, createGrantTestRandomness } from "@/lib/grant-authority-contract";
+import { createGrantTestAuthorityVerifier } from "@/lib/grant-authority-test-support";
+import { createLegacyControlGrantTestAuthority } from "@/lib/grant-authority-test-support";
+import { createEventGameRecord } from "@/lib/event-game-record";
+import type { EventGameRecordRoot } from "@/lib/foundation-record-types";
+import { FOUNDATION_MIGRATIONS } from "@/lib/foundation-migrations";
+import { createFoundationRecovery } from "@/lib/foundation-recovery";
+import { FoundationBackupPolicyError } from "@/lib/foundation-recovery-sqlite";
+import { openSqliteFoundationStorage } from "@/lib/foundation-storage-sqlite";
+
+const CURRENT_MIGRATION_COUNT = FOUNDATION_MIGRATIONS.length;
+const CURRENT_SCHEMA_VERSION = String(FOUNDATION_MIGRATIONS.at(-1)?.schemaVersion ?? 0);
+
+describe("Event foundation recovery", () => {
+  test("sanitizes Technical Admin auth physically and verifies a retained VACUUM snapshot", async () => {
+    await withRecoveryPaths(async ({ livePath, backupDirectory }) => {
+      const harness = await createHarness(livePath, backupDirectory);
+      const canary = "synthetic-passkey-canary-never-in-backup";
+      const injected = new Database(livePath);
+      injected.exec(`
+        CREATE TABLE technical_admin_credentials (credential_id TEXT PRIMARY KEY, public_key_json TEXT);
+        CREATE TABLE technical_admin_sessions (session_id TEXT PRIMARY KEY, token_hash TEXT);
+      `);
+      injected
+        .query("INSERT INTO technical_admin_credentials VALUES (?, ?)")
+        .run("credential", canary);
+      injected
+        .query("INSERT INTO technical_admin_sessions VALUES (?, ?)")
+        .run("session", `${canary}-session`);
+      injected.close();
+
+      const manifest = await harness.recovery.createPreDeploymentBackup();
+      const manifestPath = join(backupDirectory, `${manifest.snapshotId}.manifest.json`);
+      const databasePath = join(backupDirectory, manifest.databaseFile);
+      expect(await harness.recovery.verifyBackup(manifestPath)).toEqual(manifest);
+      const manifestAlias = join(backupDirectory, "manifest-alias.json");
+      await symlink(manifestPath, manifestAlias);
+      expect(harness.recovery.verifyBackup(manifestAlias)).rejects.toThrow();
+      const compactedBytes = readFileSync(databasePath);
+      expect(compactedBytes.includes(Buffer.from(canary))).toBe(false);
+      const verified = new Database(databasePath, { readonly: true });
+      expect(
+        verified
+          .query(
+            "SELECT name FROM sqlite_master WHERE type = 'table' AND name LIKE 'technical_admin_%'",
+          )
+          .all(),
+      ).toEqual([]);
+      expect(
+        verified.query("SELECT COUNT(*) AS count FROM foundation_migration_ledger").get(),
+      ).toEqual({ count: CURRENT_MIGRATION_COUNT });
+      verified.close();
+      harness.storage.close();
+    });
+  });
+
+  test("fails closed on an unclassified authority relation and retains the prior verified backup", async () => {
+    await withRecoveryPaths(async ({ livePath, backupDirectory }) => {
+      const ids = ["first", "verify-first", "second"];
+      const harness = await createHarness(livePath, backupDirectory, () => ids.shift() ?? "extra");
+      const first = await harness.recovery.createPreDeploymentBackup();
+      const firstDatabase = join(backupDirectory, first.databaseFile);
+      const injected = new Database(livePath);
+      injected.exec("CREATE TABLE plugin_authority_secrets (secret TEXT NOT NULL);");
+      injected.close();
+      expect(harness.recovery.createPreDeploymentBackup()).rejects.toBeInstanceOf(
+        FoundationBackupPolicyError,
+      );
+      expect(existsSync(firstDatabase)).toBe(true);
+      expect(existsSync(join(backupDirectory, `${first.snapshotId}.manifest.json`))).toBe(true);
+      harness.storage.close();
+    });
+  });
+
+  test("uses a private physical workspace and rejects unsafe existing paths", async () => {
+    await withRecoveryPaths(async ({ livePath, backupDirectory }) => {
+      let rawMode: number | null = null;
+      const harness = await createHarness(livePath, backupDirectory, () => "private-snapshot");
+      const recovery = createFoundationRecovery(harness.storage, {
+        ...harness.options,
+        createId: () => "private-snapshot",
+        faultInjector(phase) {
+          if (phase !== "after-vacuum") return;
+          const raw = lstatSync(join(backupDirectory, ".private-snapshot.raw.sqlite"));
+          expect(raw.isSymbolicLink()).toBe(false);
+          rawMode = raw.mode & 0o777;
+          throw new Error("inspect private raw snapshot");
+        },
+      });
+      expect(recovery.createPreDeploymentBackup()).rejects.toThrow("inspect private raw snapshot");
+      expect(Number(rawMode)).toBe(0o600);
+      expect(lstatSync(backupDirectory).mode & 0o777).toBe(0o700);
+
+      await writeFile(join(backupDirectory, "private-snapshot.sqlite"), "preserve", {
+        mode: 0o600,
+      });
+      expect(harness.recovery.createPreDeploymentBackup()).rejects.toThrow();
+      expect(await readFile(join(backupDirectory, "private-snapshot.sqlite"), "utf8")).toBe(
+        "preserve",
+      );
+      harness.storage.close();
+    });
+
+    await withRecoveryPaths(async ({ livePath, backupDirectory }) => {
+      const harness = await createHarness(livePath, backupDirectory, () => "raced-snapshot");
+      const racedPath = join(backupDirectory, "raced-snapshot.sqlite");
+      const recovery = createFoundationRecovery(harness.storage, {
+        ...harness.options,
+        createId: () => "raced-snapshot",
+        faultInjector(phase) {
+          if (phase === "after-verification") {
+            writeFileSync(racedPath, "replacement-must-survive", { mode: 0o600 });
+          }
+        },
+      });
+      expect(recovery.createPreDeploymentBackup()).rejects.toThrow();
+      expect(await readFile(racedPath, "utf8")).toBe("replacement-must-survive");
+      expect(existsSync(join(backupDirectory, "raced-snapshot.manifest.json"))).toBe(false);
+      harness.storage.close();
+    });
+
+    await withRecoveryPaths(async ({ livePath, backupDirectory }) => {
+      const redirect = `${backupDirectory}-redirect`;
+      await mkdir(redirect, { mode: 0o700 });
+      await symlink(redirect, backupDirectory);
+      const harness = await createHarness(livePath, backupDirectory);
+      expect(harness.recovery.createPreDeploymentBackup()).rejects.toThrow(
+        "owned non-symlink 0700",
+      );
+      harness.storage.close();
+    });
+
+    await withRecoveryPaths(async ({ livePath, backupDirectory }) => {
+      await mkdir(backupDirectory, { mode: 0o700 });
+      await chmod(backupDirectory, 0o777);
+      const harness = await createHarness(livePath, backupDirectory);
+      expect(harness.recovery.createPreDeploymentBackup()).rejects.toThrow(
+        "owned non-symlink 0700",
+      );
+      harness.storage.close();
+    });
+  });
+
+  test("stages restore, preserves the failed database, and rolls replacement failures back", async () => {
+    await withRecoveryPaths(async ({ livePath, backupDirectory }) => {
+      const ids = ["snapshot", "verify-backup", "verify-before-restore", "restore"];
+      const harness = await createHarness(livePath, backupDirectory, () => ids.shift() ?? "extra");
+      const manifest = await harness.recovery.createPreDeploymentBackup();
+      const manifestPath = join(backupDirectory, `${manifest.snapshotId}.manifest.json`);
+      const live = new Database(livePath);
+      live
+        .query("INSERT INTO foundation_event_catalog_events VALUES (?, ?, ?, 'unpublished', ?, ?)")
+        .run("newer-event", "Potentially newer work", "Europe/Zurich", 20, 20);
+      live.close();
+      const technicalAdminPath = harness.options.technicalAdminAuth.databasePath;
+      const technicalAdmin = new Database(technicalAdminPath, { create: true });
+      technicalAdmin.exec(
+        "CREATE TABLE technical_admin_credentials (credential_id TEXT PRIMARY KEY, public_key_json TEXT);",
+      );
+      technicalAdmin
+        .query("INSERT INTO technical_admin_credentials VALUES (?, ?)")
+        .run("active-passkey", "must-not-revive");
+      technicalAdmin.close();
+
+      const technicalAdminWalPath = `${technicalAdminPath}-wal`;
+      const technicalAdminShmPath = `${technicalAdminPath}-shm`;
+      const quarantinePath = `${livePath}.quarantine`;
+      const recovery = createFoundationRecovery(harness.storage, {
+        ...harness.options,
+        faultInjector(phase) {
+          if (phase !== "after-final-authority-evaluation") return;
+          chmodSync(livePath, 0o644);
+          chmodSync(technicalAdminPath, 0o644);
+          writeFileSync(technicalAdminWalPath, "technical-admin-wal", { mode: 0o644 });
+          writeFileSync(technicalAdminShmPath, "technical-admin-shm", { mode: 0o644 });
+          writeFileSync(quarantinePath, "quarantine", { mode: 0o644 });
+        },
+      });
+      const restored = await recovery.restore(manifestPath);
+      expect(restored.potentiallyNewerWork).toBe(true);
+      expect(existsSync(restored.failedDatabasePath)).toBe(true);
+      expect(existsSync(technicalAdminPath)).toBe(false);
+      expect(restored.failedTechnicalAdminDatabasePath).not.toBeNull();
+      expect(existsSync(restored.failedTechnicalAdminDatabasePath ?? "")).toBe(true);
+      for (const privatePath of [
+        restored.failedDatabasePath,
+        restored.failedTechnicalAdminDatabasePath ?? "",
+        `${restored.failedTechnicalAdminDatabasePath ?? ""}-wal`,
+        `${restored.failedTechnicalAdminDatabasePath ?? ""}-shm`,
+        `${restored.failedDatabasePath}.quarantine`,
+      ]) {
+        expect(lstatSync(privatePath).mode & 0o777).toBe(0o600);
+      }
+      expect(existsSync(livePath)).toBe(true);
+      const current = new Database(livePath);
+      expect(
+        current.query("SELECT COUNT(*) AS count FROM foundation_event_catalog_events").get(),
+      ).toEqual({ count: 0 });
+      current.close();
+      const failed = new Database(restored.failedDatabasePath);
+      expect(
+        failed.query("SELECT COUNT(*) AS count FROM foundation_event_catalog_events").get(),
+      ).toEqual({ count: 1 });
+      failed.close();
+      expect(JSON.parse(readFileSync(restored.evidencePath, "utf8"))).toMatchObject({
+        status: "pending-replacement",
+        restoreId: restored.restoreId,
+      });
+      expect(restored).toMatchObject({
+        completed: true,
+        completionEvidenceStatus: "written",
+      });
+      if (restored.completionEvidencePath === null) {
+        throw new Error("Expected completed restore evidence.");
+      }
+      expect(lstatSync(restored.evidencePath).mode & 0o777).toBe(0o600);
+      expect(lstatSync(restored.completionEvidencePath).mode & 0o777).toBe(0o600);
+      expect(JSON.parse(readFileSync(restored.completionEvidencePath, "utf8"))).toMatchObject({
+        status: "completed",
+        technicalAdminAuthRevived: false,
+        potentiallyNewerWork: true,
+        snapshotAtMs: manifest.snapshotAtMs,
+      });
+    });
+
+    await withRecoveryPaths(async ({ livePath, backupDirectory }) => {
+      const ids = ["snapshot-failure", "verify-1", "verify-2", "restore-failure"];
+      const initial = await createHarness(livePath, backupDirectory, () => ids.shift() ?? "extra");
+      const manifest = await initial.recovery.createPreDeploymentBackup();
+      const manifestPath = join(backupDirectory, `${manifest.snapshotId}.manifest.json`);
+      const technicalAdminPath = initial.options.technicalAdminAuth.databasePath;
+      const technicalAdmin = new Database(technicalAdminPath, { create: true });
+      technicalAdmin.exec("CREATE TABLE technical_admin_credentials (credential_id TEXT);");
+      technicalAdmin.close();
+      const recovery = createFoundationRecovery(initial.storage, {
+        ...initial.options,
+        createId: () => ids.shift() ?? "extra",
+        faultInjector(phase) {
+          if (phase === "after-final-authority-evaluation") {
+            chmodSync(livePath, 0o644);
+            chmodSync(technicalAdminPath, 0o644);
+            writeFileSync(`${technicalAdminPath}-wal`, "rollback-wal", { mode: 0o644 });
+            writeFileSync(`${technicalAdminPath}-shm`, "rollback-shm", { mode: 0o644 });
+            writeFileSync(`${livePath}.quarantine`, "rollback-quarantine", { mode: 0o644 });
+          }
+          if (phase === "before-live-replacement") throw new Error("injected replacement failure");
+        },
+      });
+      expect(recovery.restore(manifestPath)).rejects.toThrow("injected replacement failure");
+      expect(existsSync(livePath)).toBe(true);
+      expect(existsSync(technicalAdminPath)).toBe(true);
+      for (const privatePath of [
+        livePath,
+        technicalAdminPath,
+        `${technicalAdminPath}-wal`,
+        `${technicalAdminPath}-shm`,
+        `${livePath}.quarantine`,
+      ]) {
+        expect(lstatSync(privatePath).mode & 0o777).toBe(0o600);
+      }
+      await rm(`${livePath}.quarantine`);
+      const reopened = openSqliteFoundationStorage(livePath, {
+        grantKeyRing: initial.keyRing,
+        grantValidationContext: { environmentId: "test", keyRing: initial.keyRing },
+      });
+      reopened.setReadinessContext(initial.readinessContext);
+      expect(await reopened.readiness()).toMatchObject({ ok: true });
+      reopened.close();
+    });
+
+    await withRecoveryPaths(async ({ livePath, backupDirectory }) => {
+      const ids = [
+        "snapshot-completion-io",
+        "verify-backup",
+        "restore-completion-io",
+        "verify-restore",
+      ];
+      const initial = await createHarness(livePath, backupDirectory, () => ids.shift() ?? "extra");
+      const manifest = await initial.recovery.createPreDeploymentBackup();
+      const manifestPath = join(backupDirectory, `${manifest.snapshotId}.manifest.json`);
+      const recovery = createFoundationRecovery(initial.storage, {
+        ...initial.options,
+        createId: () => ids.shift() ?? "extra",
+        faultInjector(phase) {
+          if (phase === "before-completed-restore-evidence") {
+            throw new Error("ENOSPC injected after completed cutover");
+          }
+        },
+      });
+      const restored = await recovery.restore(manifestPath);
+      expect(restored).toMatchObject({
+        completed: true,
+        completionEvidencePath: null,
+        completionEvidenceStatus: "write-failed",
+      });
+      expect(JSON.parse(readFileSync(restored.evidencePath, "utf8"))).toMatchObject({
+        status: "pending-replacement",
+        restoreId: restored.restoreId,
+        snapshotId: manifest.snapshotId,
+      });
+      expect(
+        existsSync(join(backupDirectory, `${restored.restoreId}.restore-completed.json`)),
+      ).toBe(false);
+      expect(existsSync(restored.failedDatabasePath)).toBe(true);
+      const reopened = openSqliteFoundationStorage(livePath, {
+        grantKeyRing: initial.keyRing,
+        grantValidationContext: { environmentId: "test", keyRing: initial.keyRing },
+      });
+      reopened.setReadinessContext(initial.readinessContext);
+      expect(await reopened.readiness()).toMatchObject({ ok: true });
+      reopened.close();
+    });
+
+    await withRecoveryPaths(async ({ livePath, backupDirectory }) => {
+      const ids = [
+        "snapshot-pre-reevaluation-race",
+        "verify-backup",
+        "restore-pre-reevaluation-race",
+        "verify-restore",
+      ];
+      const initial = await createHarness(livePath, backupDirectory, () => ids.shift() ?? "extra");
+      const manifest = await initial.recovery.createPreDeploymentBackup();
+      const manifestPath = join(backupDirectory, `${manifest.snapshotId}.manifest.json`);
+      const backupPath = join(backupDirectory, manifest.databaseFile);
+      const stagedPath = join(
+        dirname(livePath),
+        ".foundation.sqlite.restore-pre-reevaluation-race.staged",
+      );
+      const displacedPath = `${stagedPath}.verified-inode`;
+      const recovery = createFoundationRecovery(initial.storage, {
+        ...initial.options,
+        createId: () => ids.shift() ?? "extra",
+        faultInjector(phase) {
+          if (phase === "after-authoritative-quiescence") {
+            renameSync(stagedPath, displacedPath);
+            copyFileSync(backupPath, stagedPath);
+            chmodSync(stagedPath, 0o600);
+          }
+        },
+      });
+      expect(recovery.restore(manifestPath)).rejects.toThrow("file identity");
+      expect(existsSync(stagedPath)).toBe(true);
+      expect(existsSync(displacedPath)).toBe(true);
+      const reopened = openSqliteFoundationStorage(livePath, {
+        grantKeyRing: initial.keyRing,
+        grantValidationContext: { environmentId: "test", keyRing: initial.keyRing },
+      });
+      reopened.setReadinessContext(initial.readinessContext);
+      expect(await reopened.readiness()).toMatchObject({ ok: true });
+      reopened.close();
+    });
+
+    await withRecoveryPaths(async ({ livePath, backupDirectory }) => {
+      const ids = ["snapshot-stage-race", "verify-backup", "restore-stage-race", "verify-restore"];
+      const initial = await createHarness(livePath, backupDirectory, () => ids.shift() ?? "extra");
+      const manifest = await initial.recovery.createPreDeploymentBackup();
+      const manifestPath = join(backupDirectory, `${manifest.snapshotId}.manifest.json`);
+      const stagedPath = join(dirname(livePath), ".foundation.sqlite.restore-stage-race.staged");
+      const displacedPath = `${stagedPath}.verified-inode`;
+      const recovery = createFoundationRecovery(initial.storage, {
+        ...initial.options,
+        createId: () => ids.shift() ?? "extra",
+        faultInjector(phase) {
+          if (phase === "after-final-authority-evaluation") {
+            renameSync(stagedPath, displacedPath);
+            writeFileSync(stagedPath, "replacement-must-not-be-installed", { mode: 0o600 });
+          }
+        },
+      });
+      expect(recovery.restore(manifestPath)).rejects.toThrow("file identity");
+      expect(await readFile(stagedPath, "utf8")).toBe("replacement-must-not-be-installed");
+      expect(existsSync(displacedPath)).toBe(true);
+      const reopened = openSqliteFoundationStorage(livePath, {
+        grantKeyRing: initial.keyRing,
+        grantValidationContext: { environmentId: "test", keyRing: initial.keyRing },
+      });
+      reopened.setReadinessContext(initial.readinessContext);
+      expect(await reopened.readiness()).toMatchObject({ ok: true });
+      reopened.close();
+    });
+
+    await withRecoveryPaths(async ({ livePath, backupDirectory }) => {
+      const ids = [
+        "snapshot-stage-mutation",
+        "verify-backup",
+        "restore-stage-mutation",
+        "verify-restore",
+      ];
+      const initial = await createHarness(livePath, backupDirectory, () => ids.shift() ?? "extra");
+      const manifest = await initial.recovery.createPreDeploymentBackup();
+      const manifestPath = join(backupDirectory, `${manifest.snapshotId}.manifest.json`);
+      const stagedPath = join(
+        dirname(livePath),
+        ".foundation.sqlite.restore-stage-mutation.staged",
+      );
+      const recovery = createFoundationRecovery(initial.storage, {
+        ...initial.options,
+        createId: () => ids.shift() ?? "extra",
+        faultInjector(phase) {
+          if (phase === "after-final-authority-evaluation") {
+            writeFileSync(stagedPath, "same-inode-mutation", { mode: 0o600 });
+          }
+        },
+      });
+      expect(recovery.restore(manifestPath)).rejects.toThrow(
+        "source changed before exclusive publication",
+      );
+      const reopened = openSqliteFoundationStorage(livePath, {
+        grantKeyRing: initial.keyRing,
+        grantValidationContext: { environmentId: "test", keyRing: initial.keyRing },
+      });
+      reopened.setReadinessContext(initial.readinessContext);
+      expect(await reopened.readiness()).toMatchObject({ ok: true });
+      reopened.close();
+    });
+  });
+
+  test("records one bounded gap for every action in a whole-batch rejection", async () => {
+    await withRecoveryPaths(async ({ livePath, backupDirectory }) => {
+      const harness = await createHarness(livePath, backupDirectory);
+      const action = createRecoveredAction();
+      const secondAction = {
+        ...createRecoveredAction(),
+        operationId: "original-operation-2",
+        payload: { factId: "fact-2", factType: "score", gameSideId: "side-1", value: 2 },
+        interpretation: {
+          type: "fact" as const,
+          factId: "fact-2",
+          factType: "score",
+          gameSideId: "side-1",
+          payload: { value: 2 },
+        },
+      };
+      const imported = await harness.recovery.importControllerRecovery({
+        importId: "import-1",
+        recordId: action.recordId,
+        eventGameId: action.eventGameId,
+        sessionBearer: "fresh-current-session-bearer",
+        currentGrant: { sessionId: "current-session", versionId: "current-version" },
+        currentLifecycle: {
+          phase: "malformed",
+          commencedAtMs: null,
+          finishedAtMs: null,
+          lockedAtMs: null,
+          lockReason: null,
+        } as never,
+        sourceReference: "controller-history-1",
+        actions: [
+          { action, sourceAcceptedAtMs: null },
+          { action: secondAction, sourceAcceptedAtMs: null },
+        ],
+        gaps: [
+          {
+            gapId: "gap-1",
+            category: "server-evidence-unavailable",
+            redactedDetail: "Server-only acknowledgement evidence was unavailable.",
+          },
+        ],
+      });
+      const evidence = JSON.parse(readFileSync(imported.evidencePath, "utf8"));
+      expect(evidence.gaps).toEqual([
+        expect.objectContaining({ category: "server-evidence-unavailable" }),
+        expect.objectContaining({ category: "action-rejected" }),
+        expect.objectContaining({ category: "action-rejected" }),
+      ]);
+      expect(JSON.stringify(evidence)).not.toContain("fresh-current-session-bearer");
+      harness.storage.close();
+    });
+  });
+
+  test("bounds action and supplied-gap counts before pending recovery evidence", async () => {
+    await withRecoveryPaths(async ({ livePath, backupDirectory }) => {
+      const harness = await createHarness(livePath, backupDirectory);
+      const action = createRecoveredAction();
+      const input = {
+        importId: "too-many-actions",
+        recordId: action.recordId,
+        eventGameId: action.eventGameId,
+        sessionBearer: "fresh-current-session-bearer",
+        currentGrant: { sessionId: "current-session", versionId: "current-version" },
+        currentLifecycle: action.lifecycle,
+        sourceReference: "controller-history-1",
+        actions: Array.from({ length: 101 }, (_, index) => ({
+          action: {
+            ...action,
+            operationId: `operation-${index + 1}`,
+          },
+          sourceAcceptedAtMs: null,
+        })),
+        gaps: [],
+      };
+      expect(harness.recovery.importControllerRecovery(input)).rejects.toThrow("action count");
+      expect(existsSync(join(backupDirectory, "too-many-actions.recovery-import.json"))).toBe(
+        false,
+      );
+
+      const tooManyGaps = {
+        ...input,
+        importId: "too-many-gaps",
+        actions: [{ action, sourceAcceptedAtMs: null }],
+        gaps: Array.from({ length: 101 }, (_, index) => ({
+          gapId: `gap-${index + 1}`,
+          category: "server-evidence-unavailable" as const,
+          redactedDetail: "Server-only evidence was unavailable.",
+        })),
+      };
+      expect(harness.recovery.importControllerRecovery(tooManyGaps)).rejects.toThrow("Gap count");
+      expect(existsSync(join(backupDirectory, "too-many-gaps.recovery-import.json"))).toBe(false);
+      harness.storage.close();
+    });
+  });
+
+  test("quiesces writers before preserving a pinned Game and terminating multiple exact terminal Games", async () => {
+    await withRecoveryPaths(async ({ livePath, backupDirectory }) => {
+      let now = 10;
+      const lockedEventGameIds = new Set<string>();
+      const pastGameDayEventGameIds = new Set(["game-past"]);
+      let currentEventGameId = "game-old";
+      const lateWriterLanded = {
+        lock: false,
+        gameDay: false,
+        expiry: false,
+        revocation: false,
+      };
+      const lateWriterResults: Promise<unknown>[] = [];
+      const keyRing = createGrantTestKeyRing();
+      const readinessContext = {
+        actionCodecRegistry: (
+          await import("@/lib/event-game-actions")
+        ).createControlActionCodecRegistry(),
+        interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
+      };
+      const grant: GrantAuthorityOptions = {
+        environmentId: "test",
+        clock: { nowMs: () => now },
+        randomness: createGrantTestRandomness(),
+        keyRing,
+        controlScopeResolver: {
+          resolve: () =>
+            lockedEventGameIds.has(currentEventGameId)
+              ? {
+                  status: "terminal" as const,
+                  reason: "game-locked" as const,
+                  eventGameId: currentEventGameId,
+                }
+              : { status: "eligible" as const, eventGameId: currentEventGameId },
+          resolveSession: (_scope, sessionEventGameId) =>
+            pastGameDayEventGameIds.has(sessionEventGameId)
+              ? { status: "past-game-day" as const, eventGameId: sessionEventGameId }
+              : lockedEventGameIds.has(sessionEventGameId)
+                ? {
+                    status: "game-locked" as const,
+                    eventGameId: sessionEventGameId,
+                  }
+                : sessionEventGameId === "game-old" && currentEventGameId === "game-new"
+                  ? {
+                      status: "pinned" as const,
+                      sessionEventGameId,
+                      currentEventGameId,
+                    }
+                  : { status: "current" as const, eventGameId: sessionEventGameId },
+        },
+        privilegedAuthorityVerifier: createGrantTestAuthorityVerifier(),
+      };
+      const storage = openSqliteFoundationStorage(livePath, {
+        grantKeyRing: keyRing,
+        grantValidationContext: { environmentId: "test", keyRing },
+      });
+      await storage.applyMigrations({ requireCandidate: false });
+      storage.setReadinessContext(readinessContext);
+      const authority = createGrantAuthority(storage, grant);
+      const eventAdmin = await authority.createEventAdminGrant({
+        authority: { kind: "technical-admin", id: "technical-admin" },
+        scope: {
+          eventId: "event-1",
+          eventTimeZone: "UTC",
+          finalGameDayDate: "2026-08-15",
+        },
+      });
+      if (eventAdmin.status !== "created") throw new Error("Expected Event Admin Grant.");
+      const eventSession = await authority.admitGrant({
+        qrCredential: eventAdmin.qrCredential,
+        browserContext: "event-admin-browser",
+      });
+      if (eventSession.status !== "admitted") throw new Error("Expected Event Admin session.");
+      const control = await authority.createControlGrant({
+        authority: { kind: "grant-session", sessionBearer: eventSession.sessionBearer },
+        scope: {
+          eventId: "event-1",
+          gameDayId: "day-1",
+          pitchId: "pitch-1",
+          pitchSlotId: "slot-1",
+        },
+      });
+      if (control.status !== "created") throw new Error("Expected Control Grant.");
+      const code = await authority.createGrantCode(control.grantId, {
+        kind: "grant-session",
+        sessionBearer: eventSession.sessionBearer,
+      });
+      if (code.status !== "created") throw new Error("Expected Control Grant Code.");
+      const controller = await authority.admitGrant({
+        qrCredential: control.qrCredential,
+        browserContext: "controller-old-game",
+      });
+      if (controller.status !== "admitted") throw new Error("Expected Controller session.");
+      expect(controller.eventGameId).toBe("game-old");
+      currentEventGameId = "game-other";
+      const otherController = await authority.admitGrant({
+        qrCredential: control.qrCredential,
+        browserContext: "controller-other-game",
+      });
+      if (otherController.status !== "admitted") {
+        throw new Error("Expected other-Game Controller session.");
+      }
+      expect(otherController.eventGameId).toBe("game-other");
+      currentEventGameId = "game-new";
+      const reassignedController = await authority.admitGrant({
+        qrCredential: control.qrCredential,
+        browserContext: "controller-new-game",
+      });
+      if (reassignedController.status !== "admitted") {
+        throw new Error("Expected reassigned Controller session.");
+      }
+      expect(reassignedController.eventGameId).toBe("game-new");
+      currentEventGameId = "game-past";
+      const pastGameController = await authority.admitGrant({
+        qrCredential: control.qrCredential,
+        browserContext: "controller-past-game-day",
+      });
+      if (pastGameController.status !== "admitted") {
+        throw new Error("Expected past-Game-Day Controller session fixture.");
+      }
+      currentEventGameId = "game-new";
+      expect(await storage.readiness()).toMatchObject({ ok: true });
+
+      const recovery = createFoundationRecovery(storage, {
+        backupDirectory,
+        keyRing,
+        readinessContext,
+        grant,
+        acceptance: {
+          externalScopeResolver: createPermissiveRecoveryScopeResolver(),
+          clock: () => now,
+          interpreter: readinessContext.interpreter,
+        },
+        technicalAdminAuth: {
+          databasePath: join(dirname(livePath), "technical-admin.sqlite"),
+          async quiesce() {},
+        },
+        nowMs: () => now,
+        faultInjector(phase) {
+          if (phase === "after-authoritative-quiescence") {
+            lockedEventGameIds.add("game-new");
+            lockedEventGameIds.add("game-other");
+            now = 30 * 24 * 60 * 60 * 1_000 + 10;
+          }
+          if (phase === "after-final-authority-evaluation") {
+            const attempt = (writer: () => void): void => {
+              lateWriterResults.push(
+                storage.transaction(() => writer()).catch((error: unknown) => error),
+              );
+            };
+            attempt(() => {
+              lockedEventGameIds.add("game-old");
+              lateWriterLanded.lock = true;
+            });
+            attempt(() => {
+              pastGameDayEventGameIds.add("game-old");
+              lateWriterLanded.gameDay = true;
+            });
+            attempt(() => {
+              now += 1;
+              lateWriterLanded.expiry = true;
+            });
+            lateWriterResults.push(
+              storage
+                .transaction((transaction) => {
+                  const session = transaction
+                    .listGrantSessions(control.grantId)
+                    .find((candidate) => candidate.sessionId === controller.grantSessionId);
+                  if (session !== undefined) {
+                    transaction.updateGrantSession({
+                      ...session,
+                      status: "revoked",
+                      revokedAtMs: now,
+                    });
+                    lateWriterLanded.revocation = true;
+                  }
+                })
+                .catch((error: unknown) => error),
+            );
+          }
+        },
+      });
+      const manifest = await recovery.createPreDeploymentBackup();
+      const restored = await recovery.restore(
+        join(backupDirectory, `${manifest.snapshotId}.manifest.json`),
+      );
+      expect(lateWriterResults).toHaveLength(4);
+      for (const result of await Promise.all(lateWriterResults)) {
+        expect(result).toBeInstanceOf(Error);
+      }
+      expect(lateWriterLanded).toEqual({
+        lock: false,
+        gameDay: false,
+        expiry: false,
+        revocation: false,
+      });
+      expect(lockedEventGameIds).toEqual(new Set(["game-new", "game-other"]));
+      expect(pastGameDayEventGameIds).toEqual(new Set(["game-past"]));
+      const reopened = openSqliteFoundationStorage(livePath, {
+        grantKeyRing: keyRing,
+        grantValidationContext: { environmentId: "test", keyRing },
+      });
+      reopened.setReadinessContext(readinessContext);
+      const restoredState = await reopened.transaction((transaction) => ({
+        grant: transaction.findGrantById(control.grantId),
+        sessions: transaction.listGrantSessions(control.grantId),
+        audit: transaction.listGrantAudit(control.grantId),
+        eventAdminSession: transaction
+          .listGrantSessions(eventAdmin.grantId)
+          .find((session) => session.sessionId === eventSession.grantSessionId),
+      }));
+      expect(restoredState.eventAdminSession).toMatchObject({
+        status: "expired",
+        bearerMaterialState: "erased",
+      });
+      expect(
+        restoredState.sessions.find((session) => session.sessionId === controller.grantSessionId),
+      ).toMatchObject({
+        eventGameId: "game-old",
+        status: "active",
+        bearerMaterialState: "present",
+      });
+      expect(
+        restoredState.sessions.find(
+          (session) => session.sessionId === otherController.grantSessionId,
+        ),
+      ).toMatchObject({
+        eventGameId: "game-other",
+        status: "expired",
+        bearerMaterialState: "erased",
+        bearerLookupVerifier: null,
+      });
+      expect(
+        restoredState.sessions.find(
+          (session) => session.sessionId === reassignedController.grantSessionId,
+        ),
+      ).toMatchObject({
+        eventGameId: "game-new",
+        status: "expired",
+        bearerMaterialState: "erased",
+        bearerLookupVerifier: null,
+      });
+      expect(
+        restoredState.sessions.find(
+          (session) => session.sessionId === pastGameController.grantSessionId,
+        ),
+      ).toMatchObject({
+        eventGameId: "game-past",
+        status: "expired",
+        bearerMaterialState: "erased",
+        bearerLookupVerifier: null,
+      });
+      expect(restoredState.grant?.code).toMatchObject({
+        state: "erased",
+        ciphertext: null,
+        lookupDigest: null,
+      });
+      expect(
+        restoredState.audit.filter((entry) => entry.action === "grant-code-erased-game-lock"),
+      ).toEqual([
+        expect.objectContaining({
+          eventGameId: "game-new",
+          terminalReason: "game-locked",
+          codeStateBefore: "present",
+          codeState: "erased",
+        }),
+      ]);
+      expect(
+        restoredState.audit
+          .filter((entry) => entry.action === "session-terminated")
+          .map((entry) => [entry.eventGameId, entry.terminalReason]),
+      ).toEqual(
+        expect.arrayContaining([
+          ["game-other", "game-locked"],
+          ["game-new", "game-locked"],
+          ["game-past", "past-game-day"],
+        ]),
+      );
+      if (restored.completionEvidencePath === null) {
+        throw new Error("Expected completed restore evidence.");
+      }
+      expect(
+        JSON.stringify(JSON.parse(readFileSync(restored.completionEvidencePath, "utf8"))),
+      ).not.toContain(control.grantId);
+      reopened.close();
+    });
+  });
+
+  test("retains base-contract present and disabled Grant Codes as audit-key material across readiness and backup", async () => {
+    await withRecoveryPaths(async ({ livePath, backupDirectory }) => {
+      const harness = await createHarness(livePath, backupDirectory);
+      const authority = createGrantAuthority(harness.storage, harness.options.grant);
+      const eventAdmin = await authority.createEventAdminGrant({
+        authority: { kind: "technical-admin", id: "technical-admin" },
+        scope: {
+          eventId: "event-1",
+          eventTimeZone: "UTC",
+          finalGameDayDate: "2026-08-15",
+        },
+      });
+      if (eventAdmin.status !== "created") throw new Error("Expected Event Admin Grant.");
+      const eventSession = await authority.admitGrant({
+        qrCredential: eventAdmin.qrCredential,
+        browserContext: "event-admin-key-version",
+      });
+      if (eventSession.status !== "admitted") throw new Error("Expected Event Admin session.");
+      const control = await authority.createControlGrant({
+        authority: { kind: "grant-session", sessionBearer: eventSession.sessionBearer },
+        scope: {
+          eventId: "event-1",
+          gameDayId: "day-1",
+          pitchId: "pitch-1",
+          pitchSlotId: "slot-1",
+        },
+      });
+      if (control.status !== "created") throw new Error("Expected Control Grant.");
+      const code = await authority.createGrantCode(control.grantId, {
+        kind: "grant-session",
+        sessionBearer: eventSession.sessionBearer,
+      });
+      if (code.status !== "created") throw new Error("Expected Control Grant Code.");
+
+      const disabledControl = await authority.createControlGrant({
+        authority: { kind: "grant-session", sessionBearer: eventSession.sessionBearer },
+        scope: {
+          eventId: "event-1",
+          gameDayId: "day-1",
+          pitchId: "pitch-1",
+          pitchSlotId: "slot-2",
+        },
+      });
+      if (disabledControl.status !== "created") {
+        throw new Error("Expected disabled-Code Control Grant.");
+      }
+      const disabledCode = await authority.createGrantCode(disabledControl.grantId, {
+        kind: "grant-session",
+        sessionBearer: eventSession.sessionBearer,
+      });
+      if (disabledCode.status !== "created") throw new Error("Expected second Grant Code.");
+      expect(
+        await authority.disableGrantCode(disabledControl.grantId, {
+          kind: "grant-session",
+          sessionBearer: eventSession.sessionBearer,
+        }),
+      ).toMatchObject({ status: "updated" });
+
+      const baseContractState = await harness.storage.transaction((transaction) => ({
+        present: transaction.findGrantById(control.grantId)?.code,
+        disabled: transaction.findGrantById(disabledControl.grantId)?.code,
+      }));
+      expect(baseContractState.present).toMatchObject({
+        state: "present",
+        lookupKeyVersion: harness.keyRing.audit.currentVersion,
+      });
+      expect(baseContractState.disabled).toMatchObject({
+        state: "disabled",
+        lookupKeyVersion: null,
+      });
+      harness.storage.close();
+
+      const upgradedStorage = openSqliteFoundationStorage(livePath, {
+        grantKeyRing: harness.keyRing,
+        grantValidationContext: { environmentId: "test", keyRing: harness.keyRing },
+      });
+      upgradedStorage.setReadinessContext(harness.readinessContext);
+      expect(await upgradedStorage.readiness()).toMatchObject({
+        ok: true,
+        schemaVersion: CURRENT_SCHEMA_VERSION,
+      });
+      const recovery = createFoundationRecovery(upgradedStorage, harness.options);
+
+      const manifest = await recovery.createPreDeploymentBackup();
+      expect(manifest.representedKeyVersions.lookup).toContain("lookup-v1");
+      expect(manifest.representedKeyVersions.audit).toContain("audit-v1");
+      const manifestPath = join(backupDirectory, `${manifest.snapshotId}.manifest.json`);
+      upgradedStorage.close();
+
+      const missingAuditKeyRing = {
+        ...harness.keyRing,
+        audit: {
+          currentVersion: harness.keyRing.audit.currentVersion,
+          keys: new Map<string, Uint8Array>(),
+        },
+      };
+      const verificationStorage = openSqliteFoundationStorage(livePath, {
+        grantKeyRing: missingAuditKeyRing,
+        grantValidationContext: { environmentId: "test", keyRing: missingAuditKeyRing },
+      });
+      const verifier = createFoundationRecovery(verificationStorage, {
+        ...harness.options,
+        keyRing: missingAuditKeyRing,
+        grant: { ...harness.options.grant, keyRing: missingAuditKeyRing },
+      });
+      expect(verifier.verifyBackup(manifestPath)).rejects.toThrow("supplied audit key ring");
+      verificationStorage.close();
+    });
+  });
+
+  test("aborts unavailable, ambiguous, and malformed per-session restore resolution", async () => {
+    const rejectedResolutions = [
+      { status: "unavailable" as const },
+      { status: "conflict" as const },
+      { status: "current" as const, eventGameId: "wrong-game" },
+    ];
+    for (const [index, rejectedResolution] of rejectedResolutions.entries()) {
+      await withRecoveryPaths(async ({ livePath, backupDirectory }) => {
+        const harness = await createHarness(livePath, backupDirectory);
+        const authority = createLegacyControlGrantTestAuthority(
+          harness.storage,
+          harness.options.grant,
+        );
+        const created = await authority.createControlGrant({
+          scope: createRecoveryRoot().externalScope,
+          actor: { kind: "fixture", id: `restore-resolution-${index}` },
+        });
+        if (created.status !== "created") throw new Error("Expected Control Grant.");
+        const admitted = await authority.admitControlGrant({
+          qrCredential: created.qrCredential,
+          browserContext: `restore-resolution-browser-${index}`,
+        });
+        if (admitted.status !== "admitted") throw new Error("Expected Control Session.");
+        const manifest = await harness.recovery.createPreDeploymentBackup();
+        harness.options.grant.controlScopeResolver.resolveSession = () => rejectedResolution;
+        expect(
+          harness.recovery.restore(join(backupDirectory, `${manifest.snapshotId}.manifest.json`)),
+        ).rejects.toThrow("could not be resolved");
+        expect(existsSync(livePath)).toBe(true);
+      });
+    }
+  });
+
+  test("binds recovery import to real composed acceptance and durable SQLite mutation", async () => {
+    await withRecoveryPaths(async ({ livePath, backupDirectory }) => {
+      const harness = await createHarness(livePath, backupDirectory);
+      const root = { ...createRecoveryRoot(), eventGameId: "game-1" };
+      root.ownership.eventGameId = root.eventGameId;
+      const authority = createLegacyControlGrantTestAuthority(
+        harness.storage,
+        harness.options.grant,
+      );
+      const created = await authority.createControlGrant({
+        scope: root.externalScope,
+        actor: { kind: "fixture", id: "recovery-authority" },
+      });
+      if (created.status !== "created") throw new Error("Expected Control Grant.");
+      const admitted = await authority.admitControlGrant({
+        qrCredential: created.qrCredential,
+        browserContext: "recovery-controller",
+      });
+      if (admitted.status !== "admitted") throw new Error("Expected Control Session.");
+      const record = createEventGameRecord(harness.storage, {
+        externalScopeResolver: createRecoveryScopeResolver(root),
+        interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
+        clock: () => 1_000,
+      });
+      expect(await record.registerRoot(root)).toMatchObject({ status: "registered" });
+      const source = createMemoryRecoveredAction(root);
+      const imported = await harness.recovery.importControllerRecovery({
+        importId: "memory-import",
+        recordId: root.recordId,
+        eventGameId: root.eventGameId,
+        sessionBearer: admitted.sessionBearer,
+        currentGrant: {
+          sessionId: admitted.grantSessionId,
+          versionId: created.grantVersion,
+        },
+        currentLifecycle: structuredClone(root.lifecycle),
+        sourceReference: "controller-retained-history",
+        actions: [{ action: source, sourceAcceptedAtMs: source.acceptedAtMs }],
+        gaps: [],
+      });
+      expect(imported.outcome.results.map((result) => result.status)).toEqual(["accepted"]);
+      expect((await record.readActions()).map((stored) => stored.action.operationId)).toEqual([
+        source.operationId,
+      ]);
+      expect(await record.readRecoveryProvenance()).toEqual([
+        expect.objectContaining({
+          importId: "memory-import",
+          sourceOperationId: source.operationId,
+          sourceAcceptedAtMs: source.acceptedAtMs,
+        }),
+      ]);
+      harness.storage.close();
+
+      const reopened = openSqliteFoundationStorage(livePath, {
+        grantKeyRing: harness.keyRing,
+        grantValidationContext: { environmentId: "test", keyRing: harness.keyRing },
+      });
+      reopened.setReadinessContext(harness.readinessContext);
+      const durableRecord = createEventGameRecord(reopened, {
+        externalScopeResolver: createRecoveryScopeResolver(root),
+        interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
+        clock: () => 1_000,
+      });
+      expect(await durableRecord.registerRoot(root)).toMatchObject({ status: "idempotent" });
+      expect(
+        (await durableRecord.readActions()).map((stored) => stored.action.operationId),
+      ).toEqual([source.operationId]);
+      reopened.close();
+    });
+  });
+});
+
+async function withRecoveryPaths(
+  work: (paths: { livePath: string; backupDirectory: string }) => Promise<void>,
+): Promise<void> {
+  const root = await mkdtemp(join(tmpdir(), "quadball-timer-recovery-"));
+  const liveDirectory = join(root, "live");
+  const backupDirectory = join(root, "backup");
+  const livePath = join(liveDirectory, "foundation.sqlite");
+  await mkdir(liveDirectory, { recursive: true });
+  const setup = new Database(livePath, { create: true });
+  setup.close();
+  try {
+    await work({ livePath, backupDirectory });
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+async function createHarness(
+  livePath: string,
+  backupDirectory: string,
+  createId: () => string = (() => {
+    let value = 0;
+    return () => `recovery-${++value}`;
+  })(),
+) {
+  const keyRing = createGrantTestKeyRing();
+  const readinessContext = {
+    actionCodecRegistry: (
+      await import("@/lib/event-game-actions")
+    ).createControlActionCodecRegistry(),
+    interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
+  };
+  const grant: GrantAuthorityOptions = {
+    environmentId: "test",
+    clock: { nowMs: () => 10 },
+    randomness: createGrantTestRandomness(),
+    keyRing,
+    controlScopeResolver: {
+      resolve: () => ({ status: "eligible", eventGameId: "game-1" }),
+      resolveSession: (_scope, sessionEventGameId) => ({
+        status: "current",
+        eventGameId: sessionEventGameId,
+      }),
+    },
+    privilegedAuthorityVerifier: createGrantTestAuthorityVerifier(),
+  };
+  const storage = openSqliteFoundationStorage(livePath, {
+    grantKeyRing: keyRing,
+    grantValidationContext: { environmentId: "test", keyRing },
+  });
+  await storage.applyMigrations({ requireCandidate: false });
+  storage.setReadinessContext(readinessContext);
+  const options = {
+    backupDirectory,
+    keyRing,
+    readinessContext,
+    grant,
+    acceptance: {
+      externalScopeResolver: createPermissiveRecoveryScopeResolver(),
+      clock: () => 10,
+      interpreter: readinessContext.interpreter,
+    },
+    technicalAdminAuth: {
+      databasePath: join(dirname(livePath), "technical-admin.sqlite"),
+      async quiesce() {},
+    },
+    nowMs: () => 10,
+    createId,
+  };
+  return {
+    storage,
+    recovery: createFoundationRecovery(storage, options),
+    options,
+    keyRing,
+    readinessContext,
+  };
+}
+
+function createPermissiveRecoveryScopeResolver() {
+  return {
+    resolve(scope: EventGameRecordRoot["externalScope"]) {
+      return { status: "resolved" as const, scope: structuredClone(scope) };
+    },
+    resolveEventTeam() {
+      return { status: "resolved" as const };
+    },
+  };
+}
+
+function createRecoveredAction(): ControlAction {
+  return {
+    controlActionVersion: "control-action-v1",
+    recordId: "record-1",
+    eventGameId: "game-1",
+    operationId: "original-operation-1",
+    kind: { id: "game-fact", version: "1" },
+    payload: { factId: "fact-1", factType: "score", gameSideId: "side-1", value: 1 },
+    causalPredecessorIds: [],
+    occurrence: { trustedAtMs: 6, clientOriginAtMs: 5, source: "offline" },
+    grant: { sessionId: "old-session", versionId: "old-version" },
+    lifecycle: {
+      phase: "scheduled",
+      commencedAtMs: null,
+      finishedAtMs: null,
+      lockedAtMs: null,
+      lockReason: null,
+    },
+    acceptedAtMs: 7,
+    interpretation: {
+      type: "fact",
+      factId: "fact-1",
+      factType: "score",
+      gameSideId: "side-1",
+      payload: { value: 1 },
+    },
+  };
+}
+
+function createRecoveryRoot(): EventGameRecordRoot {
+  return {
+    recordId: "recovery-record",
+    eventId: "recovery-event",
+    eventGameId: "recovery-game",
+    ownership: { eventId: "recovery-event", eventGameId: "recovery-game" },
+    externalScope: {
+      eventId: "recovery-event",
+      gameDayId: "recovery-day",
+      pitchId: "recovery-pitch",
+      pitchSlotId: "recovery-slot",
+    },
+    gameSides: [
+      { id: "side-a", eventTeamId: "team-a", teamInterpretationRef: "team-a-v1" },
+      { id: "side-b", eventTeamId: "team-b", teamInterpretationRef: "team-b-v1" },
+    ],
+    lifecycle: {
+      phase: "scheduled",
+      commencedAtMs: null,
+      finishedAtMs: null,
+      lockedAtMs: null,
+      lockReason: null,
+    },
+    compatibility: {
+      recordVersion: "record-v1",
+      schemaVersion: "schema-v1",
+      interpreterVersion: "rules-v1",
+    },
+    creationEvidence: {
+      operationId: "register-recovery",
+      actorReference: "actor-recovery",
+      source: "event-game-registration",
+      createdAtMs: 500,
+    },
+  };
+}
+
+function createRecoveryScopeResolver(root: EventGameRecordRoot) {
+  return {
+    resolve(scope: EventGameRecordRoot["externalScope"]) {
+      return JSON.stringify(scope) === JSON.stringify(root.externalScope)
+        ? { status: "resolved" as const, scope: structuredClone(scope) }
+        : { status: "mismatch" as const, detail: "scope mismatch" };
+    },
+    resolveEventTeam() {
+      return { status: "resolved" as const };
+    },
+  };
+}
+
+function createMemoryRecoveredAction(root: EventGameRecordRoot): ControlAction {
+  return {
+    controlActionVersion: "control-action-v1",
+    recordId: root.recordId,
+    eventGameId: root.eventGameId,
+    operationId: "controller-original-operation",
+    kind: { id: "game-fact", version: "1" },
+    payload: {
+      factId: "recovered-fact",
+      factType: "test",
+      gameSideId: "side-a",
+      gameTimeMs: 1,
+      data: { recovered: true },
+    },
+    causalPredecessorIds: [],
+    occurrence: { trustedAtMs: 900, clientOriginAtMs: 800, source: "offline" },
+    grant: { sessionId: "historical-session", versionId: "historical-version" },
+    lifecycle: structuredClone(root.lifecycle),
+    acceptedAtMs: 900,
+    interpretation: {
+      type: "fact",
+      factId: "recovered-fact",
+      factType: "test",
+      gameSideId: "side-a",
+      payload: { recovered: true },
+    },
+  };
+}

--- a/src/lib/foundation-recovery.ts
+++ b/src/lib/foundation-recovery.ts
@@ -1,0 +1,1290 @@
+import { createHash, randomUUID } from "node:crypto";
+import { Database } from "bun:sqlite";
+import { constants as fsConstants } from "node:fs";
+import {
+  chmod,
+  link,
+  lstat,
+  mkdir,
+  open as openFile,
+  realpath,
+  rm,
+  unlink,
+} from "node:fs/promises";
+import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
+import {
+  ACCEPTANCE_LIMITS,
+  createFoundationAcceptance,
+  type FoundationAcceptanceOptions,
+  type FoundationBatchOutcome,
+} from "@/lib/foundation-acceptance";
+import type {
+  ControlAction,
+  ControlActionGrantProvenance,
+  ControlActionLifecycleContext,
+} from "@/lib/event-game-actions";
+import type { GrantAuthorityOptions } from "@/lib/grant-authority";
+import { createAuditEntry, expireGrantIfDue } from "@/lib/grant-lifecycle";
+import { eraseGrantCode } from "@/lib/grant-code";
+import { expireSession } from "@/lib/grant-management-policy";
+import { resolveControlSession } from "@/lib/grant-management-sessions";
+import {
+  GRANT_CODE_KIND,
+  type ControlGrantScope,
+  type GrantKeyRing,
+  type StoredGrant,
+  type StoredGrantSession,
+  type TerminalGrantSessionReason,
+} from "@/lib/grant-types";
+import {
+  openSqliteFoundationStorage,
+  type SqliteFoundationStorage,
+} from "@/lib/foundation-storage-sqlite";
+import type { FoundationStorageReadinessContext } from "@/lib/foundation-storage";
+import type { FoundationStorageTransaction } from "@/lib/foundation-storage";
+import {
+  FOUNDATION_BACKUP_POLICY_VERSION,
+  inspectRecoveryDatabase,
+  readRepresentedKeyVersions,
+  removeExcludedRelations,
+  quoteRecoverySqliteString,
+  type RepresentedKeyVersions,
+  type RecoverySnapshotFacts,
+} from "@/lib/foundation-recovery-sqlite";
+
+const RECOVERY_MANIFEST_VERSION = "foundation-recovery-manifest-v1" as const;
+const RECOVERY_EVIDENCE_VERSION = "foundation-recovery-evidence-v1" as const;
+const EVENT_ADMIN_IDLE_TTL_MS = 30 * 24 * 60 * 60 * 1_000;
+
+export type FoundationRecoveryManifest = {
+  version: typeof RECOVERY_MANIFEST_VERSION;
+  snapshotId: string;
+  snapshotAtMs: number;
+  policyVersion: typeof FOUNDATION_BACKUP_POLICY_VERSION;
+  databaseFile: string;
+  databaseSha256: string;
+  logicalDigest: string;
+  actionCount: number;
+  representedKeyVersions: RepresentedKeyVersions;
+  restoredGrantVersions: readonly {
+    grantReference: string;
+    grantType: string;
+    grantVersion: string;
+  }[];
+  excludedRelations: readonly string[];
+  verifiedAtMs: number;
+};
+
+export type FoundationRecoveryOptions = {
+  backupDirectory: string;
+  keyRing: GrantKeyRing;
+  readinessContext: FoundationStorageReadinessContext;
+  grant: GrantAuthorityOptions;
+  /** Composed once against this recovery's storage and Grant environment. */
+  acceptance: Omit<FoundationAcceptanceOptions, "grant">;
+  technicalAdminAuth: {
+    /** Separate Technical Admin auth database; it is preserved but never restored as active. */
+    databasePath: string;
+    /** Stops new auth writes and drains/closes the repository before replacement. */
+    quiesce(): Promise<void>;
+  };
+  nowMs?: () => number;
+  createId?: () => string;
+  faultInjector?: (
+    phase:
+      | "after-vacuum"
+      | "after-sanitize"
+      | "after-verification"
+      | "after-restore-staging"
+      | "after-authoritative-quiescence"
+      | "after-final-authority-evaluation"
+      | "after-live-preserved"
+      | "before-live-replacement"
+      | "before-completed-restore-evidence",
+  ) => void;
+};
+
+export type RecoveryGapInput = {
+  gapId: string;
+  category: "controller-history-unavailable" | "server-evidence-unavailable" | "action-rejected";
+  redactedDetail: string;
+};
+
+export type RecoveryImportInput = {
+  importId: string;
+  recordId: string;
+  eventGameId: string;
+  sessionBearer: string;
+  currentGrant: ControlActionGrantProvenance;
+  currentLifecycle: ControlActionLifecycleContext;
+  sourceReference: string;
+  actions: readonly {
+    action: ControlAction;
+    /** Null unless surviving evidence establishes the original server acceptance time. */
+    sourceAcceptedAtMs: number | null;
+  }[];
+  gaps: readonly RecoveryGapInput[];
+};
+
+export type FoundationRecovery = {
+  createPreDeploymentBackup(): Promise<FoundationRecoveryManifest>;
+  verifyBackup(manifestPath: string): Promise<FoundationRecoveryManifest>;
+  restore(manifestPath: string): Promise<{
+    restoreId: string;
+    failedDatabasePath: string;
+    failedTechnicalAdminDatabasePath: string | null;
+    completed: true;
+    evidencePath: string;
+    completionEvidencePath: string | null;
+    completionEvidenceStatus: "written" | "write-failed";
+    potentiallyNewerWork: boolean | null;
+  }>;
+  importControllerRecovery(
+    input: RecoveryImportInput,
+  ): Promise<{ outcome: FoundationBatchOutcome; evidencePath: string }>;
+};
+
+export function createFoundationRecovery(
+  storage: SqliteFoundationStorage,
+  options: FoundationRecoveryOptions,
+): FoundationRecovery {
+  const nowMs = options.nowMs ?? (() => Date.now());
+  const createId = options.createId ?? randomUUID;
+  const backupDirectory = resolve(options.backupDirectory);
+  const livePath = resolve(storage.databasePath);
+  const liveDirectory = dirname(livePath);
+  const technicalAdminPath = resolve(options.technicalAdminAuth.databasePath);
+  if (technicalAdminPath === livePath) {
+    throw new Error("Technical Admin auth must remain separate from Event foundation storage.");
+  }
+  if (options.keyRing !== options.grant.keyRing) {
+    throw new Error("Foundation recovery and acceptance must share one Grant key-ring boundary.");
+  }
+  assertBackupOutsideLiveDirectory(liveDirectory, backupDirectory);
+  const acceptance = createFoundationAcceptance(storage, {
+    ...options.acceptance,
+    grant: options.grant,
+  });
+
+  async function createPreDeploymentBackup(): Promise<FoundationRecoveryManifest> {
+    await prepareBackupWorkspace(liveDirectory, backupDirectory);
+    const snapshotId = boundedId(createId(), "snapshotId");
+    const rawPath = join(backupDirectory, `.${snapshotId}.raw.sqlite`);
+    const stagedPath = join(backupDirectory, `.${snapshotId}.staged.sqlite`);
+    const databasePath = join(backupDirectory, `${snapshotId}.sqlite`);
+    const manifestPath = join(backupDirectory, `${snapshotId}.manifest.json`);
+    const snapshotAtMs = readTime(nowMs);
+    let publishedDatabaseIdentity: StableFileIdentity | null = null;
+    let publishedManifestIdentity: StableFileIdentity | null = null;
+    let rawIdentity: StableFileIdentity | null = null;
+    let stagedIdentity: StableFileIdentity | null = null;
+    let completed = false;
+    try {
+      await assertPathAbsent(rawPath, "raw recovery snapshot");
+      await assertPathAbsent(stagedPath, "sanitized recovery snapshot");
+      await assertPathAbsent(databasePath, "verified recovery snapshot");
+      await assertPathAbsent(manifestPath, "recovery manifest");
+      const sourceFacts = await storage.createRecoveryVacuumSnapshot(rawPath);
+      rawIdentity = await assertOwnedPrivateFile(rawPath, "raw recovery snapshot");
+      options.faultInjector?.("after-vacuum");
+      const raw = new Database(rawPath);
+      try {
+        removeExcludedRelations(raw);
+        raw.exec(`VACUUM INTO ${quoteRecoverySqliteString(stagedPath)};`);
+      } finally {
+        raw.close();
+      }
+      await chmod(stagedPath, 0o600);
+      options.faultInjector?.("after-sanitize");
+      stagedIdentity = await assertOwnedPrivateFile(stagedPath, "sanitized recovery snapshot");
+      const verified = await verifyDatabase(stagedPath, sourceFacts);
+      options.faultInjector?.("after-verification");
+      const manifest: FoundationRecoveryManifest = {
+        version: RECOVERY_MANIFEST_VERSION,
+        snapshotId,
+        snapshotAtMs,
+        policyVersion: FOUNDATION_BACKUP_POLICY_VERSION,
+        databaseFile: basename(databasePath),
+        databaseSha256: await sha256File(stagedPath),
+        logicalDigest: verified.facts.logicalDigest,
+        actionCount: verified.facts.actionCount,
+        representedKeyVersions: verified.keyVersions,
+        restoredGrantVersions: redactGrantVersions(verified.facts),
+        excludedRelations: sourceFacts.excludedRelations,
+        verifiedAtMs: readTime(nowMs),
+      };
+      publishedDatabaseIdentity = await copyStablePrivateFile(stagedPath, databasePath);
+      await removeStablePath(stagedPath, stagedIdentity);
+      stagedIdentity = null;
+      publishedManifestIdentity = await writeJsonFile(manifestPath, manifest);
+      await syncDirectory(backupDirectory);
+      completed = true;
+      return manifest;
+    } finally {
+      if (rawIdentity !== null) await removeStablePath(rawPath, rawIdentity);
+      if (stagedIdentity !== null) await removeStablePath(stagedPath, stagedIdentity);
+      if (!completed && publishedDatabaseIdentity !== null)
+        await removeStablePath(databasePath, publishedDatabaseIdentity);
+      if (!completed && publishedManifestIdentity !== null)
+        await removeStablePath(manifestPath, publishedManifestIdentity);
+    }
+  }
+
+  async function verifyBackup(manifestPath: string): Promise<FoundationRecoveryManifest> {
+    await prepareBackupWorkspace(liveDirectory, backupDirectory);
+    const manifest = await readManifest(manifestPath, backupDirectory);
+    const verificationPath = join(
+      backupDirectory,
+      `.${manifest.snapshotId}.verify-${boundedId(createId(), "verificationId")}.sqlite`,
+    );
+    let verificationIdentity: StableFileIdentity | null = null;
+    try {
+      verificationIdentity = await copyStablePrivateFile(
+        resolveBackupDatabasePath(manifestPath, manifest, backupDirectory),
+        verificationPath,
+        manifest.databaseSha256,
+      );
+      const verified = await verifyDatabase(verificationPath, {
+        logicalDigest: manifest.logicalDigest,
+        actionCount: manifest.actionCount,
+        grantVersions: [],
+        excludedRelations: manifest.excludedRelations,
+      });
+      if (
+        JSON.stringify(verified.keyVersions) !== JSON.stringify(manifest.representedKeyVersions)
+      ) {
+        throw new Error("Verified backup key-version representation changed.");
+      }
+      return manifest;
+    } finally {
+      if (verificationIdentity !== null)
+        await removeStablePath(verificationPath, verificationIdentity);
+      await rm(`${verificationPath}-wal`, { force: true });
+      await rm(`${verificationPath}-shm`, { force: true });
+      await rm(`${verificationPath}.quarantine`, { force: true });
+    }
+  }
+
+  async function restore(manifestPath: string) {
+    await prepareBackupWorkspace(liveDirectory, backupDirectory);
+    const manifest = await readManifest(manifestPath, backupDirectory);
+    const backupPath = resolveBackupDatabasePath(manifestPath, manifest, backupDirectory);
+    const restoreId = boundedId(createId(), "restoreId");
+    const stagedPath = join(liveDirectory, `.${basename(livePath)}.${restoreId}.staged`);
+    const failedDatabasePath = `${livePath}.failed-${restoreId}`;
+    const failedTechnicalAdminDatabasePath = `${technicalAdminPath}.failed-${restoreId}`;
+    const evidencePath = join(backupDirectory, `${restoreId}.restore-evidence.json`);
+    const completionEvidenceCandidatePath = join(
+      backupDirectory,
+      `${restoreId}.restore-completed.json`,
+    );
+    let staged: SqliteFoundationStorage | undefined;
+    let stagedIdentity: StableFileIdentity | null = null;
+    let evidenceIdentity: StableFileIdentity | null = null;
+    try {
+      await assertPathAbsent(failedDatabasePath, "failed Event foundation image");
+      await assertPathAbsent(failedTechnicalAdminDatabasePath, "failed Technical Admin image");
+      await assertPathAbsent(evidencePath, "restore evidence");
+      await assertPathAbsent(completionEvidenceCandidatePath, "completed restore evidence");
+      stagedIdentity = await copyStablePrivateFile(backupPath, stagedPath, manifest.databaseSha256);
+      const verified = await verifyDatabase(stagedPath, {
+        logicalDigest: manifest.logicalDigest,
+        actionCount: manifest.actionCount,
+        grantVersions: [],
+        excludedRelations: manifest.excludedRelations,
+      });
+      if (
+        JSON.stringify(verified.keyVersions) !== JSON.stringify(manifest.representedKeyVersions)
+      ) {
+        throw new Error("Verified backup key-version representation changed.");
+      }
+      options.faultInjector?.("after-restore-staging");
+
+      evidenceIdentity = await writeJsonFile(evidencePath, {
+        version: RECOVERY_EVIDENCE_VERSION,
+        kind: "restore",
+        status: "pending-replacement",
+        restoreId,
+        snapshotId: manifest.snapshotId,
+        snapshotAtMs: manifest.snapshotAtMs,
+        snapshotActionCount: manifest.actionCount,
+        technicalAdminAuthRevived: false,
+        restoredGrantVersions: manifest.restoredGrantVersions,
+      });
+
+      // Both authoritative writer domains are closed before the final current-fact
+      // evaluation. Any writer already queued drains before this boundary; any
+      // later writer is rejected by the closed repositories.
+      await options.technicalAdminAuth.quiesce();
+      await storage.quiesceForRecovery();
+      options.faultInjector?.("after-authoritative-quiescence");
+
+      await assertStablePrivateFile(
+        stagedPath,
+        stagedIdentity,
+        "independently verified restore staging image",
+      );
+      staged = openSqliteFoundationStorage(stagedPath, {
+        grantKeyRing: options.keyRing,
+        grantValidationContext: {
+          environmentId: options.grant.environmentId,
+          keyRing: options.keyRing,
+        },
+      });
+      staged.setReadinessContext(options.readinessContext);
+      await reevaluateRestoredAuthority(staged, options.grant);
+      const stagedReadiness = await staged.readiness();
+      if (!stagedReadiness.ok || stagedReadiness.evidence?.keys.missingCount !== 0) {
+        throw new Error("Restored staging database did not pass independent readiness.");
+      }
+      await staged.quiesceForRecovery();
+      staged = undefined;
+      assertNoTechnicalAdminRelations(stagedPath);
+      const reevaluatedStagedIdentity = await assertOwnedPrivateFile(
+        stagedPath,
+        "verified restore staging image",
+      );
+      if (!samePhysicalFile(reevaluatedStagedIdentity, stagedIdentity)) {
+        throw new Error("Restore staging changed file identity during authority reevaluation.");
+      }
+      stagedIdentity = reevaluatedStagedIdentity;
+      options.faultInjector?.("after-final-authority-evaluation");
+      await assertStablePrivateFile(evidencePath, evidenceIdentity, "pending restore evidence");
+
+      const liveIdentity = stableIdentity(await lstat(livePath));
+      const liveFacts = safelyInspectClosedDatabase(livePath);
+      await assertStableFileIdentity(livePath, liveIdentity, "quiesced Event foundation image");
+      const potentiallyNewerWork =
+        liveFacts === null ? null : liveFacts.logicalDigest !== manifest.logicalDigest;
+      const movedSidecars: Array<{
+        from: string;
+        to: string;
+        identity: StableFileIdentity;
+      }> = [];
+      const installedPaths: Array<{ path: string; identity: StableFileIdentity }> = [];
+      try {
+        const failedLiveIdentity = await moveToExclusivePath(
+          livePath,
+          failedDatabasePath,
+          "failed Event foundation image",
+          liveIdentity,
+        );
+        movedSidecars.push({
+          from: failedDatabasePath,
+          to: livePath,
+          identity: failedLiveIdentity,
+        });
+        for (const suffix of ["-wal", "-shm", ".quarantine"] as const) {
+          const source = `${livePath}${suffix}`;
+          if (!(await pathExists(source))) continue;
+          const failed = `${failedDatabasePath}${suffix}`;
+          const sourceIdentity = stableIdentity(await lstat(source));
+          const failedIdentity = await moveToExclusivePath(
+            source,
+            failed,
+            "failed Event foundation sidecar",
+            sourceIdentity,
+          );
+          movedSidecars.push({ from: failed, to: source, identity: failedIdentity });
+        }
+        if (await pathExists(technicalAdminPath)) {
+          const technicalAdminIdentity = stableIdentity(await lstat(technicalAdminPath));
+          const failedIdentity = await moveToExclusivePath(
+            technicalAdminPath,
+            failedTechnicalAdminDatabasePath,
+            "failed Technical Admin image",
+            technicalAdminIdentity,
+          );
+          movedSidecars.push({
+            from: failedTechnicalAdminDatabasePath,
+            to: technicalAdminPath,
+            identity: failedIdentity,
+          });
+        }
+        for (const suffix of ["-wal", "-shm"] as const) {
+          const source = `${technicalAdminPath}${suffix}`;
+          if (!(await pathExists(source))) continue;
+          const failed = `${failedTechnicalAdminDatabasePath}${suffix}`;
+          const sourceIdentity = stableIdentity(await lstat(source));
+          const failedIdentity = await moveToExclusivePath(
+            source,
+            failed,
+            "failed Technical Admin sidecar",
+            sourceIdentity,
+          );
+          movedSidecars.push({ from: failed, to: source, identity: failedIdentity });
+        }
+        options.faultInjector?.("after-live-preserved");
+        options.faultInjector?.("before-live-replacement");
+        installedPaths.push({
+          path: livePath,
+          identity: await moveToExclusivePath(
+            stagedPath,
+            livePath,
+            "restored Event foundation image",
+            stagedIdentity,
+          ),
+        });
+        stagedIdentity = null;
+        for (const suffix of ["-wal", "-shm"] as const) {
+          if (await pathExists(`${stagedPath}${suffix}`)) {
+            const stagedSidecarPath = `${stagedPath}${suffix}`;
+            const stagedSidecarIdentity = stableIdentity(await lstat(stagedSidecarPath));
+            installedPaths.push({
+              path: `${livePath}${suffix}`,
+              identity: await moveToExclusivePath(
+                stagedSidecarPath,
+                `${livePath}${suffix}`,
+                "restored Event foundation sidecar",
+                stagedSidecarIdentity,
+              ),
+            });
+          }
+        }
+        await syncDirectory(liveDirectory);
+        if (dirname(technicalAdminPath) !== liveDirectory) {
+          await syncDirectory(dirname(technicalAdminPath));
+        }
+      } catch (error) {
+        for (const installed of installedPaths.reverse())
+          await removeStablePath(installed.path, installed.identity);
+        for (const moved of movedSidecars.reverse()) {
+          if (await pathExists(moved.from))
+            await moveToExclusivePath(
+              moved.from,
+              moved.to,
+              "recovery rollback image",
+              moved.identity,
+            );
+        }
+        await syncDirectory(liveDirectory);
+        if (dirname(technicalAdminPath) !== liveDirectory) {
+          await syncDirectory(dirname(technicalAdminPath));
+        }
+        throw error;
+      }
+      const restoredFacts = safelyInspectClosedDatabase(livePath);
+      const evidence = {
+        version: RECOVERY_EVIDENCE_VERSION,
+        kind: "restore",
+        status: "completed",
+        restoreId,
+        restoredAtMs: readTime(nowMs),
+        snapshotId: manifest.snapshotId,
+        snapshotAtMs: manifest.snapshotAtMs,
+        snapshotActionCount: manifest.actionCount,
+        liveActionCountBeforeRestore: liveFacts?.actionCount ?? null,
+        potentiallyNewerWork,
+        failedDatabasePath,
+        failedTechnicalAdminDatabasePath: (await pathExists(failedTechnicalAdminDatabasePath))
+          ? failedTechnicalAdminDatabasePath
+          : null,
+        technicalAdminAuthRevived: false,
+        restoredGrantVersions:
+          restoredFacts === null
+            ? manifest.restoredGrantVersions
+            : redactGrantVersions(restoredFacts),
+      };
+      let completionEvidencePath: string | null = null;
+      let completionEvidenceStatus: "written" | "write-failed" = "write-failed";
+      try {
+        await assertStablePrivateFile(evidencePath, evidenceIdentity, "pending restore evidence");
+        options.faultInjector?.("before-completed-restore-evidence");
+        await writeAtomicJsonFile(completionEvidenceCandidatePath, evidence);
+        completionEvidencePath = completionEvidenceCandidatePath;
+        completionEvidenceStatus = "written";
+      } catch {
+        // Cutover is already complete. The immutable, synced pending record and
+        // explicit return state prevent a write failure from being reported as
+        // a failed restore or inviting an unsafe retry.
+      }
+      return {
+        restoreId,
+        failedDatabasePath,
+        failedTechnicalAdminDatabasePath: (await pathExists(failedTechnicalAdminDatabasePath))
+          ? failedTechnicalAdminDatabasePath
+          : null,
+        completed: true as const,
+        evidencePath,
+        completionEvidencePath,
+        completionEvidenceStatus,
+        potentiallyNewerWork,
+      };
+    } finally {
+      staged?.close();
+      if (stagedIdentity !== null) await removeStablePath(stagedPath, stagedIdentity);
+      await rm(`${stagedPath}-wal`, { force: true });
+      await rm(`${stagedPath}-shm`, { force: true });
+    }
+  }
+
+  async function importControllerRecovery(
+    input: RecoveryImportInput,
+  ): Promise<{ outcome: FoundationBatchOutcome; evidencePath: string }> {
+    await prepareBackupWorkspace(liveDirectory, backupDirectory);
+    const normalized = normalizeRecoveryImport(input);
+    const evidencePath = join(backupDirectory, `${normalized.importId}.recovery-import.json`);
+    await assertPathAbsent(evidencePath, "recovery import evidence");
+    const pendingEvidence = {
+      version: RECOVERY_EVIDENCE_VERSION,
+      kind: "recovery-import",
+      importId: normalized.importId,
+      recordedAtMs: readTime(nowMs),
+      status: "pending",
+      eventGameReference: redactReference(normalized.eventGameId),
+      actionOperationReferences: normalized.actions.map((action) =>
+        redactReference(action.action.operationId),
+      ),
+      gaps: normalized.gaps,
+    };
+    const evidenceIdentity = await writeJsonFile(evidencePath, pendingEvidence);
+    const actions = normalized.actions.map(({ action: source, sourceAcceptedAtMs }) => ({
+      recordId: normalized.recordId,
+      eventGameId: normalized.eventGameId,
+      operationId: source.operationId,
+      kind: source.kind,
+      payload: structuredClone(source.payload),
+      causalPredecessorIds: [...source.causalPredecessorIds],
+      occurrence: structuredClone(source.occurrence),
+      grant: structuredClone(normalized.currentGrant),
+      lifecycle: structuredClone(normalized.currentLifecycle),
+      ...(source.override === undefined ? {} : { override: structuredClone(source.override) }),
+      recoveryProvenance: {
+        importId: normalized.importId,
+        sourceRecordId: normalized.recordId,
+        sourceEventGameId: normalized.eventGameId,
+        sourceOperationId: source.operationId,
+        sourceReference: normalized.sourceReference,
+        sourceAcceptedAtMs,
+      },
+    }));
+    const outcome = await acceptance.submitBatch({
+      recordId: normalized.recordId,
+      eventGameId: normalized.eventGameId,
+      mode: "online",
+      sessionBearer: normalized.sessionBearer,
+      actions,
+    });
+    const rejectionGaps = normalized.actions.flatMap((_, index) => {
+      const result = outcome.results[index];
+      return result?.status === "accepted" || result?.status === "duplicate-accepted"
+        ? []
+        : [
+            {
+              gapId: `action-${index + 1}-not-accepted`,
+              category: "action-rejected" as const,
+              redactedDetail: "A supplied Controller action was not recovered.",
+            },
+          ];
+    });
+    await writeJsonFile(
+      evidencePath,
+      {
+        ...pendingEvidence,
+        recordedAtMs: readTime(nowMs),
+        status: outcome.status,
+        gaps: [...normalized.gaps, ...rejectionGaps],
+      },
+      "replace-owned",
+      evidenceIdentity,
+    );
+    return { outcome, evidencePath };
+  }
+
+  async function verifyDatabase(
+    databasePath: string,
+    expected: RecoverySnapshotFacts,
+  ): Promise<{ facts: RecoverySnapshotFacts; keyVersions: RepresentedKeyVersions }> {
+    const verificationPath = `${databasePath}.verify-${boundedId(createId(), "verificationId")}`;
+    const verificationIdentity = await copyStablePrivateFile(databasePath, verificationPath);
+    let verifier: SqliteFoundationStorage | undefined;
+    try {
+      assertNoTechnicalAdminRelations(verificationPath);
+      const inspection = new Database(verificationPath, { readonly: true });
+      let facts: RecoverySnapshotFacts;
+      let keyVersions: RepresentedKeyVersions;
+      try {
+        facts = inspectRecoveryDatabase(inspection);
+        keyVersions = readRepresentedKeyVersions(inspection);
+      } finally {
+        inspection.close();
+      }
+      if (
+        facts.logicalDigest !== expected.logicalDigest ||
+        facts.actionCount !== expected.actionCount
+      ) {
+        throw new Error("Backup deterministic state differs from the quiesced recovery point.");
+      }
+      requireRepresentedKeys(keyVersions, options.keyRing);
+      verifier = openSqliteFoundationStorage(verificationPath, {
+        grantKeyRing: options.keyRing,
+        grantValidationContext: {
+          environmentId: options.grant.environmentId,
+          keyRing: options.keyRing,
+        },
+      });
+      verifier.setReadinessContext(options.readinessContext);
+      const readiness = await verifier.readiness();
+      if (!readiness.ok || readiness.evidence?.keys.missingCount !== 0) {
+        throw new Error(
+          "Independent backup integrity, reference, key, or replay verification failed.",
+        );
+      }
+      return { facts, keyVersions };
+    } finally {
+      verifier?.close();
+      await removeStablePath(verificationPath, verificationIdentity);
+      await rm(`${verificationPath}-wal`, { force: true });
+      await rm(`${verificationPath}-shm`, { force: true });
+      await rm(`${verificationPath}.quarantine`, { force: true });
+    }
+  }
+
+  return { createPreDeploymentBackup, verifyBackup, restore, importControllerRecovery };
+}
+
+async function reevaluateRestoredAuthority(
+  storage: SqliteFoundationStorage,
+  options: GrantAuthorityOptions,
+): Promise<void> {
+  await storage.transaction((transaction) => {
+    const current = readTime(() => options.clock.nowMs());
+    for (const stored of transaction.listGrants()) {
+      const grant = expireGrantIfDue(transaction, options, stored);
+      if (grant.status !== "active") continue;
+      if (grant.grantType === "event-admin") {
+        for (const session of transaction.listGrantSessions(grant.grantId)) {
+          if (
+            session.status === "active" &&
+            current >=
+              Math.min(
+                grant.expiresAtMs ?? Number.MAX_SAFE_INTEGER,
+                session.lastActiveAtMs + EVENT_ADMIN_IDLE_TTL_MS,
+              )
+          )
+            expireSession(transaction, options, grant, session);
+        }
+        continue;
+      }
+      if (grant.grantType !== "control") continue;
+      const resolveSession = options.controlScopeResolver.resolveSession;
+      const activeSessions = transaction
+        .listGrantSessions(grant.grantId)
+        .filter((session) => session.status === "active");
+      if (activeSessions.length > 0 && resolveSession === undefined) {
+        throw new Error("Current Control Session lifecycle seam is unavailable during restore.");
+      }
+      const currentLockedEventGameId =
+        grant.code?.state === "present"
+          ? resolveCurrentGrantCodeGameLock(options, grant.scope as ControlGrantScope)
+          : null;
+      for (const session of activeSessions) {
+        let resolution;
+        try {
+          resolution = resolveControlSession(
+            transaction,
+            options,
+            grant.scope as ControlGrantScope,
+            session.eventGameId,
+          );
+        } catch {
+          throw new Error(
+            "Current Control Session lifecycle could not be resolved during restore.",
+          );
+        }
+        if (
+          resolution.status === "current" ||
+          resolution.status === "pinned" ||
+          resolution.status === "switchable"
+        )
+          continue;
+        if (resolution.status !== "game-locked" && resolution.status !== "past-game-day") {
+          throw new Error(
+            "Current Control Session lifecycle could not be resolved during restore.",
+          );
+        }
+        terminateExactRestoredControlSession(
+          transaction,
+          options,
+          grant,
+          session,
+          resolution.status,
+        );
+      }
+      if (currentLockedEventGameId !== null && grant.code?.state === "present") {
+        const erased = eraseGrantCode(grant.code, "erased");
+        transaction.updateGrant({ ...grant, code: erased });
+        const audit = createAuditEntry(options, {
+          action: "grant-code-erased-game-lock",
+          actor: { kind: "system", value: "grant-session-termination" },
+          grant,
+          sessionId: null,
+          replacedSessionId: null,
+          eventGameId: currentLockedEventGameId,
+          beforeStatus: grant.status,
+          afterStatus: grant.status,
+          terminalReason: "game-locked",
+        });
+        transaction.appendGrantAudit({
+          ...audit,
+          credentialKind: GRANT_CODE_KIND,
+          credentialFingerprint: grant.code.fingerprint,
+          codeFormatVersion: grant.code.formatVersion,
+          codeEncryptionKeyVersion: grant.code.encryptionKeyVersion,
+          codeLookupKeyVersion: grant.code.lookupKeyVersion,
+          codeStateBefore: grant.code.state,
+          codeState: "erased",
+          previousCodeFingerprint: grant.code.fingerprint,
+        });
+      }
+    }
+  });
+}
+
+function resolveCurrentGrantCodeGameLock(
+  options: GrantAuthorityOptions,
+  scope: ControlGrantScope,
+): string | null {
+  let resolution;
+  try {
+    resolution = options.controlScopeResolver.resolve(scope);
+  } catch {
+    throw new Error("Current Control Grant lifecycle could not be resolved during restore.");
+  }
+  if (resolution.status === "eligible") {
+    boundedId(resolution.eventGameId, "eventGameId");
+    return null;
+  }
+  if (resolution.status === "terminal") {
+    if (resolution.reason !== "game-locked") return null;
+    if (resolution.eventGameId === undefined) {
+      throw new Error("Current Control Grant Game Lock identity is unavailable during restore.");
+    }
+    return boundedId(resolution.eventGameId, "eventGameId");
+  }
+  throw new Error("Current Control Grant lifecycle could not be resolved during restore.");
+}
+
+function terminateExactRestoredControlSession(
+  transaction: FoundationStorageTransaction,
+  options: GrantAuthorityOptions,
+  grant: StoredGrant,
+  session: StoredGrantSession,
+  reason: Extract<TerminalGrantSessionReason, "game-locked" | "past-game-day">,
+): void {
+  const terminatedAtMs = readTime(() => options.clock.nowMs());
+  transaction.updateGrantSession({
+    ...session,
+    status: "expired",
+    bearerMaterialState: "erased",
+    bearerLookupVerifier: null,
+    bearerLookupKeyVersion: null,
+    revokedAtMs: terminatedAtMs,
+  });
+  transaction.appendGrantAudit(
+    createAuditEntry(options, {
+      action: "session-terminated",
+      actor: { kind: "system", value: "grant-session-termination" },
+      grant,
+      sessionId: session.sessionId,
+      replacedSessionId: null,
+      eventGameId: session.eventGameId,
+      beforeStatus: grant.status,
+      afterStatus: grant.status,
+      terminalReason: reason,
+    }),
+  );
+}
+
+function normalizeRecoveryImport(input: RecoveryImportInput): RecoveryImportInput {
+  const importId = boundedId(input.importId, "importId");
+  boundedId(input.recordId, "recordId");
+  boundedId(input.eventGameId, "eventGameId");
+  boundedId(input.sourceReference, "sourceReference");
+  if (
+    !Array.isArray(input.actions) ||
+    input.actions.length === 0 ||
+    input.actions.length > ACCEPTANCE_LIMITS.maxBatchActions
+  )
+    throw new Error("Recovery import action count is outside the bounded batch limit.");
+  if (!Array.isArray(input.gaps) || input.gaps.length > ACCEPTANCE_LIMITS.maxBatchActions)
+    throw new Error("Recovery Gap count is outside the bounded batch limit.");
+  if (input.actions.length + input.gaps.length > ACCEPTANCE_LIMITS.maxBatchActions * 2)
+    throw new Error("Recovery import evidence count is outside the bounded limit.");
+  if (typeof input.sessionBearer !== "string" || input.sessionBearer.length === 0) {
+    throw new Error("Recovery import requires fresh current Grant Session authorization.");
+  }
+  for (const recovered of input.actions) {
+    if (
+      recovered.action.recordId !== input.recordId ||
+      recovered.action.eventGameId !== input.eventGameId
+    ) {
+      throw new Error("Recovery import rejected cross-Game Controller evidence.");
+    }
+    if (
+      recovered.sourceAcceptedAtMs !== null &&
+      (!Number.isSafeInteger(recovered.sourceAcceptedAtMs) || recovered.sourceAcceptedAtMs < 0)
+    )
+      throw new Error("Recovery source acceptance time is invalid.");
+  }
+  const gaps = input.gaps.map((gap) => ({
+    gapId: boundedId(gap.gapId, "gapId"),
+    category: gap.category,
+    redactedDetail: boundedRedactedDetail(gap.redactedDetail),
+  }));
+  return { ...input, importId, gaps };
+}
+
+function requireRepresentedKeys(versions: RepresentedKeyVersions, keyRing: GrantKeyRing): void {
+  for (const category of ["encryption", "lookup", "audit"] as const) {
+    for (const version of versions[category]) {
+      if (!keyRing[category].keys.has(version)) {
+        throw new Error(
+          `Separately supplied ${category} key ring is missing a represented version.`,
+        );
+      }
+    }
+  }
+}
+
+function assertNoTechnicalAdminRelations(databasePath: string): void {
+  const database = new Database(databasePath, { readonly: true });
+  try {
+    const facts = inspectRecoveryDatabase(database);
+    if (facts.excludedRelations.length !== 0) {
+      throw new Error("Technical Admin authentication state survived backup sanitization.");
+    }
+  } finally {
+    database.close();
+  }
+}
+
+function safelyInspectClosedDatabase(databasePath: string): RecoverySnapshotFacts | null {
+  try {
+    const database = new Database(databasePath, { readonly: true });
+    try {
+      return inspectRecoveryDatabase(database);
+    } finally {
+      database.close();
+    }
+  } catch {
+    return null;
+  }
+}
+
+function redactGrantVersions(facts: RecoverySnapshotFacts) {
+  return facts.grantVersions.map((grant) => ({
+    grantReference: redactReference(grant.grantId),
+    grantType: grant.grantType,
+    grantVersion: grant.grantVersion,
+  }));
+}
+
+function redactReference(value: string): string {
+  return `sha256:${createHash("sha256").update(value).digest("hex").slice(0, 16)}`;
+}
+
+function boundedRedactedDetail(value: string): string {
+  if (typeof value !== "string" || value.length === 0 || value.length > 160) {
+    throw new Error("Recovery Gap detail must be a bounded redacted statement.");
+  }
+  if (/bearer|credential|cipher|token|secret|lookup|passkey/i.test(value)) {
+    throw new Error("Recovery Gap detail appears to contain authority material.");
+  }
+  return value;
+}
+
+function boundedId(value: string, label: string): string {
+  if (typeof value !== "string" || !/^[A-Za-z0-9._-]{1,128}$/.test(value)) {
+    throw new Error(`${label} must be an opaque bounded identifier.`);
+  }
+  return value;
+}
+
+function readTime(now: () => number): number {
+  const value = now();
+  if (!Number.isSafeInteger(value) || value < 0) throw new Error("Recovery clock is invalid.");
+  return value;
+}
+
+function assertBackupOutsideLiveDirectory(liveDirectory: string, backupDirectory: string): void {
+  if (!isAbsolute(backupDirectory)) throw new Error("Backup directory must be absolute.");
+  const location = relative(liveDirectory, backupDirectory);
+  if (location === "" || (!location.startsWith("..") && !isAbsolute(location))) {
+    throw new Error("Verified SQLite backups must be outside the live database directory.");
+  }
+}
+
+async function sha256File(path: string): Promise<string> {
+  return createHash("sha256")
+    .update(await readStablePrivateFile(path))
+    .digest("hex");
+}
+
+async function writeJsonFile(
+  path: string,
+  value: unknown,
+  mode: "create" | "replace-owned" = "create",
+  expectedIdentity?: StableFileIdentity,
+): Promise<StableFileIdentity> {
+  const flags =
+    mode === "create"
+      ? fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_NOFOLLOW
+      : fsConstants.O_WRONLY | fsConstants.O_NOFOLLOW;
+  const handle = await openFile(path, flags, 0o600);
+  let openedIdentity: StableFileIdentity | null = null;
+  try {
+    await handle.chmod(0o600);
+    openedIdentity = stableIdentity(await handle.stat());
+    await assertStablePrivateFile(path, openedIdentity, "recovery evidence");
+    if (expectedIdentity !== undefined && !samePhysicalFile(openedIdentity, expectedIdentity)) {
+      throw new Error("Recovery evidence changed file identity before it was updated.");
+    }
+    if (mode === "replace-owned") await handle.truncate(0);
+    await handle.writeFile(`${JSON.stringify(value, null, 2)}\n`);
+    await handle.sync();
+    const writtenIdentity = stableIdentity(await handle.stat());
+    if (!samePhysicalFile(openedIdentity, writtenIdentity)) {
+      throw new Error("Recovery evidence changed file identity while it was written.");
+    }
+    await assertStablePrivateFile(path, writtenIdentity, "recovery evidence");
+    await handle.close();
+    await assertStablePrivateFile(path, writtenIdentity, "recovery evidence");
+    await syncDirectory(dirname(path));
+    return writtenIdentity;
+  } catch (error) {
+    await handle.close().catch(() => undefined);
+    if (mode === "create" && openedIdentity !== null) {
+      await removeStablePath(path, openedIdentity);
+    }
+    throw error;
+  }
+}
+
+async function writeAtomicJsonFile(path: string, value: unknown): Promise<StableFileIdentity> {
+  await assertPathAbsent(path, "atomic recovery evidence");
+  const temporaryPath = `${path}.${randomUUID()}.tmp`;
+  let temporaryIdentity: StableFileIdentity | null = null;
+  try {
+    temporaryIdentity = await writeJsonFile(temporaryPath, value);
+    const publishedIdentity = await moveToExclusivePath(
+      temporaryPath,
+      path,
+      "atomic recovery evidence",
+      temporaryIdentity,
+    );
+    temporaryIdentity = null;
+    await syncDirectory(dirname(path));
+    return publishedIdentity;
+  } finally {
+    if (temporaryIdentity !== null) {
+      await removeStablePath(temporaryPath, temporaryIdentity);
+    }
+  }
+}
+
+async function syncDirectory(path: string): Promise<void> {
+  const handle = await openFile(path, "r");
+  try {
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+}
+
+async function readManifest(
+  path: string,
+  backupDirectory: string,
+): Promise<FoundationRecoveryManifest> {
+  const resolvedPath = resolve(path);
+  if (dirname(resolvedPath) !== backupDirectory) {
+    throw new Error("Recovery manifest must be in the owned backup workspace.");
+  }
+  const parsed: unknown = JSON.parse((await readStablePrivateFile(resolvedPath)).toString("utf8"));
+  if (
+    typeof parsed !== "object" ||
+    parsed === null ||
+    (parsed as { version?: unknown }).version !== RECOVERY_MANIFEST_VERSION ||
+    (parsed as { policyVersion?: unknown }).policyVersion !== FOUNDATION_BACKUP_POLICY_VERSION ||
+    typeof (parsed as { snapshotId?: unknown }).snapshotId !== "string" ||
+    typeof (parsed as { databaseFile?: unknown }).databaseFile !== "string" ||
+    !/^[a-f0-9]{64}$/.test(String((parsed as { databaseSha256?: unknown }).databaseSha256)) ||
+    !Number.isSafeInteger((parsed as { actionCount?: unknown }).actionCount) ||
+    (parsed as { actionCount: number }).actionCount < 0
+  )
+    throw new Error("Recovery manifest is incompatible.");
+  const manifest = parsed as FoundationRecoveryManifest;
+  boundedId(manifest.snapshotId, "snapshotId");
+  if (manifest.databaseFile !== `${manifest.snapshotId}.sqlite`) {
+    throw new Error("Recovery manifest database identity is invalid.");
+  }
+  return manifest;
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await lstat(path);
+    return true;
+  } catch (error) {
+    if (!isMissingPathError(error)) throw error;
+    return false;
+  }
+}
+
+type StableFileIdentity = {
+  dev: number;
+  ino: number;
+  size: number;
+  mtimeMs: number;
+};
+
+async function prepareBackupWorkspace(
+  liveDirectory: string,
+  backupDirectory: string,
+): Promise<void> {
+  try {
+    await lstat(backupDirectory);
+  } catch (error) {
+    if (!isMissingPathError(error)) throw error;
+    await mkdir(backupDirectory, { recursive: true, mode: 0o700 });
+  }
+  const workspace = await lstat(backupDirectory);
+  const currentUid = process.getuid?.();
+  if (
+    workspace.isSymbolicLink() ||
+    !workspace.isDirectory() ||
+    (workspace.mode & 0o777) !== 0o700 ||
+    (currentUid !== undefined && workspace.uid !== currentUid)
+  )
+    throw new Error("Recovery backup workspace must be an owned non-symlink 0700 directory.");
+  const physicalLiveDirectory = await realpath(liveDirectory);
+  const physicalBackupDirectory = await realpath(backupDirectory);
+  assertBackupOutsideLiveDirectory(physicalLiveDirectory, physicalBackupDirectory);
+}
+
+async function assertPathAbsent(path: string, label: string): Promise<void> {
+  try {
+    await lstat(path);
+  } catch (error) {
+    if (isMissingPathError(error)) return;
+    throw error;
+  }
+  throw new Error(`Refusing to replace a pre-existing ${label} path.`);
+}
+
+async function assertOwnedPrivateFile(path: string, label: string): Promise<StableFileIdentity> {
+  const info = await lstat(path);
+  const currentUid = process.getuid?.();
+  if (
+    info.isSymbolicLink() ||
+    !info.isFile() ||
+    (info.mode & 0o777) !== 0o600 ||
+    (currentUid !== undefined && info.uid !== currentUid)
+  )
+    throw new Error(`${label} must be an owned non-symlink 0600 regular file.`);
+  return stableIdentity(info);
+}
+
+async function assertStablePrivateFile(
+  path: string,
+  expected: StableFileIdentity,
+  label: string,
+): Promise<void> {
+  const current = await assertOwnedPrivateFile(path, label);
+  if (!samePhysicalFile(current, expected)) {
+    throw new Error(`${label} changed file identity during recovery.`);
+  }
+}
+
+async function assertStableFileIdentity(
+  path: string,
+  expected: StableFileIdentity,
+  label: string,
+): Promise<void> {
+  const current = stableIdentity(await lstat(path));
+  if (!sameFileSnapshot(current, expected)) {
+    throw new Error(`${label} changed during recovery.`);
+  }
+}
+
+async function readStablePrivateFile(path: string): Promise<Buffer> {
+  const handle = await openFile(path, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
+  try {
+    const before = stableIdentity(await handle.stat());
+    await assertStablePrivateFile(path, before, "recovery source file");
+    const content = await handle.readFile();
+    const after = stableIdentity(await handle.stat());
+    if (!sameFileSnapshot(before, after)) {
+      throw new Error("Recovery source file changed while it was read.");
+    }
+    await assertStablePrivateFile(path, before, "recovery source file");
+    return content;
+  } finally {
+    await handle.close();
+  }
+}
+
+async function copyStablePrivateFile(
+  sourcePath: string,
+  destinationPath: string,
+  expectedSha256?: string,
+): Promise<StableFileIdentity> {
+  const content = await readStablePrivateFile(sourcePath);
+  if (
+    expectedSha256 !== undefined &&
+    createHash("sha256").update(content).digest("hex") !== expectedSha256
+  )
+    throw new Error("Verified backup file identity does not match its manifest.");
+  const destination = await openFile(
+    destinationPath,
+    fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_NOFOLLOW,
+    0o600,
+  );
+  let openedIdentity: StableFileIdentity | null = null;
+  try {
+    await destination.chmod(0o600);
+    openedIdentity = stableIdentity(await destination.stat());
+    await assertStablePrivateFile(destinationPath, openedIdentity, "recovery copy");
+    await destination.writeFile(content);
+    await destination.sync();
+    const writtenIdentity = stableIdentity(await destination.stat());
+    if (!samePhysicalFile(openedIdentity, writtenIdentity)) {
+      throw new Error("Recovery copy changed file identity while it was written.");
+    }
+    await assertStablePrivateFile(destinationPath, writtenIdentity, "recovery copy");
+    await destination.close();
+    await assertStablePrivateFile(destinationPath, writtenIdentity, "recovery copy");
+    return writtenIdentity;
+  } catch (error) {
+    await destination.close().catch(() => undefined);
+    if (openedIdentity !== null) await removeStablePath(destinationPath, openedIdentity);
+    throw error;
+  }
+}
+
+async function moveToExclusivePath(
+  sourcePath: string,
+  destinationPath: string,
+  label: string,
+  expectedIdentity: StableFileIdentity,
+): Promise<StableFileIdentity> {
+  const sourceIdentity = await tightenStableOwnedFile(sourcePath, expectedIdentity, label);
+  let destinationCreated = false;
+  try {
+    await link(sourcePath, destinationPath);
+    destinationCreated = true;
+    const destinationIdentity = await assertOwnedPrivateFile(destinationPath, label);
+    if (!sameFileSnapshot(sourceIdentity, destinationIdentity)) {
+      throw new Error(`${label} source changed before exclusive publication.`);
+    }
+    const currentSource = await assertOwnedPrivateFile(sourcePath, `${label} source`);
+    if (!sameFileSnapshot(sourceIdentity, currentSource)) {
+      throw new Error(`${label} source changed during exclusive publication.`);
+    }
+    await unlink(sourcePath);
+    const publishedIdentity = await assertOwnedPrivateFile(destinationPath, label);
+    if (!sameFileSnapshot(sourceIdentity, publishedIdentity)) {
+      throw new Error(`${label} changed after exclusive publication.`);
+    }
+    return publishedIdentity;
+  } catch (error) {
+    if (destinationCreated) await removeStablePath(destinationPath, sourceIdentity);
+    throw error;
+  }
+}
+
+async function tightenStableOwnedFile(
+  path: string,
+  expected: StableFileIdentity,
+  label: string,
+): Promise<StableFileIdentity> {
+  const handle = await openFile(path, fsConstants.O_RDWR | fsConstants.O_NOFOLLOW);
+  try {
+    const beforeInfo = await handle.stat();
+    const currentUid = process.getuid?.();
+    if (!beforeInfo.isFile() || (currentUid !== undefined && beforeInfo.uid !== currentUid)) {
+      throw new Error(`${label} source must be an owned non-symlink regular file.`);
+    }
+    const before = stableIdentity(beforeInfo);
+    if (!sameFileSnapshot(before, expected)) {
+      throw new Error(`${label} source changed before exclusive publication.`);
+    }
+    await assertStableFileIdentity(path, before, `${label} source`);
+    await handle.chmod(0o600);
+    await handle.sync();
+    const afterInfo = await handle.stat();
+    const after = stableIdentity(afterInfo);
+    if (
+      !afterInfo.isFile() ||
+      (afterInfo.mode & 0o777) !== 0o600 ||
+      (currentUid !== undefined && afterInfo.uid !== currentUid) ||
+      !sameFileSnapshot(before, after)
+    ) {
+      throw new Error(`${label} source changed while its private mode was enforced.`);
+    }
+    await assertStablePrivateFile(path, after, `${label} source`);
+    return after;
+  } finally {
+    await handle.close();
+  }
+}
+
+async function removeStablePath(path: string, expected: StableFileIdentity): Promise<void> {
+  let current: StableFileIdentity;
+  try {
+    current = stableIdentity(await lstat(path));
+  } catch (error) {
+    if (isMissingPathError(error)) return;
+    throw error;
+  }
+  if (!samePhysicalFile(current, expected)) {
+    throw new Error("Refusing to remove a recovery path whose file identity changed.");
+  }
+  await unlink(path);
+}
+
+function resolveBackupDatabasePath(
+  manifestPath: string,
+  manifest: FoundationRecoveryManifest,
+  backupDirectory: string,
+): string {
+  if (dirname(resolve(manifestPath)) !== backupDirectory) {
+    throw new Error("Recovery manifest must be in the owned backup workspace.");
+  }
+  const databasePath = resolve(backupDirectory, manifest.databaseFile);
+  if (
+    dirname(databasePath) !== backupDirectory ||
+    basename(databasePath) !== manifest.databaseFile
+  ) {
+    throw new Error("Recovery manifest database path escapes its directory.");
+  }
+  return databasePath;
+}
+
+function stableIdentity(info: {
+  dev: number;
+  ino: number;
+  size: number;
+  mtimeMs: number;
+}): StableFileIdentity {
+  return { dev: info.dev, ino: info.ino, size: info.size, mtimeMs: info.mtimeMs };
+}
+
+function samePhysicalFile(left: StableFileIdentity, right: StableFileIdentity): boolean {
+  return left.dev === right.dev && left.ino === right.ino;
+}
+
+function sameFileSnapshot(left: StableFileIdentity, right: StableFileIdentity): boolean {
+  return (
+    samePhysicalFile(left, right) && left.size === right.size && left.mtimeMs === right.mtimeMs
+  );
+}
+
+function isMissingPathError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { code?: unknown }).code === "ENOENT"
+  );
+}

--- a/src/lib/foundation-storage-sqlite.ts
+++ b/src/lib/foundation-storage-sqlite.ts
@@ -1,6 +1,7 @@
 import { Database } from "bun:sqlite";
 import {
   closeSync,
+  chmodSync,
   fsyncSync,
   lstatSync,
   openSync,
@@ -51,6 +52,12 @@ import {
   type MigrationReadiness,
 } from "@/lib/foundation-migrations";
 import { verifyFoundationSchema, readValidatedFoundationRoot } from "@/lib/foundation-schema";
+import {
+  FOUNDATION_BACKUP_POLICY,
+  inspectRecoveryDatabase,
+  quoteRecoverySqliteString,
+  type RecoverySnapshotFacts,
+} from "@/lib/foundation-recovery-sqlite";
 import {
   FoundationStorageClosedError,
   FoundationStorageConstraintError,
@@ -368,10 +375,6 @@ function emptyKeyCounts(): FoundationStorageKeyCounts {
   return { encryption: 0, lookup: 0, audit: 0 };
 }
 
-function keyCategory(kind: "e" | "l" | "a"): FoundationStorageKeyCategory {
-  return kind === "e" ? "encryption" : kind === "l" ? "lookup" : "audit";
-}
-
 function extractIntegrityKeyVersion(value: unknown): string | null {
   if (typeof value !== "string") return null;
   const match = /^hmac-sha256-v1:([^:]{1,64}):[^:]{1,256}$/.exec(value);
@@ -628,6 +631,58 @@ export class SqliteFoundationStorage implements FoundationStorage {
     if (this.closed) return;
     this.closed = true;
     this.database.close();
+  }
+
+  /**
+   * Recovery-only seam. The writer queue drains before the snapshot and remains
+   * held until VACUUM INTO has fixed the complete SQLite image.
+   */
+  createRecoveryVacuumSnapshot(destinationPath: string): Promise<RecoverySnapshotFacts> {
+    return this.enqueue(() => {
+      if (this.databasePath === ":memory:") {
+        throw new Error("A file-backed database is required for recovery snapshots.");
+      }
+      if (this.unsafeFailure === "corruption") {
+        throw new FoundationStorageNotReadyError(this.readinessSync());
+      }
+      const facts = inspectRecoveryDatabase(this.database, FOUNDATION_BACKUP_POLICY);
+      const previousUmask = process.umask(0o177);
+      try {
+        this.database.exec(`VACUUM INTO ${quoteRecoverySqliteString(destinationPath)};`);
+      } finally {
+        process.umask(previousUmask);
+      }
+      // The destination lives in the recovery-owned 0700 workspace. Tighten
+      // and verify the raw unsanitized image before yielding the writer queue.
+      chmodSync(destinationPath, 0o600);
+      return facts;
+    });
+  }
+
+  /** Drain authoritative work and close the handle before a staged replacement. */
+  quiesceForRecovery(): Promise<void> {
+    const queued = this.writerTail.then(() => {
+      this.assertOpen();
+      if (this.unsafeFailure !== "corruption") {
+        const checkpoint = this.database.query("PRAGMA wal_checkpoint(TRUNCATE)").get() as {
+          busy?: number | bigint;
+        } | null;
+        if (Number(checkpoint?.busy ?? 0) !== 0) {
+          throw new Error("SQLite recovery quiescence could not checkpoint the WAL.");
+        }
+        const journalMode = readText(this.database.query("PRAGMA journal_mode = DELETE").get());
+        if (journalMode.toLowerCase() !== "delete") {
+          throw new Error("SQLite recovery quiescence could not seal a portable database image.");
+        }
+      }
+      this.closed = true;
+      this.database.close();
+    });
+    this.writerTail = queued.then(
+      () => undefined,
+      () => undefined,
+    );
+    return queued;
   }
 
   setGrantKeyRing(keyRing: GrantKeyRing): void {
@@ -1856,7 +1911,7 @@ export class SqliteFoundationStorage implements FoundationStorage {
     const keyRing = this.grantValidationContext.keyRing;
     const required = new Set<string>();
     const requiredCategories = emptyKeyCounts();
-    const addRequired = (kind: "e" | "l" | "a", version: string | null): void => {
+    const addRequired = (category: FoundationStorageKeyCategory, version: string | null): void => {
       if (
         typeof version !== "string" ||
         version.length === 0 ||
@@ -1864,66 +1919,63 @@ export class SqliteFoundationStorage implements FoundationStorage {
         !/^[A-Za-z0-9._-]+$/.test(version)
       )
         return;
-      const key = `${kind}:${version}`;
+      const key = `${category}:${version}`;
       if (required.has(key)) return;
       required.add(key);
-      requiredCategories[keyCategory(kind)] += 1;
+      requiredCategories[category] += 1;
     };
     for (const grant of listGrants(this.getGrantStatements().allGrants)) {
       if (grant.credential.materialState === "present") {
-        addRequired("e", grant.credential.encryptionKeyVersion);
-        addRequired("l", grant.credential.lookupKeyVersion);
+        addRequired("encryption", grant.credential.encryptionKeyVersion);
+        addRequired("lookup", grant.credential.lookupKeyVersion);
       }
       if (grant.code !== null && grant.code !== undefined && grant.code.state !== "erased") {
-        addRequired("e", grant.code.encryptionKeyVersion);
-        addRequired("a", grant.code.lookupKeyVersion);
+        addRequired("encryption", grant.code.encryptionKeyVersion);
+        addRequired("audit", grant.code.lookupKeyVersion);
       }
       for (const session of listGrantSessions(
         this.getGrantStatements().sessionsByGrant,
         grant.grantId,
       )) {
-        addRequired("l", session.browserContextKeyVersion);
+        addRequired("lookup", session.browserContextKeyVersion);
         if (session.bearerMaterialState === "present")
-          addRequired("l", session.bearerLookupKeyVersion);
+          addRequired("lookup", session.bearerLookupKeyVersion);
       }
     }
     for (const row of this.database
       .query("SELECT audit_integrity_tag FROM foundation_grant_audit")
       .all() as unknown[]) {
-      addRequired("a", extractIntegrityKeyVersion(asRecord(row).audit_integrity_tag));
+      addRequired("audit", extractIntegrityKeyVersion(asRecord(row).audit_integrity_tag));
     }
     for (const row of this.database
       .query("SELECT integrity_tag FROM foundation_grant_state_anchors")
       .all() as unknown[]) {
-      addRequired("a", extractIntegrityKeyVersion(asRecord(row).integrity_tag));
+      addRequired("audit", extractIntegrityKeyVersion(asRecord(row).integrity_tag));
     }
     for (const row of this.database
       .query("SELECT integrity_tag FROM foundation_grant_admission_state_anchors")
       .all() as unknown[]) {
-      addRequired("a", extractIntegrityKeyVersion(asRecord(row).integrity_tag));
+      addRequired("audit", extractIntegrityKeyVersion(asRecord(row).integrity_tag));
     }
     for (const row of this.database
       .query("SELECT key_version FROM foundation_acceptance_integrity_anchors")
       .all() as unknown[]) {
-      addRequired("a", readNullableTextValue(asRecord(row).key_version));
+      addRequired("audit", readNullableTextValue(asRecord(row).key_version));
     }
     for (const row of this.database
       .query("SELECT receipt_key_version FROM foundation_replay_receipts")
       .all() as unknown[]) {
-      addRequired("a", readNullableTextValue(asRecord(row).receipt_key_version));
+      addRequired("audit", readNullableTextValue(asRecord(row).receipt_key_version));
     }
     const availableCategories = emptyKeyCounts();
     const available = [...required].filter((key) => {
-      const [kind, version] = key.split(":");
+      const [category, version] = key.split(":") as [
+        FoundationStorageKeyCategory,
+        string | undefined,
+      ];
       if (version === undefined) return false;
-      const available =
-        keyRing !== undefined &&
-        (kind === "e"
-          ? keyRing.encryption.keys.has(version)
-          : kind === "a"
-            ? keyRing.audit.keys.has(version)
-            : keyRing.lookup.keys.has(version));
-      if (available) availableCategories[keyCategory(kind as "e" | "l" | "a")] += 1;
+      const available = keyRing !== undefined && keyRing[category].keys.has(version);
+      if (available) availableCategories[category] += 1;
       return available;
     }).length;
     const missingCategories = emptyKeyCounts();

--- a/src/lib/grant-authority.focused.ts
+++ b/src/lib/grant-authority.focused.ts
@@ -39,6 +39,9 @@ import {
   spawnProbeCommand,
 } from "@/lib/sqlite-foundation-probe-process";
 
+const CURRENT_SCHEMA_VERSION = FOUNDATION_MIGRATIONS.at(-1)?.schemaVersion ?? 0;
+const CURRENT_SCHEMA_VERSION_TEXT = String(CURRENT_SCHEMA_VERSION);
+
 describe("focused SQLite Grant authority boundary", () => {
   registerGrantAuthorityContract(test, createStorage);
 
@@ -141,7 +144,10 @@ describe("focused SQLite Grant authority boundary", () => {
           /^opaque-migration-reference-v1:[a-f0-9]{64}$/,
         );
         expect(beforeRotation.audit[0]?.credentialFingerprint).toBeNull();
-        expect(await current.readiness()).toMatchObject({ ok: true, schemaVersion: "21" });
+        expect(await current.readiness()).toMatchObject({
+          ok: true,
+          schemaVersion: CURRENT_SCHEMA_VERSION_TEXT,
+        });
 
         const forged = new Database(databasePath);
         expect(() =>
@@ -263,7 +269,10 @@ describe("focused SQLite Grant authority boundary", () => {
       const restarted = openSqliteFoundationStorage(handle.databasePath, {
         grantKeyRing: createGrantTestKeyRing(),
       });
-      expect(await restarted.readiness()).toMatchObject({ ok: true, schemaVersion: "21" });
+      expect(await restarted.readiness()).toMatchObject({
+        ok: true,
+        schemaVersion: CURRENT_SCHEMA_VERSION_TEXT,
+      });
       restarted.close();
       const database = new Database(handle.databasePath);
       database
@@ -380,7 +389,10 @@ describe("focused SQLite Grant authority boundary", () => {
       const readyRestart = openSqliteFoundationStorage(handle.databasePath, {
         grantKeyRing: keyRing,
       });
-      expect(await readyRestart.readiness()).toMatchObject({ ok: true, schemaVersion: "21" });
+      expect(await readyRestart.readiness()).toMatchObject({
+        ok: true,
+        schemaVersion: CURRENT_SCHEMA_VERSION_TEXT,
+      });
       readyRestart.close();
 
       const selfLinkDatabase = new Database(handle.databasePath);
@@ -409,7 +421,10 @@ describe("focused SQLite Grant authority boundary", () => {
       const repairedRestart = openSqliteFoundationStorage(handle.databasePath, {
         grantKeyRing: keyRing,
       });
-      expect(await repairedRestart.readiness()).toMatchObject({ ok: true, schemaVersion: "21" });
+      expect(await repairedRestart.readiness()).toMatchObject({
+        ok: true,
+        schemaVersion: CURRENT_SCHEMA_VERSION_TEXT,
+      });
       repairedRestart.close();
 
       const activeOriginDatabase = new Database(handle.databasePath);
@@ -619,7 +634,7 @@ describe("focused SQLite Grant authority boundary", () => {
       let currentClosed = false;
       try {
         const report = await current.applyMigrations({ requireCandidate: false });
-        expect(report.schemaVersion).toBe(21);
+        expect(report.schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
         expect(report.appliedMigrationIds).toEqual([
           "007-anchor-control-action-audit-versions",
           "008-anchor-current-evidence-format",
@@ -636,10 +651,11 @@ describe("focused SQLite Grant authority boundary", () => {
           "019-event-catalog",
           "020-grant-codes-and-admission-telemetry",
           "021-grant-code-game-lock-erasure-evidence",
+          "022-control-session-stay-binding",
         ]);
         expect(await current.readiness()).toMatchObject({
           ok: true,
-          schemaVersion: "21",
+          schemaVersion: CURRENT_SCHEMA_VERSION_TEXT,
         });
         const migrated = await current.transaction((transaction) => ({
           grant: transaction.findGrantById(grantId),
@@ -688,7 +704,10 @@ describe("focused SQLite Grant authority boundary", () => {
 
         const restarted = openSqliteFoundationStorage(databasePath, { grantKeyRing: keyRing });
         try {
-          expect(await restarted.readiness()).toMatchObject({ ok: true, schemaVersion: "21" });
+          expect(await restarted.readiness()).toMatchObject({
+            ok: true,
+            schemaVersion: CURRENT_SCHEMA_VERSION_TEXT,
+          });
           const restartedAudit = await restarted.transaction((transaction) =>
             transaction.listGrantAudit(grantId),
           );
@@ -1085,7 +1104,10 @@ describe("focused SQLite Grant authority boundary", () => {
         grantKeyRing: options.keyRing,
       });
       try {
-        expect(await reopened.readiness()).toMatchObject({ ok: true, schemaVersion: "21" });
+        expect(await reopened.readiness()).toMatchObject({
+          ok: true,
+          schemaVersion: CURRENT_SCHEMA_VERSION_TEXT,
+        });
         const rotated = createTypedGrantAuthority(reopened, {
           ...options,
           keyRing: createGrantTestRotatedKeyRing(keyRing),
@@ -1213,7 +1235,10 @@ describe("focused SQLite Grant authority boundary", () => {
         grantKeyRing: options.keyRing,
       });
       try {
-        expect(await reopened.readiness()).toMatchObject({ ok: true, schemaVersion: "21" });
+        expect(await reopened.readiness()).toMatchObject({
+          ok: true,
+          schemaVersion: CURRENT_SCHEMA_VERSION_TEXT,
+        });
         const reopenedAuthority = createTypedGrantAuthority(reopened, options);
         const reopenedAudit = await reopenedAuthority.listGrantAudit(control.grantId, {
           kind: "technical-admin",

--- a/src/lib/grant-code.focused.ts
+++ b/src/lib/grant-code.focused.ts
@@ -11,6 +11,9 @@ import type { GrantAdmissionMode } from "@/lib/grant-types";
 import type { GrantAuthorityOptions } from "@/lib/grant-authority";
 import { lockControlGrantEventGame } from "@/lib/grant-management-sessions";
 import { validateGrantState } from "@/lib/grant-state-validation";
+import { FOUNDATION_MIGRATIONS } from "@/lib/foundation-migrations";
+
+const CURRENT_SCHEMA_VERSION = String(FOUNDATION_MIGRATIONS.at(-1)?.schemaVersion ?? 0);
 
 describe("focused SQLite Grant Code integration", () => {
   test("survives restart and freezes same-length ciphertext and anchor tampering", async () => {
@@ -43,7 +46,10 @@ describe("focused SQLite Grant Code integration", () => {
 
       const restarted = openSqliteFoundationStorage(databasePath, { grantKeyRing: keyRing });
       createTypedGrantAuthority(restarted, createOptions(keyRing, 902));
-      expect(await restarted.readiness()).toMatchObject({ ok: true, schemaVersion: "21" });
+      expect(await restarted.readiness()).toMatchObject({
+        ok: true,
+        schemaVersion: CURRENT_SCHEMA_VERSION,
+      });
       const stored = await restarted.transaction((transaction) =>
         transaction.findGrantById(grantId),
       );
@@ -244,7 +250,10 @@ describe("focused SQLite Grant Code integration", () => {
         ...createOptions(keyRing, 910),
         clock: { nowMs: () => nowMs },
       });
-      expect(await restarted.readiness()).toMatchObject({ ok: true, schemaVersion: "21" });
+      expect(await restarted.readiness()).toMatchObject({
+        ok: true,
+        schemaVersion: CURRENT_SCHEMA_VERSION,
+      });
       const state = await restarted.transaction((transaction) => ({
         grant: transaction.findGrantById(created.grantId),
         audit: transaction.listGrantAudit(created.grantId),
@@ -343,7 +352,10 @@ describe("focused SQLite Grant Code integration", () => {
         restarted,
         createOptions(keyRing, 912, () => nowMs),
       );
-      expect(await restarted.readiness()).toMatchObject({ ok: true, schemaVersion: "21" });
+      expect(await restarted.readiness()).toMatchObject({
+        ok: true,
+        schemaVersion: CURRENT_SCHEMA_VERSION,
+      });
       expect(
         await reopened.admitGrant({
           qrCredential: created.qrCredential,
@@ -449,7 +461,10 @@ describe("focused SQLite Grant Code integration", () => {
         ...options,
         randomness: createGrantTestRandomness(9999),
       });
-      expect(await restarted.readiness()).toMatchObject({ ok: true, schemaVersion: "21" });
+      expect(await restarted.readiness()).toMatchObject({
+        ok: true,
+        schemaVersion: CURRENT_SCHEMA_VERSION,
+      });
 
       expect(await reopened.reactivateGrant(reactivation.grantId, management)).toMatchObject({
         status: "updated",
@@ -577,7 +592,10 @@ describe("focused SQLite Grant Code integration", () => {
           ...options,
           randomness: createGrantTestRandomness(915),
         });
-        expect(await finalRestart.readiness()).toMatchObject({ ok: true, schemaVersion: "21" });
+        expect(await finalRestart.readiness()).toMatchObject({
+          ok: true,
+          schemaVersion: CURRENT_SCHEMA_VERSION,
+        });
         expect(
           await finalRestart.transaction((transaction) =>
             transaction.findGrantById(dueLock.grantId),
@@ -681,7 +699,10 @@ describe("focused SQLite Grant Code integration", () => {
 
       const restarted = openSqliteFoundationStorage(databasePath, { grantKeyRing: keyRing });
       const reopened = createTypedGrantAuthority(restarted, createOptions(keyRing, 1307));
-      expect(await restarted.readiness()).toMatchObject({ ok: true, schemaVersion: "21" });
+      expect(await restarted.readiness()).toMatchObject({
+        ok: true,
+        schemaVersion: CURRENT_SCHEMA_VERSION,
+      });
       expect(
         await reopened.admitGrantCode({ grantCode: scenario.code, browserContext: "old-code" }),
       ).toMatchObject({ status: "rejected" });
@@ -714,7 +735,10 @@ describe("focused SQLite Grant Code integration", () => {
 
       const restartedAgain = openSqliteFoundationStorage(databasePath, { grantKeyRing: keyRing });
       const reopenedAgain = createTypedGrantAuthority(restartedAgain, createOptions(keyRing, 1308));
-      expect(await restartedAgain.readiness()).toMatchObject({ ok: true, schemaVersion: "21" });
+      expect(await restartedAgain.readiness()).toMatchObject({
+        ok: true,
+        schemaVersion: CURRENT_SCHEMA_VERSION,
+      });
       expect(
         await reopenedAgain.admitGrantCode({
           grantCode: scenario.code,
@@ -943,7 +967,10 @@ describe("focused SQLite Grant Code integration", () => {
 
         const restarted = openSqliteFoundationStorage(databasePath, { grantKeyRing: keyRing });
         createTypedGrantAuthority(restarted, options);
-        expect(await restarted.readiness()).toMatchObject({ ok: true, schemaVersion: "21" });
+        expect(await restarted.readiness()).toMatchObject({
+          ok: true,
+          schemaVersion: CURRENT_SCHEMA_VERSION,
+        });
         const state = await restarted.transaction((transaction) => ({
           grant: transaction.findGrantById(scenario.grantId),
           sessions: transaction.listGrantSessions(scenario.grantId),
@@ -1004,7 +1031,10 @@ describe("focused SQLite Grant Code integration", () => {
 
         const restarted = openSqliteFoundationStorage(databasePath, { grantKeyRing: keyRing });
         createTypedGrantAuthority(restarted, createOptions(keyRing, 1601 + index));
-        expect(await restarted.readiness()).toMatchObject({ ok: true, schemaVersion: "21" });
+        expect(await restarted.readiness()).toMatchObject({
+          ok: true,
+          schemaVersion: CURRENT_SCHEMA_VERSION,
+        });
         const state = await restarted.transaction((transaction) => ({
           grant: transaction.findGrantById(scenario.grantId),
           sessions: transaction.listGrantSessions(scenario.grantId),
@@ -1166,7 +1196,10 @@ describe("focused SQLite Grant Code integration", () => {
       storage.close();
       storage = openSqliteFoundationStorage(databasePath, { grantKeyRing: keyRing });
       const reopened = createTypedGrantAuthority(storage, createOptions(keyRing, 1313));
-      expect(await storage.readiness()).toMatchObject({ ok: true, schemaVersion: "21" });
+      expect(await storage.readiness()).toMatchObject({
+        ok: true,
+        schemaVersion: CURRENT_SCHEMA_VERSION,
+      });
       const fresh = await reopened.createGrantCode(scenario.grantId, {
         kind: "grant-session",
         sessionBearer: scenario.adminBearer,
@@ -1255,7 +1288,10 @@ describe("focused SQLite Grant Code integration", () => {
 
       const restarted = openSqliteFoundationStorage(databasePath, { grantKeyRing: keyRing });
       const reopened = createTypedGrantAuthority(restarted, createOptions(keyRing, 1001));
-      expect(await restarted.readiness()).toMatchObject({ ok: true, schemaVersion: "21" });
+      expect(await restarted.readiness()).toMatchObject({
+        ok: true,
+        schemaVersion: CURRENT_SCHEMA_VERSION,
+      });
       expect(
         await reopened.admitGrant({
           qrCredential: scenario.qrCredential,
@@ -1340,9 +1376,10 @@ async function createGrantCodeScenario(
   expiresAtMs?: number,
   suffix = "",
 ): Promise<{ grantId: string; qrCredential: string; code: string; adminBearer: string }> {
+  const eventId = `event-focused-code${suffix}`;
   const admin = await authority.createEventAdminGrant({
     authority: { kind: "technical-admin", id: "tech" },
-    scope: { eventId: "event-focused-code", eventTimeZone: "UTC", finalGameDayDate: "2026-03-20" },
+    scope: { eventId, eventTimeZone: "UTC", finalGameDayDate: "2026-03-20" },
   });
   if (admin.status !== "created") throw new Error("Expected Event Admin Grant.");
   const session = await authority.admitGrant({
@@ -1353,7 +1390,7 @@ async function createGrantCodeScenario(
   const grant = await authority.createControlGrant({
     authority: { kind: "grant-session", sessionBearer: session.sessionBearer },
     scope: {
-      eventId: "event-focused-code",
+      eventId,
       gameDayId: "day",
       pitchId: `pitch${suffix}`,
       pitchSlotId: `slot${suffix}`,

--- a/src/lib/grant-code.test.ts
+++ b/src/lib/grant-code.test.ts
@@ -1424,6 +1424,105 @@ describe("Grant Codes", () => {
     ).toBeNull();
   });
 
+  test("terminates reused Control Grant sessions for multiple exact Game locks and erases its Code once", async () => {
+    const storage = createInMemoryFoundationStorage();
+    let currentEventGameId = "game-a";
+    let lockEventGameId = "game-a";
+    const options = createOptions({
+      resolve: () => ({ status: "eligible" as const, eventGameId: currentEventGameId }),
+      resolveSession: (_scope, sessionEventGameId) => ({
+        status: "current" as const,
+        eventGameId: sessionEventGameId,
+      }),
+      resolveEventGameLock: () => ({ eventGameId: lockEventGameId, apply: () => {} }),
+    });
+    const authority = createTypedGrantAuthority(storage, options);
+    const admin = await authority.createEventAdminGrant({
+      authority: { kind: "technical-admin", id: "tech" },
+      scope: {
+        eventId: "event-multi-lock",
+        eventTimeZone: "UTC",
+        finalGameDayDate: "2026-03-20",
+      },
+    });
+    if (admin.status !== "created") throw new Error("Expected Event Admin Grant.");
+    const adminSession = await authority.admitGrant({
+      qrCredential: admin.qrCredential,
+      browserContext: "multi-lock-admin",
+    });
+    if (adminSession.status !== "admitted") throw new Error("Expected Event Admin Session.");
+    const grant = await authority.createControlGrant({
+      authority: { kind: "grant-session", sessionBearer: adminSession.sessionBearer },
+      scope: {
+        eventId: "event-multi-lock",
+        gameDayId: "day-multi-lock",
+        pitchId: "pitch-multi-lock",
+        pitchSlotId: "slot-multi-lock",
+      },
+    });
+    if (grant.status !== "created") throw new Error("Expected Control Grant.");
+    const code = await authority.createGrantCode(grant.grantId, {
+      kind: "grant-session",
+      sessionBearer: adminSession.sessionBearer,
+    });
+    if (code.status !== "created") throw new Error("Expected Grant Code.");
+    const gameA = await authority.admitGrant({
+      qrCredential: grant.qrCredential,
+      browserContext: "multi-lock-game-a",
+    });
+    if (gameA.status !== "admitted") throw new Error("Expected Game A Session.");
+    currentEventGameId = "game-b";
+    const gameB = await authority.admitGrant({
+      qrCredential: grant.qrCredential,
+      browserContext: "multi-lock-game-b",
+    });
+    if (gameB.status !== "admitted") throw new Error("Expected Game B Session.");
+
+    currentEventGameId = "game-a";
+    lockEventGameId = "game-a";
+    expect(await lockControlGrantEventGame(storage, options, { accepted: true })).toMatchObject({
+      status: "locked",
+      eventGameId: "game-a",
+      terminatedSessionCount: 1,
+    });
+    currentEventGameId = "game-b";
+    lockEventGameId = "game-b";
+    expect(await lockControlGrantEventGame(storage, options, { accepted: true })).toMatchObject({
+      status: "locked",
+      eventGameId: "game-b",
+      terminatedSessionCount: 1,
+    });
+    const state = await storage.transaction((transaction) => ({
+      grant: transaction.findGrantById(grant.grantId),
+      sessions: transaction.listGrantSessions(grant.grantId),
+      audit: transaction.listGrantAudit(grant.grantId),
+    }));
+    expect(
+      state.sessions
+        .filter(
+          (session) =>
+            session.sessionId === gameA.grantSessionId ||
+            session.sessionId === gameB.grantSessionId,
+        )
+        .map((session) => [session.eventGameId, session.status]),
+    ).toEqual(
+      expect.arrayContaining([
+        ["game-a", "expired"],
+        ["game-b", "expired"],
+      ]),
+    );
+    expect(state.grant?.code).toMatchObject({ state: "erased", ciphertext: null });
+    expect(state.audit.filter((entry) => entry.action === "grant-code-erased-game-lock")).toEqual([
+      expect.objectContaining({ eventGameId: "game-a", codeState: "erased" }),
+    ]);
+    expect(
+      validateGrantState([state.grant!], state.sessions, state.audit, {
+        environmentId: options.environmentId,
+        keyRing: options.keyRing,
+      }),
+    ).toBeNull();
+  });
+
   test("terminates the active session after a same-version key rewrap", async () => {
     const storage = createInMemoryFoundationStorage();
     const options = createOptions({

--- a/src/lib/grant-management-sessions.ts
+++ b/src/lib/grant-management-sessions.ts
@@ -251,13 +251,13 @@ export function authorizeGrantInTransaction(
       grant.scope as ControlGrantScope,
       session.eventGameId,
     );
-    if (relationship.status === "game-locked") {
+    if (relationship.status === "game-locked" || relationship.status === "past-game-day") {
       if (input.readOnly) return GENERIC_GRANT_AUTHORIZATION_FAILURE;
       terminateControlSessionForEventGame(
         transaction,
         options,
         grant,
-        "game-locked",
+        relationship.status,
         relationship.eventGameId,
       );
       return GENERIC_GRANT_AUTHORIZATION_FAILURE;
@@ -605,7 +605,7 @@ export async function authorizeControlGrantReplay(
   }
 }
 
-function resolveControlSession(
+export function resolveControlSession(
   transaction: FoundationStorageTransaction,
   options: GrantAuthorityOptions,
   scope: ControlGrantScope,
@@ -640,6 +640,11 @@ function resolveControlSession(
         validateOpaqueIdentifier(resolved.eventGameId, "eventGameId").ok
         ? resolved
         : { status: "mismatch" };
+    if (resolved.status === "past-game-day")
+      return resolved.eventGameId === sessionEventGameId &&
+        validateOpaqueIdentifier(resolved.eventGameId, "eventGameId").ok
+        ? resolved
+        : { status: "mismatch" };
     return resolved;
   }
   const current = options.controlScopeResolver.resolve(scope, transaction);
@@ -652,11 +657,11 @@ function resolveControlSession(
       : { status: "mismatch" };
   if (
     current.status === "terminal" &&
-    current.reason === "game-locked" &&
+    (current.reason === "game-locked" || current.reason === "past-game-day") &&
     current.eventGameId === sessionEventGameId &&
     validateOpaqueIdentifier(current.eventGameId, "eventGameId").ok
   )
-    return { status: "game-locked", eventGameId: current.eventGameId };
+    return { status: current.reason, eventGameId: current.eventGameId };
   return { status: "mismatch" };
 }
 

--- a/src/lib/grant-types.ts
+++ b/src/lib/grant-types.ts
@@ -130,6 +130,7 @@ export type ControlGrantSessionResolution =
       currentEventGameId: string;
     }
   | { status: "game-locked"; eventGameId: string }
+  | { status: "past-game-day"; eventGameId: string }
   | { status: "empty" | "conflict" | "mismatch" | "unavailable"; detail?: string };
 
 export type ControlGrantReplayResolution =


### PR DESCRIPTION
## What changed

- Added versioned, fail-closed Event foundation backup and restore orchestration.
- Creates sanitized SQLite backups outside the live database directory and physically excludes Technical Admin authentication state.
- Verifies backup hashes, schema and migration compatibility, durable integrity, deterministic replay, and required key versions before a snapshot can replace the previous verified backup.
- Restores through a staged, quiesced cutover that preserves failed Event and Technical Admin database images privately for investigation and rollback.
- Re-evaluates current Grant, Control Session, Game Day, expiry, reassignment, and Game Lock state before restored authority becomes usable.
- Imports recoverable controller work through the composed acceptance boundary while preserving original Control Action identities and recording bounded Recovery Gaps.
- Records immutable pending and atomic completion evidence, including truthful post-cutover evidence-write failure status.

## Why

Issue #81 requires a practical operator recovery path after #80 makes unsafe durable authority fail closed. A verified backup must preserve Event authority and recoverable work without reviving Technical Admin authentication, stale Grants, locked sessions, or unverifiable action history.

## Impact

- Operators can create and verify a replacement recovery snapshot, then restore it through one bounded recovery interface.
- Technical Admin credentials and sessions are never restored; the restored installation requires Technical Admin re-enrollment.
- Eligible Grants and sessions remain usable only after current lifecycle and exact Event Game relationships are re-evaluated.
- Failed live images, WAL/SHM files, and quarantine evidence are retained at owner-only permissions rather than overwritten.
- Migrations 001–021 are unchanged.

## Root cause

The durable foundation previously had fail-closed detection and quarantine but no authenticated, privacy-preserving backup/restore boundary. Raw file replacement could not prove Technical Admin exclusion, current authority, replay compatibility, key continuity, or whether newer controller work had been recovered.

## Checks

- `bun install --frozen-lockfile`
- `bun audit` — no vulnerabilities
- `bun run check` — passed with seven pre-existing Grant await-thenable warnings
- `bun test --isolate` — 411 passed, 0 failed, 16,496 expectations
- Recovery Fast suite — 10 passed
- Focused SQLite — 21 passed
- Focused acceptance — 10 passed
- Focused Grant — 36 passed
- Focused Grant Code — 15 passed
- `bun run build`
- `bun run build:executable`
- `git diff --check`
- Range-diff-equivalent replay of the accepted #81 commit onto current `origin/main`

No Qualification, soak, load, crash, recovery-qualification, exact-production-artifact, or `bun run check:sqlite-runtime` workload was run.

## Stack

- Base: current `main`, including merged #80 / PR #146
- This PR: #81 Event foundation recovery
- Next: #82 production-shaped qualification envelope (requires explicit Qualification Test authorization)

Closes #81
