### PR TITLE
Share authoritative Event Game clocks

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -5,6 +5,7 @@ import { Window } from "happy-dom";
 import { App } from "./App";
 import { createInitialGameState, projectGameView } from "@/lib/game-engine";
 import { DEFAULT_AWAY_TEAM_COLOR, DEFAULT_HOME_TEAM_COLOR } from "@/lib/team-colors";
+import { createInitialClockBaseline, projectClockBaseline } from "@/lib/clock-authority";
 
 class MockWebSocket {
   static CONNECTING = 0;
@@ -153,6 +154,166 @@ describe("App", () => {
     } finally {
       console.error = originalConsoleError;
     }
+  });
+
+  test("online Event Game Controller keeps Game Clock and play/pause visible", async () => {
+    testWindow.history.pushState({}, "", "/event-control");
+    const originalDateNow = Date.now;
+    Date.now = () => 9_000_000_000_000;
+    try {
+      const baseline = { ...createInitialClockBaseline(), gameTimeMs: 5_000 };
+      const projection = {
+        eventGameId: "event-game-1",
+        phase: "scheduled" as const,
+        scoreByGameSide: { "side-a": 0, "side-b": 0 },
+        goalCount: 0,
+        commencement: {
+          status: "provisional" as const,
+          commencedAtMs: null,
+          provisionalRunningSinceMs: null,
+          provisionalElapsedMs: 0,
+        },
+        // The server sample is deliberately from a wall clock far from this phone.
+        clock: projectClockBaseline(baseline, 4_000),
+      };
+      Object.assign(globalThis, {
+        fetch: async (input: string | URL | Request) => {
+          const url =
+            typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+          if (url.endsWith("/api/event-control/open")) {
+            return new Response(
+              JSON.stringify({
+                status: "opened",
+                eventGameId: "event-game-1",
+                session: {
+                  sessionBearer: "session-bearer",
+                  grantSessionId: "grant-session",
+                  grantVersion: "grant-version",
+                },
+                projection,
+                projectionStatus: "available",
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            );
+          }
+          return new Response("Not found", { status: 404 });
+        },
+      });
+
+      await act(async () => {
+        root.render(<App />);
+        await Promise.resolve();
+      });
+
+      const openButton = Array.from(container.getElementsByTagName("button")).find((button) =>
+        button.textContent?.includes("Open Controller Device"),
+      );
+      expect(openButton).not.toBeNull();
+      await act(async () => {
+        openButton?.click();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(container.textContent).toContain("Game Clock");
+      expect(container.textContent).toContain("00:05");
+      expect(container.textContent).toContain("Start clock");
+      expect(container.textContent).toContain("Controller projection");
+    } finally {
+      Date.now = originalDateNow;
+    }
+  });
+
+  test("online Controller renders every clock cue phase and rejects fractional correction", async () => {
+    testWindow.history.pushState({}, "", "/event-control");
+    let phaseMs = 0;
+    const makeProjection = () => ({
+      eventGameId: "event-game-1",
+      phase: "scheduled" as const,
+      scoreByGameSide: { "side-a": 0, "side-b": 0 },
+      goalCount: 0,
+      commencement: {
+        status: "provisional" as const,
+        commencedAtMs: null,
+        provisionalRunningSinceMs: null,
+        provisionalElapsedMs: 0,
+      },
+      clock: projectClockBaseline({ ...createInitialClockBaseline(), gameTimeMs: phaseMs }, 0),
+    });
+    Object.assign(globalThis, {
+      fetch: async (input: string | URL | Request) => {
+        const url =
+          typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+        if (url.endsWith("/api/event-control/open") || url.endsWith("/api/event-control/refresh")) {
+          return new Response(
+            JSON.stringify({
+              status: url.endsWith("/open") ? "opened" : "authorized",
+              eventGameId: "event-game-1",
+              session: {
+                sessionBearer: "session-bearer",
+                eventGameId: "event-game-1",
+                grantSessionId: "grant-session",
+                grantVersion: "grant-version",
+              },
+              projection: makeProjection(),
+              projectionStatus: "available",
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          );
+        }
+        return new Response("Not found", { status: 404 });
+      },
+    });
+
+    await act(async () => {
+      root.render(<App />);
+      await Promise.resolve();
+    });
+    const openButton = Array.from(container.getElementsByTagName("button")).find((button) =>
+      button.textContent?.includes("Open Controller Device"),
+    );
+    await act(async () => {
+      openButton?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(container.textContent).toContain("Flag-runner entry pending at 19:00");
+    expect(container.textContent).toContain("Seeker warning pending");
+    expect(container.textContent).toContain("Seeker release pending at 20:00");
+
+    phaseMs = 19 * 60 * 1000;
+    const refreshButton = Array.from(container.getElementsByTagName("button")).find((button) =>
+      button.textContent?.includes("Refresh assignment"),
+    );
+    await act(async () => {
+      refreshButton?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(container.textContent).toContain("FLAG-RUNNER ENTRY NOW");
+    expect(container.textContent).toContain("SEEKER WARNING: release countdown active");
+    expect(container.textContent).toContain("SEEKER COUNTDOWN: 01:00");
+
+    phaseMs = 20 * 60 * 1000;
+    await act(async () => {
+      refreshButton?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(container.textContent).toContain("SEEKER RELEASED at 20:00");
+
+    const correctionInput = container.querySelector<HTMLInputElement>("#clock-correction");
+    const correctionButton = container.querySelector<HTMLButtonElement>(
+      '[data-clock-correction="true"]',
+    );
+    if (correctionInput === null || correctionButton === null) {
+      throw new Error("Expected the bounded clock correction controls.");
+    }
+    await act(async () => {
+      correctionButton.click();
+      await Promise.resolve();
+    });
+    expect(container.textContent).toContain("Enter a whole number of milliseconds");
   });
 
   test("clock adjust controls replace helper text and can be closed from the clock toggle", async () => {

--- a/src/lib/clock-authority.test.ts
+++ b/src/lib/clock-authority.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, test } from "bun:test";
+import {
+  createInitialClockBaseline,
+  deriveClockAuthority,
+  projectClockBaseline,
+  type ClockAuthorityAction,
+} from "@/lib/clock-authority";
+
+describe("Clock Authority", () => {
+  test("serializes simultaneous transitions deterministically and transfers the holder", () => {
+    const actions: ClockAuthorityAction[] = [
+      clockAction({
+        operationId: "z-start",
+        trustedAtMs: 1_000,
+        sessionId: "session-a",
+        command: "set-running",
+        running: true,
+      }),
+      clockAction({
+        operationId: "a-pause",
+        trustedAtMs: 1_000,
+        sessionId: "session-b",
+        command: "set-running",
+        running: false,
+      }),
+    ];
+
+    const baseline = deriveClockAuthority(actions);
+
+    expect(baseline).toMatchObject({
+      gameTimeMs: 0,
+      penaltyTimeMs: 0,
+      running: true,
+      holderGrantSessionId: "session-a",
+      lastTransitionOperationId: "z-start",
+    });
+    expect(baseline.holderGeneration).toBe(2);
+  });
+
+  test("composes simultaneous relative adjustments against the canonical baseline", () => {
+    const actions: ClockAuthorityAction[] = [
+      clockAction({
+        operationId: "start",
+        trustedAtMs: 1_000,
+        sessionId: "session-a",
+        command: "set-running",
+        running: true,
+      }),
+      clockAction({
+        operationId: "adjust-a",
+        trustedAtMs: 2_000,
+        sessionId: "session-a",
+        command: "adjust",
+        adjustmentMs: 1_000,
+      }),
+      clockAction({
+        operationId: "adjust-b",
+        trustedAtMs: 2_000,
+        sessionId: "session-b",
+        command: "adjust",
+        adjustmentMs: 1_000,
+      }),
+    ];
+
+    expect(deriveClockAuthority(actions)).toMatchObject({
+      gameTimeMs: 3_000,
+      running: true,
+      lastTransitionOperationId: "adjust-b",
+    });
+    expect(deriveClockAuthority([...actions].reverse()).gameTimeMs).toBe(3_000);
+    expect(deriveClockAuthority([...actions, actions[2]!]).gameTimeMs).toBe(3_000);
+  });
+
+  test("projects the latest accepted holder even when its occurrence is earlier", () => {
+    const actions: ClockAuthorityAction[] = [
+      clockAction({
+        operationId: "accepted-first",
+        trustedAtMs: 2_000,
+        acceptedAtMs: 2_000,
+        sessionId: "session-a",
+        command: "set-running",
+        running: true,
+      }),
+      clockAction({
+        operationId: "accepted-later-earlier-occurrence",
+        trustedAtMs: 1_000,
+        acceptedAtMs: 3_000,
+        sessionId: "session-b",
+        command: "adjust",
+        adjustmentMs: 1_000,
+      }),
+    ];
+
+    for (const candidate of [actions, [...actions].reverse()]) {
+      expect(deriveClockAuthority(candidate)).toMatchObject({
+        holderGrantSessionId: "session-b",
+        holderGeneration: 2,
+        lastAcceptedAtMs: 3_000,
+      });
+    }
+  });
+
+  test("keeps penalty time independent, live-only, and paused with the game", () => {
+    const baseline = deriveClockAuthority([
+      clockAction({
+        operationId: "start",
+        trustedAtMs: 1_000,
+        sessionId: "session-a",
+        command: "set-running",
+        running: true,
+      }),
+      clockAction({
+        operationId: "penalty-start",
+        trustedAtMs: 2_000,
+        sessionId: "session-a",
+        command: "penalty-start",
+      }),
+    ]);
+
+    expect(projectClockBaseline(createInitialClockBaseline(), 20_000).activePenaltyTimeMs).toBe(0);
+
+    const projection = projectClockBaseline(baseline, 5_000);
+
+    expect(projection).toMatchObject({
+      gameTimeMs: 4_000,
+      activePenaltyTimeMs: 3_000,
+      running: true,
+      baseline: { activePenalty: { elapsedMs: 3_000 } },
+    });
+
+    const pausedBaseline = deriveClockAuthority([
+      ...baselineActions(),
+      clockAction({
+        operationId: "pause",
+        trustedAtMs: 5_000,
+        sessionId: "session-a",
+        command: "set-running",
+        running: false,
+      }),
+    ]);
+    const paused = projectClockBaseline(pausedBaseline, 9_000);
+    expect(paused.gameTimeMs).toBe(4_000);
+    expect(paused.activePenaltyTimeMs).toBe(3_000);
+    expect(paused.running).toBe(false);
+
+    const resumedBaseline = deriveClockAuthority([
+      ...baselineActions(),
+      clockAction({
+        operationId: "pause",
+        trustedAtMs: 5_000,
+        sessionId: "session-a",
+        command: "set-running",
+        running: false,
+      }),
+      clockAction({
+        operationId: "resume",
+        trustedAtMs: 9_000,
+        sessionId: "session-a",
+        command: "set-running",
+        running: true,
+      }),
+    ]);
+    expect(projectClockBaseline(resumedBaseline, 11_000).activePenaltyTimeMs).toBe(5_000);
+  });
+});
+
+function baselineActions(): ClockAuthorityAction[] {
+  return [
+    clockAction({
+      operationId: "start",
+      trustedAtMs: 1_000,
+      sessionId: "session-a",
+      command: "set-running",
+      running: true,
+    }),
+    clockAction({
+      operationId: "penalty-start",
+      trustedAtMs: 2_000,
+      sessionId: "session-a",
+      command: "penalty-start",
+    }),
+  ];
+}
+
+function clockAction(input: {
+  operationId: string;
+  trustedAtMs: number;
+  sessionId: string;
+  acceptedAtMs?: number;
+  command: ClockAuthorityAction["command"];
+  running?: boolean;
+  adjustmentMs?: number;
+}): ClockAuthorityAction {
+  return {
+    operationId: input.operationId,
+    trustedAtMs: input.trustedAtMs,
+    acceptedAtMs: input.acceptedAtMs ?? input.trustedAtMs,
+    sessionId: input.sessionId,
+    command: input.command,
+    ...(input.running === undefined ? {} : { running: input.running }),
+    ...(input.adjustmentMs === undefined ? {} : { adjustmentMs: input.adjustmentMs }),
+  };
+}

--- a/src/lib/clock-authority.ts
+++ b/src/lib/clock-authority.ts
@@ -1,0 +1,327 @@
+import {
+  SHARED_LIMITS,
+  validateClockAdjustmentMs,
+  validateGameClockMs,
+  validateIntegerInRange,
+  type ValidationResult,
+} from "@/lib/validation-policy";
+
+export const FLAG_RUNNER_ENTRY_MS = 19 * 60 * 1000;
+export const SEEKER_RELEASE_MS = 20 * 60 * 1000;
+export const CLOCK_AUTHORITY_VERSION = "clock-authority-v1" as const;
+
+export type ClockAuthorityAction = {
+  operationId: string;
+  trustedAtMs: number;
+  acceptedAtMs: number;
+  sessionId: string;
+  command: "set-running" | "adjust" | "correct" | "penalty-start";
+  running?: boolean;
+  gameTimeMs?: number;
+  adjustmentMs?: number;
+};
+
+export type ClockPenaltyBaseline = {
+  elapsedMs: number;
+  establishedAtMs: number;
+  sourceOperationId: string;
+};
+
+export type ClockBaseline = {
+  version: typeof CLOCK_AUTHORITY_VERSION;
+  gameTimeMs: number;
+  /** Compatibility field; this is the independent active-penalty elapsed value. */
+  penaltyTimeMs: number;
+  activePenalty: ClockPenaltyBaseline | null;
+  running: boolean;
+  runningSinceMs: number | null;
+  establishedAtMs: number;
+  holderGrantSessionId: string | null;
+  holderGeneration: number;
+  lastTransitionOperationId: string | null;
+  lastAcceptedAtMs: number | null;
+};
+
+export type ClockCueState = {
+  flagRunnerEntry: "pending" | "due" | "passed";
+  seekerWarning: "pending" | "due" | "passed";
+  seekerCountdownMs: number | null;
+  seekerRelease: "pending" | "released";
+};
+
+export type ClockProjection = {
+  version: typeof CLOCK_AUTHORITY_VERSION;
+  baseline: ClockBaseline;
+  gameTimeMs: number;
+  activePenaltyTimeMs: number;
+  running: boolean;
+  projectedAtMs: number;
+  synchronization: "synchronized";
+  offlineClockHolderGrantSessionId: string | null;
+  cues: ClockCueState;
+};
+
+export function validateClockFactData(value: unknown): ValidationResult<unknown> {
+  if (!isRecord(value)) return invalid("Clock Fact data must be an object.");
+  if (value.startedAtMs !== undefined && value.startedAtMs !== null) {
+    const startedAtMs = validateIntegerInRange(
+      value.startedAtMs,
+      0,
+      Number.MAX_SAFE_INTEGER,
+      "Clock Fact startedAtMs",
+    );
+    if (!startedAtMs.ok) return startedAtMs;
+  }
+  const command = value.command;
+  if (command !== "set-running" && command !== "adjust" && command !== "correct") {
+    if (typeof value.running !== "boolean") {
+      return invalid("Clock Fact data command is unsupported.");
+    }
+    return valid(value);
+  }
+  if (command === "set-running") {
+    if (typeof value.running !== "boolean") return invalid("Clock Fact running must be a boolean.");
+    return valid(value);
+  }
+  if (command === "adjust") {
+    const adjustmentMs = validateClockAdjustmentMs(value.adjustmentMs);
+    if (!adjustmentMs.ok) return adjustmentMs;
+    return valid(value);
+  }
+  const gameTimeMs = validateGameClockMs(value.gameTimeMs);
+  if (!gameTimeMs.ok) return gameTimeMs;
+  return valid(value);
+}
+
+export function createInitialClockBaseline(): ClockBaseline {
+  return {
+    version: CLOCK_AUTHORITY_VERSION,
+    gameTimeMs: 0,
+    penaltyTimeMs: 0,
+    activePenalty: null,
+    running: false,
+    runningSinceMs: null,
+    establishedAtMs: 0,
+    holderGrantSessionId: null,
+    holderGeneration: 0,
+    lastTransitionOperationId: null,
+    lastAcceptedAtMs: null,
+  };
+}
+
+/** Fold the accepted immutable action set in trusted-occurrence order. */
+export function deriveClockAuthority(actions: readonly ClockAuthorityAction[]): ClockBaseline {
+  const uniqueActions = new Map<string, ClockAuthorityAction>();
+  for (const action of actions) {
+    if (!uniqueActions.has(action.operationId)) uniqueActions.set(action.operationId, action);
+  }
+  const ordered = [...uniqueActions.values()].sort(compareClockActions);
+  let baseline = createInitialClockBaseline();
+  const appliedClockActions: ClockAuthorityAction[] = [];
+
+  for (const action of ordered) {
+    baseline = advanceBaseline(baseline, action.trustedAtMs);
+    const transitioned = applyClockAction(baseline, action);
+    if (transitioned === null) continue;
+    baseline = transitioned;
+    if (action.command !== "penalty-start") appliedClockActions.push(action);
+  }
+
+  const latestAccepted = [...appliedClockActions].sort(compareAcceptedClockActions).at(-1) ?? null;
+  return {
+    ...baseline,
+    holderGrantSessionId: latestAccepted?.sessionId ?? null,
+    holderGeneration: appliedClockActions.length,
+    lastAcceptedAtMs: latestAccepted?.acceptedAtMs ?? null,
+  };
+}
+
+/** Validate a candidate without inserting it; callers invoke this in a storage transaction. */
+export function validateClockAuthorityAction(
+  actions: readonly ClockAuthorityAction[],
+  candidate: ClockAuthorityAction,
+): ValidationResult<null> {
+  const uniqueActions = new Map<string, ClockAuthorityAction>();
+  for (const action of [...actions, candidate]) {
+    if (!uniqueActions.has(action.operationId)) uniqueActions.set(action.operationId, action);
+  }
+  let baseline = createInitialClockBaseline();
+  for (const action of [...uniqueActions.values()].sort(compareClockActions)) {
+    baseline = advanceBaseline(baseline, action.trustedAtMs);
+    const transitioned = applyClockAction(baseline, action);
+    if (transitioned === null) {
+      return action.operationId === candidate.operationId
+        ? invalid("Clock transition exceeds the durable game-clock bounds.")
+        : invalid("Clock history contains an out-of-bounds transition.");
+    }
+    baseline = transitioned;
+  }
+  return valid(null);
+}
+
+export function projectClockBaseline(baseline: ClockBaseline, nowMs: number): ClockProjection {
+  const projected = advanceBaseline(baseline, nowMs);
+  return createProjection(projected, nowMs);
+}
+
+/** Advance a server sample by local monotonic elapsed time, never wall time. */
+export function projectClockSample(
+  projection: ClockProjection,
+  elapsedMs: number,
+): ClockProjection {
+  if (!Number.isFinite(elapsedMs) || elapsedMs <= 0 || !projection.running) {
+    return structuredClone(projection);
+  }
+  const elapsed = Math.floor(elapsedMs);
+  const gameTimeMs = Math.min(SHARED_LIMITS.clock.maxMs, projection.gameTimeMs + elapsed);
+  const activePenaltyTimeMs =
+    projection.baseline.activePenalty === null
+      ? 0
+      : Math.min(SHARED_LIMITS.clock.maxMs, projection.activePenaltyTimeMs + elapsed);
+  const projected = {
+    ...structuredClone(projection),
+    gameTimeMs,
+    activePenaltyTimeMs,
+    running: gameTimeMs < SHARED_LIMITS.clock.maxMs,
+    projectedAtMs: projection.projectedAtMs + elapsed,
+  };
+  return { ...projected, cues: cuesFor(gameTimeMs) };
+}
+
+function createProjection(baseline: ClockBaseline, projectedAtMs: number): ClockProjection {
+  return {
+    version: CLOCK_AUTHORITY_VERSION,
+    baseline: structuredClone(baseline),
+    gameTimeMs: baseline.gameTimeMs,
+    activePenaltyTimeMs: baseline.activePenalty?.elapsedMs ?? 0,
+    running: baseline.running,
+    projectedAtMs,
+    synchronization: "synchronized",
+    offlineClockHolderGrantSessionId: baseline.holderGrantSessionId,
+    cues: cuesFor(baseline.gameTimeMs),
+  };
+}
+
+function cuesFor(gameTimeMs: number): ClockCueState {
+  const countdown =
+    gameTimeMs >= FLAG_RUNNER_ENTRY_MS && gameTimeMs < SEEKER_RELEASE_MS
+      ? SEEKER_RELEASE_MS - gameTimeMs
+      : null;
+  return {
+    flagRunnerEntry:
+      gameTimeMs < FLAG_RUNNER_ENTRY_MS
+        ? "pending"
+        : gameTimeMs < SEEKER_RELEASE_MS
+          ? "due"
+          : "passed",
+    seekerWarning:
+      gameTimeMs < FLAG_RUNNER_ENTRY_MS
+        ? "pending"
+        : gameTimeMs < SEEKER_RELEASE_MS
+          ? "due"
+          : "passed",
+    seekerCountdownMs: countdown,
+    seekerRelease: gameTimeMs >= SEEKER_RELEASE_MS ? "released" : "pending",
+  };
+}
+
+function advanceBaseline(baseline: ClockBaseline, atMs: number): ClockBaseline {
+  if (!Number.isSafeInteger(atMs) || atMs <= baseline.establishedAtMs || !baseline.running) {
+    return { ...baseline };
+  }
+
+  const elapsedMs = atMs - baseline.establishedAtMs;
+  const gameElapsedMs = Math.min(
+    elapsedMs,
+    Math.max(0, SHARED_LIMITS.clock.maxMs - baseline.gameTimeMs),
+  );
+  const gameTimeMs = baseline.gameTimeMs + gameElapsedMs;
+  const activePenalty =
+    baseline.activePenalty === null
+      ? null
+      : {
+          ...baseline.activePenalty,
+          elapsedMs: Math.min(
+            SHARED_LIMITS.clock.maxMs,
+            baseline.activePenalty.elapsedMs + gameElapsedMs,
+          ),
+          establishedAtMs: atMs,
+        };
+  return {
+    ...baseline,
+    gameTimeMs,
+    penaltyTimeMs: activePenalty?.elapsedMs ?? 0,
+    activePenalty,
+    establishedAtMs: atMs,
+    running: gameTimeMs < SHARED_LIMITS.clock.maxMs,
+  };
+}
+
+function compareClockActions(left: ClockAuthorityAction, right: ClockAuthorityAction): number {
+  return left.trustedAtMs - right.trustedAtMs || left.operationId.localeCompare(right.operationId);
+}
+
+function compareAcceptedClockActions(
+  left: ClockAuthorityAction,
+  right: ClockAuthorityAction,
+): number {
+  return (
+    left.acceptedAtMs - right.acceptedAtMs || left.operationId.localeCompare(right.operationId)
+  );
+}
+
+function applyClockAction(
+  baseline: ClockBaseline,
+  action: ClockAuthorityAction,
+): ClockBaseline | null {
+  if (action.command === "penalty-start") {
+    return baseline.activePenalty === null
+      ? {
+          ...baseline,
+          penaltyTimeMs: 0,
+          activePenalty: {
+            elapsedMs: 0,
+            establishedAtMs: action.trustedAtMs,
+            sourceOperationId: action.operationId,
+          },
+        }
+      : baseline;
+  }
+
+  const nextGameTimeMs =
+    action.command === "adjust"
+      ? baseline.gameTimeMs + (action.adjustmentMs ?? 0)
+      : action.command === "correct"
+        ? action.gameTimeMs
+        : baseline.gameTimeMs;
+  const validatedGameTime = validateGameClockMs(nextGameTimeMs);
+  if (!validatedGameTime.ok) return null;
+  const nextRunning =
+    action.command === "set-running" && action.running !== undefined
+      ? action.running
+      : baseline.running;
+  return {
+    ...baseline,
+    gameTimeMs: validatedGameTime.value,
+    running: nextRunning && validatedGameTime.value < SHARED_LIMITS.clock.maxMs,
+    runningSinceMs: nextRunning
+      ? baseline.running
+        ? baseline.runningSinceMs
+        : action.trustedAtMs
+      : null,
+    establishedAtMs: action.trustedAtMs,
+    lastTransitionOperationId: action.operationId,
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function valid<T>(value: T): ValidationResult<T> {
+  return { ok: true, value };
+}
+
+function invalid<T>(error: string): ValidationResult<T> {
+  return { ok: false, error };
+}

--- a/src/lib/controller-intent-retry.ts
+++ b/src/lib/controller-intent-retry.ts
@@ -27,6 +27,10 @@ export function controllerIntentRetryKey(intent: LiveEventControllerIntent): str
     case "clock":
     case "set-running":
       return JSON.stringify([intent.type, intent.running, intent.gameTimeMs]);
+    case "clock-adjust":
+      return JSON.stringify([intent.type, intent.adjustmentMs, intent.gameTimeMs]);
+    case "clock-correction":
+      return JSON.stringify([intent.type, intent.clockTimeMs, intent.gameTimeMs]);
     case "substantive":
       return JSON.stringify([intent.type, intent.trigger, intent.gameTimeMs]);
     case "reset":

--- a/src/lib/controller-reconnect.test.ts
+++ b/src/lib/controller-reconnect.test.ts
@@ -13,6 +13,7 @@ import {
   type ControllerReplicaStorage,
 } from "@/lib/controller-reconnect";
 import { LIVE_EVENT_CONTROL_INTENT_VERSION } from "@/lib/live-event-game-control";
+import { createInitialClockBaseline, projectClockBaseline } from "@/lib/clock-authority";
 
 describe("Controller reconnect replica", () => {
   test("optimistically retains immutable identity, causal dependencies, and original occurrence evidence", () => {
@@ -387,6 +388,7 @@ function createReplica() {
       phase: "scheduled",
       scoreByGameSide: { "side-a": 0, "side-b": 0 },
       goalCount: 0,
+      clock: projectClockBaseline(createInitialClockBaseline(), 0),
       commencement: {
         status: "provisional",
         commencedAtMs: null,

--- a/src/lib/controller-reconnect.ts
+++ b/src/lib/controller-reconnect.ts
@@ -3,6 +3,7 @@ import type {
   ControllerProjection,
   LiveEventControllerIntent,
 } from "@/lib/live-event-game-control";
+import { createInitialClockBaseline, projectClockBaseline } from "@/lib/clock-authority";
 import { parseLiveEventControllerIntent } from "@/lib/live-event-game-control";
 import {
   SHARED_LIMITS,
@@ -794,11 +795,15 @@ function parseProjection(value: unknown): ControllerProjection {
     "provisionalElapsedMs",
   );
   if (!elapsed.ok) throw new Error(elapsed.error);
+  const clock = isRecord(value.clock)
+    ? (structuredClone(value.clock) as ControllerProjection["clock"])
+    : projectClockBaseline(createInitialClockBaseline(), 0);
   return {
     eventGameId,
     phase,
     scoreByGameSide: scores,
     goalCount: goalCount.value,
+    clock,
     commencement: {
       status: commencementStatus,
       commencedAtMs,

--- a/src/lib/event-game-action-codecs.ts
+++ b/src/lib/event-game-action-codecs.ts
@@ -6,6 +6,7 @@ import {
   type ValidationResult,
 } from "@/lib/validation-policy";
 import { canonicalizeJson, sha256 } from "@/lib/event-game-action-json";
+import { validateClockFactData } from "@/lib/clock-authority";
 import type {
   ActionJsonValue,
   ControlActionCodec,
@@ -112,6 +113,10 @@ function createGameFactCodec(): ControlActionCodec<GameFactPayload> {
       if (payload.data !== undefined) {
         const dataResult = parseJsonValue(payload.data, "payload.data");
         if (!dataResult.ok) return dataResult;
+        if (factType.value === "clock") {
+          const clockData = validateClockFactData(dataResult.value);
+          if (!clockData.ok) return clockData;
+        }
         data = dataResult.value;
       }
       return valid({

--- a/src/lib/foundation-acceptance.ts
+++ b/src/lib/foundation-acceptance.ts
@@ -154,6 +154,17 @@ export type FoundationAcceptanceOptions = {
       | "after-lifecycle"
       | "before-receipt",
   ) => void;
+  /**
+   * Optional domain validation executed inside the serialized acceptance
+   * transaction, after authorization and before action insertion.
+   */
+  validateActionInTransaction?: (input: {
+    transaction: FoundationStorageTransaction;
+    root: EventGameRecordRoot;
+    action: ControlAction;
+  }) =>
+    | { status: "accepted" }
+    | { status: "rejected"; reason: FoundationRejectionReason; detail: string };
   /** Test-only barrier between read-only preflight and the first write transaction. */
   afterReadOnlyPreflight?: () => void | Promise<void>;
   limits?: AcceptanceLimits;
@@ -880,6 +891,24 @@ export function createFoundationAcceptance(
       );
 
     const action = materializeControlAction(prepared, readNow(clock));
+    const transactionValidation = options.validateActionInTransaction?.({
+      transaction,
+      root,
+      action,
+    });
+    if (transactionValidation?.status === "rejected")
+      return writeOutcome(
+        transaction,
+        root,
+        prepared.input,
+        prepared,
+        current,
+        mode,
+        replayState,
+        "rejected",
+        transactionValidation.reason,
+        transactionValidation.detail,
+      );
     transaction.insertAction({
       action,
       canonicalContent: prepared.canonicalContent,

--- a/src/lib/live-event-game-control.test.ts
+++ b/src/lib/live-event-game-control.test.ts
@@ -13,6 +13,8 @@ import {
   createLiveEventGameIqaInterpreter,
   LIVE_EVENT_CONTROL_INTENT_VERSION,
   parseLiveEventControllerIntent,
+  type LiveEventControllerIntent,
+  validateLiveEventClockActionInTransaction,
 } from "@/lib/live-event-game-control";
 import { createLiveEventGameControlTransport } from "@/lib/live-event-game-transport";
 
@@ -927,6 +929,371 @@ describe("Live Event Game control", () => {
     expect(await ownerState(harness)).toEqual(before);
   });
 
+  test("serializes simultaneous clock transitions, transfers the holder, and ignores goal transfer", async () => {
+    const harness = await createHarness();
+    const first = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "clock-device-a",
+    });
+    const second = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "clock-device-b",
+    });
+    if (first.status !== "opened" || second.status !== "opened") {
+      throw new Error("Expected two Controller Devices.");
+    }
+
+    const [start, pause] = await Promise.all([
+      harness.control.submitControllerIntent({
+        sessionBearer: first.session.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+        intent: clockIntent("z-start", true),
+      }),
+      harness.control.submitControllerIntent({
+        sessionBearer: second.session.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+        intent: clockIntent("a-pause", false),
+      }),
+    ]);
+    expect(start.status).toBe("accepted");
+    expect(pause.status).toBe("accepted");
+
+    const afterSimultaneous = await harness.control.refreshController({
+      sessionBearer: second.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+    });
+    expect(afterSimultaneous).toMatchObject({
+      projection: {
+        clock: {
+          running: true,
+          offlineClockHolderGrantSessionId: first.session.grantSessionId,
+        },
+      },
+    });
+
+    harness.setNow(15_000);
+    const transferred = await harness.control.submitControllerIntent({
+      sessionBearer: second.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      intent: clockIntent("b-pause", false),
+    });
+    expect(transferred).toMatchObject({
+      projection: {
+        clock: {
+          running: false,
+          gameTimeMs: 5_000,
+          offlineClockHolderGrantSessionId: second.session.grantSessionId,
+        },
+      },
+    });
+
+    const goal = await harness.control.submitControllerIntent({
+      sessionBearer: first.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      intent: goalIntent(),
+    });
+    expect(goal).toMatchObject({
+      projection: {
+        clock: { offlineClockHolderGrantSessionId: second.session.grantSessionId },
+      },
+    });
+    const duplicateGoal = await harness.control.submitControllerIntent({
+      sessionBearer: first.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      intent: goalIntent(),
+    });
+    expect(duplicateGoal).toMatchObject({
+      status: "duplicate-accepted",
+      projection: {
+        clock: { offlineClockHolderGrantSessionId: second.session.grantSessionId },
+      },
+    });
+  });
+
+  test("atomically rejects one concurrent bounded adjustment without dropping an accepted Clock action", async () => {
+    const harness = await createHarness();
+    const first = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "clock-bounds-a",
+    });
+    const second = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "clock-bounds-b",
+    });
+    if (first.status !== "opened" || second.status !== "opened") {
+      throw new Error("Expected two Controller Devices.");
+    }
+    const correction = {
+      ...clockIntent("clock-correction-105", false),
+      type: "clock-correction" as const,
+      clockTimeMs: 105 * 60 * 1000,
+    };
+    expect(
+      await harness.control.submitControllerIntent({
+        sessionBearer: first.session.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+        intent: correction,
+      }),
+    ).toMatchObject({ status: "accepted" });
+    harness.setNow(20_000);
+
+    const adjustA = clockAdjustmentIntent("clock-bounded-a", 10 * 60 * 1000);
+    const adjustB = clockAdjustmentIntent("clock-bounded-b", 10 * 60 * 1000);
+    const [resultA, resultB] = await Promise.all([
+      harness.control.submitControllerIntent({
+        sessionBearer: first.session.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+        intent: adjustA,
+      }),
+      harness.control.submitControllerIntent({
+        sessionBearer: second.session.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+        intent: adjustB,
+      }),
+    ]);
+    expect([resultA.status, resultB.status].sort()).toEqual(["accepted", "rejected"]);
+    expect(await harness.record.readActions()).toHaveLength(2);
+
+    const rejected =
+      resultA.status === "rejected"
+        ? { intent: adjustA, sessionBearer: first.session.sessionBearer }
+        : { intent: adjustB, sessionBearer: second.session.sessionBearer };
+    expect(
+      await harness.control.submitControllerIntent({
+        sessionBearer: rejected.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+        intent: rejected.intent,
+      }),
+    ).toMatchObject({ status: "rejected" });
+    expect(await harness.record.readActions()).toHaveLength(2);
+
+    const final = await harness.control.refreshController({
+      sessionBearer: first.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+    });
+    expect(final).toMatchObject({ projection: { clock: { gameTimeMs: 115 * 60 * 1000 } } });
+
+    const accepted =
+      resultA.status === "accepted"
+        ? { intent: adjustA, sessionBearer: first.session.sessionBearer }
+        : { intent: adjustB, sessionBearer: second.session.sessionBearer };
+    expect(
+      await harness.control.submitControllerIntent({
+        sessionBearer: accepted.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+        intent: accepted.intent,
+      }),
+    ).toMatchObject({ status: "duplicate-accepted" });
+    expect(await harness.record.readActions()).toHaveLength(2);
+  });
+
+  test("composes valid concurrent bounded adjustments at the durable limit", async () => {
+    const harness = await createHarness();
+    const first = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "clock-compose-a",
+    });
+    const second = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "clock-compose-b",
+    });
+    if (first.status !== "opened" || second.status !== "opened") {
+      throw new Error("Expected two Controller Devices.");
+    }
+    expect(
+      await harness.control.submitControllerIntent({
+        sessionBearer: first.session.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+        intent: {
+          ...clockIntent("clock-correction-100", false),
+          type: "clock-correction",
+          clockTimeMs: 100 * 60 * 1000,
+        },
+      }),
+    ).toMatchObject({ status: "accepted" });
+    harness.setNow(20_000);
+    const [left, right] = await Promise.all([
+      harness.control.submitControllerIntent({
+        sessionBearer: first.session.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+        intent: clockAdjustmentIntent("clock-compose-left", 10 * 60 * 1000),
+      }),
+      harness.control.submitControllerIntent({
+        sessionBearer: second.session.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+        intent: clockAdjustmentIntent("clock-compose-right", 10 * 60 * 1000),
+      }),
+    ]);
+    expect(left.status).toBe("accepted");
+    expect(right.status).toBe("accepted");
+    expect(
+      await harness.control.refreshController({
+        sessionBearer: first.session.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+      }),
+    ).toMatchObject({ projection: { clock: { gameTimeMs: 120 * 60 * 1000 } } });
+  });
+
+  test("projects clock time between snapshots, emits distinct cues, and enforces adjustment bounds", async () => {
+    const harness = await createHarness();
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "clock-projection",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+
+    await harness.control.submitControllerIntent({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      intent: {
+        ...clockIntent("clock-correct-19", false),
+        type: "clock-correction",
+        clockTimeMs: 19 * 60 * 1000,
+      },
+    });
+    const warning = await harness.control.refreshController({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+    });
+    expect(warning).toMatchObject({
+      projection: {
+        clock: {
+          gameTimeMs: 19 * 60 * 1000,
+          activePenaltyTimeMs: 0,
+          cues: {
+            flagRunnerEntry: "due",
+            seekerWarning: "due",
+            seekerRelease: "pending",
+            seekerCountdownMs: 60_000,
+          },
+        },
+      },
+    });
+
+    const adjusted = await harness.control.submitControllerIntent({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      intent: {
+        ...clockIntent("z-clock-adjust-one-second", false),
+        type: "clock-adjust",
+        adjustmentMs: 1_000,
+      },
+    });
+    expect(adjusted).toMatchObject({
+      status: "accepted",
+      projection: { clock: { gameTimeMs: 19 * 60 * 1000 + 1_000 } },
+    });
+
+    await harness.control.submitControllerIntent({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      intent: {
+        ...clockIntent("zz-clock-correct-20", false),
+        type: "clock-correction",
+        clockTimeMs: 20 * 60 * 1000,
+      },
+    });
+    const release = await harness.control.refreshController({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+    });
+    expect(release).toMatchObject({
+      projection: { clock: { cues: { seekerWarning: "passed", seekerRelease: "released" } } },
+    });
+
+    for (const invalid of [Number.NaN, 1.5, 10 * 60 * 1000 + 1]) {
+      expect(
+        parseLiveEventControllerIntent({
+          ...clockIntent(`invalid-${String(invalid)}`, true),
+          type: "clock-adjust",
+          adjustmentMs: invalid,
+        }),
+      ).toMatchObject({ ok: false });
+    }
+    expect(
+      parseLiveEventControllerIntent({
+        ...clockIntent("invalid-correction", true),
+        type: "clock-correction",
+        clockTimeMs: 120 * 60 * 1000 + 1,
+      }),
+    ).toMatchObject({ ok: false });
+  });
+
+  test("projects an independent active penalty from a card fact through pause and resume", async () => {
+    const harness = await createHarness();
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "clock-penalty",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+
+    const submit = (intent: LiveEventControllerIntent) =>
+      harness.control.submitControllerIntent({
+        sessionBearer: opened.session.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+        intent,
+      });
+
+    await submit(substantiveIntent("penalty-card", "card"));
+    const noPlay = await harness.control.refreshController({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+    });
+    expect(noPlay).toMatchObject({
+      projection: { clock: { gameTimeMs: 0, activePenaltyTimeMs: 0 } },
+    });
+
+    harness.setNow(11_000);
+    await submit(clockIntent("penalty-start-clock", true));
+    harness.setNow(14_000);
+    const live = await harness.control.refreshController({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+    });
+    expect(live).toMatchObject({
+      projection: { clock: { gameTimeMs: 3_000, activePenaltyTimeMs: 3_000 } },
+    });
+
+    harness.setNow(15_000);
+    await submit(clockIntent("penalty-pause", false));
+    harness.setNow(20_000);
+    const paused = await harness.control.refreshController({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+    });
+    expect(paused).toMatchObject({
+      projection: { clock: { gameTimeMs: 4_000, activePenaltyTimeMs: 4_000 } },
+    });
+
+    harness.setNow(25_000);
+    await submit(clockIntent("penalty-resume", true));
+    harness.setNow(27_000);
+    const resumed = await harness.control.refreshController({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+    });
+    expect(resumed).toMatchObject({
+      projection: { clock: { gameTimeMs: 6_000, activePenaltyTimeMs: 6_000 } },
+    });
+  });
+
+  test("does not acknowledge a clock transition when durable commit fails", async () => {
+    const harness = await createHarness({ failureBoundary: "after-action" });
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "clock-commit-failure",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+
+    const failed = await harness.control.submitControllerIntent({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      intent: clockIntent("clock-failure", true),
+    });
+    expect(failed).toMatchObject({ status: "retryable", operationId: "clock-failure" });
+    expect(await harness.record.readActions()).toHaveLength(0);
+  });
+
   test("exposes the Controller through its HTTP transport without changing Ad Hoc routes", async () => {
     const harness = await createHarness();
     const allowedOrigin = "https://timer.quadball.app";
@@ -1086,6 +1453,8 @@ async function createHarness(
     failureInjector: (boundary) => {
       if (boundary === failureBoundary) throw new Error("simulated durable failure");
     },
+    validateActionInTransaction: ({ transaction, root, action }) =>
+      validateLiveEventClockActionInTransaction(transaction.listActions(root.recordId), action),
   });
   const control = createLiveEventGameControl({
     resolveEventGameRecord: async (eventGameId) =>
@@ -1146,6 +1515,14 @@ function clockIntent(operationId: string, running: boolean) {
     running,
     gameTimeMs: 0,
     occurrence: { clientOriginAtMs: null },
+  };
+}
+
+function clockAdjustmentIntent(operationId: string, adjustmentMs: number) {
+  return {
+    ...clockIntent(operationId, false),
+    type: "clock-adjust" as const,
+    adjustmentMs,
   };
 }
 

--- a/src/lib/live-event-game-control.ts
+++ b/src/lib/live-event-game-control.ts
@@ -1,11 +1,22 @@
 import type { EffectiveGameFact, IqaGameRulesInterpreter } from "@/lib/event-game-actions";
 import { createDefaultControlActionCodecs } from "@/lib/event-game-actions";
+import {
+  CLOCK_AUTHORITY_VERSION,
+  deriveClockAuthority,
+  projectClockBaseline,
+  validateClockAuthorityAction,
+  type ClockAuthorityAction,
+  type ClockProjection,
+} from "@/lib/clock-authority";
 import type { EventGameLifecyclePhase, EventGameRecordRoot } from "@/lib/foundation-record-types";
 import type { EventGameRecord } from "@/lib/event-game-record";
 import type { FoundationAcceptance } from "@/lib/foundation-acceptance";
+import type { ControlAction } from "@/lib/event-game-actions";
 import type { TypedGrantAuthority } from "@/lib/grant-management-types";
 import {
   SHARED_LIMITS,
+  validateClockAdjustmentMs,
+  validateGameClockMs,
   validateIntegerInRange,
   validateOpaqueIdentifier,
 } from "@/lib/validation-policy";
@@ -32,6 +43,14 @@ export type LiveEventControllerIntent =
   | (ControllerIntentBase & {
       type: "clock" | "set-running";
       running: boolean;
+    })
+  | (ControllerIntentBase & {
+      type: "clock-adjust";
+      adjustmentMs: number;
+    })
+  | (ControllerIntentBase & {
+      type: "clock-correction";
+      clockTimeMs: number;
     })
   | (ControllerIntentBase & {
       type: "substantive";
@@ -88,6 +107,7 @@ export type LiveEventGameDerivedState = {
   phase: EventGameLifecyclePhase;
   scoreByGameSide: Readonly<Record<string, number>>;
   goalCount: number;
+  clock: ClockProjection;
 };
 
 export type ControllerProjection = {
@@ -96,6 +116,7 @@ export type ControllerProjection = {
   scoreByGameSide: Readonly<Record<string, number>>;
   goalCount: number;
   commencement: ControllerCommencement;
+  clock: ClockProjection;
 };
 
 export type ControllerSynchronization = {
@@ -192,8 +213,13 @@ export function createLiveEventGameIqaInterpreter(
 ): IqaGameRulesInterpreter {
   return {
     version,
-    rebuild({ root, effectiveFacts }) {
-      return deriveLiveEventGameState(root, effectiveFacts, version);
+    rebuild({ root, canonicalActions, effectiveFacts }) {
+      return deriveLiveEventGameState(
+        root,
+        canonicalActions.map((action) => ({ action })),
+        effectiveFacts,
+        version,
+      );
     },
   };
 }
@@ -209,11 +235,23 @@ export function parseLiveEventControllerIntent(
     value.type !== "record-goal" &&
     value.type !== "clock" &&
     value.type !== "set-running" &&
+    value.type !== "clock-adjust" &&
+    value.type !== "adjust-clock" &&
+    value.type !== "adjust-game-clock" &&
+    value.type !== "clock-correction" &&
+    value.type !== "correct-clock" &&
+    value.type !== "set-game-clock" &&
     value.type !== "substantive" &&
     value.type !== "reset" &&
     value.type !== "undo"
   )
     return invalid("Controller intent type is unsupported.");
+  const normalizedType =
+    value.type === "adjust-clock" || value.type === "adjust-game-clock"
+      ? "clock-adjust"
+      : value.type === "correct-clock" || value.type === "set-game-clock"
+        ? "clock-correction"
+        : value.type;
 
   const operationId = validateOpaqueIdentifier(value.operationId, "operationId");
   const factId = validateOpaqueIdentifier(value.factId, "factId");
@@ -237,6 +275,20 @@ export function parseLiveEventControllerIntent(
   if (value.type === "clock" || value.type === "set-running") {
     if (typeof value.running !== "boolean") return invalid("running must be a boolean.");
     running = value.running;
+  }
+  let adjustmentMs: number | undefined;
+  if (normalizedType === "clock-adjust") {
+    const adjustment = validateClockAdjustment(value.adjustmentMs ?? value.deltaMs);
+    if (!adjustment.ok) return invalid(adjustment.error);
+    adjustmentMs = adjustment.value;
+  }
+  let clockTimeMs: number | undefined;
+  if (normalizedType === "clock-correction") {
+    const clockTime = validateGameClock(
+      value.clockTimeMs ?? value.targetGameTimeMs ?? value.gameTimeMs,
+    );
+    if (!clockTime.ok) return invalid(clockTime.error);
+    clockTimeMs = clockTime.value;
   }
   let trigger: "card" | "timeout" | "suspension" | "result" | undefined;
   if (value.type === "substantive") {
@@ -276,13 +328,15 @@ export function parseLiveEventControllerIntent(
     ok: true,
     value: {
       version: LIVE_EVENT_CONTROL_INTENT_VERSION,
-      type: value.type,
+      type: normalizedType,
       operationId: operationId.value,
       factId: factId.value,
       gameTimeMs: gameTimeMs.value,
       occurrence: { clientOriginAtMs, ...(source === undefined ? {} : { source }) },
       ...(gameSideId === undefined ? {} : { gameSideId }),
       ...(running === undefined ? {} : { running }),
+      ...(adjustmentMs === undefined ? {} : { adjustmentMs }),
+      ...(clockTimeMs === undefined ? {} : { clockTimeMs }),
       ...(trigger === undefined ? {} : { trigger }),
     } as LiveEventControllerIntent,
   };
@@ -591,6 +645,14 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
     }
     const nowMs = clock();
     const previousClockStartMs = latestRunningClockStart(actionsBefore);
+    const clockBefore = projectClockBaseline(
+      deriveClockAuthority(readClockAuthorityActions(actionsBefore)),
+      nowMs,
+    );
+    const clockData = readClockIntentData(parsed.value, clockBefore, nowMs);
+    if (clockData.status === "rejected") {
+      return rejectedAction(parsed.value.operationId);
+    }
     const clockStartMs =
       parsed.value.type === "clock" || parsed.value.type === "set-running"
         ? parsed.value.running
@@ -613,8 +675,8 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
         data:
           parsed.value.type === "record-goal"
             ? { points: 10 }
-            : parsed.value.type === "clock" || parsed.value.type === "set-running"
-              ? { running: parsed.value.running, startedAtMs: clockStartMs }
+            : clockData.value !== null
+              ? clockData.value
               : parsed.value.type === "substantive"
                 ? { trigger: parsed.value.trigger }
                 : null,
@@ -935,6 +997,7 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
         phase: derived.phase,
         scoreByGameSide: structuredClone(derived.scoreByGameSide),
         goalCount: derived.goalCount,
+        clock: projectClockBaseline(derived.clock.baseline, clock()),
         commencement: {
           status: root.lifecycle.commencedAtMs === null ? "provisional" : "commenced",
           commencedAtMs: root.lifecycle.commencedAtMs,
@@ -961,6 +1024,7 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
 
 function deriveLiveEventGameState(
   root: EventGameRecordRoot,
+  canonicalActions: readonly { action: import("@/lib/event-game-actions").ControlAction }[],
   effectiveFacts: readonly EffectiveGameFact[],
   version: string,
 ): LiveEventGameDerivedState {
@@ -981,12 +1045,22 @@ function deriveLiveEventGameState(
     phase: root.lifecycle.phase,
     scoreByGameSide,
     goalCount,
+    clock: projectClockBaseline(
+      deriveClockAuthority(readClockAuthorityActions(canonicalActions)),
+      0,
+    ),
   };
 }
 
 function controllerFactType(intent: LiveEventControllerIntent): string {
   if (intent.type === "record-goal") return "goal";
-  if (intent.type === "clock" || intent.type === "set-running") return "clock";
+  if (
+    intent.type === "clock" ||
+    intent.type === "set-running" ||
+    intent.type === "clock-adjust" ||
+    intent.type === "clock-correction"
+  )
+    return "clock";
   if (intent.type === "substantive") return intent.trigger;
   return intent.type;
 }
@@ -1079,12 +1153,150 @@ function readDerivedState(value: unknown): LiveEventGameDerivedState | null {
     value.goalCount < 0
   )
     return null;
+  const clock = readClockProjection(value.clock);
+  if (clock === null) return null;
   return {
     interpreterVersion: value.interpreterVersion,
     phase: value.phase,
     scoreByGameSide,
     goalCount: value.goalCount,
+    clock,
   };
+}
+
+export function validateLiveEventClockActionInTransaction(
+  actions: readonly { action: ControlAction }[],
+  candidate: ControlAction,
+): { status: "accepted" } | { status: "rejected"; reason: "invalid-action"; detail: string } {
+  const candidateClock = readClockAuthorityActions([{ action: candidate }])[0];
+  if (candidateClock === undefined || candidateClock.command === "penalty-start") {
+    return { status: "accepted" };
+  }
+  const validation = validateClockAuthorityAction(
+    readClockAuthorityActions(actions),
+    candidateClock,
+  );
+  return validation.ok
+    ? { status: "accepted" }
+    : { status: "rejected", reason: "invalid-action", detail: validation.error };
+}
+
+function readClockAuthorityActions(
+  actions: readonly {
+    action?: {
+      operationId: string;
+      occurrence: { trustedAtMs: number };
+      acceptedAtMs: number;
+      grant: { sessionId: string };
+      interpretation: unknown;
+    };
+    operationId?: string;
+    occurrence?: { trustedAtMs: number };
+    acceptedAtMs?: number;
+    grant?: { sessionId: string };
+    interpretation?: unknown;
+  }[],
+): ClockAuthorityAction[] {
+  const clockActions: ClockAuthorityAction[] = [];
+  for (const stored of actions) {
+    const storedAction = stored.action ?? stored;
+    if (
+      storedAction.operationId === undefined ||
+      storedAction.occurrence === undefined ||
+      storedAction.acceptedAtMs === undefined ||
+      storedAction.grant === undefined ||
+      storedAction.interpretation === undefined
+    )
+      continue;
+    const interpretation = storedAction.interpretation;
+    if (!isRecord(interpretation) || interpretation.type !== "fact") continue;
+    if (interpretation.factType !== "clock" && interpretation.factType !== "card") continue;
+    if (!isRecord(interpretation.payload)) continue;
+    const data = interpretation.payload.data;
+    if (!isRecord(data)) continue;
+    if (interpretation.factType === "card") {
+      clockActions.push({
+        operationId: storedAction.operationId,
+        trustedAtMs: storedAction.occurrence.trustedAtMs,
+        acceptedAtMs: storedAction.acceptedAtMs,
+        sessionId: storedAction.grant.sessionId,
+        command: "penalty-start",
+      });
+      continue;
+    }
+    const command =
+      data.command === "adjust" || data.command === "correct" || data.command === "set-running"
+        ? data.command
+        : typeof data.running === "boolean"
+          ? "set-running"
+          : null;
+    if (command === null) continue;
+    const clockAction: ClockAuthorityAction = {
+      operationId: storedAction.operationId,
+      trustedAtMs: storedAction.occurrence.trustedAtMs,
+      acceptedAtMs: storedAction.acceptedAtMs,
+      sessionId: storedAction.grant.sessionId,
+      command,
+      ...(typeof data.running === "boolean" ? { running: data.running } : {}),
+      ...(typeof data.gameTimeMs === "number" ? { gameTimeMs: data.gameTimeMs } : {}),
+      ...(typeof data.adjustmentMs === "number" ? { adjustmentMs: data.adjustmentMs } : {}),
+    };
+    clockActions.push(clockAction);
+  }
+  return clockActions;
+}
+
+function readClockIntentData(
+  intent: LiveEventControllerIntent,
+  current: ClockProjection,
+  nowMs: number,
+): { status: "ready"; value: Record<string, unknown> | null } | { status: "rejected" } {
+  if (intent.type === "clock" || intent.type === "set-running") {
+    return {
+      status: "ready",
+      value: {
+        command: "set-running",
+        running: intent.running,
+        startedAtMs: intent.running
+          ? (current.baseline.runningSinceMs ?? nowMs)
+          : current.baseline.runningSinceMs,
+      },
+    };
+  }
+  if (intent.type === "clock-adjust") {
+    return {
+      status: "ready",
+      value: {
+        command: "adjust",
+        adjustmentMs: intent.adjustmentMs,
+      },
+    };
+  }
+  if (intent.type === "clock-correction") {
+    return {
+      status: "ready",
+      value: {
+        command: "correct",
+        gameTimeMs: intent.clockTimeMs,
+      },
+    };
+  }
+  return { status: "ready", value: null };
+}
+
+function readClockProjection(value: unknown): ClockProjection | null {
+  if (!isRecord(value) || value.version !== CLOCK_AUTHORITY_VERSION) return null;
+  if (!isRecord(value.baseline)) return null;
+  if (
+    !validateGameClockMs(value.gameTimeMs).ok ||
+    !validateGameClockMs(value.activePenaltyTimeMs).ok ||
+    typeof value.running !== "boolean" ||
+    typeof value.projectedAtMs !== "number" ||
+    !Number.isSafeInteger(value.projectedAtMs) ||
+    value.synchronization !== "synchronized"
+  )
+    return null;
+  return value as unknown as ClockProjection;
 }
 
 function synchronized(): ControllerSynchronization {
@@ -1158,4 +1370,12 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function invalid(error: string): { ok: false; error: string } {
   return { ok: false, error };
+}
+
+function validateClockAdjustment(value: unknown) {
+  return validateClockAdjustmentMs(value);
+}
+
+function validateGameClock(value: unknown) {
+  return validateGameClockMs(value);
 }

--- a/src/lib/live-event-game-runtime.ts
+++ b/src/lib/live-event-game-runtime.ts
@@ -9,6 +9,7 @@ import {
 import {
   createLiveEventGameControl,
   createLiveEventGameIqaInterpreter,
+  validateLiveEventClockActionInTransaction,
 } from "@/lib/live-event-game-control";
 import { createTypedGrantAuthority } from "@/lib/grant-management";
 import type { GrantAuthorityOptions } from "@/lib/grant-authority";
@@ -52,6 +53,8 @@ export async function openLiveEventGameRuntime(input: {
       externalScopeResolver: scopeResolver,
       interpreter: createLiveEventGameIqaInterpreter(),
       clock,
+      validateActionInTransaction: ({ transaction, root, action }) =>
+        validateLiveEventClockActionInTransaction(transaction.listActions(root.recordId), action),
     });
     const records = new Map<string, EventGameRecord>();
     const resolveEventGameRecord = async (eventGameId: string) => {

--- a/src/pages/event-game-controller-page.test.tsx
+++ b/src/pages/event-game-controller-page.test.tsx
@@ -9,6 +9,7 @@ import {
   dispatchControllerAction,
 } from "@/lib/controller-reconnect";
 import type { ControllerProjection } from "@/lib/live-event-game-control";
+import { createInitialClockBaseline, projectClockBaseline } from "@/lib/clock-authority";
 
 describe("Event Game Controller reconnect browser seam", () => {
   const originalWindow = globalThis.window;
@@ -698,6 +699,7 @@ function projection(eventGameId = "game-browser"): ControllerProjection {
     phase: "scheduled",
     scoreByGameSide: { "side-a": 0, "side-b": 0 },
     goalCount: 0,
+    clock: projectClockBaseline(createInitialClockBaseline(), 0),
     commencement: {
       status: "provisional",
       commencedAtMs: null,

--- a/src/pages/event-game-controller-page.tsx
+++ b/src/pages/event-game-controller-page.tsx
@@ -3,12 +3,18 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import {
+  createInitialClockBaseline,
+  projectClockBaseline,
+  projectClockSample,
+} from "@/lib/clock-authority";
 import type {
   ControllerProjection,
   LiveEventGameControlResult,
   LiveEventControllerIntent,
 } from "@/lib/live-event-game-control";
 import { LIVE_EVENT_CONTROL_INTENT_VERSION } from "@/lib/live-event-game-control";
+import { validateGameClockMs } from "@/lib/validation-policy";
 import { readControllerDeviceContext } from "@/lib/controller-device-context";
 import {
   acknowledgeControllerProjection,
@@ -59,6 +65,11 @@ type ReplayRequest = { state: ControllerReplicaState; authority: ReplayAuthority
 
 type ActiveReplay = ReplayRequest & { requestToken: symbol };
 
+type ClockReceiptAnchor = {
+  projection: ControllerProjection["clock"];
+  localMonotonicMs: number;
+};
+
 export function EventGameControllerPage() {
   const persisted = readPersistedControllerSession();
   const [qrCredential, setQrCredential] = useState("");
@@ -74,6 +85,9 @@ export function EventGameControllerPage() {
   const [switchTarget, setSwitchTarget] = useState<string | null>(null);
   const [stayedOnAssignment, setStayedOnAssignment] = useState<string | null>(null);
   const [clockRunning, setClockRunning] = useState(false);
+  const [clockReceiptAnchor, setClockReceiptAnchor] = useState<ClockReceiptAnchor | null>(null);
+  const [localMonotonicMs, setLocalMonotonicMs] = useState(readMonotonicNow);
+  const [clockCorrectionInput, setClockCorrectionInput] = useState("");
   const [message, setMessage] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [persistedReplicaLoad] = useState<ControllerReplicaLoad>(() =>
@@ -91,11 +105,24 @@ export function EventGameControllerPage() {
   const [browserContext] = useState(() => readControllerDeviceContext());
 
   useEffect(() => {
+    const timer = window.setInterval(() => setLocalMonotonicMs(readMonotonicNow()), 250);
+    return () => window.clearInterval(timer);
+  }, []);
+
+  const clockProjection =
+    clockReceiptAnchor === null
+      ? null
+      : projectClockSample(
+          clockReceiptAnchor.projection,
+          localMonotonicMs - clockReceiptAnchor.localMonotonicMs,
+        );
+
+  useEffect(() => {
     if (sessionBearer === null || eventGameId === null) {
-      sessionStorage.removeItem("quadball:event-controller-session");
+      window.sessionStorage.removeItem("quadball:event-controller-session");
       return;
     }
-    sessionStorage.setItem(
+    window.sessionStorage.setItem(
       "quadball:event-controller-session",
       JSON.stringify({ sessionBearer, eventGameId } satisfies PersistedControllerSession),
     );
@@ -154,8 +181,7 @@ export function EventGameControllerPage() {
       if (response.status !== "opened") throw new Error("open failed");
       setSessionBearer(response.session.sessionBearer);
       setEventGameId(response.eventGameId);
-      setProjection(response.projection);
-      setProjectionStatus(response.projectionStatus);
+      receiveProjection(response.projection);
       const existingReplica = replicaRef.current;
       const restoredLoad = loadControllerReplica(
         browserReplicaStorage(response.eventGameId),
@@ -210,8 +236,7 @@ export function EventGameControllerPage() {
       if (response.status === "rejected") throw new Error("refresh failed");
       setSwitchTarget(null);
       setEventGameId(response.session.eventGameId);
-      setProjection(response.projection);
-      setProjectionStatus(response.projectionStatus);
+      receiveProjection(response.projection);
       const currentReplica = replicaRef.current;
       const refreshedSession = {
         eventGameId: response.session.eventGameId,
@@ -258,8 +283,7 @@ export function EventGameControllerPage() {
       });
       if (response.status !== "authorized") throw new Error("switch failed");
       setEventGameId(response.session.eventGameId);
-      setProjection(response.projection);
-      setProjectionStatus(response.projectionStatus);
+      receiveProjection(response.projection);
       const restoredLoad = loadControllerReplica(
         browserReplicaStorage(response.session.eventGameId),
         response.session.eventGameId,
@@ -307,8 +331,7 @@ export function EventGameControllerPage() {
       setStayedOnAssignment(switchTarget);
       setSwitchTarget(null);
       setEventGameId(response.session.eventGameId);
-      setProjection(response.projection);
-      setProjectionStatus(response.projectionStatus);
+      receiveProjection(response.projection);
       if (replicaRef.current !== null) {
         const nextReplica = rebindControllerReplica(
           replicaRef.current,
@@ -451,8 +474,7 @@ export function EventGameControllerPage() {
       if (!isInstalledReplayAuthority(request.authority)) return;
       const nextReplica = reconcileControllerReplay(replicaRef.current ?? prepared.state, response);
       commitReplica(nextReplica);
-      setProjection(nextReplica.projection);
-      setProjectionStatus(response.projection === null ? "unavailable" : "available");
+      receiveProjection(response.projection);
       if (
         response.status === "synchronized" &&
         nextReplica.pendingActions.some((action) => action.status === "pending")
@@ -545,6 +567,74 @@ export function EventGameControllerPage() {
     );
   }
 
+  function adjustClock(adjustmentMs: number) {
+    const bearer = sessionBearer;
+    const currentEventGameId = eventGameId;
+    if (bearer === null || currentEventGameId === null) return;
+    if (navigator.onLine === false) {
+      setMessage("Clock control is unavailable while disconnected and was not retained.");
+      return;
+    }
+    void submitOnlineControllerIntent(
+      {
+        version: LIVE_EVENT_CONTROL_INTENT_VERSION,
+        type: "clock-adjust",
+        adjustmentMs,
+        operationId: crypto.randomUUID(),
+        factId: crypto.randomUUID(),
+        gameTimeMs: 0,
+        occurrence: { clientOriginAtMs: Date.now(), source: "online" },
+      },
+      bearer,
+      currentEventGameId,
+    );
+  }
+
+  function correctClock() {
+    if (clockCorrectionInput.trim() === "") {
+      setMessage("Enter a whole number of milliseconds from 0 to 7200000.");
+      return;
+    }
+    const candidate = Number(clockCorrectionInput);
+    const validated = validateGameClockMs(candidate);
+    if (!validated.ok) {
+      setMessage("Clock correction must be a whole number from 0 to 7200000 milliseconds.");
+      return;
+    }
+    const bearer = sessionBearer;
+    const currentEventGameId = eventGameId;
+    if (bearer === null || currentEventGameId === null) return;
+    if (navigator.onLine === false) {
+      setMessage("Clock control is unavailable while disconnected and was not retained.");
+      return;
+    }
+    void submitOnlineControllerIntent(
+      {
+        version: LIVE_EVENT_CONTROL_INTENT_VERSION,
+        type: "clock-correction",
+        clockTimeMs: validated.value,
+        operationId: crypto.randomUUID(),
+        factId: crypto.randomUUID(),
+        gameTimeMs: 0,
+        occurrence: { clientOriginAtMs: Date.now(), source: "online" },
+      },
+      bearer,
+      currentEventGameId,
+    );
+    setClockCorrectionInput("");
+  }
+
+  function receiveProjection(nextProjection: ControllerProjection | null) {
+    setProjection(nextProjection);
+    setProjectionStatus(nextProjection === null ? "unavailable" : "available");
+    setClockRunning(nextProjection?.clock.running ?? false);
+    setClockReceiptAnchor(
+      nextProjection === null
+        ? null
+        : { projection: nextProjection.clock, localMonotonicMs: readMonotonicNow() },
+    );
+  }
+
   async function submitOnlineControllerIntent(
     intent: LiveEventControllerIntent,
     bearer: string,
@@ -560,9 +650,6 @@ export function EventGameControllerPage() {
         setMessage("The online Controller action was not accepted.");
         return;
       }
-      setClockRunning(
-        intent.type === "clock" || intent.type === "set-running" ? intent.running : false,
-      );
       if (response.projection !== null) {
         const current = replicaRef.current;
         if (current?.eventGameId === currentEventGameId) {
@@ -570,8 +657,10 @@ export function EventGameControllerPage() {
           replicaRef.current = nextReplica;
           setReplica(nextReplica);
         }
-        setProjection(response.projection);
-        setProjectionStatus(response.projectionStatus);
+        receiveProjection(response.projection);
+        if (intent.type === "clock" || intent.type === "set-running") {
+          setClockRunning(intent.running);
+        }
       }
     } catch {
       setMessage("The online Controller action could not be submitted.");
@@ -590,6 +679,8 @@ export function EventGameControllerPage() {
     setProjection(null);
     setProjectionStatus("unavailable");
     setClockRunning(false);
+    setClockReceiptAnchor(null);
+    setClockCorrectionInput("");
     setRevealedQr(null);
     setSwitchTarget(null);
     setStayedOnAssignment(null);
@@ -668,10 +759,79 @@ export function EventGameControllerPage() {
                   <code className="mt-2 block break-all text-xs">{revealedQr}</code>
                 </div>
               )}
+              <div className="rounded-lg border bg-slate-950 p-4 text-center text-white">
+                <p className="text-xs uppercase tracking-[0.2em] text-slate-300">Game Clock</p>
+                <p className="mt-1 text-5xl font-semibold tabular-nums">
+                  {clockProjection === null ? "--:--" : formatClock(clockProjection.gameTimeMs)}
+                </p>
+                <p className="mt-1 text-xs text-slate-300">
+                  {clockProjection?.running ? "Play" : "Paused"} · Controller projection
+                </p>
+              </div>
+              {clockProjection === null ? null : (
+                <div className="space-y-1 rounded-lg border border-amber-500/50 bg-amber-50 p-3 text-sm text-amber-950">
+                  <p data-clock-cue="flag-runner">
+                    {clockProjection.cues.flagRunnerEntry === "pending"
+                      ? "Flag-runner entry pending at 19:00"
+                      : clockProjection.cues.flagRunnerEntry === "due"
+                        ? "FLAG-RUNNER ENTRY NOW"
+                        : "Flag-runner entry complete"}
+                  </p>
+                  <p data-clock-cue="seeker-warning">
+                    {clockProjection.cues.seekerWarning === "pending"
+                      ? "Seeker warning pending"
+                      : clockProjection.cues.seekerWarning === "due"
+                        ? "SEEKER WARNING: release countdown active"
+                        : "Seeker warning complete"}
+                  </p>
+                  <p data-clock-cue="seeker-countdown">
+                    {clockProjection.cues.seekerCountdownMs === null
+                      ? "Seeker countdown: complete"
+                      : `SEEKER COUNTDOWN: ${formatClock(clockProjection.cues.seekerCountdownMs)}`}
+                  </p>
+                  <p data-clock-cue="seeker-release">
+                    {clockProjection.cues.seekerRelease === "released"
+                      ? "SEEKER RELEASED at 20:00"
+                      : "Seeker release pending at 20:00"}
+                  </p>
+                </div>
+              )}
               <div className="flex flex-wrap gap-2">
                 <Button onClick={toggleClock} disabled={busy}>
                   {clockRunning ? "Pause clock" : "Start clock"}
                 </Button>
+                {[-60_000, -10_000, 10_000, 60_000].map((adjustmentMs) => (
+                  <Button
+                    key={adjustmentMs}
+                    variant="outline"
+                    onClick={() => adjustClock(adjustmentMs)}
+                    disabled={busy}
+                  >
+                    {adjustmentMs < 0 ? "−" : "+"}
+                    {Math.abs(adjustmentMs) / 1000}s
+                  </Button>
+                ))}
+                <div className="flex w-full flex-wrap items-end gap-2 rounded border p-2 text-left">
+                  <div className="min-w-48 flex-1 space-y-1">
+                    <Label htmlFor="clock-correction">Set game clock (milliseconds)</Label>
+                    <Input
+                      id="clock-correction"
+                      inputMode="numeric"
+                      value={clockCorrectionInput}
+                      onChange={(event) => setClockCorrectionInput(event.target.value)}
+                      placeholder="0–7200000"
+                      disabled={busy}
+                    />
+                  </div>
+                  <Button
+                    variant="outline"
+                    data-clock-correction="true"
+                    onClick={correctClock}
+                    disabled={busy}
+                  >
+                    Correct clock
+                  </Button>
+                </div>
                 <Button variant="outline" onClick={() => trigger("card")} disabled={busy}>
                   Record card
                 </Button>
@@ -723,6 +883,17 @@ export function EventGameControllerPage() {
   );
 }
 
+function formatClock(milliseconds: number): string {
+  const totalSeconds = Math.floor(milliseconds / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes.toString().padStart(2, "0")}:${seconds.toString().padStart(2, "0")}`;
+}
+
+function readMonotonicNow(): number {
+  return typeof performance === "undefined" ? 0 : performance.now();
+}
+
 async function postJson<T>(path: string, body: unknown): Promise<T> {
   const response = await fetch(path, {
     method: "POST",
@@ -748,7 +919,7 @@ function replicaMatchesAuthority(
 
 function readPersistedControllerSession(): PersistedControllerSession | null {
   try {
-    const raw = sessionStorage.getItem("quadball:event-controller-session");
+    const raw = window.sessionStorage.getItem("quadball:event-controller-session");
     if (raw === null) return null;
     const value = JSON.parse(raw) as Partial<PersistedControllerSession>;
     return typeof value.sessionBearer === "string" && typeof value.eventGameId === "string"
@@ -761,7 +932,7 @@ function readPersistedControllerSession(): PersistedControllerSession | null {
 
 function readPersistedControllerReplica(eventGameId: string | undefined): ControllerReplicaLoad {
   try {
-    if (typeof localStorage === "undefined") {
+    if (typeof window === "undefined") {
       return { state: null, warning: null, quarantined: false };
     }
     return loadControllerReplica(browserReplicaStorage(eventGameId), eventGameId);
@@ -777,9 +948,9 @@ function readPersistedControllerReplica(eventGameId: string | undefined): Contro
 function browserReplicaStorage(eventGameId?: string): ControllerReplicaStorage {
   const storageKey = controllerReplicaStorageKey(eventGameId);
   return {
-    read: () => localStorage.getItem(storageKey),
-    write: (value) => localStorage.setItem(storageKey, value),
-    quarantine: (value) => localStorage.setItem(`${storageKey}:quarantine`, value),
+    read: () => window.localStorage.getItem(storageKey),
+    write: (value) => window.localStorage.setItem(storageKey, value),
+    quarantine: (value) => window.localStorage.setItem(`${storageKey}:quarantine`, value),
   };
 }
 
@@ -789,6 +960,7 @@ function emptyProjection(eventGameId: string): ControllerProjection {
     phase: "scheduled",
     scoreByGameSide: {},
     goalCount: 0,
+    clock: projectClockBaseline(createInitialClockBaseline(), 0),
     commencement: {
       status: "provisional",
       commencedAtMs: null,


### PR DESCRIPTION
## What changed

- add a deterministic shared online Clock Authority folded from durable trusted-occurrence transitions
- validate Clock bounds against the serialized canonical baseline and retain explicit durable rejection outcomes
- project the Offline Clock Holder from acceptance order while preventing non-clock actions from transferring ownership
- couple independent card-backed penalty clocks to game-clock running state and expose 19:00/20:00 officiating cues
- integrate bounded Controller clock correction and monotonic browser sampling without adding Clock actions to offline reconnect replay

## Why

Multiple Controllers need one durable sporting-time authority that remains deterministic under delayed or reordered delivery while keeping ordinary reconnect behavior separate from online-only Clock control.

## Impact

Controllers now share the same authoritative game and penalty clock state, receive visible seeker and flag-runner timing cues, and can apply bounded corrections. Invalid concurrent transitions are rejected durably rather than omitted or clamped.

## Validation

- `bun run check`
- `bun run test` — 486 passed
- `bun run build`
- `git diff --check`
- focused Clock Authority, Controller, runtime, and browser suites — 74 passed

Stacked on #172.

Closes #87
