### PR TITLE
Enable Ad Hoc Control QR handoff

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test:focused:event-catalog-cli": "bun test --isolate ./scripts/event-catalog-cli.focused.ts",
     "test:focused:grant-code": "bun test --isolate ./src/lib/grant-code.focused.ts",
     "test:focused:ad-hoc": "bun test --isolate ./src/lib/ad-hoc-games.focused.ts",
+    "test:focused:adhoc-browser": "bun scripts/test-ad-hoc-browser.ts",
     "test:changed": "bun test --changed",
     "format": "bunx --bun oxfmt \"**/*.{js,jsx,ts,tsx,mjs,cjs}\" \"!docs/**\"",
     "format:check": "bunx --bun oxfmt \"**/*.{js,jsx,ts,tsx,mjs,cjs}\" \"!docs/**\" --check",

--- a/scripts/test-ad-hoc-browser.ts
+++ b/scripts/test-ad-hoc-browser.ts
@@ -1,0 +1,369 @@
+#!/usr/bin/env bun
+import { chromium, type Page } from "playwright";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+let directory = "";
+let certificatePath = "";
+let keyPath = "";
+let databasePath = "";
+let port = 0;
+let origin = "";
+let environment: NodeJS.ProcessEnv = {};
+
+let server: Bun.Subprocess | null = null;
+let serverDrains: Promise<unknown>[] = [];
+let browser: Awaited<ReturnType<typeof chromium.launch>> | null = null;
+let setupProcess: Bun.Subprocess | null = null;
+
+const lifecycleController = new AbortController();
+const lifecycleTimer = setTimeout(() => lifecycleController.abort(), 52_000);
+
+async function run() {
+  directory = mkdtempSync(join(tmpdir(), "quadball-timer-adhoc-browser-"));
+  certificatePath = join(directory, "localhost.crt");
+  keyPath = join(directory, "localhost.key");
+  databasePath = join(directory, "ad-hoc.sqlite");
+  port = 39_000 + Math.floor(Math.random() * 1_000);
+  origin = `https://localhost:${port}`;
+  environment = {
+    ...process.env,
+    NODE_ENV: "test",
+    QUADBALL_ENVIRONMENT: "test",
+    AD_HOC_ENVIRONMENT_ID: "adhoc-browser-test",
+    AD_HOC_DATABASE: databasePath,
+    PUBLIC_ORIGIN: origin,
+    TECHNICAL_ADMIN_DATABASE: join(directory, "technical-admin.sqlite"),
+    TLS_CERT_FILE: certificatePath,
+    TLS_KEY_FILE: keyPath,
+    HOST: "127.0.0.1",
+    PORT: String(port),
+  };
+
+  let runError: unknown = null;
+  let cleanupError: Error | null = null;
+  try {
+    setupProcess = Bun.spawn(
+      [
+        "openssl",
+        "req",
+        "-x509",
+        "-newkey",
+        "rsa:2048",
+        "-nodes",
+        "-subj",
+        "/CN=localhost",
+        "-addext",
+        "subjectAltName=DNS:localhost",
+        "-days",
+        "1",
+        "-keyout",
+        keyPath,
+        "-out",
+        certificatePath,
+      ],
+      { stdout: "ignore", stderr: "ignore" },
+    );
+    const certificateExit = await raceWithDeadline(setupProcess.exited, lifecycleController.signal);
+    setupProcess = null;
+    if (certificateExit !== 0) throw new Error("openssl could not create a certificate.");
+
+    await raceWithDeadline(startServer(), lifecycleController.signal);
+    browser = await raceWithDeadline(
+      chromium.launch({ headless: true }),
+      lifecycleController.signal,
+    );
+    await raceWithDeadline(
+      (async () => {
+        const firstContext = await browser!.newContext({ ignoreHTTPSErrors: true });
+        let secondContext = await browser!.newContext({ ignoreHTTPSErrors: true });
+        const first = await firstContext.newPage();
+        let second = await secondContext.newPage();
+        first.setDefaultTimeout(15_000);
+        second.setDefaultTimeout(15_000);
+
+        await first.goto(origin);
+        await first.getByRole("button", { name: /Start an Ad Hoc Game/ }).click();
+        await first.waitForURL(/\/game\/adhoc-/u);
+        await assertAccessibleQr(first, "creator");
+
+        const gameId = new URL(first.url()).pathname.split("/").at(-1);
+        if (gameId === undefined) throw new Error("Game route did not contain a Game ID.");
+        const snapshot = (await first.evaluate(async (id) => {
+          const response = await fetch(`/api/games/${id}`);
+          return (await response.json()) as { game?: { controlQr?: string | null } };
+        }, gameId)) as { game?: { controlQr?: string | null } };
+        const controlQr = snapshot.game?.controlQr;
+        if (typeof controlQr !== "string") throw new Error("Ad Hoc Control QR was not authorized.");
+
+        const handoffUrl = `${origin}/#adhoc-game=${encodeURIComponent(gameId)}&adhoc-control=${encodeURIComponent(controlQr)}`;
+        await second.goto(handoffUrl);
+        await waitForGameRoute(second, gameId);
+        await assertAccessibleQr(second, "second browser");
+
+        await second.getByRole("button", { name: "Start game" }).click();
+        await first.getByText("Running", { exact: true }).waitFor();
+        await second.getByRole("button", { name: "Pause game" }).click();
+        await second.getByRole("button", { name: "Game end" }).click();
+        await second.getByRole("button", { name: "Double forfeit" }).click();
+        await second.getByText("Finished", { exact: true }).waitFor();
+        await first.getByText("new admission is paused.", { exact: false }).waitFor();
+        await second.getByRole("button", { name: "Correct back to unfinished" }).click();
+        await waitForUnfinishedGame(second, gameId);
+
+        const secondStorageState = await secondContext.storageState();
+        await secondContext.close();
+        await stopServer();
+        await startServer();
+
+        await first.reload();
+        await waitForGameRoute(first, gameId);
+        await first.getByText("Paused", { exact: true }).waitFor();
+        secondContext = await browser.newContext({
+          ignoreHTTPSErrors: true,
+          storageState: secondStorageState,
+        });
+        second = await secondContext.newPage();
+        second.setDefaultTimeout(15_000);
+        await second.goto(`${origin}/game/${gameId}`);
+        await waitForGameRoute(second, gameId);
+        await second.getByText("Paused", { exact: true }).waitFor();
+        await assertAccessibleQr(second, "recreated second browser after restart");
+
+        await second.getByRole("button", { name: "Start game" }).click();
+        await first.getByText("Running", { exact: true }).waitFor();
+        await second.getByRole("button", { name: "Pause game" }).click();
+        await second.getByRole("button", { name: "Leave", exact: true }).click();
+        if (new URL(second.url()).pathname !== "/") await second.waitForURL(`${origin}/`);
+        await first.getByText("Paused", { exact: true }).waitFor();
+
+        await second.goto(handoffUrl);
+        await waitForGameRoute(second, gameId);
+        await assertAccessibleQr(second, "readmitted second browser");
+      })(),
+      lifecycleController.signal,
+    );
+  } catch (error) {
+    runError = error;
+  } finally {
+    if (setupProcess !== null) {
+      try {
+        await terminateChild(setupProcess);
+      } catch (error) {
+        cleanupError = asError(error, "OpenSSL cleanup failed.");
+      }
+      setupProcess = null;
+    }
+    if (browser !== null) {
+      const activeBrowser = browser;
+      const closed = await Promise.race([
+        activeBrowser.close().then(() => true),
+        Bun.sleep(2_000).then(() => false),
+      ]);
+      if (!closed || activeBrowser.isConnected()) {
+        cleanupError ??= new Error("Browser cleanup did not complete within its deadline.");
+      }
+      browser = null;
+    }
+    try {
+      await stopServer();
+    } catch (error) {
+      cleanupError ??= asError(error, "Server cleanup failed.");
+    }
+    rmSync(directory, { recursive: true, force: true });
+  }
+  if (cleanupError !== null) throw cleanupError;
+  if (runError !== null) throw runError;
+}
+
+try {
+  await run();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+} finally {
+  clearTimeout(lifecycleTimer);
+}
+
+function raceWithDeadline<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted)
+    return Promise.reject(new Error("Ad Hoc browser test exceeded 52 second work deadline."));
+  return Promise.race([
+    promise,
+    new Promise<never>((_, reject) => {
+      signal.addEventListener(
+        "abort",
+        () => reject(new Error("Ad Hoc browser test exceeded 52 second work deadline.")),
+        { once: true },
+      );
+    }),
+  ]);
+}
+
+async function startServer() {
+  if (server !== null) throw new Error("Ad Hoc browser server is already running.");
+  const child = Bun.spawn([process.execPath, "run", "src/index.ts"], {
+    cwd: process.cwd(),
+    env: environment,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  server = child;
+  let resolveReady!: () => void;
+  let rejectReady!: (error: Error) => void;
+  const ready = new Promise<void>((resolve, reject) => {
+    resolveReady = resolve;
+    rejectReady = reject;
+  });
+  let output = "";
+  const stdoutDrain = drainBounded(child.stdout, 64 * 1024, (chunk) => {
+    output += new TextDecoder().decode(chunk, { stream: true });
+    const match = output.match(/Server running at https?:\/\/[^\s]+/u);
+    if (
+      match !== null &&
+      new URL(match[0].replace("Server running at ", "")).port === String(port)
+    ) {
+      resolveReady();
+    }
+  }).catch((error) => {
+    rejectReady(error instanceof Error ? error : new Error("server output failed"));
+    throw error;
+  });
+  const stderrDrain = drainBounded(child.stderr, 64 * 1024);
+  serverDrains = [stdoutDrain, stderrDrain];
+  await Promise.race([
+    ready,
+    child.exited.then(() => {
+      throw new Error("Ad Hoc browser server exited before readiness.");
+    }),
+  ]);
+  await waitForServer();
+}
+
+async function stopServer() {
+  const child = server;
+  if (child === null) return;
+  server = null;
+  child.kill("SIGTERM");
+  let exited = await waitForExit(child, 2_000);
+  if (!exited) {
+    child.kill("SIGKILL");
+    exited = await waitForExit(child, 1_000);
+  }
+  await Promise.race([Promise.allSettled(serverDrains), Bun.sleep(500)]);
+  serverDrains = [];
+  if (!exited) throw new Error("Ad Hoc browser server did not exit after SIGKILL.");
+}
+
+async function terminateChild(child: Bun.Subprocess) {
+  child.kill("SIGTERM");
+  if (await waitForExit(child, 250)) return;
+  child.kill("SIGKILL");
+  if (!(await waitForExit(child, 1_000))) {
+    throw new Error("OpenSSL did not exit after SIGKILL.");
+  }
+}
+
+function asError(error: unknown, fallback: string): Error {
+  return error instanceof Error ? error : new Error(fallback);
+}
+
+async function waitForExit(child: Bun.Subprocess, timeoutMs: number) {
+  return await Promise.race([
+    child.exited.then(() => true),
+    Bun.sleep(timeoutMs).then(() => false),
+  ]);
+}
+
+async function drainBounded(
+  stream: ReadableStream<Uint8Array> | number | undefined,
+  limit: number,
+  onChunk?: (chunk: Uint8Array) => void,
+) {
+  if (stream === undefined || typeof stream === "number")
+    throw new Error("server output unavailable");
+  const reader = stream.getReader();
+  let length = 0;
+  while (true) {
+    const chunk = await reader.read();
+    if (chunk.done) return;
+    onChunk?.(chunk.value);
+    length += chunk.value.byteLength;
+    if (length > limit) throw new Error("server output exceeded cap");
+  }
+}
+
+async function waitForServer() {
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    const response = Bun.spawnSync([
+      "curl",
+      "-k",
+      "-sSf",
+      "-H",
+      `host: localhost:${port}`,
+      `${origin}/internal/healthz`,
+    ]);
+    if (response.exitCode === 0) return;
+    await Bun.sleep(50);
+  }
+  throw new Error("Ad Hoc browser server did not become ready.");
+}
+
+async function waitForGameRoute(page: Page, gameId: string) {
+  if (page.url() !== `${origin}/game/${gameId}`) await page.waitForURL(`${origin}/game/${gameId}`);
+}
+
+async function assertAccessibleQr(page: Page, stage: string) {
+  try {
+    const trigger = page.getByRole("button", { name: "Show Ad Hoc Control QR" });
+    await trigger.click();
+    const dialog = page.getByRole("dialog", { name: "Ad Hoc Control QR dialog" });
+    if ((await dialog.getAttribute("aria-modal")) !== "true")
+      throw new Error("dialog is not modal");
+    const close = dialog.getByRole("button", { name: "Close Control QR" });
+    if (!(await close.evaluate((element) => element === document.activeElement))) {
+      throw new Error("dialog did not focus its close control");
+    }
+    await page.keyboard.press("Tab");
+    if (!(await close.evaluate((element) => element === document.activeElement))) {
+      throw new Error("dialog did not contain Tab focus");
+    }
+    await page.keyboard.press("Escape");
+    await trigger.waitFor();
+    await page.waitForFunction(
+      () =>
+        document.activeElement?.tagName === "BUTTON" &&
+        document.activeElement?.textContent?.trim() === "Show Ad Hoc Control QR",
+    );
+    if (!(await trigger.evaluate((element) => element === document.activeElement))) {
+      throw new Error("Escape did not restore focus to the QR trigger");
+    }
+    await trigger.click();
+    await page.getByAltText("Ad Hoc Control QR code").waitFor();
+    await close.click();
+    await trigger.waitFor();
+    await page.waitForFunction(
+      () =>
+        document.activeElement?.tagName === "BUTTON" &&
+        document.activeElement?.textContent?.trim() === "Show Ad Hoc Control QR",
+    );
+    if (!(await trigger.evaluate((element) => element === document.activeElement))) {
+      throw new Error("Close did not restore focus to the QR trigger");
+    }
+  } catch (error) {
+    throw new Error(`${stage} QR display failed at ${page.url()}.`, { cause: error });
+  }
+}
+
+async function waitForUnfinishedGame(page: Page, gameId: string) {
+  await page.waitForFunction(async (id) => {
+    const response = await fetch(`/api/games/${id}`);
+    if (!response.ok) return false;
+    const payload = (await response.json()) as {
+      game?: { controlQr?: unknown; state?: { isFinished?: unknown } };
+    };
+    return payload.game?.state?.isFinished === false && typeof payload.game.controlQr === "string";
+  }, gameId);
+}

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -3,6 +3,7 @@ import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { Window } from "happy-dom";
 import { App, parseRoute } from "./App";
+import { captureAdHocHandoffFromLocation } from "@/lib/ad-hoc-handoff";
 import { createInitialGameState, projectGameView } from "@/lib/game-engine";
 import { DEFAULT_AWAY_TEAM_COLOR, DEFAULT_HOME_TEAM_COLOR } from "@/lib/team-colors";
 import { createInitialClockBaseline, projectClockBaseline } from "@/lib/clock-authority";
@@ -72,6 +73,69 @@ describe("App", () => {
       type: "game",
       gameId: "adhoc-id_with_underscore",
       role: "controller",
+    });
+  });
+
+  test("parses a QR handoff from the URL fragment without putting the credential in the path", () => {
+    expect(
+      parseRoute(
+        "/",
+        "",
+        "#adhoc-game=adhoc-game-123&adhoc-control=secret-token-abcdefghijklmnopqrstuvwxyz",
+      ),
+    ).toEqual({
+      type: "ad-hoc-handoff",
+      handoff: {
+        gameId: "adhoc-game-123",
+        controlQr: "secret-token-abcdefghijklmnopqrstuvwxyz",
+      },
+    });
+  });
+
+  test("captures and scrubs a QR handoff before the first render", () => {
+    const handoffWindow = new Window({
+      url: "http://localhost:3000/#adhoc-game=adhoc-game-123&adhoc-control=secret-token-abcdefghijklmnopqrstuvwxyz",
+    });
+    const handoff = captureAdHocHandoffFromLocation(handoffWindow.location, handoffWindow.history);
+
+    expect(handoff).toEqual({
+      attempted: true,
+      handoff: {
+        gameId: "adhoc-game-123",
+        controlQr: "secret-token-abcdefghijklmnopqrstuvwxyz",
+      },
+    });
+    expect(handoffWindow.location.hash).toBe("");
+    expect(handoffWindow.location.pathname).toBe("/");
+    expect(handoffWindow.history.state).toBeNull();
+  });
+
+  test("scrubs malformed Ad Hoc attempts and preserves unrelated hashes", () => {
+    const malformedWindow = new Window({
+      url: "http://localhost:3000/#adhoc-game=partial",
+    });
+    expect(
+      captureAdHocHandoffFromLocation(malformedWindow.location, malformedWindow.history),
+    ).toEqual({
+      attempted: true,
+      handoff: null,
+    });
+    expect(malformedWindow.location.hash).toBe("");
+    expect(malformedWindow.history.state).toBeNull();
+
+    const unrelatedWindow = new Window({ url: "http://localhost:3000/#scoreboard" });
+    expect(
+      captureAdHocHandoffFromLocation(unrelatedWindow.location, unrelatedWindow.history),
+    ).toEqual({
+      attempted: false,
+      handoff: null,
+    });
+    expect(unrelatedWindow.location.hash).toBe("#scoreboard");
+  });
+
+  test("routes malformed Ad Hoc attempts to the generic unavailable result", () => {
+    expect(parseRoute("/", "", "#adhoc-control=partial")).toEqual({
+      type: "ad-hoc-unavailable",
     });
   });
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,12 @@ import { EventOperationsPrototypePage } from "@/pages/event-operations-prototype
 import { EventAdminPage } from "@/pages/event-admin-page";
 import { EventGameControllerPage } from "@/pages/event-game-controller-page";
 import { GamePage } from "@/pages/game-page";
