### PR TITLE
Correct Test environment provisioning paths

### DIFF
--- a/deploy/activate-test-release.sh
+++ b/deploy/activate-test-release.sh
@@ -84,7 +84,7 @@ check_service_contract() {
     [[ " $effective_environment " != *" FOUNDATION_DATABASE=/var/lib/quadball-timer-test/foundation.sqlite "* ]] ||
     [[ " $effective_environment " != *" EVENT_GAME_DATABASE=/var/lib/quadball-timer-test/event-game.sqlite "* ]]; then
     echo "Test service does not provide the required isolated state contract." >&2
-    echo "Install ${release_dir}/deploy/systemd/quadball-timer-test.service and run systemctl daemon-reload." >&2
+    echo "Install ${release_dir}/deploy/quadball-timer-test.service and run systemctl daemon-reload." >&2
     return 1
   fi
 }

--- a/deploy/test-environment-provisioning.md
+++ b/deploy/test-environment-provisioning.md
@@ -134,7 +134,7 @@ and load the unit after that upload. Replace `$release_id` with the
 
 ```fish
 set release_id "REPLACE_WITH_40_CHARACTER_WORKFLOW_COMMIT"
-set unit_source /srv/quadball-timer-test/releases/$release_id/deploy/systemd/quadball-timer-test.service
+set unit_source /srv/quadball-timer-test/releases/$release_id/deploy/quadball-timer-test.service
 
 sudo install -o root -g root -m 0644 $unit_source /etc/systemd/system/quadball-timer-test.service
 sudo systemctl daemon-reload
@@ -145,7 +145,7 @@ sudo visudo -f /etc/sudoers.d/deploy-quadball-timer-test
 The sudoers file must contain only:
 
 ```text
-deploy-quadball-timer-test ALL=(root) NOPASSWD: /bin/systemctl restart quadball-timer-test
+deploy-quadball-timer-test ALL=(root) NOPASSWD: /usr/bin/systemctl restart quadball-timer-test
 ```
 
 Verify the bounded result without printing the key file:

--- a/src/test-environment-deployment.test.ts
+++ b/src/test-environment-deployment.test.ts
@@ -46,6 +46,8 @@ describe("Test Environment deployment contract", () => {
     expect(activation).toContain('service_name="quadball-timer-test"');
     expect(activation).toContain("Test environment — not for live games");
     expect(activation).toContain("executableSha256");
+    expect(activation).toContain("${release_dir}/deploy/quadball-timer-test.service");
+    expect(activation).not.toContain("${release_dir}/deploy/systemd/");
     expect(activation).not.toContain("quadball-timer.service");
     expect(activation).not.toContain("/srv/quadball-timer/current");
   });
@@ -64,5 +66,9 @@ describe("Test Environment deployment contract", () => {
       provisioning.indexOf("useradd --system --home-dir $base_dir"),
     );
     expect(provisioning).not.toContain("--gid $app");
+    expect(provisioning).toContain("/releases/$release_id/deploy/quadball-timer-test.service");
+    expect(provisioning).not.toContain("/releases/$release_id/deploy/systemd/");
+    expect(provisioning).toContain("NOPASSWD: /usr/bin/systemctl restart quadball-timer-test");
+    expect(provisioning).not.toContain("NOPASSWD: /bin/systemctl");
   });
 });


### PR DESCRIPTION
## Summary

- correct the packaged Test systemd-unit path used by activation diagnostics and the provisioning runbook
- document the verified `/usr/bin/systemctl` sudoers command used on the host
- lock both paths into the Test deployment contract tests

## Context

PR #180 independently replaced the route composition that caused the live empty HTTP 204. After rebasing onto that merge, #182 deliberately drops its obsolete route changes and retains only the operational corrections discovered during #160 provisioning.

## Verification

- `bun run check`
- focused HTML, Ad Hoc routing, and Test deployment tests (17 passing)
- conflict resolution preserves the new direct HTML routes and asset-aware Test handler from PR #180

## Operator impact

The currently installed Test service and sudoers rule already use these corrected paths. Merging this PR aligns repository guidance and diagnostics with the verified host configuration. No Production service or data is changed.

Tracks #160 and #158 without auto-closing them; live HTTPS verification remains before #160 is complete.