### PR TITLE
Implement durable creator-only Ad Hoc Games

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "test:focused:event-catalog": "bun test --isolate ./src/lib/event-catalog.focused.ts",
     "test:focused:event-catalog-cli": "bun test --isolate ./scripts/event-catalog-cli.focused.ts",
     "test:focused:grant-code": "bun test --isolate ./src/lib/grant-code.focused.ts",
+    "test:focused:ad-hoc": "bun test --isolate ./src/lib/ad-hoc-games.focused.ts",
     "test:changed": "bun test --changed",
     "format": "bunx --bun oxfmt \"**/*.{js,jsx,ts,tsx,mjs,cjs}\" \"!docs/**\"",
     "format:check": "bunx --bun oxfmt \"**/*.{js,jsx,ts,tsx,mjs,cjs}\" \"!docs/**\" --check",

--- a/scripts/ad-hoc-restart-worker.ts
+++ b/scripts/ad-hoc-restart-worker.ts
@@ -1,0 +1,56 @@
+import { openSqliteAdHocStore, createAdHocGamesService } from "@/lib/ad-hoc-games";
+
+const databasePath = process.argv[2];
+const mode = process.argv[3];
+if (databasePath === undefined || mode === undefined)
+  throw new Error("database path and mode required");
+
+const service = createAdHocGamesService({
+  store: openSqliteAdHocStore(databasePath),
+  now: () => 10_000,
+});
+try {
+  if (mode === "create") {
+    const created = await service.create({
+      homeName: "Restart Home",
+      awayName: "Restart Away",
+      sourceKey: "focused-source",
+    });
+    if (created.status !== "accepted") throw new Error(`create failed: ${created.reason}`);
+    console.log(JSON.stringify({ gameId: created.gameId, sessionId: created.sessionId }));
+  } else if (mode === "apply" || mode === "duplicate") {
+    const gameId = process.argv[4];
+    const sessionId = process.argv[5];
+    if (gameId === undefined || sessionId === undefined)
+      throw new Error("resume identity required");
+    const applied = await service.apply({
+      gameId,
+      sessionId,
+      operations: [
+        {
+          id: "restart-operation",
+          clientSentAtMs: 10_000,
+          command: { type: "set-running", running: true },
+        },
+      ],
+    });
+    const read = await service.read({ gameId, sessionId });
+    if (applied.status === "rejected" || read.status !== "accepted")
+      throw new Error("resume failed");
+    if (mode === "apply" && applied.status !== "accepted")
+      throw new Error("initial apply was not accepted");
+    if (mode === "duplicate" && applied.status !== "duplicate")
+      throw new Error("operation was not duplicate");
+    console.log(
+      JSON.stringify({
+        running: read.game.state.isRunning,
+        gameId: read.game.gameId,
+        status: applied.status,
+      }),
+    );
+  } else {
+    throw new Error(`unknown mode ${mode}`);
+  }
+} finally {
+  service.close();
+}

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { Window } from "happy-dom";
-import { App } from "./App";
+import { App, parseRoute } from "./App";
 import { createInitialGameState, projectGameView } from "@/lib/game-engine";
 import { DEFAULT_AWAY_TEAM_COLOR, DEFAULT_HOME_TEAM_COLOR } from "@/lib/team-colors";
 
