### PR TITLE
Preserve Controller actions through reconnect

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -305,6 +305,11 @@ async function startServer() {
             return liveEventControlTransport.submitControllerIntent(req);
           },
         },
+        "/api/event-control/replay": {
+          POST(req: Request) {
+            return liveEventControlTransport.replayControllerActions(req);
+          },
+        },
         "/api/event-control/refresh": {
           POST(req: Request) {
             return liveEventControlTransport.refreshController(req);

--- a/src/lib/controller-reconnect.test.ts
+++ b/src/lib/controller-reconnect.test.ts
@@ -1,0 +1,433 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildControllerReplayBatch,
+  createControllerReplica,
+  dispatchControllerAction,
+  loadControllerReplica,
+  prepareControllerReplayBatch,
+  parseControllerReplica,
+  persistControllerReplica,
+  rebindControllerReplica,
+  reconcileControllerReplay,
+  serializeControllerReplica,
+  type ControllerReplicaStorage,
+} from "@/lib/controller-reconnect";
+import { LIVE_EVENT_CONTROL_INTENT_VERSION } from "@/lib/live-event-game-control";
+
+describe("Controller reconnect replica", () => {
+  test("optimistically retains immutable identity, causal dependencies, and original occurrence evidence", () => {
+    let state = createReplica();
+    const first = dispatchControllerAction(state, goal("goal-1", "fact-1"), { nowMs: 100 });
+    state = first.state;
+    const second = dispatchControllerAction(state, goal("goal-2", "fact-2"), {
+      nowMs: 101,
+      causalPredecessorIds: [first.action.intent.operationId],
+    });
+    state = second.state;
+
+    expect(state.projection.scoreByGameSide).toEqual({ "side-a": 20, "side-b": 0 });
+    expect(state.pendingActions.map((action) => action.counter)).toEqual([1, 2]);
+    expect(state.pendingActions[0]?.intent.occurrence).toEqual({
+      clientOriginAtMs: 42,
+      source: "offline",
+    });
+    expect(second.action.causalPredecessorIds).toEqual([first.action.intent.operationId]);
+    expect(buildControllerReplayBatch(state)?.actions).toHaveLength(2);
+  });
+
+  test("optimistically applies every ordinary Controller action family with existing lifecycle semantics", () => {
+    for (const trigger of ["card", "timeout", "suspension"] as const) {
+      const next = dispatchControllerAction(
+        createReplica(),
+        substantive(`substantive-${trigger}`, trigger),
+        { nowMs: 100 },
+      ).state;
+      expect(next.projection.phase).toBe("in-progress");
+      expect(next.projection.commencement.status).toBe("commenced");
+    }
+    const finished = dispatchControllerAction(
+      createReplica(),
+      substantive("substantive-result", "result"),
+      { nowMs: 101 },
+    ).state;
+    expect(finished.projection.phase).toBe("finished");
+    const resetState = dispatchControllerAction(createReplica(), reset("reset", "reset-fact"), {
+      nowMs: 102,
+    }).state;
+    const undoState = dispatchControllerAction(createReplica(), reset("undo", "undo-fact"), {
+      nowMs: 103,
+    }).state;
+    expect(resetState.pendingActions).toHaveLength(1);
+    expect(undoState.pendingActions).toHaveLength(1);
+    expect(resetState.projection.phase).toBe("scheduled");
+    expect(undoState.projection.phase).toBe("scheduled");
+  });
+
+  test("keeps mixed causal optimistic effects while unrelated actions progress", () => {
+    let state = createReplica();
+    const card = dispatchControllerAction(state, substantive("card", "card"), { nowMs: 100 });
+    state = card.state;
+    state = dispatchControllerAction(state, goal("unrelated-goal", "unrelated-fact"), {
+      nowMs: 101,
+    }).state;
+    state = dispatchControllerAction(state, substantive("result", "result"), {
+      nowMs: 102,
+      causalPredecessorIds: [card.action.intent.operationId],
+    }).state;
+    expect(state.projection).toMatchObject({ phase: "finished", goalCount: 1 });
+    expect(state.pendingActions.map((action) => action.intent.operationId)).toEqual([
+      "card",
+      "unrelated-goal",
+      "result",
+    ]);
+  });
+
+  test("reconciles explicit outcomes without deleting retryable or causally blocked evidence", () => {
+    let state = createReplica();
+    state = dispatchControllerAction(state, goal("accepted", "fact-a"), { nowMs: 100 }).state;
+    state = dispatchControllerAction(state, goal("retry", "fact-b"), { nowMs: 101 }).state;
+    state = dispatchControllerAction(state, goal("blocked", "fact-c"), {
+      nowMs: 102,
+      causalPredecessorIds: ["retry"],
+    }).state;
+    const prepared = prepareControllerReplayBatch(state);
+    if (prepared === null) throw new Error("Expected replay batch.");
+    const reconciled = reconcileControllerReplay(prepared.state, {
+      batchId: prepared.batch.batchId,
+      replicaGeneration: prepared.batch.replicaGeneration,
+      session: prepared.batch.session,
+      eventGameId: prepared.batch.eventGameId,
+      status: "retryable",
+      projection: state.projection,
+      outcomes: [
+        { operationId: "accepted", status: "accepted" },
+        { operationId: "retry", status: "retryable" },
+        { operationId: "blocked", status: "causally-blocked" },
+      ],
+    });
+    expect(reconciled.outcomes).toMatchObject({
+      accepted: "accepted",
+      retry: "retryable",
+      blocked: "causally-blocked",
+    });
+    expect(reconciled.pendingActions.map((action) => action.intent.operationId)).toEqual([
+      "retry",
+      "blocked",
+    ]);
+  });
+
+  test("adopts the durable projection, reapplies retryable work, and holds finished evidence", () => {
+    let state = createReplica();
+    state = dispatchControllerAction(state, goal("accepted", "fact-a"), { nowMs: 100 }).state;
+    state = dispatchControllerAction(state, goal("retry", "fact-b"), { nowMs: 101 }).state;
+    const prepared = prepareControllerReplayBatch(state);
+    if (prepared === null) throw new Error("Expected replay batch.");
+    const reconciled = reconcileControllerReplay(prepared.state, {
+      batchId: prepared.batch.batchId,
+      replicaGeneration: prepared.batch.replicaGeneration,
+      session: prepared.batch.session,
+      eventGameId: prepared.batch.eventGameId,
+      status: "retryable",
+      projection: {
+        ...state.projection,
+        goalCount: 1,
+        scoreByGameSide: { "side-a": 10, "side-b": 0 },
+      },
+      outcomes: [
+        { operationId: "accepted", status: "accepted" },
+        { operationId: "retry", status: "retryable" },
+      ],
+    });
+    expect(reconciled.projection.goalCount).toBe(2);
+    expect(reconciled.pendingActions.map((action) => action.intent.operationId)).toEqual(["retry"]);
+
+    const held = reconcileControllerReplay(
+      {
+        ...prepared.state,
+        pendingActions: prepared.state.pendingActions.map((action) => ({ ...action })),
+      },
+      {
+        ...prepared.batch,
+        status: "synchronized",
+        outcomes: prepared.batch.actions.map((action) => ({
+          operationId: action.intent.operationId,
+          status: "held-for-correction" as const,
+        })),
+        projection: state.projection,
+      },
+    );
+    expect(held.pendingActions.every((action) => action.status === "held-for-correction")).toBe(
+      true,
+    );
+    expect(buildControllerReplayBatch(held)).toBeNull();
+  });
+
+  test("ignores a delayed response after the replica is rebound and rejects Clock reconnect work", () => {
+    let state = createReplica();
+    state = dispatchControllerAction(state, goal("goal-a", "fact-a"), { nowMs: 100 }).state;
+    const prepared = prepareControllerReplayBatch(state);
+    if (prepared === null) throw new Error("Expected replay batch.");
+    const rebound = rebindControllerReplica(
+      prepared.state,
+      { ...prepared.state.session, grantVersion: "grant-version-2" },
+      prepared.state.projection,
+    );
+    const response = {
+      ...prepared.batch,
+      status: "synchronized" as const,
+      outcomes: [{ operationId: "goal-a", status: "accepted" as const }],
+      projection: prepared.state.projection,
+    };
+    expect(reconcileControllerReplay(rebound, response)).toBe(rebound);
+    expect(() =>
+      dispatchControllerAction(rebound, {
+        version: LIVE_EVENT_CONTROL_INTENT_VERSION,
+        type: "clock",
+        operationId: "clock-a",
+        factId: "clock-fact",
+        running: true,
+        gameTimeMs: 0,
+        occurrence: { clientOriginAtMs: 100 },
+      }),
+    ).toThrow("Clock reconnect belongs to Clock Authority");
+  });
+
+  test("derives optimism exactly once across null and authoritative rebinds", () => {
+    let state = createReplica();
+    state = dispatchControllerAction(state, goal("goal-rebind", "fact-goal-rebind"), {
+      nowMs: 100,
+    }).state;
+    state = dispatchControllerAction(state, substantive("card-rebind", "card"), {
+      nowMs: 101,
+    }).state;
+    state = dispatchControllerAction(state, substantive("timeout-rebind", "timeout"), {
+      nowMs: 102,
+    }).state;
+    const optimistic = structuredClone(state.projection);
+    expect(optimistic).toMatchObject({
+      phase: "in-progress",
+      scoreByGameSide: { "side-a": 10, "side-b": 0 },
+      goalCount: 1,
+    });
+
+    const firstNullRebind = rebindControllerReplica(
+      state,
+      { ...state.session, grantSessionId: "session-2", grantVersion: "grant-version-2" },
+      null,
+    );
+    expect(firstNullRebind.authoritativeProjection).toEqual(state.authoritativeProjection);
+    expect(firstNullRebind.projection).toEqual(optimistic);
+
+    const secondNullRebind = rebindControllerReplica(
+      firstNullRebind,
+      { ...firstNullRebind.session, grantVersion: "grant-version-3" },
+      null,
+    );
+    expect(secondNullRebind.projection).toEqual(optimistic);
+
+    const authoritative = {
+      ...state.authoritativeProjection,
+      scoreByGameSide: { "side-a": 20, "side-b": 0 },
+      goalCount: 2,
+    };
+    const replaced = rebindControllerReplica(
+      secondNullRebind,
+      { ...secondNullRebind.session, grantVersion: "grant-version-4" },
+      authoritative,
+    );
+    expect(replaced.authoritativeProjection).toEqual(authoritative);
+    expect(replaced.projection).toMatchObject({
+      phase: "in-progress",
+      scoreByGameSide: { "side-a": 30, "side-b": 0 },
+      goalCount: 3,
+    });
+
+    const restored = parseControllerReplica(
+      JSON.parse(serializeControllerReplica(replaced)),
+      "game-1",
+    );
+    expect(restored.authoritativeProjection).toEqual(authoritative);
+    expect(restored.projection).toEqual(replaced.projection);
+    const corrupted = JSON.parse(serializeControllerReplica(replaced)) as Record<string, any>;
+    corrupted.projection.goalCount += 1;
+    expect(() => parseControllerReplica(corrupted, "game-1")).toThrow(
+      "optimistic projection is inconsistent",
+    );
+  });
+
+  test("rejects malformed, duplicate, and unknown causal predecessors without weakening the action", () => {
+    const state = createReplica();
+    const candidate = goal("goal-a", "fact-a");
+    expect(() =>
+      dispatchControllerAction(state, candidate, {
+        causalPredecessorIds: [null as unknown as string],
+      }),
+    ).toThrow();
+    expect(() =>
+      dispatchControllerAction(state, candidate, {
+        causalPredecessorIds: ["missing", "missing"],
+      }),
+    ).toThrow();
+    expect(() =>
+      dispatchControllerAction(state, candidate, { causalPredecessorIds: ["missing"] }),
+    ).toThrow();
+  });
+
+  test("keeps one stable batch across lost transport and accepts reordered outcomes", () => {
+    let state = createReplica();
+    state = dispatchControllerAction(state, goal("first", "fact-first"), { nowMs: 100 }).state;
+    state = dispatchControllerAction(state, goal("second", "fact-second"), {
+      nowMs: 101,
+      causalPredecessorIds: ["first"],
+    }).state;
+    const firstBatch = prepareControllerReplayBatch(state);
+    if (firstBatch === null) throw new Error("Expected replay batch.");
+    expect(prepareControllerReplayBatch(firstBatch.state)?.batch.batchId).toBe(
+      firstBatch.batch.batchId,
+    );
+    expect(
+      reconcileControllerReplay(firstBatch.state, {
+        ...firstBatch.batch,
+        status: "synchronized",
+        outcomes: [
+          { operationId: "second", status: "accepted" },
+          { operationId: "first", status: "accepted" },
+        ],
+        projection: { ...state.projection, goalCount: 2 },
+      }).pendingActions,
+    ).toHaveLength(0);
+  });
+
+  test("quarantines duplicate and inconsistent retained counters", () => {
+    let state = createReplica();
+    state = dispatchControllerAction(state, goal("goal-a", "fact-a"), { nowMs: 100 }).state;
+    state = dispatchControllerAction(state, goal("goal-b", "fact-b"), { nowMs: 101 }).state;
+    const encoded = JSON.parse(serializeControllerReplica(state)) as Record<string, any>;
+    const duplicateCounter = structuredClone(encoded);
+    duplicateCounter.pendingActions[1].counter = duplicateCounter.pendingActions[0].counter;
+    duplicateCounter.pendingActions[1].identity.counter =
+      duplicateCounter.pendingActions[0].counter;
+    expect(() => parseControllerReplica(duplicateCounter, "game-1")).toThrow();
+    const repairedCounter = structuredClone(encoded);
+    repairedCounter.identity.nextCounter = 2;
+    expect(() => parseControllerReplica(repairedCounter, "game-1")).toThrow();
+  });
+
+  test("rejects corrupt, cross-Game, cyclic, and malformed persisted state", () => {
+    const state = createReplica();
+    const encoded = JSON.parse(serializeControllerReplica(state)) as Record<string, unknown>;
+    expect(() =>
+      parseControllerReplica({ ...encoded, eventGameId: "another-game" }, "game-1"),
+    ).toThrow();
+    expect(() => parseControllerReplica({ ...encoded, version: "future" }, "game-1")).toThrow();
+    expect(() =>
+      parseControllerReplica(
+        { ...encoded, projection: { ...state.projection, eventGameId: "another-game" } },
+        "game-1",
+      ),
+    ).toThrow();
+  });
+
+  test("quarantines corrupt storage and reports quota failure without silent eviction", () => {
+    let quarantined: string | null = null;
+    const corruptStorage: ControllerReplicaStorage = {
+      read: () => "{not-json",
+      write: () => undefined,
+      quarantine: (value) => {
+        quarantined = value;
+      },
+    };
+    expect(loadControllerReplica(corruptStorage, "game-1")).toMatchObject({
+      state: null,
+      quarantined: true,
+    });
+    expect(String(quarantined)).toBe("{not-json");
+
+    const state = createReplica();
+    const fullStorage: ControllerReplicaStorage = {
+      read: () => null,
+      write: () => {
+        throw new Error("quota");
+      },
+    };
+    const memoryOnly = persistControllerReplica(state, fullStorage);
+    expect(memoryOnly).toMatchObject({
+      state: { durability: "memory-only" },
+      warning: expect.stringContaining("full"),
+    });
+    expect(
+      dispatchControllerAction(memoryOnly.state, goal("after-quota", "fact-after-quota")).state,
+    ).toMatchObject({ pendingActions: [{ status: "pending" }] });
+  });
+
+  test("retains 10,000 stable identities deterministically", () => {
+    let state = createReplica();
+    for (let index = 0; index < 10_000; index += 1) {
+      state = dispatchControllerAction(state, reset(`operation-${index}`, `fact-${index}`), {
+        nowMs: index,
+      }).state;
+    }
+    expect(state.pendingActions).toHaveLength(10_000);
+    expect(state.identity.nextCounter).toBe(10_001);
+    expect(
+      parseControllerReplica(JSON.parse(serializeControllerReplica(state)), "game-1")
+        .pendingActions,
+    ).toHaveLength(10_000);
+  });
+});
+
+function createReplica() {
+  return createControllerReplica({
+    eventGameId: "game-1",
+    grantSessionId: "session-1",
+    grantVersion: "grant-version-1",
+    deviceId: "device-1",
+    projection: {
+      eventGameId: "game-1",
+      phase: "scheduled",
+      scoreByGameSide: { "side-a": 0, "side-b": 0 },
+      goalCount: 0,
+      commencement: {
+        status: "provisional",
+        commencedAtMs: null,
+        provisionalRunningSinceMs: null,
+        provisionalElapsedMs: 0,
+      },
+    },
+  });
+}
+
+function goal(operationId: string, factId: string) {
+  return {
+    version: LIVE_EVENT_CONTROL_INTENT_VERSION,
+    type: "record-goal" as const,
+    operationId,
+    factId,
+    gameSideId: "side-a",
+    gameTimeMs: 42,
+    occurrence: { clientOriginAtMs: 42, source: "offline" as const },
+  };
+}
+
+function reset(operationId: string, factId: string) {
+  return {
+    version: LIVE_EVENT_CONTROL_INTENT_VERSION,
+    type: "reset" as const,
+    operationId,
+    factId,
+    gameTimeMs: 0,
+    occurrence: { clientOriginAtMs: 0, source: "offline" as const },
+  };
+}
+
+function substantive(operationId: string, trigger: "card" | "timeout" | "suspension" | "result") {
+  return {
+    version: LIVE_EVENT_CONTROL_INTENT_VERSION,
+    type: "substantive" as const,
+    trigger,
+    operationId,
+    factId: `fact-${operationId}`,
+    gameTimeMs: 0,
+    occurrence: { clientOriginAtMs: 0, source: "offline" as const },
+  };
+}

--- a/src/lib/controller-reconnect.ts
+++ b/src/lib/controller-reconnect.ts
@@ -1,0 +1,910 @@
+import type {
+  ControllerSessionAttachment,
+  ControllerProjection,
+  LiveEventControllerIntent,
+} from "@/lib/live-event-game-control";
+import { parseLiveEventControllerIntent } from "@/lib/live-event-game-control";
+import {
+  SHARED_LIMITS,
+  validateIntegerInRange,
+  validateOpaqueIdentifier,
+} from "@/lib/validation-policy";
+
+export const CONTROLLER_REPLICA_VERSION = "controller-replica-v3" as const;
+export const CONTROLLER_REPLICA_STORAGE_KEY = "quadball:event-controller-replica";
+
+export function controllerReplicaStorageKey(eventGameId?: string): string {
+  return eventGameId === undefined
+    ? CONTROLLER_REPLICA_STORAGE_KEY
+    : `${CONTROLLER_REPLICA_STORAGE_KEY}:${eventGameId}`;
+}
+
+export type ControllerActionOutcomeStatus =
+  | "pending"
+  | "accepted"
+  | "idempotent"
+  | "retryable"
+  | "causally-blocked"
+  | "held-for-correction"
+  | "terminally-rejected";
+
+export type PendingControllerAction = {
+  eventGameId: string;
+  intent: LiveEventControllerIntent;
+  causalPredecessorIds: readonly string[];
+  dispatchedAtMs: number;
+  identity: {
+    deviceId: string;
+    counter: number;
+  };
+  counter: number;
+  status: ControllerActionOutcomeStatus;
+  detail?: string;
+};
+
+export type ControllerReplicaState = {
+  version: typeof CONTROLLER_REPLICA_VERSION;
+  eventGameId: string;
+  authoritativeProjection: ControllerProjection;
+  projection: ControllerProjection;
+  pendingActions: readonly PendingControllerAction[];
+  outcomes: Readonly<Record<string, ControllerActionOutcomeStatus>>;
+  identity: {
+    deviceId: string;
+    nextCounter: number;
+  };
+  session: ControllerSessionAttachment;
+  replicaGeneration: string;
+  unacknowledgedBatch: {
+    batchId: string;
+    replicaGeneration: string;
+    session: ControllerSessionAttachment;
+    actionOperationIds: readonly string[];
+  } | null;
+  durability: "durable" | "memory-only";
+};
+
+export type ControllerReplicaStorage = {
+  read(): string | null;
+  write(value: string): void;
+  quarantine?(value: string): void;
+};
+
+export type ControllerReplicaLoad = {
+  state: ControllerReplicaState | null;
+  warning: string | null;
+  quarantined: boolean;
+};
+
+export type ControllerReplayBatch = {
+  batchId: string;
+  replicaGeneration: string;
+  session: ControllerSessionAttachment;
+  eventGameId: string;
+  actions: readonly {
+    eventGameId: string;
+    intent: LiveEventControllerIntent;
+    causalPredecessorIds: readonly string[];
+  }[];
+};
+
+export type ControllerReplayBatchResponse = {
+  batchId: string;
+  replicaGeneration: string;
+  session: ControllerSessionAttachment;
+  eventGameId: string;
+  status: "synchronized" | "retryable" | "rejected";
+  outcomes: readonly {
+    operationId: string;
+    status: Exclude<ControllerActionOutcomeStatus, "pending">;
+    detail?: string;
+  }[];
+  projection: ControllerProjection | null;
+};
+
+export function createControllerReplica(input: {
+  eventGameId: string;
+  projection: ControllerProjection;
+  grantSessionId: string;
+  grantVersion: string;
+  deviceId?: string;
+  replicaGeneration?: string;
+}): ControllerReplicaState {
+  const eventGameId = requireIdentifier(input.eventGameId, "eventGameId");
+  if (input.projection.eventGameId !== eventGameId) {
+    throw new Error("Controller projection belongs to another Event Game.");
+  }
+  const deviceId = input.deviceId ?? `controller-device-${crypto.randomUUID()}`;
+  requireIdentifier(deviceId, "deviceId");
+  return {
+    version: CONTROLLER_REPLICA_VERSION,
+    eventGameId,
+    authoritativeProjection: cloneProjection(input.projection),
+    projection: cloneProjection(input.projection),
+    pendingActions: [],
+    outcomes: {},
+    identity: { deviceId, nextCounter: 1 },
+    session: {
+      eventGameId,
+      grantSessionId: requireIdentifier(input.grantSessionId, "grantSessionId"),
+      grantVersion: requireIdentifier(input.grantVersion, "grantVersion"),
+    },
+    replicaGeneration: requireIdentifier(
+      input.replicaGeneration ?? crypto.randomUUID(),
+      "replicaGeneration",
+    ),
+    unacknowledgedBatch: null,
+    durability: "durable",
+  };
+}
+
+export function dispatchControllerAction(
+  state: ControllerReplicaState,
+  intent: LiveEventControllerIntent,
+  options: { nowMs?: number; causalPredecessorIds?: readonly string[] } = {},
+): { state: ControllerReplicaState; action: PendingControllerAction } {
+  const parsed = parseLiveEventControllerIntent(intent);
+  if (!parsed.ok) throw new Error(`Cannot dispatch invalid Controller action: ${parsed.error}`);
+  if (parsed.value.type === "clock" || parsed.value.type === "set-running") {
+    throw new Error("Clock reconnect belongs to Clock Authority.");
+  }
+  const predecessors = [...(options.causalPredecessorIds ?? [])];
+  validateCausalPredecessors(state, parsed.value.operationId, predecessors);
+  if (predecessors.some((predecessor) => state.outcomes[predecessor] === "terminally-rejected")) {
+    throw new Error("Causal predecessor was terminally rejected.");
+  }
+  const existing = state.pendingActions.find(
+    (action) => action.intent.operationId === parsed.value.operationId,
+  );
+  if (existing !== undefined) return { state, action: existing };
+  const counter = state.identity.nextCounter;
+  const action: PendingControllerAction = {
+    eventGameId: state.eventGameId,
+    intent: structuredClone(parsed.value),
+    causalPredecessorIds: predecessors,
+    dispatchedAtMs: options.nowMs ?? Date.now(),
+    identity: { deviceId: state.identity.deviceId, counter },
+    counter,
+    status: "pending",
+  };
+  const nextState = applyOptimisticAction(
+    {
+      ...state,
+      pendingActions: [...state.pendingActions, action],
+      identity: { ...state.identity, nextCounter: counter + 1 },
+    },
+    action,
+  );
+  return { state: nextState, action };
+}
+
+export function buildControllerReplayBatch(
+  state: ControllerReplicaState,
+): ControllerReplayBatch | null {
+  const prepared = prepareControllerReplayBatch(state);
+  return prepared?.batch ?? null;
+}
+
+export function prepareControllerReplayBatch(
+  state: ControllerReplicaState,
+): { state: ControllerReplicaState; batch: ControllerReplayBatch } | null {
+  const eligibleStatuses = new Set<ControllerActionOutcomeStatus>([
+    "pending",
+    "retryable",
+    "causally-blocked",
+  ]);
+  const priorBatch = state.unacknowledgedBatch;
+  const pending = state.pendingActions.filter((action) => eligibleStatuses.has(action.status));
+  if (pending.length === 0) return null;
+  const selected =
+    priorBatch === null
+      ? pending.slice(0, SHARED_LIMITS.replay.maxControlActions)
+      : priorBatch.actionOperationIds.flatMap((operationId) => {
+          const action = pending.find((candidate) => candidate.intent.operationId === operationId);
+          return action === undefined ? [] : [action];
+        });
+  if (selected.length === 0) {
+    return prepareControllerReplayBatch({ ...state, unacknowledgedBatch: null });
+  }
+  const batchId = priorBatch?.batchId ?? crypto.randomUUID();
+  const nextState = {
+    ...state,
+    unacknowledgedBatch: {
+      batchId,
+      replicaGeneration: state.replicaGeneration,
+      session: structuredClone(state.session),
+      actionOperationIds: selected.map((action) => action.intent.operationId),
+    },
+  };
+  return {
+    state: nextState,
+    batch: {
+      batchId,
+      replicaGeneration: state.replicaGeneration,
+      session: structuredClone(state.session),
+      eventGameId: state.eventGameId,
+      actions: selected.map((action) => ({
+        eventGameId: action.eventGameId,
+        intent: structuredClone(action.intent),
+        causalPredecessorIds: [...action.causalPredecessorIds],
+      })),
+    },
+  };
+}
+
+export function reconcileControllerReplay(
+  state: ControllerReplicaState,
+  response: ControllerReplayBatchResponse,
+): ControllerReplicaState {
+  if (
+    response.batchId !== state.unacknowledgedBatch?.batchId ||
+    response.replicaGeneration !== state.replicaGeneration ||
+    response.eventGameId !== state.eventGameId ||
+    response.session.eventGameId !== state.session.eventGameId ||
+    response.session.grantSessionId !== state.session.grantSessionId ||
+    response.session.grantVersion !== state.session.grantVersion
+  ) {
+    return state;
+  }
+  const batchOperationIds = new Set(state.unacknowledgedBatch.actionOperationIds);
+  const responseOperationIds = new Set<string>();
+  if (
+    response.outcomes.some((outcome) => {
+      const invalid =
+        !batchOperationIds.has(outcome.operationId) ||
+        responseOperationIds.has(outcome.operationId) ||
+        ![
+          "accepted",
+          "idempotent",
+          "retryable",
+          "causally-blocked",
+          "held-for-correction",
+          "terminally-rejected",
+        ].includes(outcome.status);
+      responseOperationIds.add(outcome.operationId);
+      return invalid;
+    })
+  ) {
+    return state;
+  }
+  const outcomeByOperation = new Map(
+    response.outcomes.map((outcome) => [outcome.operationId, outcome]),
+  );
+  const outcomes = { ...state.outcomes };
+  const pendingActions = state.pendingActions.map((action) => {
+    const outcome = outcomeByOperation.get(action.intent.operationId);
+    if (outcome === undefined) return action;
+    outcomes[action.intent.operationId] = outcome.status;
+    return {
+      ...action,
+      status: outcome.status,
+      ...(outcome.detail === undefined ? {} : { detail: outcome.detail }),
+    };
+  });
+  const authoritativeProjection =
+    response.projection === null
+      ? state.authoritativeProjection
+      : cloneProjection(response.projection);
+  const reconciled = {
+    ...state,
+    authoritativeProjection,
+    outcomes,
+    unacknowledgedBatch: null,
+    pendingActions: pendingActions.filter(
+      (action) =>
+        action.status === "pending" ||
+        action.status === "retryable" ||
+        action.status === "causally-blocked" ||
+        action.status === "held-for-correction",
+    ),
+  };
+  return reapplyPendingOptimisticActions(reconciled);
+}
+
+export function acknowledgeControllerProjection(
+  state: ControllerReplicaState,
+  projection: ControllerProjection | null,
+): ControllerReplicaState {
+  if (projection === null) return state;
+  return reapplyPendingOptimisticActions({
+    ...state,
+    authoritativeProjection: cloneProjection(projection),
+  });
+}
+
+export function rebindControllerReplica(
+  state: ControllerReplicaState,
+  session: ControllerSessionAttachment,
+  projection: ControllerProjection | null,
+): ControllerReplicaState {
+  if (session.eventGameId !== state.eventGameId) {
+    throw new Error("Controller session belongs to another Event Game.");
+  }
+  return reapplyPendingOptimisticActions({
+    ...state,
+    authoritativeProjection:
+      projection === null ? state.authoritativeProjection : cloneProjection(projection),
+    session: structuredClone(session),
+    replicaGeneration: crypto.randomUUID(),
+    unacknowledgedBatch: null,
+  });
+}
+
+export function invalidateControllerReplica(state: ControllerReplicaState): ControllerReplicaState {
+  return {
+    ...state,
+    replicaGeneration: crypto.randomUUID(),
+    unacknowledgedBatch: null,
+  };
+}
+
+export function reapplyPendingOptimisticActions(
+  state: ControllerReplicaState,
+): ControllerReplicaState {
+  const pendingByOperationId = new Map(
+    state.pendingActions.map((action) => [action.intent.operationId, action]),
+  );
+  const blocked = new Set(
+    Object.entries(state.outcomes)
+      .filter(([, status]) => status === "terminally-rejected" || status === "held-for-correction")
+      .map(([operationId]) => operationId),
+  );
+  const canReapply = (action: PendingControllerAction): boolean =>
+    (action.status === "pending" ||
+      action.status === "retryable" ||
+      action.status === "causally-blocked") &&
+    !action.causalPredecessorIds.some((predecessor) => {
+      if (blocked.has(predecessor)) return true;
+      const pending = pendingByOperationId.get(predecessor);
+      return pending !== undefined && !canReapply(pending);
+    });
+  return state.pendingActions.reduce(
+    (current, action) => {
+      if (canReapply(action)) return applyOptimisticAction(current, action);
+      return current;
+    },
+    {
+      ...state,
+      projection: cloneProjection(state.authoritativeProjection),
+    },
+  );
+}
+
+export function serializeControllerReplica(state: ControllerReplicaState): string {
+  validateControllerReplica(state);
+  return JSON.stringify(state);
+}
+
+export function parseControllerReplica(
+  value: unknown,
+  expectedEventGameId?: string,
+): ControllerReplicaState {
+  if (!isRecord(value)) throw new Error("Controller replica must be an object.");
+  if (value.version !== CONTROLLER_REPLICA_VERSION)
+    throw new Error("Controller replica version is unsupported.");
+  const eventGameId = requireIdentifier(value.eventGameId, "eventGameId");
+  if (expectedEventGameId !== undefined && eventGameId !== expectedEventGameId) {
+    throw new Error("Controller replica belongs to another Event Game.");
+  }
+  const authoritativeProjection = parseProjection(value.authoritativeProjection);
+  const projection = parseProjection(value.projection);
+  if (
+    authoritativeProjection.eventGameId !== eventGameId ||
+    projection.eventGameId !== eventGameId
+  ) {
+    throw new Error("Controller projection belongs to another Event Game.");
+  }
+  if (!Array.isArray(value.pendingActions)) throw new Error("pendingActions must be an array.");
+  if (value.pendingActions.length > 10_000)
+    throw new Error("pendingActions exceeds the retained limit.");
+  const identity = parseIdentity(value.identity);
+  const pendingActions = value.pendingActions.map((action) =>
+    parsePendingAction(action, eventGameId, identity.deviceId),
+  );
+  const session = parseSession(value.session, eventGameId);
+  const outcomes = parseOutcomes(value.outcomes);
+  const replicaGeneration = requireIdentifier(value.replicaGeneration, "replicaGeneration");
+  const unacknowledgedBatch = parseUnacknowledgedBatch(
+    value.unacknowledgedBatch,
+    eventGameId,
+    replicaGeneration,
+  );
+  if (value.durability !== "durable" && value.durability !== "memory-only") {
+    throw new Error("Replica durability is invalid.");
+  }
+  const state: ControllerReplicaState = {
+    version: CONTROLLER_REPLICA_VERSION,
+    eventGameId,
+    authoritativeProjection,
+    projection,
+    pendingActions,
+    outcomes,
+    identity,
+    session,
+    replicaGeneration,
+    unacknowledgedBatch,
+    durability: value.durability,
+  };
+  if (
+    state.unacknowledgedBatch !== null &&
+    !sameSession(state.unacknowledgedBatch.session, session)
+  ) {
+    throw new Error("Unacknowledged batch session is stale.");
+  }
+  if (
+    state.unacknowledgedBatch !== null &&
+    state.unacknowledgedBatch.actionOperationIds.some(
+      (operationId) =>
+        !state.pendingActions.some((action) => action.intent.operationId === operationId),
+    )
+  ) {
+    throw new Error("Unacknowledged batch action is not retained.");
+  }
+  validateCausalGraph(state);
+  validateDerivedProjection(state);
+  return state;
+}
+
+export function loadControllerReplica(
+  storage: ControllerReplicaStorage,
+  expectedEventGameId?: string,
+): ControllerReplicaLoad {
+  let raw: string | null;
+  try {
+    raw = storage.read();
+  } catch {
+    return {
+      state: null,
+      warning: "Controller recovery storage is unavailable; changes remain in memory.",
+      quarantined: false,
+    };
+  }
+  if (raw === null) return { state: null, warning: null, quarantined: false };
+  try {
+    return {
+      state: parseControllerReplica(JSON.parse(raw), expectedEventGameId),
+      warning: null,
+      quarantined: false,
+    };
+  } catch {
+    try {
+      storage.quarantine?.(raw);
+    } catch {
+      // Quarantine is best effort. The malformed data is never used as authority.
+    }
+    return {
+      state: null,
+      warning: "Saved Controller recovery data was rejected and quarantined.",
+      quarantined: true,
+    };
+  }
+}
+
+export function persistControllerReplica(
+  state: ControllerReplicaState,
+  storage: ControllerReplicaStorage,
+): { state: ControllerReplicaState; warning: string | null } {
+  try {
+    storage.write(serializeControllerReplica(state));
+    return { state: { ...state, durability: "durable" }, warning: null };
+  } catch {
+    return {
+      state: { ...state, durability: "memory-only" },
+      warning: "Controller recovery storage is full or unavailable; changes remain in memory.",
+    };
+  }
+}
+
+export function validateControllerReplica(state: ControllerReplicaState): void {
+  if (state.version !== CONTROLLER_REPLICA_VERSION)
+    throw new Error("Controller replica version is unsupported.");
+  requireIdentifier(state.eventGameId, "eventGameId");
+  parseProjection(state.authoritativeProjection);
+  parseProjection(state.projection);
+  if (
+    state.authoritativeProjection.eventGameId !== state.eventGameId ||
+    state.projection.eventGameId !== state.eventGameId
+  ) {
+    throw new Error("Controller projection belongs to another Event Game.");
+  }
+  parseIdentity(state.identity);
+  parseSession(state.session, state.eventGameId);
+  requireIdentifier(state.replicaGeneration, "replicaGeneration");
+  parseUnacknowledgedBatch(state.unacknowledgedBatch, state.eventGameId, state.replicaGeneration);
+  if (
+    state.unacknowledgedBatch !== null &&
+    !sameSession(state.unacknowledgedBatch.session, state.session)
+  ) {
+    throw new Error("Unacknowledged batch session is stale.");
+  }
+  if (!Array.isArray(state.pendingActions) || state.pendingActions.length > 10_000) {
+    throw new Error("pendingActions is invalid.");
+  }
+  for (const action of state.pendingActions)
+    parsePendingAction(action, state.eventGameId, state.identity.deviceId);
+  if (
+    state.unacknowledgedBatch !== null &&
+    state.unacknowledgedBatch.actionOperationIds.some(
+      (operationId) =>
+        !state.pendingActions.some((action) => action.intent.operationId === operationId),
+    )
+  ) {
+    throw new Error("Unacknowledged batch action is not retained.");
+  }
+  validateCausalGraph(state);
+  validateDerivedProjection(state);
+}
+
+function applyOptimisticAction(
+  state: ControllerReplicaState,
+  action: PendingControllerAction,
+): ControllerReplicaState {
+  const intent = action.intent;
+  if (
+    action.status !== "pending" &&
+    action.status !== "retryable" &&
+    action.status !== "causally-blocked"
+  )
+    return state;
+  if (intent.type === "record-goal") {
+    const current = state.projection.scoreByGameSide[intent.gameSideId];
+    if (current === undefined) return state;
+    return {
+      ...state,
+      projection: {
+        ...state.projection,
+        scoreByGameSide: { ...state.projection.scoreByGameSide, [intent.gameSideId]: current + 10 },
+        goalCount: state.projection.goalCount + 1,
+      },
+    };
+  }
+  if (intent.type === "substantive") {
+    const commencement =
+      state.projection.commencement.status === "commenced"
+        ? state.projection.commencement
+        : {
+            status: "commenced" as const,
+            commencedAtMs: action.dispatchedAtMs,
+            provisionalRunningSinceMs: null,
+            provisionalElapsedMs: state.projection.commencement.provisionalElapsedMs,
+          };
+    return {
+      ...state,
+      projection: {
+        ...state.projection,
+        phase:
+          intent.trigger === "result"
+            ? "finished"
+            : state.projection.commencement.status === "provisional"
+              ? "in-progress"
+              : state.projection.phase,
+        commencement,
+      },
+    };
+  }
+  return {
+    ...state,
+  };
+}
+
+function validateCausalPredecessors(
+  state: ControllerReplicaState,
+  operationId: string,
+  predecessors: readonly string[],
+) {
+  const unique = new Set(predecessors);
+  if (unique.size !== predecessors.length || unique.has(operationId))
+    throw new Error("Causal predecessors are invalid.");
+  for (const predecessor of predecessors) {
+    requireIdentifier(predecessor, "causalPredecessorId");
+    if (
+      !state.pendingActions.some((action) => action.intent.operationId === predecessor) &&
+      state.outcomes[predecessor] === undefined
+    ) {
+      throw new Error("Causal predecessor is not retained.");
+    }
+  }
+}
+
+function validateCausalGraph(state: ControllerReplicaState) {
+  const ids = new Set<string>();
+  const counters = new Set<number>();
+  let maximumCounter = 0;
+  const pendingByOperationId = new Map(
+    state.pendingActions.map((action) => [action.intent.operationId, action]),
+  );
+  for (const [operationId, outcome] of Object.entries(state.outcomes)) {
+    const pending = pendingByOperationId.get(operationId);
+    if (pending !== undefined && pending.status !== outcome) {
+      throw new Error("Controller action outcome is inconsistent.");
+    }
+  }
+  for (const action of state.pendingActions) {
+    const operationId = action.intent.operationId;
+    if (ids.has(operationId)) throw new Error("Controller action identities must be unique.");
+    ids.add(operationId);
+    if (
+      action.identity.deviceId !== state.identity.deviceId ||
+      action.counter !== action.identity.counter
+    ) {
+      throw new Error("Controller action identity is inconsistent.");
+    }
+    if (counters.has(action.counter)) throw new Error("Controller action counters must be unique.");
+    counters.add(action.counter);
+    maximumCounter = Math.max(maximumCounter, action.counter);
+  }
+  if (state.identity.nextCounter <= maximumCounter)
+    throw new Error("nextCounter must exceed every retained action counter.");
+  for (const action of state.pendingActions) {
+    validateCausalPredecessors(
+      {
+        ...state,
+        pendingActions: state.pendingActions.filter((candidate) => candidate !== action),
+      },
+      action.intent.operationId,
+      action.causalPredecessorIds,
+    );
+    if (hasCausalCycle(action.intent.operationId, state.pendingActions, new Set()))
+      throw new Error("Controller causal graph contains a cycle.");
+  }
+}
+
+function validateDerivedProjection(state: ControllerReplicaState) {
+  const derived = reapplyPendingOptimisticActions({
+    ...state,
+    projection: cloneProjection(state.authoritativeProjection),
+  }).projection;
+  if (!sameProjection(derived, state.projection)) {
+    throw new Error(
+      "Controller optimistic projection is inconsistent with its authoritative base.",
+    );
+  }
+}
+
+function sameProjection(left: ControllerProjection, right: ControllerProjection): boolean {
+  const leftScores = Object.entries(left.scoreByGameSide).sort(([a], [b]) => a.localeCompare(b));
+  const rightScores = Object.entries(right.scoreByGameSide).sort(([a], [b]) => a.localeCompare(b));
+  return (
+    left.eventGameId === right.eventGameId &&
+    left.phase === right.phase &&
+    left.goalCount === right.goalCount &&
+    left.commencement.status === right.commencement.status &&
+    left.commencement.commencedAtMs === right.commencement.commencedAtMs &&
+    left.commencement.provisionalRunningSinceMs === right.commencement.provisionalRunningSinceMs &&
+    left.commencement.provisionalElapsedMs === right.commencement.provisionalElapsedMs &&
+    leftScores.length === rightScores.length &&
+    leftScores.every(
+      ([side, score], index) =>
+        rightScores[index]?.[0] === side && rightScores[index]?.[1] === score,
+    )
+  );
+}
+
+function hasCausalCycle(
+  operationId: string,
+  actions: readonly PendingControllerAction[],
+  seen: Set<string>,
+): boolean {
+  if (seen.has(operationId)) return true;
+  const action = actions.find((candidate) => candidate.intent.operationId === operationId);
+  if (action === undefined) return false;
+  const nextSeen = new Set(seen).add(operationId);
+  return action.causalPredecessorIds.some((predecessor) =>
+    hasCausalCycle(predecessor, actions, nextSeen),
+  );
+}
+
+function parsePendingAction(
+  value: unknown,
+  eventGameId: string,
+  expectedDeviceId: string,
+): PendingControllerAction {
+  if (!isRecord(value) || value.eventGameId !== eventGameId)
+    throw new Error("Pending action has the wrong Event Game.");
+  const intent = parseLiveEventControllerIntent(value.intent);
+  if (!intent.ok) throw new Error(intent.error);
+  if (!Array.isArray(value.causalPredecessorIds))
+    throw new Error("causalPredecessorIds must be an array.");
+  const dispatchedAtMs = validateIntegerInRange(
+    value.dispatchedAtMs,
+    0,
+    Number.MAX_SAFE_INTEGER,
+    "dispatchedAtMs",
+  );
+  const counter = validateIntegerInRange(value.counter, 1, Number.MAX_SAFE_INTEGER, "counter");
+  if (!dispatchedAtMs.ok || !counter.ok)
+    throw new Error("Pending action timing or counter is invalid.");
+  if (
+    ![
+      "pending",
+      "accepted",
+      "idempotent",
+      "retryable",
+      "causally-blocked",
+      "held-for-correction",
+      "terminally-rejected",
+    ].includes(value.status as string)
+  ) {
+    throw new Error("Pending action status is invalid.");
+  }
+  const predecessors = value.causalPredecessorIds.map((candidate) =>
+    requireIdentifier(candidate, "causalPredecessorId"),
+  );
+  if (!isRecord(value.identity)) throw new Error("Pending action identity is invalid.");
+  const identityDeviceId = requireIdentifier(value.identity.deviceId, "action.identity.deviceId");
+  const identityCounter = validateIntegerInRange(
+    value.identity.counter,
+    1,
+    Number.MAX_SAFE_INTEGER,
+    "action.identity.counter",
+  );
+  if (!identityCounter.ok) throw new Error(identityCounter.error);
+  if (identityDeviceId !== expectedDeviceId || identityCounter.value !== counter.value) {
+    throw new Error("Pending action identity is inconsistent.");
+  }
+  if (intent.value.type === "clock" || intent.value.type === "set-running") {
+    throw new Error("Clock actions are not eligible for reconnect.");
+  }
+  return {
+    eventGameId,
+    intent: intent.value,
+    causalPredecessorIds: predecessors,
+    dispatchedAtMs: dispatchedAtMs.value,
+    identity: { deviceId: identityDeviceId, counter: identityCounter.value },
+    counter: counter.value,
+    status: value.status as ControllerActionOutcomeStatus,
+    ...(typeof value.detail === "string" ? { detail: value.detail } : {}),
+  };
+}
+
+function parseProjection(value: unknown): ControllerProjection {
+  if (!isRecord(value)) throw new Error("Controller projection is invalid.");
+  const eventGameId = requireIdentifier(value.eventGameId, "projection.eventGameId");
+  const phase = value.phase;
+  if (phase !== "scheduled" && phase !== "in-progress" && phase !== "finished")
+    throw new Error("Projection phase is invalid.");
+  if (!isRecord(value.scoreByGameSide)) throw new Error("Projection scores are invalid.");
+  const scores: Record<string, number> = {};
+  for (const [side, score] of Object.entries(value.scoreByGameSide)) {
+    requireIdentifier(side, "gameSideId");
+    const parsed = validateIntegerInRange(
+      score,
+      SHARED_LIMITS.score.min,
+      SHARED_LIMITS.score.max,
+      "score",
+    );
+    if (!parsed.ok) throw new Error(parsed.error);
+    scores[side] = parsed.value;
+  }
+  const goalCount = validateIntegerInRange(value.goalCount, 0, 10_000, "goalCount");
+  if (!goalCount.ok) throw new Error(goalCount.error);
+  if (!isRecord(value.commencement)) throw new Error("Projection commencement is invalid.");
+  const commencementStatus = value.commencement.status;
+  if (commencementStatus !== "provisional" && commencementStatus !== "commenced")
+    throw new Error("Projection commencement status is invalid.");
+  const commencedAtMs = nullableNumber(value.commencement.commencedAtMs, "commencedAtMs");
+  const runningSinceMs = nullableNumber(
+    value.commencement.provisionalRunningSinceMs,
+    "provisionalRunningSinceMs",
+  );
+  const elapsed = validateIntegerInRange(
+    value.commencement.provisionalElapsedMs,
+    0,
+    Number.MAX_SAFE_INTEGER,
+    "provisionalElapsedMs",
+  );
+  if (!elapsed.ok) throw new Error(elapsed.error);
+  return {
+    eventGameId,
+    phase,
+    scoreByGameSide: scores,
+    goalCount: goalCount.value,
+    commencement: {
+      status: commencementStatus,
+      commencedAtMs,
+      provisionalRunningSinceMs: runningSinceMs,
+      provisionalElapsedMs: elapsed.value,
+    },
+  };
+}
+
+function parseIdentity(value: unknown): ControllerReplicaState["identity"] {
+  if (!isRecord(value)) throw new Error("Replica identity is invalid.");
+  const deviceId = requireIdentifier(value.deviceId, "deviceId");
+  const nextCounter = validateIntegerInRange(
+    value.nextCounter,
+    1,
+    Number.MAX_SAFE_INTEGER,
+    "nextCounter",
+  );
+  if (!nextCounter.ok) throw new Error(nextCounter.error);
+  return { deviceId, nextCounter: nextCounter.value };
+}
+
+function parseSession(value: unknown, eventGameId: string): ControllerReplicaState["session"] {
+  if (!isRecord(value) || value.eventGameId !== eventGameId)
+    throw new Error("Replica session scope is invalid.");
+  return {
+    eventGameId,
+    grantSessionId: requireIdentifier(value.grantSessionId, "grantSessionId"),
+    grantVersion: requireIdentifier(value.grantVersion, "grantVersion"),
+  };
+}
+
+function parseOutcomes(value: unknown): Readonly<Record<string, ControllerActionOutcomeStatus>> {
+  if (!isRecord(value)) throw new Error("Replica outcomes are invalid.");
+  const outcomes: Record<string, ControllerActionOutcomeStatus> = {};
+  for (const [operationId, outcome] of Object.entries(value)) {
+    requireIdentifier(operationId, "operationId");
+    if (
+      ![
+        "accepted",
+        "idempotent",
+        "retryable",
+        "causally-blocked",
+        "held-for-correction",
+        "terminally-rejected",
+      ].includes(outcome as string)
+    )
+      throw new Error("Replica outcome is invalid.");
+    outcomes[operationId] = outcome as ControllerActionOutcomeStatus;
+  }
+  return outcomes;
+}
+
+function parseUnacknowledgedBatch(
+  value: unknown,
+  eventGameId: string,
+  replicaGeneration: string,
+): ControllerReplicaState["unacknowledgedBatch"] {
+  if (value === null) return null;
+  if (!isRecord(value)) throw new Error("Unacknowledged batch is invalid.");
+  const batchId = requireIdentifier(value.batchId, "batchId");
+  if (value.replicaGeneration !== replicaGeneration) {
+    throw new Error("Unacknowledged batch generation is stale.");
+  }
+  if (!Array.isArray(value.actionOperationIds) || value.actionOperationIds.length === 0) {
+    throw new Error("Unacknowledged batch actions are invalid.");
+  }
+  const actionOperationIds = value.actionOperationIds.map((operationId) =>
+    requireIdentifier(operationId, "batch.actionOperationId"),
+  );
+  if (new Set(actionOperationIds).size !== actionOperationIds.length) {
+    throw new Error("Unacknowledged batch actions must be unique.");
+  }
+  if (!isRecord(value.session)) throw new Error("Batch session is invalid.");
+  const session = parseSession(value.session, eventGameId);
+  return { batchId, replicaGeneration, session, actionOperationIds };
+}
+
+function nullableNumber(value: unknown, field: string): number | null {
+  if (value === null) return null;
+  const parsed = validateIntegerInRange(value, 0, Number.MAX_SAFE_INTEGER, field);
+  if (!parsed.ok) throw new Error(parsed.error);
+  return parsed.value;
+}
+
+function sameSession(
+  left: ControllerSessionAttachment,
+  right: ControllerSessionAttachment,
+): boolean {
+  return (
+    left.eventGameId === right.eventGameId &&
+    left.grantSessionId === right.grantSessionId &&
+    left.grantVersion === right.grantVersion
+  );
+}
+
+function requireIdentifier(value: unknown, field: string): string {
+  const parsed = validateOpaqueIdentifier(value, field);
+  if (!parsed.ok) throw new Error(parsed.error);
+  return parsed.value;
+}
+
+function cloneProjection(projection: ControllerProjection): ControllerProjection {
+  return structuredClone(projection);
+}
+
+function isRecord(value: unknown): value is Record<string, any> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/lib/live-event-game-control.test.ts
+++ b/src/lib/live-event-game-control.test.ts
@@ -532,6 +532,178 @@ describe("Live Event Game control", () => {
     expect(actions[0]?.action.occurrence.trustedAtMs).toBeGreaterThan(10_000);
   });
 
+  test("replays one bounded batch with per-action outcomes and causal blocking", async () => {
+    const harness = await createHarness();
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "reconnect-device",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+    const result = await harness.control.replayControllerActions({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      batchId: "batch-replay-test",
+      replicaGeneration: "generation-replay-test",
+      expectedGrantSessionId: opened.session.grantSessionId,
+      expectedGrantVersion: opened.session.grantVersion,
+      actions: [
+        {
+          eventGameId: harness.root.eventGameId,
+          intent: {
+            ...goalIntent({ gameSideId: "side-a" }),
+            operationId: "blocked-goal",
+            factId: "blocked-fact",
+          },
+          causalPredecessorIds: ["operation-goal"],
+        },
+        {
+          eventGameId: harness.root.eventGameId,
+          intent: goalIntent({ gameSideId: "missing-side" }),
+        },
+        {
+          eventGameId: harness.root.eventGameId,
+          intent: { ...goalIntent(), operationId: "unrelated-goal", factId: "unrelated-fact" },
+        },
+        {
+          eventGameId: harness.root.eventGameId,
+          intent: { ...goalIntent(), operationId: "unresolved-goal", factId: "unresolved-fact" },
+          causalPredecessorIds: ["not-retained"],
+        },
+      ],
+    });
+    expect(result.status).toBe("synchronized");
+    expect(
+      Object.fromEntries(result.outcomes.map((outcome) => [outcome.operationId, outcome.status])),
+    ).toEqual({
+      "operation-goal": "terminally-rejected",
+      "blocked-goal": "causally-blocked",
+      "unrelated-goal": "accepted",
+      "unresolved-goal": "terminally-rejected",
+    });
+    expect((await harness.record.readActions()).map((stored) => stored.action.operationId)).toEqual(
+      ["unrelated-goal"],
+    );
+  });
+
+  test("holds new replay evidence for a finished but unlocked Game", async () => {
+    const harness = await createHarness();
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "finished-reconnect-device",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+    const finish = await harness.control.submitControllerIntent({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      intent: substantiveIntent("finish-before-replay", "result"),
+    });
+    expect(finish.status).toBe("accepted");
+    const replay = await harness.control.replayControllerActions({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      batchId: "batch-finished-hold",
+      replicaGeneration: "generation-finished-hold",
+      expectedGrantSessionId: opened.session.grantSessionId,
+      expectedGrantVersion: opened.session.grantVersion,
+      actions: [
+        {
+          eventGameId: harness.root.eventGameId,
+          intent: goalIntent({ operationId: "held-goal", factId: "held-fact" }),
+          causalPredecessorIds: [],
+        },
+      ],
+    });
+    expect(replay.outcomes).toEqual([{ operationId: "held-goal", status: "held-for-correction" }]);
+    expect(await harness.record.readActions()).toHaveLength(1);
+  });
+
+  test("holds actions that follow an accepted result in the same replay batch", async () => {
+    const harness = await createHarness();
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "same-batch-finish-device",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+    const replay = await harness.control.replayControllerActions({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      batchId: "batch-same-batch-finish",
+      replicaGeneration: "generation-same-batch-finish",
+      expectedGrantSessionId: opened.session.grantSessionId,
+      expectedGrantVersion: opened.session.grantVersion,
+      actions: [
+        {
+          eventGameId: harness.root.eventGameId,
+          intent: substantiveIntent("same-batch-result", "result"),
+          causalPredecessorIds: [],
+        },
+        {
+          eventGameId: harness.root.eventGameId,
+          intent: goalIntent({ operationId: "post-result-goal", factId: "post-result-fact" }),
+          causalPredecessorIds: [],
+        },
+      ],
+    });
+    expect(replay.outcomes).toEqual([
+      { operationId: "same-batch-result", status: "accepted" },
+      { operationId: "post-result-goal", status: "held-for-correction" },
+    ]);
+    expect((await harness.record.readActions()).map((stored) => stored.action.operationId)).toEqual(
+      ["same-batch-result"],
+    );
+  });
+
+  test("rejects replay authority mismatches and malformed causal evidence without submission", async () => {
+    const harness = await createHarness();
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "malformed-reconnect-device",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+    const mismatch = await harness.control.replayControllerActions({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      batchId: "batch-mismatch",
+      replicaGeneration: "generation-mismatch",
+      expectedGrantSessionId: opened.session.grantSessionId,
+      expectedGrantVersion: "expired-version",
+      actions: [{ eventGameId: harness.root.eventGameId, intent: goalIntent() }],
+    });
+    expect(mismatch.status).toBe("rejected");
+    expect(await harness.record.readActions()).toHaveLength(0);
+    const malformed = await harness.control.replayControllerActions({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      batchId: "batch-malformed",
+      replicaGeneration: "generation-malformed",
+      expectedGrantSessionId: opened.session.grantSessionId,
+      expectedGrantVersion: opened.session.grantVersion,
+      actions: [
+        {
+          eventGameId: harness.root.eventGameId,
+          intent: { ...goalIntent(), operationId: "bad-dependency" },
+          causalPredecessorIds: [42],
+        },
+        {
+          eventGameId: harness.root.eventGameId,
+          intent: { ...goalIntent(), operationId: "duplicate-dependency" },
+          causalPredecessorIds: ["same", "same"],
+        },
+        {
+          eventGameId: "another-game",
+          intent: { ...goalIntent(), operationId: "cross-game" },
+          causalPredecessorIds: [],
+        },
+      ],
+    });
+    expect(malformed.outcomes.map((outcome) => outcome.status)).toEqual([
+      "terminally-rejected",
+      "terminally-rejected",
+      "terminally-rejected",
+    ]);
+    expect(await harness.record.readActions()).toHaveLength(0);
+  });
+
   test("keeps distinct Controller Devices active while reopening one device replaces only itself", async () => {
     const harness = await createHarness();
     const first = await harness.control.openController({
@@ -664,6 +836,50 @@ describe("Live Event Game control", () => {
       clientOriginAtMs: 10_000,
       source: "online",
     });
+  });
+
+  test("distinguishes direct online provenance from later offline replay evidence", async () => {
+    const harness = await createHarness();
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "provenance-device",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+    await harness.control.submitControllerIntent({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      intent: {
+        ...goalIntent({ operationId: "online-provenance", factId: "online-fact" }),
+        occurrence: { clientOriginAtMs: 1_000, source: "online" as const },
+      },
+    });
+    const offline = {
+      ...goalIntent({ operationId: "offline-provenance", factId: "offline-fact" }),
+      occurrence: { clientOriginAtMs: 2_000, source: "offline" as const },
+    };
+    const replay = await harness.control.replayControllerActions({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      batchId: "provenance-batch",
+      replicaGeneration: "provenance-generation",
+      expectedGrantSessionId: opened.session.grantSessionId,
+      expectedGrantVersion: opened.session.grantVersion,
+      actions: [
+        { eventGameId: harness.root.eventGameId, intent: offline, causalPredecessorIds: [] },
+      ],
+    });
+    expect(replay.outcomes).toEqual([{ operationId: "offline-provenance", status: "accepted" }]);
+    const actions = await harness.record.readActions();
+    expect(
+      actions.map((stored) => ({
+        operationId: stored.action.operationId,
+        clientOriginAtMs: stored.action.occurrence.clientOriginAtMs,
+        source: stored.action.occurrence.source,
+      })),
+    ).toEqual([
+      { operationId: "online-provenance", clientOriginAtMs: 1_000, source: "online" },
+      { operationId: "offline-provenance", clientOriginAtMs: 2_000, source: "offline" },
+    ]);
   });
 
   test("acknowledges a committed goal when projection rebuild is unavailable", async () => {
@@ -907,12 +1123,14 @@ async function createHarness(
   };
 }
 
-function goalIntent(overrides: { gameSideId?: string } = {}) {
+function goalIntent(
+  overrides: { gameSideId?: string; operationId?: string; factId?: string } = {},
+) {
   return {
     version: LIVE_EVENT_CONTROL_INTENT_VERSION,
     type: "record-goal",
-    operationId: "operation-goal",
-    factId: "fact-goal",
+    operationId: overrides.operationId ?? "operation-goal",
+    factId: overrides.factId ?? "fact-goal",
     gameSideId: overrides.gameSideId ?? "side-a",
     gameTimeMs: 12_000,
     occurrence: { clientOriginAtMs: 10_000 },

--- a/src/lib/live-event-game-control.ts
+++ b/src/lib/live-event-game-control.ts
@@ -20,6 +20,7 @@ type ControllerIntentBase = {
   gameTimeMs: number;
   occurrence: {
     clientOriginAtMs: number | null;
+    source?: "online" | "offline";
   };
 };
 
@@ -164,6 +165,28 @@ export type LiveEventGameControlOptions = {
   projectionFailure?: () => boolean;
 };
 
+export type ControllerReplayOutcome = {
+  operationId: string;
+  status:
+    | "accepted"
+    | "idempotent"
+    | "retryable"
+    | "causally-blocked"
+    | "held-for-correction"
+    | "terminally-rejected";
+  detail?: string;
+};
+
+export type ControllerReplayResult = {
+  batchId: string;
+  replicaGeneration: string;
+  session: ControllerSessionAttachment;
+  eventGameId: string;
+  status: "synchronized" | "retryable" | "rejected";
+  outcomes: readonly ControllerReplayOutcome[];
+  projection: ControllerProjection | null;
+};
+
 export function createLiveEventGameIqaInterpreter(
   version = LIVE_EVENT_IQA_INTERPRETER_VERSION,
 ): IqaGameRulesInterpreter {
@@ -242,6 +265,13 @@ export function parseLiveEventControllerIntent(
     if (!clientOrigin.ok) return invalid(clientOrigin.error);
     clientOriginAtMs = clientOrigin.value;
   }
+  let source: "online" | "offline" | undefined;
+  if (value.occurrence.source !== undefined) {
+    if (value.occurrence.source !== "online" && value.occurrence.source !== "offline") {
+      return invalid("occurrence.source is unsupported.");
+    }
+    source = value.occurrence.source;
+  }
   return {
     ok: true,
     value: {
@@ -250,7 +280,7 @@ export function parseLiveEventControllerIntent(
       operationId: operationId.value,
       factId: factId.value,
       gameTimeMs: gameTimeMs.value,
-      occurrence: { clientOriginAtMs },
+      occurrence: { clientOriginAtMs, ...(source === undefined ? {} : { source }) },
       ...(gameSideId === undefined ? {} : { gameSideId }),
       ...(running === undefined ? {} : { running }),
       ...(trigger === undefined ? {} : { trigger }),
@@ -267,6 +297,7 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
     throw new Error("The game-fact runtime codec is unavailable.");
   }
   const goalCodec = gameFactCodec;
+  const replayingSessions = new Set<string>();
 
   async function openController(input: {
     qrCredential: string;
@@ -516,6 +547,7 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
     sessionBearer: string;
     eventGameId: string;
     intent: unknown;
+    causalPredecessorIds?: readonly string[];
   }): Promise<LiveEventGameControlResult> {
     const authorized = await options.grantAuthority.authorizeGrant({
       sessionBearer: input.sessionBearer,
@@ -587,11 +619,11 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
                 ? { trigger: parsed.value.trigger }
                 : null,
       },
-      causalPredecessorIds: [],
+      causalPredecessorIds: [...(input.causalPredecessorIds ?? [])],
       occurrence: {
         trustedAtMs: nowMs,
         clientOriginAtMs: parsed.value.occurrence.clientOriginAtMs,
-        source: "online",
+        source: parsed.value.occurrence.source ?? "online",
       },
       grant: {
         sessionId: authorized.grantSessionId,
@@ -662,6 +694,229 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
     };
   }
 
+  async function replayControllerActions(input: {
+    sessionBearer: string;
+    eventGameId: string;
+    batchId: string;
+    replicaGeneration: string;
+    expectedGrantSessionId: string;
+    expectedGrantVersion: string;
+    actions: readonly {
+      eventGameId: string;
+      intent: unknown;
+      causalPredecessorIds?: readonly unknown[];
+    }[];
+  }): Promise<ControllerReplayResult> {
+    const requestedSession: ControllerSessionAttachment = {
+      eventGameId: input.eventGameId,
+      grantSessionId: input.expectedGrantSessionId,
+      grantVersion: input.expectedGrantVersion,
+    };
+    const replayContext = {
+      batchId: input.batchId,
+      replicaGeneration: input.replicaGeneration,
+      session: requestedSession,
+      eventGameId: input.eventGameId,
+    };
+    if (
+      !validateOpaqueIdentifier(input.batchId, "batchId").ok ||
+      !validateOpaqueIdentifier(input.replicaGeneration, "replicaGeneration").ok ||
+      !validateOpaqueIdentifier(input.expectedGrantSessionId, "grantSessionId").ok ||
+      !validateOpaqueIdentifier(input.expectedGrantVersion, "grantVersion").ok
+    ) {
+      return replayRejected(input.actions, replayContext);
+    }
+    const authorized = await options.grantAuthority.authorizeGrant({
+      sessionBearer: input.sessionBearer,
+      eventGameId: input.eventGameId,
+      readOnly: true,
+    });
+    if (
+      authorized.status !== "authorized" ||
+      authorized.grantType !== "control" ||
+      authorized.eventGameId === null
+    ) {
+      return replayRejected(input.actions, replayContext);
+    }
+    if (
+      authorized.grantSessionId !== input.expectedGrantSessionId ||
+      authorized.grantVersion !== input.expectedGrantVersion
+    ) {
+      return replayRejected(input.actions, replayContext);
+    }
+    if (
+      input.actions.length === 0 ||
+      input.actions.length > SHARED_LIMITS.replay.maxControlActions ||
+      replayingSessions.has(authorized.grantSessionId)
+    ) {
+      return replayRetryable(input.actions, replayContext);
+    }
+    replayingSessions.add(authorized.grantSessionId);
+    try {
+      const replayOwner = await options.resolveEventGameRecord(authorized.eventGameId);
+      if (replayOwner === null) return replayRetryable(input.actions, replayContext);
+      const persistedActions = await replayOwner.record.readActions();
+      const persistedOperationIds = new Set(
+        persistedActions.map((stored) => stored.action.operationId),
+      );
+      const replayRoot = await replayOwner.record.readRoot(replayOwner.recordId);
+      if (replayRoot === null) return replayRetryable(input.actions, replayContext);
+      let finishedUnlocked =
+        replayRoot.lifecycle.phase === "finished" && replayRoot.lifecycle.lockedAtMs === null;
+      const outcomes: ControllerReplayOutcome[] = [];
+      const completed = new Set<string>();
+      const blocked = new Set<string>();
+      const held = new Set<string>();
+      const operationCounts = new Map<string, number>();
+      for (const candidate of input.actions) {
+        const operationId = readOperationId(candidate.intent);
+        if (operationId !== null)
+          operationCounts.set(operationId, (operationCounts.get(operationId) ?? 0) + 1);
+      }
+      const batchOperationIds = new Set(
+        input.actions.flatMap((candidate) => {
+          const operationId = readOperationId(candidate.intent);
+          return operationId === null ? [] : [operationId];
+        }),
+      );
+      let remaining = [...input.actions];
+      while (remaining.length > 0) {
+        let progressed = false;
+        const deferred: typeof remaining = [];
+        for (const candidate of remaining) {
+          const operationId = readOperationId(candidate.intent);
+          const predecessors = candidate.causalPredecessorIds ?? [];
+          if (operationId === null) continue;
+          const parsedIntent = parseLiveEventControllerIntent(candidate.intent);
+          if (
+            !parsedIntent.ok ||
+            parsedIntent.value.type === "clock" ||
+            parsedIntent.value.type === "set-running" ||
+            (operationCounts.get(operationId) ?? 0) > 1
+          ) {
+            outcomes.push({ operationId, status: "terminally-rejected" });
+            blocked.add(operationId);
+            progressed = true;
+            continue;
+          }
+          if (
+            candidate.eventGameId !== authorized.eventGameId ||
+            !Array.isArray(predecessors) ||
+            predecessors.some(
+              (predecessor) => !validateOpaqueIdentifier(predecessor, "causalPredecessorId").ok,
+            ) ||
+            new Set(predecessors).size !== predecessors.length ||
+            predecessors.some((predecessor) => predecessor === operationId)
+          ) {
+            outcomes.push({ operationId, status: "terminally-rejected" });
+            blocked.add(operationId);
+            progressed = true;
+            continue;
+          }
+          if (predecessors.some((predecessor) => blocked.has(predecessor))) {
+            outcomes.push({ operationId, status: "causally-blocked" });
+            blocked.add(operationId);
+            progressed = true;
+            continue;
+          }
+          if (
+            predecessors.some(
+              (predecessor) =>
+                !batchOperationIds.has(predecessor) && !persistedOperationIds.has(predecessor),
+            )
+          ) {
+            outcomes.push({ operationId, status: "terminally-rejected" });
+            blocked.add(operationId);
+            progressed = true;
+            continue;
+          }
+          if (predecessors.some((predecessor) => held.has(predecessor))) {
+            outcomes.push({ operationId, status: "held-for-correction" });
+            held.add(operationId);
+            progressed = true;
+            continue;
+          }
+          if (finishedUnlocked && !persistedOperationIds.has(operationId)) {
+            outcomes.push({ operationId, status: "held-for-correction" });
+            held.add(operationId);
+            progressed = true;
+            continue;
+          }
+          if (
+            predecessors.some(
+              (predecessor) => batchOperationIds.has(predecessor) && !completed.has(predecessor),
+            )
+          ) {
+            deferred.push(candidate);
+            continue;
+          }
+          const result = await submitControllerIntent({
+            sessionBearer: input.sessionBearer,
+            eventGameId: authorized.eventGameId,
+            intent: candidate.intent,
+            causalPredecessorIds: predecessors,
+          });
+          if (result.status === "accepted") {
+            outcomes.push({ operationId, status: "accepted" });
+            completed.add(operationId);
+            if (
+              parsedIntent.value.type === "substantive" &&
+              parsedIntent.value.trigger === "result"
+            ) {
+              finishedUnlocked = true;
+            }
+          } else if (result.status === "duplicate-accepted") {
+            outcomes.push({ operationId, status: "idempotent" });
+            completed.add(operationId);
+          } else if (result.status === "retryable") {
+            outcomes.push({ operationId, status: "retryable", detail: "retryable server outcome" });
+          } else if (finishedUnlocked && !persistedOperationIds.has(operationId)) {
+            outcomes.push({ operationId, status: "held-for-correction" });
+            held.add(operationId);
+          } else {
+            outcomes.push({
+              operationId,
+              status: "terminally-rejected",
+              detail: "terminal server rejection",
+            });
+            blocked.add(operationId);
+          }
+          progressed = true;
+        }
+        if (!progressed) {
+          for (const candidate of deferred) {
+            const operationId = readOperationId(candidate.intent);
+            if (operationId !== null) {
+              outcomes.push({ operationId, status: "causally-blocked" });
+              blocked.add(operationId);
+            }
+          }
+          break;
+        }
+        remaining = deferred;
+      }
+      const owner = await options.resolveEventGameRecord(authorized.eventGameId);
+      const root = owner === null ? null : await owner.record.readRoot(owner.recordId);
+      const projection =
+        owner === null || root === null ? null : await readProjection(owner.record, root);
+      return {
+        ...replayContext,
+        session: {
+          eventGameId: authorized.eventGameId,
+          grantSessionId: authorized.grantSessionId,
+          grantVersion: authorized.grantVersion,
+        },
+        status: outcomes.some((outcome) => outcome.status === "retryable")
+          ? "retryable"
+          : "synchronized",
+        outcomes,
+        projection,
+      };
+    } finally {
+      replayingSessions.delete(authorized.grantSessionId);
+    }
+  }
+
   async function readProjection(
     record: EventGameRecord,
     root: EventGameRecordRoot,
@@ -700,6 +955,7 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
     revealControllerQr,
     leaveController,
     submitControllerIntent,
+    replayControllerActions,
   };
 }
 
@@ -852,6 +1108,43 @@ function retryableAction(operationId: string | null): LiveEventGameControlResult
     status: "retryable",
     message: "Controller action was not committed; retry is safe.",
     operationId,
+  };
+}
+
+type ReplayContext = {
+  batchId: string;
+  replicaGeneration: string;
+  session: ControllerSessionAttachment;
+  eventGameId: string;
+};
+
+function replayRejected(
+  actions: readonly { intent: unknown }[],
+  context: ReplayContext,
+): ControllerReplayResult {
+  return {
+    ...context,
+    status: "rejected",
+    outcomes: actions.flatMap((action) => {
+      const operationId = readOperationId(action.intent);
+      return operationId === null ? [] : [{ operationId, status: "retryable" as const }];
+    }),
+    projection: null,
+  };
+}
+
+function replayRetryable(
+  actions: readonly { intent: unknown }[],
+  context: ReplayContext,
+): ControllerReplayResult {
+  return {
+    ...context,
+    status: "retryable",
+    outcomes: actions.flatMap((action) => {
+      const operationId = readOperationId(action.intent);
+      return operationId === null ? [] : [{ operationId, status: "retryable" as const }];
+    }),
+    projection: null,
   };
 }
 

--- a/src/lib/live-event-game-transport.ts
+++ b/src/lib/live-event-game-transport.ts
@@ -3,6 +3,7 @@ import type {
   ControllerLeaveResult,
   ControllerQrResult,
   ControllerRefreshResult,
+  ControllerReplayResult,
   LiveEventGameControlResult,
   OpenControllerResult,
 } from "@/lib/live-event-game-control";
@@ -16,6 +17,7 @@ export type LiveEventGameControlTransport = {
   revealControllerQr(request: Request): Promise<Response>;
   leaveController(request: Request): Promise<Response>;
   submitControllerIntent(request: Request): Promise<Response>;
+  replayControllerActions(request: Request): Promise<Response>;
 };
 
 export type LiveEventGameControlTransportTarget = {
@@ -42,6 +44,19 @@ export type LiveEventGameControlTransportTarget = {
     eventGameId: string;
     intent: unknown;
   }): Promise<LiveEventGameControlResult>;
+  replayControllerActions(input: {
+    sessionBearer: string;
+    eventGameId: string;
+    batchId: string;
+    replicaGeneration: string;
+    expectedGrantSessionId: string;
+    expectedGrantVersion: string;
+    actions: readonly {
+      eventGameId: string;
+      intent: unknown;
+      causalPredecessorIds?: readonly unknown[];
+    }[];
+  }): Promise<ControllerReplayResult>;
 };
 
 export function createLiveEventGameControlTransport(
@@ -91,6 +106,53 @@ export function createLiveEventGameControlTransport(
         sessionBearer: body.body.sessionBearer,
         eventGameId: body.body.eventGameId,
         intent: body.body.intent,
+      });
+      return noStoreJson(result, resultStatus(result));
+    },
+    async replayControllerActions(request) {
+      if (!isAllowedRequest(request)) return unavailable();
+      const control = resolve();
+      if (control === null) return unavailable();
+      const body = await readJsonBodyWithinLimit(
+        request,
+        SHARED_LIMITS.transport.httpJsonBodyBytes,
+      );
+      if (
+        !body.ok ||
+        !isRecord(body.body) ||
+        typeof body.body.sessionBearer !== "string" ||
+        typeof body.body.eventGameId !== "string" ||
+        typeof body.body.batchId !== "string" ||
+        typeof body.body.replicaGeneration !== "string" ||
+        typeof body.body.grantSessionId !== "string" ||
+        typeof body.body.grantVersion !== "string" ||
+        !Array.isArray(body.body.actions)
+      )
+        return unavailable();
+      if (
+        body.body.actions.length === 0 ||
+        body.body.actions.length > SHARED_LIMITS.replay.maxControlActions
+      ) {
+        return unavailable();
+      }
+      const result = await control.replayControllerActions({
+        sessionBearer: body.body.sessionBearer,
+        eventGameId: body.body.eventGameId,
+        batchId: body.body.batchId,
+        replicaGeneration: body.body.replicaGeneration,
+        expectedGrantSessionId: body.body.grantSessionId,
+        expectedGrantVersion: body.body.grantVersion,
+        actions: body.body.actions.map((action) => {
+          if (!isRecord(action))
+            return { eventGameId: "", intent: null, causalPredecessorIds: [null] };
+          return {
+            eventGameId: typeof action.eventGameId === "string" ? action.eventGameId : "",
+            intent: action.intent,
+            causalPredecessorIds: Array.isArray(action.causalPredecessorIds)
+              ? action.causalPredecessorIds
+              : [null],
+          };
+        }),
       });
       return noStoreJson(result, resultStatus(result));
     },
@@ -165,7 +227,7 @@ async function readSessionInput(
   return { sessionBearer: body.body.sessionBearer };
 }
 
-function resultStatus(result: LiveEventGameControlResult): number {
+function resultStatus(result: LiveEventGameControlResult | ControllerReplayResult): number {
   if (result.status === "retryable") return 503;
   if (result.status === "rejected") return 403;
   return 200;

--- a/src/pages/event-game-controller-page.test.tsx
+++ b/src/pages/event-game-controller-page.test.tsx
@@ -1,0 +1,708 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { Window } from "happy-dom";
+import { EventGameControllerPage } from "@/pages/event-game-controller-page";
+import {
+  controllerReplicaStorageKey,
+  createControllerReplica,
+  dispatchControllerAction,
+} from "@/lib/controller-reconnect";
+import type { ControllerProjection } from "@/lib/live-event-game-control";
+
+describe("Event Game Controller reconnect browser seam", () => {
+  const originalWindow = globalThis.window;
+  const originalDocument = globalThis.document;
+  const originalNavigator = globalThis.navigator;
+  const originalSessionStorage = globalThis.sessionStorage;
+  const originalLocalStorage = globalThis.localStorage;
+  const originalFetch = globalThis.fetch;
+  const originalActEnvironment = (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean })
+    .IS_REACT_ACT_ENVIRONMENT;
+  let testWindow: Window;
+  let container: HTMLDivElement;
+  let root: Root;
+  let replayMode: "lost" | "success" | "deferred";
+  let replayCalls: number;
+  let replayBodies: Record<string, any>[];
+  let intentCalls: number;
+  let intentBodies: Record<string, any>[];
+  let openGrantSessionId: string;
+  let openGrantVersion: string;
+  let openBearer: string;
+  let refreshProjection: ControllerProjection | null;
+  let refreshRejected: boolean;
+  let switchRequested: boolean;
+  let deferredReplay: ((response: Response) => void) | null;
+  let deferredReplayResponse: Response | null;
+
+  beforeEach(() => {
+    replayMode = "lost";
+    replayCalls = 0;
+    replayBodies = [];
+    intentCalls = 0;
+    intentBodies = [];
+    openGrantSessionId = "session";
+    openGrantVersion = "version";
+    openBearer = "bearer";
+    refreshProjection = projection();
+    refreshRejected = false;
+    switchRequested = false;
+    deferredReplay = null;
+    deferredReplayResponse = null;
+    testWindow = new Window({ url: "http://timer.quadball.app/event-control" });
+    Object.assign(globalThis, {
+      window: testWindow,
+      document: testWindow.document,
+      navigator: testWindow.navigator,
+      sessionStorage: testWindow.sessionStorage,
+      localStorage: testWindow.localStorage,
+      fetch: async (input: string | URL | Request, init?: RequestInit) => {
+        const url =
+          typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+        if (url.endsWith("/api/event-control/open")) {
+          return new Response(
+            JSON.stringify({
+              status: "opened",
+              eventGameId: "game-browser",
+              session: {
+                sessionBearer: openBearer,
+                grantSessionId: openGrantSessionId,
+                grantVersion: openGrantVersion,
+              },
+              projection: projection(),
+              projectionStatus: "available",
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          );
+        }
+        if (url.endsWith("/api/event-control/replay")) {
+          replayCalls += 1;
+          const rawBody = typeof init?.body === "string" ? init.body : "";
+          const body = JSON.parse(rawBody) as {
+            batchId: string;
+            replicaGeneration: string;
+            eventGameId: string;
+            grantSessionId: string;
+            grantVersion: string;
+            actions: { intent: { operationId: string } }[];
+          };
+          replayBodies.push(body);
+          if (replayMode === "lost") throw new Error("offline");
+          const replayResponse = new Response(
+            JSON.stringify({
+              batchId: body.batchId,
+              replicaGeneration: body.replicaGeneration,
+              eventGameId: body.eventGameId,
+              session: {
+                eventGameId: body.eventGameId,
+                grantSessionId: body.grantSessionId,
+                grantVersion: body.grantVersion,
+              },
+              status: "synchronized",
+              outcomes: body.actions.map((action) => ({
+                operationId: action.intent.operationId,
+                status: "accepted",
+              })),
+              projection: projection(),
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          );
+          if (replayMode === "deferred") {
+            deferredReplayResponse = replayResponse;
+            return await new Promise<Response>((resolve) => {
+              deferredReplay = resolve;
+            });
+          }
+          return replayResponse;
+        }
+        if (url.endsWith("/api/event-control/refresh")) {
+          if (refreshRejected) return new Response("rejected", { status: 401 });
+          if (switchRequested) {
+            return new Response(
+              JSON.stringify({
+                status: "switch-required",
+                previousEventGameId: "game-browser",
+                currentEventGameId: "game-b",
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            );
+          }
+          return new Response(
+            JSON.stringify({
+              status: "authorized",
+              session: {
+                eventGameId: "game-browser",
+                grantSessionId: openGrantSessionId,
+                grantVersion: openGrantVersion,
+              },
+              projection: refreshProjection,
+              projectionStatus: refreshProjection === null ? "unavailable" : "available",
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          );
+        }
+        if (url.endsWith("/api/event-control/intent")) {
+          intentCalls += 1;
+          const rawBody = typeof init?.body === "string" ? init.body : "";
+          const body = JSON.parse(rawBody) as {
+            intent: { operationId: string };
+          };
+          intentBodies.push(body as Record<string, any>);
+          return new Response(
+            JSON.stringify({
+              status: "accepted",
+              acknowledgement: { status: "acknowledged", operationId: body.intent.operationId },
+              projection: projection(),
+              projectionStatus: "available",
+              synchronization: { status: "synchronized", pendingCount: 0 },
+              auditReference: { kind: "control", id: "audit-online" },
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          );
+        }
+        if (url.endsWith("/api/event-control/leave")) {
+          return new Response(JSON.stringify({ status: "left" }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        if (url.endsWith("/api/event-control/switch")) {
+          return new Response(
+            JSON.stringify({
+              status: "authorized",
+              session: {
+                eventGameId: "game-b",
+                grantSessionId: "session-b",
+                grantVersion: "version-b",
+              },
+              projection: projection("game-b"),
+              projectionStatus: "available",
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          );
+        }
+        return new Response("Not found", { status: 404 });
+      },
+    });
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  async function enterAndOpen() {
+    await act(async () => {
+      root.render(<EventGameControllerPage />);
+      await Promise.resolve();
+    });
+    const grantInput = container.querySelector("input#control-grant") as HTMLInputElement;
+    await act(async () => {
+      grantInput.value = "qr-credential";
+      grantInput.dispatchEvent(
+        new testWindow.Event("input", { bubbles: true }) as unknown as Event,
+      );
+      grantInput.dispatchEvent(
+        new testWindow.Event("change", { bubbles: true }) as unknown as Event,
+      );
+      await Promise.resolve();
+    });
+    await act(async () => {
+      Array.from(container.getElementsByTagName("button"))
+        .find((button) => button.textContent?.includes("Open Controller"))
+        ?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  }
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+      await Promise.resolve();
+    });
+    container.remove();
+    testWindow.close();
+    Object.assign(globalThis, {
+      window: originalWindow,
+      document: originalDocument,
+      navigator: originalNavigator,
+      sessionStorage: originalSessionStorage,
+      localStorage: originalLocalStorage,
+      fetch: originalFetch,
+    });
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+      originalActEnvironment;
+  });
+
+  test("renders an optimistic action immediately and retains it through a lost replay", async () => {
+    await act(async () => {
+      root.render(<EventGameControllerPage />);
+      await Promise.resolve();
+    });
+    const grantInput = container.querySelector("input#control-grant") as HTMLInputElement;
+    await act(async () => {
+      grantInput.value = "qr-credential";
+      grantInput.dispatchEvent(
+        new testWindow.Event("input", { bubbles: true }) as unknown as Event,
+      );
+      grantInput.dispatchEvent(
+        new testWindow.Event("change", { bubbles: true }) as unknown as Event,
+      );
+      await Promise.resolve();
+    });
+    const openButton = Array.from(container.getElementsByTagName("button")).find((button) =>
+      button.textContent?.includes("Open Controller"),
+    );
+    await act(async () => {
+      openButton?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const goalButton = Array.from(container.getElementsByTagName("button")).find((button) =>
+      button.textContent?.includes("Record 10-point goal"),
+    );
+    expect(goalButton).not.toBeNull();
+    await act(async () => {
+      goalButton?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(container.textContent).toContain("10");
+    expect(container.textContent).toContain("retained for reconnect replay");
+    const stored = JSON.parse(
+      testWindow.localStorage.getItem(controllerReplicaStorageKey("game-browser")) ?? "null",
+    ) as { pendingActions?: unknown[] };
+    expect(stored.pendingActions).toHaveLength(1);
+  });
+
+  test("revalidates a fresh same-Game authority before foreground replay", async () => {
+    replayMode = "success";
+    await act(async () => {
+      root.render(<EventGameControllerPage />);
+      await Promise.resolve();
+    });
+    const grantInput = container.querySelector("input#control-grant") as HTMLInputElement;
+    await act(async () => {
+      grantInput.value = "qr-credential";
+      grantInput.dispatchEvent(
+        new testWindow.Event("input", { bubbles: true }) as unknown as Event,
+      );
+      grantInput.dispatchEvent(
+        new testWindow.Event("change", { bubbles: true }) as unknown as Event,
+      );
+      await Promise.resolve();
+    });
+    await act(async () => {
+      Array.from(container.getElementsByTagName("button"))
+        .find((button) => button.textContent?.includes("Open Controller"))
+        ?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const goalButton = Array.from(container.getElementsByTagName("button")).find((button) =>
+      button.textContent?.includes("Record 10-point goal"),
+    );
+    await act(async () => {
+      goalButton?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(replayCalls).toBe(1);
+    expect(replayBodies[0]?.actions[0]?.intent.occurrence.source).toBe("online");
+    expect(container.textContent).not.toContain("retained for reconnect replay");
+  });
+
+  test("fresh same-Game scan replays retained work with original evidence", async () => {
+    replayMode = "lost";
+    await enterAndOpen();
+    Object.defineProperty(testWindow.navigator, "onLine", { configurable: true, value: false });
+    const goalButton = Array.from(container.getElementsByTagName("button")).find((button) =>
+      button.textContent?.includes("Record 10-point goal"),
+    );
+    await act(async () => {
+      goalButton?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const retainedBody = replayBodies[0];
+    expect(retainedBody?.actions).toHaveLength(1);
+    const retainedIntent = retainedBody?.actions[0]?.intent;
+    await act(async () => {
+      Array.from(container.getElementsByTagName("button"))
+        .find((button) => button.textContent?.includes("Leave Controller Session"))
+        ?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    openGrantSessionId = "session-fresh";
+    openGrantVersion = "version-fresh";
+    replayMode = "success";
+    Object.defineProperty(testWindow.navigator, "onLine", { configurable: true, value: true });
+    await enterAndOpen();
+    expect(replayCalls).toBe(2);
+    expect(replayBodies[1]?.grantSessionId).toBe("session-fresh");
+    expect(replayBodies[1]?.grantVersion).toBe("version-fresh");
+    expect(replayBodies[1]?.actions[0]?.intent).toMatchObject({
+      operationId: retainedIntent?.operationId,
+      factId: retainedIntent?.factId,
+      occurrence: retainedIntent?.occurrence,
+    });
+  });
+
+  test("foreground revalidation completes before replaying retained work", async () => {
+    replayMode = "lost";
+    await enterAndOpen();
+    Object.defineProperty(testWindow.navigator, "onLine", { configurable: true, value: false });
+    const goalButton = Array.from(container.getElementsByTagName("button")).find((button) =>
+      button.textContent?.includes("Record 10-point goal"),
+    );
+    await act(async () => {
+      goalButton?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(replayCalls).toBe(1);
+    replayMode = "success";
+    Object.defineProperty(testWindow.navigator, "onLine", { configurable: true, value: true });
+    await act(async () => {
+      document.dispatchEvent(new testWindow.Event("visibilitychange") as unknown as Event);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(replayCalls).toBe(2);
+    expect(container.textContent).not.toContain("retained for reconnect replay");
+  });
+
+  test("unmount and remount restores persisted work before foreground replay", async () => {
+    replayMode = "lost";
+    await enterAndOpen();
+    Object.defineProperty(testWindow.navigator, "onLine", { configurable: true, value: false });
+    const goalButton = Array.from(container.getElementsByTagName("button")).find((button) =>
+      button.textContent?.includes("Record 10-point goal"),
+    );
+    await act(async () => {
+      goalButton?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    await act(async () => {
+      root.unmount();
+      await Promise.resolve();
+    });
+    replayMode = "success";
+    Object.defineProperty(testWindow.navigator, "onLine", { configurable: true, value: true });
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<EventGameControllerPage />);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(replayCalls).toBe(2);
+    expect(container.textContent).not.toContain("retained for reconnect replay");
+  });
+
+  test("unmount and remount preserves the authoritative base when refresh has no projection", async () => {
+    replayMode = "lost";
+    await enterAndOpen();
+    Object.defineProperty(testWindow.navigator, "onLine", { configurable: true, value: false });
+    await act(async () => {
+      Array.from(container.getElementsByTagName("button"))
+        .find((button) => button.textContent?.includes("Record 10-point goal"))
+        ?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const storageKey = controllerReplicaStorageKey("game-browser");
+    const before = JSON.parse(testWindow.localStorage.getItem(storageKey) ?? "null") as {
+      authoritativeProjection: ControllerProjection;
+      projection: ControllerProjection;
+    };
+    expect(before.authoritativeProjection.goalCount).toBe(0);
+    expect(before.projection.goalCount).toBe(1);
+
+    await act(async () => {
+      root.unmount();
+      await Promise.resolve();
+    });
+    refreshProjection = null;
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<EventGameControllerPage />);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(container.textContent).toContain("Goals: 1");
+    expect(container.textContent).not.toContain("Goals: 2");
+    const after = JSON.parse(testWindow.localStorage.getItem(storageKey) ?? "null") as {
+      authoritativeProjection: ControllerProjection;
+      projection: ControllerProjection;
+    };
+    expect(after.authoritativeProjection.goalCount).toBe(0);
+    expect(after.projection.goalCount).toBe(1);
+  });
+
+  test("reconnect drains successive bounded batches without another wake event", async () => {
+    replayMode = "success";
+    let storedReplica = createControllerReplica({
+      eventGameId: "game-browser",
+      projection: projection(),
+      grantSessionId: "session",
+      grantVersion: "version",
+      deviceId: "batch-drain-device",
+      replicaGeneration: "batch-drain-generation",
+    });
+    for (let index = 0; index < 101; index += 1) {
+      storedReplica = dispatchControllerAction(storedReplica, {
+        version: "live-event-control-intent-v1",
+        type: "reset",
+        operationId: `batch-drain-operation-${index}`,
+        factId: `batch-drain-fact-${index}`,
+        gameTimeMs: 0,
+        occurrence: { clientOriginAtMs: index, source: "offline" },
+      }).state;
+    }
+    testWindow.localStorage.setItem(
+      controllerReplicaStorageKey("game-browser"),
+      JSON.stringify(storedReplica),
+    );
+    testWindow.sessionStorage.setItem(
+      "quadball:event-controller-session",
+      JSON.stringify({ sessionBearer: "bearer", eventGameId: "game-browser" }),
+    );
+
+    await act(async () => {
+      root.render(<EventGameControllerPage />);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(replayCalls).toBe(2);
+    expect(replayBodies.map((body) => body.actions.length)).toEqual([100, 1]);
+    expect(container.textContent).not.toContain("retained for reconnect replay");
+  });
+
+  test("fresh authority supersedes an in-flight replay and starts exactly one newest-bearer replay", async () => {
+    replayMode = "deferred";
+    await enterAndOpen();
+    const goalButton = Array.from(container.getElementsByTagName("button")).find((button) =>
+      button.textContent?.includes("Record 10-point goal"),
+    );
+    await act(async () => {
+      goalButton?.click();
+      await Promise.resolve();
+    });
+    expect(replayCalls).toBe(1);
+    expect(deferredReplay).not.toBeNull();
+    const retainedIntent = replayBodies[0]?.actions[0]?.intent;
+
+    await act(async () => {
+      Array.from(container.getElementsByTagName("button"))
+        .find((button) => button.textContent?.includes("Leave Controller Session"))
+        ?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    openBearer = "bearer-b";
+    openGrantSessionId = "session-b";
+    openGrantVersion = "version-b";
+    replayMode = "success";
+    await enterAndOpen();
+    expect(replayCalls).toBe(1);
+
+    expect(deferredReplayResponse).not.toBeNull();
+    deferredReplay?.(deferredReplayResponse as Response);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(replayCalls).toBe(2);
+    expect(replayBodies[1]).toMatchObject({
+      sessionBearer: "bearer-b",
+      grantSessionId: "session-b",
+      grantVersion: "version-b",
+    });
+    expect(replayBodies[1]?.actions[0]?.intent).toMatchObject({
+      operationId: retainedIntent?.operationId,
+      factId: retainedIntent?.factId,
+      occurrence: retainedIntent?.occurrence,
+    });
+    expect(container.textContent).not.toContain("retained for reconnect replay");
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(replayCalls).toBe(2);
+  });
+
+  test("online Clock submits directly while disconnected Clock taps stay out of the replica", async () => {
+    await enterAndOpen();
+    Object.defineProperty(testWindow.navigator, "onLine", { configurable: true, value: true });
+    await act(async () => {
+      Array.from(container.getElementsByTagName("button"))
+        .find((button) => button.textContent?.includes("Start clock"))
+        ?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(intentCalls).toBe(1);
+    expect(intentBodies[0]?.intent.occurrence.source).toBe("online");
+    Object.defineProperty(testWindow.navigator, "onLine", { configurable: true, value: false });
+    await act(async () => {
+      Array.from(container.getElementsByTagName("button"))
+        .find((button) => button.textContent?.includes("Pause clock"))
+        ?.click();
+      await Promise.resolve();
+    });
+    expect(intentCalls).toBe(1);
+    expect(container.textContent).toContain("unavailable while disconnected");
+    const stored = JSON.parse(
+      testWindow.localStorage.getItem(controllerReplicaStorageKey("game-browser")) ?? "null",
+    ) as { pendingActions?: unknown[] };
+    expect(stored.pendingActions).toHaveLength(0);
+  });
+
+  test("quota warning is prominent while ordinary actions continue in memory", async () => {
+    Object.defineProperty(testWindow.localStorage, "setItem", {
+      configurable: true,
+      value: () => {
+        throw new Error("quota");
+      },
+    });
+    await enterAndOpen();
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain("full or unavailable");
+    const goalButton = Array.from(container.getElementsByTagName("button")).find((button) =>
+      button.textContent?.includes("Record 10-point goal"),
+    );
+    await act(async () => {
+      goalButton?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(container.textContent).toContain("10");
+    expect(container.textContent).toContain("retained for reconnect replay");
+  });
+
+  test("failed foreground authority revalidation retains evidence and submits no replay", async () => {
+    await act(async () => {
+      root.render(<EventGameControllerPage />);
+      await Promise.resolve();
+    });
+    const grantInput = container.querySelector("input#control-grant") as HTMLInputElement;
+    await act(async () => {
+      grantInput.value = "qr-credential";
+      grantInput.dispatchEvent(
+        new testWindow.Event("input", { bubbles: true }) as unknown as Event,
+      );
+      grantInput.dispatchEvent(
+        new testWindow.Event("change", { bubbles: true }) as unknown as Event,
+      );
+      await Promise.resolve();
+    });
+    await act(async () => {
+      Array.from(container.getElementsByTagName("button"))
+        .find((button) => button.textContent?.includes("Open Controller"))
+        ?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const goalButton = Array.from(container.getElementsByTagName("button")).find((button) =>
+      button.textContent?.includes("Record 10-point goal"),
+    );
+    await act(async () => {
+      goalButton?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const callsBeforeRefresh = replayCalls;
+    refreshRejected = true;
+    await act(async () => {
+      document.dispatchEvent(new testWindow.Event("visibilitychange") as unknown as Event);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(replayCalls).toBe(callsBeforeRefresh);
+    expect(container.textContent).toContain("retained for reconnect replay");
+  });
+
+  test("switching Games invalidates a deferred old response", async () => {
+    replayMode = "deferred";
+    await act(async () => {
+      root.render(<EventGameControllerPage />);
+      await Promise.resolve();
+    });
+    const grantInput = container.querySelector("input#control-grant") as HTMLInputElement;
+    await act(async () => {
+      grantInput.value = "qr-credential";
+      grantInput.dispatchEvent(
+        new testWindow.Event("input", { bubbles: true }) as unknown as Event,
+      );
+      grantInput.dispatchEvent(
+        new testWindow.Event("change", { bubbles: true }) as unknown as Event,
+      );
+      await Promise.resolve();
+    });
+    await act(async () => {
+      Array.from(container.getElementsByTagName("button"))
+        .find((button) => button.textContent?.includes("Open Controller"))
+        ?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const goalButton = Array.from(container.getElementsByTagName("button")).find((button) =>
+      button.textContent?.includes("Record 10-point goal"),
+    );
+    await act(async () => {
+      goalButton?.click();
+      await Promise.resolve();
+    });
+    expect(deferredReplay).not.toBeNull();
+    switchRequested = true;
+    await act(async () => {
+      Array.from(container.getElementsByTagName("button"))
+        .find((button) => button.textContent?.includes("Refresh assignment"))
+        ?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    await act(async () => {
+      Array.from(container.getElementsByTagName("button"))
+        .find((button) => button.textContent?.includes("Switch Event Game"))
+        ?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(deferredReplayResponse).not.toBeNull();
+    deferredReplay?.(deferredReplayResponse as Response);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(container.textContent).toContain("Controller Device: game-b");
+    const oldGame = JSON.parse(
+      testWindow.localStorage.getItem(controllerReplicaStorageKey("game-browser")) ?? "null",
+    ) as { pendingActions?: unknown[] };
+    expect(oldGame.pendingActions).toHaveLength(1);
+  });
+});
+
+function projection(eventGameId = "game-browser"): ControllerProjection {
+  return {
+    eventGameId,
+    phase: "scheduled",
+    scoreByGameSide: { "side-a": 0, "side-b": 0 },
+    goalCount: 0,
+    commencement: {
+      status: "provisional",
+      commencedAtMs: null,
+      provisionalRunningSinceMs: null,
+      provisionalElapsedMs: 0,
+    },
+  };
+}

--- a/src/pages/event-game-controller-page.tsx
+++ b/src/pages/event-game-controller-page.tsx
@@ -1,39 +1,63 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import type {
   ControllerProjection,
+  LiveEventGameControlResult,
   LiveEventControllerIntent,
 } from "@/lib/live-event-game-control";
-import {
-  LIVE_EVENT_CONTROL_INTENT_VERSION,
-  parseLiveEventControllerIntent,
-} from "@/lib/live-event-game-control";
+import { LIVE_EVENT_CONTROL_INTENT_VERSION } from "@/lib/live-event-game-control";
 import { readControllerDeviceContext } from "@/lib/controller-device-context";
 import {
-  retainControllerIntent,
-  type PendingControllerIntent,
-} from "@/lib/controller-intent-retry";
+  acknowledgeControllerProjection,
+  controllerReplicaStorageKey,
+  createControllerReplica,
+  dispatchControllerAction,
+  invalidateControllerReplica,
+  loadControllerReplica,
+  prepareControllerReplayBatch,
+  persistControllerReplica,
+  rebindControllerReplica,
+  reconcileControllerReplay,
+  type ControllerReplicaLoad,
+  type ControllerReplicaState,
+  type ControllerReplayBatchResponse,
+  type ControllerReplicaStorage,
+} from "@/lib/controller-reconnect";
 
 type PersistedControllerSession = { sessionBearer: string; eventGameId: string };
 type ControllerOpenResponse = {
   status: "opened";
   eventGameId: string;
-  session: { sessionBearer: string };
+  session: { sessionBearer: string; grantSessionId: string; grantVersion: string };
   projection: ControllerProjection | null;
   projectionStatus: "available" | "unavailable";
 };
 type ControllerRefreshResponse =
   | {
       status: "authorized";
-      session: { eventGameId: string };
+      session: { eventGameId: string; grantSessionId: string; grantVersion: string };
       projection: ControllerProjection | null;
       projectionStatus: "available" | "unavailable";
     }
   | { status: "switch-required"; previousEventGameId: string; currentEventGameId: string }
   | { status: "rejected"; message: string };
+
+type ReplayAuthority = {
+  ownerKey: string;
+  bearer: string;
+  bearerGeneration: number;
+  eventGameId: string;
+  replicaGeneration: string;
+  grantSessionId: string;
+  grantVersion: string;
+};
+
+type ReplayRequest = { state: ControllerReplicaState; authority: ReplayAuthority };
+
+type ActiveReplay = ReplayRequest & { requestToken: symbol };
 
 export function EventGameControllerPage() {
   const persisted = readPersistedControllerSession();
@@ -52,8 +76,17 @@ export function EventGameControllerPage() {
   const [clockRunning, setClockRunning] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
-  const [pendingIntent, setPendingIntent] = useState<PendingControllerIntent | null>(() =>
-    readPersistedPendingIntent(),
+  const [persistedReplicaLoad] = useState<ControllerReplicaLoad>(() =>
+    readPersistedControllerReplica(persisted?.eventGameId),
+  );
+  const [replica, setReplica] = useState<ControllerReplicaState | null>(persistedReplicaLoad.state);
+  const replicaRef = useRef<ControllerReplicaState | null>(replica);
+  const bearerGenerationRef = useRef(0);
+  const installedReplayAuthorityRef = useRef<ReplayAuthority | null>(null);
+  const activeReplayRef = useRef<ActiveReplay | null>(null);
+  const queuedReplayRef = useRef<ReplayRequest | null>(null);
+  const [durabilityWarning, setDurabilityWarning] = useState<string | null>(
+    persistedReplicaLoad.warning,
   );
   const [browserContext] = useState(() => readControllerDeviceContext());
 
@@ -69,15 +102,16 @@ export function EventGameControllerPage() {
   }, [eventGameId, sessionBearer]);
 
   useEffect(() => {
-    if (pendingIntent === null) {
-      sessionStorage.removeItem("quadball:event-controller-pending-intent");
-      return;
-    }
-    sessionStorage.setItem(
-      "quadball:event-controller-pending-intent",
-      JSON.stringify(pendingIntent),
+    replicaRef.current = replica;
+    if (replica === null) return;
+    setProjection(replica.projection);
+    setProjectionStatus("available");
+    const persistedReplica = persistControllerReplica(
+      replica,
+      browserReplicaStorage(replica.eventGameId),
     );
-  }, [pendingIntent]);
+    if (persistedReplica.warning !== null) setDurabilityWarning(persistedReplica.warning);
+  }, [replica]);
 
   useEffect(() => {
     if (persisted !== null) void refreshController(true);
@@ -85,9 +119,33 @@ export function EventGameControllerPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  useEffect(() => {
+    const reconcileWhenForegrounded = () => {
+      if (document.visibilityState === "hidden") return;
+      void (async () => {
+        const revalidated = await refreshController(true);
+        if (revalidated && replicaRef.current !== null) {
+          await flushReplica(replicaRef.current);
+        }
+      })();
+    };
+    window.addEventListener("online", reconcileWhenForegrounded);
+    document.addEventListener("visibilitychange", reconcileWhenForegrounded);
+    return () => {
+      window.removeEventListener("online", reconcileWhenForegrounded);
+      document.removeEventListener("visibilitychange", reconcileWhenForegrounded);
+    };
+  }, [eventGameId, sessionBearer]);
+
   async function openController() {
     setBusy(true);
     setMessage(null);
+    clearReplayAuthority();
+    if (replicaRef.current !== null) {
+      const invalidated = invalidateControllerReplica(replicaRef.current);
+      replicaRef.current = invalidated;
+      setReplica(invalidated);
+    }
     try {
       const response = await postJson<ControllerOpenResponse>("/api/event-control/open", {
         qrCredential,
@@ -98,6 +156,35 @@ export function EventGameControllerPage() {
       setEventGameId(response.eventGameId);
       setProjection(response.projection);
       setProjectionStatus(response.projectionStatus);
+      const existingReplica = replicaRef.current;
+      const restoredLoad = loadControllerReplica(
+        browserReplicaStorage(response.eventGameId),
+        response.eventGameId,
+      );
+      if (restoredLoad.warning !== null) setDurabilityWarning(restoredLoad.warning);
+      const scopedReplica =
+        existingReplica?.eventGameId === response.eventGameId
+          ? existingReplica
+          : restoredLoad.state;
+      const nextReplica =
+        scopedReplica?.eventGameId === response.eventGameId
+          ? rebindControllerReplica(
+              scopedReplica,
+              {
+                eventGameId: response.eventGameId,
+                grantSessionId: response.session.grantSessionId,
+                grantVersion: response.session.grantVersion,
+              },
+              response.projection,
+            )
+          : createControllerReplica({
+              eventGameId: response.eventGameId,
+              projection: response.projection ?? emptyProjection(response.eventGameId),
+              grantSessionId: response.session.grantSessionId,
+              grantVersion: response.session.grantVersion,
+            });
+      commitReplica(nextReplica);
+      await flushReplica(nextReplica, response.session.sessionBearer);
     } catch {
       clearSession();
       setMessage("Unable to open Controller experience.");
@@ -106,8 +193,8 @@ export function EventGameControllerPage() {
     }
   }
 
-  async function refreshController(silent = false) {
-    if (sessionBearer === null || eventGameId === null) return;
+  async function refreshController(silent = false): Promise<boolean> {
+    if (sessionBearer === null || eventGameId === null) return false;
     if (!silent) setBusy(true);
     try {
       const response = await postJson<ControllerRefreshResponse>("/api/event-control/refresh", {
@@ -118,15 +205,38 @@ export function EventGameControllerPage() {
         setSwitchTarget(
           stayedOnAssignment === response.currentEventGameId ? null : response.currentEventGameId,
         );
-        return;
+        return false;
       }
       if (response.status === "rejected") throw new Error("refresh failed");
       setSwitchTarget(null);
       setEventGameId(response.session.eventGameId);
       setProjection(response.projection);
       setProjectionStatus(response.projectionStatus);
+      const currentReplica = replicaRef.current;
+      const refreshedSession = {
+        eventGameId: response.session.eventGameId,
+        grantSessionId: response.session.grantSessionId,
+        grantVersion: response.session.grantVersion,
+      };
+      const nextReplica =
+        currentReplica?.eventGameId === response.session.eventGameId &&
+        currentReplica.session.grantSessionId === response.session.grantSessionId &&
+        currentReplica.session.grantVersion === response.session.grantVersion
+          ? acknowledgeControllerProjection(currentReplica, response.projection)
+          : currentReplica?.eventGameId === response.session.eventGameId
+            ? rebindControllerReplica(currentReplica, refreshedSession, response.projection)
+            : createControllerReplica({
+                eventGameId: response.session.eventGameId,
+                projection: response.projection ?? emptyProjection(response.session.eventGameId),
+                grantSessionId: response.session.grantSessionId,
+                grantVersion: response.session.grantVersion,
+              });
+      commitReplica(nextReplica);
+      await flushReplica(nextReplica, sessionBearer);
+      return true;
     } catch {
       if (!silent) setMessage("Unable to refresh Controller session.");
+      return false;
     } finally {
       if (!silent) setBusy(false);
     }
@@ -135,6 +245,13 @@ export function EventGameControllerPage() {
   async function switchController() {
     if (sessionBearer === null) return;
     setBusy(true);
+    clearReplayAuthority();
+    const current = replicaRef.current;
+    if (current !== null) {
+      const invalidated = invalidateControllerReplica(current);
+      replicaRef.current = invalidated;
+      setReplica(invalidated);
+    }
     try {
       const response = await postJson<ControllerRefreshResponse>("/api/event-control/switch", {
         sessionBearer,
@@ -143,6 +260,31 @@ export function EventGameControllerPage() {
       setEventGameId(response.session.eventGameId);
       setProjection(response.projection);
       setProjectionStatus(response.projectionStatus);
+      const restoredLoad = loadControllerReplica(
+        browserReplicaStorage(response.session.eventGameId),
+        response.session.eventGameId,
+      );
+      if (restoredLoad.warning !== null) setDurabilityWarning(restoredLoad.warning);
+      const restored = restoredLoad.state;
+      const nextReplica =
+        restored === null
+          ? createControllerReplica({
+              eventGameId: response.session.eventGameId,
+              projection: response.projection ?? emptyProjection(response.session.eventGameId),
+              grantSessionId: response.session.grantSessionId,
+              grantVersion: response.session.grantVersion,
+            })
+          : rebindControllerReplica(
+              restored,
+              {
+                eventGameId: response.session.eventGameId,
+                grantSessionId: response.session.grantSessionId,
+                grantVersion: response.session.grantVersion,
+              },
+              response.projection,
+            );
+      commitReplica(nextReplica);
+      await flushReplica(nextReplica, sessionBearer);
       setSwitchTarget(null);
       setStayedOnAssignment(null);
       setMessage("Controller Device switched to the newly assigned Event Game.");
@@ -167,6 +309,19 @@ export function EventGameControllerPage() {
       setEventGameId(response.session.eventGameId);
       setProjection(response.projection);
       setProjectionStatus(response.projectionStatus);
+      if (replicaRef.current !== null) {
+        const nextReplica = rebindControllerReplica(
+          replicaRef.current,
+          {
+            eventGameId: response.session.eventGameId,
+            grantSessionId: response.session.grantSessionId,
+            grantVersion: response.session.grantVersion,
+          },
+          response.projection,
+        );
+        commitReplica(nextReplica);
+        await flushReplica(nextReplica, sessionBearer);
+      }
       setMessage("Staying on the current Event Game until the assignment changes again.");
     } catch {
       setMessage("Unable to retain the current Event Game assignment.");
@@ -209,30 +364,6 @@ export function EventGameControllerPage() {
     }
   }
 
-  async function submitIntent(intent: LiveEventControllerIntent) {
-    if (sessionBearer === null || eventGameId === null) return;
-    setBusy(true);
-    try {
-      const response = await postJson<
-        | { status: "accepted" | "duplicate-accepted"; projection: ControllerProjection | null }
-        | { status: "rejected" | "retryable" }
-      >("/api/event-control/intent", { sessionBearer, eventGameId, intent });
-      if (response.status !== "accepted" && response.status !== "duplicate-accepted") {
-        if (response.status === "rejected") setPendingIntent(null);
-        setMessage("The Controller action was not committed; retry is safe.");
-        return;
-      }
-      setPendingIntent(null);
-      setProjection(response.projection);
-      setProjectionStatus(response.projection === null ? "unavailable" : "available");
-      if (intent.type === "clock" || intent.type === "set-running") setClockRunning(intent.running);
-    } catch {
-      setMessage("The Controller action may still be pending. Retry the same action.");
-    } finally {
-      setBusy(false);
-    }
-  }
-
   function recordGoal(gameSideId: string) {
     queueIntent({
       version: LIVE_EVENT_CONTROL_INTENT_VERSION,
@@ -257,29 +388,208 @@ export function EventGameControllerPage() {
     });
   }
 
-  function toggleClock() {
-    queueIntent({
-      version: LIVE_EVENT_CONTROL_INTENT_VERSION,
-      type: "clock",
-      running: !clockRunning,
-      operationId: crypto.randomUUID(),
-      factId: crypto.randomUUID(),
-      gameTimeMs: 0,
-      occurrence: { clientOriginAtMs: Date.now() },
-    });
+  function queueIntent(candidate: LiveEventControllerIntent) {
+    const current = replicaRef.current;
+    if (current === null) return;
+    try {
+      const dispatched = dispatchControllerAction(current, {
+        ...candidate,
+        occurrence: {
+          ...candidate.occurrence,
+          source: navigator.onLine === false ? "offline" : "online",
+        },
+      });
+      replicaRef.current = dispatched.state;
+      setReplica(dispatched.state);
+      setProjection(dispatched.state.projection);
+      setProjectionStatus("available");
+      void flushReplica(dispatched.state);
+    } catch {
+      setMessage("The Controller action could not be retained safely.");
+    }
   }
 
-  function queueIntent(candidate: LiveEventControllerIntent) {
-    const intent = retainControllerIntent(pendingIntent, candidate);
-    setPendingIntent(intent);
-    void submitIntent(intent);
+  async function flushReplica(state: ControllerReplicaState, bearer = sessionBearer) {
+    if (bearer === null) return;
+    const request = { state, authority: installReplayAuthority(state, bearer) };
+    const active = activeReplayRef.current;
+    if (active !== null) {
+      if (active.authority.ownerKey !== request.authority.ownerKey || active.state !== state) {
+        queuedReplayRef.current = request;
+      }
+      return;
+    }
+    await runReplay(request);
+  }
+
+  async function runReplay(request: ReplayRequest) {
+    if (!isInstalledReplayAuthority(request.authority)) return;
+    const current = replicaRef.current;
+    const replayState =
+      current !== null && replicaMatchesAuthority(current, request.authority)
+        ? current
+        : request.state;
+    const prepared = prepareControllerReplayBatch(replayState);
+    if (prepared === null) return;
+    commitReplica(prepared.state);
+    const active: ActiveReplay = {
+      state: prepared.state,
+      authority: request.authority,
+      requestToken: Symbol("controller-replay"),
+    };
+    activeReplayRef.current = active;
+    try {
+      const response = await postJson<ControllerReplayBatchResponse>("/api/event-control/replay", {
+        sessionBearer: request.authority.bearer,
+        eventGameId: prepared.batch.eventGameId,
+        batchId: prepared.batch.batchId,
+        replicaGeneration: prepared.batch.replicaGeneration,
+        grantSessionId: prepared.batch.session.grantSessionId,
+        grantVersion: prepared.batch.session.grantVersion,
+        actions: prepared.batch.actions,
+      });
+      if (!isInstalledReplayAuthority(request.authority)) return;
+      const nextReplica = reconcileControllerReplay(replicaRef.current ?? prepared.state, response);
+      commitReplica(nextReplica);
+      setProjection(nextReplica.projection);
+      setProjectionStatus(response.projection === null ? "unavailable" : "available");
+      if (
+        response.status === "synchronized" &&
+        nextReplica.pendingActions.some((action) => action.status === "pending")
+      ) {
+        queuedReplayRef.current = { state: nextReplica, authority: request.authority };
+      }
+      if (response.status === "retryable")
+        setMessage("Reconnect is incomplete; retained actions will retry.");
+    } catch {
+      if (isInstalledReplayAuthority(request.authority)) {
+        setMessage("Connection lost. Pending Controller actions remain safely retained.");
+      }
+    } finally {
+      if (activeReplayRef.current?.requestToken === active.requestToken) {
+        activeReplayRef.current = null;
+        const queued = queuedReplayRef.current;
+        queuedReplayRef.current = null;
+        const installed = installedReplayAuthorityRef.current;
+        if (
+          queued !== null &&
+          installed !== null &&
+          queued.authority.ownerKey === installed.ownerKey
+        ) {
+          void runReplay({ state: replicaRef.current ?? queued.state, authority: installed });
+        }
+      }
+    }
+  }
+
+  function installReplayAuthority(state: ControllerReplicaState, bearer: string): ReplayAuthority {
+    const current = installedReplayAuthorityRef.current;
+    if (current !== null && current.bearer === bearer && replicaMatchesAuthority(state, current)) {
+      return current;
+    }
+    const bearerGeneration = bearerGenerationRef.current + 1;
+    bearerGenerationRef.current = bearerGeneration;
+    const authority: ReplayAuthority = {
+      ownerKey: [
+        state.eventGameId,
+        state.replicaGeneration,
+        state.session.grantSessionId,
+        state.session.grantVersion,
+        bearerGeneration,
+      ].join("\u001f"),
+      bearer,
+      bearerGeneration,
+      eventGameId: state.eventGameId,
+      replicaGeneration: state.replicaGeneration,
+      grantSessionId: state.session.grantSessionId,
+      grantVersion: state.session.grantVersion,
+    };
+    installedReplayAuthorityRef.current = authority;
+    return authority;
+  }
+
+  function isInstalledReplayAuthority(authority: ReplayAuthority): boolean {
+    return installedReplayAuthorityRef.current?.ownerKey === authority.ownerKey;
+  }
+
+  function clearReplayAuthority() {
+    installedReplayAuthorityRef.current = null;
+    queuedReplayRef.current = null;
+  }
+
+  function commitReplica(state: ControllerReplicaState) {
+    replicaRef.current = state;
+    setReplica(state);
+  }
+
+  function toggleClock() {
+    const bearer = sessionBearer;
+    const currentEventGameId = eventGameId;
+    if (bearer === null || currentEventGameId === null) return;
+    if (navigator.onLine === false) {
+      setMessage("Clock control is unavailable while disconnected and was not retained.");
+      return;
+    }
+    void submitOnlineControllerIntent(
+      {
+        version: LIVE_EVENT_CONTROL_INTENT_VERSION,
+        type: "clock",
+        running: !clockRunning,
+        operationId: crypto.randomUUID(),
+        factId: crypto.randomUUID(),
+        gameTimeMs: 0,
+        occurrence: { clientOriginAtMs: Date.now(), source: "online" },
+      },
+      bearer,
+      currentEventGameId,
+    );
+  }
+
+  async function submitOnlineControllerIntent(
+    intent: LiveEventControllerIntent,
+    bearer: string,
+    currentEventGameId: string,
+  ) {
+    try {
+      const response = await postJson<LiveEventGameControlResult>("/api/event-control/intent", {
+        sessionBearer: bearer,
+        eventGameId: currentEventGameId,
+        intent,
+      });
+      if (response.status !== "accepted" && response.status !== "duplicate-accepted") {
+        setMessage("The online Controller action was not accepted.");
+        return;
+      }
+      setClockRunning(
+        intent.type === "clock" || intent.type === "set-running" ? intent.running : false,
+      );
+      if (response.projection !== null) {
+        const current = replicaRef.current;
+        if (current?.eventGameId === currentEventGameId) {
+          const nextReplica = acknowledgeControllerProjection(current, response.projection);
+          replicaRef.current = nextReplica;
+          setReplica(nextReplica);
+        }
+        setProjection(response.projection);
+        setProjectionStatus(response.projectionStatus);
+      }
+    } catch {
+      setMessage("The online Controller action could not be submitted.");
+    }
   }
 
   function clearSession() {
+    clearReplayAuthority();
+    if (replicaRef.current !== null) {
+      const invalidated = invalidateControllerReplica(replicaRef.current);
+      replicaRef.current = invalidated;
+      setReplica(invalidated);
+    }
     setSessionBearer(null);
     setEventGameId(null);
     setProjection(null);
     setProjectionStatus("unavailable");
+    setClockRunning(false);
     setRevealedQr(null);
     setSwitchTarget(null);
     setStayedOnAssignment(null);
@@ -393,9 +703,15 @@ export function EventGameControllerPage() {
                   ))}
                 </div>
               )}
-              {pendingIntent === null ? null : (
+              {replica !== null && replica.pendingActions.length > 0 ? (
                 <p className="text-sm text-amber-700">
-                  An uncertain Controller action is retained for safe retry.
+                  {replica.pendingActions.length} Controller action(s) retained for reconnect
+                  replay.
+                </p>
+              ) : null}
+              {durabilityWarning === null ? null : (
+                <p role="alert" className="text-sm font-medium text-amber-700">
+                  {durabilityWarning}
                 </p>
               )}
             </>
@@ -418,6 +734,18 @@ async function postJson<T>(path: string, body: unknown): Promise<T> {
   return result;
 }
 
+function replicaMatchesAuthority(
+  state: ControllerReplicaState,
+  authority: ReplayAuthority,
+): boolean {
+  return (
+    state.eventGameId === authority.eventGameId &&
+    state.replicaGeneration === authority.replicaGeneration &&
+    state.session.grantSessionId === authority.grantSessionId &&
+    state.session.grantVersion === authority.grantVersion
+  );
+}
+
 function readPersistedControllerSession(): PersistedControllerSession | null {
   try {
     const raw = sessionStorage.getItem("quadball:event-controller-session");
@@ -431,13 +759,41 @@ function readPersistedControllerSession(): PersistedControllerSession | null {
   }
 }
 
-function readPersistedPendingIntent(): PendingControllerIntent | null {
+function readPersistedControllerReplica(eventGameId: string | undefined): ControllerReplicaLoad {
   try {
-    const raw = sessionStorage.getItem("quadball:event-controller-pending-intent");
-    if (raw === null) return null;
-    const parsed = parseLiveEventControllerIntent(JSON.parse(raw));
-    return parsed.ok ? parsed.value : null;
+    if (typeof localStorage === "undefined") {
+      return { state: null, warning: null, quarantined: false };
+    }
+    return loadControllerReplica(browserReplicaStorage(eventGameId), eventGameId);
   } catch {
-    return null;
+    return {
+      state: null,
+      warning: "Controller recovery storage is unavailable; changes remain in memory.",
+      quarantined: false,
+    };
   }
+}
+
+function browserReplicaStorage(eventGameId?: string): ControllerReplicaStorage {
+  const storageKey = controllerReplicaStorageKey(eventGameId);
+  return {
+    read: () => localStorage.getItem(storageKey),
+    write: (value) => localStorage.setItem(storageKey, value),
+    quarantine: (value) => localStorage.setItem(`${storageKey}:quarantine`, value),
+  };
+}
+
+function emptyProjection(eventGameId: string): ControllerProjection {
+  return {
+    eventGameId,
+    phase: "scheduled",
+    scoreByGameSide: {},
+    goalCount: 0,
+    commencement: {
+      status: "provisional",
+      commencedAtMs: null,
+      provisionalRunningSinceMs: null,
+      provisionalElapsedMs: 0,
+    },
+  };
 }


### PR DESCRIPTION
## What changed

- add a versioned, runtime-validated local Event Game Controller replica with stable action identities, causal dependencies, and scoped session ownership
- preserve and optimistically reapply ordinary non-clock actions across disconnects, refreshes, foregrounding, and same-Game authority replacement
- reconcile bounded replay batches through explicit per-action outcomes while retaining retryable, blocked, and correction-held evidence
- reject or quarantine malformed, cross-Game, stale, and unsupported replica state without replaying it into another Game
- add focused browser, transport, control, and replica coverage, including 10,000 retained identities and successive 100-action batch draining

## Why

Controllers need to keep ordinary scoring and administration work usable through unreliable event connectivity without making the browser the durable shared authority or weakening Grant Session boundaries.

## Impact

Controller actions now remain visible and recoverable during offline and reconnect flows. Clock actions remain online-only, finished unlocked Games retain later evidence for deliberate correction, and storage failures surface a durability warning instead of silently evicting work.

## Validation

- `bun run check`
- `bun run test` — 474 passed
- `bun run build`
- `git diff --check`
- focused Controller reconnect and browser suites

Closes #86
