### PR TITLE
Continue clock control through outages

### DIFF
--- a/docs/agents/event-game-runtime.md
+++ b/docs/agents/event-game-runtime.md
@@ -18,3 +18,15 @@ Foundation migrations to this database. Runtime startup only checks schema
 readiness and compatibility; it never migrates or upgrades the production
 database. Migration remains an explicit operational step with its backup,
 quiescence, readiness, and rollback procedure.
+
+Clock operation has a separate outage boundary. The server-issued Clock Baseline
+identifies the Offline Clock Holder, authority generation, and last synchronization.
+The holder may retain disconnected clock actions locally; other disconnected
+Controllers retain ordinary non-clock actions but cannot create clock authority.
+An already-admitted device may record a deliberate emergency takeover only after
+physical Timekeeper or Head Referee confirmation. Takeovers create a new baseline
+and generation; actions carrying a superseded generation remain audit evidence and
+are ignored by projection. Running local projections are estimated from monotonic
+elapsed time, paused projections are stale, and an untrustworthy projection is
+unavailable with manual timing required. A fresh device never reconstructs clock
+authority during a total server outage.

--- a/src/lib/clock-authority.test.ts
+++ b/src/lib/clock-authority.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   createInitialClockBaseline,
   deriveClockAuthority,
+  projectClockSample,
   projectClockBaseline,
   type ClockAuthorityAction,
 } from "@/lib/clock-authority";
@@ -162,6 +163,80 @@ describe("Clock Authority", () => {
     ]);
     expect(projectClockBaseline(resumedBaseline, 11_000).activePenaltyTimeMs).toBe(5_000);
   });
+
+  test("uses monotonic elapsed time for estimated running projections and stale paused projections", () => {
+    const baseline = deriveClockAuthority([
+      clockAction({
+        operationId: "start-monotonic",
+        trustedAtMs: 10_000,
+        sessionId: "session-a",
+        command: "set-running",
+        running: true,
+      }),
+    ]);
+    const receipt = projectClockBaseline(baseline, 10_000);
+    const estimated = projectClockSample(receipt, 2_500);
+    expect(estimated).toMatchObject({
+      gameTimeMs: 2_500,
+      synchronization: "estimated",
+      lastSynchronizedAtMs: 10_000,
+    });
+    expect(projectClockSample(receipt, 86_400_000).gameTimeMs).toBe(7_200_000);
+
+    const paused = projectClockSample(
+      projectClockBaseline(
+        deriveClockAuthority([
+          clockAction({
+            operationId: "paused",
+            trustedAtMs: 10_000,
+            sessionId: "session-a",
+            command: "set-running",
+            running: false,
+          }),
+        ]),
+        10_000,
+      ),
+      2_500,
+    );
+    expect(paused).toMatchObject({ gameTimeMs: 0, synchronization: "stale" });
+  });
+
+  test("creates a new takeover generation and retains stale-generation evidence", () => {
+    const baseline = deriveClockAuthority([
+      clockAction({
+        operationId: "holder-start",
+        trustedAtMs: 1_000,
+        sessionId: "session-a",
+        command: "set-running",
+        running: true,
+      }),
+      clockAction({
+        operationId: "takeover",
+        trustedAtMs: 2_000,
+        sessionId: "session-b",
+        command: "takeover",
+        gameTimeMs: 5_000,
+        running: false,
+        authorityGeneration: 1,
+      }),
+      clockAction({
+        operationId: "stale-holder-action",
+        trustedAtMs: 3_000,
+        sessionId: "session-a",
+        command: "set-running",
+        running: true,
+        authorityGeneration: 1,
+      }),
+    ]);
+
+    expect(baseline).toMatchObject({
+      gameTimeMs: 5_000,
+      running: false,
+      holderGrantSessionId: "session-b",
+      authorityGeneration: 2,
+      staleGenerationOperationIds: ["stale-holder-action"],
+    });
+  });
 });
 
 function baselineActions(): ClockAuthorityAction[] {
@@ -190,6 +265,8 @@ function clockAction(input: {
   command: ClockAuthorityAction["command"];
   running?: boolean;
   adjustmentMs?: number;
+  gameTimeMs?: number;
+  authorityGeneration?: number;
 }): ClockAuthorityAction {
   return {
     operationId: input.operationId,
@@ -199,5 +276,9 @@ function clockAction(input: {
     command: input.command,
     ...(input.running === undefined ? {} : { running: input.running }),
     ...(input.adjustmentMs === undefined ? {} : { adjustmentMs: input.adjustmentMs }),
+    ...(input.gameTimeMs === undefined ? {} : { gameTimeMs: input.gameTimeMs }),
+    ...(input.authorityGeneration === undefined
+      ? {}
+      : { authorityGeneration: input.authorityGeneration }),
   };
 }

--- a/src/lib/clock-authority.ts
+++ b/src/lib/clock-authority.ts
@@ -10,12 +10,17 @@ export const FLAG_RUNNER_ENTRY_MS = 19 * 60 * 1000;
 export const SEEKER_RELEASE_MS = 20 * 60 * 1000;
 export const CLOCK_AUTHORITY_VERSION = "clock-authority-v1" as const;
 
+export type ClockSynchronization = "synchronized" | "estimated" | "stale" | "unavailable";
+
 export type ClockAuthorityAction = {
   operationId: string;
   trustedAtMs: number;
   acceptedAtMs: number;
   sessionId: string;
-  command: "set-running" | "adjust" | "correct" | "penalty-start";
+  command: "set-running" | "adjust" | "correct" | "penalty-start" | "takeover";
+  authorityGeneration?: number;
+  source?: "online" | "offline";
+  takeover?: boolean;
   running?: boolean;
   gameTimeMs?: number;
   adjustmentMs?: number;
@@ -40,6 +45,8 @@ export type ClockBaseline = {
   holderGeneration: number;
   lastTransitionOperationId: string | null;
   lastAcceptedAtMs: number | null;
+  authorityGeneration: number;
+  staleGenerationOperationIds: readonly string[];
 };
 
 export type ClockCueState = {
@@ -56,7 +63,8 @@ export type ClockProjection = {
   activePenaltyTimeMs: number;
   running: boolean;
   projectedAtMs: number;
-  synchronization: "synchronized";
+  synchronization: ClockSynchronization;
+  lastSynchronizedAtMs: number | null;
   offlineClockHolderGrantSessionId: string | null;
   cues: ClockCueState;
 };
@@ -73,6 +81,23 @@ export function validateClockFactData(value: unknown): ValidationResult<unknown>
     if (!startedAtMs.ok) return startedAtMs;
   }
   const command = value.command;
+  if (command === "takeover") {
+    const gameTimeMs = validateGameClockMs(value.gameTimeMs);
+    const authorityGeneration = validateIntegerInRange(
+      value.authorityGeneration,
+      0,
+      Number.MAX_SAFE_INTEGER,
+      "Clock takeover authorityGeneration",
+    );
+    if (!gameTimeMs.ok) return gameTimeMs;
+    if (typeof value.running !== "boolean")
+      return invalid("Clock takeover running must be a boolean.");
+    if (!authorityGeneration.ok) return authorityGeneration;
+    if (value.confirmation !== "physical-timekeeper-or-head-referee") {
+      return invalid("Clock takeover confirmation is required.");
+    }
+    return valid(value);
+  }
   if (command !== "set-running" && command !== "adjust" && command !== "correct") {
     if (typeof value.running !== "boolean") {
       return invalid("Clock Fact data command is unsupported.");
@@ -106,6 +131,8 @@ export function createInitialClockBaseline(): ClockBaseline {
     holderGeneration: 0,
     lastTransitionOperationId: null,
     lastAcceptedAtMs: null,
+    authorityGeneration: 0,
+    staleGenerationOperationIds: [],
   };
 }
 
@@ -124,7 +151,12 @@ export function deriveClockAuthority(actions: readonly ClockAuthorityAction[]): 
     const transitioned = applyClockAction(baseline, action);
     if (transitioned === null) continue;
     baseline = transitioned;
-    if (action.command !== "penalty-start") appliedClockActions.push(action);
+    if (
+      action.command !== "penalty-start" &&
+      baseline.lastTransitionOperationId === action.operationId
+    ) {
+      appliedClockActions.push(action);
+    }
   }
 
   const latestAccepted = [...appliedClockActions].sort(compareAcceptedClockActions).at(-1) ?? null;
@@ -133,6 +165,7 @@ export function deriveClockAuthority(actions: readonly ClockAuthorityAction[]): 
     holderGrantSessionId: latestAccepted?.sessionId ?? null,
     holderGeneration: appliedClockActions.length,
     lastAcceptedAtMs: latestAccepted?.acceptedAtMs ?? null,
+    authorityGeneration: appliedClockActions.length,
   };
 }
 
@@ -164,13 +197,88 @@ export function projectClockBaseline(baseline: ClockBaseline, nowMs: number): Cl
   return createProjection(projected, nowMs);
 }
 
+export function markClockProjectionUnavailable(projection: ClockProjection): ClockProjection {
+  return {
+    ...structuredClone(projection),
+    synchronization: "unavailable",
+  };
+}
+
+export function applyClockProjectionAction(
+  projection: ClockProjection,
+  action: {
+    command: "set-running" | "adjust" | "correct" | "takeover";
+    running?: boolean;
+    gameTimeMs?: number;
+    adjustmentMs?: number;
+    authorityGeneration?: number;
+    sessionId?: string;
+    operationId?: string;
+  },
+): ClockProjection {
+  const current = structuredClone(projection);
+  const baselineDefaults = {
+    authorityGeneration: Number.isSafeInteger(current.baseline.authorityGeneration)
+      ? current.baseline.authorityGeneration
+      : 0,
+    staleGenerationOperationIds: current.baseline.staleGenerationOperationIds ?? [],
+  };
+  current.baseline = { ...current.baseline, ...baselineDefaults };
+  const currentGameTimeMs = current.gameTimeMs;
+  const actionGameTimeMs = action.gameTimeMs ?? currentGameTimeMs;
+  const nextGameTimeMs =
+    action.command === "adjust"
+      ? actionGameTimeMs + (action.adjustmentMs ?? 0)
+      : action.command === "correct" || action.command === "takeover"
+        ? actionGameTimeMs
+        : currentGameTimeMs;
+  const validatedGameTime = validateGameClockMs(nextGameTimeMs);
+  if (!validatedGameTime.ok) return current;
+  const running =
+    action.command === "set-running" || action.command === "takeover"
+      ? action.running === true
+      : current.running;
+  const baseline: ClockBaseline = {
+    ...current.baseline,
+    gameTimeMs: validatedGameTime.value,
+    penaltyTimeMs: current.baseline.activePenalty?.elapsedMs ?? 0,
+    running: running && validatedGameTime.value < SHARED_LIMITS.clock.maxMs,
+    runningSinceMs: !running
+      ? null
+      : action.command === "takeover" || !current.running
+        ? current.projectedAtMs
+        : current.baseline.runningSinceMs,
+    establishedAtMs: current.projectedAtMs,
+    holderGrantSessionId: action.sessionId ?? current.baseline.holderGrantSessionId,
+    authorityGeneration:
+      action.command === "takeover"
+        ? current.baseline.authorityGeneration + 1
+        : Math.max(current.baseline.authorityGeneration, action.authorityGeneration ?? 0) + 1,
+    lastTransitionOperationId: action.operationId ?? current.baseline.lastTransitionOperationId,
+  };
+  baseline.holderGeneration = baseline.authorityGeneration;
+  return {
+    ...current,
+    baseline,
+    gameTimeMs: baseline.gameTimeMs,
+    running: baseline.running,
+    activePenaltyTimeMs: baseline.activePenalty?.elapsedMs ?? 0,
+    synchronization: baseline.running ? "estimated" : "stale",
+    lastSynchronizedAtMs: current.lastSynchronizedAtMs ?? current.baseline.lastAcceptedAtMs ?? null,
+    cues: cuesFor(baseline.gameTimeMs),
+  };
+}
+
 /** Advance a server sample by local monotonic elapsed time, never wall time. */
 export function projectClockSample(
   projection: ClockProjection,
   elapsedMs: number,
 ): ClockProjection {
   if (!Number.isFinite(elapsedMs) || elapsedMs <= 0 || !projection.running) {
-    return structuredClone(projection);
+    return {
+      ...structuredClone(projection),
+      synchronization: projection.running ? "estimated" : "stale",
+    };
   }
   const elapsed = Math.floor(elapsedMs);
   const gameTimeMs = Math.min(SHARED_LIMITS.clock.maxMs, projection.gameTimeMs + elapsed);
@@ -184,6 +292,7 @@ export function projectClockSample(
     activePenaltyTimeMs,
     running: gameTimeMs < SHARED_LIMITS.clock.maxMs,
     projectedAtMs: projection.projectedAtMs + elapsed,
+    synchronization: "estimated" as const,
   };
   return { ...projected, cues: cuesFor(gameTimeMs) };
 }
@@ -197,6 +306,7 @@ function createProjection(baseline: ClockBaseline, projectedAtMs: number): Clock
     running: baseline.running,
     projectedAtMs,
     synchronization: "synchronized",
+    lastSynchronizedAtMs: baseline.lastAcceptedAtMs ?? null,
     offlineClockHolderGrantSessionId: baseline.holderGrantSessionId,
     cues: cuesFor(baseline.gameTimeMs),
   };