@@ -65,6 +65,14 @@ describe("App", () => {
   let testWindow: Window;
   let container: HTMLDivElement;
   let root: Root;
+
+  test("accepts underscore-containing generated Ad Hoc Game IDs", () => {
+    expect(parseRoute("/game/adhoc-id_with_underscore", "")).toEqual({
+      type: "game",
+      gameId: "adhoc-id_with_underscore",
+      role: "controller",
+    });
+  });
 
   beforeEach(() => {
     testWindow = new Window({

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,9 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import type { ControllerRole, GameSummary } from "@/lib/game-types";
+import type { ControllerRole } from "@/lib/game-types";
 import { DEFAULT_AWAY_TEAM_COLOR, DEFAULT_HOME_TEAM_COLOR } from "@/lib/team-colors";
 import { ColorTestPage } from "@/pages/color-test-page";
 import { EventOperationsPrototypePage } from "@/pages/event-operations-prototype-page";
@@ -39,8 +39,6 @@ type Route =
       role: ControllerRole;
     };
 
-type ConnectionState = "connecting" | "online" | "offline" | "local-only";
-
 export function App() {
   const route = useRoute();
 
@@ -72,92 +70,10 @@ export function App() {
 }
 
 function HomePage() {
-  const nowMs = useNow(500);
-  const [games, setGames] = useState<GameSummary[]>([]);
-  const [clockOffsetMs, setClockOffsetMs] = useState(0);
-  const [connectionState, setConnectionState] = useState<ConnectionState>("connecting");
   const [homeName, setHomeName] = useState("Home");
   const [awayName, setAwayName] = useState("Away");
   const [homeColor, setHomeColor] = useState(DEFAULT_HOME_TEAM_COLOR);
   const [awayColor, setAwayColor] = useState(DEFAULT_AWAY_TEAM_COLOR);
-  const reconnectTimeoutRef = useRef<number | null>(null);
-
-  const wsUrl = useMemo(createWebSocketUrl, []);
-
-  useEffect(() => {
-    let cancelled = false;
-    let currentWs: WebSocket | null = null;
-
-    const fetchGames = async () => {
-      try {
-        const response = await fetch("/api/games");
-        if (!response.ok) {
-          return;
-        }
-
-        const payload = (await response.json()) as { games?: GameSummary[] };
-        if (!cancelled && Array.isArray(payload.games)) {
-          setGames(payload.games);
-        }
-      } catch {
-        // Ignore startup fetch errors; websocket reconnect handles updates.
-      }
-    };
-
-    const connect = () => {
-      if (cancelled) {
-        return;
-      }
-
-      setConnectionState("connecting");
-      const ws = new WebSocket(wsUrl);
-      currentWs = ws;
-
-      ws.onopen = () => {
-        setConnectionState("online");
-        ws.send(JSON.stringify({ type: "subscribe-lobby" }));
-      };
-
-      ws.onmessage = (event) => {
-        const parsed = parseServerMessage(event.data);
-        if (
-          parsed === null ||
-          parsed.type !== "lobby-snapshot" ||
-          !Array.isArray(parsed.games) ||
-          typeof parsed.serverNowMs !== "number"
-        ) {
-          return;
-        }
-
-        setClockOffsetMs(parsed.serverNowMs - Date.now());
-        setGames(parsed.games);
-      };
-
-      ws.onclose = () => {
-        setConnectionState("offline");
-        if (!cancelled) {
-          reconnectTimeoutRef.current = window.setTimeout(connect, 1_000);
-        }
-      };
-
-      ws.onerror = () => {
-        ws.close();
-      };
-    };
-
-    void fetchGames();
-    connect();
-
-    return () => {
-      cancelled = true;
-      currentWs?.close();
-      if (reconnectTimeoutRef.current !== null) {
-        window.clearTimeout(reconnectTimeoutRef.current);
-      }
-    };
-  }, [wsUrl]);
-
-  const nowWithOffsetMs = nowMs + clockOffsetMs;
 
   const handleCreateGame = useCallback(async () => {
     const response = await fetch("/api/games", {
@@ -177,7 +93,7 @@ function HomePage() {
 
     const payload = (await response.json()) as { gameId?: string };
     if (typeof payload.gameId === "string") {
-      navigateTo(`/game/${payload.gameId}?mode=controller`);
+      navigateTo(`/game/${payload.gameId}`);
     }
   }, [awayColor, awayName, homeColor, homeName]);
 
@@ -203,8 +119,10 @@ function HomePage() {
       <div className="grid gap-4 lg:grid-cols-[1fr_2fr]">
         <Card>
           <CardHeader>
-            <CardTitle>Create Game</CardTitle>
-            <CardDescription>The creator joins in controller mode.</CardDescription>
+            <CardTitle>Start an Ad Hoc Game</CardTitle>
+            <CardDescription>
+              You are admitted as the initially admitted Ad Hoc Controller.
+            </CardDescription>
           </CardHeader>
           <CardContent className="space-y-3">
             <div className="space-y-2">
@@ -246,73 +164,22 @@ function HomePage() {
               </div>
             </div>
             <Button className="w-full" onClick={handleCreateGame}>
-              Create new game
+              Start an Ad Hoc Game <span className="sr-only">Create new game</span>
             </Button>
           </CardContent>
         </Card>
 
         <Card>
           <CardHeader>
-            <CardTitle>Running and Past Games</CardTitle>
+            <CardTitle>Private Controller access</CardTitle>
             <CardDescription>
-              {connectionState === "online"
-                ? "Live updates connected"
-                : "Reconnecting live updates"}
+              Retained Ad Hoc Games are never listed or spectated publicly.
             </CardDescription>
           </CardHeader>
-          <CardContent className="space-y-3">
-            {games.length === 0 ? (
-              <p className="text-sm text-muted-foreground">No games yet.</p>
-            ) : (
-              games.map((game) => {
-                const displayClock = deriveLiveClockMs(game, nowWithOffsetMs);
-
-                return (
-                  <div
-                    key={game.id}
-                    className="rounded-xl border bg-background/80 p-3 shadow-[inset_0_1px_0_rgba(255,255,255,0.2)]"
-                  >
-                    <div className="flex items-start justify-between gap-3">
-                      <div>
-                        <p className="text-sm font-semibold">
-                          {game.homeName} vs {game.awayName}
-                        </p>
-                        <p className="text-xs text-muted-foreground">
-                          {game.isFinished
-                            ? "Past"
-                            : game.isSuspended
-                              ? "Suspended"
-                              : game.isRunning
-                                ? "Running"
-                                : "Paused"}{" "}
-                          • {formatClock(displayClock)}
-                        </p>
-                      </div>
-                      <p className="text-lg font-semibold tabular-nums">
-                        {game.score.home}:{game.score.away}
-                      </p>
-                    </div>
-                    <div className="mt-3 flex flex-wrap gap-2">
-                      <Button
-                        size="sm"
-                        variant="outline"
-                        onClick={() => navigateTo(`/game/${game.id}?mode=spectator`)}
-                      >
-                        Spectate
-                      </Button>
-                      {!game.isFinished ? (
-                        <Button
-                          size="sm"
-                          onClick={() => navigateTo(`/game/${game.id}?mode=controller`)}
-                        >
-                          Control
-                        </Button>
-                      ) : null}
-                    </div>
-                  </div>
-                );
-              })
-            )}
+          <CardContent>
+            <p className="text-sm text-muted-foreground">
+              Control starts immediately after atomic creation and admission.
+            </p>
           </CardContent>
         </Card>
       </div>
@@ -337,13 +204,17 @@ function useRoute(): Route {
   return route;
 }
 
-function parseRoute(pathname: string, search: string): Route {
+export function parseRoute(pathname: string, _search: string): Route {
   if (pathname === "/admin" || pathname === "/admin/") {
     return { type: "technical-admin", enrollment: false };
   }
 
   if (pathname === "/admin/enroll" || pathname === "/admin/enroll/") {
     return { type: "technical-admin", enrollment: true };
+  }
+
+  if (pathname === "/events" || pathname === "/events/") {
+    return { type: "home" };
   }
 
   if (pathname === "/color-test") {
@@ -362,72 +233,21 @@ function parseRoute(pathname: string, search: string): Route {
     return { type: "event-game-controller" };
   }
 
-  const match = pathname.match(/^\/game\/([a-zA-Z0-9-]+)$/);
+  const match = pathname.match(/^\/game\/([a-zA-Z0-9_-]+)$/);
   if (match === null) {
     return { type: "home" };
   }
 
-  const params = new URLSearchParams(search);
-  const mode = params.get("mode") === "controller" ? "controller" : "spectator";
-
   return {
     type: "game",
     gameId: match[1] ?? "",
-    role: mode,
+    role: "controller",
   };
-}
-
-function useNow(intervalMs: number) {
-  const [now, setNow] = useState(() => Date.now());
-
-  useEffect(() => {
-    const interval = window.setInterval(() => {
-      setNow(Date.now());
-    }, intervalMs);
-
-    return () => window.clearInterval(interval);
-  }, [intervalMs]);
-
-  return now;
-}
-
-function createWebSocketUrl() {
-  const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
-  return `${protocol}//${window.location.host}/ws`;
-}
-
-function parseServerMessage(
-  input: unknown,
-): { type?: string; games?: GameSummary[]; serverNowMs?: number } | null {
-  if (typeof input !== "string") {
-    return null;
-  }
-
-  try {
-    return JSON.parse(input) as { type?: string; games?: GameSummary[]; serverNowMs?: number };
-  } catch {
-    return null;
-  }
 }
 
 function navigateTo(path: string) {
   window.history.pushState(null, "", path);
   window.dispatchEvent(new PopStateEvent("popstate"));
-}
-
-function formatClock(ms: number) {
-  const totalSeconds = Math.max(0, Math.floor(ms / 1_000));
-  const minutes = Math.floor(totalSeconds / 60);
-  const seconds = totalSeconds % 60;
-  return `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
-}
-
-function deriveLiveClockMs(game: GameSummary, nowMs: number) {
-  if (!game.isRunning || game.isFinished) {
-    return game.gameClockMs;
-  }
-
-  return game.gameClockMs + Math.max(0, nowMs - game.updatedAtMs);
 }
 
 export default App;

--- a/src/index-ad-hoc.test.ts
+++ b/src/index-ad-hoc.test.ts
@@ -1,28 +1,260 @@
 import { describe, expect, test } from "bun:test";
-import { applyAdHocCommand, createGame, readAdHocGame } from "./index";
+import {
+  createAdHocGamesService,
+  createInMemoryAdHocStore,
+  type AdHocGamesService,
+} from "@/lib/ad-hoc-games";
+import {
+  adHocFallbackRoute,
+  createGame,
+  leaveGame,
+  readAdHocSession,
+  readAuthorizedAdHocGame,
+  readGame,
+  resolveAdHocWebSocketSubscription,
+} from "./index";
 
-describe("Ad Hoc HTTP route persistence", () => {
-  test("keeps the existing create, command, and read path working", async () => {
-    const createdResponse = await createGame(
-      new Request("http://localhost/api/games", {
+function service(): AdHocGamesService {
+  return createAdHocGamesService({
+    store: createInMemoryAdHocStore(),
+    now: () => 1_000,
+    random: (() => {
+      let counter = 0;
+      return () => `secret-${String(++counter).padStart(2, "0")}-abcdefghijklmnopqrstuvwxyz`;
+    })(),
+  });
+}
+
+async function createViaHttp(games: AdHocGamesService, homeName: string) {
+  const response = await createGame(
+    new Request("http://localhost/api/games", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ homeName, awayName: "Away" }),
+    }),
+    games,
+  );
+  expect(response.status).toBe(201);
+  const payload = (await response.json()) as { gameId: string; controlQr: string };
+  const setCookie = response.headers.get("set-cookie");
+  if (setCookie === null) throw new Error("creation did not return authority");
+  return { ...payload, setCookie, cookie: setCookie.split(";")[0]! };
+}
+
+describe("Ad Hoc HTTP and WebSocket authority boundaries", () => {
+  test("retains two Games in one browser authority set and leaving one preserves the other", async () => {
+    const games = service();
+    const first = await createViaHttp(games, "First");
+    const second = await createViaHttp(games, "Second");
+    const authoritySet = `${first.cookie}; ${second.cookie}`;
+    expect(first.setCookie).toContain("Max-Age=31536000");
+    expect(second.setCookie).toContain("Max-Age=31536000");
+
+    expect(readAdHocSession(authoritySet, first.gameId)).toBeTruthy();
+    expect(readAdHocSession(authoritySet, second.gameId)).toBeTruthy();
+    expect(
+      (
+        await readGame(
+          new Request(`http://localhost/api/games/${first.gameId}`, {
+            headers: { cookie: authoritySet },
+          }),
+          games,
+        )
+      ).status,
+    ).toBe(200);
+    expect(
+      (
+        await readGame(
+          new Request(`http://localhost/api/games/${second.gameId}`, {
+            headers: { cookie: authoritySet },
+          }),
+          games,
+        )
+      ).status,
+    ).toBe(200);
+
+    const left = await leaveGame(
+      new Request(`http://localhost/api/games/${first.gameId}/leave`, {
         method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ homeName: "A", awayName: "B" }),
+        headers: { cookie: authoritySet },
       }),
+      games,
     );
-    expect(createdResponse.status).toBe(201);
-    const created = (await createdResponse.json()) as { gameId: string };
+    expect(left.status).toBe(200);
+    expect(
+      (
+        await readGame(
+          new Request(`http://localhost/api/games/${first.gameId}`, {
+            headers: { cookie: authoritySet },
+          }),
+          games,
+        )
+      ).status,
+    ).toBe(404);
+    expect(
+      (
+        await readGame(
+          new Request(`http://localhost/api/games/${second.gameId}`, {
+            headers: { cookie: authoritySet },
+          }),
+          games,
+        )
+      ).status,
+    ).toBe(200);
+    expect(left.headers.get("set-cookie")).toContain(`adhoc_session_${first.gameId}=`);
+    expect(left.headers.get("set-cookie")).toContain("Max-Age=0");
+  });
+
+  test("lets an admitted Ad Hoc Controller operate with equal authority", async () => {
+    const games = service();
+    const created = await games.create({ homeName: "Home", awayName: "Away" });
+    if (created.status !== "accepted") throw new Error("creation failed");
+    const admitted = await games.admit({ gameId: created.gameId, controlQr: created.controlQr });
+    if (admitted.status !== "accepted") throw new Error("admission failed");
+
+    const applied = await games.apply({
+      gameId: created.gameId,
+      sessionId: admitted.game.sessionId,
+      operations: [
+        {
+          id: "admitted-controller-operation",
+          clientSentAtMs: 1_000,
+          command: { type: "set-running", running: true },
+        },
+      ],
+    });
+    expect(applied.status).toBe("accepted");
+    const creatorView = await readAuthorizedAdHocGame(games, created.gameId, created.sessionId);
+    const admittedView = await readAuthorizedAdHocGame(
+      games,
+      created.gameId,
+      admitted.game.sessionId,
+    );
+    expect(creatorView?.state.isRunning).toBe(true);
+    expect(admittedView?.state.isRunning).toBe(true);
+    expect(admittedView?.sessionId).toBe(admitted.game.sessionId);
+    expect(admittedView?.sessionId).not.toBe(creatorView?.sessionId);
+  });
+
+  test("returns one generic HTTP outcome for known, unknown, malformed, and unauthorized Games", async () => {
+    const games = service();
+    const known = await createViaHttp(games, "Known");
+    const paths = [
+      `/api/games/${known.gameId}`,
+      "/api/games/adhoc-missing",
+      "/api/games/not-a-game-id",
+    ];
+    const responses = await Promise.all(
+      paths.map((path) => readGame(new Request(`http://localhost${path}`), games)),
+    );
+    expect(responses.map((response) => response.status)).toEqual([404, 404, 404]);
+    expect(await Promise.all(responses.map((response) => response.text()))).toEqual([
+      '{"error":"Ad Hoc Game unavailable."}',
+      '{"error":"Ad Hoc Game unavailable."}',
+      '{"error":"Ad Hoc Game unavailable."}',
+    ]);
+  });
+
+  test("returns one generic WebSocket outcome for known, unknown, and malformed Games", async () => {
+    const games = service();
+    const known = await createViaHttp(games, "Known");
+    const results = await Promise.all(
+      [known.gameId, "adhoc-missing", "not-a-game-id"].map((gameId) =>
+        resolveAdHocWebSocketSubscription({ service: games, cookieHeader: null, gameId }),
+      ),
+    );
+    expect(results).toEqual([
+      { status: "unavailable" },
+      { status: "unavailable" },
+      { status: "unavailable" },
+    ]);
+  });
+
+  test("keeps malformed live Ad Hoc route shapes generic instead of serving the SPA", async () => {
+    const paths = ["/game/adhoc-x/extra", "/api/games/adhoc-x/extra", "/api/games//leave"];
+    const responses = paths.map((path) => {
+      const response = adHocFallbackRoute(new Request(`http://localhost${path}`));
+      if (!(response instanceof Response)) throw new Error("malformed Ad Hoc path served the SPA");
+      return response;
+    });
+
+    expect(responses.map((response) => response.status)).toEqual([404, 404, 404]);
+    expect(await Promise.all(responses.map((response) => response.text()))).toEqual([
+      '{"error":"Ad Hoc Game unavailable."}',
+      '{"error":"Ad Hoc Game unavailable."}',
+      '{"error":"Ad Hoc Game unavailable."}',
+    ]);
+  });
+
+  test("accepts underscore-containing Game IDs through the authorized HTTP and WebSocket seams", async () => {
+    let next = 0;
+    const games = createAdHocGamesService({
+      store: createInMemoryAdHocStore(),
+      now: () => 1_000,
+      random: () =>
+        [
+          "id_with_underscore",
+          "session-token-abcdefghijklmnopqrstuvwxyz",
+          "qr-token-abcdefghijklmnopqrstuvwxyz",
+        ][next++]!,
+    });
+    const created = await createViaHttp(games, "Underscore");
+    expect(created.gameId).toBe("adhoc-id_with_underscore");
+    expect(parseCookieHeaderForGame(created.setCookie, created.gameId)).toBeTruthy();
 
     expect(
-      applyAdHocCommand({
-        gameId: created.gameId,
-        id: "ad-hoc-command-1",
-        clientSentAtMs: Date.now(),
-        command: { type: "set-running", running: true },
-      }),
-    ).toBe(true);
-    expect(readAdHocGame(created.gameId)).toMatchObject({
-      state: { isRunning: true },
-    });
+      (
+        await readGame(
+          new Request(`http://localhost/api/games/${created.gameId}`, {
+            headers: { cookie: created.cookie },
+          }),
+          games,
+        )
+      ).status,
+    ).toBe(200);
+    expect(
+      (
+        await resolveAdHocWebSocketSubscription({
+          service: games,
+          cookieHeader: created.cookie,
+          gameId: created.gameId,
+        })
+      ).status,
+    ).toBe("accepted");
+  });
+
+  test("resolves each WebSocket subscription from the requested Game cookie", async () => {
+    const games = service();
+    const first = await createViaHttp(games, "First");
+    const second = await createViaHttp(games, "Second");
+    const cookieHeader = `${first.cookie}; ${second.cookie}`;
+    const [firstResult, secondResult] = await Promise.all([
+      resolveAdHocWebSocketSubscription({ service: games, cookieHeader, gameId: first.gameId }),
+      resolveAdHocWebSocketSubscription({ service: games, cookieHeader, gameId: second.gameId }),
+    ]);
+
+    expect(firstResult.status).toBe("accepted");
+    expect(secondResult.status).toBe("accepted");
+    if (firstResult.status !== "accepted" || secondResult.status !== "accepted") return;
+    expect(firstResult.game.gameId).toBe(first.gameId);
+    expect(secondResult.game.gameId).toBe(second.gameId);
+    expect(firstResult.sessionId).not.toBe(secondResult.sessionId);
+  });
+
+  test("fails creation unavailable without committing a Game when storage is contended", async () => {
+    const store = {
+      ...createInMemoryAdHocStore(),
+      createGame() {
+        throw new Error("database is locked");
+      },
+    };
+    const games = createAdHocGamesService({ store, now: () => 1_000 });
+    const result = await games.create({ homeName: "Home", awayName: "Away" });
+    expect(result).toMatchObject({ status: "rejected", reason: "unavailable" });
+    expect(store.listGames()).toHaveLength(0);
   });
 });
+
+function parseCookieHeaderForGame(setCookie: string, gameId: string) {
+  return readAdHocSession(setCookie.split(";")[0]!, gameId);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,8 @@
 import { serve, type ServerWebSocket } from "bun";
 import index from "./index.html";
-import {
-  applyGameCommand,
-  createInitialGameState,
-  projectGameSummary,
-  projectGameView,
-} from "@/lib/game-engine";
-import type { ControllerRole, GameCommand, GameState } from "@/lib/game-types";
 import { readJsonBodyWithinLimit } from "@/lib/http-body";
 import { isInternalHealthHost } from "@/lib/internal-health";
-import { normalizeBoundedText, SHARED_LIMITS } from "@/lib/validation-policy";
+import { SHARED_LIMITS } from "@/lib/validation-policy";
 import {
   parseSqliteProbeInvocation,
   runSqliteFoundationProbe,
@@ -57,12 +50,12 @@ import { openSqliteFoundationStorage } from "@/lib/foundation-storage-sqlite";
 import type { FoundationStorage } from "@/lib/foundation-storage";
 import { assertProductionStateBoundary } from "@/lib/runtime-storage-config";
 import { createStartupCleanup } from "@/lib/startup-resources";
-
-type ManagedGame = {
-  state: GameState;
-  appliedCommandIds: Set<string>;
-  appliedCommandOrder: string[];
-};
+import {
+  createAdHocGamesService,
+  openSqliteAdHocStore,
+  type AdHocGameView,
+  type AdHocGamesService,
+} from "@/lib/ad-hoc-games";
 
 type SessionSubscription =
   | {
@@ -74,18 +67,18 @@ type SessionSubscription =
   | {
       type: "game";
       gameId: string;
-      role: ControllerRole;
+      sessionId: string;
     };
 
 type SessionData = {
   id: string;
+  cookieHeader: string | null;
+  sessionId: string | null;
   subscription: SessionSubscription;
 };
 
-const games = new Map<string, ManagedGame>();
 const sockets = new Set<ServerWebSocket<SessionData>>();
-
-const MAX_TRACKED_COMMAND_IDS = 5_000;
+const defaultAdHocService = createAdHocGamesService();
 
 const probeInvocation = parseSqliteProbeInvocation(process.argv.slice(1));
 
@@ -120,6 +113,24 @@ async function startServer() {
     const { technicalAdmin: technicalAdminConfig, storagePaths } = readRuntimeConfig();
     const { environment } = technicalAdminConfig;
     assertProductionStateBoundary(environment, storagePaths);
+    const adHocDatabasePath =
+      process.env.AD_HOC_DATABASE?.trim() ||
+      (environment === "production"
+        ? "/var/lib/quadball-timer/ad-hoc.sqlite"
+        : `data/${environment}/ad-hoc.sqlite`);
+    if (
+      environment === "production" &&
+      adHocDatabasePath !== "/var/lib/quadball-timer/ad-hoc.sqlite"
+    ) {
+      throw new Error("Production Ad Hoc database must use its canonical path.");
+    }
+    const adHocService = createAdHocGamesService({
+      store:
+        environment === "test" && !process.env.AD_HOC_DATABASE?.trim()
+          ? undefined
+          : openSqliteAdHocStore(adHocDatabasePath),
+    });
+    startupCleanup.add(() => adHocService.close());
     const databasePath = storagePaths.technicalAdminDatabase;
     technicalAdminRepository = createSqliteTechnicalAdminAuthRepository(databasePath, {
       environment: technicalAdminConfig.environment,
@@ -250,6 +261,8 @@ async function startServer() {
           const upgraded = routeServer.upgrade(req, {
             data: {
               id: crypto.randomUUID(),
+              cookieHeader: req.headers.get("cookie"),
+              sessionId: null,
               subscription: { type: "none" },
             },
           });
@@ -273,26 +286,40 @@ async function startServer() {
         },
         "/api/games": {
           GET() {
-            const nowMs = Date.now();
-            const snapshots = [...games.values()]
-              .map((game) => projectGameSummary(game.state, nowMs))
-              .sort((a, b) => b.updatedAtMs - a.updatedAtMs);
-
-            return json({ games: snapshots });
+            return adHocUnavailableResponse();
           },
           POST(req: Request) {
-            return createGame(req);
+            return createGame(
+              req,
+              adHocService,
+              requestSource(req, technicalAdminConfig.trustProxyHeaders),
+            );
           },
         },
         "/api/games/:gameId": {
           GET(req: Request) {
-            const gameId = new URL(req.url).pathname.replace("/api/games/", "");
-            const game = readAdHocGame(gameId);
-            if (game === null) {
-              return json({ error: "Game not found." }, 404);
-            }
-
-            return json({ game });
+            return readGame(req, adHocService);
+          },
+        },
+        "/api/games/:gameId/admit": {
+          async POST(req: Request) {
+            const gameId = new URL(req.url).pathname.split("/").at(-2) ?? "";
+            const body = await readJsonRecord(req);
+            const result = await adHocService.admit({
+              gameId,
+              controlQr: body?.controlQr,
+              browserId: requestSource(req, technicalAdminConfig.trustProxyHeaders),
+            });
+            return result.status === "accepted"
+              ? sensitiveJson({ game: stripSession(result.game) }, 200, [
+                  ["set-cookie", adHocSessionCookie(gameId, result.game.sessionId)],
+                ])
+              : adHocUnavailableResponse();
+          },
+        },
+        "/api/games/:gameId/leave": {
+          POST(req: Request) {
+            return leaveGame(req, adHocService);
           },
         },
         "/api/event-control/open": {
@@ -724,7 +751,15 @@ async function startServer() {
             return json({ ok: true });
           },
         },
-        "/*": index,
+        "/game/:gameId": {
+          async GET(req: Request) {
+            const gameId = new URL(req.url).pathname.split("/").at(-1) ?? "";
+            const sessionId = readAdHocSession(req.headers.get("cookie"), gameId);
+            const result = await adHocService.read({ gameId, sessionId });
+            return result.status === "accepted" ? index : adHocUnavailableResponse();
+          },
+        },
+        "/*": adHocFallbackRoute,
       },
       development: process.env.NODE_ENV !== "production" && {
         hmr: true,
@@ -736,8 +771,15 @@ async function startServer() {
         },
         close(ws) {
           sockets.delete(ws);
+          if (ws.data.subscription.type === "game" && ws.data.sessionId !== null) {
+            void adHocService.setConnection({
+              gameId: ws.data.subscription.gameId,
+              sessionId: ws.data.sessionId,
+              connected: false,
+            });
+          }
         },
-        message(ws, message) {
+        async message(ws, message) {
           if (typeof message !== "string") {
             sendMessage(ws, {
               type: "error",
@@ -759,32 +801,42 @@ async function startServer() {
 
           switch (parsed.message.type) {
             case "subscribe-lobby": {
-              ws.data.subscription = {
-                type: "lobby",
-              };
-              sendLobbySnapshot(ws);
+              sendMessage(ws, { type: "error", message: adHocService.genericUnavailableMessage });
               return;
             }
 
             case "subscribe-game": {
-              const game = games.get(parsed.message.gameId);
-              if (game === undefined) {
-                sendMessage(ws, {
-                  type: "error",
-                  message: "Game not found.",
-                });
+              const result = await resolveAdHocWebSocketSubscription({
+                service: adHocService,
+                cookieHeader: ws.data.cookieHeader,
+                gameId: parsed.message.gameId,
+              });
+              if (result.status !== "accepted") {
+                sendMessage(ws, { type: "error", message: adHocService.genericUnavailableMessage });
                 return;
               }
-
+              if (ws.data.subscription.type === "game") {
+                await adHocService.setConnection({
+                  gameId: ws.data.subscription.gameId,
+                  sessionId: ws.data.subscription.sessionId,
+                  connected: false,
+                });
+              }
+              await adHocService.setConnection({
+                gameId: parsed.message.gameId,
+                sessionId: result.sessionId,
+                connected: true,
+              });
+              ws.data.sessionId = result.sessionId;
               ws.data.subscription = {
                 type: "game",
                 gameId: parsed.message.gameId,
-                role: parsed.message.role,
+                sessionId: result.sessionId,
               };
-
-              sendGameSnapshot({
-                ws,
-                game,
+              sendMessage(ws, {
+                type: "game-snapshot",
+                game: stripSession(result.game),
+                serverNowMs: Date.now(),
                 ackedCommandIds: [],
               });
               return;
@@ -799,14 +851,6 @@ async function startServer() {
                 return;
               }
 
-              if (ws.data.subscription.role !== "controller") {
-                sendMessage(ws, {
-                  type: "error",
-                  message: "Spectators cannot apply commands.",
-                });
-                return;
-              }
-
               if (ws.data.subscription.gameId !== parsed.message.gameId) {
                 sendMessage(ws, {
                   type: "error",
@@ -815,27 +859,27 @@ async function startServer() {
                 return;
               }
 
-              const game = games.get(parsed.message.gameId);
-              if (game === undefined) {
+              const result = await adHocService.apply({
+                gameId: parsed.message.gameId,
+                sessionId: ws.data.subscription.sessionId,
+                operations: parsed.message.commands,
+              });
+              if (result.status === "rejected") {
                 sendMessage(ws, {
                   type: "error",
-                  message: "Game not found.",
+                  message:
+                    result.reason === "unavailable"
+                      ? adHocService.genericUnavailableMessage
+                      : "Ad Hoc operation rejected.",
                 });
                 return;
               }
-
-              const ackedCommandIds = applyCommandsToGame({
-                managedGame: game,
-                commands: parsed.message.commands,
-              });
-
-              broadcastGameSnapshot({
+              await broadcastGameSnapshot({
                 gameId: parsed.message.gameId,
-                game,
+                service: adHocService,
                 sender: ws,
-                senderAckedCommandIds: ackedCommandIds,
+                senderAckedCommandIds: result.ackedOperationIds,
               });
-              broadcastLobbySnapshot();
               return;
             }
 
@@ -904,7 +948,11 @@ async function runProbeMode(
   }
 }
 
-export async function createGame(req: Request) {
+export async function createGame(
+  req: Request,
+  service: AdHocGamesService = defaultAdHocService,
+  sourceKey = "anonymous-browser",
+) {
   const body = await readJsonBodyWithinLimit(req, SHARED_LIMITS.transport.httpJsonBodyBytes);
   if (!body.ok) {
     return json({ error: body.error }, body.status);
@@ -915,191 +963,165 @@ export async function createGame(req: Request) {
   }
 
   const payload = body.body;
-  const homeName =
-    payload.homeName === undefined
-      ? { ok: true as const, value: "Home" }
-      : normalizeBoundedText(
-          payload.homeName,
-          SHARED_LIMITS.names.teamAndPitchMaxCodePoints,
-          "homeName",
-        );
-  const awayName =
-    payload.awayName === undefined
-      ? { ok: true as const, value: "Away" }
-      : normalizeBoundedText(
-          payload.awayName,
-          SHARED_LIMITS.names.teamAndPitchMaxCodePoints,
-          "awayName",
-        );
-
-  if (!homeName.ok) {
-    return json(
+  const result = await service.create({
+    homeName: payload.homeName === undefined ? "Home" : payload.homeName,
+    awayName: payload.awayName === undefined ? "Away" : payload.awayName,
+    homeColor: payload.homeColor,
+    awayColor: payload.awayColor,
+    sourceKey,
+  });
+  if (result.status !== "accepted") {
+    const status =
+      result.reason === "invalid-input" ? 400 : result.reason === "unavailable" ? 503 : 429;
+    return sensitiveJson(
       {
-        error: homeName.error,
+        error: result.detail ?? "Unable to create an Ad Hoc Game.",
+        retryAfterMs: result.retryAfterMs,
       },
-      400,
+      status,
     );
   }
-  if (!awayName.ok) {
-    return json({ error: awayName.error }, 400);
-  }
-
-  const homeColor = typeof payload.homeColor === "string" ? payload.homeColor : undefined;
-  const awayColor = typeof payload.awayColor === "string" ? payload.awayColor : undefined;
-
-  const id = createGameId();
-  const nowMs = Date.now();
-  const managedGame: ManagedGame = {
-    state: createInitialGameState({
-      id,
-      nowMs,
-      homeName: homeName.value,
-      awayName: awayName.value,
-      homeColor,
-      awayColor,
-    }),
-    appliedCommandIds: new Set(),
-    appliedCommandOrder: [],
-  };
-
-  games.set(id, managedGame);
-  broadcastLobbySnapshot();
-
-  return json(
-    {
-      gameId: id,
-      game: projectGameView(managedGame.state, nowMs),
-    },
+  return sensitiveJson(
+    { gameId: result.gameId, controlQr: result.controlQr, game: stripSession(result.game) },
     201,
+    [["set-cookie", adHocSessionCookie(result.gameId, result.sessionId)]],
   );
 }
 
-export function readAdHocGame(gameId: string) {
-  const game = games.get(gameId);
-  return game === undefined ? null : projectGameView(game.state, Date.now());
+export async function readGame(req: Request, service: AdHocGamesService = defaultAdHocService) {
+  const gameId = new URL(req.url).pathname.replace("/api/games/", "");
+  const sessionId = readAdHocSession(req.headers.get("cookie"), gameId);
+  const result = await service.read({ gameId, sessionId });
+  return result.status === "accepted"
+    ? sensitiveJson({ game: stripSession(result.game) })
+    : adHocUnavailableResponse(service);
 }
 
-export function applyAdHocCommand(input: {
-  gameId: string;
-  id: string;
-  clientSentAtMs: number;
-  command: GameCommand;
-}) {
-  const managedGame = games.get(input.gameId);
-  if (managedGame === undefined) return false;
-  applyCommandsToGame({ managedGame, commands: [input] });
-  return true;
+export async function leaveGame(req: Request, service: AdHocGamesService = defaultAdHocService) {
+  const gameId = new URL(req.url).pathname.split("/").at(-2) ?? "";
+  const sessionId = readAdHocSession(req.headers.get("cookie"), gameId);
+  const left = await service.leave({ gameId, sessionId });
+  return left
+    ? sensitiveJson({ left: true }, 200, [["set-cookie", clearAdHocSessionCookie(gameId)]])
+    : adHocUnavailableResponse(service);
 }
 
-function createGameId() {
-  return `game-${crypto.randomUUID().slice(0, 8)}`;
-}
-
-function applyCommandsToGame({
-  managedGame,
-  commands,
-}: {
-  managedGame: ManagedGame;
-  commands: {
-    id: string;
-    clientSentAtMs: number;
-    command: GameCommand;
-  }[];
-}) {
-  const ackedCommandIds: string[] = [];
-
-  for (const envelope of commands) {
-    if (managedGame.appliedCommandIds.has(envelope.id)) {
-      ackedCommandIds.push(envelope.id);
-      continue;
-    }
-
-    managedGame.state = applyGameCommand({
-      state: managedGame.state,
-      command: envelope.command,
-      nowMs: envelope.clientSentAtMs,
-    });
-
-    managedGame.appliedCommandIds.add(envelope.id);
-    managedGame.appliedCommandOrder.push(envelope.id);
-    ackedCommandIds.push(envelope.id);
-
-    if (managedGame.appliedCommandOrder.length > MAX_TRACKED_COMMAND_IDS) {
-      const removedId = managedGame.appliedCommandOrder.shift();
-      if (removedId !== undefined) {
-        managedGame.appliedCommandIds.delete(removedId);
-      }
-    }
-  }
-
-  return ackedCommandIds;
-}
-
-function broadcastLobbySnapshot() {
-  for (const ws of sockets) {
-    if (ws.data.subscription.type === "lobby") {
-      sendLobbySnapshot(ws);
-    }
-  }
-}
-
-function sendLobbySnapshot(ws: ServerWebSocket<SessionData>) {
-  const nowMs = Date.now();
-  const summaries = [...games.values()]
-    .map((game) => projectGameSummary(game.state, nowMs))
-    .sort((a, b) => b.updatedAtMs - a.updatedAtMs);
-
-  sendMessage(ws, {
-    type: "lobby-snapshot",
-    games: summaries,
-    serverNowMs: nowMs,
-  });
-}
-
-function broadcastGameSnapshot({
+export async function resolveAdHocWebSocketSubscription({
+  service,
+  cookieHeader,
   gameId,
-  game,
+}: {
+  service: AdHocGamesService;
+  cookieHeader: string | null;
+  gameId: unknown;
+}): Promise<
+  { status: "accepted"; sessionId: string; game: AdHocGameView } | { status: "unavailable" }
+> {
+  const sessionId = readAdHocSession(cookieHeader, gameId);
+  const result = await service.read({ gameId, sessionId });
+  if (result.status !== "accepted") return { status: "unavailable" };
+  return { status: "accepted", sessionId: result.game.sessionId, game: result.game };
+}
+
+export async function readAuthorizedAdHocGame(
+  service: AdHocGamesService,
+  gameId: string,
+  sessionId: string,
+  nowMs?: number,
+): Promise<AdHocGameView | null> {
+  const result = await service.read({ gameId, sessionId, nowMs });
+  return result.status === "accepted" ? result.game : null;
+}
+
+async function broadcastGameSnapshot({
+  gameId,
+  service,
   sender,
   senderAckedCommandIds,
 }: {
   gameId: string;
-  game: ManagedGame;
+  service: AdHocGamesService;
   sender: ServerWebSocket<SessionData>;
   senderAckedCommandIds: string[];
 }) {
-  for (const ws of sockets) {
-    if (ws.data.subscription.type !== "game" || ws.data.subscription.gameId !== gameId) {
-      continue;
-    }
-
-    sendGameSnapshot({
-      ws,
-      game,
-      ackedCommandIds: ws === sender ? senderAckedCommandIds : [],
-    });
-  }
-}
-
-function sendGameSnapshot({
-  ws,
-  game,
-  ackedCommandIds,
-}: {
-  ws: ServerWebSocket<SessionData>;
-  game: ManagedGame;
-  ackedCommandIds: string[];
-}) {
-  const nowMs = Date.now();
-  sendMessage(ws, {
-    type: "game-snapshot",
-    game: projectGameView(game.state, nowMs),
-    serverNowMs: nowMs,
-    ackedCommandIds,
-  });
+  await Promise.all(
+    [...sockets].map(async (ws) => {
+      if (ws.data.subscription.type !== "game" || ws.data.subscription.gameId !== gameId) {
+        return;
+      }
+      const serverNowMs = Date.now();
+      const game = await readAuthorizedAdHocGame(
+        service,
+        gameId,
+        ws.data.subscription.sessionId,
+        serverNowMs,
+      );
+      if (game === null) return;
+      sendMessage(ws, {
+        type: "game-snapshot",
+        game: stripSession(game),
+        serverNowMs,
+        ackedCommandIds: ws === sender ? senderAckedCommandIds : [],
+      });
+    }),
+  );
 }
 
 function sendMessage(ws: ServerWebSocket<SessionData>, payload: ServerWsMessage) {
   ws.send(JSON.stringify(payload));
+}
+
+function stripSession<T extends { sessionId: string }>(game: T) {
+  const { sessionId: _sessionId, ...safe } = game;
+  return safe;
+}
+
+function adHocUnavailableResponse(service: AdHocGamesService = defaultAdHocService) {
+  return sensitiveJson({ error: service.genericUnavailableMessage }, 404);
+}
+
+export function readAdHocSession(cookieHeader: string | null, gameId: unknown): string | null {
+  if (cookieHeader === null) return null;
+  const cookieName = adHocSessionCookieName(gameId);
+  if (cookieName === null) return null;
+  for (const cookie of cookieHeader.split(";")) {
+    const [name, ...value] = cookie.trim().split("=");
+    if (name === cookieName && value.length > 0) {
+      try {
+        return decodeURIComponent(value.join("="));
+      } catch {
+        return null;
+      }
+    }
+  }
+  return null;
+}
+
+function adHocSessionCookieName(gameId: unknown): string | null {
+  if (typeof gameId !== "string" || !/^adhoc-[a-zA-Z0-9_-]+$/.test(gameId)) return null;
+  return `adhoc_session_${gameId}`;
+}
+
+function adHocSessionCookie(gameId: string, sessionId: string): string {
+  return `${adHocSessionCookieName(gameId)}=${encodeURIComponent(sessionId)}; Path=/; Max-Age=31536000; HttpOnly; SameSite=Lax`;
+}
+
+function clearAdHocSessionCookie(gameId: string): string {
+  return `${adHocSessionCookieName(gameId)}=; Path=/; Max-Age=0; HttpOnly; SameSite=Lax`;
+}
+
+export function adHocFallbackRoute(req: Request) {
+  const pathname = new URL(req.url).pathname;
+  return isAdHocPath(pathname) ? adHocUnavailableResponse() : index;
+}
+
+function isAdHocPath(pathname: string): boolean {
+  return (
+    pathname === "/game" ||
+    pathname.startsWith("/game/") ||
+    pathname === "/api/games" ||
+    pathname.startsWith("/api/games/")
+  );
 }
 
 function json(payload: unknown, status = 200, extraHeaders: Iterable<[string, string]> = []) {

--- a/src/lib/ad-hoc-games.focused.ts
+++ b/src/lib/ad-hoc-games.focused.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+describe("Ad Hoc SQLite focused integration", () => {
+  test("migration, state, and operation identity survive a bounded process-boundary restart", async () => {
+    const root = await mkdtemp(join(tmpdir(), "quadball-timer-adhoc-focused-"));
+    const databasePath = join(root, "ad-hoc.sqlite");
+    const worker = join(process.cwd(), "scripts/ad-hoc-restart-worker.ts");
+    try {
+      const created = await runWorker(worker, databasePath, "create");
+      const identity = JSON.parse(created) as { gameId: string; sessionId: string };
+      const applied = await runWorker(
+        worker,
+        databasePath,
+        "apply",
+        identity.gameId,
+        identity.sessionId,
+      );
+      expect(JSON.parse(applied)).toEqual({
+        gameId: identity.gameId,
+        running: true,
+        status: "accepted",
+      });
+      const duplicate = await runWorker(
+        worker,
+        databasePath,
+        "duplicate",
+        identity.gameId,
+        identity.sessionId,
+      );
+      expect(JSON.parse(duplicate)).toEqual({
+        gameId: identity.gameId,
+        running: true,
+        status: "duplicate",
+      });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+async function runWorker(worker: string, databasePath: string, mode: string, ...args: string[]) {
+  const child = Bun.spawn([process.execPath, "run", worker, databasePath, mode, ...args], {
+    cwd: process.cwd(),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const output = Promise.all([
+      readBounded(child.stdout, 16 * 1024),
+      readBounded(child.stderr, 16 * 1024),
+      child.exited,
+    ]);
+    const result = await Promise.race([
+      output,
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(
+          () => reject(new Error("focused worker exceeded 10 second deadline")),
+          10_000,
+        );
+      }),
+    ]);
+    const [stdout, stderr, exitCode] = result;
+    if (exitCode !== 0) throw new Error(`worker failed: ${stderr || stdout}`);
+    return stdout.trim();
+  } catch (error) {
+    await terminateChild(child);
+    throw error;
+  } finally {
+    if (timeout !== undefined) clearTimeout(timeout);
+  }
+}
+
+async function terminateChild(child: ReturnType<typeof Bun.spawn>) {
+  child.kill("SIGTERM");
+  if (await waitForExit(child, 250)) return;
+
+  child.kill("SIGKILL");
+  if (!(await waitForExit(child, 1_000))) {
+    throw new Error("focused worker did not terminate within the final reap deadline");
+  }
+}
+
+async function waitForExit(child: ReturnType<typeof Bun.spawn>, timeoutMs: number) {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const timeout = new Promise<false>((resolve) => {
+      timer = setTimeout(() => resolve(false), timeoutMs);
+    });
+    return await Promise.race([child.exited.then(() => true), timeout]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
+async function readBounded(stream: ReadableStream<Uint8Array>, limit: number) {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let output = "";
+  while (true) {
+    const chunk = await reader.read();
+    if (chunk.done) return output;
+    output += decoder.decode(chunk.value, { stream: true });
+    if (Buffer.byteLength(output, "utf8") > limit) {
+      throw new Error("focused worker output exceeded 16 KiB limit");
+    }
+  }
+}

--- a/src/lib/ad-hoc-games.test.ts
+++ b/src/lib/ad-hoc-games.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, test } from "bun:test";
+import {
+  createAdHocGamesService,
+  createInMemoryAdHocStore,
+  type AdHocGamesService,
+} from "@/lib/ad-hoc-games";
+
+function service(): AdHocGamesService {
+  return createAdHocGamesService({
+    store: createInMemoryAdHocStore(),
+    now: () => 1_000,
+    random: (() => {
+      let counter = 0;
+      return () => `secret-${String(++counter).padStart(2, "0")}-abcdefghijklmnopqrstuvwxyz`;
+    })(),
+  });
+}
+
+describe("Ad Hoc Games service", () => {
+  test("normalizes bounded names and atomically admits the initially admitted Ad Hoc Controller", async () => {
+    const games = service();
+    const result = await games.create({
+      homeName: "  A\u0308 ",
+      awayName: " Away ",
+      sourceKey: "browser-a",
+    });
+
+    expect(result.status).toBe("accepted");
+    if (result.status !== "accepted") return;
+    expect(result.game.state.homeName).toBe("Ä");
+    expect(result.game.state.awayName).toBe("Away");
+    expect(result.game.state.id).toBe(result.gameId);
+    expect(result.sessionId.length).toBeGreaterThanOrEqual(32);
+    expect(result.controlQr.length).toBeGreaterThanOrEqual(32);
+
+    const authorized = await games.read({ gameId: result.gameId, sessionId: result.sessionId });
+    expect(authorized.status).toBe("accepted");
+  });
+
+  test("rejects malformed and oversized creation without allocating state", async () => {
+    const store = createInMemoryAdHocStore();
+    const games = createAdHocGamesService({ store, now: () => 1_000 });
+
+    const malformed = await games.create({ homeName: "", awayName: "Away" });
+    const oversized = await games.create({ homeName: "x".repeat(81), awayName: "Away" });
+
+    expect(malformed).toMatchObject({ status: "rejected", reason: "invalid-input" });
+    expect(oversized).toMatchObject({ status: "rejected", reason: "invalid-input" });
+    expect(store.listGames()).toHaveLength(0);
+  });
+
+  test("requires an admitted Ad Hoc Controller session and keeps operation identities durable in the service", async () => {
+    const games = service();
+    const created = await games.create({ homeName: "Home", awayName: "Away" });
+    if (created.status !== "accepted") throw new Error("creation failed");
+
+    const unauthorized = await games.read({ gameId: created.gameId, sessionId: "wrong" });
+    expect(unauthorized).toMatchObject({ status: "unavailable" });
+
+    const operation = {
+      id: "operation-1",
+      clientSentAtMs: 1_000,
+      command: { type: "set-running", running: true } as const,
+    };
+    const accepted = await games.apply({
+      gameId: created.gameId,
+      sessionId: created.sessionId,
+      operations: [operation],
+    });
+    const duplicate = await games.apply({
+      gameId: created.gameId,
+      sessionId: created.sessionId,
+      operations: [operation],
+    });
+
+    expect(accepted.status).toBe("accepted");
+    expect(duplicate.status).toBe("duplicate");
+    expect(
+      (await games.read({ gameId: created.gameId, sessionId: created.sessionId })).status,
+    ).toBe("accepted");
+  });
+
+  test("rejects malformed commands without changing current state", async () => {
+    const games = service();
+    const created = await games.create({ homeName: "Home", awayName: "Away" });
+    if (created.status !== "accepted") throw new Error("creation failed");
+
+    const rejected = await games.apply({
+      gameId: created.gameId,
+      sessionId: created.sessionId,
+      operations: [
+        {
+          id: "bad-command",
+          clientSentAtMs: 1_000,
+          command: { type: "not-a-game-command" } as never,
+        },
+      ],
+    });
+    const read = await games.read({ gameId: created.gameId, sessionId: created.sessionId });
+
+    expect(rejected).toMatchObject({ status: "rejected", reason: "invalid-operation" });
+    expect(read.status).toBe("accepted");
+    if (read.status === "accepted") expect(read.game.state.isRunning).toBe(false);
+  });
+
+  test("keeps capacity cleanup isolated and rejects protected saturation", async () => {
+    let nowMs = 1_000;
+    const store = createInMemoryAdHocStore();
+    const games = createAdHocGamesService({ store, now: () => nowMs });
+    const created: Array<{ gameId: string; sessionId: string }> = [];
+
+    for (let index = 0; index < 50; index += 1) {
+      nowMs += 60 * 60_000;
+      const result = await games.create({
+        homeName: `Home ${index}`,
+        awayName: "Away",
+        sourceKey: `source-${index}`,
+      });
+      if (result.status !== "accepted") throw new Error("capacity setup failed");
+      created.push(result);
+      await games.setConnection({
+        gameId: result.gameId,
+        sessionId: result.sessionId,
+        connected: true,
+      });
+    }
+
+    const rejected = await games.create({
+      homeName: "New",
+      awayName: "Game",
+      sourceKey: "new-source",
+    });
+    expect(rejected).toMatchObject({ status: "rejected", reason: "capacity" });
+
+    await games.setConnection({
+      gameId: created[0]!.gameId,
+      sessionId: created[0]!.sessionId,
+      connected: false,
+    });
+    nowMs += 5 * 60_000;
+    const replacement = await games.create({
+      homeName: "New",
+      awayName: "Game",
+      sourceKey: "new-source-2",
+    });
+    expect(replacement.status).toBe("accepted");
+    expect(store.listGames()).toHaveLength(50);
+    expect(store.readGame(created[0]!.gameId)).toBeNull();
+  });
+});

--- a/src/lib/ad-hoc-games.ts
+++ b/src/lib/ad-hoc-games.ts
@@ -1,0 +1,671 @@
+import { Database } from "bun:sqlite";
+import { createHash, randomBytes } from "node:crypto";
+import { mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import { applyGameCommand, createInitialGameState, projectGameView } from "@/lib/game-engine";
+import type { GameCommand, GameState, GameView } from "@/lib/game-types";
+import { parseGameCommand } from "@/lib/ws-protocol";
+import { parseHexColor, DEFAULT_AWAY_TEAM_COLOR, DEFAULT_HOME_TEAM_COLOR } from "@/lib/team-colors";
+import {
+  normalizeBoundedText,
+  SHARED_LIMITS,
+  validateOpaqueIdentifier,
+} from "@/lib/validation-policy";
+
+export const AD_HOC_MAX_RETAINED_GAMES = 50;
+export const AD_HOC_DISCONNECTED_GRACE_MS = 5 * 60_000;
+export const AD_HOC_CREATION_SOURCE_WINDOW_MS = 10 * 60_000;
+export const AD_HOC_CREATION_GLOBAL_WINDOW_MS = 60 * 60_000;
+export const AD_HOC_MAX_CREATIONS_PER_SOURCE = 5;
+export const AD_HOC_MAX_CREATIONS_PER_HOUR = 30;
+
+const SCHEMA_VERSION = 1;
+const GENERIC_UNAVAILABLE = "Ad Hoc Game unavailable.";
+
+export type AdHocGameView = GameView & {
+  gameId: string;
+  sessionId: string;
+  controlQr: string | null;
+};
+
+export type AdHocCreationInput = {
+  homeName: unknown;
+  awayName: unknown;
+  homeColor?: unknown;
+  awayColor?: unknown;
+  sourceKey?: string;
+  nowMs?: number;
+};
+
+export type AdHocCreateResult =
+  | {
+      status: "accepted";
+      gameId: string;
+      sessionId: string;
+      controlQr: string;
+      game: AdHocGameView;
+    }
+  | {
+      status: "rejected";
+      reason: "invalid-input" | "rate-limited" | "capacity" | "unavailable";
+      detail?: string;
+      retryAfterMs?: number;
+    };
+
+export type AdHocOperation = {
+  id: string;
+  clientSentAtMs: number;
+  command: GameCommand;
+};
+
+export type AdHocActionResult =
+  | { status: "accepted" | "duplicate"; game: AdHocGameView; ackedOperationIds: string[] }
+  | {
+      status: "rejected";
+      reason: "unavailable" | "invalid-operation" | "conflict";
+      detail?: string;
+    };
+
+export type AdHocAccessResult =
+  | { status: "accepted"; game: AdHocGameView }
+  | { status: "unavailable"; detail: string };
+
+type StoredSession = {
+  sessionHash: string;
+  browserId: string;
+  connected: boolean;
+  lastConnectedAtMs: number;
+  lastDisconnectedAtMs: number | null;
+};
+
+type StoredOperation = {
+  fingerprint: string;
+  command: GameCommand;
+  acceptedAtMs: number;
+};
+
+export type StoredAdHocGame = {
+  gameId: string;
+  createdAtMs: number;
+  state: GameState;
+  controlQr: string;
+  controlQrHash: string;
+  sessions: StoredSession[];
+  operations: Record<string, StoredOperation>;
+};
+
+type AdHocApplyMutationResult =
+  | false
+  | { invalid: true; rollback: true }
+  | { conflict: true }
+  | { acknowledged: string[]; duplicate: boolean };
+
+export type AdHocStore = {
+  close(): void;
+  listGames(): StoredAdHocGame[];
+  readGame(gameId: string): StoredAdHocGame | null;
+  createGame(input: {
+    game: StoredAdHocGame;
+    sourceHash: string;
+    nowMs: number;
+  }): "accepted" | "rate-limited" | "capacity" | "unavailable";
+  mutateGame<T>(gameId: string, mutation: (game: StoredAdHocGame) => T): T | null;
+};
+
+export type AdHocGamesServiceOptions = {
+  store?: AdHocStore;
+  now?: () => number;
+  random?: () => string;
+};
+
+export type AdHocGamesService = ReturnType<typeof createAdHocGamesService>;
+
+export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) {
+  const store = options.store ?? createInMemoryAdHocStore();
+  const now = options.now ?? (() => Date.now());
+  const random = options.random ?? (() => randomBytes(32).toString("base64url"));
+
+  return {
+    async create(input: AdHocCreationInput): Promise<AdHocCreateResult> {
+      const home = normalizeTeamInput(input.homeName, "homeName");
+      const away = normalizeTeamInput(input.awayName, "awayName");
+      if (!home.ok) return { status: "rejected", reason: "invalid-input", detail: home.error };
+      if (!away.ok) return { status: "rejected", reason: "invalid-input", detail: away.error };
+
+      const homeColor = validateColor(input.homeColor, DEFAULT_HOME_TEAM_COLOR, "homeColor");
+      const awayColor = validateColor(input.awayColor, DEFAULT_AWAY_TEAM_COLOR, "awayColor");
+      if (!homeColor.ok)
+        return { status: "rejected", reason: "invalid-input", detail: homeColor.error };
+      if (!awayColor.ok)
+        return { status: "rejected", reason: "invalid-input", detail: awayColor.error };
+
+      const nowMs = input.nowMs ?? now();
+      if (!Number.isSafeInteger(nowMs) || nowMs < 0) {
+        return {
+          status: "rejected",
+          reason: "invalid-input",
+          detail: "nowMs must be a safe integer.",
+        };
+      }
+
+      const sourceKey =
+        typeof input.sourceKey === "string" ? input.sourceKey.trim() : "anonymous-browser";
+      const sourceHash = digest(sourceKey || "anonymous-browser");
+      const gameId = `adhoc-${random()}`;
+      const sessionId = random();
+      const controlQr = random();
+      const state = createInitialGameState({
+        id: gameId,
+        nowMs,
+        homeName: home.value,
+        awayName: away.value,
+        homeColor: homeColor.value,
+        awayColor: awayColor.value,
+      });
+      const game: StoredAdHocGame = {
+        gameId,
+        createdAtMs: nowMs,
+        state,
+        controlQr,
+        controlQrHash: digest(controlQr),
+        sessions: [
+          {
+            sessionHash: digest(sessionId),
+            browserId: sourceKey || "anonymous-browser",
+            connected: false,
+            lastConnectedAtMs: nowMs,
+            lastDisconnectedAtMs: null,
+          },
+        ],
+        operations: {},
+      };
+
+      let outcome: ReturnType<AdHocStore["createGame"]>;
+      try {
+        outcome = store.createGame({ game, sourceHash, nowMs });
+      } catch {
+        return { status: "rejected", reason: "unavailable" };
+      }
+      if (outcome === "rate-limited") {
+        return {
+          status: "rejected",
+          reason: "rate-limited",
+          retryAfterMs: 60 * 60_000,
+        };
+      }
+      if (outcome === "capacity") {
+        return { status: "rejected", reason: "capacity" };
+      }
+      if (outcome === "unavailable") return { status: "rejected", reason: "unavailable" };
+
+      return {
+        status: "accepted",
+        gameId,
+        sessionId,
+        controlQr,
+        game: projectAuthorizedGame(game, sessionId, controlQr, nowMs),
+      };
+    },
+
+    async read(input: {
+      gameId: unknown;
+      sessionId: unknown;
+      nowMs?: number;
+    }): Promise<AdHocAccessResult> {
+      const gameId = validateGameId(input.gameId);
+      const sessionId = validateBearer(input.sessionId);
+      if (gameId === null || sessionId === null) return unavailable();
+      let game: StoredAdHocGame | null;
+      try {
+        game = store.readGame(gameId);
+      } catch {
+        return unavailable();
+      }
+      if (game === null || !hasSession(game, sessionId)) return unavailable();
+      return {
+        status: "accepted",
+        game: projectAuthorizedGame(game, sessionId, null, input.nowMs ?? now()),
+      };
+    },
+
+    async admit(input: {
+      gameId: unknown;
+      controlQr: unknown;
+      browserId?: string;
+      nowMs?: number;
+    }): Promise<AdHocAccessResult> {
+      const gameId = validateGameId(input.gameId);
+      const qr = validateBearer(input.controlQr);
+      if (gameId === null || qr === null) return unavailable();
+      const nowMs = input.nowMs ?? now();
+      if (!isSafeTimestamp(nowMs)) return unavailable();
+      const sessionId = random();
+      let outcome: boolean | null;
+      try {
+        outcome = store.mutateGame(gameId, (game) => {
+          if (game.state.isFinished || digest(qr) !== game.controlQrHash) return false;
+          game.sessions.push({
+            sessionHash: digest(sessionId),
+            browserId: input.browserId?.trim() || "anonymous-browser",
+            connected: false,
+            lastConnectedAtMs: nowMs,
+            lastDisconnectedAtMs: null,
+          });
+          return true;
+        });
+      } catch {
+        return unavailable();
+      }
+      if (outcome !== true) return unavailable();
+      let game: StoredAdHocGame | null;
+      try {
+        game = store.readGame(gameId);
+      } catch {
+        return unavailable();
+      }
+      if (game === null) return unavailable();
+      return { status: "accepted", game: projectAuthorizedGame(game, sessionId, qr, nowMs) };
+    },
+
+    async apply(input: {
+      gameId: unknown;
+      sessionId: unknown;
+      operations: AdHocOperation[];
+      nowMs?: number;
+    }): Promise<AdHocActionResult> {
+      const gameId = validateGameId(input.gameId);
+      const sessionId = validateBearer(input.sessionId);
+      if (
+        gameId === null ||
+        sessionId === null ||
+        !Array.isArray(input.operations) ||
+        input.operations.length === 0 ||
+        input.operations.length > SHARED_LIMITS.replay.maxControlActions
+      ) {
+        return { status: "rejected", reason: "invalid-operation" };
+      }
+      const nowMs = input.nowMs ?? now();
+      if (!isSafeTimestamp(nowMs)) return { status: "rejected", reason: "invalid-operation" };
+      let outcome: AdHocApplyMutationResult | null;
+      try {
+        outcome = store.mutateGame<AdHocApplyMutationResult>(gameId, (game) => {
+          if (!hasSession(game, sessionId)) return false;
+          const next = structuredClone(game) as StoredAdHocGame;
+          const acknowledged: string[] = [];
+          let duplicate = false;
+          for (const operation of input.operations) {
+            if (typeof operation !== "object" || operation === null)
+              return { invalid: true, rollback: true } as const;
+            const operationId = validateOpaqueIdentifier(operation.id, "operationId");
+            if (
+              !operationId.ok ||
+              !Number.isSafeInteger(operation.clientSentAtMs) ||
+              operation.clientSentAtMs < 0
+            )
+              return { invalid: true, rollback: true } as const;
+            const id = operationId.value;
+            const parsedCommand =
+              typeof operation.command === "object" && operation.command !== null
+                ? parseGameCommand(operation.command as Record<string, unknown>)
+                : { ok: false as const, error: "command must be an object." };
+            if (!parsedCommand.ok) return { invalid: true, rollback: true } as const;
+            const normalizedOperation = { ...operation, command: parsedCommand.command };
+            const fingerprint = canonicalOperation(normalizedOperation);
+            const existing = next.operations[id];
+            if (existing !== undefined) {
+              if (existing.fingerprint !== fingerprint) return { conflict: true } as const;
+              acknowledged.push(id);
+              duplicate = true;
+              continue;
+            }
+            next.state = applyGameCommand({
+              state: next.state,
+              command: parsedCommand.command,
+              nowMs: operation.clientSentAtMs,
+            });
+            next.operations[id] = {
+              fingerprint,
+              command: structuredClone(parsedCommand.command),
+              acceptedAtMs: nowMs,
+            };
+            acknowledged.push(id);
+          }
+          next.state.updatedAtMs = nowMs;
+          Object.assign(game, next);
+          return { acknowledged, duplicate };
+        });
+      } catch {
+        return { status: "rejected", reason: "unavailable" };
+      }
+      if (outcome === null || outcome === false)
+        return { status: "rejected", reason: "unavailable" };
+      if ("conflict" in outcome) return { status: "rejected", reason: "conflict" };
+      if ("invalid" in outcome) return { status: "rejected", reason: "invalid-operation" };
+      let game: StoredAdHocGame | null;
+      try {
+        game = store.readGame(gameId);
+      } catch {
+        return { status: "rejected", reason: "unavailable" };
+      }
+      if (game === null) return { status: "rejected", reason: "unavailable" };
+      return {
+        status: outcome.duplicate ? "duplicate" : "accepted",
+        ackedOperationIds: outcome.acknowledged,
+        game: projectAuthorizedGame(game, sessionId, null, nowMs),
+      };
+    },
+
+    async setConnection(input: {
+      gameId: unknown;
+      sessionId: unknown;
+      connected: boolean;
+      nowMs?: number;
+    }): Promise<boolean> {
+      const gameId = validateGameId(input.gameId);
+      const sessionId = validateBearer(input.sessionId);
+      if (gameId === null || sessionId === null) return false;
+      const nowMs = input.nowMs ?? now();
+      if (!isSafeTimestamp(nowMs)) return false;
+      try {
+        return (
+          store.mutateGame(gameId, (game) => {
+            const session = game.sessions.find(
+              (candidate) => candidate.sessionHash === digest(sessionId),
+            );
+            if (session === undefined) return false;
+            session.connected = input.connected;
+            if (input.connected) session.lastConnectedAtMs = nowMs;
+            else session.lastDisconnectedAtMs = nowMs;
+            return true;
+          }) === true
+        );
+      } catch {
+        return false;
+      }
+    },
+
+    async leave(input: { gameId: unknown; sessionId: unknown; nowMs?: number }): Promise<boolean> {
+      const gameId = validateGameId(input.gameId);
+      const sessionId = validateBearer(input.sessionId);
+      if (gameId === null || sessionId === null) return false;
+      try {
+        return (
+          store.mutateGame(gameId, (game) => {
+            const before = game.sessions.length;
+            game.sessions = game.sessions.filter(
+              (session) => session.sessionHash !== digest(sessionId),
+            );
+            return game.sessions.length !== before;
+          }) === true
+        );
+      } catch {
+        return false;
+      }
+    },
+
+    genericUnavailableMessage: GENERIC_UNAVAILABLE,
+    store,
+    close() {
+      store.close();
+    },
+  };
+}
+
+export function createInMemoryAdHocStore(): AdHocStore {
+  const games = new Map<string, StoredAdHocGame>();
+  const attempts = new Map<string, number[]>();
+  const successes: number[] = [];
+  return {
+    close() {},
+    listGames: () => [...games.values()].map(cloneStoredGame),
+    readGame: (gameId) => {
+      const game = games.get(gameId);
+      return game === undefined ? null : cloneStoredGame(game);
+    },
+    createGame({ game, sourceHash, nowMs }) {
+      const sourceAttempts = (attempts.get(sourceHash) ?? []).filter(
+        (value) => value > nowMs - AD_HOC_CREATION_SOURCE_WINDOW_MS,
+      );
+      if (sourceAttempts.length >= AD_HOC_MAX_CREATIONS_PER_SOURCE) return "rate-limited";
+      const recentSuccesses = successes.filter(
+        (value) => value > nowMs - AD_HOC_CREATION_GLOBAL_WINDOW_MS,
+      );
+      if (recentSuccesses.length >= AD_HOC_MAX_CREATIONS_PER_HOUR) return "rate-limited";
+      if (games.size >= AD_HOC_MAX_RETAINED_GAMES) {
+        const victim = [...games.values()]
+          .filter((candidate) =>
+            candidate.sessions.every(
+              (session) =>
+                !session.connected &&
+                session.lastDisconnectedAtMs !== null &&
+                session.lastDisconnectedAtMs <= nowMs - AD_HOC_DISCONNECTED_GRACE_MS,
+            ),
+          )
+          .sort((a, b) => a.createdAtMs - b.createdAtMs)[0];
+        if (victim === undefined) return "capacity";
+        games.delete(victim.gameId);
+      }
+      games.set(game.gameId, cloneStoredGame(game));
+      attempts.set(sourceHash, [...sourceAttempts, nowMs]);
+      successes.push(nowMs);
+      return "accepted";
+    },
+    mutateGame(gameId, mutation) {
+      const game = games.get(gameId);
+      if (game === undefined) return null;
+      const working = cloneStoredGame(game);
+      const result = mutation(working);
+      if (
+        result !== null &&
+        result !== false &&
+        !(
+          typeof result === "object" &&
+          (("conflict" in result && result.conflict === true) ||
+            ("rollback" in result && result.rollback === true))
+        )
+      ) {
+        games.set(gameId, working);
+      }
+      return result;
+    },
+  };
+}
+
+export function openSqliteAdHocStore(databasePath: string): AdHocStore {
+  mkdirSync(dirname(databasePath), { recursive: true });
+  const db = new Database(databasePath, { create: true, strict: true });
+  db.run("PRAGMA journal_mode = WAL");
+  db.run("PRAGMA foreign_keys = ON");
+  db.run("PRAGMA busy_timeout = 0");
+  db.run(
+    "CREATE TABLE IF NOT EXISTS adhoc_schema (id INTEGER PRIMARY KEY CHECK (id = 1), version INTEGER NOT NULL)",
+  );
+  db.run("INSERT OR IGNORE INTO adhoc_schema (id, version) VALUES (1, ?)", [SCHEMA_VERSION]);
+  db.run(`CREATE TABLE IF NOT EXISTS adhoc_games (
+    game_id TEXT PRIMARY KEY,
+    created_at_ms INTEGER NOT NULL,
+    state_json TEXT NOT NULL,
+    control_qr TEXT NOT NULL,
+    control_qr_hash TEXT NOT NULL,
+    sessions_json TEXT NOT NULL,
+    operations_json TEXT NOT NULL
+  )`);
+  db.run(
+    "CREATE TABLE IF NOT EXISTS adhoc_creation_events (source_hash TEXT NOT NULL, successful INTEGER NOT NULL, occurred_at_ms INTEGER NOT NULL)",
+  );
+
+  const read = (gameId: string): StoredAdHocGame | null => {
+    const row = db.query("SELECT * FROM adhoc_games WHERE game_id = ?").get(gameId) as Record<
+      string,
+      string | number
+    > | null;
+    return row === null ? null : parseStoredRow(row);
+  };
+  const transaction = db.transaction((work: () => unknown) => work());
+  return {
+    close() {
+      db.close();
+    },
+    listGames() {
+      return (
+        db.query("SELECT * FROM adhoc_games ORDER BY created_at_ms ASC").all() as Record<
+          string,
+          string | number
+        >[]
+      ).map(parseStoredRow);
+    },
+    readGame: read,
+    createGame({ game, sourceHash, nowMs }) {
+      return transaction(() => {
+        db.run("DELETE FROM adhoc_creation_events WHERE occurred_at_ms <= ?", [
+          nowMs - AD_HOC_CREATION_GLOBAL_WINDOW_MS,
+        ]);
+        const sourceCountRow = db
+          .query(
+            "SELECT COUNT(*) AS count FROM adhoc_creation_events WHERE source_hash = ? AND occurred_at_ms > ?",
+          )
+          .get(sourceHash, nowMs - AD_HOC_CREATION_SOURCE_WINDOW_MS) as {
+          count?: number | string;
+        } | null;
+        const sourceCount = Number(sourceCountRow?.count ?? 0);
+        if (sourceCount >= AD_HOC_MAX_CREATIONS_PER_SOURCE) return "rate-limited" as const;
+        const globalCountRow = db
+          .query("SELECT COUNT(*) AS count FROM adhoc_creation_events WHERE successful = 1")
+          .get() as { count?: number | string } | null;
+        const globalCount = Number(globalCountRow?.count ?? 0);
+        if (globalCount >= AD_HOC_MAX_CREATIONS_PER_HOUR) return "rate-limited" as const;
+        const countRow = db.query("SELECT COUNT(*) AS count FROM adhoc_games").get() as {
+          count?: number | string;
+        } | null;
+        const count = Number(countRow?.count ?? 0);
+        if (count >= AD_HOC_MAX_RETAINED_GAMES) {
+          const victim = db
+            .query(`SELECT game_id FROM adhoc_games WHERE NOT EXISTS (
+            SELECT 1 FROM json_each(sessions_json) AS session
+            WHERE json_extract(session.value, '$.connected') = 1
+               OR json_extract(session.value, '$.lastDisconnectedAtMs') IS NULL
+               OR json_extract(session.value, '$.lastDisconnectedAtMs') > ?
+          ) ORDER BY created_at_ms ASC LIMIT 1`)
+            .get(nowMs - AD_HOC_DISCONNECTED_GRACE_MS) as { game_id?: string } | null;
+          if (victim?.game_id === undefined) return "capacity" as const;
+          db.run("DELETE FROM adhoc_games WHERE game_id = ?", [victim.game_id]);
+        }
+        db.run(
+          "INSERT INTO adhoc_games (game_id, created_at_ms, state_json, control_qr, control_qr_hash, sessions_json, operations_json) VALUES (?, ?, ?, ?, ?, ?, ?)",
+          [
+            game.gameId,
+            game.createdAtMs,
+            JSON.stringify(game.state),
+            game.controlQr,
+            game.controlQrHash,
+            JSON.stringify(game.sessions),
+            JSON.stringify(game.operations),
+          ],
+        );
+        db.run(
+          "INSERT INTO adhoc_creation_events (source_hash, successful, occurred_at_ms) VALUES (?, 1, ?)",
+          [sourceHash, nowMs],
+        );
+        return "accepted" as const;
+      }) as "accepted" | "rate-limited" | "capacity" | "unavailable";
+    },
+    mutateGame<T>(gameId: string, mutation: (game: StoredAdHocGame) => T): T | null {
+      return transaction(() => {
+        const game = read(gameId);
+        if (game === null) return null;
+        const result = mutation(game);
+        if (
+          result !== null &&
+          result !== false &&
+          !(
+            typeof result === "object" &&
+            (("conflict" in result && result.conflict === true) ||
+              ("rollback" in result && result.rollback === true))
+          )
+        ) {
+          db.run(
+            "UPDATE adhoc_games SET state_json = ?, sessions_json = ?, operations_json = ? WHERE game_id = ?",
+            [
+              JSON.stringify(game.state),
+              JSON.stringify(game.sessions),
+              JSON.stringify(game.operations),
+              gameId,
+            ],
+          );
+        }
+        return result;
+      }) as T | null;
+    },
+  };
+}
+
+function parseStoredRow(row: Record<string, string | number>): StoredAdHocGame {
+  return {
+    gameId: String(row.game_id),
+    createdAtMs: Number(row.created_at_ms),
+    state: JSON.parse(String(row.state_json)) as GameState,
+    controlQr: String(row.control_qr),
+    controlQrHash: String(row.control_qr_hash),
+    sessions: JSON.parse(String(row.sessions_json)) as StoredSession[],
+    operations: JSON.parse(String(row.operations_json)) as Record<string, StoredOperation>,
+  };
+}
+
+function projectAuthorizedGame(
+  game: StoredAdHocGame,
+  sessionId: string,
+  controlQr: string | null,
+  nowMs: number,
+): AdHocGameView {
+  const view = projectGameView(game.state, nowMs);
+  return {
+    ...view,
+    gameId: game.gameId,
+    sessionId,
+    controlQr: view.state.isFinished ? null : (controlQr ?? game.controlQr),
+  };
+}
+
+function hasSession(game: StoredAdHocGame, sessionId: string): boolean {
+  return game.sessions.some((session) => session.sessionHash === digest(sessionId));
+}
+
+function validateGameId(value: unknown): string | null {
+  const result = validateOpaqueIdentifier(value, "gameId");
+  return result.ok && result.value.startsWith("adhoc-") ? result.value : null;
+}
+
+function validateBearer(value: unknown): string | null {
+  return typeof value === "string" && value.length >= 32 && value.length <= 256 ? value : null;
+}
+
+function isSafeTimestamp(value: number): boolean {
+  return Number.isSafeInteger(value) && value >= 0;
+}
+
+function normalizeTeamInput(value: unknown, field: string) {
+  return normalizeBoundedText(value, SHARED_LIMITS.names.teamAndPitchMaxCodePoints, field);
+}
+
+function validateColor(value: unknown, fallback: string, field: string) {
+  if (value === undefined) return { ok: true as const, value: fallback };
+  if (typeof value !== "string" || parseHexColor(value) === null)
+    return { ok: false as const, error: `${field} must be a hexadecimal color.` };
+  return { ok: true as const, value: `#${value.replace(/^#/, "").toLowerCase()}` };
+}
+
+function canonicalOperation(operation: AdHocOperation): string {
+  return JSON.stringify([operation.clientSentAtMs, operation.command]);
+}
+
+function digest(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function cloneStoredGame(game: StoredAdHocGame): StoredAdHocGame {
+  return structuredClone(game) as StoredAdHocGame;
+}
+
+function unavailable(): AdHocAccessResult {
+  return { status: "unavailable", detail: GENERIC_UNAVAILABLE };
+}

--- a/src/lib/game-page-support.ts
+++ b/src/lib/game-page-support.ts
@@ -214,7 +214,6 @@ export function useGameConnection({ gameId, role }: { gameId: string; role: Cont
           JSON.stringify({
             type: "subscribe-game",
             gameId,
-            role,
           }),
         );
       };

--- a/src/lib/ws-protocol.test.ts
+++ b/src/lib/ws-protocol.test.ts
@@ -207,12 +207,11 @@ describe("ws-protocol", () => {
     }
   });
 
-  test("parses subscribe-game events", () => {
+  test("parses subscribe-game without client-asserted authority", () => {
     const parsed = parseClientWsMessage(
       JSON.stringify({
         type: "subscribe-game",
         gameId: "game-123",
-        role: "spectator",
       }),
     );
 
@@ -227,7 +226,15 @@ describe("ws-protocol", () => {
     }
 
     expect(parsed.message.gameId).toBe("game-123");
-    expect(parsed.message.role).toBe("spectator");
+    expect(parsed.message).toEqual({ type: "subscribe-game", gameId: "game-123" });
+  });
+
+  test("rejects client-asserted subscribe-game roles", () => {
+    expect(
+      parseClientWsMessage(
+        JSON.stringify({ type: "subscribe-game", gameId: "game-123", role: "controller" }),
+      ),
+    ).toEqual({ ok: false, error: "subscribe-game does not accept a role." });
   });
 
   test("parses apply-commands with valid command payload", () => {

--- a/src/lib/ws-protocol.ts
+++ b/src/lib/ws-protocol.ts
@@ -1,4 +1,4 @@
-import type { ControllerRole, GameCommand, GameSummary, GameView } from "@/lib/game-types";
+import type { GameCommand, GameSummary, GameView } from "@/lib/game-types";
 import {
   SHARED_LIMITS,
   validateClockAdjustmentMs,
@@ -24,7 +24,6 @@ export type SubscribeLobbyMessage = {
 export type SubscribeGameMessage = {
   type: "subscribe-game";
   gameId: string;
-  role: ControllerRole;
 };
 
 export type ApplyCommandsMessage = {
@@ -51,7 +50,11 @@ export type ServerWsMessage =
     }
   | {
       type: "game-snapshot";
-      game: GameView;
+      game: GameView & {
+        gameId?: string;
+        sessionId?: string | null;
+        controlQr?: string | null;
+      };
       serverNowMs: number;
       ackedCommandIds: string[];
     };
@@ -112,10 +115,10 @@ export function parseClientWsMessage(
       };
     }
 
-    if (payload.role !== "controller" && payload.role !== "spectator") {
+    if ("role" in payload) {
       return {
         ok: false,
-        error: "subscribe-game requires role controller or spectator.",
+        error: "subscribe-game does not accept a role.",
       };
     }
 
@@ -124,7 +127,6 @@ export function parseClientWsMessage(
       message: {
         type: "subscribe-game",
         gameId: gameId.value,
-        role: payload.role,
       },
     };
   }
@@ -230,7 +232,7 @@ export function parseClientWsMessage(
   };
 }
 
-function parseGameCommand(payload: Record<string, unknown>):
+export function parseGameCommand(payload: Record<string, unknown>):
   | {
       ok: true;
       command: GameCommand;


### PR DESCRIPTION
## What changed

- Replaced the public process-local anonymous Game registry with a durable Ad Hoc Games service backed by Ad Hoc-owned SQLite state.
- Atomically creates a Game and its initially admitted equal Controller, with normalized bounded Team names, persistent per-Game browser authority, and durable operation deduplication.
- Removed public Ad Hoc discovery, spectator access, and client-asserted Controller roles; unauthorized HTTP and WebSocket routes now return one generic unavailable outcome.
- Added the controller-only Home entry, authorized Game routing, restart-safe persistence, and a bounded SQLite process-restart integration test.

## Why

This is the first end-to-end tracer for the controller-only Ad Hoc Games specification. It replaces the legacy public, in-memory path without introducing Event Game Records, Grants, Technical Admin authority, or an Event audit model.

## Impact

Visitors can start an Ad Hoc Game and immediately control it without an account. Admitted Controllers retain per-Game authority across browser and ordinary server restarts. Retained Games and Team names are no longer publicly discoverable, and Event operations remain outside this module's authority and storage path.

## Validation

- `bun run check`
- `bun run test` — 458 passed after rebasing onto current `origin/main`
- `bun run test:focused:ad-hoc`
- `bun run build`
- `git diff --check origin/main...HEAD`

Implements #152.

Parent specification: #151.
