### PR TITLE
Hand one Pitch to a Pitch Manager

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "test:focused:acceptance": "bun test --isolate ./src/lib/foundation-acceptance-sqlite.focused.ts",
     "test:focused:grant": "bun test ./src/lib/grant-authority.focused.ts",
     "test:focused:event-catalog": "bun test --isolate ./src/lib/event-catalog.focused.ts",
+    "test:focused:pitch-manager": "bun test --isolate ./src/lib/pitch-manager-administration-sqlite.focused.ts",
     "test:focused:event-catalog-cli": "bun test --isolate ./scripts/event-catalog-cli.focused.ts",
     "test:focused:grant-code": "bun test --isolate ./src/lib/grant-code.focused.ts",
     "test:focused:ad-hoc": "bun test --isolate ./src/lib/ad-hoc-games.focused.ts",

--- a/scripts/test-technical-admin-browser.ts
+++ b/scripts/test-technical-admin-browser.ts
@@ -3,6 +3,8 @@ import { chromium, type Page } from "playwright";
 import { mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { openSqliteFoundationStorage } from "@/lib/foundation-storage-sqlite";
+import { readGrantAuthorityOptions } from "@/lib/grant-runtime";
 
 const directory = mkdtempSync(join(tmpdir(), "quadball-timer-admin-browser-"));
 const certificatePath = join(directory, "localhost.crt");
@@ -17,6 +19,7 @@ const environment = {
   PUBLIC_ORIGIN: origin,
   WEBAUTHN_RP_ID: "localhost",
   TECHNICAL_ADMIN_DATABASE: databasePath,
+  FOUNDATION_DATABASE: join(directory, "foundation.sqlite"),
   TLS_CERT_FILE: certificatePath,
   TLS_KEY_FILE: keyPath,
   PORT: String(port),
@@ -48,6 +51,13 @@ try {
   ]);
   if (certificate.exitCode !== 0)
     throw new Error("openssl could not create a temporary certificate.");
+
+  const grantOptions = readGrantAuthorityOptions("test", environment);
+  const foundation = openSqliteFoundationStorage(join(directory, "foundation.sqlite"), {
+    grantKeyRing: grantOptions.keyRing,
+  });
+  await foundation.applyMigrations();
+  foundation.close();
 
   server = Bun.spawn(["bun", "run", "src/index.ts"], {
     cwd: process.cwd(),
@@ -244,7 +254,7 @@ try {
   );
   await page.getByRole("button", { name: "Open Event Hub" }).click();
   await page.getByText("Event Hub", { exact: true }).waitFor();
-  await page.getByLabel("Game Day").selectOption({ index: 1 });
+  await page.getByLabel("Game Day", { exact: true }).selectOption({ index: 1 });
   const eventAdminContext = await browser.newContext({ ignoreHTTPSErrors: true });
   const eventAdminPage = await eventAdminContext.newPage();
   eventAdminPage.setDefaultTimeout(5_000);
@@ -252,7 +262,7 @@ try {
   await eventAdminPage.getByLabel("Scanned Event Admin QR value").fill(revealedCredential);
   await eventAdminPage.getByRole("button", { name: "Admit Event Admin" }).click();
   await eventAdminPage.getByText(/event-admin/u).waitFor();
-  const eventAdminGameDaySelector = eventAdminPage.getByLabel("Game Day");
+  const eventAdminGameDaySelector = eventAdminPage.getByLabel("Game Day", { exact: true });
   await eventAdminGameDaySelector.selectOption({ index: 1 });
   const firstSelectedGameDay = await expectSelectValue(eventAdminGameDaySelector, 1);
   await eventAdminGameDaySelector.selectOption({ index: 2 });
@@ -387,6 +397,230 @@ try {
     .getByText(/Slot 1/)
     .last()
     .waitFor();
+  await eventAdminPage.getByLabel("Pitch Manager Game Day").selectOption({ index: 2 });
+  await eventAdminPage.getByLabel("Pitch Manager Pitch").selectOption({ label: "Pitch Main" });
+  const pitchManagerCreateResponsePromise = eventAdminPage.waitForResponse(
+    (response) =>
+      response.url().includes("/pitch-manager-grant") && response.request().method() === "POST",
+  );
+  await eventAdminPage.getByRole("button", { name: "Create Grant" }).last().click();
+  const pitchManagerCreateResponse = await pitchManagerCreateResponsePromise;
+  assert(pitchManagerCreateResponse.status() === 201, "Pitch Manager Grant creation failed");
+  assertCappedEventAdminCookie(
+    (await pitchManagerCreateResponse.headersArray()).find((header) => header.name === "set-cookie")
+      ?.value,
+  );
+  const duplicatePitchManagerGrant = await eventAdminContext.request.post(
+    `${origin}/api/event-admin/events/${eventId}/game-days/${await eventAdminPage.getByLabel("Pitch Manager Game Day").inputValue()}/pitches/${await eventAdminPage.getByLabel("Pitch Manager Pitch").inputValue()}/pitch-manager-grant`,
+  );
+  assert(
+    duplicatePitchManagerGrant.status() === 400 &&
+      duplicatePitchManagerGrant.headers()["cache-control"] === "no-store" &&
+      duplicatePitchManagerGrant.headers()["referrer-policy"] === "no-referrer" &&
+      duplicatePitchManagerGrant.headers()["set-cookie"] === undefined,
+    "invalid duplicate Pitch Manager Grant response was not generic and uncached",
+  );
+  await eventAdminPage.getByText(/active.*expires/u).waitFor();
+  const pitchManagerRevealResponsePromise = eventAdminPage.waitForResponse(
+    (response) =>
+      response.url().includes("/pitch-manager-grant/reveal") &&
+      response.request().method() === "POST",
+  );
+  await eventAdminPage.getByRole("button", { name: "Reveal QR" }).click();
+  const pitchManagerRevealResponse = await pitchManagerRevealResponsePromise;
+  assertCappedEventAdminCookie(
+    (await pitchManagerRevealResponse.headersArray()).find((header) => header.name === "set-cookie")
+      ?.value,
+  );
+  const pitchManagerRevealPayload = (await pitchManagerRevealResponse.json()) as {
+    status: string;
+    value?: { qrCredential?: string };
+  };
+  const pitchManagerCredential = pitchManagerRevealPayload.value?.qrCredential ?? "";
+  assert(
+    pitchManagerRevealResponse.status() === 200 && pitchManagerCredential.length > 0,
+    "Pitch Manager QR reveal failed",
+  );
+  const pitchManagerContext = await browser.newContext({
+    ignoreHTTPSErrors: true,
+    timezoneId: "UTC",
+  });
+  const pitchManagerPage = await pitchManagerContext.newPage();
+  pitchManagerPage.setDefaultTimeout(5_000);
+  browserPage = pitchManagerPage;
+  await pitchManagerPage.goto(`${origin}/pitch-manager`);
+  const wrongPitchManagerAdmission = await postJsonFromPage(
+    pitchManagerPage,
+    `${origin}/api/pitch-manager/admit`,
+    { qrCredential: revealedCredential },
+  );
+  assert(
+    wrongPitchManagerAdmission.status === 401 &&
+      wrongPitchManagerAdmission.cacheControl === "no-store" &&
+      wrongPitchManagerAdmission.referrerPolicy === "no-referrer" &&
+      wrongPitchManagerAdmission.setCookie === null,
+    "wrong Grant type was admitted or disclosed by Pitch Manager admission",
+  );
+  const eventAdminSessionBeforeWrongType = (await eventAdminContext.cookies()).find(
+    (cookie) => cookie.name === "__Host-event-admin-session",
+  );
+  const wrongEventAdminAdmission = await postJsonFromPage(
+    eventAdminPage,
+    `${origin}/api/event-admin/admit`,
+    { qrCredential: pitchManagerCredential },
+  );
+  const eventAdminSessionAfterWrongType = (await eventAdminContext.cookies()).find(
+    (cookie) => cookie.name === "__Host-event-admin-session",
+  );
+  assert(
+    wrongEventAdminAdmission.status === 401 &&
+      wrongEventAdminAdmission.cacheControl === "no-store" &&
+      wrongEventAdminAdmission.referrerPolicy === "no-referrer" &&
+      wrongEventAdminAdmission.setCookie === null &&
+      eventAdminSessionBeforeWrongType?.value === eventAdminSessionAfterWrongType?.value,
+    "wrong Grant type was admitted or disclosed by Event Admin admission",
+  );
+  await pitchManagerPage.getByLabel("Scanned Pitch Manager QR value").fill(pitchManagerCredential);
+  await pitchManagerPage.getByRole("button", { name: "Open Pitch" }).click();
+  await pitchManagerPage.getByText("Pitch Main", { exact: true }).waitFor();
+  await pitchManagerPage.getByText(/Pitch Manager.*Game Day/u).waitFor();
+  await pitchManagerPage.getByText(/2026-08-15 10:00 Europe\/Zurich/u).waitFor();
+  await pitchManagerPage
+    .getByText(/Control Grant:/u)
+    .first()
+    .waitFor();
+  await pitchManagerPage.reload();
+  await pitchManagerPage.getByText("Pitch Main", { exact: true }).waitFor();
+  await pitchManagerPage.getByText(/2026-08-15 10:00 Europe\/Zurich/u).waitFor();
+  await restartServerProcess(origin, environment);
+  const currentAfterRestart = await fetchFromPage(
+    pitchManagerPage,
+    `${origin}/api/pitch-manager/current`,
+  );
+  assert(
+    currentAfterRestart.status === 200,
+    `Pitch Manager current projection failed after restart (${currentAfterRestart.status})`,
+  );
+  await pitchManagerPage.reload();
+  await pitchManagerPage.getByText("Pitch Main", { exact: true }).waitFor();
+  await pitchManagerPage.getByText(/2026-08-15 10:00 Europe\/Zurich/u).waitFor();
+  const pitchManagerInspectBeforeRotation = await eventAdminContext.request.get(
+    `${origin}/api/event-admin/events/${eventId}/game-days/${await eventAdminPage.getByLabel("Pitch Manager Game Day").inputValue()}/pitches/${await eventAdminPage.getByLabel("Pitch Manager Pitch").inputValue()}/pitch-manager-grant`,
+  );
+  const pitchManagerInspectBeforeRotationPayload =
+    (await pitchManagerInspectBeforeRotation.json()) as {
+      status: string;
+      value?: { grantVersion?: string };
+    };
+  const originalPitchManagerVersion =
+    pitchManagerInspectBeforeRotationPayload.value?.grantVersion ?? "";
+  assert(originalPitchManagerVersion.length > 0, "Pitch Manager Grant version was not inspectable");
+  const pitchManagerRotateResponsePromise = eventAdminPage.waitForResponse(
+    (response) =>
+      response.url().includes("/pitch-manager-grant/rotate") &&
+      response.request().method() === "POST",
+  );
+  await eventAdminPage.getByRole("button", { name: "Rotate Pitch Manager Grant" }).click();
+  assert(
+    (await pitchManagerRotateResponsePromise).status() === 200,
+    "Pitch Manager Grant rotation failed",
+  );
+  const rotatedPitchManagerInspect = await eventAdminContext.request.get(
+    `${origin}/api/event-admin/events/${eventId}/game-days/${await eventAdminPage.getByLabel("Pitch Manager Game Day").inputValue()}/pitches/${await eventAdminPage.getByLabel("Pitch Manager Pitch").inputValue()}/pitch-manager-grant`,
+  );
+  const rotatedPitchManagerPayload = (await rotatedPitchManagerInspect.json()) as {
+    status: string;
+    value?: { grantVersion?: string };
+  };
+  const rotatedPitchManagerVersion = rotatedPitchManagerPayload.value?.grantVersion ?? "";
+  assert(
+    rotatedPitchManagerVersion.length > 0 &&
+      rotatedPitchManagerVersion !== originalPitchManagerVersion,
+    "Pitch Manager rotation did not create a new Grant version",
+  );
+  const stalePitchManagerAfterRotation = await fetchFromPage(
+    pitchManagerPage,
+    `${origin}/api/pitch-manager/current`,
+  );
+  assert(
+    stalePitchManagerAfterRotation.status === 401,
+    "rotated Pitch Manager session remained live",
+  );
+  const pitchManagerDisableResponsePromise = eventAdminPage.waitForResponse(
+    (response) =>
+      response.url().includes("/pitch-manager-grant/disable") &&
+      response.request().method() === "POST",
+  );
+  await eventAdminPage.getByRole("button", { name: "Disable Pitch Manager Grant" }).click();
+  assert(
+    (await pitchManagerDisableResponsePromise).status() === 200,
+    "Pitch Manager Grant disable failed",
+  );
+  const pitchManagerReactivateResponsePromise = eventAdminPage.waitForResponse(
+    (response) =>
+      response.url().includes("/pitch-manager-grant/reactivate") &&
+      response.request().method() === "POST",
+  );
+  await eventAdminPage.getByRole("button", { name: "Reactivate Pitch Manager Grant" }).click();
+  assert(
+    (await pitchManagerReactivateResponsePromise).status() === 200,
+    "Pitch Manager Grant reactivation failed",
+  );
+  const reactivatedPitchManagerInspect = await eventAdminContext.request.get(
+    `${origin}/api/event-admin/events/${eventId}/game-days/${await eventAdminPage.getByLabel("Pitch Manager Game Day").inputValue()}/pitches/${await eventAdminPage.getByLabel("Pitch Manager Pitch").inputValue()}/pitch-manager-grant`,
+  );
+  const reactivatedPitchManagerPayload = (await reactivatedPitchManagerInspect.json()) as {
+    status: string;
+    value?: { grantVersion?: string };
+  };
+  const reactivatedPitchManagerVersion = reactivatedPitchManagerPayload.value?.grantVersion ?? "";
+  assert(
+    reactivatedPitchManagerVersion.length > 0 &&
+      reactivatedPitchManagerVersion !== rotatedPitchManagerVersion,
+    "Pitch Manager reactivation did not create a new Grant version",
+  );
+  const reactivatedPitchManagerRevealResponsePromise = eventAdminPage.waitForResponse(
+    (response) =>
+      response.url().includes("/pitch-manager-grant/reveal") &&
+      response.request().method() === "POST",
+  );
+  await eventAdminPage.getByRole("button", { name: "Reveal QR" }).click();
+  const reactivatedPitchManagerReveal = await reactivatedPitchManagerRevealResponsePromise;
+  const reactivatedPitchManagerRevealPayload = (await reactivatedPitchManagerReveal.json()) as {
+    status: string;
+    value?: { qrCredential?: string };
+  };
+  const reactivatedPitchManagerCredential =
+    reactivatedPitchManagerRevealPayload.value?.qrCredential ?? "";
+  assert(
+    reactivatedPitchManagerReveal.status() === 200 &&
+      reactivatedPitchManagerCredential.length > 0 &&
+      reactivatedPitchManagerCredential !== pitchManagerCredential,
+    "Pitch Manager reactivation did not reveal a new QR credential",
+  );
+  const reactivatedPitchManagerAdmission = await postJsonFromPage(
+    pitchManagerPage,
+    `${origin}/api/pitch-manager/admit`,
+    { qrCredential: reactivatedPitchManagerCredential },
+  );
+  assert(
+    reactivatedPitchManagerAdmission.status === 200 &&
+      reactivatedPitchManagerAdmission.cacheControl === "no-store" &&
+      reactivatedPitchManagerAdmission.referrerPolicy === "no-referrer",
+    "Pitch Manager reactivation did not admit a new session",
+  );
+  const reactivatedPitchManagerCurrent = await fetchFromPage(
+    pitchManagerPage,
+    `${origin}/api/pitch-manager/current`,
+  );
+  assert(
+    reactivatedPitchManagerCurrent.status === 200,
+    "reactivated Pitch Manager session was not live",
+  );
+  assert(
+    reactivatedPitchManagerCurrent.cacheControl === "no-store",
+    "reactivated Pitch Manager projection was cacheable",
+  );
   const sessionCookieBeforeRefresh = (await eventAdminContext.cookies()).find(
     (cookie) => cookie.name === "__Host-event-admin-session",
   );
@@ -472,6 +706,7 @@ try {
     revokedFreshSession.status === 401,
     "explicitly revoked live Event Admin session remained live",
   );
+  await pitchManagerContext.close();
   await eventAdminContext.close();
   await revokedEventAdminContext.close();
   const removeButtons = page.getByRole("button", { name: "Remove", exact: true });
@@ -537,6 +772,8 @@ try {
       qrRender: true,
       eventHubDelegation: true,
       eventAdminRotationRevocationIsolation: true,
+      pitchManagerHandoff: true,
+      pitchManagerScopedView: true,
       forgedAuthorityRejected: true,
       revocationRevalidated: true,
     }),
@@ -579,6 +816,22 @@ async function waitForServer(url: string) {
   throw new Error("Technical Admin browser server did not become ready.");
 }
 
+async function restartServerProcess(serverOrigin: string, serverEnvironment: NodeJS.ProcessEnv) {
+  if (server !== null) {
+    server.kill();
+    await server.exited;
+    await Bun.sleep(250);
+  }
+  server = Bun.spawn(["bun", "run", "src/index.ts"], {
+    cwd: process.cwd(),
+    env: serverEnvironment,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  serverStderr = new Response(server.stderr as unknown as BodyInit).text();
+  await waitForServer(`${serverOrigin}/internal/healthz`);
+}
+
 function assert(condition: boolean, message: string): asserts condition {
   if (!condition) throw new Error(message);
 }
@@ -601,6 +854,25 @@ async function fetchFromPage(page: Page, url: string) {
   }, url);
 }
 
+async function postJsonFromPage(page: Page, url: string, body: Record<string, string>) {
+  return page.evaluate(
+    async ({ requestUrl, requestBody }) => {
+      const response = await fetch(requestUrl, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(requestBody),
+      });
+      return {
+        status: response.status,
+        cacheControl: response.headers.get("cache-control"),
+        referrerPolicy: response.headers.get("referrer-policy"),
+        setCookie: response.headers.get("set-cookie"),
+      };
+    },
+    { requestUrl: url, requestBody: body },
+  );
+}
+
 function redactBrowserUrl(value: string) {
   try {
     const url = new URL(value);
@@ -613,4 +885,13 @@ function redactBrowserUrl(value: string) {
 
 function redactDiagnosticText(value: string) {
   return value.replace(/(https?:\/\/[^\s"'<>#]+)#\S+/giu, "$1");
+}
+
+function assertCappedEventAdminCookie(setCookie: string | undefined) {
+  const match = setCookie?.match(/__Host-event-admin-session=[^;]+;[^\n]*Max-Age=(\d+)/u);
+  const maxAge = match?.[1] === undefined ? null : Number(match[1]);
+  assert(
+    maxAge !== null && maxAge > 0 && maxAge < 2_592_000,
+    `Event Admin session cap was reset (maxAge=${maxAge ?? "missing"})`,
+  );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { DEFAULT_AWAY_TEAM_COLOR, DEFAULT_HOME_TEAM_COLOR } from "@/lib/team-col
 import { ColorTestPage } from "@/pages/color-test-page";
 import { EventOperationsPrototypePage } from "@/pages/event-operations-prototype-page";
 import { EventAdminPage } from "@/pages/event-admin-page";
+import { PitchManagerPage } from "@/pages/pitch-manager-page";
 import { EventGameControllerPage } from "@/pages/event-game-controller-page";
 import { GamePage } from "@/pages/game-page";
 import { TechnicalAdminPage } from "@/pages/technical-admin-page";
@@ -25,6 +26,9 @@ type Route =
     }
   | {
       type: "event-admin";
+    }
+  | {
+      type: "pitch-manager";
     }
   | {
       type: "event-game-controller";
@@ -56,6 +60,10 @@ export function App() {
 
   if (route.type === "event-admin") {
     return <EventAdminPage />;
+  }
+
+  if (route.type === "pitch-manager") {
+    return <PitchManagerPage />;
   }
 
   if (route.type === "event-game-controller") {
@@ -227,6 +235,9 @@ export function parseRoute(pathname: string, _search: string): Route {
 
   if (pathname === "/event-admin" || pathname === "/event-admin/") {
     return { type: "event-admin" };
+  }
+  if (pathname === "/pitch-manager" || pathname === "/pitch-manager/") {
+    return { type: "pitch-manager" };
   }
 
   if (pathname === "/event-control" || pathname === "/event-control/") {

--- a/src/index-event-admin-headers.focused.ts
+++ b/src/index-event-admin-headers.focused.ts
@@ -23,6 +23,63 @@ describe("Event Hub early response headers", () => {
   });
 });
 
+describe("Pitch Manager early response headers", () => {
+  test("keeps malformed, missing-credential, and missing-session failures sensitive", async () => {
+    await withServer({}, async (serverUrl) => {
+      const malformed = await fetch(new URL("/api/pitch-manager/admit", serverUrl), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{",
+      });
+      await expectSensitiveFailure(malformed, 400, { error: "Unable to admit this Grant." });
+
+      const missingCredential = await fetch(new URL("/api/pitch-manager/admit", serverUrl), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({}),
+      });
+      await expectSensitiveFailure(missingCredential, 400, {
+        error: "Unable to admit this Grant.",
+      });
+
+      const missingBody = await fetch(new URL("/api/pitch-manager/admit", serverUrl), {
+        method: "POST",
+      });
+      await expectSensitiveFailure(missingBody, 400, { error: "Unable to admit this Grant." });
+
+      const missingSessionLeave = await fetch(new URL("/api/pitch-manager/leave", serverUrl), {
+        method: "POST",
+      });
+      await expectSensitiveFailure(missingSessionLeave, 401, { error: "Authentication failed." });
+    });
+
+    await withServer({ incompleteGrantKeys: true }, async (serverUrl) => {
+      const unavailableAdmit = await fetch(new URL("/api/pitch-manager/admit", serverUrl), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ qrCredential: "opaque" }),
+      });
+      await expectSensitiveFailure(unavailableAdmit, 503, { error: "Authentication failed." });
+
+      const unavailableLeave = await fetch(new URL("/api/pitch-manager/leave", serverUrl), {
+        method: "POST",
+      });
+      await expectSensitiveFailure(unavailableLeave, 503, { error: "Authentication failed." });
+    });
+  });
+});
+
+async function expectSensitiveFailure(
+  response: Response,
+  status: number,
+  body: Record<string, string>,
+) {
+  expect(response.status).toBe(status);
+  expect(response.headers.get("cache-control")).toBe("no-store");
+  expect(response.headers.get("referrer-policy")).toBe("no-referrer");
+  expect(await response.json()).toEqual(body);
+}
+
 async function withServer(
   options: { incompleteGrantKeys?: boolean },
   work: (serverUrl: URL) => Promise<void>,

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,7 @@ import {
 } from "@/lib/event-administration";
 import { createGrantAuthority } from "@/lib/grant-authority";
 import { readGrantAuthorityOptions } from "@/lib/grant-runtime";
+import type { TypedGrantMutation, TypedGrantReveal } from "@/lib/grant-management";
 import { createInMemoryFoundationStorage } from "@/lib/foundation-storage-memory";
 import { openSqliteFoundationStorage } from "@/lib/foundation-storage-sqlite";
 import type { FoundationStorage } from "@/lib/foundation-storage";
@@ -137,6 +138,12 @@ async function startServer() {
           : openSqliteAdHocStore(adHocDatabasePath),
     });
     startupCleanup.add(() => adHocService.close());
+    let runtimeGrantOptions: ReturnType<typeof readGrantAuthorityOptions> | null = null;
+    try {
+      runtimeGrantOptions = readGrantAuthorityOptions(environment);
+    } catch {
+      // Grant configuration remains an Event Administration dependency.
+    }
     const databasePath = storagePaths.technicalAdminDatabase;
     technicalAdminRepository = createSqliteTechnicalAdminAuthRepository(databasePath, {
       environment: technicalAdminConfig.environment,
@@ -159,7 +166,9 @@ async function startServer() {
       candidateFoundation =
         environment === "test" && !process.env.FOUNDATION_DATABASE?.trim()
           ? createInMemoryFoundationStorage()
-          : openSqliteFoundationStorage(foundationDatabasePath);
+          : openSqliteFoundationStorage(foundationDatabasePath, {
+              grantKeyRing: runtimeGrantOptions?.keyRing,
+            });
       const readiness = await candidateFoundation.readiness();
       if (readiness.ok) {
         const readyFoundation = candidateFoundation;
@@ -192,7 +201,7 @@ async function startServer() {
       try {
         const grantAuthority = createGrantAuthority(
           foundationStorage,
-          readGrantAuthorityOptions(environment),
+          runtimeGrantOptions ?? readGrantAuthorityOptions(environment),
         );
         eventAdministration = createEventAdministration({
           storage: foundationStorage,
@@ -239,6 +248,59 @@ async function startServer() {
         const eventId = new URL(req.url).pathname.split("/").at(-3) ?? "";
         return eventAdministrationResponse(await eventAdministration[operation](eventId, token));
       };
+    const pitchManagerGrantMutation = async (
+      req: Request,
+      operation:
+        | "revealPitchManagerGrant"
+        | "rotatePitchManagerGrant"
+        | "disablePitchManagerGrant"
+        | "revokePitchManagerGrant"
+        | "reactivatePitchManagerGrant",
+    ) => {
+      if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
+      const authority = resolveEventAdministrationAuthority(req, technicalAdminAuth);
+      const path = new URL(req.url).pathname.split("/");
+      if (authority === null) return sensitiveGenericAuthFailure(401);
+      const result =
+        operation === "revealPitchManagerGrant"
+          ? await eventAdministration.revealPitchManagerGrant(
+              path[4] ?? "",
+              path[6] ?? "",
+              path[8] ?? "",
+              authority,
+            )
+          : operation === "rotatePitchManagerGrant"
+            ? await eventAdministration.rotatePitchManagerGrant(
+                path[4] ?? "",
+                path[6] ?? "",
+                path[8] ?? "",
+                authority,
+              )
+            : operation === "disablePitchManagerGrant"
+              ? await eventAdministration.disablePitchManagerGrant(
+                  path[4] ?? "",
+                  path[6] ?? "",
+                  path[8] ?? "",
+                  authority,
+                )
+              : operation === "revokePitchManagerGrant"
+                ? await eventAdministration.revokePitchManagerGrant(
+                    path[4] ?? "",
+                    path[6] ?? "",
+                    path[8] ?? "",
+                    authority,
+                  )
+                : await eventAdministration.reactivatePitchManagerGrant(
+                    path[4] ?? "",
+                    path[6] ?? "",
+                    path[8] ?? "",
+                    authority,
+                  );
+      return sensitiveEventAdministrationMutationResponse<TypedGrantMutation | TypedGrantReveal>(
+        result,
+        authority,
+      );
+    };
     const tls =
       process.env.TLS_CERT_FILE && process.env.TLS_KEY_FILE
         ? { cert: Bun.file(process.env.TLS_CERT_FILE), key: Bun.file(process.env.TLS_KEY_FILE) }
@@ -744,6 +806,134 @@ async function startServer() {
             );
           },
         },
+        "/api/event-admin/events/:eventId/game-days/:gameDayId/pitches/:pitchId/pitch-manager-grant":
+          {
+            async GET(req: Request) {
+              if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
+              const authority = resolveEventAdministrationAuthority(req, technicalAdminAuth);
+              const path = new URL(req.url).pathname.split("/");
+              if (authority === null) return sensitiveGenericAuthFailure(401);
+              return sensitiveEventAdministrationResponse(
+                await eventAdministration.inspectPitchManagerGrant(
+                  path.at(-6) ?? "",
+                  path.at(-4) ?? "",
+                  path.at(-2) ?? "",
+                  authority,
+                ),
+              );
+            },
+            async POST(req: Request) {
+              if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
+              const authority = resolveEventAdministrationAuthority(req, technicalAdminAuth);
+              const path = new URL(req.url).pathname.split("/");
+              if (authority === null) return sensitiveGenericAuthFailure(401);
+              return sensitiveEventAdministrationMutationResponse(
+                await eventAdministration.createPitchManagerGrant(
+                  path.at(-6) ?? "",
+                  path.at(-4) ?? "",
+                  path.at(-2) ?? "",
+                  authority,
+                ),
+                authority,
+                201,
+              );
+            },
+          },
+        "/api/event-admin/events/:eventId/game-days/:gameDayId/pitches/:pitchId/pitch-manager-grant/reveal":
+          {
+            POST: (req: Request) => pitchManagerGrantMutation(req, "revealPitchManagerGrant"),
+          },
+        "/api/event-admin/events/:eventId/game-days/:gameDayId/pitches/:pitchId/pitch-manager-grant/rotate":
+          {
+            POST: (req: Request) => pitchManagerGrantMutation(req, "rotatePitchManagerGrant"),
+          },
+        "/api/event-admin/events/:eventId/game-days/:gameDayId/pitches/:pitchId/pitch-manager-grant/disable":
+          {
+            POST: (req: Request) => pitchManagerGrantMutation(req, "disablePitchManagerGrant"),
+          },
+        "/api/event-admin/events/:eventId/game-days/:gameDayId/pitches/:pitchId/pitch-manager-grant/revoke":
+          {
+            POST: (req: Request) => pitchManagerGrantMutation(req, "revokePitchManagerGrant"),
+          },
+        "/api/event-admin/events/:eventId/game-days/:gameDayId/pitches/:pitchId/pitch-manager-grant/reactivate":
+          {
+            POST: (req: Request) => pitchManagerGrantMutation(req, "reactivatePitchManagerGrant"),
+          },
+        "/api/pitch-manager/admit": {
+          async POST(req: Request) {
+            if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
+            const body = await readJsonRecord(req);
+            if (body === null || typeof body.qrCredential !== "string")
+              return sensitiveJson({ error: "Unable to admit this Grant." }, 400);
+            const context =
+              readPitchManagerContext(req.headers.get("cookie")) ?? crypto.randomUUID();
+            const result = await eventAdministration.admitPitchManager({
+              qrCredential: body.qrCredential,
+              browserContext: context,
+              deviceClass: body.deviceClass,
+              browserClass: body.browserClass,
+            });
+            if (result.status !== "admitted") return sensitiveJson(result, 401);
+            return sensitiveJson(
+              {
+                status: "admitted",
+                grantId: result.grantId,
+                grantVersion: result.grantVersion,
+                grantType: result.grantType,
+                scope: result.scope,
+                grantSessionId: result.grantSessionId,
+                sessionExpiresAtMs: result.sessionExpiresAtMs ?? null,
+              },
+              200,
+              [
+                ["set-cookie", pitchManagerContextCookie(context)],
+                [
+                  "set-cookie",
+                  pitchManagerSessionCookie(result.sessionBearer, result.sessionExpiresAtMs),
+                ],
+              ],
+            );
+          },
+        },
+        "/api/pitch-manager/view": {
+          async GET(req: Request) {
+            if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
+            const url = new URL(req.url);
+            const authority = resolvePitchManagerAuthority(req, technicalAdminAuth);
+            if (authority === null) return sensitiveGenericAuthFailure(401);
+            return sensitiveEventAdministrationResponse(
+              await eventAdministration.openPitchManagerView({
+                eventId: url.searchParams.get("eventId") ?? "",
+                gameDayId: url.searchParams.get("gameDayId") ?? "",
+                pitchId: url.searchParams.get("pitchId") ?? "",
+                authority,
+              }),
+            );
+          },
+        },
+        "/api/pitch-manager/current": {
+          async GET(req: Request) {
+            if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
+            const sessionBearer = readPitchManagerSession(req.headers.get("cookie"));
+            if (sessionBearer === null) return sensitiveGenericAuthFailure(401);
+            return sensitiveEventAdministrationResponse(
+              await eventAdministration.openPitchManagerCurrentView({
+                authority: { kind: "grant-session", sessionBearer },
+              }),
+            );
+          },
+        },
+        "/api/pitch-manager/leave": {
+          async POST(req: Request) {
+            if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
+            const sessionBearer = readPitchManagerSession(req.headers.get("cookie"));
+            if (sessionBearer === null) return sensitiveGenericAuthFailure(401);
+            const result = await eventAdministration.leavePitchManagerSession(sessionBearer);
+            return sensitiveJson(result, result.status === "updated" ? 200 : 401, [
+              ["set-cookie", clearPitchManagerSessionCookie()],
+            ]);
+          },
+        },
         "/api/event-admin/hub": {
           async GET(req: Request) {
             if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
@@ -1011,6 +1201,7 @@ async function startServer() {
         "/color-test": index,
         "/prototype/event-operations": index,
         "/event-admin": index,
+        "/pitch-manager": index,
         "/event-control": index,
         "/*": adHocFallbackRoute,
       },
@@ -1572,12 +1763,32 @@ function resolveEventAdministrationAuthority(
   return sessionBearer === null ? null : { kind: "grant-session", sessionBearer };
 }
 
+function resolvePitchManagerAuthority(
+  req: Request,
+  technicalAdminAuth: ReturnType<typeof createTechnicalAdminAuth>,
+): EventAdministrationAuthority | null {
+  const technicalToken = readTechnicalAdminCookie(req.headers.get("cookie"));
+  const technical =
+    technicalToken === null ? null : technicalAdminAuth.resolveCurrentAuthority(technicalToken);
+  if (technical !== null) return technical;
+  const sessionBearer = readPitchManagerSession(req.headers.get("cookie"));
+  return sessionBearer === null ? null : { kind: "grant-session", sessionBearer };
+}
+
 function readEventAdminContext(header: string | null): string | null {
   return readCookieValue(header, "__Host-event-admin-context");
 }
 
 function readEventAdminSession(header: string | null): string | null {
   return readCookieValue(header, "__Host-event-admin-session");
+}
+
+function readPitchManagerContext(header: string | null): string | null {
+  return readCookieValue(header, "__Host-pitch-manager-context");
+}
+
+function readPitchManagerSession(header: string | null): string | null {
+  return readCookieValue(header, "__Host-pitch-manager-session");
 }
 
 function readCookieValue(header: string | null, cookieName: string): string | null {
@@ -1601,8 +1812,24 @@ function eventAdminSessionCookie(value: string, expiresAtMs: number | null | und
   return `__Host-event-admin-session=${encodeURIComponent(value)}; Path=/; Max-Age=${maxAgeSeconds}; HttpOnly; Secure; SameSite=Strict`;
 }
 
+function pitchManagerContextCookie(value: string): string {
+  return `__Host-pitch-manager-context=${encodeURIComponent(value)}; Path=/; HttpOnly; Secure; SameSite=Strict`;
+}
+
+function pitchManagerSessionCookie(value: string, expiresAtMs: number | null | undefined): string {
+  const maxAgeSeconds =
+    expiresAtMs === null || expiresAtMs === undefined
+      ? 0
+      : Math.max(0, Math.ceil((expiresAtMs - Date.now()) / 1_000));
+  return `__Host-pitch-manager-session=${encodeURIComponent(value)}; Path=/; Max-Age=${maxAgeSeconds}; HttpOnly; Secure; SameSite=Strict`;
+}
+
 function clearEventAdminSessionCookie(): string {
   return "__Host-event-admin-session=; Path=/; Max-Age=0; HttpOnly; Secure; SameSite=Strict";
+}
+
+function clearPitchManagerSessionCookie(): string {
+  return "__Host-pitch-manager-session=; Path=/; Max-Age=0; HttpOnly; Secure; SameSite=Strict";
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/lib/event-administration.test.ts
+++ b/src/lib/event-administration.test.ts
@@ -401,6 +401,79 @@ describe("Event Administration handoff", () => {
     expect(await readState()).toEqual(before);
   });
 
+  test("does not retain a Pitch Manager Grant after its atomic handoff fails", async () => {
+    const baseStorage = createInMemoryFoundationStorage();
+    let failNext = false;
+    const storage = new Proxy(baseStorage, {
+      get(target, property, receiver) {
+        if (property === "transaction") {
+          return (work: Parameters<FoundationStorage["transaction"]>[0]) =>
+            target.transaction((transaction) => {
+              const result = work(transaction);
+              if (failNext) {
+                failNext = false;
+                throw new Error("injected Pitch Manager handoff failure");
+              }
+              return result;
+            });
+        }
+        const value = Reflect.get(target, property, receiver);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    }) as FoundationStorage;
+    const fixture = createFixture(storage);
+    const event = await fixture.catalog.createEvent(
+      { name: "Pitch Manager Failure Event", timeZone: "UTC" },
+      fixture.technical,
+    );
+    if (event.status !== "accepted") throw new Error("Expected Event.");
+    const day = await fixture.catalog.addGameDay(
+      event.value.eventId,
+      { date: "2026-08-14" },
+      fixture.technical,
+    );
+    const pitch = await fixture.administration.createPitch(
+      event.value.eventId,
+      { name: "Pitch A" },
+      fixture.technical,
+    );
+    if (day.status !== "accepted" || pitch.status !== "accepted")
+      throw new Error("Expected schedule structure.");
+    const eventGrant = await fixture.administration.createEventAdminGrant(
+      event.value.eventId,
+      fixture.technical,
+    );
+    if (eventGrant.status !== "accepted") throw new Error("Expected Event Admin Grant.");
+    const eventQr = await fixture.grants.revealGrant(eventGrant.value.grantId, fixture.technical);
+    if (eventQr.status !== "revealed") throw new Error("Expected Event Admin QR.");
+    const eventSession = await fixture.administration.admitEventAdmin({
+      qrCredential: eventQr.qrCredential,
+      browserContext: "pitch-manager-failure-browser",
+    });
+    if (eventSession.status !== "admitted") throw new Error("Expected Event Admin session.");
+    const before = await baseStorage.transaction((transaction) => ({
+      grants: transaction.listGrants(),
+      sessions: transaction.listGrantSessions(eventGrant.value.grantId),
+      audit: transaction.listGrantAudit(eventGrant.value.grantId),
+    }));
+    failNext = true;
+    expect(
+      await fixture.administration.createPitchManagerGrant(
+        event.value.eventId,
+        day.value.gameDayId,
+        pitch.value.pitchId,
+        { kind: "grant-session", sessionBearer: eventSession.sessionBearer },
+      ),
+    ).toMatchObject({ status: "retryable-failure" });
+    expect(
+      await baseStorage.transaction((transaction) => ({
+        grants: transaction.listGrants(),
+        sessions: transaction.listGrantSessions(eventGrant.value.grantId),
+        audit: transaction.listGrantAudit(eventGrant.value.grantId),
+      })),
+    ).toEqual(before);
+  });
+
   test("rejects forged Event Admin catalog authority and serializes revocation with mutation", async () => {
     const fixture = createFixture();
     const event = await fixture.catalog.createEvent(
@@ -735,6 +808,258 @@ describe("Event Administration handoff", () => {
         },
       ],
     });
+  });
+
+  test("hands one Pitch and Game Day to a persistent, narrow Pitch Manager session", async () => {
+    const fixture = createFixture();
+    const event = await fixture.catalog.createEvent(
+      { name: "Pitch Handoff", timeZone: "Europe/Zurich" },
+      fixture.technical,
+    );
+    if (event.status !== "accepted") throw new Error("Expected Event.");
+    const firstDay = await fixture.catalog.addGameDay(
+      event.value.eventId,
+      { date: "2026-08-14" },
+      fixture.technical,
+    );
+    const secondDay = await fixture.catalog.addGameDay(
+      event.value.eventId,
+      { date: "2026-08-15" },
+      fixture.technical,
+    );
+    const pitch = await fixture.administration.createPitch(
+      event.value.eventId,
+      { name: "Pitch A" },
+      fixture.technical,
+    );
+    if (
+      firstDay.status !== "accepted" ||
+      secondDay.status !== "accepted" ||
+      pitch.status !== "accepted"
+    )
+      throw new Error("Expected schedule structure.");
+    const eventGrant = await fixture.administration.createEventAdminGrant(
+      event.value.eventId,
+      fixture.technical,
+    );
+    if (eventGrant.status !== "accepted") throw new Error("Expected Event Admin Grant.");
+    const eventCredential = await fixture.grants.revealGrant(
+      eventGrant.value.grantId,
+      fixture.technical,
+    );
+    if (eventCredential.status !== "revealed") throw new Error("Expected Event Admin QR.");
+    const eventAdmission = await fixture.administration.admitEventAdmin({
+      qrCredential: eventCredential.qrCredential,
+      browserContext: "event-admin-phone",
+    });
+    if (eventAdmission.status !== "admitted") throw new Error("Expected Event Admin session.");
+    const eventAuthority = {
+      kind: "grant-session",
+      sessionBearer: eventAdmission.sessionBearer,
+    } as const;
+
+    const created = await fixture.administration.createPitchManagerGrant(
+      event.value.eventId,
+      firstDay.value.gameDayId,
+      pitch.value.pitchId,
+      eventAuthority,
+    );
+    expect(created).toMatchObject({
+      status: "accepted",
+      value: {
+        gameDayId: firstDay.value.gameDayId,
+        pitchId: pitch.value.pitchId,
+        status: "active",
+      },
+    });
+    if (created.status !== "accepted") throw new Error("Expected Pitch Manager Grant.");
+    expect(
+      await fixture.administration.createPitchManagerGrant(
+        event.value.eventId,
+        firstDay.value.gameDayId,
+        pitch.value.pitchId,
+        eventAuthority,
+      ),
+    ).toMatchObject({ status: "rejected", reason: "invalid-input" });
+    const pitchCredential = await fixture.administration.revealPitchManagerGrant(
+      event.value.eventId,
+      firstDay.value.gameDayId,
+      pitch.value.pitchId,
+      eventAuthority,
+    );
+    if (pitchCredential.status !== "accepted" || pitchCredential.value.status !== "revealed")
+      throw new Error("Expected Pitch Manager QR.");
+    const managerAdmission = await fixture.administration.admitPitchManager({
+      qrCredential: pitchCredential.value.qrCredential,
+      browserContext: "manager-phone",
+    });
+    if (managerAdmission.status !== "admitted") throw new Error("Expected Pitch Manager session.");
+
+    const slot = await fixture.administration.createGameplaySlot(
+      event.value.eventId,
+      firstDay.value.gameDayId,
+      { sequence: 1, scheduledStart: "2026-08-14T10:00" },
+      fixture.technical,
+    );
+    if (slot.status !== "accepted") throw new Error("Expected Gameplay Slot.");
+    const pitchSlot = await fixture.storage.transaction(
+      (transaction) => transaction.listPitchSlots(firstDay.value.gameDayId, pitch.value.pitchId)[0],
+    );
+    if (pitchSlot === undefined) throw new Error("Expected Pitch Slot.");
+    const game = await fixture.administration.createEventGame(
+      event.value.eventId,
+      firstDay.value.gameDayId,
+      {
+        gameplaySlotId: slot.value.gameplaySlotId,
+        pitchSlotId: pitchSlot.pitchSlotId,
+        sideA: { sourceLabel: "A" },
+        sideB: { sourceLabel: "B" },
+      },
+      fixture.technical,
+    );
+    if (game.status !== "accepted") throw new Error("Expected Event Game.");
+    const control = await fixture.grants.createControlGrant({
+      authority: { kind: "grant-session", sessionBearer: managerAdmission.sessionBearer },
+      scope: {
+        eventId: event.value.eventId,
+        gameDayId: firstDay.value.gameDayId,
+        pitchId: pitch.value.pitchId,
+        pitchSlotId: pitchSlot.pitchSlotId,
+      },
+    });
+    expect(control).toMatchObject({ status: "created", grantType: "control" });
+
+    const view = await fixture.administration.openPitchManagerView({
+      eventId: event.value.eventId,
+      gameDayId: firstDay.value.gameDayId,
+      pitchId: pitch.value.pitchId,
+      authority: { kind: "grant-session", sessionBearer: managerAdmission.sessionBearer },
+    });
+    expect(view).toMatchObject({
+      status: "accepted",
+      value: {
+        eventId: event.value.eventId,
+        gameDayId: firstDay.value.gameDayId,
+        eventTimeZone: "Europe/Zurich",
+        pitch: { pitchId: pitch.value.pitchId },
+        schedule: [
+          {
+            expectedStart: "2026-08-14 10:00 Europe/Zurich",
+            eventGame: {
+              eventGameId: game.value.eventGameId,
+              sideA: { displayName: "A" },
+              sideB: { displayName: "B" },
+            },
+            conflictEventGameIds: [game.value.eventGameId],
+            controlGrantStatus: "active",
+          },
+        ],
+        grantSessionExpiresAt: "2026-08-15 04:30 Europe/Zurich",
+      },
+    });
+    if (view.status === "accepted") {
+      expect(view.value).not.toHaveProperty("eventGames");
+      expect(view.value).not.toHaveProperty("createdAtMs");
+      expect(view.value).not.toHaveProperty("updatedAtMs");
+    }
+    expect(
+      await fixture.administration.openPitchManagerCurrentView({
+        authority: { kind: "grant-session", sessionBearer: managerAdmission.sessionBearer },
+      }),
+    ).toMatchObject({
+      status: "accepted",
+      value: {
+        eventId: event.value.eventId,
+        gameDayId: firstDay.value.gameDayId,
+        pitch: { pitchId: pitch.value.pitchId },
+      },
+    });
+    expect(
+      await fixture.administration.openPitchManagerView({
+        eventId: event.value.eventId,
+        gameDayId: secondDay.value.gameDayId,
+        pitchId: pitch.value.pitchId,
+        authority: { kind: "grant-session", sessionBearer: managerAdmission.sessionBearer },
+      }),
+    ).toMatchObject({ status: "rejected", reason: "unauthorized" });
+
+    fixture.setNow(created.value.expiresAtMs ?? 0);
+    expect(
+      await fixture.administration.openPitchManagerView({
+        eventId: event.value.eventId,
+        gameDayId: firstDay.value.gameDayId,
+        pitchId: pitch.value.pitchId,
+        authority: { kind: "grant-session", sessionBearer: managerAdmission.sessionBearer },
+      }),
+    ).toMatchObject({ status: "rejected", reason: "unauthorized" });
+    expect(
+      await fixture.administration.reactivatePitchManagerGrant(
+        event.value.eventId,
+        firstDay.value.gameDayId,
+        pitch.value.pitchId,
+        fixture.technical,
+      ),
+    ).toMatchObject({ status: "rejected" });
+    const laterDayGrant = await fixture.administration.createPitchManagerGrant(
+      event.value.eventId,
+      secondDay.value.gameDayId,
+      pitch.value.pitchId,
+      eventAuthority,
+    );
+    expect(laterDayGrant).toMatchObject({
+      status: "accepted",
+      value: { gameDayId: secondDay.value.gameDayId, pitchId: pitch.value.pitchId },
+    });
+    if (laterDayGrant.status !== "accepted") throw new Error("Expected later-day Grant.");
+    const laterQr = await fixture.administration.revealPitchManagerGrant(
+      event.value.eventId,
+      secondDay.value.gameDayId,
+      pitch.value.pitchId,
+      eventAuthority,
+    );
+    if (laterQr.status !== "accepted" || laterQr.value.status !== "revealed")
+      throw new Error("Expected later-day QR.");
+    const oldLaterSession = await fixture.administration.admitPitchManager({
+      qrCredential: laterQr.value.qrCredential,
+      browserContext: "later-manager",
+    });
+    if (oldLaterSession.status !== "admitted") throw new Error("Expected later-day session.");
+    const rotated = await fixture.administration.rotatePitchManagerGrant(
+      event.value.eventId,
+      secondDay.value.gameDayId,
+      pitch.value.pitchId,
+      eventAuthority,
+    );
+    expect(rotated).toMatchObject({ status: "accepted", value: { status: "updated" } });
+    expect(
+      await fixture.administration.openPitchManagerView({
+        eventId: event.value.eventId,
+        gameDayId: secondDay.value.gameDayId,
+        pitchId: pitch.value.pitchId,
+        authority: { kind: "grant-session", sessionBearer: oldLaterSession.sessionBearer },
+      }),
+    ).toMatchObject({ status: "rejected", reason: "unauthorized" });
+    const revoked = await fixture.administration.revokePitchManagerGrant(
+      event.value.eventId,
+      secondDay.value.gameDayId,
+      pitch.value.pitchId,
+      eventAuthority,
+    );
+    expect(revoked).toMatchObject({ status: "accepted", value: { status: "updated" } });
+    const reactivated = await fixture.administration.reactivatePitchManagerGrant(
+      event.value.eventId,
+      secondDay.value.gameDayId,
+      pitch.value.pitchId,
+      eventAuthority,
+    );
+    expect(reactivated).toMatchObject({ status: "accepted", value: { status: "updated" } });
+    const reactivatedQr = await fixture.administration.revealPitchManagerGrant(
+      event.value.eventId,
+      secondDay.value.gameDayId,
+      pitch.value.pitchId,
+      eventAuthority,
+    );
+    expect(reactivatedQr).toMatchObject({ status: "accepted", value: { status: "revealed" } });
   });
 
   test("lets Technical and Event Admin authority publish and hide without revoking the Grant", async () => {

--- a/src/lib/event-administration.ts
+++ b/src/lib/event-administration.ts
@@ -2,6 +2,7 @@ import type { FoundationStorage, FoundationStorageTransaction } from "@/lib/foun
 import {
   createEventCatalog,
   createFoundationEventCatalogStorage,
+  projectExpectedStartMs,
   projectEventProjection,
   type CatalogOutcome,
   type EventCatalog,
@@ -23,7 +24,14 @@ import type {
   TypedGrantMutation,
   TypedGrantReveal,
 } from "@/lib/grant-management";
-import { EVENT_ADMIN_GRANT_TYPE, type StoredGrant } from "@/lib/grant-types";
+import {
+  EVENT_ADMIN_GRANT_TYPE,
+  PITCH_MANAGER_GRANT_TYPE,
+  type PitchManagerGrantScope,
+  type StoredGrant,
+  validateControlGrantScope,
+  validatePitchManagerGrantScope,
+} from "@/lib/grant-types";
 import { isTechnicalAdminAuthority } from "@/lib/technical-admin-auth";
 import { validateOpaqueIdentifier } from "@/lib/validation-policy";
 
@@ -42,6 +50,19 @@ export type EventAdminGrantProjection = {
   grantVersion: string;
   grantType: typeof EVENT_ADMIN_GRANT_TYPE;
   eventId: string;
+  status: StoredGrant["status"];
+  createdAtMs: number;
+  expiresAtMs: number | null;
+};
+
+export type PitchManagerGrantProjection = {
+  grantId: string;
+  grantVersion: string;
+  grantType: typeof PITCH_MANAGER_GRANT_TYPE;
+  eventId: string;
+  gameDayId: string;
+  gameDayDate: string;
+  pitchId: string;
   status: StoredGrant["status"];
   createdAtMs: number;
   expiresAtMs: number | null;
@@ -72,6 +93,31 @@ export type PitchViewProjection = {
   eventGames: readonly EventGame[];
 };
 
+export type PitchManagerViewProjection = {
+  eventId: string;
+  gameDayId: string;
+  gameDayDate: string;
+  eventTimeZone: string;
+  pitch: { pitchId: string; name: string };
+  schedule: readonly {
+    pitchSlotId: string;
+    gameplaySlotId: string;
+    sequence: number;
+    expectedStart: string;
+    eventGame: {
+      eventGameId: string;
+      gameCode: string | null;
+      gameDesignation: string | null;
+      sideA: { displayName: string };
+      sideB: { displayName: string };
+    } | null;
+    conflictEventGameIds: readonly string[];
+    controlGrantStatus: StoredGrant["status"] | "not-created";
+  }[];
+  grantSessionId: string | null;
+  grantSessionExpiresAt: string | null;
+};
+
 export type EventAdministrationOutcome<T> =
   | { status: "accepted"; value: T }
   | { status: "rejected"; reason: "invalid-input" | "unauthorized" | "not-found"; detail: string }
@@ -93,6 +139,48 @@ export type EventAdministration = {
     eventId: unknown,
     authority: TechnicalAdminAuthority,
   ): Promise<EventAdministrationOutcome<EventAdminGrantProjection>>;
+  createPitchManagerGrant(
+    eventId: unknown,
+    gameDayId: unknown,
+    pitchId: unknown,
+    authority: EventAdministrationAuthority,
+  ): Promise<EventAdministrationMutationOutcome<PitchManagerGrantProjection>>;
+  inspectPitchManagerGrant(
+    eventId: unknown,
+    gameDayId: unknown,
+    pitchId: unknown,
+    authority: EventAdministrationAuthority,
+  ): Promise<EventAdministrationOutcome<PitchManagerGrantProjection | null>>;
+  revealPitchManagerGrant(
+    eventId: unknown,
+    gameDayId: unknown,
+    pitchId: unknown,
+    authority: EventAdministrationAuthority,
+  ): Promise<EventAdministrationMutationOutcome<TypedGrantReveal>>;
+  rotatePitchManagerGrant(
+    eventId: unknown,
+    gameDayId: unknown,
+    pitchId: unknown,
+    authority: EventAdministrationAuthority,
+  ): Promise<EventAdministrationMutationOutcome<TypedGrantMutation>>;
+  disablePitchManagerGrant(
+    eventId: unknown,
+    gameDayId: unknown,
+    pitchId: unknown,
+    authority: EventAdministrationAuthority,
+  ): Promise<EventAdministrationMutationOutcome<TypedGrantMutation>>;
+  revokePitchManagerGrant(
+    eventId: unknown,
+    gameDayId: unknown,
+    pitchId: unknown,
+    authority: EventAdministrationAuthority,
+  ): Promise<EventAdministrationMutationOutcome<TypedGrantMutation>>;
+  reactivatePitchManagerGrant(
+    eventId: unknown,
+    gameDayId: unknown,
+    pitchId: unknown,
+    authority: EventAdministrationAuthority,
+  ): Promise<EventAdministrationMutationOutcome<TypedGrantMutation>>;
   inspectEventAdminGrant(
     eventId: unknown,
     authority: EventAdministrationAuthority,
@@ -123,7 +211,14 @@ export type EventAdministration = {
     deviceClass?: unknown;
     browserClass?: unknown;
   }): Promise<TypedGrantAdmission | TypedGrantAdmissionThrottled>;
+  admitPitchManager(input: {
+    qrCredential: unknown;
+    browserContext: unknown;
+    deviceClass?: unknown;
+    browserClass?: unknown;
+  }): Promise<TypedGrantAdmission | TypedGrantAdmissionThrottled>;
   leaveEventAdminSession(sessionBearer: unknown): Promise<TypedGrantMutation>;
+  leavePitchManagerSession(sessionBearer: unknown): Promise<TypedGrantMutation>;
   openEventHub(input: {
     eventId: unknown;
     gameDayId?: unknown;
@@ -199,6 +294,15 @@ export type EventAdministration = {
     pitchId: unknown,
     authority: EventAdministrationAuthority,
   ): Promise<EventAdministrationOutcome<PitchViewProjection>>;
+  openPitchManagerView(input: {
+    eventId: unknown;
+    gameDayId: unknown;
+    pitchId: unknown;
+    authority: EventAdministrationAuthority;
+  }): Promise<EventAdministrationOutcome<PitchManagerViewProjection>>;
+  openPitchManagerCurrentView(input: {
+    authority: EventAdministrationAuthority;
+  }): Promise<EventAdministrationOutcome<PitchManagerViewProjection>>;
 };
 
 export function createEventAdministration(
@@ -241,6 +345,130 @@ export function createEventAdministration(
       } catch {
         return unavailable();
       }
+    },
+
+    async createPitchManagerGrant(eventIdInput, gameDayIdInput, pitchIdInput, authority) {
+      const ids = validateScopeIds(eventIdInput, gameDayIdInput, pitchIdInput);
+      if (!ids.ok) return invalid(ids.error);
+      try {
+        return await options.storage.transaction((transaction) => {
+          const scope = readPitchManagerScope(transaction, ids.value);
+          if (scope === null) return notFound("Pitch or Game Day was not found.");
+          const authorized = authorizeEventScopeInTransaction(
+            options,
+            transaction,
+            ids.value.eventId,
+            authority,
+          );
+          if (authorized === null) return unauthorized();
+          if (
+            transaction
+              .listGrants()
+              .some(
+                (grant) =>
+                  grant.grantType === PITCH_MANAGER_GRANT_TYPE &&
+                  samePitchManagerScope(grant.scope, scope),
+              )
+          )
+            return invalid("A Pitch Manager Grant already exists for this Pitch and Game Day.");
+          const result = options.grants.createPitchManagerGrantInTransaction(transaction, {
+            authority,
+            scope,
+          });
+          if (result.status !== "created") return grantMutationRejection(result);
+          const stored = transaction.findGrantById(result.grantId);
+          if (stored === null) return unavailable();
+          return {
+            ...accepted(projectPitchManagerGrant(stored)),
+            sessionExpiresAtMs: authorized.sessionExpiresAtMs,
+          };
+        });
+      } catch {
+        return unavailable();
+      }
+    },
+
+    async inspectPitchManagerGrant(eventIdInput, gameDayIdInput, pitchIdInput, authority) {
+      const ids = validateScopeIds(eventIdInput, gameDayIdInput, pitchIdInput);
+      if (!ids.ok) return invalid(ids.error);
+      try {
+        return await options.storage.transaction((transaction) => {
+          if (
+            authorizeEventScopeInTransaction(
+              options,
+              transaction,
+              ids.value.eventId,
+              authority,
+              true,
+            ) === null
+          )
+            return unauthorized();
+          const grant = findPitchManagerGrantInTransaction(transaction, ids.value);
+          return accepted(grant === null ? null : projectPitchManagerGrant(grant));
+        });
+      } catch {
+        return unavailable();
+      }
+    },
+
+    async revealPitchManagerGrant(eventIdInput, gameDayIdInput, pitchIdInput, authority) {
+      const grant = await findPitchManagerGrant(
+        options,
+        eventIdInput,
+        gameDayIdInput,
+        pitchIdInput,
+      );
+      if (grant.status !== "accepted") return grant;
+      if (grant.value === null) return notFound("Pitch Manager Grant was not found.");
+      const authorization = await authorizePitchManagerManagement(options, grant.value, authority);
+      if (authorization !== null) {
+        const result = await options.grants.revealGrant(grant.value.grantId, authority);
+        if (result.status === "revealed")
+          return { ...accepted(result), sessionExpiresAtMs: authorization.sessionExpiresAtMs };
+        return grantMutationRejection(result);
+      }
+      return unauthorized();
+    },
+
+    async rotatePitchManagerGrant(eventIdInput, gameDayIdInput, pitchIdInput, authority) {
+      return managePitchManagerGrant(
+        options,
+        eventIdInput,
+        gameDayIdInput,
+        pitchIdInput,
+        authority,
+        "rotateGrant",
+      );
+    },
+    async disablePitchManagerGrant(eventIdInput, gameDayIdInput, pitchIdInput, authority) {
+      return managePitchManagerGrant(
+        options,
+        eventIdInput,
+        gameDayIdInput,
+        pitchIdInput,
+        authority,
+        "disableGrant",
+      );
+    },
+    async revokePitchManagerGrant(eventIdInput, gameDayIdInput, pitchIdInput, authority) {
+      return managePitchManagerGrant(
+        options,
+        eventIdInput,
+        gameDayIdInput,
+        pitchIdInput,
+        authority,
+        "revokeGrant",
+      );
+    },
+    async reactivatePitchManagerGrant(eventIdInput, gameDayIdInput, pitchIdInput, authority) {
+      return managePitchManagerGrant(
+        options,
+        eventIdInput,
+        gameDayIdInput,
+        pitchIdInput,
+        authority,
+        "reactivateGrant",
+      );
     },
 
     async inspectEventAdminGrant(eventIdInput, authority) {
@@ -307,7 +535,23 @@ export function createEventAdministration(
         input.browserContext.length === 0
       )
         return options.grants.admitGrant({ qrCredential: "", browserContext: "" });
-      return options.grants.admitGrant({
+      return options.grants.admitEventAdminGrant({
+        qrCredential: input.qrCredential,
+        browserContext: input.browserContext,
+        deviceClass: typeof input.deviceClass === "string" ? input.deviceClass : undefined,
+        browserClass: typeof input.browserClass === "string" ? input.browserClass : undefined,
+      });
+    },
+
+    async admitPitchManager(input) {
+      if (
+        typeof input.qrCredential !== "string" ||
+        typeof input.browserContext !== "string" ||
+        input.qrCredential.length === 0 ||
+        input.browserContext.length === 0
+      )
+        return options.grants.admitGrant({ qrCredential: "", browserContext: "" });
+      return options.grants.admitPitchManagerGrant({
         qrCredential: input.qrCredential,
         browserContext: input.browserContext,
         deviceClass: typeof input.deviceClass === "string" ? input.deviceClass : undefined,
@@ -316,6 +560,12 @@ export function createEventAdministration(
     },
 
     async leaveEventAdminSession(sessionBearer) {
+      if (typeof sessionBearer !== "string")
+        return { status: "rejected", reason: "invalid-input", detail: "Grant Session is invalid." };
+      return options.grants.leaveGrantSession(sessionBearer);
+    },
+
+    async leavePitchManagerSession(sessionBearer) {
       if (typeof sessionBearer !== "string")
         return { status: "rejected", reason: "invalid-input", detail: "Grant Session is invalid." };
       return options.grants.leaveGrantSession(sessionBearer);
@@ -450,6 +700,14 @@ export function createEventAdministration(
         "pitch",
         pitchIdInput,
       );
+    },
+
+    async openPitchManagerView(input) {
+      return openPitchManagerProjection(options, input);
+    },
+
+    async openPitchManagerCurrentView(input) {
+      return openPitchManagerCurrentProjection(options, input.authority);
     },
   };
 }
@@ -587,6 +845,339 @@ async function runCatalogMutation<T>(
   } catch {
     return unavailable();
   }
+}
+
+type ScopeIds = { eventId: string; gameDayId: string; pitchId: string };
+
+function validateScopeIds(
+  eventIdInput: unknown,
+  gameDayIdInput: unknown,
+  pitchIdInput: unknown,
+): { ok: true; value: ScopeIds } | { ok: false; error: string } {
+  const eventId = validateEventId(eventIdInput);
+  const gameDayId = validateEventId(gameDayIdInput);
+  const pitchId = validateEventId(pitchIdInput);
+  if (!eventId.ok) return eventId;
+  if (!gameDayId.ok) return gameDayId;
+  if (!pitchId.ok) return pitchId;
+  return {
+    ok: true,
+    value: { eventId: eventId.value, gameDayId: gameDayId.value, pitchId: pitchId.value },
+  };
+}
+
+function readPitchManagerScope(
+  transaction: FoundationStorageTransaction,
+  ids: ScopeIds,
+): PitchManagerGrantScope | null {
+  const event = transaction.findEvent(ids.eventId);
+  const gameDay = transaction
+    .listGameDays(ids.eventId)
+    .find((day) => day.gameDayId === ids.gameDayId);
+  const pitch = transaction.findPitch(ids.pitchId);
+  if (event === null || gameDay === undefined || pitch === null || pitch.eventId !== event.eventId)
+    return null;
+  return {
+    eventId: event.eventId,
+    gameDayId: gameDay.gameDayId,
+    gameDayDate: gameDay.date,
+    eventTimeZone: event.timeZone,
+    pitchId: pitch.pitchId,
+  };
+}
+
+function samePitchManagerScope(value: unknown, expected: PitchManagerGrantScope): boolean {
+  if (!isRecord(value)) return false;
+  return (
+    value.eventId === expected.eventId &&
+    value.gameDayId === expected.gameDayId &&
+    value.pitchId === expected.pitchId
+  );
+}
+
+function findPitchManagerGrantInTransaction(
+  transaction: FoundationStorageTransaction,
+  ids: ScopeIds,
+): StoredGrant | null {
+  const scope = readPitchManagerScope(transaction, ids);
+  if (scope === null) return null;
+  return (
+    transaction
+      .listGrants()
+      .filter(
+        (grant) =>
+          grant.grantType === PITCH_MANAGER_GRANT_TYPE && samePitchManagerScope(grant.scope, scope),
+      )
+      .sort((left, right) => right.createdAtMs - left.createdAtMs)[0] ?? null
+  );
+}
+
+function projectPitchManagerGrant(grant: StoredGrant): PitchManagerGrantProjection {
+  const scope = validatePitchManagerGrantScope(grant.scope);
+  if (!scope.ok) throw new Error("Pitch Manager Grant scope is invalid.");
+  return {
+    grantId: grant.grantId,
+    grantVersion: grant.grantVersion,
+    grantType: PITCH_MANAGER_GRANT_TYPE,
+    eventId: scope.value.eventId,
+    gameDayId: scope.value.gameDayId,
+    gameDayDate: scope.value.gameDayDate,
+    pitchId: scope.value.pitchId,
+    status: grant.status,
+    createdAtMs: grant.createdAtMs,
+    expiresAtMs: grant.expiresAtMs,
+  };
+}
+
+async function findPitchManagerGrant(
+  options: EventAdministrationOptions,
+  eventIdInput: unknown,
+  gameDayIdInput: unknown,
+  pitchIdInput: unknown,
+): Promise<EventAdministrationOutcome<StoredGrant | null>> {
+  const ids = validateScopeIds(eventIdInput, gameDayIdInput, pitchIdInput);
+  if (!ids.ok) return invalid(ids.error);
+  try {
+    return accepted(
+      await options.storage.transaction((transaction) =>
+        findPitchManagerGrantInTransaction(transaction, ids.value),
+      ),
+    );
+  } catch {
+    return unavailable();
+  }
+}
+
+async function authorizePitchManagerManagement(
+  options: EventAdministrationOptions,
+  grant: StoredGrant,
+  authority: EventAdministrationAuthority,
+): Promise<{ sessionExpiresAtMs: number | null } | null> {
+  try {
+    return await options.storage.transaction((transaction) => {
+      const scope = validatePitchManagerGrantScope(grant.scope);
+      if (!scope.ok) return null;
+      const authorized = authorizeEventScopeInTransaction(
+        options,
+        transaction,
+        scope.value.eventId,
+        authority,
+      );
+      if (authorized === null) return null;
+      if (transaction.findGrantById(grant.grantId)?.grantVersion !== grant.grantVersion)
+        return null;
+      return { sessionExpiresAtMs: authorized.sessionExpiresAtMs };
+    });
+  } catch {
+    return null;
+  }
+}
+
+async function managePitchManagerGrant(
+  options: EventAdministrationOptions,
+  eventIdInput: unknown,
+  gameDayIdInput: unknown,
+  pitchIdInput: unknown,
+  authority: EventAdministrationAuthority,
+  operation: "rotateGrant" | "disableGrant" | "revokeGrant" | "reactivateGrant",
+): Promise<EventAdministrationMutationOutcome<TypedGrantMutation>> {
+  const grant = await findPitchManagerGrant(options, eventIdInput, gameDayIdInput, pitchIdInput);
+  if (grant.status !== "accepted") return grant;
+  if (grant.value === null) return notFound("Pitch Manager Grant was not found.");
+  const authorization = await authorizePitchManagerManagement(options, grant.value, authority);
+  if (authorization === null) return unauthorized();
+  const result = await options.grants[operation](grant.value.grantId, authority);
+  return result.status === "updated"
+    ? { ...accepted(result), sessionExpiresAtMs: authorization.sessionExpiresAtMs }
+    : grantMutationRejection(result);
+}
+
+async function openPitchManagerProjection(
+  options: EventAdministrationOptions,
+  input: {
+    eventId: unknown;
+    gameDayId: unknown;
+    pitchId: unknown;
+    authority: EventAdministrationAuthority;
+  },
+): Promise<EventAdministrationOutcome<PitchManagerViewProjection>> {
+  const ids = validateScopeIds(input.eventId, input.gameDayId, input.pitchId);
+  if (!ids.ok) return unauthorized();
+  try {
+    return await options.storage.transaction((transaction) => {
+      if (isTechnicalAdminAuthority(input.authority))
+        return projectPitchManagerView(transaction, ids.value, null, null, null);
+      if (
+        !isRecord(input.authority) ||
+        input.authority.kind !== "grant-session" ||
+        typeof input.authority.sessionBearer !== "string"
+      )
+        return unauthorized();
+      const result = options.grants.authorizeGrantInTransaction(transaction, {
+        sessionBearer: input.authority.sessionBearer,
+      });
+      if (result.status !== "authorized" || result.grantType !== PITCH_MANAGER_GRANT_TYPE)
+        return unauthorized();
+      const scope = validatePitchManagerGrantScope(result.scope);
+      if (
+        !scope.ok ||
+        scope.value.eventId !== ids.value.eventId ||
+        scope.value.gameDayId !== ids.value.gameDayId ||
+        scope.value.pitchId !== ids.value.pitchId
+      )
+        return unauthorized();
+      return projectPitchManagerView(
+        transaction,
+        ids.value,
+        result.grantSessionId,
+        result.sessionExpiresAtMs ?? null,
+        scope.value,
+      );
+    });
+  } catch {
+    return unavailable();
+  }
+}
+
+async function openPitchManagerCurrentProjection(
+  options: EventAdministrationOptions,
+  authority: EventAdministrationAuthority,
+): Promise<EventAdministrationOutcome<PitchManagerViewProjection>> {
+  if (
+    !isRecord(authority) ||
+    authority.kind !== "grant-session" ||
+    typeof authority.sessionBearer !== "string"
+  )
+    return unauthorized();
+  try {
+    return await options.storage.transaction((transaction) => {
+      const result = options.grants.authorizeGrantInTransaction(transaction, {
+        sessionBearer: authority.sessionBearer,
+      });
+      if (result.status !== "authorized" || result.grantType !== PITCH_MANAGER_GRANT_TYPE)
+        return unauthorized();
+      const scope = validatePitchManagerGrantScope(result.scope);
+      if (!scope.ok) return unauthorized();
+      return projectPitchManagerView(
+        transaction,
+        {
+          eventId: scope.value.eventId,
+          gameDayId: scope.value.gameDayId,
+          pitchId: scope.value.pitchId,
+        },
+        result.grantSessionId,
+        result.sessionExpiresAtMs ?? null,
+        scope.value,
+      );
+    });
+  } catch {
+    return unavailable();
+  }
+}
+
+function projectPitchManagerView(
+  transaction: FoundationStorageTransaction,
+  ids: ScopeIds,
+  grantSessionId: string | null,
+  grantSessionExpiresAtMs: number | null,
+  grantScope: PitchManagerGrantScope | null,
+): EventAdministrationOutcome<PitchManagerViewProjection> {
+  const event = transaction.findEvent(ids.eventId);
+  const day = transaction
+    .listGameDays(ids.eventId)
+    .find((candidate) => candidate.gameDayId === ids.gameDayId);
+  const pitch = transaction.findPitch(ids.pitchId);
+  if (event === null || day === undefined || pitch === null || pitch.eventId !== event.eventId)
+    return unauthorized();
+  if (
+    grantScope !== null &&
+    (grantScope.eventId !== event.eventId ||
+      grantScope.gameDayId !== day.gameDayId ||
+      grantScope.pitchId !== pitch.pitchId ||
+      grantScope.gameDayDate !== day.date ||
+      grantScope.eventTimeZone !== event.timeZone)
+  )
+    return unauthorized();
+  const pitchSlots = transaction
+    .listPitchSlots(day.gameDayId, pitch.pitchId)
+    .sort((left, right) => left.sequence - right.sequence);
+  const eventGames = transaction
+    .listEventGames(day.gameDayId)
+    .filter((game) => pitchSlots.some((slot) => slot.pitchSlotId === game.pitchSlotId));
+  const gamesByPitchSlot = new Map<string, EventGame[]>();
+  for (const game of eventGames) {
+    const games = gamesByPitchSlot.get(game.pitchSlotId) ?? [];
+    games.push(game);
+    gamesByPitchSlot.set(game.pitchSlotId, games);
+  }
+  const controlGrantStatuses = new Map<string, StoredGrant["status"]>();
+  for (const grant of transaction.listGrants()) {
+    if (grant.grantType !== "control") continue;
+    const scope = validateControlGrantScope(grant.scope);
+    if (
+      !scope.ok ||
+      scope.value.eventId !== event.eventId ||
+      scope.value.gameDayId !== day.gameDayId ||
+      scope.value.pitchId !== pitch.pitchId ||
+      !pitchSlots.some((slot) => slot.pitchSlotId === scope.value.pitchSlotId)
+    )
+      continue;
+    controlGrantStatuses.set(scope.value.pitchSlotId, grant.status);
+  }
+  const schedule: PitchManagerViewProjection["schedule"] = pitchSlots.map((slot) => {
+    const gameplaySlot = transaction.findGameplaySlot(slot.gameplaySlotId);
+    if (gameplaySlot === null) throw new Error("Pitch Slot references a missing Gameplay Slot.");
+    const games = gamesByPitchSlot.get(slot.pitchSlotId) ?? [];
+    const game = games[0] ?? null;
+    return {
+      pitchSlotId: slot.pitchSlotId,
+      gameplaySlotId: slot.gameplaySlotId,
+      sequence: slot.sequence,
+      expectedStart: formatPitchManagerDateTime(
+        projectExpectedStartMs(gameplaySlot, slot),
+        event.timeZone,
+      ),
+      eventGame:
+        game === null
+          ? null
+          : {
+              eventGameId: game.eventGameId,
+              gameCode: game.gameCode,
+              gameDesignation: game.gameDesignation,
+              sideA: { displayName: game.sideA.eventTeamName ?? game.sideA.sourceLabel ?? "TBD" },
+              sideB: { displayName: game.sideB.eventTeamName ?? game.sideB.sourceLabel ?? "TBD" },
+            },
+      conflictEventGameIds: games.map((candidate) => candidate.eventGameId),
+      controlGrantStatus: controlGrantStatuses.get(slot.pitchSlotId) ?? "not-created",
+    };
+  });
+  return accepted({
+    eventId: event.eventId,
+    gameDayId: day.gameDayId,
+    gameDayDate: day.date,
+    eventTimeZone: event.timeZone,
+    pitch: { pitchId: pitch.pitchId, name: pitch.name },
+    schedule,
+    grantSessionId,
+    grantSessionExpiresAt:
+      grantSessionExpiresAtMs === null
+        ? null
+        : formatPitchManagerDateTime(grantSessionExpiresAtMs, event.timeZone),
+  });
+}
+
+function formatPitchManagerDateTime(instantMs: number, timeZone: string): string {
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hourCycle: "h23",
+  }).formatToParts(new Date(instantMs));
+  const values = Object.fromEntries(parts.map((part) => [part.type, part.value]));
+  return `${values.year}-${values.month}-${values.day} ${values.hour}:${values.minute} ${timeZone}`;
 }
 
 async function findEventAdminGrant(

--- a/src/lib/event-catalog.test.ts
+++ b/src/lib/event-catalog.test.ts
@@ -4,6 +4,7 @@ import {
   createFoundationEventCatalogStorage,
   createInMemoryEventCatalogStorage,
   createUnavailableEventCatalogStorage,
+  projectExpectedStartMs,
   type InMemoryEventCatalogStorage,
 } from "@/lib/event-catalog";
 import { createInMemoryFoundationStorage } from "@/lib/foundation-storage-memory";
@@ -34,6 +35,15 @@ function createFixture(storage: InMemoryEventCatalogStorage = createInMemoryEven
 }
 
 describe("Event operations catalog", () => {
+  test("projects Expected Start from the greater Gameplay and Pitch Slot delay", () => {
+    expect(
+      projectExpectedStartMs(
+        { scheduledStartMs: Date.parse("2026-08-14T10:00:00Z"), expectedDelayMs: 5 * 60_000 },
+        { expectedDelayMs: 20 * 60_000 },
+      ),
+    ).toBe(Date.parse("2026-08-14T10:20:00Z"));
+  });
+
   test("requires the complete Event Catalog adapter capability at composition", () => {
     const foundation = createInMemoryFoundationStorage();
     const incomplete = new Proxy(foundation, {

--- a/src/lib/event-catalog.ts
+++ b/src/lib/event-catalog.ts
@@ -58,6 +58,20 @@ export type EventGame = StoredEventCatalogGame;
 export type EventGameSide = StoredEventGameSide;
 export type EventAdministrationAuditEntry = EventCatalogAuditEntry;
 
+/** Canonical Expected Start projection shared by schedule and handoff views. */
+export function projectExpectedStartMs(
+  gameplaySlot: Pick<GameplaySlot, "scheduledStartMs" | "expectedDelayMs"> | null,
+  pitchSlot: Pick<PitchSlot, "expectedDelayMs"> | null,
+): number {
+  const scheduledStartMs = gameplaySlot?.scheduledStartMs ?? 0;
+  const gameplayDelayMs = gameplaySlot?.expectedDelayMs ?? 0;
+  const pitchDelayMs = pitchSlot?.expectedDelayMs ?? 0;
+  return Math.max(
+    scheduledStartMs + gameplayDelayMs,
+    scheduledStartMs + Math.max(gameplayDelayMs, pitchDelayMs),
+  );
+}
+
 export type EventGameDay = StoredGameDay & {
   classification: GameDayClassification;
 };

--- a/src/lib/foundation-storage.ts
+++ b/src/lib/foundation-storage.ts
@@ -173,6 +173,8 @@ export type StoredGameplaySlot = {
   gameDayId: string;
   sequence: number;
   scheduledStartMs: number;
+  /** Optional until the schedule-delay projection is persisted by the catalog. */
+  expectedDelayMs?: number;
   createdAtMs: number;
   updatedAtMs: number;
 };
@@ -184,6 +186,8 @@ export type StoredPitchSlot = {
   pitchId: string;
   gameplaySlotId: string;
   sequence: number;
+  /** Optional until the schedule-delay projection is persisted by the catalog. */
+  expectedDelayMs?: number;
   createdAtMs: number;
   updatedAtMs: number;
 };

--- a/src/lib/grant-management-policy.ts
+++ b/src/lib/grant-management-policy.ts
@@ -143,7 +143,8 @@ export function canManageInTransaction(
   operation: "manage" | "reveal",
 ): boolean {
   authority = resolveManagementAuthority(transaction, options, authority) ?? authority;
-  if (authority.kind === "technical-admin") return grant.grantType === "event-admin";
+  if (authority.kind === "technical-admin")
+    return grant.grantType === "event-admin" || grant.grantType === "pitch-manager";
   if (authority.kind === "fixture") return true;
   if (authority.kind !== "grant-session") return false;
   const session = findSessionByBearer(transaction, options, authority.sessionBearer);
@@ -210,7 +211,8 @@ export function canCreateInTransaction(
 ): boolean {
   authority = resolveManagementAuthority(transaction, options, authority) ?? authority;
   if (authority.kind === "fixture") return true;
-  if (authority.kind === "technical-admin") return grant.grantType === "event-admin";
+  if (authority.kind === "technical-admin")
+    return grant.grantType === "event-admin" || grant.grantType === "pitch-manager";
   if (authority.kind !== "grant-session") return false;
   const session = findSessionByBearer(transaction, options, authority.sessionBearer);
   if (session === null || session.status !== "active") return false;

--- a/src/lib/grant-management-sessions.ts
+++ b/src/lib/grant-management-sessions.ts
@@ -9,6 +9,10 @@ import {
   EVENT_ADMIN_GRANT_TYPE,
   GRANT_CODE_KIND,
   GRANT_TYPE,
+  PITCH_MANAGER_GRANT_TYPE,
+  type GrantType,
+  validateEventAdminGrantScope,
+  validatePitchManagerGrantScope,
   type ControlGrantScope,
   type ControlGrantScopeResolution,
   type ControlGrantSessionDecision,
@@ -70,6 +74,7 @@ export async function admitGrant(
     deviceClass?: string;
     browserClass?: string;
   },
+  expectedGrantType?: GrantType,
 ): Promise<TypedGrantAdmission | ReturnType<typeof grantAdmissionThrottled>> {
   const record: Record<string, unknown> = isGrantRecord(input) ? input : {};
   try {
@@ -97,6 +102,23 @@ export async function admitGrant(
       ) {
         recordAdmissionFailure(transaction, "qr", budget.sourceDigest, nowMs);
         return GENERIC_GRANT_ADMISSION_FAILURE;
+      }
+      if (expectedGrantType !== undefined && current.grantType !== expectedGrantType) {
+        recordAdmissionFailure(transaction, "qr", budget.sourceDigest, nowMs);
+        return GENERIC_GRANT_ADMISSION_FAILURE;
+      }
+      if (expectedGrantType === PITCH_MANAGER_GRANT_TYPE) {
+        const scope = validatePitchManagerGrantScope(current.scope);
+        if (!scope.ok || !isLivePitchManagerScope(transaction, scope.value)) {
+          recordAdmissionFailure(transaction, "qr", budget.sourceDigest, nowMs);
+          return GENERIC_GRANT_ADMISSION_FAILURE;
+        }
+      }
+      if (expectedGrantType === EVENT_ADMIN_GRANT_TYPE) {
+        if (!validateEventAdminGrantScope(current.scope).ok) {
+          recordAdmissionFailure(transaction, "qr", budget.sourceDigest, nowMs);
+          return GENERIC_GRANT_ADMISSION_FAILURE;
+        }
       }
       let eventGameId: string | null = null;
       if (current.grantType === GRANT_TYPE) {
@@ -173,12 +195,39 @@ export async function admitGrant(
         sessionExpiresAtMs:
           current.grantType === EVENT_ADMIN_GRANT_TYPE
             ? Math.min(current.expiresAtMs ?? Number.MAX_SAFE_INTEGER, nowMs + 30 * DAY_MS)
-            : null,
+            : current.grantType === "pitch-manager"
+              ? current.expiresAtMs
+              : null,
       };
     });
   } catch {
     return GENERIC_GRANT_ADMISSION_FAILURE;
   }
+}
+
+function isLivePitchManagerScope(
+  transaction: FoundationStorageTransaction,
+  scope: {
+    eventId: string;
+    gameDayId: string;
+    gameDayDate: string;
+    eventTimeZone: string;
+    pitchId: string;
+  },
+): boolean {
+  const event = transaction.findEvent(scope.eventId);
+  const gameDay = transaction
+    .listGameDays(scope.eventId)
+    .find((candidate) => candidate.gameDayId === scope.gameDayId);
+  const pitch = transaction.findPitch(scope.pitchId);
+  return (
+    event !== null &&
+    gameDay !== undefined &&
+    gameDay.date === scope.gameDayDate &&
+    event.timeZone === scope.eventTimeZone &&
+    pitch !== null &&
+    pitch.eventId === scope.eventId
+  );
 }
 
 export async function authorizeGrant(
@@ -327,7 +376,9 @@ export function authorizeGrantInTransaction(
             grant.expiresAtMs ?? Number.MAX_SAFE_INTEGER,
             effectiveActivityAtMs + 30 * DAY_MS,
           )
-        : null,
+        : grant.grantType === "pitch-manager"
+          ? grant.expiresAtMs
+          : null,
   };
 }
 

--- a/src/lib/grant-management-types.ts
+++ b/src/lib/grant-management-types.ts
@@ -171,6 +171,10 @@ export type TypedGrantAuthority = {
   createPitchManagerGrant(
     input: Omit<CreateTypedGrantInput, "grantType"> & { scope: PitchManagerGrantScope },
   ): Promise<TypedGrantCreated | TypedGrantMutation>;
+  createPitchManagerGrantInTransaction(
+    transaction: FoundationStorageTransaction,
+    input: Omit<CreateTypedGrantInput, "grantType"> & { scope: PitchManagerGrantScope },
+  ): TypedGrantCreated | TypedGrantMutation;
   createControlGrant(
     input: Omit<CreateTypedGrantInput, "grantType"> & { scope: ControlGrantScope },
   ): Promise<TypedGrantCreated | TypedGrantMutation>;
@@ -193,6 +197,18 @@ export type TypedGrantAuthority = {
     browserClass?: string;
   }): Promise<TypedGrantAdmission | TypedGrantAdmissionThrottled>;
   admitGrant(input: {
+    qrCredential: string;
+    browserContext: string;
+    deviceClass?: string;
+    browserClass?: string;
+  }): Promise<TypedGrantAdmission | TypedGrantAdmissionThrottled>;
+  admitPitchManagerGrant(input: {
+    qrCredential: string;
+    browserContext: string;
+    deviceClass?: string;
+    browserClass?: string;
+  }): Promise<TypedGrantAdmission | TypedGrantAdmissionThrottled>;
+  admitEventAdminGrant(input: {
     qrCredential: string;
     browserContext: string;
     deviceClass?: string;

--- a/src/lib/grant-management.test.ts
+++ b/src/lib/grant-management.test.ts
@@ -239,6 +239,59 @@ describe("typed Grant management", () => {
     expect(control).toMatchObject({ status: "created", grantType: GRANT_TYPE });
     if (control.status !== "created") throw new Error("Expected Control Grant.");
 
+    const eventSessionsBefore = await storage.transaction((transaction) =>
+      transaction.listGrantSessions(eventAdmin.grantId),
+    );
+    expect(
+      await authority.admitPitchManagerGrant({
+        qrCredential: eventAdmin.qrCredential,
+        browserContext: "wrong-event-admin",
+      }),
+    ).toMatchObject({ status: "rejected" });
+    expect(
+      await storage.transaction((transaction) => transaction.listGrantSessions(eventAdmin.grantId)),
+    ).toEqual(eventSessionsBefore);
+    const pitchManagerSessionsBeforeEventAdminAdmission = await storage.transaction((transaction) =>
+      transaction.listGrantSessions(pitchManager.grantId),
+    );
+    expect(
+      await authority.admitEventAdminGrant({
+        qrCredential: pitchManager.qrCredential,
+        browserContext: "wrong-pitch-manager-for-event-admin",
+      }),
+    ).toMatchObject({ status: "rejected" });
+    expect(
+      await storage.transaction((transaction) =>
+        transaction.listGrantSessions(pitchManager.grantId),
+      ),
+    ).toEqual(pitchManagerSessionsBeforeEventAdminAdmission);
+    const controlCredential = await authority.revealGrant(control.grantId, {
+      kind: "grant-session",
+      sessionBearer: eventSession.sessionBearer,
+    });
+    if (controlCredential.status !== "revealed") throw new Error("Expected Control QR.");
+    const controlSessionsBefore = await storage.transaction((transaction) =>
+      transaction.listGrantSessions(control.grantId),
+    );
+    expect(
+      await authority.admitEventAdminGrant({
+        qrCredential: controlCredential.qrCredential,
+        browserContext: "wrong-control-for-event-admin",
+      }),
+    ).toMatchObject({ status: "rejected" });
+    expect(
+      await storage.transaction((transaction) => transaction.listGrantSessions(control.grantId)),
+    ).toEqual(controlSessionsBefore);
+    expect(
+      await authority.admitPitchManagerGrant({
+        qrCredential: controlCredential.qrCredential,
+        browserContext: "wrong-control",
+      }),
+    ).toMatchObject({ status: "rejected" });
+    expect(
+      await storage.transaction((transaction) => transaction.listGrantSessions(control.grantId)),
+    ).toEqual(controlSessionsBefore);
+
     const pitchSession = await authority.admitGrant({
       qrCredential: pitchManager.qrCredential,
       browserContext: "manager",

--- a/src/lib/grant-management.ts
+++ b/src/lib/grant-management.ts
@@ -66,6 +66,11 @@ export function createTypedGrantAuthority(
       }),
     createPitchManagerGrant: (input) =>
       createGrant(storage, options, { ...input, grantType: PITCH_MANAGER_GRANT_TYPE }),
+    createPitchManagerGrantInTransaction: (transaction, input) =>
+      createGrantInTransaction(transaction, options, {
+        ...input,
+        grantType: PITCH_MANAGER_GRANT_TYPE,
+      }),
     createControlGrant: (input) =>
       createGrant(storage, options, { ...input, grantType: GRANT_TYPE }),
     createGrantCode: (grantId, authority) =>
@@ -76,6 +81,9 @@ export function createTypedGrantAuthority(
       disableGrantCode(storage, options, grantId, authority),
     admitGrantCode: (input) => admitGrantCode(storage, options, input),
     admitGrant: (input) => admitGrant(storage, options, input),
+    admitPitchManagerGrant: (input) =>
+      admitGrant(storage, options, input, PITCH_MANAGER_GRANT_TYPE),
+    admitEventAdminGrant: (input) => admitGrant(storage, options, input, EVENT_ADMIN_GRANT_TYPE),
     authorizeGrant: (input) => authorizeGrant(storage, options, input),
     authorizeGrantInTransaction: (transaction, input) =>
       authorizeGrantInTransaction(transaction, options, input),

--- a/src/lib/pitch-manager-administration-sqlite.focused.ts
+++ b/src/lib/pitch-manager-administration-sqlite.focused.ts
@@ -1,0 +1,150 @@
+import { expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createEventAdministration } from "@/lib/event-administration";
+import { createEventCatalog, createFoundationEventCatalogStorage } from "@/lib/event-catalog";
+import { openSqliteFoundationStorage } from "@/lib/foundation-storage-sqlite";
+import { createGrantAuthority, createGrantAuthorityVerifier } from "@/lib/grant-authority";
+import type { FoundationStorage } from "@/lib/foundation-storage";
+import type { GrantKeyRing } from "@/lib/grant-types";
+import {
+  MemoryTechnicalAdminAuthRepository,
+  createTechnicalAdminAuth,
+  isTechnicalAdminAuthority,
+} from "@/lib/technical-admin-auth";
+
+const keyRing: GrantKeyRing = {
+  encryption: { currentVersion: "v1", keys: new Map([["v1", bytes(1)]]) },
+  lookup: { currentVersion: "v1", keys: new Map([["v1", bytes(2)]]) },
+  audit: { currentVersion: "v1", keys: new Map([["v1", bytes(3)]]) },
+};
+
+test("SQLite persists a Pitch Manager handoff across restart and expires it at Event time", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "quadball-timer-pitch-manager-"));
+  const databasePath = join(directory, "foundation.sqlite");
+  let nowMs = Date.parse("2026-08-14T10:00:00Z");
+  const technical = createTechnicalAdminAuth(
+    { environment: "test", origin: "https://timer.example", rpId: "timer.example" },
+    new MemoryTechnicalAdminAuthRepository(),
+  ).resolveHostLocalAuthority();
+  let storage: FoundationStorage | undefined;
+  try {
+    const initial = openSqliteFoundationStorage(databasePath, { grantKeyRing: keyRing });
+    storage = initial;
+    await initial.applyMigrations();
+    const first = createFixture(storage, () => nowMs);
+    const event = await first.catalog.createEvent(
+      { name: "SQLite Pitch Manager", timeZone: "Europe/Zurich" },
+      technical,
+    );
+    if (event.status !== "accepted") throw new Error("Expected Event.");
+    const day = await first.catalog.addGameDay(
+      event.value.eventId,
+      { date: "2026-08-14" },
+      technical,
+    );
+    const pitch = await first.administration.createPitch(
+      event.value.eventId,
+      { name: "Pitch A" },
+      technical,
+    );
+    if (day.status !== "accepted" || pitch.status !== "accepted")
+      throw new Error("Expected Event schedule.");
+    const eventGrant = await first.administration.createEventAdminGrant(
+      event.value.eventId,
+      technical,
+    );
+    if (eventGrant.status !== "accepted") throw new Error("Expected Event Admin Grant.");
+    const eventQr = await first.grants.revealGrant(eventGrant.value.grantId, technical);
+    if (eventQr.status !== "revealed") throw new Error("Expected Event Admin QR.");
+    const eventSession = await first.administration.admitEventAdmin({
+      qrCredential: eventQr.qrCredential,
+      browserContext: "sqlite-event-admin",
+    });
+    if (eventSession.status !== "admitted") throw new Error("Expected Event Admin session.");
+    const managerGrant = await first.administration.createPitchManagerGrant(
+      event.value.eventId,
+      day.value.gameDayId,
+      pitch.value.pitchId,
+      { kind: "grant-session", sessionBearer: eventSession.sessionBearer },
+    );
+    if (managerGrant.status !== "accepted") throw new Error("Expected Pitch Manager Grant.");
+    const managerQr = await first.administration.revealPitchManagerGrant(
+      event.value.eventId,
+      day.value.gameDayId,
+      pitch.value.pitchId,
+      { kind: "grant-session", sessionBearer: eventSession.sessionBearer },
+    );
+    if (managerQr.status !== "accepted" || managerQr.value.status !== "revealed")
+      throw new Error("Expected Pitch Manager QR.");
+    const managerSession = await first.administration.admitPitchManager({
+      qrCredential: managerQr.value.qrCredential,
+      browserContext: "sqlite-manager",
+    });
+    if (managerSession.status !== "admitted") throw new Error("Expected Manager session.");
+    const expiry = managerGrant.value.expiresAtMs;
+    storage.close();
+    storage = undefined;
+
+    const reopened = openSqliteFoundationStorage(databasePath, { grantKeyRing: keyRing });
+    storage = reopened;
+    const afterRestart = createFixture(reopened, () => nowMs);
+    const view = await afterRestart.administration.openPitchManagerCurrentView({
+      authority: { kind: "grant-session", sessionBearer: managerSession.sessionBearer },
+    });
+    expect(view).toMatchObject({
+      status: "accepted",
+      value: { eventId: event.value.eventId, gameDayId: day.value.gameDayId },
+    });
+    if (expiry === null) throw new Error("Expected Pitch Manager expiry.");
+    nowMs = expiry;
+    expect(
+      await afterRestart.administration.openPitchManagerCurrentView({
+        authority: { kind: "grant-session", sessionBearer: managerSession.sessionBearer },
+      }),
+    ).toMatchObject({ status: "rejected", reason: "unauthorized" });
+    const state = await reopened.transaction((transaction) => ({
+      grant: transaction.findGrantById(managerGrant.value.grantId),
+      session: transaction.listGrantSessions(managerGrant.value.grantId)[0],
+      audit: transaction.listGrantAudit(managerGrant.value.grantId),
+    }));
+    expect(state.grant?.status).toBe("expired");
+    expect(state.session?.status).toBe("expired");
+    expect(state.audit.some((entry) => entry.action === "grant-expired")).toBe(true);
+  } finally {
+    storage?.close();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+function createFixture(storage: FoundationStorage, nowMs: () => number) {
+  const catalog = createEventCatalog(createFoundationEventCatalogStorage(storage), {
+    clock: { nowMs },
+  });
+  const grants = createGrantAuthority(storage, {
+    environmentId: "test",
+    clock: { nowMs },
+    randomness: { bytes: (length) => crypto.getRandomValues(new Uint8Array(length)) },
+    keyRing,
+    controlScopeResolver: { resolve: () => ({ status: "unavailable" as const }) },
+    privilegedAuthorityVerifier: createGrantAuthorityVerifier((input) => {
+      if (isTechnicalAdminAuthority(input)) return { kind: "technical-admin", id: input.sessionId };
+      if (
+        typeof input === "object" &&
+        input !== null &&
+        "kind" in input &&
+        input.kind === "grant-session" &&
+        "sessionBearer" in input &&
+        typeof input.sessionBearer === "string"
+      )
+        return { kind: "grant-session", sessionBearer: input.sessionBearer, sessionId: "session" };
+      return null;
+    }),
+  });
+  return { catalog, grants, administration: createEventAdministration({ storage, grants, nowMs }) };
+}
+
+function bytes(value: number): Uint8Array {
+  return new Uint8Array(32).fill(value);
+}

--- a/src/pages/event-admin-page.tsx
+++ b/src/pages/event-admin-page.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import QRCode from "qrcode/lib/browser";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -61,6 +62,18 @@ type ScheduleResponse = {
     eventGames: HubResponse["value"]["event"]["eventGames"];
   };
 };
+type PitchManagerGrantResponse = {
+  status: "accepted";
+  value: {
+    grantId: string;
+    grantVersion: string;
+    gameDayId: string;
+    gameDayDate: string;
+    pitchId: string;
+    status: string;
+    expiresAtMs: number | null;
+  };
+};
 
 class EventPublicationValidationError extends Error {}
 
@@ -108,6 +121,11 @@ export function EventAdminPage() {
     pitchSlots: HubResponse["value"]["event"]["pitchSlots"];
     eventGames: HubResponse["value"]["event"]["eventGames"];
   } | null>(null);
+  const [pitchManagerPitchId, setPitchManagerPitchId] = useState("");
+  const [pitchManagerGrant, setPitchManagerGrant] = useState<
+    PitchManagerGrantResponse["value"] | null
+  >(null);
+  const [pitchManagerQrDataUrl, setPitchManagerQrDataUrl] = useState<string | null>(null);
   const [publicationImpactConfirmed, setPublicationImpactConfirmed] = useState(false);
 
   const loadHub = async (nextGameDayId = selectedGameDayId) => {
@@ -186,6 +204,17 @@ export function EventAdminPage() {
     setPitchView(payload.value);
   };
 
+  const loadPitchManagerGrant = async () => {
+    if (selectedGameDayId === null || pitchManagerPitchId.length === 0) return;
+    const response = await fetch(
+      `/api/event-admin/events/${eventId}/game-days/${selectedGameDayId}/pitches/${pitchManagerPitchId}/pitch-manager-grant`,
+    );
+    const payload = (await response.json()) as PitchManagerGrantResponse | { status: string };
+    if (!response.ok || payload.status !== "accepted") throw new Error("Grant lookup failed.");
+    setPitchManagerGrant((payload as PitchManagerGrantResponse).value ?? null);
+    setPitchManagerQrDataUrl(null);
+  };
+
   const changePublicationStatus = async (status: "unpublished" | "published" | "cancelled") => {
     if (hub === null) return;
     const leavingPublished = hub.event.publicationStatus === "published" && status !== "published";
@@ -222,6 +251,18 @@ export function EventAdminPage() {
         : "Publication Status updated.",
     );
     await loadHub(selectedGameDayId);
+  };
+
+  const managePitchManagerGrant = async (
+    operation: "rotate" | "disable" | "revoke" | "reactivate",
+  ) => {
+    if (selectedGameDayId === null || pitchManagerPitchId.length === 0) return;
+    const response = await fetch(
+      `/api/event-admin/events/${eventId}/game-days/${selectedGameDayId}/pitches/${pitchManagerPitchId}/pitch-manager-grant/${operation}`,
+      { method: "POST" },
+    );
+    if (!response.ok) throw new Error("Pitch Manager Grant lifecycle change failed.");
+    await loadPitchManagerGrant();
   };
 
   const confirmGameplaySlot = async (
@@ -928,6 +969,153 @@ export function EventAdminPage() {
                       );
                     })}
                   </div>
+                ) : null}
+              </div>
+              <div className="space-y-3 rounded-lg border p-3">
+                <div>
+                  <p className="font-semibold">Pitch Manager handoff</p>
+                  <p className="text-xs text-muted-foreground">
+                    One Grant covers exactly one Pitch and Game Day. The QR is revealed only on
+                    demand.
+                  </p>
+                </div>
+                <div className="grid gap-2 sm:grid-cols-2">
+                  <select
+                    aria-label="Pitch Manager Game Day"
+                    className="h-10 rounded-md border bg-background px-3 text-sm"
+                    value={selectedGameDayId ?? ""}
+                    onChange={(event) => {
+                      setSelectedGameDayId(event.target.value);
+                      setPitchManagerGrant(null);
+                      setPitchManagerQrDataUrl(null);
+                    }}
+                  >
+                    <option value="">Game Day</option>
+                    {hub.event.gameDays.map((day) => (
+                      <option key={day.gameDayId} value={day.gameDayId}>
+                        {day.date}
+                      </option>
+                    ))}
+                  </select>
+                  <select
+                    aria-label="Pitch Manager Pitch"
+                    className="h-10 rounded-md border bg-background px-3 text-sm"
+                    value={pitchManagerPitchId}
+                    onChange={(event) => {
+                      setPitchManagerPitchId(event.target.value);
+                      setPitchManagerGrant(null);
+                      setPitchManagerQrDataUrl(null);
+                    }}
+                  >
+                    <option value="">Pitch</option>
+                    {hub.event.pitches.map((pitch) => (
+                      <option key={pitch.pitchId} value={pitch.pitchId}>
+                        {pitch.name}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  <Button
+                    variant="outline"
+                    disabled={
+                      busy || selectedGameDayId === null || pitchManagerPitchId.length === 0
+                    }
+                    onClick={() => void run(loadPitchManagerGrant)}
+                  >
+                    Inspect Grant
+                  </Button>
+                  <Button
+                    disabled={
+                      busy || selectedGameDayId === null || pitchManagerPitchId.length === 0
+                    }
+                    onClick={() =>
+                      void run(async () => {
+                        const response = await fetch(
+                          `/api/event-admin/events/${eventId}/game-days/${selectedGameDayId}/pitches/${pitchManagerPitchId}/pitch-manager-grant`,
+                          { method: "POST" },
+                        );
+                        if (!response.ok) throw new Error("Pitch Manager Grant creation failed.");
+                        await loadPitchManagerGrant();
+                      })
+                    }
+                  >
+                    Create Grant
+                  </Button>
+                  <Button
+                    variant="outline"
+                    disabled={busy || pitchManagerGrant === null}
+                    onClick={() =>
+                      void run(async () => {
+                        const response = await fetch(
+                          `/api/event-admin/events/${eventId}/game-days/${selectedGameDayId}/pitches/${pitchManagerPitchId}/pitch-manager-grant/reveal`,
+                          { method: "POST" },
+                        );
+                        const payload = (await response.json()) as {
+                          status: string;
+                          value?: { qrCredential?: string };
+                        };
+                        if (
+                          !response.ok ||
+                          payload.status !== "accepted" ||
+                          payload.value?.qrCredential === undefined
+                        )
+                          throw new Error("Pitch Manager QR reveal failed.");
+                        setPitchManagerQrDataUrl(
+                          await QRCode.toDataURL(payload.value.qrCredential),
+                        );
+                      })
+                    }
+                  >
+                    Reveal QR
+                  </Button>
+                  <Button
+                    variant="outline"
+                    aria-label="Rotate Pitch Manager Grant"
+                    disabled={busy || pitchManagerGrant === null}
+                    onClick={() => void run(() => managePitchManagerGrant("rotate"))}
+                  >
+                    Rotate Grant
+                  </Button>
+                  <Button
+                    variant="outline"
+                    aria-label="Disable Pitch Manager Grant"
+                    disabled={busy || pitchManagerGrant === null}
+                    onClick={() => void run(() => managePitchManagerGrant("disable"))}
+                  >
+                    Disable Grant
+                  </Button>
+                  <Button
+                    variant="outline"
+                    aria-label="Revoke Pitch Manager Grant"
+                    disabled={busy || pitchManagerGrant === null}
+                    onClick={() => void run(() => managePitchManagerGrant("revoke"))}
+                  >
+                    Revoke Grant
+                  </Button>
+                  <Button
+                    variant="outline"
+                    aria-label="Reactivate Pitch Manager Grant"
+                    disabled={busy || pitchManagerGrant === null}
+                    onClick={() => void run(() => managePitchManagerGrant("reactivate"))}
+                  >
+                    Reactivate Grant
+                  </Button>
+                </div>
+                {pitchManagerGrant ? (
+                  <p className="text-sm">
+                    {pitchManagerGrant.status} · expires{" "}
+                    {pitchManagerGrant.expiresAtMs === null
+                      ? "never"
+                      : new Date(pitchManagerGrant.expiresAtMs).toLocaleString()}
+                  </p>
+                ) : null}
+                {pitchManagerQrDataUrl ? (
+                  <img
+                    alt="Pitch Manager Grant QR code"
+                    className="h-48 w-48 rounded border bg-white p-2"
+                    src={pitchManagerQrDataUrl}
+                  />
                 ) : null}
               </div>
               <Button variant="outline" onClick={() => setHub(null)}>

--- a/src/pages/pitch-manager-page.tsx
+++ b/src/pages/pitch-manager-page.tsx
@@ -1,0 +1,179 @@
+import { useCallback, useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+type Scope = {
+  eventId: string;
+  gameDayId: string;
+  gameDayDate: string;
+  eventTimeZone: string;
+  pitchId: string;
+};
+
+type View = {
+  eventId: string;
+  gameDayId: string;
+  gameDayDate: string;
+  eventTimeZone: string;
+  pitch: { pitchId: string; name: string };
+  schedule: Array<{
+    pitchSlotId: string;
+    gameplaySlotId: string;
+    sequence: number;
+    expectedStart: string;
+    eventGame: {
+      eventGameId: string;
+      gameCode: string | null;
+      gameDesignation: string | null;
+      sideA: { displayName: string };
+      sideB: { displayName: string };
+    } | null;
+    conflictEventGameIds: string[];
+    controlGrantStatus: string;
+  }>;
+  grantSessionExpiresAt: string | null;
+};
+
+export function PitchManagerPage() {
+  const [credential, setCredential] = useState("");
+  const [scope, setScope] = useState<Scope | null>(null);
+  const [view, setView] = useState<View | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const loadCurrent = useCallback(async () => {
+    const response = await fetch("/api/pitch-manager/current");
+    const payload = (await response.json()) as { status: string; value?: View };
+    if (!response.ok || payload.status !== "accepted" || payload.value === undefined)
+      throw new Error("Unable to open the Pitch Manager view.");
+    const nextScope: Scope = {
+      eventId: payload.value.eventId,
+      gameDayId: payload.value.gameDayId,
+      gameDayDate: payload.value.gameDayDate,
+      eventTimeZone: payload.value.eventTimeZone,
+      pitchId: payload.value.pitch.pitchId,
+    };
+    setScope(nextScope);
+    setView(payload.value);
+  }, []);
+
+  const admit = async () => {
+    setBusy(true);
+    setMessage(null);
+    try {
+      const response = await fetch("/api/pitch-manager/admit", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ qrCredential: credential, deviceClass: "mobile" }),
+      });
+      const payload = (await response.json()) as { status: string };
+      if (!response.ok || payload.status !== "admitted")
+        throw new Error("Unable to admit this Pitch Manager QR.");
+      await loadCurrent();
+    } catch {
+      setMessage("Unable to admit this Pitch Manager QR.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  useEffect(() => {
+    if (scope !== null || view !== null) return;
+    void loadCurrent().catch(() => undefined);
+  }, [loadCurrent, scope, view]);
+
+  const leave = async () => {
+    await fetch("/api/pitch-manager/leave", { method: "POST" });
+    setScope(null);
+    setView(null);
+  };
+
+  if (view === null || scope === null) {
+    return (
+      <main className="mx-auto flex min-h-screen w-full max-w-xl items-center justify-center p-4">
+        <Card className="w-full">
+          <CardHeader>
+            <CardTitle>Pitch Manager handoff</CardTitle>
+            <CardDescription>Scan the QR for one Pitch and Game Day.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="pitch-manager-credential">Scanned Pitch Manager QR value</Label>
+              <Input
+                id="pitch-manager-credential"
+                type="password"
+                autoComplete="off"
+                value={credential}
+                onChange={(event) => setCredential(event.target.value)}
+              />
+            </div>
+            <Button disabled={busy || credential.length === 0} onClick={() => void admit()}>
+              Open Pitch
+            </Button>
+            {message ? <p className="text-sm text-destructive">{message}</p> : null}
+          </CardContent>
+        </Card>
+      </main>
+    );
+  }
+
+  return (
+    <main className="mx-auto min-h-screen w-full max-w-3xl p-4 pb-12 sm:p-6">
+      <Card>
+        <CardHeader className="flex-row items-start justify-between gap-4">
+          <div>
+            <CardTitle>{view.pitch.name}</CardTitle>
+            <CardDescription>
+              Pitch Manager · Game Day {view.gameDayDate} · {view.eventTimeZone} ·{" "}
+              {view.schedule.length} Slots
+            </CardDescription>
+          </div>
+          <Button variant="outline" onClick={() => void leave()}>
+            Leave
+          </Button>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p className="text-sm text-muted-foreground">
+            Session valid until{" "}
+            {view.grantSessionExpiresAt === null ? "the Grant expires" : view.grantSessionExpiresAt}
+            .
+          </p>
+          <div className="space-y-2" aria-label="Pitch schedule">
+            {view.schedule.map((slot) => {
+              const game = slot.eventGame;
+              return (
+                <div
+                  className={`rounded border p-3 ${slot.conflictEventGameIds.length > 1 ? "border-destructive" : ""}`}
+                  key={slot.pitchSlotId}
+                >
+                  <div className="flex flex-wrap justify-between gap-2">
+                    <span className="font-medium">Slot {slot.sequence}</span>
+                    <span>{slot.expectedStart}</span>
+                  </div>
+                  <p className="text-sm">
+                    {game === null
+                      ? "No Event Game"
+                      : `${game.gameCode ?? game.eventGameId} · ${game.sideA.displayName} vs ${game.sideB.displayName}`}
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    Control Grant: {slot.controlGrantStatus}
+                    {slot.conflictEventGameIds.length > 1 ? " · Schedule conflict" : ""}
+                  </p>
+                </div>
+              );
+            })}
+          </div>
+          {message ? <p className="text-sm text-destructive">{message}</p> : null}
+          <Button
+            variant="outline"
+            onClick={() => void loadCurrent().catch(() => setMessage("View refresh failed."))}
+          >
+            Refresh Pitch
+          </Button>
+        </CardContent>
+      </Card>
+    </main>
+  );
+}


### PR DESCRIPTION
## What changed

Implements GitHub #115, “Hand one Pitch to a Pitch Manager,” for parent Spec #105. An Event Admin can manage a Pitch Manager Grant for one Pitch and Game Day, and a Pitch Manager can use the protected QR credential to view the operational schedule for that exact scope.

## Why

This supplies the minimum reliable two-day Pitch Manager admission path while preserving the canonical Grant, QR, session, redaction, sensitive-response, catalog, and transaction seams.

## Impact and boundaries

- Admission is type-bound to an active Pitch Manager Grant with exact Event, Game Day, and Pitch scope; Event Admin and Control credentials are rejected generically without creating sessions.
- QR admission creates a pseudonymous durable HttpOnly session. Reload and server restart recover the scope from the live session, with revocation, expiry, and version revalidation on every request.
- The view is an independently allowlisted Pitch Manager DTO: only the scoped Pitch schedule, slots, Games, canonical Expected Starts, conflicts, relevant Control Grant status, event timezone, and fixed Event Team display names are disclosed.
- No schedule mutation or cross-scope access is available.
- Authority and session expiry follow Event time at 04:30 after the Game Day, including DST; expiry never revives, and rotation/reactivation creates a new Grant version, QR, and session lifecycle.
- Grant, catalog projection, session, and audit changes remain atomic. Event Admin session expiry caps sensitive mutation cookies rather than refreshing them to a new 30-day window.
- Admission and leave outcomes use sensitive no-store/no-referrer responses, including malformed, wrong-type, unavailable, and missing-session failures.

## Validation

- `bun run check` passed; only the repository’s existing seven `await-thenable` warnings remain.
- `bun run test` passed: 523 tests, 0 failures.
- `bun run build` passed.
- Focused Pitch Manager/catalog/header/SQLite coverage passed: 38 tests, 0 failures.
- Focused browser coverage passed for both wrong-type directions, generic privacy failures, capped cookies, Event-time formatting, reload/restart, exact scope, rotation invalidation, disable/reactivation, and new version/QR/session.
- `git diff --check` passed; local and remote branch tips are exact and the worktree is clean.