@@ -274,6 +384,26 @@ function applyClockAction(
   baseline: ClockBaseline,
   action: ClockAuthorityAction,
 ): ClockBaseline | null {
+  if (
+    action.authorityGeneration !== undefined &&
+    action.command !== "takeover" &&
+    action.authorityGeneration !== baseline.authorityGeneration
+  ) {
+    return {
+      ...baseline,
+      staleGenerationOperationIds: [...baseline.staleGenerationOperationIds, action.operationId],
+    };
+  }
+  if (
+    action.command === "takeover" &&
+    action.authorityGeneration !== undefined &&
+    action.authorityGeneration !== baseline.authorityGeneration
+  ) {
+    return {
+      ...baseline,
+      staleGenerationOperationIds: [...baseline.staleGenerationOperationIds, action.operationId],
+    };
+  }
   if (action.command === "penalty-start") {
     return baseline.activePenalty === null
       ? {
@@ -286,6 +416,22 @@ function applyClockAction(
           },
         }
       : baseline;
+  }
+
+  if (action.command === "takeover") {
+    const validatedGameTime = validateGameClockMs(action.gameTimeMs);
+    if (!validatedGameTime.ok || action.running === undefined) return null;
+    return {
+      ...baseline,
+      gameTimeMs: validatedGameTime.value,
+      running: action.running && validatedGameTime.value < SHARED_LIMITS.clock.maxMs,
+      runningSinceMs: action.running ? action.trustedAtMs : null,
+      establishedAtMs: action.trustedAtMs,
+      holderGrantSessionId: action.sessionId,
+      holderGeneration: baseline.holderGeneration + 1,
+      authorityGeneration: baseline.authorityGeneration + 1,
+      lastTransitionOperationId: action.operationId,
+    };
   }
 
   const nextGameTimeMs =
@@ -311,6 +457,7 @@ function applyClockAction(
       : null,
     establishedAtMs: action.trustedAtMs,
     lastTransitionOperationId: action.operationId,
+    authorityGeneration: baseline.authorityGeneration + 1,
   };
 }
 