+import {
+  getAdHocBrowserId,
+  hasAdHocHandoffAttempt,
+  parseAdHocHandoffHash,
+  type AdHocHandoff,
+} from "@/lib/ad-hoc-handoff";
 import { TechnicalAdminPage } from "@/pages/technical-admin-page";
 import "./index.css";
 
@@ -37,10 +43,23 @@ type Route =
       type: "game";
       gameId: string;
       role: ControllerRole;
+    }
+  | {
+      type: "ad-hoc-handoff";
+      handoff: AdHocHandoff;
+    }
+  | {
+      type: "ad-hoc-unavailable";
     };
 
-export function App() {
-  const route = useRoute();
+export function App({
+  initialAdHocHandoff = null,
+  initialAdHocHandoffAttempted = false,
+}: {
+  initialAdHocHandoff?: AdHocHandoff | null;
+  initialAdHocHandoffAttempted?: boolean;
+}) {
+  const route = useRoute(initialAdHocHandoff, initialAdHocHandoffAttempted);
 
   if (route.type === "home") {
     return <HomePage />;
@@ -66,6 +85,25 @@ export function App() {
     return <TechnicalAdminPage enrollment={route.enrollment} />;
   }
 
+  if (route.type === "ad-hoc-handoff") {
+    return <AdHocHandoffPage handoff={route.handoff} />;
+  }
+
+  if (route.type === "ad-hoc-unavailable") {
+    return (
+      <div className="mx-auto flex min-h-screen w-full max-w-xl items-center p-6">
+        <Card className="w-full">
+          <CardHeader>
+            <CardTitle>Ad Hoc Game unavailable.</CardTitle>
+            <CardDescription>
+              This Ad Hoc handoff is invalid or no longer available.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      </div>
+    );
+  }
+
   return <GamePage gameId={route.gameId} role={route.role} />;
 }
 
@@ -84,6 +122,7 @@ function HomePage() {
         awayName,
         homeColor,
         awayColor,
+        browserId: getAdHocBrowserId(),
       }),
     });
 
