### PR TITLE
Correct Game Facts and apply Official Overrides

### DIFF
--- a/src/lib/controller-intent-retry.ts
+++ b/src/lib/controller-intent-retry.ts
@@ -23,7 +23,20 @@ export function retainControllerIntent(
 export function controllerIntentRetryKey(intent: LiveEventControllerIntent): string {
   switch (intent.type) {
     case "record-goal":
-      return JSON.stringify([intent.type, intent.gameSideId, intent.gameTimeMs]);
+      return JSON.stringify([
+        intent.type,
+        intent.gameSideId,
+        intent.gameTimeMs,
+        intent.sportingOrder ?? null,
+        intent.override ?? null,
+      ]);
+    case "correct-fact":
+      return JSON.stringify([
+        intent.type,
+        intent.targetFactId,
+        intent.effective,
+        intent.gameTimeMs,
+      ]);
     case "clock":
     case "set-running":
       return JSON.stringify([intent.type, intent.running, intent.gameTimeMs]);
@@ -40,7 +53,14 @@ export function controllerIntentRetryKey(intent: LiveEventControllerIntent): str
         intent.gameTimeMs,
       ]);
     case "substantive":
-      return JSON.stringify([intent.type, intent.trigger, intent.gameTimeMs]);
+      return JSON.stringify([
+        intent.type,
+        intent.trigger,
+        intent.heatAction ?? null,
+        intent.gameTimeMs,
+        intent.sportingOrder ?? null,
+        intent.override ?? null,
+      ]);
     case "reset":
     case "undo":
       return JSON.stringify([intent.type, intent.gameTimeMs]);

--- a/src/lib/controller-reconnect.ts
+++ b/src/lib/controller-reconnect.ts
@@ -1,8 +1,14 @@
 import type {
+  ControllerGameFact,
   ControllerSessionAttachment,
   ControllerProjection,
   LiveEventControllerIntent,
+  LiveHeatState,
+  LiveResultState,
+  LiveStoppageState,
+  LiveTimeoutState,
 } from "@/lib/live-event-game-control";
+import { parseJsonValue } from "@/lib/event-game-action-codecs";
 import {
   applyClockProjectionAction,
   createInitialClockBaseline,
@@ -605,16 +611,73 @@ function applyOptimisticAction(
   if (intent.type === "record-goal") {
     const current = state.projection.scoreByGameSide[intent.gameSideId];
     if (current === undefined) return state;
+    const nextFacts = appendOptimisticFact(state.projection, {
+      factId: intent.factId,
+      factType: "goal",
+      gameSideId: intent.gameSideId,
+      gameTimeMs: intent.gameTimeMs,
+      sportingOrder: intent.sportingOrder ?? intent.gameTimeMs,
+      data: { points: 10, sportingOrder: intent.sportingOrder ?? intent.gameTimeMs },
+    });
     return {
       ...state,
       projection: {
         ...state.projection,
         scoreByGameSide: { ...state.projection.scoreByGameSide, [intent.gameSideId]: current + 10 },
         goalCount: state.projection.goalCount + 1,
+        gameFacts: nextFacts,
+      },
+    };
+  }
+  if (intent.type === "correct-fact") {
+    const gameFacts = (state.projection.gameFacts ?? []).map((fact) =>
+      fact.factId === intent.targetFactId ? { ...fact, effective: intent.effective } : fact,
+    );
+    const scoreByGameSide = Object.fromEntries(
+      Object.keys(state.projection.scoreByGameSide).map((side) => [side, 0]),
+    );
+    const dependentState = deriveOptimisticDependentState(gameFacts);
+    let goalCount = 0;
+    for (const fact of gameFacts) {
+      if (!fact.effective || fact.factType !== "goal") continue;
+      if (fact.gameSideId !== null && fact.gameSideId in scoreByGameSide) {
+        scoreByGameSide[fact.gameSideId] = (scoreByGameSide[fact.gameSideId] ?? 0) + 10;
+      }
+      goalCount += 1;
+    }
+    return {
+      ...state,
+      projection: {
+        ...state.projection,
+        gameFacts,
+        scoreByGameSide,
+        goalCount,
+        phase: gameFacts.some((fact) => fact.effective && fact.factType === "result")
+          ? "finished"
+          : state.projection.phase === "finished"
+            ? "in-progress"
+            : state.projection.phase,
+        ...(state.projection.timeout === undefined ? {} : { timeout: dependentState.timeout }),
+        ...(state.projection.stoppage === undefined ? {} : { stoppage: dependentState.stoppage }),
+        ...(state.projection.heat === undefined ? {} : { heat: dependentState.heat }),
+        ...(state.projection.result === undefined ? {} : { result: dependentState.result }),
       },
     };
   }
   if (intent.type === "substantive") {
+    const nextFacts = appendOptimisticFact(state.projection, {
+      factId: intent.factId,
+      factType: intent.trigger,
+      gameSideId: null,
+      gameTimeMs: intent.gameTimeMs,
+      sportingOrder: intent.sportingOrder ?? intent.gameTimeMs,
+      data: {
+        trigger: intent.trigger,
+        sportingOrder: intent.sportingOrder ?? intent.gameTimeMs,
+        ...(intent.heatAction === undefined ? {} : { heatAction: intent.heatAction }),
+      },
+    });
+    const dependentState = deriveOptimisticDependentState(nextFacts);
     const commencement =
       state.projection.commencement.status === "commenced"
         ? state.projection.commencement
@@ -635,6 +698,11 @@ function applyOptimisticAction(
               ? "in-progress"
               : state.projection.phase,
         commencement,
+        gameFacts: nextFacts,
+        ...(state.projection.timeout === undefined ? {} : { timeout: dependentState.timeout }),
+        ...(state.projection.stoppage === undefined ? {} : { stoppage: dependentState.stoppage }),
+        ...(state.projection.heat === undefined ? {} : { heat: dependentState.heat }),
+        ...(state.projection.result === undefined ? {} : { result: dependentState.result }),
       },
     };
   }
@@ -751,6 +819,20 @@ function validateDerivedProjection(state: ControllerReplicaState) {
 function sameProjection(left: ControllerProjection, right: ControllerProjection): boolean {
   const leftScores = Object.entries(left.scoreByGameSide).sort(([a], [b]) => a.localeCompare(b));
   const rightScores = Object.entries(right.scoreByGameSide).sort(([a], [b]) => a.localeCompare(b));
+  const leftFacts = JSON.stringify(left.gameFacts ?? []);
+  const rightFacts = JSON.stringify(right.gameFacts ?? []);
+  const leftDependent = JSON.stringify([
+    left.timeout ?? null,
+    left.stoppage ?? null,
+    left.heat ?? null,
+    left.result ?? null,
+  ]);
+  const rightDependent = JSON.stringify([
+    right.timeout ?? null,
+    right.stoppage ?? null,
+    right.heat ?? null,
+    right.result ?? null,
+  ]);
   return (
     left.eventGameId === right.eventGameId &&
     left.phase === right.phase &&
@@ -760,6 +842,8 @@ function sameProjection(left: ControllerProjection, right: ControllerProjection)
     left.commencement.provisionalRunningSinceMs === right.commencement.provisionalRunningSinceMs &&
     left.commencement.provisionalElapsedMs === right.commencement.provisionalElapsedMs &&
     JSON.stringify(left.clock) === JSON.stringify(right.clock) &&
+    leftFacts === rightFacts &&
+    leftDependent === rightDependent &&
     leftScores.length === rightScores.length &&
     leftScores.every(
       ([side, score], index) =>
@@ -882,11 +966,23 @@ function parseProjection(value: unknown): ControllerProjection {
   const clock = isRecord(value.clock)
     ? (structuredClone(value.clock) as ControllerProjection["clock"])
     : projectClockBaseline(createInitialClockBaseline(), 0);
+  const gameFacts = parseGameFacts(value.gameFacts);
+  const guardrails = parseGuardrails(value.guardrails);
+  const timeout = value.timeout === undefined ? undefined : parseTimeoutState(value.timeout);
+  const stoppage = value.stoppage === undefined ? undefined : parseStoppageState(value.stoppage);
+  const heat = value.heat === undefined ? undefined : parseHeatState(value.heat);
+  const result = value.result === undefined ? undefined : parseResultState(value.result);
   return {
     eventGameId,
     phase,
     scoreByGameSide: scores,
     goalCount: goalCount.value,
+    ...(value.timeout === undefined ? {} : { timeout }),
+    ...(value.stoppage === undefined ? {} : { stoppage }),
+    ...(value.heat === undefined ? {} : { heat }),
+    ...(value.result === undefined ? {} : { result }),
+    ...(value.gameFacts === undefined ? {} : { gameFacts }),
+    ...(value.guardrails === undefined ? {} : { guardrails }),
     clock,
     commencement: {
       status: commencementStatus,
@@ -895,6 +991,111 @@ function parseProjection(value: unknown): ControllerProjection {
       provisionalElapsedMs: elapsed.value,
     },
   };
+}
+
+function parseTimeoutState(value: unknown): LiveTimeoutState {
+  if (!isRecord(value) || (value.status !== "inactive" && value.status !== "started")) {
+    throw new Error("Projection timeout state is invalid.");
+  }
+  return { status: value.status, factId: parseNullableFactId(value.factId, "timeout.factId") };
+}
+
+function parseStoppageState(value: unknown): LiveStoppageState {
+  if (
+    !isRecord(value) ||
+    (value.status !== "none" && value.status !== "suspension" && value.status !== "heat-stoppage")
+  ) {
+    throw new Error("Projection stoppage state is invalid.");
+  }
+  return {
+    status: value.status,
+    factId: parseNullableFactId(value.factId, "stoppage.factId"),
+  };
+}
+
+function parseHeatState(value: unknown): LiveHeatState {
+  if (
+    !isRecord(value) ||
+    (value.status !== "inactive" &&
+      value.status !== "started" &&
+      value.status !== "ended" &&
+      value.status !== "skipped" &&
+      value.status !== "extended")
+  ) {
+    throw new Error("Projection heat state is invalid.");
+  }
+  const startedAtGameTimeMs = parseNullableBoundedNumber(
+    value.startedAtGameTimeMs,
+    "heat.startedAtGameTimeMs",
+  );
+  const nominalDurationMs = parseNullableBoundedNumber(
+    value.nominalDurationMs,
+    "heat.nominalDurationMs",
+  );
+  return {
+    status: value.status,
+    factId: parseNullableFactId(value.factId, "heat.factId"),
+    startedAtGameTimeMs,
+    nominalDurationMs,
+  };
+}
+
+function parseResultState(value: unknown): LiveResultState {
+  if (value === null) return null;
+  if (!isRecord(value)) throw new Error("Projection result state is invalid.");
+  const factId = requireIdentifier(value.factId, "result.factId");
+  const data = parseJsonValue(value.data, "result.data");
+  if (!data.ok) throw new Error(data.error);
+  return { factId, data: data.value };
+}
+
+function parseNullableFactId(value: unknown, field: string): string | null {
+  return value === null ? null : requireIdentifier(value, field);
+}
+
+function parseNullableBoundedNumber(value: unknown, field: string): number | null {
+  if (value === undefined || value === null) return null;
+  const parsed = validateIntegerInRange(value, 0, SHARED_LIMITS.clock.maxMs, field);
+  if (!parsed.ok) throw new Error(parsed.error);
+  return parsed.value;
+}
+
+function parseGuardrails(value: unknown): ControllerProjection["guardrails"] {
+  if (value === undefined) return [];
+  if (!Array.isArray(value) || value.length > 20) {
+    throw new Error("Projection guardrails are invalid.");
+  }
+  return structuredClone(value) as ControllerProjection["guardrails"];
+}
+
+function parseGameFacts(value: unknown): ControllerProjection["gameFacts"] {
+  if (value === undefined) return [];
+  if (!Array.isArray(value) || value.length > SHARED_LIMITS.replay.maxControlActions) {
+    throw new Error("Projection game facts are invalid.");
+  }
+  return value.map((candidate) => {
+    if (!isRecord(candidate)) throw new Error("Projection game fact is invalid.");
+    const factId = requireIdentifier(candidate.factId, "gameFacts.factId");
+    const factType = requireIdentifier(candidate.factType, "gameFacts.factType");
+    const gameSideId =
+      candidate.gameSideId === null
+        ? null
+        : requireIdentifier(candidate.gameSideId, "gameFacts.gameSideId");
+    if (!Number.isSafeInteger(candidate.gameTimeMs) && candidate.gameTimeMs !== null)
+      throw new Error("Projection game fact time is invalid.");
+    if (
+      !Number.isSafeInteger(candidate.sportingOrder) ||
+      !Number.isSafeInteger(candidate.synchronizationOrder) ||
+      typeof candidate.effective !== "boolean"
+    )
+      throw new Error("Projection game fact ordering is invalid.");
+    return {
+      ...(structuredClone(candidate) as ControllerGameFact),
+      factId,
+      factType,
+      gameSideId,
+    };
+  });
 }
 
 function parseIdentity(value: unknown): ControllerReplicaState["identity"] {
@@ -992,6 +1193,116 @@ function requireIdentifier(value: unknown, field: string): string {
 
 function cloneProjection(projection: ControllerProjection): ControllerProjection {
   return structuredClone(projection);
+}
+
+function appendOptimisticFact(
+  projection: ControllerProjection,
+  fact: {
+    factId: string;
+    factType: string;
+    gameSideId: string | null;
+    gameTimeMs: number;
+    sportingOrder: number;
+    data: unknown;
+  },
+) {
+  const facts = [...(projection.gameFacts ?? [])];
+  const synchronizationOrder =
+    facts.reduce((highest, candidate) => Math.max(highest, candidate.synchronizationOrder), 0) + 1;
+  facts.push({
+    factId: fact.factId,
+    factType: fact.factType,
+    gameSideId: fact.gameSideId,
+    gameTimeMs: fact.gameTimeMs,
+    sportingOrder: fact.sportingOrder,
+    synchronizationOrder,
+    effective: true,
+    data: fact.data as ControllerGameFact["data"],
+  });
+  return facts.sort(
+    (left, right) =>
+      left.sportingOrder - right.sportingOrder ||
+      left.synchronizationOrder - right.synchronizationOrder,
+  );
+}
+
+function deriveOptimisticDependentState(facts: readonly ControllerGameFact[]): {
+  timeout: LiveTimeoutState;
+  stoppage: LiveStoppageState;
+  heat: LiveHeatState;
+  result: LiveResultState;
+} {
+  const latest = (factType: string) =>
+    facts.filter((fact) => fact.effective && fact.factType === factType).at(-1) ?? null;
+  const timeoutFact = latest("timeout");
+  const suspensionFact = latest("suspension");
+  const heatFact = latest("heat-stoppage");
+  const resultFact = latest("result");
+  const heatData =
+    heatFact !== null && isRecord(heatFact.data)
+      ? (heatFact.data as Record<string, unknown>)
+      : null;
+  const heatAction =
+    heatData !== null &&
+    (heatData.heatAction === "end" ||
+      heatData.heatAction === "skip-required" ||
+      heatData.heatAction === "extend-permitted")
+      ? heatData.heatAction
+      : null;
+  const heatStatus: LiveHeatState["status"] =
+    heatFact === null
+      ? "inactive"
+      : heatAction === "end"
+        ? "ended"
+        : heatAction === "skip-required"
+          ? "skipped"
+          : heatAction === "extend-permitted"
+            ? "extended"
+            : "started";
+  const effectiveHeatStarts = facts.filter((fact) => {
+    const data = isRecord(fact.data) ? (fact.data as unknown as Record<string, unknown>) : null;
+    return (
+      fact.effective &&
+      fact.factType === "heat-stoppage" &&
+      (data === null ||
+        (data.heatAction !== "end" &&
+          data.heatAction !== "skip-required" &&
+          data.heatAction !== "extend-permitted"))
+    );
+  });
+  const nominalDurationMs =
+    heatStatus === "started" || heatStatus === "extended"
+      ? effectiveHeatStarts.length <= 1
+        ? 4 * 60 * 1000
+        : 2 * 60 * 1000
+      : null;
+  const startedAtGameTimeMs =
+    nominalDurationMs === null || heatFact?.gameTimeMs === null
+      ? null
+      : (heatFact?.gameTimeMs ?? null);
+  const heat: LiveHeatState = {
+    status: heatStatus,
+    factId: heatFact?.factId ?? null,
+    startedAtGameTimeMs,
+    nominalDurationMs,
+  };
+  return {
+    timeout: {
+      status: timeoutFact === null ? "inactive" : "started",
+      factId: timeoutFact?.factId ?? null,
+    },
+    stoppage:
+      suspensionFact !== null
+        ? { status: "suspension", factId: suspensionFact.factId }
+        : heat.status === "started" || heat.status === "extended"
+          ? { status: "heat-stoppage", factId: heat.factId }
+          : { status: "none", factId: null },
+    heat,
+    result:
+      resultFact === null
+        ? null
+        : { factId: resultFact.factId, data: structuredClone(resultFact.data) },
+  };
 }
 
 function isRecord(value: unknown): value is Record<string, any> {

--- a/src/lib/event-game-action-codecs.ts
+++ b/src/lib/event-game-action-codecs.ts
@@ -351,6 +351,14 @@ export function validateOverride(
     SHARED_LIMITS.clock.maxMs,
     "override.gameTimeMs",
   );
+  const beforeValue =
+    value.beforeValue === undefined
+      ? valid(undefined)
+      : parseJsonValue(value.beforeValue, "override.beforeValue");
+  const afterValue =
+    value.afterValue === undefined
+      ? valid(undefined)
+      : parseJsonValue(value.afterValue, "override.afterValue");
   const reason = validateOptionalBoundedText(value.reason, "override.reason");
   const note = validateOptionalBoundedText(value.note, "override.note");
   if (!guardrail.ok) return guardrail;
@@ -358,6 +366,8 @@ export function validateOverride(
   if (!confirmation.ok) return confirmation;
   if (!authorityReference.ok) return authorityReference;
   if (!gameTimeMs.ok) return gameTimeMs;
+  if (!beforeValue.ok) return beforeValue;
+  if (!afterValue.ok) return afterValue;
   if (!reason.ok) return reason;
   if (!note.ok) return note;
   return valid({
@@ -366,6 +376,8 @@ export function validateOverride(
     confirmation: confirmation.value,
     authorityReference: authorityReference.value,
     gameTimeMs: gameTimeMs.value,
+    ...(beforeValue.value === undefined ? {} : { beforeValue: beforeValue.value }),
+    ...(afterValue.value === undefined ? {} : { afterValue: afterValue.value }),
     ...(reason.value === undefined ? {} : { reason: reason.value }),
     ...(note.value === undefined ? {} : { note: note.value }),
   });

--- a/src/lib/event-game-actions.ts
+++ b/src/lib/event-game-actions.ts
@@ -76,6 +76,8 @@ export type OfficialOverrideMetadata = {
   confirmation: string;
   authorityReference: string;
   gameTimeMs: number;
+  beforeValue?: ActionJsonValue;
+  afterValue?: ActionJsonValue;
   reason?: string;
   note?: string;
 };

--- a/src/lib/foundation-acceptance.ts
+++ b/src/lib/foundation-acceptance.ts
@@ -932,7 +932,10 @@ export function createFoundationAcceptance(
       "action-accepted",
       ACCEPTED_AUDIT_DETAIL,
       action.acceptedAtMs,
-      { interpretation: prepared.interpretation, relatedOperationIds: [] },
+      {
+        interpretation: prepared.interpretation,
+        relatedOperationIds: relatedFactOperationIds(transaction, root, prepared.interpretation),
+      },
     );
     return writeAcceptedOutcome(
       transaction,
@@ -1126,7 +1129,10 @@ export function createFoundationAcceptance(
       "action-duplicate",
       "The Control Action was already committed.",
       nowMs,
-      { interpretation: existing.interpretation },
+      {
+        interpretation: existing.interpretation,
+        relatedOperationIds: relatedFactOperationIds(transaction, root, existing.interpretation),
+      },
     );
     controlAudit.outcome = "accepted";
     const acceptanceId = `accept-${sha256(`${root.recordId}:${prepared.input.operationId}:duplicate`)}`;
@@ -2076,6 +2082,17 @@ function readNow(clock: () => number): number {
     throw new Error("Acceptance clock returned an invalid timestamp.");
   return nowMs;
 }
+
+function relatedFactOperationIds(
+  transaction: FoundationStorageSnapshot,
+  root: EventGameRecordRoot,
+  interpretation: ControlAction["interpretation"],
+): readonly string[] {
+  if (interpretation.type !== "correction") return [];
+  const target = findFactById(transaction.listActions(root.recordId), interpretation.targetFactId);
+  return target === null ? [] : [target.action.operationId];
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/src/lib/live-event-game-control.test.ts
+++ b/src/lib/live-event-game-control.test.ts
@@ -14,11 +14,447 @@ import {
   LIVE_EVENT_CONTROL_INTENT_VERSION,
   parseLiveEventControllerIntent,
   type LiveEventControllerIntent,
-  validateLiveEventClockActionInTransaction,
+  validateLiveEventGameActionInTransaction,
 } from "@/lib/live-event-game-control";
 import { createLiveEventGameControlTransport } from "@/lib/live-event-game-transport";
 
 describe("Live Event Game control", () => {
+  test("exposes stable Game Facts and rebuilds score through contextual correction and reinstatement", async () => {
+    const harness = await createHarness();
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "facts-and-corrections",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+
+    expect(
+      await harness.control.submitControllerIntent({
+        sessionBearer: opened.session.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+        intent: goalIntent({ gameTimeMs: 12_000 }),
+      }),
+    ).toMatchObject({
+      status: "accepted",
+      projection: {
+        gameFacts: [
+          expect.objectContaining({
+            factId: "fact-goal",
+            factType: "goal",
+            effective: true,
+            sportingOrder: 12_000,
+            synchronizationOrder: 1,
+          }),
+        ],
+      },
+    });
+
+    const corrected = await harness.control.submitControllerIntent({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      causalPredecessorIds: ["operation-goal"],
+      intent: correctionIntent("correction-goal", "correction-fact", false),
+    });
+    expect(corrected).toMatchObject({
+      status: "accepted",
+      projection: {
+        scoreByGameSide: { "side-a": 0, "side-b": 0 },
+        goalCount: 0,
+        gameFacts: [expect.objectContaining({ factId: "fact-goal", effective: false })],
+      },
+    });
+
+    const reinstated = await harness.control.submitControllerIntent({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      causalPredecessorIds: ["correction-goal"],
+      intent: correctionIntent("reinstate-goal", "reinstate-fact", true),
+    });
+    expect(reinstated).toMatchObject({
+      status: "accepted",
+      projection: {
+        scoreByGameSide: { "side-a": 10, "side-b": 0 },
+        goalCount: 1,
+        gameFacts: [expect.objectContaining({ factId: "fact-goal", effective: true })],
+      },
+    });
+    expect(await harness.record.readActions()).toHaveLength(3);
+    expect((await harness.record.readActions())[1]?.action.interpretation).toMatchObject({
+      type: "correction",
+      targetFactId: "fact-goal",
+      effective: false,
+    });
+  });
+
+  test("keeps sporting order distinct from synchronization order for late Controller information", async () => {
+    const harness = await createHarness();
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "sporting-order",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+
+    await harness.control.submitControllerIntent({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      intent: goalIntent({
+        operationId: "operation-late",
+        factId: "fact-late",
+        gameTimeMs: 20_000,
+      }),
+    });
+    harness.setNow(11_000);
+    const result = await harness.control.submitControllerIntent({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      intent: goalIntent({
+        operationId: "operation-early",
+        factId: "fact-early",
+        gameTimeMs: 10_000,
+      }),
+    });
+    const facts = (result as unknown as { projection: { gameFacts: any[] } }).projection.gameFacts;
+    const synchronizationOrders = facts.map((fact) => fact.synchronizationOrder);
+    expect(synchronizationOrders[0]).toBeGreaterThan(synchronizationOrders[1] ?? 0);
+    expect(facts).toMatchObject([
+      expect.objectContaining({ factId: "fact-early", sportingOrder: 10_000 }),
+      expect.objectContaining({ factId: "fact-late", sportingOrder: 20_000 }),
+    ]);
+
+    const unadjudicated = await harness.control.submitControllerIntent({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      intent: {
+        ...goalIntent({ operationId: "operation-unadjudicated", factId: "fact-unadjudicated" }),
+        sportingOrder: 1_000,
+      },
+    });
+    expect(unadjudicated).toMatchObject({ status: "rejected" });
+
+    const adjudicated = await harness.control.submitControllerIntent({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      intent: {
+        ...goalIntent({ operationId: "operation-adjudicated", factId: "fact-adjudicated" }),
+        sportingOrder: 1_000,
+        override: {
+          guardrail: "sporting-order-adjudication",
+          direction: "head-referee-adjudicated-sporting-order",
+          confirmation: "head-referee-confirmed",
+          authorityReference: "head-referee",
+          gameTimeMs: 12_000,
+          beforeValue: { sportingOrder: 12_000 },
+          afterValue: { sportingOrder: 1_000 },
+          reason: "head-referee-direction",
+        },
+      },
+    });
+    expect(adjudicated).toMatchObject({ status: "accepted" });
+    expect((await harness.record.readActions()).at(-1)?.action.override).toMatchObject({
+      guardrail: "sporting-order-adjudication",
+    });
+  });
+
+  test("rebuilds penalty, timeout, stoppage, heat, and result state through Corrections", async () => {
+    const harness = await createHarness();
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "dependent-state-corrections",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+
+    const submit = (intent: unknown) =>
+      harness.control.submitControllerIntent({
+        sessionBearer: opened.session.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+        intent,
+      });
+    await submit(clockIntent("dependent-clock-start", true));
+    harness.setNow(11_000);
+    await submit(substantiveIntent("card-state", "card"));
+    harness.setNow(12_000);
+    await submit(clockIntent("dependent-clock-pause", false));
+    await submit(substantiveIntent("timeout-state", "timeout"));
+    await submit(substantiveIntent("suspension-state", "suspension"));
+    await submit({
+      ...substantiveIntent("heat-state", "heat-stoppage"),
+      heatAction: "start",
+    });
+    await submit(substantiveIntent("result-state", "result"));
+
+    const finished = await harness.control.refreshController({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+    });
+    expect(finished).toMatchObject({
+      projection: {
+        phase: "finished",
+        timeout: { status: "started", factId: "fact-timeout-state" },
+        stoppage: { status: "suspension", factId: "fact-suspension-state" },
+        heat: { status: "started", factId: "fact-heat-state" },
+        result: { factId: "fact-result-state" },
+      },
+    });
+    if (finished.status !== "authorized" || finished.projection === null) {
+      throw new Error("Expected the finished Controller projection.");
+    }
+    expect(finished.projection.clock.activePenaltyTimeMs).toBe(1_000);
+
+    await submit(
+      correctionIntent("correct-card-state", "correction-card-state", false, "fact-card-state"),
+    );
+    await submit(
+      correctionIntent(
+        "correct-timeout-state",
+        "correction-timeout-state",
+        false,
+        "fact-timeout-state",
+      ),
+    );
+    await submit(
+      correctionIntent(
+        "correct-suspension-state",
+        "correction-suspension-state",
+        false,
+        "fact-suspension-state",
+      ),
+    );
+    await submit(
+      correctionIntent("correct-heat-state", "correction-heat-state", false, "fact-heat-state"),
+    );
+    const corrected = await submit(
+      correctionIntent(
+        "correct-result-state",
+        "correction-result-state",
+        false,
+        "fact-result-state",
+      ),
+    );
+    expect(corrected).toMatchObject({
+      status: "accepted",
+      projection: {
+        phase: "in-progress",
+        timeout: { status: "inactive", factId: null },
+        stoppage: { status: "none", factId: null },
+        heat: { status: "inactive", factId: null },
+        result: null,
+      },
+    });
+    if (corrected.status !== "accepted" || corrected.projection === null) {
+      throw new Error("Expected the corrected Controller projection.");
+    }
+    expect(corrected.projection.clock.activePenaltyTimeMs).toBe(0);
+
+    const continued = await submit(
+      goalIntent({ operationId: "post-result-goal", factId: "fact-post-result" }),
+    );
+    expect(continued).toMatchObject({
+      status: "accepted",
+      projection: {
+        phase: "in-progress",
+        scoreByGameSide: { "side-a": 10, "side-b": 0 },
+      },
+    });
+
+    const reinstated = await submit(
+      correctionIntent(
+        "reinstate-result-state",
+        "reinstate-result-state",
+        true,
+        "fact-result-state",
+      ),
+    );
+    expect(reinstated).toMatchObject({
+      status: "accepted",
+      projection: {
+        phase: "finished",
+        result: { factId: "fact-result-state" },
+      },
+    });
+  });
+
+  test("records explainable Head Referee Official Override evidence and rejects clock misclassification", async () => {
+    const harness = await createHarness();
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "official-override",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+
+    const running = await harness.control.submitControllerIntent({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      intent: clockIntent("timeout-running", true),
+    });
+    expect(running).toMatchObject({ status: "accepted" });
+
+    const normalTimeout = await harness.control.submitControllerIntent({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      intent: substantiveIntent("timeout-without-override", "timeout"),
+    });
+    expect(normalTimeout).toMatchObject({ status: "rejected" });
+
+    const overridden = await harness.control.submitControllerIntent({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      intent: {
+        ...substantiveIntent("timeout-override", "timeout"),
+        gameTimeMs: 15_000,
+        override: {
+          guardrail: "timeout-requires-paused-play",
+          direction: "head-referee-directed-timeout-while-running",
+          confirmation: "head-referee-confirmed",
+          authorityReference: "head-referee",
+          gameTimeMs: 15_000,
+          reason: "head-referee-direction",
+          beforeValue: { running: true },
+          afterValue: { timeout: "started" },
+        },
+      },
+    });
+    expect(overridden).toMatchObject({ status: "accepted" });
+    const acceptedAction = (await harness.record.readActions())[1]?.action;
+    expect(acceptedAction?.override).toMatchObject({
+      guardrail: "timeout-requires-paused-play",
+      confirmation: "head-referee-confirmed",
+      authorityReference: "head-referee",
+      reason: "head-referee-direction",
+      beforeValue: { running: true },
+      afterValue: { timeout: "started" },
+    });
+    expect(acceptedAction?.grant.sessionId).toBe(opened.session.grantSessionId);
+
+    const invalidEvidence = await harness.control.submitControllerIntent({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      intent: {
+        ...substantiveIntent("timeout-invalid-evidence", "timeout"),
+        override: {
+          guardrail: "timeout-requires-paused-play",
+          direction: "head-referee-directed-timeout-while-running",
+          confirmation: "head-referee-confirmed",
+          authorityReference: "head-referee",
+          gameTimeMs: 0,
+          reason: "head-referee-direction",
+          beforeValue: { running: false },
+          afterValue: { timeout: "started" },
+        },
+      },
+    });
+    expect(invalidEvidence).toMatchObject({ status: "rejected" });
+
+    const validHeat = await harness.control.submitControllerIntent({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      intent: {
+        ...substantiveIntent("heat-skip", "result"),
+        trigger: "heat-stoppage",
+        heatAction: "skip-required",
+      },
+    });
+    expect(validHeat).toMatchObject({ status: "accepted" });
+    expect((await harness.record.readActions())[2]?.action.override).toBeUndefined();
+
+    const fabricatedHeatOverride = await harness.control.submitControllerIntent({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      intent: {
+        ...substantiveIntent("fabricated-heat-override", "heat-stoppage"),
+        heatAction: "skip-required",
+        override: {
+          guardrail: "heat-stoppage-rule-deviation",
+          direction: "head-referee-directed-heat-stoppage",
+          confirmation: "head-referee-confirmed",
+          authorityReference: "head-referee",
+          gameTimeMs: 0,
+          beforeValue: { heat: "inactive" },
+          afterValue: { heat: "skipped" },
+          reason: "head-referee-direction",
+        },
+      },
+    });
+    expect(fabricatedHeatOverride).toMatchObject({ status: "rejected" });
+
+    const paused = await harness.control.submitControllerIntent({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      intent: clockIntent("timeout-pause", false),
+    });
+    expect(paused).toMatchObject({ status: "accepted" });
+
+    const unnecessaryTimeoutOverride = await harness.control.submitControllerIntent({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      intent: {
+        ...substantiveIntent("unnecessary-timeout-override", "timeout"),
+        override: {
+          guardrail: "timeout-requires-paused-play",
+          direction: "head-referee-directed-timeout-while-running",
+          confirmation: "head-referee-confirmed",
+          authorityReference: "head-referee",
+          gameTimeMs: 0,
+          beforeValue: { running: false },
+          afterValue: { timeout: "started" },
+          reason: "head-referee-direction",
+        },
+      },
+    });
+    expect(unnecessaryTimeoutOverride).toMatchObject({ status: "rejected" });
+
+    const clockWithOverride = await harness.control.submitControllerIntent({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      intent: {
+        ...clockCorrectionIntent("clock-with-override"),
+        override: {
+          guardrail: "normal-event-game-operation",
+          direction: "head-referee-directed",
+          confirmation: "head-referee-confirmed",
+          authorityReference: "head-referee",
+          gameTimeMs: 1_000,
+          reason: "head-referee-direction",
+        },
+      },
+    });
+    expect(clockWithOverride).toMatchObject({ status: "rejected" });
+    expect(await harness.record.readActions()).toHaveLength(4);
+  });
+
+  test("keeps a failed live Correction atomic and safely retryable", async () => {
+    const harness = await createHarness();
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "correction-atomicity",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+    await harness.control.submitControllerIntent({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      intent: goalIntent(),
+    });
+
+    harness.failureBoundary = "after-action";
+    const failed = await harness.control.submitControllerIntent({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      intent: correctionIntent("atomic-correction", "atomic-correction-id", false),
+    });
+    expect(failed).toMatchObject({ status: "retryable", operationId: "atomic-correction" });
+    expect(await harness.record.readActions()).toHaveLength(1);
+    expect(await harness.record.rebuild()).toMatchObject({ status: "ready" });
+
+    harness.failureBoundary = undefined;
+    const retried = await harness.control.submitControllerIntent({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      intent: correctionIntent("atomic-correction", "atomic-correction-id", false),
+    });
+    expect(retried).toMatchObject({
+      status: "accepted",
+      projection: { scoreByGameSide: { "side-a": 0, "side-b": 0 } },
+    });
+  });
+
   test("opens from a Control Grant and durably acknowledges a ten-point goal with a rebuilt projection", async () => {
     const harness = await createHarness();
     const opened = await harness.control.openController({
@@ -652,6 +1088,91 @@ describe("Live Event Game control", () => {
     ]);
     expect((await harness.record.readActions()).map((stored) => stored.action.operationId)).toEqual(
       ["same-batch-result"],
+    );
+  });
+
+  test("replays a reversed result Correction chain against rebuilt effective phase", async () => {
+    const harness = await createHarness();
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "reversed-result-correction-chain",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+    const finish = await harness.control.submitControllerIntent({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      intent: substantiveIntent("replay-order-result", "result"),
+    });
+    expect(finish.status).toBe("accepted");
+
+    const replay = await harness.control.replayControllerActions({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      batchId: "batch-reversed-result-correction",
+      replicaGeneration: "generation-reversed-result-correction",
+      expectedGrantSessionId: opened.session.grantSessionId,
+      expectedGrantVersion: opened.session.grantVersion,
+      actions: [
+        {
+          eventGameId: harness.root.eventGameId,
+          intent: goalIntent({
+            operationId: "after-reinstatement-goal",
+            factId: "fact-after-reinstatement",
+          }),
+          causalPredecessorIds: ["replay-order-reinstate"],
+        },
+        {
+          eventGameId: harness.root.eventGameId,
+          intent: correctionIntent(
+            "replay-order-reinstate",
+            "correction-replay-order-reinstate",
+            true,
+            "fact-replay-order-result",
+          ),
+          causalPredecessorIds: ["replay-order-goal"],
+        },
+        {
+          eventGameId: harness.root.eventGameId,
+          intent: goalIntent({
+            operationId: "replay-order-goal",
+            factId: "fact-replay-order-goal",
+          }),
+          causalPredecessorIds: ["replay-order-correct-result"],
+        },
+        {
+          eventGameId: harness.root.eventGameId,
+          intent: correctionIntent(
+            "replay-order-correct-result",
+            "correction-replay-order-result",
+            false,
+            "fact-replay-order-result",
+          ),
+          causalPredecessorIds: ["replay-order-result"],
+        },
+      ],
+    });
+
+    expect(replay.outcomes).toEqual([
+      { operationId: "replay-order-correct-result", status: "accepted" },
+      { operationId: "replay-order-goal", status: "accepted" },
+      { operationId: "replay-order-reinstate", status: "accepted" },
+      { operationId: "after-reinstatement-goal", status: "held-for-correction" },
+    ]);
+    expect(replay.projection).toMatchObject({
+      phase: "finished",
+      scoreByGameSide: { "side-a": 10, "side-b": 0 },
+      result: { factId: "fact-replay-order-result" },
+      gameFacts: expect.arrayContaining([
+        expect.objectContaining({ factId: "fact-replay-order-goal", effective: true }),
+      ]),
+    });
+    expect((await harness.record.readActions()).map((stored) => stored.action.operationId)).toEqual(
+      [
+        "replay-order-result",
+        "replay-order-correct-result",
+        "replay-order-goal",
+        "replay-order-reinstate",
+      ],
     );
   });
 
@@ -1560,7 +2081,11 @@ async function createHarness(
       if (boundary === failureBoundary) throw new Error("simulated durable failure");
     },
     validateActionInTransaction: ({ transaction, root, action }) =>
-      validateLiveEventClockActionInTransaction(transaction.listActions(root.recordId), action),
+      validateLiveEventGameActionInTransaction(
+        transaction.listActions(root.recordId),
+        root,
+        action,
+      ),
   });
   const control = createLiveEventGameControl({
     resolveEventGameRecord: async (eventGameId) =>
@@ -1599,7 +2124,12 @@ async function createHarness(
 }
 
 function goalIntent(
-  overrides: { gameSideId?: string; operationId?: string; factId?: string } = {},
+  overrides: {
+    gameSideId?: string;
+    operationId?: string;
+    factId?: string;
+    gameTimeMs?: number;
+  } = {},
 ) {
   return {
     version: LIVE_EVENT_CONTROL_INTENT_VERSION,
@@ -1607,8 +2137,38 @@ function goalIntent(
     operationId: overrides.operationId ?? "operation-goal",
     factId: overrides.factId ?? "fact-goal",
     gameSideId: overrides.gameSideId ?? "side-a",
-    gameTimeMs: 12_000,
+    gameTimeMs: overrides.gameTimeMs ?? 12_000,
     occurrence: { clientOriginAtMs: 10_000 },
+  };
+}
+
+function correctionIntent(
+  operationId: string,
+  factId: string,
+  effective: boolean,
+  targetFactId = "fact-goal",
+) {
+  return {
+    version: LIVE_EVENT_CONTROL_INTENT_VERSION,
+    type: "correct-fact" as const,
+    operationId,
+    factId,
+    targetFactId,
+    effective,
+    gameTimeMs: 13_000,
+    occurrence: { clientOriginAtMs: 13_000, source: "offline" as const },
+  };
+}
+
+function clockCorrectionIntent(operationId: string) {
+  return {
+    version: LIVE_EVENT_CONTROL_INTENT_VERSION,
+    type: "clock-correction" as const,
+    operationId,
+    factId: `fact-${operationId}`,
+    clockTimeMs: 1_000,
+    gameTimeMs: 0,
+    occurrence: { clientOriginAtMs: null },
   };
 }
 
@@ -1642,7 +2202,7 @@ function clockAdjustmentIntent(operationId: string, adjustmentMs: number) {
 
 function substantiveIntent(
   operationId: string,
-  trigger: "card" | "timeout" | "suspension" | "result",
+  trigger: "card" | "timeout" | "suspension" | "result" | "heat-stoppage",
 ) {
   return {
     version: LIVE_EVENT_CONTROL_INTENT_VERSION,

--- a/src/lib/live-event-game-control.ts
+++ b/src/lib/live-event-game-control.ts
@@ -1,5 +1,16 @@
-import type { EffectiveGameFact, IqaGameRulesInterpreter } from "@/lib/event-game-actions";
-import { createDefaultControlActionCodecs } from "@/lib/event-game-actions";
+import type {
+  ActionJsonValue,
+  EffectiveGameFact,
+  IqaGameRulesInterpreter,
+  OfficialOverrideMetadata,
+} from "@/lib/event-game-actions";
+import {
+  canonicalizeJson,
+  createControlActionCodecRegistry,
+  createDefaultControlActionCodecs,
+  rebuildControlActionHistory,
+} from "@/lib/event-game-actions";
+import { parseJsonValue, validateOverride } from "@/lib/event-game-action-codecs";
 import {
   CLOCK_AUTHORITY_VERSION,
   deriveClockAuthority,
@@ -29,17 +40,24 @@ type ControllerIntentBase = {
   operationId: string;
   factId: string;
   gameTimeMs: number;
+  sportingOrder?: number;
   occurrence: {
     clientOriginAtMs: number | null;
     source?: "online" | "offline";
   };
   clockGeneration?: number;
+  override?: OfficialOverrideMetadata;
 };
 
 export type LiveEventControllerIntent =
   | (ControllerIntentBase & {
       type: "record-goal";
       gameSideId: string;
+    })
+  | (ControllerIntentBase & {
+      type: "correct-fact";
+      targetFactId: string;
+      effective: boolean;
     })
   | (ControllerIntentBase & {
       type: "clock" | "set-running";
@@ -62,7 +80,8 @@ export type LiveEventControllerIntent =
     })
   | (ControllerIntentBase & {
       type: "substantive";
-      trigger: "card" | "timeout" | "suspension" | "result";
+      trigger: "card" | "timeout" | "suspension" | "result" | "heat-stoppage";
+      heatAction?: "start" | "end" | "skip-required" | "extend-permitted";
     })
   | (ControllerIntentBase & {
       type: "reset" | "undo";
@@ -116,6 +135,51 @@ export type LiveEventGameDerivedState = {
   scoreByGameSide: Readonly<Record<string, number>>;
   goalCount: number;
   clock: ClockProjection;
+  timeout: LiveTimeoutState;
+  stoppage: LiveStoppageState;
+  heat: LiveHeatState;
+  result: LiveResultState;
+  gameFacts: readonly ControllerGameFact[];
+};
+
+export type LiveTimeoutState = {
+  status: "inactive" | "started";
+  factId: string | null;
+};
+
+export type LiveStoppageState = {
+  status: "none" | "suspension" | "heat-stoppage";
+  factId: string | null;
+};
+
+export type LiveHeatState = {
+  status: "inactive" | "started" | "ended" | "skipped" | "extended";
+  factId: string | null;
+  startedAtGameTimeMs: number | null;
+  nominalDurationMs: number | null;
+};
+
+export type LiveResultState = {
+  factId: string;
+  data: ActionJsonValue;
+} | null;
+
+export type ControllerGameFact = {
+  factId: string;
+  factType: string;
+  gameSideId: string | null;
+  gameTimeMs: number | null;
+  sportingOrder: number;
+  synchronizationOrder: number;
+  effective: boolean;
+  data: ActionJsonValue;
+};
+
+export type LiveEventGuardrailExplanation = {
+  guardrail: string;
+  normalBehavior: string;
+  overrideAllowed: boolean;
+  fixedReason: "head-referee-direction" | null;
 };
 
 export type ControllerProjection = {
@@ -123,6 +187,12 @@ export type ControllerProjection = {
   phase: EventGameLifecyclePhase;
   scoreByGameSide: Readonly<Record<string, number>>;
   goalCount: number;
+  timeout?: LiveTimeoutState;
+  stoppage?: LiveStoppageState;
+  heat?: LiveHeatState;
+  result?: LiveResultState;
+  gameFacts?: readonly ControllerGameFact[];
+  guardrails?: readonly LiveEventGuardrailExplanation[];
   commencement: ControllerCommencement;
   clock: ClockProjection;
 };
@@ -241,6 +311,8 @@ export function parseLiveEventControllerIntent(
   }
   if (
     value.type !== "record-goal" &&
+    value.type !== "correct-fact" &&
+    value.type !== "correction" &&
     value.type !== "clock" &&
     value.type !== "set-running" &&
     value.type !== "clock-adjust" &&
@@ -260,7 +332,9 @@ export function parseLiveEventControllerIntent(
       ? "clock-adjust"
       : value.type === "correct-clock" || value.type === "set-game-clock"
         ? "clock-correction"
-        : value.type;
+        : value.type === "correction"
+          ? "correct-fact"
+          : value.type;
 
   const operationId = validateOpaqueIdentifier(value.operationId, "operationId");
   const factId = validateOpaqueIdentifier(value.factId, "factId");
@@ -274,11 +348,32 @@ export function parseLiveEventControllerIntent(
   if (!factId.ok) return invalid(factId.error);
   if (!gameTimeMs.ok) return invalid(gameTimeMs.error);
 
+  let sportingOrder: number | undefined;
+  if (value.sportingOrder !== undefined) {
+    const parsedSportingOrder = validateIntegerInRange(
+      value.sportingOrder,
+      0,
+      SHARED_LIMITS.clock.maxMs,
+      "sportingOrder",
+    );
+    if (!parsedSportingOrder.ok) return invalid(parsedSportingOrder.error);
+    sportingOrder = parsedSportingOrder.value;
+  }
+
   let gameSideId: string | undefined;
   if (value.type === "record-goal") {
     const parsedSide = validateOpaqueIdentifier(value.gameSideId, "gameSideId");
     if (!parsedSide.ok) return invalid(parsedSide.error);
     gameSideId = parsedSide.value;
+  }
+  let targetFactId: string | undefined;
+  let effective: boolean | undefined;
+  if (normalizedType === "correct-fact") {
+    const parsedTarget = validateOpaqueIdentifier(value.targetFactId, "targetFactId");
+    if (!parsedTarget.ok) return invalid(parsedTarget.error);
+    if (typeof value.effective !== "boolean") return invalid("effective must be a boolean.");
+    targetFactId = parsedTarget.value;
+    effective = value.effective;
   }
   let running: boolean | undefined;
   if (value.type === "clock" || value.type === "set-running" || value.type === "clock-takeover") {
@@ -333,16 +428,30 @@ export function parseLiveEventControllerIntent(
       clockGeneration = generation.value;
     }
   }
-  let trigger: "card" | "timeout" | "suspension" | "result" | undefined;
+  let trigger: "card" | "timeout" | "suspension" | "result" | "heat-stoppage" | undefined;
+  let heatAction: "start" | "end" | "skip-required" | "extend-permitted" | undefined;
   if (value.type === "substantive") {
     if (
       value.trigger !== "card" &&
       value.trigger !== "timeout" &&
       value.trigger !== "suspension" &&
-      value.trigger !== "result"
+      value.trigger !== "result" &&
+      value.trigger !== "heat-stoppage"
     )
       return invalid("substantive trigger is unsupported.");
     trigger = value.trigger;
+    if (trigger === "heat-stoppage") {
+      if (
+        value.heatAction !== undefined &&
+        value.heatAction !== "start" &&
+        value.heatAction !== "end" &&
+        value.heatAction !== "skip-required" &&
+        value.heatAction !== "extend-permitted"
+      ) {
+        return invalid("heatAction is unsupported.");
+      }
+      heatAction = value.heatAction;
+    }
   }
 
   if (!isRecord(value.occurrence)) return invalid("occurrence must be an object.");
@@ -367,6 +476,8 @@ export function parseLiveEventControllerIntent(
     }
     source = value.occurrence.source;
   }
+  const overrideResult = validateOverride(value.override);
+  if (!overrideResult.ok) return invalid(overrideResult.error);
   return {
     ok: true,
     value: {
@@ -376,6 +487,9 @@ export function parseLiveEventControllerIntent(
       factId: factId.value,
       gameTimeMs: gameTimeMs.value,
       occurrence: { clientOriginAtMs, ...(source === undefined ? {} : { source }) },
+      ...(sportingOrder === undefined ? {} : { sportingOrder }),
+      ...(targetFactId === undefined ? {} : { targetFactId }),
+      ...(effective === undefined ? {} : { effective }),
       ...(gameSideId === undefined ? {} : { gameSideId }),
       ...(running === undefined ? {} : { running }),
       ...(adjustmentMs === undefined ? {} : { adjustmentMs }),
@@ -384,7 +498,59 @@ export function parseLiveEventControllerIntent(
       ...(confirmation === undefined ? {} : { confirmation }),
       ...(clockGeneration === undefined ? {} : { clockGeneration }),
       ...(trigger === undefined ? {} : { trigger }),
+      ...(heatAction === undefined ? {} : { heatAction }),
+      ...(overrideResult.value === undefined ? {} : { override: overrideResult.value }),
     } as LiveEventControllerIntent,
+  };
+}
+
+export function explainLiveEventGuardrail(intent: {
+  type: LiveEventControllerIntent["type"];
+  trigger?: "card" | "timeout" | "suspension" | "result" | "heat-stoppage";
+  gameTimeMs?: number;
+  sportingOrder?: number;
+}): LiveEventGuardrailExplanation {
+  if (
+    intent.gameTimeMs !== undefined &&
+    intent.sportingOrder !== undefined &&
+    intent.sportingOrder !== intent.gameTimeMs
+  ) {
+    return {
+      guardrail: "sporting-order-adjudication",
+      normalBehavior: "Sporting order follows the ordinary trusted game-time timeline.",
+      overrideAllowed: true,
+      fixedReason: "head-referee-direction",
+    };
+  }
+  if (intent.type === "substantive" && intent.trigger === "timeout") {
+    return {
+      guardrail: "timeout-requires-paused-play",
+      normalBehavior: "A timeout starts while play is paused.",
+      overrideAllowed: true,
+      fixedReason: "head-referee-direction",
+    };
+  }
+  if (intent.type === "substantive" && intent.trigger === "suspension") {
+    return {
+      guardrail: "suspension-requires-head-referee-direction",
+      normalBehavior: "A suspension is recorded as a normal Controller action.",
+      overrideAllowed: false,
+      fixedReason: null,
+    };
+  }
+  if (intent.type === "substantive" && intent.trigger === "heat-stoppage") {
+    return {
+      guardrail: "heat-stoppage-rule-deviation",
+      normalBehavior: "A valid heat-stoppage action follows the settled heat workflow.",
+      overrideAllowed: true,
+      fixedReason: "head-referee-direction",
+    };
+  }
+  return {
+    guardrail: "normal-event-game-operation",
+    normalBehavior: "The Controller action follows the ordinary Event Game workflow.",
+    overrideAllowed: false,
+    fixedReason: null,
   };
 }
 
@@ -686,7 +852,15 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
     const existingAction = actionsBefore.find(
       (stored) => stored.action.operationId === parsed.value.operationId,
     );
-    if (activeRoot.lifecycle.phase === "finished" && existingAction === undefined) {
+    const effectiveStateBefore = rebuildLiveDerivedState(activeRoot, actionsBefore);
+    if (effectiveStateBefore === null) {
+      return retryableAction(parsed.value.operationId);
+    }
+    if (
+      effectiveStateBefore.phase === "finished" &&
+      existingAction === undefined &&
+      parsed.value.type !== "correct-fact"
+    ) {
       return rejectedAction(parsed.value.operationId);
     }
     const nowMs = clock();
@@ -725,26 +899,55 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
         : null;
     const factType = controllerFactType(parsed.value);
     const gameSideId = parsed.value.type === "record-goal" ? parsed.value.gameSideId : null;
+    const isCorrection = parsed.value.type === "correct-fact";
+    let override: OfficialOverrideMetadata | undefined;
+    try {
+      override = buildLiveOfficialOverride(parsed.value, authorized.grantSessionId);
+    } catch {
+      return rejectedAction(parsed.value.operationId);
+    }
 
     const action = {
       recordId: owner.recordId,
       eventGameId: activeRoot.eventGameId,
       operationId: parsed.value.operationId,
-      kind: { id: goalCodec.kind, version: goalCodec.version },
-      payload: {
-        factId: parsed.value.factId,
-        factType,
-        gameSideId,
-        gameTimeMs: parsed.value.gameTimeMs,
-        data:
-          parsed.value.type === "record-goal"
-            ? { points: 10 }
-            : clockData.value !== null
-              ? clockData.value
-              : parsed.value.type === "substantive"
-                ? { trigger: parsed.value.trigger }
-                : null,
-      },
+      kind:
+        parsed.value.type === "correct-fact"
+          ? { id: "correction", version: "1" }
+          : { id: goalCodec.kind, version: goalCodec.version },
+      payload:
+        parsed.value.type === "correct-fact"
+          ? {
+              correctionId: parsed.value.factId,
+              targetFactId: parsed.value.targetFactId,
+              effective: parsed.value.effective,
+            }
+          : {
+              factId: parsed.value.factId,
+              factType,
+              gameSideId,
+              gameTimeMs: parsed.value.gameTimeMs,
+              data:
+                parsed.value.type === "record-goal"
+                  ? {
+                      points: 10,
+                      sportingOrder: parsed.value.sportingOrder ?? parsed.value.gameTimeMs,
+                    }
+                  : clockData.value !== null
+                    ? {
+                        ...clockData.value,
+                        sportingOrder: parsed.value.sportingOrder ?? parsed.value.gameTimeMs,
+                      }
+                    : parsed.value.type === "substantive"
+                      ? {
+                          trigger: parsed.value.trigger,
+                          sportingOrder: parsed.value.sportingOrder ?? parsed.value.gameTimeMs,
+                          ...(parsed.value.heatAction === undefined
+                            ? {}
+                            : { heatAction: parsed.value.heatAction }),
+                        }
+                      : null,
+            },
       causalPredecessorIds: [...(input.causalPredecessorIds ?? [])],
       occurrence: {
         trustedAtMs: nowMs,
@@ -756,9 +959,12 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
         versionId: authorized.grantVersion,
       },
       lifecycle: structuredClone(existingAction?.action.lifecycle ?? activeRoot.lifecycle),
+      ...(override === undefined ? {} : { override }),
     };
 
-    const shouldCommence = shouldRecordCommencement(parsed.value, activeRoot, nowMs, clockStartMs);
+    const shouldCommence = isCorrection
+      ? null
+      : shouldRecordCommencement(parsed.value, activeRoot, nowMs, clockStartMs);
     const shouldFinish =
       parsed.value.type === "substantive" &&
       parsed.value.trigger === "result" &&
@@ -887,8 +1093,17 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
       );
       const replayRoot = await replayOwner.record.readRoot(replayOwner.recordId);
       if (replayRoot === null) return replayRetryable(input.actions, replayContext);
+      const replayState = rebuildLiveDerivedState(replayRoot, persistedActions);
+      if (replayState === null) return replayRetryable(input.actions, replayContext);
       let finishedUnlocked =
-        replayRoot.lifecycle.phase === "finished" && replayRoot.lifecycle.lockedAtMs === null;
+        replayState.phase === "finished" && replayRoot.lifecycle.lockedAtMs === null;
+      const refreshFinishedState = async (): Promise<boolean> => {
+        const currentRoot = await replayOwner.record.readRoot(replayOwner.recordId);
+        if (currentRoot === null) return true;
+        const currentActions = await replayOwner.record.readActions();
+        const currentState = rebuildLiveDerivedState(currentRoot, currentActions);
+        return currentState?.phase === "finished" && currentRoot.lifecycle.lockedAtMs === null;
+      };
       const outcomes: ControllerReplayOutcome[] = [];
       const completed = new Set<string>();
       const blocked = new Set<string>();
@@ -957,18 +1172,22 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
             progressed = true;
             continue;
           }
-          if (finishedUnlocked && !persistedOperationIds.has(operationId)) {
-            outcomes.push({ operationId, status: "held-for-correction" });
-            held.add(operationId);
-            progressed = true;
-            continue;
-          }
           if (
             predecessors.some(
               (predecessor) => batchOperationIds.has(predecessor) && !completed.has(predecessor),
             )
           ) {
             deferred.push(candidate);
+            continue;
+          }
+          if (
+            finishedUnlocked &&
+            parsedIntent.value.type !== "correct-fact" &&
+            !persistedOperationIds.has(operationId)
+          ) {
+            outcomes.push({ operationId, status: "held-for-correction" });
+            held.add(operationId);
+            progressed = true;
             continue;
           }
           const result = await submitControllerIntent({
@@ -980,15 +1199,11 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
           if (result.status === "accepted") {
             outcomes.push({ operationId, status: "accepted" });
             completed.add(operationId);
-            if (
-              parsedIntent.value.type === "substantive" &&
-              parsedIntent.value.trigger === "result"
-            ) {
-              finishedUnlocked = true;
-            }
+            finishedUnlocked = await refreshFinishedState();
           } else if (result.status === "duplicate-accepted") {
             outcomes.push({ operationId, status: "idempotent" });
             completed.add(operationId);
+            finishedUnlocked = await refreshFinishedState();
           } else if (result.status === "retryable") {
             outcomes.push({ operationId, status: "retryable", detail: "retryable server outcome" });
           } else if (finishedUnlocked && !persistedOperationIds.has(operationId)) {
@@ -1051,11 +1266,25 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
       const actions = await record.readActions();
       const runningSinceMs =
         root.lifecycle.commencedAtMs === null ? latestRunningClockStart(actions) : null;
-      return {
+      const controllerProjection: ControllerProjection = {
         eventGameId: root.eventGameId,
         phase: derived.phase,
         scoreByGameSide: structuredClone(derived.scoreByGameSide),
         goalCount: derived.goalCount,
+        timeout: structuredClone(derived.timeout),
+        stoppage: structuredClone(derived.stoppage),
+        heat: structuredClone(derived.heat),
+        result: structuredClone(derived.result),
+        gameFacts: derived.gameFacts.map((fact) => ({
+          ...fact,
+          data: structuredClone(fact.data),
+        })),
+        guardrails: [
+          explainLiveEventGuardrail({ type: "substantive", trigger: "timeout" }),
+          explainLiveEventGuardrail({ type: "substantive", trigger: "suspension" }),
+          explainLiveEventGuardrail({ type: "substantive", trigger: "heat-stoppage" }),
+          explainLiveEventGuardrail({ type: "record-goal", gameTimeMs: 1, sportingOrder: 0 }),
+        ],
         clock: projectClockBaseline(derived.clock.baseline, clock()),
         commencement: {
           status: root.lifecycle.commencedAtMs === null ? "provisional" : "commenced",
@@ -1064,6 +1293,7 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
           provisionalElapsedMs: runningSinceMs === null ? 0 : Math.max(0, clock() - runningSinceMs),
         },
       };
+      return controllerProjection;
     } catch {
       return null;
     }
@@ -1099,13 +1329,135 @@ function deriveLiveEventGameState(
     }
     goalCount += 1;
   }
+  const effectiveFactIds = new Set(effectiveFacts.map((fact) => fact.factId));
+  const synchronizationOrderByOperationId = new Map(
+    [...canonicalActions]
+      .sort(
+        ({ action: left }, { action: right }) =>
+          left.acceptedAtMs - right.acceptedAtMs ||
+          left.operationId.localeCompare(right.operationId),
+      )
+      .map(({ action }, index) => [action.operationId, index + 1]),
+  );
+  const gameFacts = canonicalActions
+    .flatMap(({ action }) => {
+      if (action.interpretation.type !== "fact") return [];
+      const payload = action.interpretation.payload;
+      const gameTimeMs =
+        isRecord(payload) && typeof payload.gameTimeMs === "number" ? payload.gameTimeMs : null;
+      const data = isRecord(payload) && "data" in payload ? payload.data : null;
+      const sportingOrder =
+        isRecord(data) && typeof data.sportingOrder === "number"
+          ? data.sportingOrder
+          : (gameTimeMs ?? 0);
+      return [
+        {
+          factId: action.interpretation.factId,
+          factType: action.interpretation.factType,
+          gameSideId: action.interpretation.gameSideId,
+          gameTimeMs,
+          sportingOrder,
+          synchronizationOrder: synchronizationOrderByOperationId.get(action.operationId) ?? 0,
+          effective: effectiveFactIds.has(action.interpretation.factId),
+          data: isActionJsonValue(data) ? structuredClone(data) : null,
+        } satisfies ControllerGameFact,
+      ];
+    })
+    .sort(
+      (left, right) =>
+        left.sportingOrder - right.sportingOrder ||
+        left.synchronizationOrder - right.synchronizationOrder ||
+        left.factId.localeCompare(right.factId),
+    );
+  const latestEffectiveFact = (factType: string): ControllerGameFact | null =>
+    gameFacts.filter((fact) => fact.effective && fact.factType === factType).at(-1) ?? null;
+  const timeoutFact = latestEffectiveFact("timeout");
+  const suspensionFact = latestEffectiveFact("suspension");
+  const heatFact = latestEffectiveFact("heat-stoppage");
+  const resultFact = latestEffectiveFact("result");
+  const heatAction =
+    isRecord(heatFact?.data) &&
+    (heatFact.data.heatAction === "start" ||
+      heatFact.data.heatAction === "end" ||
+      heatFact.data.heatAction === "skip-required" ||
+      heatFact.data.heatAction === "extend-permitted")
+      ? heatFact.data.heatAction
+      : heatFact === null
+        ? null
+        : "start";
+  const heatStatus: LiveHeatState["status"] =
+    heatFact === null
+      ? "inactive"
+      : heatAction === "end"
+        ? "ended"
+        : heatAction === "skip-required"
+          ? "skipped"
+          : heatAction === "extend-permitted"
+            ? "extended"
+            : "started";
+  const effectiveHeatStarts = gameFacts.filter(
+    (fact) =>
+      fact.effective &&
+      fact.factType === "heat-stoppage" &&
+      (!isRecord(fact.data) ||
+        (fact.data.heatAction !== "end" &&
+          fact.data.heatAction !== "skip-required" &&
+          fact.data.heatAction !== "extend-permitted")),
+  );
+  const heatNominalDurationMs =
+    heatStatus === "started" || heatStatus === "extended"
+      ? effectiveHeatStarts.length <= 1
+        ? 4 * 60 * 1000
+        : 2 * 60 * 1000
+      : null;
+  const heatStartedAtGameTimeMs =
+    heatNominalDurationMs === null || heatFact?.gameTimeMs === null
+      ? null
+      : (heatFact?.gameTimeMs ?? null);
+  const timeout: LiveTimeoutState = {
+    status: timeoutFact === null ? "inactive" : "started",
+    factId: timeoutFact?.factId ?? null,
+  };
+  const heat: LiveHeatState = {
+    status: heatStatus,
+    factId: heatFact?.factId ?? null,
+    startedAtGameTimeMs: heatStartedAtGameTimeMs,
+    nominalDurationMs: heatNominalDurationMs,
+  };
+  const stoppage: LiveStoppageState =
+    suspensionFact !== null
+      ? { status: "suspension", factId: suspensionFact.factId }
+      : heat.status === "started" || heat.status === "extended"
+        ? { status: "heat-stoppage", factId: heat.factId }
+        : { status: "none", factId: null };
+  const result: LiveResultState =
+    resultFact === null
+      ? null
+      : { factId: resultFact.factId, data: structuredClone(resultFact.data) };
+  const effectiveResult = gameFacts.some((fact) => fact.effective && fact.factType === "result");
+  const effectiveSuspension = gameFacts.some(
+    (fact) => fact.effective && fact.factType === "suspension",
+  );
+  const phase =
+    root.lifecycle.phase === "finished" && !effectiveResult
+      ? "in-progress"
+      : effectiveSuspension && root.lifecycle.phase !== "finished"
+        ? "suspended"
+        : root.lifecycle.phase;
   return {
     interpreterVersion: version,
-    phase: root.lifecycle.phase,
+    phase,
     scoreByGameSide,
     goalCount,
+    timeout,
+    stoppage,
+    heat,
+    result,
+    gameFacts,
     clock: projectClockBaseline(
-      deriveClockAuthority(readClockAuthorityActions(canonicalActions)),
+      deriveClockAuthority(
+        readClockAuthorityActions(effectiveFacts.map((fact) => ({ action: fact.action }))),
+      ),
       0,
     ),
   };
@@ -1122,6 +1474,7 @@ function controllerFactType(intent: LiveEventControllerIntent): string {
   )
     return "clock";
   if (intent.type === "substantive") return intent.trigger;
+  if (intent.type === "correct-fact") return "correction";
   return intent.type;
 }
 
@@ -1215,13 +1568,166 @@ function readDerivedState(value: unknown): LiveEventGameDerivedState | null {
     return null;
   const clock = readClockProjection(value.clock);
   if (clock === null) return null;
+  const timeout = readLiveTimeoutState(value.timeout);
+  const stoppage = readLiveStoppageState(value.stoppage);
+  const heat = readLiveHeatState(value.heat);
+  const result = readLiveResultState(value.result);
+  const gameFacts = readControllerGameFacts(value.gameFacts);
+  if (gameFacts === null) return null;
   return {
     interpreterVersion: value.interpreterVersion,
     phase: value.phase,
     scoreByGameSide,
     goalCount: value.goalCount,
+    timeout,
+    stoppage,
+    heat,
+    result,
+    gameFacts,
     clock,
   };
+}
+
+function readControllerGameFacts(value: unknown): ControllerGameFact[] | null {
+  if (value === undefined) return [];
+  if (!Array.isArray(value) || value.length > SHARED_LIMITS.replay.maxControlActions) return null;
+  const facts: ControllerGameFact[] = [];
+  for (const candidate of value) {
+    if (!isRecord(candidate)) return null;
+    const factId = validateOpaqueIdentifier(candidate.factId, "gameFacts.factId");
+    const factType = validateOpaqueIdentifier(candidate.factType, "gameFacts.factType");
+    const gameSideId =
+      candidate.gameSideId === null
+        ? null
+        : validateOpaqueIdentifier(candidate.gameSideId, "gameFacts.gameSideId");
+    const gameTimeMsResult =
+      candidate.gameTimeMs === null
+        ? ({ ok: true, value: null } as const)
+        : validateIntegerInRange(candidate.gameTimeMs, 0, SHARED_LIMITS.clock.maxMs, "gameTimeMs");
+    const sportingOrder = validateIntegerInRange(
+      candidate.sportingOrder,
+      0,
+      SHARED_LIMITS.clock.maxMs,
+      "sportingOrder",
+    );
+    const synchronizationOrder = validateIntegerInRange(
+      candidate.synchronizationOrder,
+      1,
+      SHARED_LIMITS.replay.maxControlActions,
+      "synchronizationOrder",
+    );
+    const data = parseJsonValue(candidate.data, "gameFacts.data");
+    if (
+      !factId.ok ||
+      !factType.ok ||
+      (gameSideId !== null && !gameSideId.ok) ||
+      !gameTimeMsResult.ok ||
+      !sportingOrder.ok ||
+      !synchronizationOrder.ok ||
+      !data.ok ||
+      typeof candidate.effective !== "boolean"
+    )
+      return null;
+    facts.push({
+      factId: factId.value,
+      factType: factType.value,
+      gameSideId: gameSideId === null ? null : gameSideId.value,
+      gameTimeMs: gameTimeMsResult.value,
+      sportingOrder: sportingOrder.value,
+      synchronizationOrder: synchronizationOrder.value,
+      effective: candidate.effective,
+      data: data.value,
+    });
+  }
+  return facts;
+}
+
+function readLiveTimeoutState(value: unknown): LiveTimeoutState {
+  if (value === undefined) return { status: "inactive", factId: null };
+  if (!isRecord(value)) throw new Error("Derived timeout state is invalid.");
+  if (value.status !== "inactive" && value.status !== "started") {
+    throw new Error("Derived timeout status is invalid.");
+  }
+  const factId =
+    value.factId === null ? null : validateOpaqueIdentifier(value.factId, "timeout.factId");
+  if (factId !== null && !factId.ok) throw new Error("Derived timeout fact is invalid.");
+  return { status: value.status, factId: factId === null ? null : factId.value };
+}
+
+function readLiveStoppageState(value: unknown): LiveStoppageState {
+  if (value === undefined) return { status: "none", factId: null };
+  if (!isRecord(value)) throw new Error("Derived stoppage state is invalid.");
+  if (
+    value.status !== "none" &&
+    value.status !== "suspension" &&
+    value.status !== "heat-stoppage"
+  ) {
+    throw new Error("Derived stoppage status is invalid.");
+  }
+  const factId =
+    value.factId === null ? null : validateOpaqueIdentifier(value.factId, "stoppage.factId");
+  if (factId !== null && !factId.ok) throw new Error("Derived stoppage fact is invalid.");
+  return { status: value.status, factId: factId === null ? null : factId.value };
+}
+
+function readLiveHeatState(value: unknown): LiveHeatState {
+  if (value === undefined) {
+    return { status: "inactive", factId: null, startedAtGameTimeMs: null, nominalDurationMs: null };
+  }
+  if (!isRecord(value)) throw new Error("Derived heat state is invalid.");
+  if (
+    value.status !== "inactive" &&
+    value.status !== "started" &&
+    value.status !== "ended" &&
+    value.status !== "skipped" &&
+    value.status !== "extended"
+  ) {
+    throw new Error("Derived heat status is invalid.");
+  }
+  const factId =
+    value.factId === null ? null : validateOpaqueIdentifier(value.factId, "heat.factId");
+  if (factId !== null && !factId.ok) throw new Error("Derived heat fact is invalid.");
+  const startedAtGameTimeMs =
+    value.startedAtGameTimeMs === undefined || value.startedAtGameTimeMs === null
+      ? ({ ok: true, value: null } as const)
+      : validateIntegerInRange(
+          value.startedAtGameTimeMs,
+          0,
+          SHARED_LIMITS.clock.maxMs,
+          "heat.startedAtGameTimeMs",
+        );
+  const nominalDurationMs =
+    value.nominalDurationMs === undefined || value.nominalDurationMs === null
+      ? ({ ok: true, value: null } as const)
+      : validateIntegerInRange(
+          value.nominalDurationMs,
+          0,
+          SHARED_LIMITS.clock.maxMs,
+          "heat.nominalDurationMs",
+        );
+  if (
+    !startedAtGameTimeMs.ok ||
+    !nominalDurationMs.ok ||
+    (value.status === "inactive" &&
+      (startedAtGameTimeMs.value !== null || nominalDurationMs.value !== null))
+  ) {
+    throw new Error("Derived heat timing is invalid.");
+  }
+  return {
+    status: value.status,
+    factId: factId === null ? null : factId.value,
+    startedAtGameTimeMs: startedAtGameTimeMs.value,
+    nominalDurationMs: nominalDurationMs.value,
+  };
+}
+
+function readLiveResultState(value: unknown): LiveResultState {
+  if (value === undefined || value === null) return null;
+  if (!isRecord(value)) throw new Error("Derived result state is invalid.");
+  const factId = validateOpaqueIdentifier(value.factId, "result.factId");
+  const data = parseJsonValue(value.data, "result.data");
+  if (!factId.ok || !data.ok) throw new Error("Derived result state is invalid.");
+  return { factId: factId.value, data: data.value };
 }
 
 export function validateLiveEventClockActionInTransaction(
@@ -1265,6 +1771,189 @@ export function validateLiveEventClockActionInTransaction(
   return validation.ok
     ? { status: "accepted" }
     : { status: "rejected", reason: "invalid-action", detail: validation.error };
+}
+
+function rebuildLiveDerivedState(
+  root: EventGameRecordRoot,
+  actions: readonly {
+    action: ControlAction;
+    canonicalContent: string;
+    contentFingerprint: string;
+  }[],
+): LiveEventGameDerivedState | null {
+  const rebuilt = rebuildControlActionHistory(
+    root,
+    actions,
+    createControlActionCodecRegistry(createDefaultControlActionCodecs()),
+    createLiveEventGameIqaInterpreter(),
+  );
+  if (rebuilt.status !== "ready") return null;
+  return deriveLiveEventGameState(
+    root,
+    rebuilt.canonicalActions.map((action) => ({ action })),
+    rebuilt.effectiveFacts,
+    LIVE_EVENT_IQA_INTERPRETER_VERSION,
+  );
+}
+
+export function validateLiveEventGameActionInTransaction(
+  actions: readonly {
+    action: ControlAction;
+    canonicalContent: string;
+    contentFingerprint: string;
+  }[],
+  root: EventGameRecordRoot,
+  candidate: ControlAction,
+): { status: "accepted" } | { status: "rejected"; reason: "invalid-action"; detail: string } {
+  const clockValidation = validateLiveEventClockActionInTransaction(actions, candidate);
+  if (clockValidation.status === "rejected") return clockValidation;
+
+  const current = rebuildLiveDerivedState(root, actions);
+  if (current === null) {
+    return {
+      status: "rejected",
+      reason: "invalid-action",
+      detail: "The current Event Game state cannot be rebuilt authoritatively.",
+    };
+  }
+  if (candidate.interpretation.type === "correction") {
+    return candidate.override === undefined
+      ? { status: "accepted" }
+      : rejectedLiveAction("Official Overrides cannot be attached to a Correction.");
+  }
+  if (candidate.interpretation.type !== "fact") {
+    return candidate.override === undefined
+      ? { status: "accepted" }
+      : rejectedLiveAction("Official Overrides require a supported live Game Fact.");
+  }
+  const payload = candidate.interpretation.payload;
+  if (!isRecord(payload)) return rejectedLiveAction("The live Game Fact payload is invalid.");
+  const gameTimeMs = typeof payload.gameTimeMs === "number" ? payload.gameTimeMs : null;
+  const data = isRecord(payload.data) ? payload.data : null;
+  const sportingOrder =
+    data !== null && typeof data.sportingOrder === "number" ? data.sportingOrder : gameTimeMs;
+  const sportingOrderDiffers =
+    gameTimeMs !== null && sportingOrder !== null && sportingOrder !== gameTimeMs;
+  if (candidate.interpretation.factType === "timeout" && current.clock.running) {
+    if (candidate.override?.guardrail !== "timeout-requires-paused-play") {
+      return rejectedLiveAction("A normal timeout requires paused play.");
+    }
+  }
+  const expected = expectedLiveOverride(candidate, current, sportingOrderDiffers, gameTimeMs, data);
+  if (expected === null) {
+    return candidate.override === undefined
+      ? { status: "accepted" }
+      : rejectedLiveAction("The Official Override does not match a supported live guardrail.");
+  }
+  if (candidate.override === undefined) {
+    return expected.required || sportingOrderDiffers
+      ? rejectedLiveAction("Head Referee provenance is required for adjudicated sporting order.")
+      : { status: "accepted" };
+  }
+  return validateLiveOfficialOverrideEvidence(candidate, expected);
+}
+
+type LiveOverrideExpectation = {
+  required: boolean;
+  guardrail: string;
+  direction: string;
+  beforeValue: ActionJsonValue;
+  afterValue: ActionJsonValue;
+  gameTimeMs: number;
+};
+
+function expectedLiveOverride(
+  candidate: ControlAction,
+  current: LiveEventGameDerivedState,
+  sportingOrderDiffers: boolean,
+  gameTimeMs: number | null,
+  data: Record<string, unknown> | null,
+): LiveOverrideExpectation | null {
+  if (gameTimeMs === null) return null;
+  if (candidate.interpretation.type !== "fact") return null;
+  const factType = candidate.interpretation.factType;
+  if (sportingOrderDiffers) {
+    const adjudicatedSportingOrder =
+      data !== null && typeof data.sportingOrder === "number" ? data.sportingOrder : gameTimeMs;
+    return {
+      required: true,
+      guardrail: "sporting-order-adjudication",
+      direction: "head-referee-adjudicated-sporting-order",
+      beforeValue: { sportingOrder: gameTimeMs },
+      afterValue: { sportingOrder: adjudicatedSportingOrder },
+      gameTimeMs,
+    };
+  }
+  if (factType === "timeout") {
+    if (!current.clock.running) return null;
+    return {
+      required: true,
+      guardrail: "timeout-requires-paused-play",
+      direction: "head-referee-directed-timeout-while-running",
+      beforeValue: { running: current.clock.running },
+      afterValue: { timeout: "started" },
+      gameTimeMs,
+    };
+  }
+  if (factType === "heat-stoppage") {
+    const heatAction = data?.heatAction;
+    if (
+      heatAction !== "end" ||
+      current.heat.status !== "started" ||
+      current.heat.startedAtGameTimeMs === null ||
+      current.heat.nominalDurationMs === null ||
+      gameTimeMs >= current.heat.startedAtGameTimeMs + current.heat.nominalDurationMs
+    ) {
+      return null;
+    }
+    const afterValue =
+      heatAction === "end"
+        ? "ended"
+        : heatAction === "skip-required"
+          ? "skipped"
+          : heatAction === "extend-permitted"
+            ? "extended"
+            : "started";
+    return {
+      required: true,
+      guardrail: "heat-stoppage-rule-deviation",
+      direction: "head-referee-directed-heat-stoppage",
+      beforeValue: { heat: current.heat.status },
+      afterValue: { heat: afterValue },
+      gameTimeMs,
+    };
+  }
+  return null;
+}
+
+function validateLiveOfficialOverrideEvidence(
+  candidate: ControlAction,
+  expected: LiveOverrideExpectation,
+): { status: "accepted" } | { status: "rejected"; reason: "invalid-action"; detail: string } {
+  const override = candidate.override;
+  if (override === undefined) return rejectedLiveAction("Official Override evidence is missing.");
+  if (
+    override.guardrail !== expected.guardrail ||
+    override.direction !== expected.direction ||
+    override.confirmation !== "head-referee-confirmed" ||
+    override.reason !== "head-referee-direction" ||
+    override.gameTimeMs !== expected.gameTimeMs ||
+    override.beforeValue === undefined ||
+    override.afterValue === undefined ||
+    canonicalizeJson(override.beforeValue) !== canonicalizeJson(expected.beforeValue) ||
+    canonicalizeJson(override.afterValue) !== canonicalizeJson(expected.afterValue)
+  ) {
+    return rejectedLiveAction("Official Override evidence does not match effective state.");
+  }
+  return { status: "accepted" };
+}
+
+function rejectedLiveAction(detail: string): {
+  status: "rejected";
+  reason: "invalid-action";
+  detail: string;
+} {
+  return { status: "rejected", reason: "invalid-action", detail };
 }
 
 function readClockAuthorityActions(
@@ -1500,6 +2189,48 @@ function replayRetryable(
 
 function readOperationId(value: unknown): string | null {
   return isRecord(value) && typeof value.operationId === "string" ? value.operationId : null;
+}
+
+function isActionJsonValue(value: unknown): value is ActionJsonValue {
+  if (value === null || typeof value === "string" || typeof value === "boolean") return true;
+  if (typeof value === "number") return Number.isFinite(value);
+  if (Array.isArray(value)) return value.every((item) => isActionJsonValue(item));
+  return isRecord(value) && Object.values(value).every((item) => isActionJsonValue(item));
+}
+
+function buildLiveOfficialOverride(
+  intent: LiveEventControllerIntent,
+  sessionId: string,
+): OfficialOverrideMetadata | undefined {
+  if (intent.override === undefined) return undefined;
+  if (
+    intent.type === "clock" ||
+    intent.type === "set-running" ||
+    intent.type === "clock-adjust" ||
+    intent.type === "clock-correction" ||
+    intent.type === "reset" ||
+    intent.type === "undo" ||
+    intent.type === "correct-fact"
+  ) {
+    throw new Error("Official Overrides are not valid for this Controller action.");
+  }
+  const expected = explainLiveEventGuardrail({
+    type: intent.type,
+    ...(intent.type === "substantive" ? { trigger: intent.trigger } : {}),
+    gameTimeMs: intent.gameTimeMs,
+    sportingOrder: intent.sportingOrder,
+  });
+  if (!expected.overrideAllowed || intent.override.guardrail !== expected.guardrail) {
+    throw new Error("The Official Override does not match the active IQA guardrail.");
+  }
+  if (intent.override.reason !== expected.fixedReason) {
+    throw new Error("The Official Override requires the fixed Head Referee reason.");
+  }
+  return {
+    ...structuredClone(intent.override),
+    gameTimeMs: intent.gameTimeMs,
+    authorityReference: intent.override.authorityReference || sessionId,
+  };
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/lib/live-event-game-runtime.ts
+++ b/src/lib/live-event-game-runtime.ts
@@ -9,7 +9,7 @@ import {
 import {
   createLiveEventGameControl,
   createLiveEventGameIqaInterpreter,
-  validateLiveEventClockActionInTransaction,
+  validateLiveEventGameActionInTransaction,
 } from "@/lib/live-event-game-control";
 import { createTypedGrantAuthority } from "@/lib/grant-management";
 import type { GrantAuthorityOptions } from "@/lib/grant-authority";
@@ -54,7 +54,11 @@ export async function openLiveEventGameRuntime(input: {
       interpreter: createLiveEventGameIqaInterpreter(),
       clock,
       validateActionInTransaction: ({ transaction, root, action }) =>
-        validateLiveEventClockActionInTransaction(transaction.listActions(root.recordId), action),
+        validateLiveEventGameActionInTransaction(
+          transaction.listActions(root.recordId),
+          root,
+          action,
+        ),
     });
     const records = new Map<string, EventGameRecord>();
     const resolveEventGameRecord = async (eventGameId: string) => {

--- a/src/pages/event-game-controller-page.test.tsx
+++ b/src/pages/event-game-controller-page.test.tsx
@@ -277,6 +277,27 @@ describe("Event Game Controller reconnect browser seam", () => {
     expect(stored.pendingActions).toHaveLength(1);
   });
 
+  test("renders stable fact identity and sends a contextual Correction from the browser seam", async () => {
+    await enterAndOpen();
+    expect(container.querySelector('[data-game-fact-id="fact-goal"]')).not.toBeNull();
+    const correctButton = container
+      .querySelector('[data-game-fact-id="fact-goal"]')
+      ?.querySelector("button");
+    await act(async () => {
+      correctButton?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const correction = replayBodies
+      .flatMap((body) => body.actions ?? [])
+      .find((action) => action.intent.type === "correct-fact");
+    expect(correction?.intent).toMatchObject({
+      type: "correct-fact",
+      targetFactId: "fact-goal",
+      effective: false,
+    });
+  });
+
   test("revalidates a fresh same-Game authority before foreground replay", async () => {
     replayMode = "success";
     await act(async () => {
@@ -733,6 +754,18 @@ function projection(eventGameId = "game-browser"): ControllerProjection {
     phase: "scheduled",
     scoreByGameSide: { "side-a": 0, "side-b": 0 },
     goalCount: 0,
+    gameFacts: [
+      {
+        factId: "fact-goal",
+        factType: "goal",
+        gameSideId: "side-a",
+        gameTimeMs: 12_000,
+        sportingOrder: 12_000,
+        synchronizationOrder: 1,
+        effective: true,
+        data: { points: 10 },
+      },
+    ],
     clock: projectClockBaseline(baseline, 0),
     commencement: {
       status: "provisional",

--- a/src/pages/event-game-controller-page.tsx
+++ b/src/pages/event-game-controller-page.tsx
@@ -424,6 +424,19 @@ export function EventGameControllerPage() {
     });
   }
 
+  function correctFact(factId: string, effective: boolean) {
+    queueIntent({
+      version: LIVE_EVENT_CONTROL_INTENT_VERSION,
+      type: "correct-fact",
+      operationId: crypto.randomUUID(),
+      factId: crypto.randomUUID(),
+      targetFactId: factId,
+      effective,
+      gameTimeMs: projection?.clock.gameTimeMs ?? 0,
+      occurrence: { clientOriginAtMs: Date.now() },
+    });
+  }
+
   function trigger(type: "card" | "timeout" | "suspension" | "result") {
     queueIntent({
       version: LIVE_EVENT_CONTROL_INTENT_VERSION,
@@ -1033,6 +1046,14 @@ export function EventGameControllerPage() {
                   <p className="text-sm text-muted-foreground">
                     Phase: {projection.phase} · Goals: {projection.goalCount}
                   </p>
+                  <p className="text-xs text-muted-foreground">
+                    Timeout: {projection.timeout?.status ?? "inactive"} · Stoppage:{" "}
+                    {projection.stoppage?.status ?? "none"} · Heat:{" "}
+                    {projection.heat?.status ?? "inactive"}
+                    {projection.result === null || projection.result === undefined
+                      ? ""
+                      : " · Result recorded"}
+                  </p>
                   {Object.entries(projection.scoreByGameSide).map(([gameSideId, score]) => (
                     <div key={gameSideId} className="flex items-center justify-between gap-3">
                       <span className="font-medium">Game Side {gameSideId}</span>
@@ -1044,6 +1065,38 @@ export function EventGameControllerPage() {
                       </div>
                     </div>
                   ))}
+                  <div className="space-y-2 rounded-lg border p-3">
+                    <p className="text-sm font-medium">Game Facts</p>
+                    {(projection.gameFacts ?? []).length === 0 ? (
+                      <p className="text-sm text-muted-foreground">No Game Facts recorded.</p>
+                    ) : (
+                      (projection.gameFacts ?? []).map((fact) => (
+                        <div
+                          key={fact.factId}
+                          data-game-fact-id={fact.factId}
+                          className="flex items-center justify-between gap-3 text-sm"
+                        >
+                          <span className="min-w-0">
+                            <span className="font-medium">{fact.factType}</span>
+                            <code className="ml-2 text-xs text-muted-foreground">
+                              {fact.factId}
+                            </code>
+                            <span className="ml-2 text-xs text-muted-foreground">
+                              sporting {fact.sportingOrder} · sync {fact.synchronizationOrder}
+                            </span>
+                          </span>
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            onClick={() => correctFact(fact.factId, !fact.effective)}
+                            disabled={busy}
+                          >
+                            {fact.effective ? "Correct" : "Reinstate"}
+                          </Button>
+                        </div>
+                      ))
+                    )}
+                  </div>
                 </div>
               )}
               {replica !== null && replica.pendingActions.length > 0 ? (


### PR DESCRIPTION
## What changed

- expose stable visible Game Fact identities and contextual Correction/reinstatement controls without deleting history
- rebuild effective score, phase, clock, penalties, timeout, stoppage, heat, and result state deterministically from effective facts
- separate Head Referee-adjudicated sporting order from synchronization order with authoritative provenance
- enforce rule-derived guardrails and validate deliberate Official Override evidence against effective state
- reopen ordinary control when a result Correction makes the effective Game in progress, while reinstatement restores finished-state holding
- make replay converge across reversed causal order by deferring unresolved predecessors before finished-state evaluation

## Why

Officials need to repair late or incorrect Game Facts without mutable history, stale dependent state, arbitrary undo-latest behavior, or unverified override claims.

## Impact

Controllers can select a visible Fact to correct or reinstate, see rebuilt effective state, and record Head Referee-directed exceptions with durable audit evidence. Offline and concurrent Corrections remain replayable and causally repairable.

## Validation

- `bun run check`
- `bun run test` — 525 passed after rebasing onto current `main`
- `bun run build`
- `git diff --check`
- focused Clock, facts, Correction, reconnect, and browser suites — 78 passed

Closes #89