--- a/src/lib/controller-intent-retry.ts
+++ b/src/lib/controller-intent-retry.ts
@@ -31,6 +31,14 @@ export function controllerIntentRetryKey(intent: LiveEventControllerIntent): str
       return JSON.stringify([intent.type, intent.adjustmentMs, intent.gameTimeMs]);
     case "clock-correction":
       return JSON.stringify([intent.type, intent.clockTimeMs, intent.gameTimeMs]);
+    case "clock-takeover":
+      return JSON.stringify([
+        intent.type,
+        intent.clockTimeMs,
+        intent.running,
+        intent.authorityGeneration,
+        intent.gameTimeMs,
+      ]);
     case "substantive":
       return JSON.stringify([intent.type, intent.trigger, intent.gameTimeMs]);
     case "reset":

--- a/src/lib/controller-reconnect.test.ts
+++ b/src/lib/controller-reconnect.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   buildControllerReplayBatch,
   createControllerReplica,
+  dispatchControllerClockAction,
   dispatchControllerAction,
   loadControllerReplica,
   prepareControllerReplayBatch,
@@ -193,6 +194,67 @@ describe("Controller reconnect replica", () => {
     ).toThrow("Clock reconnect belongs to Clock Authority");
   });
 
+  test("keeps disconnected clock authority with the holder and permits deliberate admitted takeover", () => {
+    const holder = createReplica();
+    const queued = dispatchControllerClockAction(holder, clock("offline-clock", true), {
+      nowMs: 200,
+    });
+    expect(queued.state.projection.clock.running).toBe(true);
+    expect(queued.state.pendingActions).toHaveLength(1);
+
+    expect(() =>
+      dispatchControllerClockAction(
+        createReplica({ grantSessionId: "session-2" }),
+        clock("non-holder-clock", true),
+      ),
+    ).toThrow("Offline Clock Holder");
+
+    const takeover = dispatchControllerClockAction(
+      createReplica({ grantSessionId: "session-2" }),
+      {
+        ...clock("takeover", false),
+        type: "clock-takeover" as const,
+        clockTimeMs: 5_000,
+        authorityGeneration: 1,
+        confirmation: "physical-timekeeper-or-head-referee" as const,
+      },
+      { nowMs: 300 },
+    );
+    expect(takeover.state.projection.clock).toMatchObject({
+      gameTimeMs: 5_000,
+      synchronization: "stale",
+      baseline: { authorityGeneration: 2, holderGrantSessionId: "session-2" },
+    });
+  });
+
+  test("fails closed for disconnected clock actions before an Offline Clock Holder exists", () => {
+    const state = createControllerReplica({
+      eventGameId: "game-1",
+      grantSessionId: "session-without-holder",
+      grantVersion: "grant-version-1",
+      deviceId: "device-1",
+      projection: {
+        eventGameId: "game-1",
+        phase: "scheduled",
+        scoreByGameSide: { "side-a": 0, "side-b": 0 },
+        goalCount: 0,
+        clock: projectClockBaseline(createInitialClockBaseline(), 0),
+        commencement: {
+          status: "provisional",
+          commencedAtMs: null,
+          provisionalRunningSinceMs: null,
+          provisionalElapsedMs: 0,
+        },
+      },
+    });
+
+    expect(() => dispatchControllerClockAction(state, clock("no-holder", true))).toThrow(
+      "Offline Clock Holder",
+    );
+    expect(state.pendingActions).toHaveLength(0);
+    expect(state.projection.clock.gameTimeMs).toBe(0);
+  });
+
   test("derives optimism exactly once across null and authoritative rebinds", () => {
     let state = createReplica();
     state = dispatchControllerAction(state, goal("goal-rebind", "fact-goal-rebind"), {
@@ -377,10 +439,14 @@ describe("Controller reconnect replica", () => {
   });
 });
 
-function createReplica() {
+function createReplica(input: { grantSessionId?: string } = {}) {
+  const baseline = createInitialClockBaseline();
+  baseline.holderGrantSessionId = "session-1";
+  baseline.holderGeneration = 1;
+  baseline.authorityGeneration = 1;
   return createControllerReplica({
     eventGameId: "game-1",
-    grantSessionId: "session-1",
+    grantSessionId: input.grantSessionId ?? "session-1",
     grantVersion: "grant-version-1",
     deviceId: "device-1",
     projection: {
@@ -388,7 +454,7 @@ function createReplica() {
       phase: "scheduled",
       scoreByGameSide: { "side-a": 0, "side-b": 0 },
       goalCount: 0,
-      clock: projectClockBaseline(createInitialClockBaseline(), 0),
+      clock: projectClockBaseline(baseline, 0),
       commencement: {
         status: "provisional",
         commencedAtMs: null,
@@ -397,6 +463,18 @@ function createReplica() {
       },
     },
   });
+}
+
+function clock(operationId: string, running: boolean) {
+  return {
+    version: LIVE_EVENT_CONTROL_INTENT_VERSION,
+    type: "clock" as const,
+    operationId,
+    factId: `fact-${operationId}`,
+    running,
+    gameTimeMs: 0,
+    occurrence: { clientOriginAtMs: null, source: "offline" as const },
+  };
 }
 
 function goal(operationId: string, factId: string) {

--- a/src/lib/controller-reconnect.ts
+++ b/src/lib/controller-reconnect.ts
@@ -3,7 +3,11 @@ import type {
   ControllerProjection,
   LiveEventControllerIntent,
 } from "@/lib/live-event-game-control";
-import { createInitialClockBaseline, projectClockBaseline } from "@/lib/clock-authority";
+import {
+  applyClockProjectionAction,
+  createInitialClockBaseline,
+  projectClockBaseline,
+} from "@/lib/clock-authority";
 import { parseLiveEventControllerIntent } from "@/lib/live-event-game-control";
 import {
   SHARED_LIMITS,
@@ -154,6 +158,57 @@ export function dispatchControllerAction(
   if (predecessors.some((predecessor) => state.outcomes[predecessor] === "terminally-rejected")) {
     throw new Error("Causal predecessor was terminally rejected.");
   }
+  const existing = state.pendingActions.find(
+    (action) => action.intent.operationId === parsed.value.operationId,
+  );
+  if (existing !== undefined) return { state, action: existing };
+  const counter = state.identity.nextCounter;
+  const action: PendingControllerAction = {
+    eventGameId: state.eventGameId,
+    intent: structuredClone(parsed.value),
+    causalPredecessorIds: predecessors,
+    dispatchedAtMs: options.nowMs ?? Date.now(),
+    identity: { deviceId: state.identity.deviceId, counter },
+    counter,
+    status: "pending",
+  };
+  const nextState = applyOptimisticAction(
+    {
+      ...state,
+      pendingActions: [...state.pendingActions, action],
+      identity: { ...state.identity, nextCounter: counter + 1 },
+    },
+    action,
+  );
+  return { state: nextState, action };
+}
+
+/** Queue a disconnected clock action without widening the ordinary reconnect path. */
+export function dispatchControllerClockAction(
+  state: ControllerReplicaState,
+  intent: LiveEventControllerIntent,
+  options: { nowMs?: number; causalPredecessorIds?: readonly string[] } = {},
+): { state: ControllerReplicaState; action: PendingControllerAction } {
+  const parsed = parseLiveEventControllerIntent(intent);
+  if (!parsed.ok) throw new Error(`Cannot dispatch invalid Controller action: ${parsed.error}`);
+  if (
+    parsed.value.type !== "clock" &&
+    parsed.value.type !== "set-running" &&
+    parsed.value.type !== "clock-adjust" &&
+    parsed.value.type !== "clock-correction" &&
+    parsed.value.type !== "clock-takeover"
+  ) {
+    throw new Error("Only clock actions belong to Clock Authority.");
+  }
+  if (
+    parsed.value.type !== "clock-takeover" &&
+    (state.projection.clock.offlineClockHolderGrantSessionId === null ||
+      state.projection.clock.offlineClockHolderGrantSessionId !== state.session.grantSessionId)
+  ) {
+    throw new Error("Only the Offline Clock Holder may submit disconnected clock actions.");
+  }
+  const predecessors = [...(options.causalPredecessorIds ?? [])];
+  validateCausalPredecessors(state, parsed.value.operationId, predecessors);
   const existing = state.pendingActions.find(
     (action) => action.intent.operationId === parsed.value.operationId,
   );
@@ -583,6 +638,37 @@ function applyOptimisticAction(
       },
     };
   }
+  if (
+    intent.type === "clock" ||
+    intent.type === "set-running" ||
+    intent.type === "clock-adjust" ||
+    intent.type === "clock-correction" ||
+    intent.type === "clock-takeover"
+  ) {
+    return {
+      ...state,
+      projection: {
+        ...state.projection,
+        clock: applyClockProjectionAction(state.projection.clock, {
+          command:
+            intent.type === "clock" || intent.type === "set-running"
+              ? "set-running"
+              : intent.type === "clock-adjust"
+                ? "adjust"
+                : intent.type === "clock-correction"
+                  ? "correct"
+                  : "takeover",
+          running: "running" in intent ? intent.running : undefined,
+          gameTimeMs: "clockTimeMs" in intent ? intent.clockTimeMs : undefined,
+          adjustmentMs: "adjustmentMs" in intent ? intent.adjustmentMs : undefined,
+          authorityGeneration:
+            "authorityGeneration" in intent ? intent.authorityGeneration : intent.clockGeneration,
+          sessionId: state.session.grantSessionId,
+          operationId: intent.operationId,
+        }),
+      },
+    };
+  }
   return {
     ...state,
   };
@@ -673,6 +759,7 @@ function sameProjection(left: ControllerProjection, right: ControllerProjection)
     left.commencement.commencedAtMs === right.commencement.commencedAtMs &&
     left.commencement.provisionalRunningSinceMs === right.commencement.provisionalRunningSinceMs &&
     left.commencement.provisionalElapsedMs === right.commencement.provisionalElapsedMs &&
+    JSON.stringify(left.clock) === JSON.stringify(right.clock) &&
     leftScores.length === rightScores.length &&
     leftScores.every(
       ([side, score], index) =>
@@ -742,9 +829,6 @@ function parsePendingAction(
   if (!identityCounter.ok) throw new Error(identityCounter.error);
   if (identityDeviceId !== expectedDeviceId || identityCounter.value !== counter.value) {
     throw new Error("Pending action identity is inconsistent.");
-  }
-  if (intent.value.type === "clock" || intent.value.type === "set-running") {
-    throw new Error("Clock actions are not eligible for reconnect.");
   }
   return {
     eventGameId,

--- a/src/lib/live-event-game-control.test.ts
+++ b/src/lib/live-event-game-control.test.ts
@@ -1294,6 +1294,112 @@ describe("Live Event Game control", () => {
     expect(await harness.record.readActions()).toHaveLength(0);
   });
 
+  test("keeps offline holder continuity, accepts deliberate takeover, and ignores stale generation evidence", async () => {
+    const harness = await createHarness();
+    const first = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "holder-phone",
+    });
+    if (first.status !== "opened") throw new Error("Expected the holder Controller to open.");
+    const started = await harness.control.submitControllerIntent({
+      sessionBearer: first.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      intent: clockIntent("holder-start", true),
+    });
+    expect(started).toMatchObject({ status: "accepted" });
+
+    const second = await harness.authority.admitGrant({
+      qrCredential: harness.qrCredential,
+      browserContext: "replacement-phone",
+    });
+    if (second.status !== "admitted")
+      throw new Error("Expected the replacement Controller to open.");
+    const rejectedNonHolder = await harness.control.submitControllerIntent({
+      sessionBearer: second.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      intent: clockIntent("non-holder-offline", false, {
+        source: "offline",
+        clockGeneration: 1,
+      }),
+    });
+    expect(rejectedNonHolder.status).toBe("rejected");
+
+    harness.setNow(11_000);
+    const takeover = await harness.control.submitControllerIntent({
+      sessionBearer: second.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      intent: {
+        ...clockIntent("emergency-takeover", false, { source: "offline" }),
+        type: "clock-takeover" as const,
+        clockTimeMs: 5_000,
+        authorityGeneration: 1,
+        confirmation: "physical-timekeeper-or-head-referee" as const,
+      },
+    });
+    expect(takeover).toMatchObject({
+      status: "accepted",
+      projection: {
+        clock: {
+          gameTimeMs: 5_000,
+          running: false,
+          baseline: { authorityGeneration: 2, holderGrantSessionId: second.grantSessionId },
+        },
+      },
+    });
+
+    harness.setNow(12_000);
+    const stale = await harness.control.submitControllerIntent({
+      sessionBearer: first.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      intent: clockIntent("stale-holder-action", true, {
+        source: "offline",
+        clockGeneration: 1,
+      }),
+    });
+    expect(stale).toMatchObject({
+      status: "accepted",
+      projection: {
+        clock: {
+          gameTimeMs: 5_000,
+          running: false,
+          baseline: { staleGenerationOperationIds: ["stale-holder-action"] },
+        },
+      },
+    });
+    expect(await harness.record.readActions()).toHaveLength(3);
+  });
+
+  test("rejects an ordinary offline clock action before any Offline Clock Holder exists", async () => {
+    const harness = await createHarness();
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "fresh-offline-phone",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+
+    const rejected = await harness.control.submitControllerIntent({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      intent: clockIntent("no-offline-holder", true, { source: "offline" }),
+    });
+
+    expect(rejected).toMatchObject({ status: "rejected", operationId: "no-offline-holder" });
+    expect(await harness.record.readActions()).toHaveLength(0);
+    const refreshed = await harness.control.refreshController({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+    });
+    if (refreshed.status !== "authorized" || refreshed.projection === null) {
+      throw new Error("Expected an authorized Controller projection.");
+    }
+    expect(refreshed.projection.clock).toMatchObject({
+      gameTimeMs: 0,
+      running: false,
+      offlineClockHolderGrantSessionId: null,
+      baseline: { authorityGeneration: 0, holderGrantSessionId: null },
+    });
+  });
+
   test("exposes the Controller through its HTTP transport without changing Ad Hoc routes", async () => {
     const harness = await createHarness();
     const allowedOrigin = "https://timer.quadball.app";
@@ -1506,7 +1612,11 @@ function goalIntent(
   };
 }
 
-function clockIntent(operationId: string, running: boolean) {
+function clockIntent(
+  operationId: string,
+  running: boolean,
+  options: { source?: "online" | "offline"; clockGeneration?: number } = {},
+) {
   return {
     version: LIVE_EVENT_CONTROL_INTENT_VERSION,
     type: "clock" as const,
@@ -1514,7 +1624,11 @@ function clockIntent(operationId: string, running: boolean) {
     factId: `fact-${operationId}`,
     running,
     gameTimeMs: 0,
-    occurrence: { clientOriginAtMs: null },
+    occurrence: {
+      clientOriginAtMs: null,
+      ...(options.source === undefined ? {} : { source: options.source }),
+    },
+    ...(options.clockGeneration === undefined ? {} : { clockGeneration: options.clockGeneration }),
   };
 }
 

--- a/src/lib/live-event-game-control.ts
+++ b/src/lib/live-event-game-control.ts
@@ -33,6 +33,7 @@ type ControllerIntentBase = {
     clientOriginAtMs: number | null;
     source?: "online" | "offline";
   };
+  clockGeneration?: number;
 };
 
 export type LiveEventControllerIntent =
@@ -51,6 +52,13 @@ export type LiveEventControllerIntent =
   | (ControllerIntentBase & {
       type: "clock-correction";
       clockTimeMs: number;
+    })
+  | (ControllerIntentBase & {
+      type: "clock-takeover";
+      clockTimeMs: number;
+      running: boolean;
+      authorityGeneration: number;
+      confirmation: "physical-timekeeper-or-head-referee";
     })
   | (ControllerIntentBase & {
       type: "substantive";
@@ -239,6 +247,7 @@ export function parseLiveEventControllerIntent(
     value.type !== "adjust-clock" &&
     value.type !== "adjust-game-clock" &&
     value.type !== "clock-correction" &&
+    value.type !== "clock-takeover" &&
     value.type !== "correct-clock" &&
     value.type !== "set-game-clock" &&
     value.type !== "substantive" &&
@@ -272,7 +281,7 @@ export function parseLiveEventControllerIntent(
     gameSideId = parsedSide.value;
   }
   let running: boolean | undefined;
-  if (value.type === "clock" || value.type === "set-running") {
+  if (value.type === "clock" || value.type === "set-running" || value.type === "clock-takeover") {
     if (typeof value.running !== "boolean") return invalid("running must be a boolean.");
     running = value.running;
   }
@@ -283,12 +292,46 @@ export function parseLiveEventControllerIntent(
     adjustmentMs = adjustment.value;
   }
   let clockTimeMs: number | undefined;
-  if (normalizedType === "clock-correction") {
+  if (normalizedType === "clock-correction" || normalizedType === "clock-takeover") {
     const clockTime = validateGameClock(
       value.clockTimeMs ?? value.targetGameTimeMs ?? value.gameTimeMs,
     );
     if (!clockTime.ok) return invalid(clockTime.error);
     clockTimeMs = clockTime.value;
+  }
+  let authorityGeneration: number | undefined;
+  let confirmation: "physical-timekeeper-or-head-referee" | undefined;
+  if (normalizedType === "clock-takeover") {
+    const generation = validateIntegerInRange(
+      value.authorityGeneration,
+      0,
+      Number.MAX_SAFE_INTEGER,
+      "authorityGeneration",
+    );
+    if (!generation.ok) return invalid(generation.error);
+    if (value.confirmation !== "physical-timekeeper-or-head-referee") {
+      return invalid("Clock takeover requires physical Timekeeper or Head Referee confirmation.");
+    }
+    authorityGeneration = generation.value;
+    confirmation = value.confirmation;
+  }
+  let clockGeneration: number | undefined;
+  if (
+    value.type === "clock" ||
+    value.type === "set-running" ||
+    value.type === "clock-adjust" ||
+    value.type === "clock-correction"
+  ) {
+    if (value.clockGeneration !== undefined) {
+      const generation = validateIntegerInRange(
+        value.clockGeneration,
+        0,
+        Number.MAX_SAFE_INTEGER,
+        "clockGeneration",
+      );
+      if (!generation.ok) return invalid(generation.error);
+      clockGeneration = generation.value;
+    }
   }
   let trigger: "card" | "timeout" | "suspension" | "result" | undefined;
   if (value.type === "substantive") {
@@ -337,6 +380,9 @@ export function parseLiveEventControllerIntent(
       ...(running === undefined ? {} : { running }),
       ...(adjustmentMs === undefined ? {} : { adjustmentMs }),
       ...(clockTimeMs === undefined ? {} : { clockTimeMs }),
+      ...(authorityGeneration === undefined ? {} : { authorityGeneration }),
+      ...(confirmation === undefined ? {} : { confirmation }),
+      ...(clockGeneration === undefined ? {} : { clockGeneration }),
       ...(trigger === undefined ? {} : { trigger }),
     } as LiveEventControllerIntent,
   };
@@ -653,6 +699,24 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
     if (clockData.status === "rejected") {
       return rejectedAction(parsed.value.operationId);
     }
+    if (isClockIntent(parsed.value)) {
+      if (
+        parsed.value.type === "clock-takeover" &&
+        parsed.value.authorityGeneration !== clockBefore.baseline.authorityGeneration
+      ) {
+        return rejectedAction(parsed.value.operationId);
+      }
+      if (
+        parsed.value.type !== "clock-takeover" &&
+        parsed.value.occurrence.source === "offline" &&
+        (clockBefore.baseline.holderGrantSessionId === null ||
+          (clockBefore.baseline.holderGrantSessionId !== authorized.grantSessionId &&
+            (parsed.value.clockGeneration === undefined ||
+              parsed.value.clockGeneration === clockBefore.baseline.authorityGeneration)))
+      ) {
+        return rejectedAction(parsed.value.operationId);
+      }
+    }
     const clockStartMs =
       parsed.value.type === "clock" || parsed.value.type === "set-running"
         ? parsed.value.running
@@ -850,12 +914,7 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
           const predecessors = candidate.causalPredecessorIds ?? [];
           if (operationId === null) continue;
           const parsedIntent = parseLiveEventControllerIntent(candidate.intent);
-          if (
-            !parsedIntent.ok ||
-            parsedIntent.value.type === "clock" ||
-            parsedIntent.value.type === "set-running" ||
-            (operationCounts.get(operationId) ?? 0) > 1
-          ) {
+          if (!parsedIntent.ok || (operationCounts.get(operationId) ?? 0) > 1) {
             outcomes.push({ operationId, status: "terminally-rejected" });
             blocked.add(operationId);
             progressed = true;
@@ -1058,7 +1117,8 @@ function controllerFactType(intent: LiveEventControllerIntent): string {
     intent.type === "clock" ||
     intent.type === "set-running" ||
     intent.type === "clock-adjust" ||
-    intent.type === "clock-correction"
+    intent.type === "clock-correction" ||
+    intent.type === "clock-takeover"
   )
     return "clock";
   if (intent.type === "substantive") return intent.trigger;
@@ -1172,6 +1232,32 @@ export function validateLiveEventClockActionInTransaction(
   if (candidateClock === undefined || candidateClock.command === "penalty-start") {
     return { status: "accepted" };
   }
+  const current = deriveClockAuthority(readClockAuthorityActions(actions));
+  if (
+    candidateClock.command === "takeover" &&
+    candidateClock.authorityGeneration !== undefined &&
+    candidateClock.authorityGeneration !== current.authorityGeneration
+  ) {
+    return {
+      status: "rejected",
+      reason: "invalid-action",
+      detail: "Clock takeover generation is stale.",
+    };
+  }
+  if (
+    candidateClock.command !== "takeover" &&
+    candidateClock.source === "offline" &&
+    (current.holderGrantSessionId === null ||
+      (candidateClock.sessionId !== current.holderGrantSessionId &&
+        (candidateClock.authorityGeneration === undefined ||
+          candidateClock.authorityGeneration === current.authorityGeneration)))
+  ) {
+    return {
+      status: "rejected",
+      reason: "invalid-action",
+      detail: "Only the Offline Clock Holder may submit disconnected clock actions.",
+    };
+  }
   const validation = validateClockAuthorityAction(
     readClockAuthorityActions(actions),
     candidateClock,
@@ -1185,13 +1271,13 @@ function readClockAuthorityActions(
   actions: readonly {
     action?: {
       operationId: string;
-      occurrence: { trustedAtMs: number };
+      occurrence: { trustedAtMs: number; source: "online" | "offline" };
       acceptedAtMs: number;
       grant: { sessionId: string };
       interpretation: unknown;
     };
     operationId?: string;
-    occurrence?: { trustedAtMs: number };
+    occurrence?: { trustedAtMs: number; source: "online" | "offline" };
     acceptedAtMs?: number;
     grant?: { sessionId: string };
     interpretation?: unknown;
@@ -1225,7 +1311,10 @@ function readClockAuthorityActions(
       continue;
     }
     const command =
-      data.command === "adjust" || data.command === "correct" || data.command === "set-running"
+      data.command === "adjust" ||
+      data.command === "correct" ||
+      data.command === "set-running" ||
+      data.command === "takeover"
         ? data.command
         : typeof data.running === "boolean"
           ? "set-running"
@@ -1237,6 +1326,11 @@ function readClockAuthorityActions(
       acceptedAtMs: storedAction.acceptedAtMs,
       sessionId: storedAction.grant.sessionId,
       command,
+      source: storedAction.occurrence.source,
+      ...(typeof data.authorityGeneration === "number"
+        ? { authorityGeneration: data.authorityGeneration }
+        : {}),
+      ...(data.command === "takeover" ? { takeover: true } : {}),
       ...(typeof data.running === "boolean" ? { running: data.running } : {}),
       ...(typeof data.gameTimeMs === "number" ? { gameTimeMs: data.gameTimeMs } : {}),
       ...(typeof data.adjustmentMs === "number" ? { adjustmentMs: data.adjustmentMs } : {}),
@@ -1251,12 +1345,28 @@ function readClockIntentData(
   current: ClockProjection,
   nowMs: number,
 ): { status: "ready"; value: Record<string, unknown> | null } | { status: "rejected" } {
+  if (intent.type === "clock-takeover") {
+    return {
+      status: "ready",
+      value: {
+        command: "takeover",
+        running: intent.running,
+        gameTimeMs: intent.clockTimeMs,
+        authorityGeneration: intent.authorityGeneration,
+        confirmation: intent.confirmation,
+        startedAtMs: intent.running ? nowMs : null,
+      },
+    };
+  }
   if (intent.type === "clock" || intent.type === "set-running") {
     return {
       status: "ready",
       value: {
         command: "set-running",
         running: intent.running,
+        ...(intent.clockGeneration === undefined
+          ? {}
+          : { authorityGeneration: intent.clockGeneration }),
         startedAtMs: intent.running
           ? (current.baseline.runningSinceMs ?? nowMs)
           : current.baseline.runningSinceMs,
@@ -1269,6 +1379,9 @@ function readClockIntentData(
       value: {
         command: "adjust",
         adjustmentMs: intent.adjustmentMs,
+        ...(intent.clockGeneration === undefined
+          ? {}
+          : { authorityGeneration: intent.clockGeneration }),
       },
     };
   }
@@ -1278,10 +1391,28 @@ function readClockIntentData(
       value: {
         command: "correct",
         gameTimeMs: intent.clockTimeMs,
+        ...(intent.clockGeneration === undefined
+          ? {}
+          : { authorityGeneration: intent.clockGeneration }),
       },
     };
   }
   return { status: "ready", value: null };
+}
+
+function isClockIntent(
+  intent: LiveEventControllerIntent,
+): intent is Extract<
+  LiveEventControllerIntent,
+  { type: "clock" | "set-running" | "clock-adjust" | "clock-correction" | "clock-takeover" }
+> {
+  return (
+    intent.type === "clock" ||
+    intent.type === "set-running" ||
+    intent.type === "clock-adjust" ||
+    intent.type === "clock-correction" ||
+    intent.type === "clock-takeover"
+  );
 }
 
 function readClockProjection(value: unknown): ClockProjection | null {
@@ -1293,10 +1424,17 @@ function readClockProjection(value: unknown): ClockProjection | null {
     typeof value.running !== "boolean" ||
     typeof value.projectedAtMs !== "number" ||
     !Number.isSafeInteger(value.projectedAtMs) ||
-    value.synchronization !== "synchronized"
+    (value.synchronization !== "synchronized" &&
+      value.synchronization !== "estimated" &&
+      value.synchronization !== "stale" &&
+      value.synchronization !== "unavailable")
   )
     return null;
-  return value as unknown as ClockProjection;
+  return {
+    ...(value as unknown as ClockProjection),
+    lastSynchronizedAtMs:
+      typeof value.lastSynchronizedAtMs === "number" ? value.lastSynchronizedAtMs : null,
+  };
 }
 
 function synchronized(): ControllerSynchronization {

--- a/src/pages/event-game-controller-page.test.tsx
+++ b/src/pages/event-game-controller-page.test.tsx
@@ -374,6 +374,7 @@ describe("Event Game Controller reconnect browser seam", () => {
     });
     expect(replayCalls).toBe(2);
     expect(container.textContent).not.toContain("retained for reconnect replay");
+    expect(container.textContent).toContain("Clock resynchronized.");
   });
 
   test("unmount and remount restores persisted work before foreground replay", async () => {
@@ -542,7 +543,7 @@ describe("Event Game Controller reconnect browser seam", () => {
     expect(replayCalls).toBe(2);
   });
 
-  test("online Clock submits directly while disconnected Clock taps stay out of the replica", async () => {
+  test("online Clock submits directly while disconnected holder Clock taps stay in the replica", async () => {
     await enterAndOpen();
     Object.defineProperty(testWindow.navigator, "onLine", { configurable: true, value: true });
     await act(async () => {
@@ -562,11 +563,40 @@ describe("Event Game Controller reconnect browser seam", () => {
       await Promise.resolve();
     });
     expect(intentCalls).toBe(1);
-    expect(container.textContent).toContain("unavailable while disconnected");
+    expect(container.textContent).toContain("Clock action retained for synchronization");
     const stored = JSON.parse(
       testWindow.localStorage.getItem(controllerReplicaStorageKey("game-browser")) ?? "null",
     ) as { pendingActions?: unknown[] };
-    expect(stored.pendingActions).toHaveLength(0);
+    expect(stored.pendingActions).toHaveLength(1);
+  });
+
+  test("admitted device performs a confirmed emergency takeover while disconnected", async () => {
+    replayMode = "lost";
+    await enterAndOpen();
+    Object.defineProperty(testWindow.navigator, "onLine", { configurable: true, value: false });
+    Object.defineProperty(testWindow, "confirm", {
+      configurable: true,
+      value: () => true,
+    });
+    const takeover = container.querySelector(
+      'button[data-clock-takeover="true"]',
+    ) as HTMLButtonElement;
+    expect(takeover).not.toBeNull();
+    await act(async () => {
+      takeover.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(container.textContent).toContain(
+      "Emergency clock takeover retained for synchronization",
+    );
+    const stored = JSON.parse(
+      testWindow.localStorage.getItem(controllerReplicaStorageKey("game-browser")) ?? "null",
+    ) as { pendingActions?: { intent?: { type?: string; confirmation?: string } }[] };
+    expect(stored.pendingActions?.[0]?.intent).toMatchObject({
+      type: "clock-takeover",
+      confirmation: "physical-timekeeper-or-head-referee",
+    });
   });
 
   test("quota warning is prominent while ordinary actions continue in memory", async () => {
@@ -694,12 +724,16 @@ describe("Event Game Controller reconnect browser seam", () => {
 });
 
 function projection(eventGameId = "game-browser"): ControllerProjection {
+  const baseline = createInitialClockBaseline();
+  baseline.holderGrantSessionId = "session";
+  baseline.holderGeneration = 1;
+  baseline.authorityGeneration = 1;
   return {
     eventGameId,
     phase: "scheduled",
     scoreByGameSide: { "side-a": 0, "side-b": 0 },
     goalCount: 0,
-    clock: projectClockBaseline(createInitialClockBaseline(), 0),
+    clock: projectClockBaseline(baseline, 0),
     commencement: {
       status: "provisional",
       commencedAtMs: null,

--- a/src/pages/event-game-controller-page.tsx
+++ b/src/pages/event-game-controller-page.tsx
@@ -20,6 +20,7 @@ import {
   acknowledgeControllerProjection,
   controllerReplicaStorageKey,
   createControllerReplica,
+  dispatchControllerClockAction,
   dispatchControllerAction,
   invalidateControllerReplica,
   loadControllerReplica,
@@ -88,6 +89,7 @@ export function EventGameControllerPage() {
   const [clockReceiptAnchor, setClockReceiptAnchor] = useState<ClockReceiptAnchor | null>(null);
   const [localMonotonicMs, setLocalMonotonicMs] = useState(readMonotonicNow);
   const [clockCorrectionInput, setClockCorrectionInput] = useState("");
+  const [takeoverAdjustmentInput, setTakeoverAdjustmentInput] = useState("");
   const [message, setMessage] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [persistedReplicaLoad] = useState<ControllerReplicaLoad>(() =>
@@ -99,6 +101,7 @@ export function EventGameControllerPage() {
   const installedReplayAuthorityRef = useRef<ReplayAuthority | null>(null);
   const activeReplayRef = useRef<ActiveReplay | null>(null);
   const queuedReplayRef = useRef<ReplayRequest | null>(null);
+  const resynchronizationTimerRef = useRef<number | null>(null);
   const [durabilityWarning, setDurabilityWarning] = useState<string | null>(
     persistedReplicaLoad.warning,
   );
@@ -106,7 +109,12 @@ export function EventGameControllerPage() {
 
   useEffect(() => {
     const timer = window.setInterval(() => setLocalMonotonicMs(readMonotonicNow()), 250);
-    return () => window.clearInterval(timer);
+    return () => {
+      window.clearInterval(timer);
+      if (resynchronizationTimerRef.current !== null) {
+        window.clearTimeout(resynchronizationTimerRef.current);
+      }
+    };
   }, []);
 
   const clockProjection =
@@ -116,6 +124,19 @@ export function EventGameControllerPage() {
           clockReceiptAnchor.projection,
           localMonotonicMs - clockReceiptAnchor.localMonotonicMs,
         );
+
+  function projectClockImmediately() {
+    const now = readMonotonicNow();
+    setLocalMonotonicMs(now);
+    setClockReceiptAnchor((anchor) =>
+      anchor === null
+        ? null
+        : {
+            projection: projectClockSample(anchor.projection, now - anchor.localMonotonicMs),
+            localMonotonicMs: now,
+          },
+    );
+  }
 
   useEffect(() => {
     if (sessionBearer === null || eventGameId === null) {
@@ -149,6 +170,7 @@ export function EventGameControllerPage() {
   useEffect(() => {
     const reconcileWhenForegrounded = () => {
       if (document.visibilityState === "hidden") return;
+      projectClockImmediately();
       void (async () => {
         const revalidated = await refreshController(true);
         if (revalidated && replicaRef.current !== null) {
@@ -213,7 +235,9 @@ export function EventGameControllerPage() {
       await flushReplica(nextReplica, response.session.sessionBearer);
     } catch {
       clearSession();
-      setMessage("Unable to open Controller experience.");
+      setMessage(
+        "Unable to open Controller experience. A fresh device cannot reconstruct Clock Authority during a server outage; use manual timing.",
+      );
     } finally {
       setBusy(false);
     }
@@ -221,6 +245,7 @@ export function EventGameControllerPage() {
 
   async function refreshController(silent = false): Promise<boolean> {
     if (sessionBearer === null || eventGameId === null) return false;
+    projectClockImmediately();
     if (!silent) setBusy(true);
     try {
       const response = await postJson<ControllerRefreshResponse>("/api/event-control/refresh", {
@@ -236,7 +261,7 @@ export function EventGameControllerPage() {
       if (response.status === "rejected") throw new Error("refresh failed");
       setSwitchTarget(null);
       setEventGameId(response.session.eventGameId);
-      receiveProjection(response.projection);
+      receiveProjection(response.projection, { resynchronized: true });
       const currentReplica = replicaRef.current;
       const refreshedSession = {
         eventGameId: response.session.eventGameId,
@@ -485,7 +510,24 @@ export function EventGameControllerPage() {
         setMessage("Reconnect is incomplete; retained actions will retry.");
     } catch {
       if (isInstalledReplayAuthority(request.authority)) {
-        setMessage("Connection lost. Pending Controller actions remain safely retained.");
+        const hasPendingClock = replicaRef.current?.pendingActions.some(
+          (action) =>
+            action.intent.type === "clock" ||
+            action.intent.type === "set-running" ||
+            action.intent.type === "clock-adjust" ||
+            action.intent.type === "clock-correction" ||
+            action.intent.type === "clock-takeover",
+        );
+        const hasPendingTakeover = replicaRef.current?.pendingActions.some(
+          (action) => action.intent.type === "clock-takeover",
+        );
+        setMessage(
+          hasPendingTakeover
+            ? "Emergency clock takeover retained for synchronization."
+            : hasPendingClock
+              ? "Clock action retained for synchronization."
+              : "Connection lost. Pending Controller actions remain safely retained.",
+        );
       }
     } finally {
       if (activeReplayRef.current?.requestToken === active.requestToken) {
@@ -549,7 +591,15 @@ export function EventGameControllerPage() {
     const currentEventGameId = eventGameId;
     if (bearer === null || currentEventGameId === null) return;
     if (navigator.onLine === false) {
-      setMessage("Clock control is unavailable while disconnected and was not retained.");
+      queueClockAuthorityIntent({
+        version: LIVE_EVENT_CONTROL_INTENT_VERSION,
+        type: "clock",
+        running: !clockRunning,
+        operationId: crypto.randomUUID(),
+        factId: crypto.randomUUID(),
+        gameTimeMs: clockProjection?.gameTimeMs ?? projection?.clock.gameTimeMs ?? 0,
+        occurrence: { clientOriginAtMs: Date.now(), source: "offline" },
+      });
       return;
     }
     void submitOnlineControllerIntent(
@@ -572,7 +622,15 @@ export function EventGameControllerPage() {
     const currentEventGameId = eventGameId;
     if (bearer === null || currentEventGameId === null) return;
     if (navigator.onLine === false) {
-      setMessage("Clock control is unavailable while disconnected and was not retained.");
+      queueClockAuthorityIntent({
+        version: LIVE_EVENT_CONTROL_INTENT_VERSION,
+        type: "clock-adjust",
+        adjustmentMs,
+        operationId: crypto.randomUUID(),
+        factId: crypto.randomUUID(),
+        gameTimeMs: clockProjection?.gameTimeMs ?? projection?.clock.gameTimeMs ?? 0,
+        occurrence: { clientOriginAtMs: Date.now(), source: "offline" },
+      });
       return;
     }
     void submitOnlineControllerIntent(
@@ -605,7 +663,15 @@ export function EventGameControllerPage() {
     const currentEventGameId = eventGameId;
     if (bearer === null || currentEventGameId === null) return;
     if (navigator.onLine === false) {
-      setMessage("Clock control is unavailable while disconnected and was not retained.");
+      queueClockAuthorityIntent({
+        version: LIVE_EVENT_CONTROL_INTENT_VERSION,
+        type: "clock-correction",
+        clockTimeMs: validated.value,
+        operationId: crypto.randomUUID(),
+        factId: crypto.randomUUID(),
+        gameTimeMs: clockProjection?.gameTimeMs ?? projection?.clock.gameTimeMs ?? 0,
+        occurrence: { clientOriginAtMs: Date.now(), source: "offline" },
+      });
       return;
     }
     void submitOnlineControllerIntent(
@@ -624,7 +690,85 @@ export function EventGameControllerPage() {
     setClockCorrectionInput("");
   }
 
-  function receiveProjection(nextProjection: ControllerProjection | null) {
+  function emergencyClockTakeover() {
+    const current = clockProjection ?? projection?.clock;
+    if (current === undefined || replicaRef.current === null) {
+      setMessage("Clock is unavailable; use manual timing until an admitted device reconnects.");
+      return;
+    }
+    if (!window.confirm("Confirm emergency clock takeover with the Timekeeper or Head Referee.")) {
+      return;
+    }
+    const parsedAdjustment =
+      takeoverAdjustmentInput.trim() === "" ? 0 : Number(takeoverAdjustmentInput);
+    const confirmationElapsedMs = current.running
+      ? Math.max(0, readMonotonicNow() - localMonotonicMs)
+      : 0;
+    const adjustment = validateGameClockMs(
+      current.gameTimeMs + confirmationElapsedMs + parsedAdjustment,
+    );
+    if (!adjustment.ok) {
+      setMessage(
+        "Takeover adjustment must keep the game clock between 0 and 7200000 milliseconds.",
+      );
+      return;
+    }
+    queueClockAuthorityIntent({
+      version: LIVE_EVENT_CONTROL_INTENT_VERSION,
+      type: "clock-takeover",
+      clockTimeMs: adjustment.value,
+      running: current.running,
+      authorityGeneration: current.baseline.authorityGeneration,
+      confirmation: "physical-timekeeper-or-head-referee",
+      operationId: crypto.randomUUID(),
+      factId: crypto.randomUUID(),
+      gameTimeMs: adjustment.value,
+      occurrence: {
+        clientOriginAtMs: Date.now(),
+        source: navigator.onLine === false ? "offline" : "online",
+      },
+    });
+    setTakeoverAdjustmentInput("");
+  }
+
+  function queueClockAuthorityIntent(intent: LiveEventControllerIntent) {
+    const current = replicaRef.current;
+    if (current === null) return;
+    try {
+      const dispatched = dispatchControllerClockAction(
+        current,
+        {
+          ...intent,
+          ...(intent.type === "clock" ||
+          intent.type === "set-running" ||
+          intent.type === "clock-adjust" ||
+          intent.type === "clock-correction"
+            ? { clockGeneration: current.projection.clock.baseline.authorityGeneration }
+            : {}),
+        },
+        { nowMs: Math.floor(readMonotonicNow()) },
+      );
+      commitReplica(dispatched.state);
+      receiveProjection(dispatched.state.projection);
+      setMessage(
+        intent.type === "clock-takeover"
+          ? "Emergency clock takeover retained for synchronization."
+          : "Clock action retained for synchronization.",
+      );
+      void flushReplica(dispatched.state);
+    } catch (error) {
+      setMessage(
+        error instanceof Error && error.message.includes("Offline Clock Holder")
+          ? "Only the Offline Clock Holder may control the disconnected clock."
+          : "Clock action could not be retained safely.",
+      );
+    }
+  }
+
+  function receiveProjection(
+    nextProjection: ControllerProjection | null,
+    options: { resynchronized?: boolean } = {},
+  ) {
     setProjection(nextProjection);
     setProjectionStatus(nextProjection === null ? "unavailable" : "available");
     setClockRunning(nextProjection?.clock.running ?? false);
@@ -633,6 +777,15 @@ export function EventGameControllerPage() {
         ? null
         : { projection: nextProjection.clock, localMonotonicMs: readMonotonicNow() },
     );
+    if (options.resynchronized) {
+      setMessage("Clock resynchronized.");
+      if (resynchronizationTimerRef.current !== null) {
+        window.clearTimeout(resynchronizationTimerRef.current);
+      }
+      resynchronizationTimerRef.current = window.setTimeout(() => {
+        setMessage((current) => (current === "Clock resynchronized." ? null : current));
+      }, 2_000);
+    }
   }
 
   async function submitOnlineControllerIntent(
@@ -762,10 +915,17 @@ export function EventGameControllerPage() {
               <div className="rounded-lg border bg-slate-950 p-4 text-center text-white">
                 <p className="text-xs uppercase tracking-[0.2em] text-slate-300">Game Clock</p>
                 <p className="mt-1 text-5xl font-semibold tabular-nums">
-                  {clockProjection === null ? "--:--" : formatClock(clockProjection.gameTimeMs)}
+                  {clockProjection === null || clockProjection.synchronization === "unavailable"
+                    ? "--:--"
+                    : formatClock(clockProjection.gameTimeMs)}
                 </p>
                 <p className="mt-1 text-xs text-slate-300">
                   {clockProjection?.running ? "Play" : "Paused"} · Controller projection
+                </p>
+                <p className="mt-2 text-xs text-slate-300" data-clock-freshness="true">
+                  {clockProjection === null
+                    ? "Unavailable · manual timing required"
+                    : `${clockProjection.synchronization} · last synchronization: ${formatSynchronizationTime(clockProjection.lastSynchronizedAtMs)}`}
                 </p>
               </div>
               {clockProjection === null ? null : (
@@ -832,6 +992,29 @@ export function EventGameControllerPage() {
                     Correct clock
                   </Button>
                 </div>
+                <div className="flex w-full flex-wrap items-end gap-2 rounded border border-amber-500/50 p-2 text-left">
+                  <div className="min-w-48 flex-1 space-y-1">
+                    <Label htmlFor="clock-takeover-adjustment">
+                      Emergency takeover adjustment (ms)
+                    </Label>
+                    <Input
+                      id="clock-takeover-adjustment"
+                      inputMode="numeric"
+                      value={takeoverAdjustmentInput}
+                      onChange={(event) => setTakeoverAdjustmentInput(event.target.value)}
+                      placeholder="optional, e.g. -1000"
+                      disabled={busy}
+                    />
+                  </div>
+                  <Button
+                    variant="outline"
+                    data-clock-takeover="true"
+                    onClick={emergencyClockTakeover}
+                    disabled={busy}
+                  >
+                    Emergency clock takeover
+                  </Button>
+                </div>
                 <Button variant="outline" onClick={() => trigger("card")} disabled={busy}>
                   Record card
                 </Button>
@@ -888,6 +1071,10 @@ function formatClock(milliseconds: number): string {
   const minutes = Math.floor(totalSeconds / 60);
   const seconds = totalSeconds % 60;
   return `${minutes.toString().padStart(2, "0")}:${seconds.toString().padStart(2, "0")}`;
+}
+
+function formatSynchronizationTime(milliseconds: number | null | undefined): string {
+  return typeof milliseconds !== "number" ? "not available" : new Date(milliseconds).toISOString();
 }
 
 function readMonotonicNow(): number {


### PR DESCRIPTION
## What changed

- preserve official disconnected Clock continuity exclusively for the established Offline Clock Holder
- add deliberate, physically confirmed emergency takeover for an already-admitted device, creating a new authority generation and Clock Baseline
- retain stale-generation evidence without allowing superseded actions to rewrite the current baseline
- project disconnected running clocks as estimated, paused clocks as stale, and untrustworthy clocks as unavailable with last-synchronization context
- restore local clock state immediately during foreground and reconnect, then visibly resynchronize to the authoritative baseline

## Why

Event connectivity and individual Controller phones can fail during play. Officials need honest local continuity and a simple recovery path without allowing an arbitrary disconnected device or wall-clock jump to establish sporting authority.

## Impact

The current Clock Holder can continue timing through an outage. Another admitted Controller can take over only through explicit confirmation, while fresh devices fail closed and direct officials to manual timing. Ordinary non-clock reconnect behavior remains unchanged.

## Validation

- `bun run check`
- `bun run test` — 507 passed after rebasing onto current `main`
- `bun run build`
- `git diff --check`
- focused Clock Authority, Controller reconnect, live control, and browser suites — 69 passed

Closes #88