@@ -121,7 +160,8 @@ function HomePage() {
           <CardHeader>
             <CardTitle>Start an Ad Hoc Game</CardTitle>
             <CardDescription>
-              You are admitted as the initially admitted Ad Hoc Controller.
+              You are admitted as an equal Ad Hoc Controller. Share the reusable Control QR from the
+              game screen with another device.
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-3">
@@ -187,14 +227,57 @@ function HomePage() {
   );
 }
 
-function useRoute(): Route {
+function AdHocHandoffPage({ handoff }: { handoff: AdHocHandoff }) {
+  const [message, setMessage] = useState("Joining Ad Hoc Game…");
+
+  useEffect(() => {
+    let cancelled = false;
+    void fetch(`/api/games/${handoff.gameId}/admit`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ controlQr: handoff.controlQr, browserId: getAdHocBrowserId() }),
+    })
+      .then(async (response) => {
+        if (!response.ok) throw new Error("unavailable");
+        if (cancelled) return;
+        navigateTo(`/game/${handoff.gameId}`);
+      })
+      .catch(() => {
+        if (!cancelled) setMessage("Ad Hoc Game unavailable.");
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [handoff.controlQr, handoff.gameId]);
+
+  return (
+    <div className="mx-auto flex min-h-screen w-full max-w-xl items-center p-6">
+      <Card className="w-full">
+        <CardHeader>
+          <CardTitle>Ad Hoc Controller handoff</CardTitle>
+          <CardDescription>{message}</CardDescription>
+        </CardHeader>
+      </Card>
+    </div>
+  );
+}
+
+function useRoute(
+  initialAdHocHandoff: AdHocHandoff | null,
+  initialAdHocHandoffAttempted: boolean,
+): Route {
   const [route, setRoute] = useState<Route>(() =>
-    parseRoute(window.location.pathname, window.location.search),
+    initialAdHocHandoff !== null
+      ? { type: "ad-hoc-handoff", handoff: initialAdHocHandoff }
+      : initialAdHocHandoffAttempted
+        ? { type: "ad-hoc-unavailable" }
+        : parseRoute(window.location.pathname, window.location.search, window.location.hash),
   );
 
   useEffect(() => {
     const onPopState = () => {
-      setRoute(parseRoute(window.location.pathname, window.location.search));
+      setRoute(parseRoute(window.location.pathname, window.location.search, window.location.hash));
     };
 
     window.addEventListener("popstate", onPopState);
@@ -204,7 +287,15 @@ function useRoute(): Route {
   return route;
 }
 
-export function parseRoute(pathname: string, _search: string): Route {
+export function parseRoute(pathname: string, _search: string, hash = ""): Route {
+  const handoff = parseAdHocHandoffHash(hash);
+  if (handoff !== null) {
+    return { type: "ad-hoc-handoff", handoff };
+  }
+  if (hasAdHocHandoffAttempt(hash)) {
+    return { type: "ad-hoc-unavailable" };
+  }
+
   if (pathname === "/admin" || pathname === "/admin/") {
     return { type: "technical-admin", enrollment: false };
   }

--- a/src/components/game-controller-action-panels.tsx
+++ b/src/components/game-controller-action-panels.tsx
@@ -68,6 +68,7 @@ export function GameControllerActionPanels({
   suspendGame,
   requestForfeitWin,
   recordDoubleForfeit,
+  correctBackToUnfinished,
   requestTargetScoreWin,
   requestConcedeWin,
   recordOrConfirmFlagCatch,
@@ -117,6 +118,7 @@ export function GameControllerActionPanels({
   suspendGame: () => void;
   requestForfeitWin: (penalizedTeam: TeamId) => void;
   recordDoubleForfeit: () => void;
+  correctBackToUnfinished: () => void;
   requestTargetScoreWin: (team: TeamId) => void;
   requestConcedeWin: (team: TeamId) => void;
   recordOrConfirmFlagCatch: (team: TeamId) => void;
@@ -378,7 +380,18 @@ export function GameControllerActionPanels({
               </div>
             ) : null}
             {state.isFinished ? (
-              <p className="text-[11px] text-slate-600">{finishSummary ?? "Game finished."}</p>
+              <>
+                <p className="text-[11px] text-slate-600">{finishSummary ?? "Game finished."}</p>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="h-8 rounded-xl border-slate-300 bg-white text-slate-900"
+                  onClick={correctBackToUnfinished}
+                  disabled={!controller}
+                >
+                  Correct back to unfinished
+                </Button>
+              </>
             ) : state.isSuspended ? (
               <>
                 <p className="text-[11px] text-slate-600">

--- a/src/frontend.tsx
+++ b/src/frontend.tsx
@@ -1,8 +1,15 @@
 import { createRoot } from "react-dom/client";
 import { App } from "./App";
+import { captureAdHocHandoffFromLocation } from "@/lib/ad-hoc-handoff";
 
 const elem = document.getElementById("root")!;
-const app = <App />;
+const initialAdHocHandoff = captureAdHocHandoffFromLocation(window.location, window.history);
+const app = (
+  <App
+    initialAdHocHandoff={initialAdHocHandoff.handoff}
+    initialAdHocHandoffAttempted={initialAdHocHandoff.attempted}
+  />
+);
 
 if (import.meta.hot) {
   // With hot module reloading, `import.meta.hot.data` is persisted.

--- a/src/index-ad-hoc.test.ts
+++ b/src/index-ad-hoc.test.ts
@@ -6,6 +6,7 @@ import {
 } from "@/lib/ad-hoc-games";
 import {
   adHocFallbackRoute,
+  admitGame,
   createGame,
   leaveGame,
   readAdHocSession,
@@ -25,12 +26,12 @@ function service(): AdHocGamesService {
   });
 }
 
-async function createViaHttp(games: AdHocGamesService, homeName: string) {
+async function createViaHttp(games: AdHocGamesService, homeName: string, browserId?: string) {
   const response = await createGame(
     new Request("http://localhost/api/games", {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ homeName, awayName: "Away" }),
+      body: JSON.stringify({ homeName, awayName: "Away", browserId }),
     }),
     games,
   );
@@ -134,6 +135,129 @@ describe("Ad Hoc HTTP and WebSocket authority boundaries", () => {
     expect(admittedView?.state.isRunning).toBe(true);
     expect(admittedView?.sessionId).toBe(admitted.game.sessionId);
     expect(admittedView?.sessionId).not.toBe(creatorView?.sessionId);
+  });
+
+  test("admits a second browser directly and replaces only its prior persistent session", async () => {
+    const games = service();
+    const created = await createViaHttp(games, "Home", "device-a");
+    const firstAdmission = await admitGame(
+      new Request(`http://localhost/api/games/${created.gameId}/admit`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ controlQr: created.controlQr, browserId: "device-b" }),
+      }),
+      games,
+    );
+    expect(firstAdmission.status).toBe(200);
+    const firstCookie = firstAdmission.headers.get("set-cookie");
+    if (firstCookie === null) throw new Error("first admission did not return a session");
+
+    const secondAdmission = await admitGame(
+      new Request(`http://localhost/api/games/${created.gameId}/admit`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ controlQr: created.controlQr, browserId: "device-b" }),
+      }),
+      games,
+    );
+    expect(secondAdmission.status).toBe(200);
+    const secondCookie = secondAdmission.headers.get("set-cookie");
+    if (secondCookie === null) throw new Error("second admission did not return a session");
+    expect(
+      (
+        await readGame(
+          new Request(`http://localhost/api/games/${created.gameId}`, {
+            headers: { cookie: firstCookie },
+          }),
+          games,
+        )
+      ).status,
+    ).toBe(404);
+    expect(
+      (
+        await readGame(
+          new Request(`http://localhost/api/games/${created.gameId}`, {
+            headers: { cookie: secondCookie },
+          }),
+          games,
+        )
+      ).status,
+    ).toBe(200);
+  });
+
+  test("keeps copied QR admission generic when the runtime environment differs", async () => {
+    const store = createInMemoryAdHocStore();
+    const field = createAdHocGamesService({
+      store,
+      environmentIdentity: "field-a",
+      now: () => 1_000,
+    });
+    const copiedField = createAdHocGamesService({
+      store,
+      environmentIdentity: "field-b",
+      now: () => 1_000,
+    });
+    const created = await createViaHttp(field, "Home");
+    const response = await admitGame(
+      new Request(`http://localhost/api/games/${created.gameId}/admit`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ controlQr: created.controlQr }),
+      }),
+      copiedField,
+    );
+
+    expect(response.status).toBe(404);
+    expect(await response.text()).toBe('{"error":"Ad Hoc Game unavailable."}');
+  });
+
+  test("uses the current HttpOnly Game cookie to replace a session without browser storage", async () => {
+    const games = service();
+    const created = await createViaHttp(games, "Home");
+    const firstAdmission = await admitGame(
+      new Request(`http://localhost/api/games/${created.gameId}/admit`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ controlQr: created.controlQr }),
+      }),
+      games,
+    );
+    const firstCookie = firstAdmission.headers.get("set-cookie");
+    if (firstCookie === null) throw new Error("first admission did not return a session");
+    const secondAdmission = await admitGame(
+      new Request(`http://localhost/api/games/${created.gameId}/admit`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          cookie: firstCookie.split(";")[0]!,
+        },
+        body: JSON.stringify({ controlQr: created.controlQr }),
+      }),
+      games,
+    );
+    const secondCookie = secondAdmission.headers.get("set-cookie");
+    if (secondCookie === null) throw new Error("second admission did not return a session");
+
+    expect(
+      (
+        await readGame(
+          new Request(`http://localhost/api/games/${created.gameId}`, {
+            headers: { cookie: firstCookie },
+          }),
+          games,
+        )
+      ).status,
+    ).toBe(404);
+    expect(
+      (
+        await readGame(
+          new Request(`http://localhost/api/games/${created.gameId}`, {
+            headers: { cookie: secondCookie },
+          }),
+          games,
+        )
+      ).status,
+    ).toBe(200);
   });
 
   test("returns one generic HTTP outcome for known, unknown, malformed, and unauthorized Games", async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { serve, type ServerWebSocket } from "bun";
+import { dirname, resolve } from "node:path";
 import index from "./index.html";
 import { readJsonBodyWithinLimit } from "@/lib/http-body";
 import { isInternalHealthHost } from "@/lib/internal-health";
@@ -124,11 +125,14 @@ async function startServer() {
     ) {
       throw new Error("Production Ad Hoc database must use its canonical path.");
     }
+    const adHocEnvironmentIdentity =
+      process.env.AD_HOC_ENVIRONMENT_ID?.trim() || `${environment}:${technicalAdminConfig.origin}`;
     const adHocService = createAdHocGamesService({
+      environmentIdentity: adHocEnvironmentIdentity,
       store:
         environment === "test" && !process.env.AD_HOC_DATABASE?.trim()
           ? undefined
-          : openSqliteAdHocStore(adHocDatabasePath),
+          : openSqliteAdHocStore(adHocDatabasePath, adHocEnvironmentIdentity),
     });
     startupCleanup.add(() => adHocService.close());
     const databasePath = storagePaths.technicalAdminDatabase;
@@ -242,7 +246,10 @@ async function startServer() {
     process.once("SIGTERM", shutdown);
     process.once("SIGINT", shutdown);
 
-    const htmlRoute = environment === "test" ? await createTestHtmlRoute() : index;
+    const htmlRoute =
+      environment === "test" && process.env.NODE_ENV === "production"
+        ? await createTestHtmlRoute()
+        : index;
 
     server = serve<SessionData>({
       hostname: process.env.HOST ?? "127.0.0.1",
@@ -304,18 +311,7 @@ async function startServer() {
         },
         "/api/games/:gameId/admit": {
           async POST(req: Request) {
-            const gameId = new URL(req.url).pathname.split("/").at(-2) ?? "";
-            const body = await readJsonRecord(req);
-            const result = await adHocService.admit({
-              gameId,
-              controlQr: body?.controlQr,
-              browserId: requestSource(req, technicalAdminConfig.trustProxyHeaders),
-            });
-            return result.status === "accepted"
-              ? sensitiveJson({ game: stripSession(result.game) }, 200, [
-                  ["set-cookie", adHocSessionCookie(gameId, result.game.sessionId)],
-                ])
-              : adHocUnavailableResponse();
+            return admitGame(req, adHocService);
           },
         },
         "/api/games/:gameId/leave": {
@@ -757,15 +753,24 @@ async function startServer() {
             return json({ ok: true });
           },
         },
-        "/game/:gameId": {
-          async GET(req: Request) {
-            const gameId = new URL(req.url).pathname.split("/").at(-1) ?? "";
-            const sessionId = readAdHocSession(req.headers.get("cookie"), gameId);
-            const result = await adHocService.read({ gameId, sessionId });
-            return result.status === "accepted" ? htmlRoute : adHocUnavailableResponse();
-          },
-        },
-        "/*": (req: Request) => adHocFallbackRouteFor(req, htmlRoute),
+        "/game/:gameId": htmlRoute,
+        "/": htmlRoute,
+        "/events": htmlRoute,
+        "/events/": htmlRoute,
+        "/admin": htmlRoute,
+        "/admin/": htmlRoute,
+        "/admin/enroll": htmlRoute,
+        "/admin/enroll/": htmlRoute,
+        "/color-test": htmlRoute,
+        "/prototype/event-operations": htmlRoute,
+        "/event-admin": htmlRoute,
+        "/event-admin/": htmlRoute,
+        "/event-control": htmlRoute,
+        "/event-control/": htmlRoute,
+        "/game": () => adHocUnavailableResponse(),
+        "/game/*": () => adHocUnavailableResponse(),
+        "/api/games/*": () => adHocUnavailableResponse(),
+        "/*": htmlRoute,
       },
       development: process.env.NODE_ENV !== "production" && {
         hmr: true,
@@ -932,8 +937,22 @@ async function createTestHtmlRoute() {
     "content-type": "text/html; charset=utf-8",
     "x-robots-tag": "noindex, nofollow, noarchive, noimageindex",
   };
+  const assetDirectory = dirname(index.index);
+  const assetPaths = new Map<string, string>();
+  for (const match of html.matchAll(/(?:href|src)="\.\/([a-zA-Z0-9._-]+)"/gu)) {
+    const assetName = match[1];
+    if (assetName !== undefined)
+      assetPaths.set(`/${assetName}`, resolve(assetDirectory, assetName));
+  }
 
-  return () => new Response(body, { headers });
+  return (req: Request) => {
+    const assetPath = assetPaths.get(new URL(req.url).pathname);
+    return assetPath === undefined
+      ? new Response(body, { headers })
+      : new Response(Bun.file(assetPath), {
+          headers: { "cache-control": "no-store", "x-robots-tag": headers["x-robots-tag"] },
+        });
+  };
 }
 
 if (import.meta.main) void main();
@@ -1000,6 +1019,7 @@ export async function createGame(
     awayName: payload.awayName === undefined ? "Away" : payload.awayName,
     homeColor: payload.homeColor,
     awayColor: payload.awayColor,
+    browserId: payload.browserId,
     sourceKey,
   });
   if (result.status !== "accepted") {
@@ -1018,6 +1038,23 @@ export async function createGame(
     201,
     [["set-cookie", adHocSessionCookie(result.gameId, result.sessionId)]],
   );
+}
+
+export async function admitGame(req: Request, service: AdHocGamesService = defaultAdHocService) {
+  const gameId = new URL(req.url).pathname.split("/").at(-2) ?? "";
+  const body = await readJsonRecord(req);
+  const priorSessionId = readAdHocSession(req.headers.get("cookie"), gameId);
+  const result = await service.admit({
+    gameId,
+    controlQr: body?.controlQr,
+    browserId: body?.browserId,
+    priorSessionId,
+  });
+  return result.status === "accepted"
+    ? sensitiveJson({ game: stripSession(result.game) }, 200, [
+        ["set-cookie", adHocSessionCookie(gameId, result.game.sessionId)],
+      ])
+    : adHocUnavailableResponse(service);
 }
 
 export async function readGame(req: Request, service: AdHocGamesService = defaultAdHocService) {
@@ -1146,9 +1183,15 @@ export function adHocFallbackRoute(req: Request) {
   return adHocFallbackRouteFor(req, index);
 }
 
-function adHocFallbackRouteFor<HtmlRoute>(req: Request, htmlRoute: HtmlRoute) {
+type HtmlRoute = typeof index | ((req: Request) => Response);
+
+function adHocFallbackRouteFor(req: Request, htmlRoute: HtmlRoute) {
   const pathname = new URL(req.url).pathname;
-  return isAdHocPath(pathname) ? adHocUnavailableResponse() : htmlRoute;
+  return isAdHocPath(pathname) ? adHocUnavailableResponse() : resolveHtmlRoute(req, htmlRoute);
+}
+
+function resolveHtmlRoute(req: Request, htmlRoute: HtmlRoute) {
+  return typeof htmlRoute === "function" ? htmlRoute(req) : htmlRoute;
 }
 
 function isAdHocPath(pathname: string): boolean {

--- a/src/lib/ad-hoc-games.test.ts
+++ b/src/lib/ad-hoc-games.test.ts
@@ -1,9 +1,16 @@
 import { describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { createHash } from "node:crypto";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   createAdHocGamesService,
   createInMemoryAdHocStore,
+  openSqliteAdHocStore,
   type AdHocGamesService,
 } from "@/lib/ad-hoc-games";
+import { createInitialGameState } from "@/lib/game-engine";
 
 function service(): AdHocGamesService {
   return createAdHocGamesService({
@@ -77,6 +84,240 @@ describe("Ad Hoc Games service", () => {
     expect(duplicate.status).toBe("duplicate");
     expect(
       (await games.read({ gameId: created.gameId, sessionId: created.sessionId })).status,
+    ).toBe("accepted");
+  });
+
+  test("binds QR admission and retained sessions to the configured environment", async () => {
+    const store = createInMemoryAdHocStore();
+    const field = createAdHocGamesService({
+      store,
+      environmentIdentity: "field-a",
+      now: () => 1_000,
+    });
+    const restartedField = createAdHocGamesService({
+      store,
+      environmentIdentity: "field-a",
+      now: () => 1_000,
+    });
+    const copiedField = createAdHocGamesService({
+      store,
+      environmentIdentity: "field-b",
+      now: () => 1_000,
+    });
+    const created = await field.create({ homeName: "Home", awayName: "Away" });
+    if (created.status !== "accepted") throw new Error("creation failed");
+
+    expect(
+      (await restartedField.read({ gameId: created.gameId, sessionId: created.sessionId })).status,
+    ).toBe("accepted");
+    expect(
+      (await copiedField.read({ gameId: created.gameId, sessionId: created.sessionId })).status,
+    ).toBe("unavailable");
+    expect(
+      (await copiedField.admit({ gameId: created.gameId, controlQr: created.controlQr })).status,
+    ).toBe("unavailable");
+  });
+
+  test("migrates a retained #152 SQLite Game into the upgrading environment", async () => {
+    const root = mkdtempSync(join(tmpdir(), "quadball-timer-adhoc-migration-"));
+    const databasePath = join(root, "ad-hoc.sqlite");
+    const gameId = "adhoc-legacy-game-1234567890";
+    const sessionId = "legacy-session-1234567890-abcdefghijklmnopqrstuvwxyz";
+    const controlQr = "legacy-control-qr-1234567890-abcdefghijklmnopqrstuvwxyz";
+    const state = createInitialGameState({
+      id: gameId,
+      nowMs: 1_000,
+      homeName: "Home",
+      awayName: "Away",
+      homeColor: "#0f172a",
+      awayColor: "#f8fafc",
+    });
+    const digest = (value: string) => createHash("sha256").update(value).digest("hex");
+    const legacyDb = new Database(databasePath, { create: true, strict: true });
+    legacyDb.run(
+      "CREATE TABLE adhoc_schema (id INTEGER PRIMARY KEY CHECK (id = 1), version INTEGER NOT NULL)",
+    );
+    legacyDb.run("INSERT INTO adhoc_schema (id, version) VALUES (1, 1)");
+    legacyDb.run(`CREATE TABLE adhoc_games (
+      game_id TEXT PRIMARY KEY,
+      created_at_ms INTEGER NOT NULL,
+      state_json TEXT NOT NULL,
+      control_qr TEXT NOT NULL,
+      control_qr_hash TEXT NOT NULL,
+      sessions_json TEXT NOT NULL,
+      operations_json TEXT NOT NULL
+    )`);
+    legacyDb.run(`CREATE TABLE adhoc_creation_events (
+      source_hash TEXT NOT NULL,
+      successful INTEGER NOT NULL,
+      occurred_at_ms INTEGER NOT NULL
+    )`);
+    legacyDb.run(
+      "INSERT INTO adhoc_games (game_id, created_at_ms, state_json, control_qr, control_qr_hash, sessions_json, operations_json) VALUES (?, ?, ?, ?, ?, ?, ?)",
+      [
+        gameId,
+        1_000,
+        JSON.stringify(state),
+        controlQr,
+        digest(controlQr),
+        JSON.stringify([
+          {
+            sessionHash: digest(sessionId),
+            browserId: null,
+            connected: false,
+            lastConnectedAtMs: 1_000,
+            lastDisconnectedAtMs: null,
+          },
+        ]),
+        JSON.stringify({}),
+      ],
+    );
+    legacyDb.close();
+
+    try {
+      const firstStore = openSqliteAdHocStore(databasePath, "field-a");
+      const first = createAdHocGamesService({
+        store: firstStore,
+        environmentIdentity: "field-a",
+        now: () => 1_000,
+      });
+      const firstRead = await first.read({ gameId, sessionId });
+      expect(firstRead.status).toBe("accepted");
+      if (firstRead.status !== "accepted") return;
+      expect(firstRead.game.controlQr).toBe(controlQr);
+      first.close();
+
+      const secondStore = openSqliteAdHocStore(databasePath, "field-a");
+      const restarted = createAdHocGamesService({
+        store: secondStore,
+        environmentIdentity: "field-a",
+        now: () => 1_000,
+      });
+      const restartedRead = await restarted.read({ gameId, sessionId });
+      expect(restartedRead.status).toBe("accepted");
+      if (restartedRead.status === "accepted") {
+        expect(restartedRead.game.controlQr).toBe(controlQr);
+      }
+      const admitted = await restarted.admit({ gameId, controlQr });
+      expect(admitted.status).toBe("accepted");
+      restarted.close();
+
+      const copiedStore = openSqliteAdHocStore(databasePath, "field-b");
+      const copied = createAdHocGamesService({
+        store: copiedStore,
+        environmentIdentity: "field-b",
+        now: () => 1_000,
+      });
+      expect((await copied.read({ gameId, sessionId })).status).toBe("unavailable");
+      copied.close();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("hands the unchanged QR to every Controller and replaces only a re-admitting browser", async () => {
+    const games = service();
+    const created = await games.create({
+      homeName: "Home",
+      awayName: "Away",
+      browserId: "device-a",
+    });
+    if (created.status !== "accepted") throw new Error("creation failed");
+
+    const secondDevice = await games.admit({
+      gameId: created.gameId,
+      controlQr: created.controlQr,
+      browserId: "device-b",
+    });
+    if (secondDevice.status !== "accepted") throw new Error("second admission failed");
+    expect(secondDevice.game.controlQr).toBe(created.controlQr);
+
+    const refreshedDevice = await games.admit({
+      gameId: created.gameId,
+      controlQr: created.controlQr,
+      browserId: "device-b",
+    });
+    if (refreshedDevice.status !== "accepted") throw new Error("refresh admission failed");
+    expect(refreshedDevice.game.controlQr).toBe(created.controlQr);
+    expect(
+      (await games.read({ gameId: created.gameId, sessionId: secondDevice.game.sessionId })).status,
+    ).toBe("unavailable");
+    expect(
+      (await games.read({ gameId: created.gameId, sessionId: created.sessionId })).status,
+    ).toBe("accepted");
+    expect(
+      (await games.read({ gameId: created.gameId, sessionId: refreshedDevice.game.sessionId }))
+        .status,
+    ).toBe("accepted");
+  });
+
+  test("finishing blocks new admission, preserves existing authority, and re-enables the same QR", async () => {
+    const games = service();
+    const created = await games.create({ homeName: "Home", awayName: "Away" });
+    if (created.status !== "accepted") throw new Error("creation failed");
+    const admitted = await games.admit({ gameId: created.gameId, controlQr: created.controlQr });
+    if (admitted.status !== "accepted") throw new Error("admission failed");
+
+    const finished = await games.apply({
+      gameId: created.gameId,
+      sessionId: created.sessionId,
+      operations: [
+        {
+          id: "finish",
+          clientSentAtMs: 1_000,
+          command: { type: "record-double-forfeit" },
+        },
+      ],
+    });
+    expect(finished.status).toBe("accepted");
+    if (finished.status !== "accepted") return;
+    expect(finished.game.state.isFinished).toBe(true);
+    expect(finished.game.controlQr).toBeNull();
+    expect(
+      (await games.admit({ gameId: created.gameId, controlQr: created.controlQr })).status,
+    ).toBe("unavailable");
+    expect(
+      (
+        await games.apply({
+          gameId: created.gameId,
+          sessionId: admitted.game.sessionId,
+          operations: [
+            {
+              id: "correction",
+              clientSentAtMs: 1_001,
+              command: { type: "correct-to-unfinished" },
+            },
+          ],
+        })
+      ).status,
+    ).toBe("accepted");
+
+    const reopened = await games.read({ gameId: created.gameId, sessionId: created.sessionId });
+    expect(reopened.status).toBe("accepted");
+    if (reopened.status !== "accepted") return;
+    expect(reopened.game.state.isFinished).toBe(false);
+    expect(reopened.game.controlQr).toBe(created.controlQr);
+    expect(
+      (await games.admit({ gameId: created.gameId, controlQr: created.controlQr })).status,
+    ).toBe("accepted");
+  });
+
+  test("leave revokes only the leaving browser and requires a fresh QR admission", async () => {
+    const games = service();
+    const created = await games.create({ homeName: "Home", awayName: "Away" });
+    if (created.status !== "accepted") throw new Error("creation failed");
+    const other = await games.admit({ gameId: created.gameId, controlQr: created.controlQr });
+    if (other.status !== "accepted") throw new Error("admission failed");
+
+    expect(await games.leave({ gameId: created.gameId, sessionId: created.sessionId })).toBe(true);
+    expect(
+      (await games.read({ gameId: created.gameId, sessionId: created.sessionId })).status,
+    ).toBe("unavailable");
+    expect(
+      (await games.read({ gameId: created.gameId, sessionId: other.game.sessionId })).status,
+    ).toBe("accepted");
+    expect(
+      (await games.admit({ gameId: created.gameId, controlQr: created.controlQr })).status,
     ).toBe("accepted");
   });
 

--- a/src/lib/ad-hoc-games.ts
+++ b/src/lib/ad-hoc-games.ts
@@ -19,7 +19,7 @@ export const AD_HOC_CREATION_GLOBAL_WINDOW_MS = 60 * 60_000;
 export const AD_HOC_MAX_CREATIONS_PER_SOURCE = 5;
 export const AD_HOC_MAX_CREATIONS_PER_HOUR = 30;
 
-const SCHEMA_VERSION = 1;
+const SCHEMA_VERSION = 2;
 const GENERIC_UNAVAILABLE = "Ad Hoc Game unavailable.";
 
 export type AdHocGameView = GameView & {
@@ -33,6 +33,7 @@ export type AdHocCreationInput = {
   awayName: unknown;
   homeColor?: unknown;
   awayColor?: unknown;
+  browserId?: unknown;
   sourceKey?: string;
   nowMs?: number;
 };
@@ -72,7 +73,7 @@ export type AdHocAccessResult =
 
 type StoredSession = {
   sessionHash: string;
-  browserId: string;
+  browserId: string | null;
   connected: boolean;
   lastConnectedAtMs: number;
   lastDisconnectedAtMs: number | null;
@@ -86,6 +87,7 @@ type StoredOperation = {
 
 export type StoredAdHocGame = {
   gameId: string;
+  environmentIdentity: string;
   createdAtMs: number;
   state: GameState;
   controlQr: string;
@@ -116,6 +118,7 @@ export type AdHocGamesServiceOptions = {
   store?: AdHocStore;
   now?: () => number;
   random?: () => string;
+  environmentIdentity?: string;
 };
 
 export type AdHocGamesService = ReturnType<typeof createAdHocGamesService>;
@@ -124,6 +127,7 @@ export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) 
   const store = options.store ?? createInMemoryAdHocStore();
   const now = options.now ?? (() => Date.now());
   const random = options.random ?? (() => randomBytes(32).toString("base64url"));
+  const environmentIdentity = options.environmentIdentity?.trim() || "test";
 
   return {
     async create(input: AdHocCreationInput): Promise<AdHocCreateResult> {
@@ -150,6 +154,7 @@ export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) 
 
       const sourceKey =
         typeof input.sourceKey === "string" ? input.sourceKey.trim() : "anonymous-browser";
+      const browserId = validateBrowserId(input.browserId);
       const sourceHash = digest(sourceKey || "anonymous-browser");
       const gameId = `adhoc-${random()}`;
       const sessionId = random();
@@ -164,6 +169,7 @@ export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) 
       });
       const game: StoredAdHocGame = {
         gameId,
+        environmentIdentity,
         createdAtMs: nowMs,
         state,
         controlQr,
@@ -171,7 +177,7 @@ export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) 
         sessions: [
           {
             sessionHash: digest(sessionId),
-            browserId: sourceKey || "anonymous-browser",
+            browserId,
             connected: false,
             lastConnectedAtMs: nowMs,
             lastDisconnectedAtMs: null,
@@ -221,7 +227,12 @@ export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) 
       } catch {
         return unavailable();
       }
-      if (game === null || !hasSession(game, sessionId)) return unavailable();
+      if (
+        game === null ||
+        game.environmentIdentity !== environmentIdentity ||
+        !hasSession(game, sessionId)
+      )
+        return unavailable();
       return {
         status: "accepted",
         game: projectAuthorizedGame(game, sessionId, null, input.nowMs ?? now()),
@@ -231,7 +242,8 @@ export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) 
     async admit(input: {
       gameId: unknown;
       controlQr: unknown;
-      browserId?: string;
+      browserId?: unknown;
+      priorSessionId?: unknown;
       nowMs?: number;
     }): Promise<AdHocAccessResult> {
       const gameId = validateGameId(input.gameId);
@@ -239,14 +251,26 @@ export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) 
       if (gameId === null || qr === null) return unavailable();
       const nowMs = input.nowMs ?? now();
       if (!isSafeTimestamp(nowMs)) return unavailable();
+      const browserId = validateBrowserId(input.browserId);
+      const priorSessionId = validateBearer(input.priorSessionId);
       const sessionId = random();
       let outcome: boolean | null;
       try {
         outcome = store.mutateGame(gameId, (game) => {
-          if (game.state.isFinished || digest(qr) !== game.controlQrHash) return false;
+          if (
+            game.environmentIdentity !== environmentIdentity ||
+            game.state.isFinished ||
+            digest(qr) !== game.controlQrHash
+          )
+            return false;
+          game.sessions = game.sessions.filter(
+            (session) =>
+              (priorSessionId === null || session.sessionHash !== digest(priorSessionId)) &&
+              (browserId === null || session.browserId !== browserId),
+          );
           game.sessions.push({
             sessionHash: digest(sessionId),
-            browserId: input.browserId?.trim() || "anonymous-browser",
+            browserId,
             connected: false,
             lastConnectedAtMs: nowMs,
             lastDisconnectedAtMs: null,
@@ -289,7 +313,8 @@ export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) 
       let outcome: AdHocApplyMutationResult | null;
       try {
         outcome = store.mutateGame<AdHocApplyMutationResult>(gameId, (game) => {
-          if (!hasSession(game, sessionId)) return false;
+          if (game.environmentIdentity !== environmentIdentity || !hasSession(game, sessionId))
+            return false;
           const next = structuredClone(game) as StoredAdHocGame;
           const acknowledged: string[] = [];
           let duplicate = false;
@@ -369,6 +394,7 @@ export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) 
       try {
         return (
           store.mutateGame(gameId, (game) => {
+            if (game.environmentIdentity !== environmentIdentity) return false;
             const session = game.sessions.find(
               (candidate) => candidate.sessionHash === digest(sessionId),
             );
@@ -391,6 +417,7 @@ export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) 
       try {
         return (
           store.mutateGame(gameId, (game) => {
+            if (game.environmentIdentity !== environmentIdentity) return false;
             const before = game.sessions.length;
             game.sessions = game.sessions.filter(
               (session) => session.sessionHash !== digest(sessionId),
@@ -471,7 +498,10 @@ export function createInMemoryAdHocStore(): AdHocStore {
   };
 }
 
-export function openSqliteAdHocStore(databasePath: string): AdHocStore {
+export function openSqliteAdHocStore(
+  databasePath: string,
+  environmentIdentity = "test",
+): AdHocStore {
   mkdirSync(dirname(databasePath), { recursive: true });
   const db = new Database(databasePath, { create: true, strict: true });
   db.run("PRAGMA journal_mode = WAL");
@@ -480,9 +510,14 @@ export function openSqliteAdHocStore(databasePath: string): AdHocStore {
   db.run(
     "CREATE TABLE IF NOT EXISTS adhoc_schema (id INTEGER PRIMARY KEY CHECK (id = 1), version INTEGER NOT NULL)",
   );
+  const schemaRow = db.query("SELECT version FROM adhoc_schema WHERE id = 1").get() as {
+    version?: number | string;
+  } | null;
+  const previousSchemaVersion = Number(schemaRow?.version ?? SCHEMA_VERSION);
   db.run("INSERT OR IGNORE INTO adhoc_schema (id, version) VALUES (1, ?)", [SCHEMA_VERSION]);
   db.run(`CREATE TABLE IF NOT EXISTS adhoc_games (
     game_id TEXT PRIMARY KEY,
+    environment_identity TEXT NOT NULL DEFAULT '',
     created_at_ms INTEGER NOT NULL,
     state_json TEXT NOT NULL,
     control_qr TEXT NOT NULL,
@@ -490,6 +525,19 @@ export function openSqliteAdHocStore(databasePath: string): AdHocStore {
     sessions_json TEXT NOT NULL,
     operations_json TEXT NOT NULL
   )`);
+  const columns = db.query("PRAGMA table_info(adhoc_games)").all() as { name?: string }[];
+  if (!columns.some((column) => column.name === "environment_identity")) {
+    db.run("ALTER TABLE adhoc_games ADD COLUMN environment_identity TEXT NOT NULL DEFAULT ''");
+  }
+  if (previousSchemaVersion < SCHEMA_VERSION) {
+    const migrate = db.transaction(() => {
+      db.run("UPDATE adhoc_games SET environment_identity = ? WHERE environment_identity = ''", [
+        environmentIdentity.trim() || "test",
+      ]);
+      db.run("UPDATE adhoc_schema SET version = ? WHERE id = 1", [SCHEMA_VERSION]);
+    });
+    migrate();
+  }
   db.run(
     "CREATE TABLE IF NOT EXISTS adhoc_creation_events (source_hash TEXT NOT NULL, successful INTEGER NOT NULL, occurred_at_ms INTEGER NOT NULL)",
   );
@@ -551,9 +599,10 @@ export function openSqliteAdHocStore(databasePath: string): AdHocStore {
           db.run("DELETE FROM adhoc_games WHERE game_id = ?", [victim.game_id]);
         }
         db.run(
-          "INSERT INTO adhoc_games (game_id, created_at_ms, state_json, control_qr, control_qr_hash, sessions_json, operations_json) VALUES (?, ?, ?, ?, ?, ?, ?)",
+          "INSERT INTO adhoc_games (game_id, environment_identity, created_at_ms, state_json, control_qr, control_qr_hash, sessions_json, operations_json) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
           [
             game.gameId,
+            game.environmentIdentity,
             game.createdAtMs,
             JSON.stringify(game.state),
             game.controlQr,
@@ -602,6 +651,7 @@ export function openSqliteAdHocStore(databasePath: string): AdHocStore {
 function parseStoredRow(row: Record<string, string | number>): StoredAdHocGame {
   return {
     gameId: String(row.game_id),
+    environmentIdentity: String(row.environment_identity ?? ""),
     createdAtMs: Number(row.created_at_ms),
     state: JSON.parse(String(row.state_json)) as GameState,
     controlQr: String(row.control_qr),
@@ -637,6 +687,12 @@ function validateGameId(value: unknown): string | null {
 
 function validateBearer(value: unknown): string | null {
   return typeof value === "string" && value.length >= 32 && value.length <= 256 ? value : null;
+}
+
+function validateBrowserId(value: unknown): string | null {
+  if (value === undefined || value === null) return null;
+  const result = validateOpaqueIdentifier(value, "browserId");
+  return result.ok ? result.value : null;
 }
 
 function isSafeTimestamp(value: number): boolean {

--- a/src/lib/ad-hoc-handoff.ts
+++ b/src/lib/ad-hoc-handoff.ts
@@ -1,0 +1,77 @@
+import { validateOpaqueIdentifier } from "@/lib/validation-policy";
+
+export const AD_HOC_BROWSER_ID_STORAGE_KEY = "quadball:adhoc-browser-id";
+
+export type AdHocHandoff = {
+  gameId: string;
+  controlQr: string;
+};
+
+export type AdHocHandoffCapture = {
+  handoff: AdHocHandoff | null;
+  attempted: boolean;
+};
+
+export function getAdHocBrowserId(): string {
+  try {
+    const existing = window.localStorage.getItem(AD_HOC_BROWSER_ID_STORAGE_KEY);
+    if (existing !== null && validateOpaqueIdentifier(existing, "browserId").ok) {
+      return existing;
+    }
+
+    const created = crypto.randomUUID();
+    window.localStorage.setItem(AD_HOC_BROWSER_ID_STORAGE_KEY, created);
+    return created;
+  } catch {
+    return crypto.randomUUID();
+  }
+}
+
+export function buildAdHocControlQrPayload(
+  gameId: string,
+  controlQr: string,
+  origin = window.location.origin,
+): string {
+  const handoff = new URL(origin);
+  handoff.pathname = "/";
+  handoff.search = "";
+  handoff.hash = new URLSearchParams({
+    "adhoc-game": gameId,
+    "adhoc-control": controlQr,
+  }).toString();
+  return handoff.toString();
+}
+
+export function parseAdHocHandoffHash(hash: string): AdHocHandoff | null {
+  const params = new URLSearchParams(hash.startsWith("#") ? hash.slice(1) : hash);
+  const gameId = params.get("adhoc-game");
+  const controlQr = params.get("adhoc-control");
+  if (
+    gameId === null ||
+    !gameId.startsWith("adhoc-") ||
+    !validateOpaqueIdentifier(gameId, "gameId").ok ||
+    controlQr === null ||
+    controlQr.length < 32 ||
+    controlQr.length > 256
+  ) {
+    return null;
+  }
+  return { gameId, controlQr };
+}
+
+export function hasAdHocHandoffAttempt(hash: string): boolean {
+  const params = new URLSearchParams(hash.startsWith("#") ? hash.slice(1) : hash);
+  return params.has("adhoc-game") || params.has("adhoc-control");
+}
+
+export function captureAdHocHandoffFromLocation(
+  location: Pick<Location, "pathname" | "search" | "hash">,
+  history: Pick<History, "replaceState">,
+): AdHocHandoffCapture {
+  const handoff = parseAdHocHandoffHash(location.hash);
+  const attempted = hasAdHocHandoffAttempt(location.hash);
+  if (attempted) {
+    history.replaceState(null, "", `${location.pathname}${location.search}`);
+  }
+  return { handoff, attempted };
+}

--- a/src/lib/controller-session.ts
+++ b/src/lib/controller-session.ts
@@ -16,6 +16,14 @@ export function getControllerSessionStorageKey(gameId: string) {
   return `quadball:controller-session:${gameId}`;
 }
 
+export function clearPersistedControllerSession(gameId: string) {
+  try {
+    window.localStorage.removeItem(getControllerSessionStorageKey(gameId));
+  } catch {
+    // Best-effort cleanup; the server-side leave remains authoritative.
+  }
+}
+
 export function createPersistedControllerSession({
   gameId,
   state,

--- a/src/lib/game-engine.test.ts
+++ b/src/lib/game-engine.test.ts
@@ -940,6 +940,24 @@ describe("game-engine", () => {
     expect(state.score.away).toBe(0);
   });
 
+  test("Correction can make a finished Ad Hoc Game unfinished without changing its facts", () => {
+    let state = createInitialGameState({ id: "game-correction", nowMs: 0 });
+    state = applyGameCommand({
+      state,
+      command: { type: "record-double-forfeit" },
+      nowMs: 1,
+    });
+    state = applyGameCommand({
+      state,
+      command: { type: "correct-to-unfinished" },
+      nowMs: 2,
+    });
+
+    expect(state.isFinished).toBe(false);
+    expect(state.finishReason).toBeNull();
+    expect(state.winner).toBeNull();
+  });
+
   test("flag catch that does not create a lead enters overtime instead of ending game", () => {
     const makeId = createIdGenerator();
     let state = createInitialGameState({ id: "game-22", nowMs: 0 });

--- a/src/lib/game-engine.ts
+++ b/src/lib/game-engine.ts
@@ -247,6 +247,17 @@ export function applyGameCommand({
       return next;
     }
 
+    case "correct-to-unfinished": {
+      if (!next.isFinished) {
+        return next;
+      }
+
+      next.isFinished = false;
+      next.winner = null;
+      next.finishReason = null;
+      return next;
+    }
+
     case "adjust-game-clock": {
       const adjustment = validateClockAdjustmentMs(command.deltaMs);
       const nextGameClockMs = next.gameClockMs + command.deltaMs;

--- a/src/lib/game-page-support.ts
+++ b/src/lib/game-page-support.ts
@@ -38,6 +38,7 @@ const RELEASE_EVENT_VISIBLE_MS = 30_000;
 export function useGameConnection({ gameId, role }: { gameId: string; role: ControllerRole }) {
   const wsUrl = useMemo(createWebSocketUrl, []);
   const [baseState, setBaseState] = useState<GameState | null>(null);
+  const [controlQr, setControlQr] = useState<string | null>(null);
   const [clockOffsetMs, setClockOffsetMs] = useState(0);
   const [connectionState, setConnectionState] = useState<ConnectionState>("connecting");
   const [error, setError] = useState<string | null>(null);
@@ -161,13 +162,16 @@ export function useGameConnection({ gameId, role }: { gameId: string; role: Cont
             return;
           }
 
-          setError("Game not found.");
+          setError("Ad Hoc Game unavailable.");
           return;
         }
 
-        const payload = (await response.json()) as { game?: GameView };
+        const payload = (await response.json()) as {
+          game?: GameView & { controlQr?: string | null };
+        };
         if (!cancelled && payload.game !== undefined) {
           setError(null);
+          setControlQr(payload.game.controlQr ?? null);
 
           let reconciled = payload.game.state;
           for (const command of pendingRef.current) {
@@ -185,7 +189,7 @@ export function useGameConnection({ gameId, role }: { gameId: string; role: Cont
             return;
           }
 
-          setError("Unable to fetch game snapshot.");
+          setError("Ad Hoc Game unavailable.");
         }
       }
     };
@@ -243,6 +247,7 @@ export function useGameConnection({ gameId, role }: { gameId: string; role: Cont
           setLocalOnlyState(false);
           setConnectionState("online");
           setError(null);
+          setControlQr(parsed.game.controlQr ?? null);
           reconcileWithServer({
             state: parsed.game.state,
             serverNowMs: parsed.serverNowMs,
@@ -331,6 +336,7 @@ export function useGameConnection({ gameId, role }: { gameId: string; role: Cont
 
   return {
     baseState,
+    controlQr,
     clockOffsetMs,
     dispatchCommand,
     connectionState,

--- a/src/lib/game-types.ts
+++ b/src/lib/game-types.ts
@@ -139,6 +139,9 @@ export type GameCommand =
       running: boolean;
     }
   | {
+      type: "correct-to-unfinished";
+    }
+  | {
       type: "adjust-game-clock";
       deltaMs: number;
     }

--- a/src/lib/ws-protocol.test.ts
+++ b/src/lib/ws-protocol.test.ts
@@ -432,6 +432,24 @@ describe("ws-protocol", () => {
     expect(parsed.message.commands[0].command.swapped).toBe(true);
   });
 
+  test("parses the Ad Hoc finished-state Correction", () => {
+    const parsed = parseClientWsMessage(
+      JSON.stringify({
+        type: "apply-commands",
+        gameId: "game-123",
+        commands: [
+          {
+            id: "cmd-correction",
+            clientSentAtMs: 123_456,
+            command: { type: "correct-to-unfinished" },
+          },
+        ],
+      }),
+    );
+
+    expect(parsed.ok).toBe(true);
+  });
+
   test("parses suspend-game command", () => {
     const parsed = parseClientWsMessage(
       JSON.stringify({

--- a/src/lib/ws-protocol.ts
+++ b/src/lib/ws-protocol.ts
@@ -258,6 +258,20 @@ export function parseGameCommand(payload: Record<string, unknown>):
     };
   }
 
+  if (payload.type === "correct-to-unfinished") {
+    if (Object.keys(payload).some((key) => key !== "type")) {
+      return {
+        ok: false,
+        error: "correct-to-unfinished does not accept fields.",
+      };
+    }
+
+    return {
+      ok: true,
+      command: { type: "correct-to-unfinished" },
+    };
+  }
+
   if (payload.type === "adjust-game-clock") {
     if (typeof payload.deltaMs !== "number") {
       return {

--- a/src/pages/game-page.tsx
+++ b/src/pages/game-page.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from "react";
+import QRCode from "qrcode/lib/browser";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { CloudOff, Eye, OctagonX, Shield, TriangleAlert, UserX, Wifi, WifiOff } from "lucide-react";
@@ -32,6 +33,8 @@ import {
   useNow,
   willFlagCatchWin,
 } from "@/lib/game-page-support";
+import { buildAdHocControlQrPayload } from "@/lib/ad-hoc-handoff";
+import { clearPersistedControllerSession } from "@/lib/controller-session";
 import {
   DEFAULT_AWAY_TEAM_COLOR,
   DEFAULT_HOME_TEAM_COLOR,
@@ -104,15 +107,30 @@ export function GamePage({ gameId, role }: { gameId: string; role: ControllerRol
 
   const {
     baseState,
+    controlQr,
     clockOffsetMs,
     dispatchCommand,
     connectionState,
+    error,
     pendingCommands,
     localOnlyMode,
   } = useGameConnection({
     gameId,
     role,
   });
+  const [leaveMessage, setLeaveMessage] = useState<string | null>(null);
+
+  const leaveAdHocGame = useCallback(async () => {
+    setLeaveMessage(null);
+    try {
+      const response = await fetch(`/api/games/${gameId}/leave`, { method: "POST" });
+      if (!response.ok) throw new Error("leave failed");
+      clearPersistedControllerSession(gameId);
+      navigateTo("/");
+    } catch {
+      setLeaveMessage("Ad Hoc Game unavailable.");
+    }
+  }, [gameId]);
 
   useEffect(() => {
     if (baseState !== null) {
@@ -496,8 +514,10 @@ export function GamePage({ gameId, role }: { gameId: string; role: ControllerRol
       <div className="mx-auto flex min-h-screen w-full max-w-3xl items-center justify-center p-6">
         <Card className="w-full">
           <CardHeader>
-            <CardTitle>Loading game</CardTitle>
-            <CardDescription>Waiting for snapshot from server.</CardDescription>
+            <CardTitle>{error ?? "Loading game"}</CardTitle>
+            <CardDescription>
+              {error === null ? "Waiting for snapshot from server." : "Return to the Games page."}
+            </CardDescription>
           </CardHeader>
           <CardContent>
             <Button variant="outline" onClick={() => navigateTo("/")}>
@@ -816,8 +836,21 @@ export function GamePage({ gameId, role }: { gameId: string; role: ControllerRol
               >
                 Games
               </Button>
+              {controller ? (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-7 border-slate-300 bg-white px-2 text-[11px] text-slate-800 hover:bg-slate-100"
+                  onClick={() => void leaveAdHocGame()}
+                >
+                  Leave
+                </Button>
+              ) : null}
             </div>
           </div>
+          {leaveMessage ? (
+            <p className="mt-1 text-[10px] font-medium text-rose-700">{leaveMessage}</p>
+          ) : null}
           {controller ? (
             localOnlyMode ? (
               <p className="mt-1 text-[10px] font-medium text-amber-700">{LOCAL_ONLY_MESSAGE}</p>
@@ -828,6 +861,14 @@ export function GamePage({ gameId, role }: { gameId: string; role: ControllerRol
             ) : null
           ) : null}
         </section>
+
+        {controller ? (
+          <AdHocControlHandoff
+            gameId={gameId}
+            controlQr={controlQr}
+            isFinished={state.isFinished}
+          />
+        ) : null}
 
         <ControllerTopSection
           controller={controller}
@@ -986,6 +1027,7 @@ export function GamePage({ gameId, role }: { gameId: string; role: ControllerRol
             });
           }}
           recordDoubleForfeit={() => dispatchCommand({ type: "record-double-forfeit" })}
+          correctBackToUnfinished={() => dispatchCommand({ type: "correct-to-unfinished" })}
           requestTargetScoreWin={(team) =>
             requestWinConfirmation(`${displayTeamName(team)} reached target score and wins.`, {
               type: "record-target-score",
@@ -1016,6 +1058,149 @@ export function GamePage({ gameId, role }: { gameId: string; role: ControllerRol
         />
       </div>
     </div>
+  );
+}
+
+function AdHocControlHandoff({
+  gameId,
+  controlQr,
+  isFinished,
+}: {
+  gameId: string;
+  controlQr: string | null;
+  isFinished: boolean;
+}) {
+  const [qrDataUrl, setQrDataUrl] = useState<string | null>(null);
+  const [qrError, setQrError] = useState(false);
+  const [qrOpen, setQrOpen] = useState(false);
+  const dialogRef = useRef<HTMLDivElement | null>(null);
+  const closeQrButtonRef = useRef<HTMLButtonElement | null>(null);
+  const showQrButtonRef = useRef<HTMLButtonElement | null>(null);
+  const payload = controlQr === null ? null : buildAdHocControlQrPayload(gameId, controlQr);
+
+  const closeQr = useCallback(() => {
+    setQrOpen(false);
+    window.setTimeout(() => showQrButtonRef.current?.focus(), 0);
+  }, []);
+
+  useEffect(() => {
+    if (!qrOpen) return;
+    closeQrButtonRef.current?.focus();
+    const dialog = dialogRef.current;
+    if (dialog === null) return;
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        closeQr();
+        return;
+      }
+      if (event.key !== "Tab") return;
+      const focusable = Array.from(
+        dialog.querySelectorAll<HTMLElement>(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+        ),
+      ).filter((element) => !element.hasAttribute("disabled"));
+      if (focusable.length === 0) {
+        event.preventDefault();
+        return;
+      }
+      const first = focusable[0];
+      const last = focusable.at(-1);
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last?.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first?.focus();
+      }
+    };
+
+    dialog.addEventListener("keydown", onKeyDown);
+    return () => dialog.removeEventListener("keydown", onKeyDown);
+  }, [closeQr, qrOpen]);
+
+  useEffect(() => {
+    if (payload === null) {
+      setQrDataUrl(null);
+      setQrError(false);
+      return;
+    }
+
+    let cancelled = false;
+    setQrError(false);
+    void QRCode.toDataURL(payload, {
+      errorCorrectionLevel: "M",
+      margin: 2,
+      width: 320,
+    })
+      .then((dataUrl) => {
+        if (!cancelled) setQrDataUrl(dataUrl);
+      })
+      .catch(() => {
+        if (!cancelled) setQrError(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [payload]);
+
+  return (
+    <section
+      aria-label="Ad Hoc Controller handoff"
+      className="rounded-2xl border border-slate-300 bg-white p-3 shadow-[0_8px_18px_rgba(15,23,42,0.08)]"
+    >
+      <p className="text-xs font-semibold tracking-wide text-slate-900">Share Ad Hoc Control</p>
+      {isFinished ? (
+        <p className="mt-1 text-[11px] text-slate-600">
+          This Game is finished. Existing Controllers can still make Corrections; new admission is
+          paused.
+        </p>
+      ) : qrOpen ? (
+        <div
+          aria-label="Ad Hoc Control QR dialog"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/50 p-4"
+          aria-modal="true"
+          ref={dialogRef}
+          role="dialog"
+        >
+          <div className="w-full max-w-sm space-y-3 rounded-2xl bg-white p-4 shadow-xl">
+            <div className="flex items-center justify-between gap-2">
+              <p className="text-sm font-semibold text-slate-900">Ad Hoc Control QR</p>
+              <Button ref={closeQrButtonRef} size="sm" variant="outline" onClick={closeQr}>
+                Close Control QR
+              </Button>
+            </div>
+            {qrError ? (
+              <p className="text-[11px] text-rose-700">Unable to display the Control QR.</p>
+            ) : qrDataUrl !== null ? (
+              <>
+                <img
+                  alt="Ad Hoc Control QR code"
+                  className="mx-auto size-64 max-w-full rounded border border-slate-200"
+                  src={qrDataUrl}
+                />
+                <p className="text-center text-[11px] text-slate-600">
+                  Scan this QR on another device to join directly as an equal Controller.
+                </p>
+              </>
+            ) : (
+              <p className="text-[11px] text-slate-600">Preparing the reusable Control QR…</p>
+            )}
+          </div>
+        </div>
+      ) : (
+        <Button
+          ref={showQrButtonRef}
+          size="sm"
+          variant="outline"
+          className="mt-2"
+          onClick={() => setQrOpen(true)}
+        >
+          Show Ad Hoc Control QR
+        </Button>
+      )}
+    </section>
   );
 }
 


### PR DESCRIPTION
## What changed

- added reusable, environment-bound Ad Hoc Control QR handoff for equal Controllers
- made each browser session persistent and independently replaceable or revocable
- kept existing Controllers active after finish while pausing QR display and new admission
- restored the same QR after an ordinary Correction back to unfinished
- scrubbed QR fragments before rendering and kept unauthorized routes, HTTP, and WebSocket outcomes generic
- added accessible QR lifecycle controls and a bounded two-browser restart/readmission Focused Integration Test
- migrated retained schema-v1 Ad Hoc Games without losing same-environment session or QR authority

## Why

Ad Hoc Games need direct capability handoff without accounts, creator ownership, Event Grants, Technical Admin authority, or a public spectator surface. This completes the authority lifecycle while preserving the disposable Ad Hoc model and keeping Event operations isolated.

## Impact

Any admitted Ad Hoc Controller can hand control to another browser by QR. Both browsers have equal authority, survive ordinary browser/server restart, and can leave independently. QR or session material remains outside public data and generic failures. No Event Game authority, storage, audit, Grant, or rate budget is reused.

## Checks

- `bun run check`
- `bun run test` — 532 passed, 0 failed
- `bun run test:focused:adhoc-browser`
- `bun run test:focused:ad-hoc`
- `bun run build`
- `git diff --check origin/main...HEAD`

Implements #153.

Parent specification: #151.
