### PR TITLE
Synchronize Ad Hoc Controllers offline

### DIFF
--- a/scripts/test-ad-hoc-browser.ts
+++ b/scripts/test-ad-hoc-browser.ts
@@ -104,6 +104,13 @@ async function run() {
 
         await second.getByRole("button", { name: "Start game" }).click();
         await first.getByText("Running", { exact: true }).waitFor();
+        await stopServer();
+        await second.getByRole("button", { name: "Pause game" }).click();
+        await second.getByRole("button", { name: "Start game" }).click();
+        await second.getByText(/Offline 2/u).waitFor();
+        await startServer();
+        await second.getByText("Live", { exact: true }).waitFor();
+        await first.getByText("Running", { exact: true }).waitFor();
         await second.getByRole("button", { name: "Pause game" }).click();
         await second.getByRole("button", { name: "Game end" }).click();
         await second.getByRole("button", { name: "Double forfeit" }).click();
@@ -141,6 +148,14 @@ async function run() {
         await second.goto(handoffUrl);
         await waitForGameRoute(second, gameId);
         await assertAccessibleQr(second, "readmitted second browser");
+
+        await stopServer();
+        rmSync(databasePath, { force: true });
+        await startServer();
+        await second.reload();
+        await waitForGameRoute(second, gameId);
+        await second.getByText("Local", { exact: true }).waitFor();
+        await second.getByText("Server does not know this game", { exact: false }).waitFor();
       })(),
       lifecycleController.signal,
     );

--- a/src/index.ts
+++ b/src/index.ts
@@ -876,6 +876,15 @@ async function startServer() {
                 operations: parsed.message.commands,
               });
               if (result.status === "rejected") {
+                if (result.outcomes !== undefined) {
+                  await broadcastGameSnapshot({
+                    gameId: parsed.message.gameId,
+                    service: adHocService,
+                    sender: ws,
+                    senderAckedCommandIds: [],
+                    operationOutcomes: result.outcomes,
+                  });
+                }
                 sendMessage(ws, {
                   type: "error",
                   message:
@@ -890,6 +899,7 @@ async function startServer() {
                 service: adHocService,
                 sender: ws,
                 senderAckedCommandIds: result.ackedOperationIds,
+                operationOutcomes: result.outcomes,
               });
               return;
             }
@@ -1107,11 +1117,18 @@ async function broadcastGameSnapshot({
   service,
   sender,
   senderAckedCommandIds,
+  operationOutcomes,
 }: {
   gameId: string;
   service: AdHocGamesService;
   sender: ServerWebSocket<SessionData>;
   senderAckedCommandIds: string[];
+  operationOutcomes: readonly {
+    operationId: string;
+    workflow: "ad-hoc" | "event";
+    status: "accepted" | "duplicate" | "rejected" | "causally-blocked";
+    detail?: string;
+  }[];
 }) {
   await Promise.all(
     [...sockets].map(async (ws) => {
@@ -1131,6 +1148,7 @@ async function broadcastGameSnapshot({
         game: stripSession(game),
         serverNowMs,
         ackedCommandIds: ws === sender ? senderAckedCommandIds : [],
+        operationOutcomes,
       });
     }),
   );

--- a/src/lib/ad-hoc-controller-session.test.ts
+++ b/src/lib/ad-hoc-controller-session.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+import {
+  parseAdHocControllerSession,
+  serializeAdHocControllerSession,
+  type AdHocControllerSession,
+} from "@/lib/ad-hoc-controller-session";
+import { createInitialGameState } from "@/lib/game-engine";
+
+function session(): AdHocControllerSession {
+  return {
+    version: "ad-hoc-controller-session-v1",
+    workflow: "ad-hoc",
+    gameId: "adhoc-codec-test",
+    state: createInitialGameState({ id: "adhoc-codec-test", nowMs: 1_000 }),
+    authoritativeState: createInitialGameState({ id: "adhoc-codec-test", nowMs: 1_000 }),
+    pendingOperations: [
+      {
+        id: "offline-1",
+        clientSentAtMs: 1_001,
+        command: { type: "set-running", running: true },
+        workflow: "ad-hoc",
+        causalPredecessorIds: [],
+      },
+    ],
+    outcomes: {},
+    operationCounter: 1,
+    savedAtMs: 1_001,
+  };
+}
+
+describe("Ad Hoc Controller session codecs", () => {
+  test("round-trips the deep GameState and authoritative base", () => {
+    const parsed = parseAdHocControllerSession(
+      serializeAdHocControllerSession(session()),
+      "adhoc-codec-test",
+    );
+    expect(parsed?.authoritativeState?.id).toBe("adhoc-codec-test");
+  });
+
+  test("rejects corrupt branches, unsafe counters, and causal self references", () => {
+    const value = JSON.parse(serializeAdHocControllerSession(session())) as Record<string, unknown>;
+    (value.state as Record<string, unknown>).score = null;
+    expect(parseAdHocControllerSession(JSON.stringify(value), "adhoc-codec-test")).toBeNull();
+
+    const counterCorrupt = JSON.parse(serializeAdHocControllerSession(session())) as Record<
+      string,
+      unknown
+    >;
+    counterCorrupt.operationCounter = Number.MAX_SAFE_INTEGER + 1;
+    expect(
+      parseAdHocControllerSession(JSON.stringify(counterCorrupt), "adhoc-codec-test"),
+    ).toBeNull();
+
+    const causalCorrupt = JSON.parse(serializeAdHocControllerSession(session())) as Record<
+      string,
+      unknown
+    >;
+    const pending = causalCorrupt.pendingOperations as Array<Record<string, unknown>>;
+    pending[0]!.causalPredecessorIds = ["offline-1"];
+    expect(
+      parseAdHocControllerSession(JSON.stringify(causalCorrupt), "adhoc-codec-test"),
+    ).toBeNull();
+  });
+});

--- a/src/lib/ad-hoc-controller-session.ts
+++ b/src/lib/ad-hoc-controller-session.ts
@@ -1,0 +1,383 @@
+import type { GameCommand, GameState } from "@/lib/game-types";
+import { parseGameCommand } from "@/lib/ws-protocol";
+import { validateOpaqueIdentifier } from "@/lib/validation-policy";
+
+export const AD_HOC_CONTROLLER_SESSION_VERSION = "ad-hoc-controller-session-v1" as const;
+
+export type AdHocPendingOperation = {
+  id: string;
+  clientSentAtMs: number;
+  command: GameCommand;
+  workflow: "ad-hoc";
+  causalPredecessorIds: string[];
+};
+
+export type AdHocControllerSession = {
+  version: typeof AD_HOC_CONTROLLER_SESSION_VERSION;
+  workflow: "ad-hoc";
+  gameId: string;
+  state: GameState;
+  authoritativeState?: GameState;
+  pendingOperations: AdHocPendingOperation[];
+  outcomes: Record<string, "accepted" | "duplicate" | "rejected" | "causally-blocked">;
+  operationCounter: number;
+  savedAtMs: number;
+};
+
+export function getAdHocControllerSessionStorageKey(gameId: string) {
+  return `quadball:ad-hoc-controller:${gameId}`;
+}
+
+export function clearAdHocControllerSession(gameId: string) {
+  try {
+    window.localStorage.removeItem(getAdHocControllerSessionStorageKey(gameId));
+  } catch {
+    // Local recovery is best effort; server authority remains authoritative.
+  }
+}
+
+export function serializeAdHocControllerSession(session: AdHocControllerSession) {
+  validateAdHocControllerSession(session);
+  return JSON.stringify(session);
+}
+
+export function parseAdHocControllerSession(
+  raw: string,
+  expectedGameId: string,
+): AdHocControllerSession | null {
+  try {
+    const value = JSON.parse(raw) as unknown;
+    if (!isRecord(value) || value.version !== AD_HOC_CONTROLLER_SESSION_VERSION) return null;
+    if (value.workflow !== "ad-hoc" || value.gameId !== expectedGameId) return null;
+    if (!isValidGameState(value.state, expectedGameId)) return null;
+    if (
+      value.authoritativeState !== undefined &&
+      !isValidGameState(value.authoritativeState, expectedGameId)
+    )
+      return null;
+    if (!Array.isArray(value.pendingOperations) || !isRecord(value.outcomes)) return null;
+    if (
+      typeof value.operationCounter !== "number" ||
+      !Number.isSafeInteger(value.operationCounter) ||
+      value.operationCounter < 0 ||
+      typeof value.savedAtMs !== "number" ||
+      !Number.isSafeInteger(value.savedAtMs) ||
+      value.savedAtMs < 0
+    ) {
+      return null;
+    }
+    const pendingOperations = value.pendingOperations.map(parsePendingOperation);
+    if (pendingOperations.some((operation) => operation === null)) return null;
+    const pendingIds = new Set(
+      pendingOperations
+        .map((operation) => operation?.id)
+        .filter((id): id is string => id !== undefined),
+    );
+    for (const operation of pendingOperations) {
+      if (operation === null) continue;
+      if (
+        new Set(operation.causalPredecessorIds).size !== operation.causalPredecessorIds.length ||
+        operation.causalPredecessorIds.includes(operation.id) ||
+        operation.causalPredecessorIds.some(
+          (predecessor) =>
+            !pendingIds.has(predecessor) && !outcomeIsAccepted(value.outcomes, predecessor),
+        )
+      )
+        return null;
+    }
+    const outcomes: AdHocControllerSession["outcomes"] = {};
+    for (const [operationId, status] of Object.entries(value.outcomes)) {
+      if (!validateOpaqueIdentifier(operationId, "operationId").ok) return null;
+      if (
+        status !== "accepted" &&
+        status !== "duplicate" &&
+        status !== "rejected" &&
+        status !== "causally-blocked"
+      ) {
+        return null;
+      }
+      outcomes[operationId] = status;
+    }
+    const pendingGraph = new Map(
+      pendingOperations
+        .filter((operation): operation is AdHocPendingOperation => operation !== null)
+        .map((operation) => [operation.id, operation.causalPredecessorIds]),
+    );
+    for (const operationId of pendingGraph.keys()) {
+      if (hasCycle(operationId, pendingGraph, new Set(), new Set())) return null;
+    }
+    return {
+      version: AD_HOC_CONTROLLER_SESSION_VERSION,
+      workflow: "ad-hoc",
+      gameId: expectedGameId,
+      state: value.state as GameState,
+      authoritativeState: value.authoritativeState as GameState | undefined,
+      pendingOperations: pendingOperations as AdHocPendingOperation[],
+      outcomes,
+      operationCounter: value.operationCounter,
+      savedAtMs: value.savedAtMs,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function validateAdHocControllerSession(session: AdHocControllerSession) {
+  if (session.version !== AD_HOC_CONTROLLER_SESSION_VERSION || session.workflow !== "ad-hoc") {
+    throw new Error("Ad Hoc Controller session version is unsupported.");
+  }
+  if (!isValidGameState(session.state, session.gameId)) {
+    throw new Error("Ad Hoc Controller session state is invalid.");
+  }
+  if (
+    session.authoritativeState !== undefined &&
+    !isValidGameState(session.authoritativeState, session.gameId)
+  ) {
+    throw new Error("Ad Hoc Controller authoritative state is invalid.");
+  }
+  if (!Number.isSafeInteger(session.operationCounter) || session.operationCounter < 0) {
+    throw new Error("Ad Hoc Controller operation counter is invalid.");
+  }
+  for (const operation of session.pendingOperations) {
+    if (parsePendingOperation(operation) === null) {
+      throw new Error("Ad Hoc pending operation is invalid.");
+    }
+  }
+  const pendingIds = new Set(session.pendingOperations.map((operation) => operation.id));
+  const graph = new Map(
+    session.pendingOperations.map((operation) => [operation.id, operation.causalPredecessorIds]),
+  );
+  for (const operation of session.pendingOperations) {
+    if (
+      new Set(operation.causalPredecessorIds).size !== operation.causalPredecessorIds.length ||
+      operation.causalPredecessorIds.includes(operation.id) ||
+      operation.causalPredecessorIds.some(
+        (predecessor) =>
+          !pendingIds.has(predecessor) &&
+          session.outcomes[predecessor] !== "accepted" &&
+          session.outcomes[predecessor] !== "duplicate",
+      )
+    )
+      throw new Error("Ad Hoc pending causal references are invalid.");
+  }
+  for (const operationId of graph.keys()) {
+    if (hasCycle(operationId, graph, new Set(), new Set()))
+      throw new Error("Ad Hoc pending causal graph contains a cycle.");
+  }
+}
+
+function parsePendingOperation(value: unknown): AdHocPendingOperation | null {
+  if (!isRecord(value)) return null;
+  const id = validateOpaqueIdentifier(value.id, "operationId");
+  if (
+    !id.ok ||
+    value.workflow !== "ad-hoc" ||
+    typeof value.clientSentAtMs !== "number" ||
+    !Number.isSafeInteger(value.clientSentAtMs) ||
+    value.clientSentAtMs < 0 ||
+    !isRecord(value.command) ||
+    !Array.isArray(value.causalPredecessorIds) ||
+    value.causalPredecessorIds.some(
+      (predecessor) => !validateOpaqueIdentifier(predecessor, "causalPredecessorId").ok,
+    )
+  ) {
+    return null;
+  }
+  const command = parseGameCommand(value.command);
+  if (!command.ok) return null;
+  return {
+    id: id.value,
+    clientSentAtMs: value.clientSentAtMs,
+    command: command.command,
+    workflow: "ad-hoc",
+    causalPredecessorIds: [...value.causalPredecessorIds],
+  };
+}
+
+function outcomeIsAccepted(value: unknown, operationId: string) {
+  return (
+    isRecord(value) && (value[operationId] === "accepted" || value[operationId] === "duplicate")
+  );
+}
+
+function isValidGameState(value: unknown, expectedId: string): value is GameState {
+  if (!isRecord(value) || value.id !== expectedId) return false;
+  const numericFields = ["createdAtMs", "updatedAtMs", "gameClockMs"];
+  if (numericFields.some((field) => !isSafeNumber(value[field]))) return false;
+  if (value.gameClockMs < 0 || value.gameClockMs > 7_200_000) return false;
+  if (
+    typeof value.homeName !== "string" ||
+    value.homeName.trim().length === 0 ||
+    typeof value.awayName !== "string" ||
+    value.awayName.trim().length === 0 ||
+    typeof value.homeColor !== "string" ||
+    !/^#?[0-9a-fA-F]{6}$/u.test(value.homeColor) ||
+    typeof value.awayColor !== "string" ||
+    !/^#?[0-9a-fA-F]{6}$/u.test(value.awayColor)
+  )
+    return false;
+  if (
+    ["displaySidesSwapped", "isRunning", "isFinished", "isSuspended", "isOvertime"].some(
+      (field) => typeof value[field] !== "boolean",
+    ) ||
+    (value.suspendedAtMs !== null && !isSafeNumber(value.suspendedAtMs)) ||
+    (value.winner !== null && value.winner !== "home" && value.winner !== "away") ||
+    (value.finishReason !== null &&
+      !["forfeit", "double-forfeit", "flag-catch", "target-score", "concede"].includes(
+        value.finishReason,
+      ))
+  )
+    return false;
+  if (!isRecord(value.score) || !isScore(value.score.home) || !isScore(value.score.away))
+    return false;
+  if (
+    !Array.isArray(value.scoreEvents) ||
+    !Array.isArray(value.cardEvents) ||
+    !Array.isArray(value.pendingExpirations) ||
+    !Array.isArray(value.recentReleases) ||
+    !isRecord(value.players) ||
+    !isRecord(value.timeouts) ||
+    !isRecord(value.nextUnknownPlayerId) ||
+    !isScore(value.nextUnknownPlayerId.home) ||
+    !isScore(value.nextUnknownPlayerId.away)
+  )
+    return false;
+  if (
+    !isRecord(value.timeouts.home) ||
+    !isRecord(value.timeouts.away) ||
+    typeof value.timeouts.home.used !== "boolean" ||
+    typeof value.timeouts.away.used !== "boolean" ||
+    (value.timeouts.active !== null && !isRecord(value.timeouts.active))
+  )
+    return false;
+  if (
+    value.timeouts.active !== null &&
+    (!isTeam(value.timeouts.active.team) ||
+      typeof value.timeouts.active.running !== "boolean" ||
+      !isSafeNumber(value.timeouts.active.remainingMs))
+  )
+    return false;
+  if (
+    value.flagCatch !== null &&
+    (!isRecord(value.flagCatch) ||
+      !isTeam(value.flagCatch.team) ||
+      !isSafeNumber(value.flagCatch.createdAtMs))
+  )
+    return false;
+  for (const [key, player] of Object.entries(value.players)) {
+    if (
+      !validateOpaqueIdentifier(key, "playerKey").ok ||
+      !isRecord(player) ||
+      player.key !== key ||
+      !isTeam(player.team)
+    )
+      return false;
+    if (player.playerNumber !== null && !isScore(player.playerNumber)) return false;
+    if (!Array.isArray(player.segments)) return false;
+    for (const segment of player.segments) {
+      if (
+        !isRecord(segment) ||
+        !validateOpaqueIdentifier(segment.id, "segmentId").ok ||
+        !isSafeNumber(segment.remainingMs) ||
+        segment.remainingMs < 0 ||
+        typeof segment.expirableByScore !== "boolean"
+      )
+        return false;
+    }
+  }
+  return (
+    value.scoreEvents.every(isPersistedScoreEvent) &&
+    value.cardEvents.every(isPersistedCardEvent) &&
+    value.pendingExpirations.every(isPersistedPending) &&
+    value.recentReleases.every(isPersistedRelease)
+  );
+}
+
+function isPersistedScoreEvent(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    validateOpaqueIdentifier(value.id, "scoreEventId").ok &&
+    isTeam(value.team) &&
+    isScoreEventPoints(value.points) &&
+    isSafeNumber(value.createdAtMs) &&
+    (value.reason === "goal" || value.reason === "flag-catch") &&
+    (value.pendingExpirationId === null ||
+      validateOpaqueIdentifier(value.pendingExpirationId, "pendingExpirationId").ok) &&
+    (value.undoneAtMs === null || isSafeNumber(value.undoneAtMs))
+  );
+}
+function isPersistedCardEvent(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    validateOpaqueIdentifier(value.id, "cardEventId").ok &&
+    isTeam(value.team) &&
+    (value.playerKey === null || validateOpaqueIdentifier(value.playerKey, "playerKey").ok) &&
+    (value.playerNumber === null || isScore(value.playerNumber)) &&
+    ["blue", "yellow", "red", "ejection"].includes(value.cardType) &&
+    isSafeNumber(value.createdAtMs)
+  );
+}
+function isPersistedPending(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    validateOpaqueIdentifier(value.id, "pendingId").ok &&
+    isTeam(value.penalizedTeam) &&
+    isTeam(value.benefitingTeam) &&
+    (value.reason === "score" || value.reason === "flag-catch") &&
+    isSafeNumber(value.createdAtMs) &&
+    Array.isArray(value.candidatePlayerKeys) &&
+    value.candidatePlayerKeys.every(
+      (key) => validateOpaqueIdentifier(key, "candidatePlayerKey").ok,
+    ) &&
+    isSafeNumber(value.expireMs) &&
+    (value.resolvedAtMs === null || isSafeNumber(value.resolvedAtMs)) &&
+    (value.resolvedPlayerKey === null ||
+      validateOpaqueIdentifier(value.resolvedPlayerKey, "resolvedPlayerKey").ok)
+  );
+}
+function isPersistedRelease(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    validateOpaqueIdentifier(value.id, "releaseId").ok &&
+    isTeam(value.team) &&
+    validateOpaqueIdentifier(value.playerKey, "playerKey").ok &&
+    (value.playerNumber === null || isScore(value.playerNumber)) &&
+    isSafeNumber(value.releasedAtMs) &&
+    (value.reason === "served" || value.reason === "expired")
+  );
+}
+
+function hasCycle(
+  id: string,
+  graph: ReadonlyMap<string, readonly string[]>,
+  active: Set<string>,
+  visited: Set<string>,
+): boolean {
+  if (active.has(id)) return true;
+  if (visited.has(id)) return false;
+  active.add(id);
+  for (const predecessor of graph.get(id) ?? []) {
+    if (graph.has(predecessor) && hasCycle(predecessor, graph, active, visited)) return true;
+  }
+  active.delete(id);
+  visited.add(id);
+  return false;
+}
+function isSafeNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+}
+function isScoreEventPoints(value: unknown): value is number {
+  return (
+    typeof value === "number" && Number.isSafeInteger(value) && value >= -1_000 && value <= 1_000
+  );
+}
+function isScore(value: unknown): value is number {
+  return isSafeNumber(value) && value <= 1_000;
+}
+function isTeam(value: unknown): value is "home" | "away" {
+  return value === "home" || value === "away";
+}
+
+function isRecord(value: unknown): value is Record<string, any> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/lib/ad-hoc-games.focused.ts
+++ b/src/lib/ad-hoc-games.focused.ts
@@ -1,9 +1,270 @@
 import { describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { createHash } from "node:crypto";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { applyGameCommand, createInitialGameState } from "@/lib/game-engine";
+import { createAdHocGamesService, openSqliteAdHocStore } from "@/lib/ad-hoc-games";
 
 describe("Ad Hoc SQLite focused integration", () => {
+  test("migrates accepted history as a replay baseline and preserves duplicate/conflict outcomes after restart", async () => {
+    const root = await mkdtemp(join(tmpdir(), "quadball-timer-adhoc-migration-focused-"));
+    const databasePath = join(root, "ad-hoc.sqlite");
+    const gameId = "adhoc-legacy-game-1234567890";
+    const sessionId = "legacy-session-1234567890-abcdefghijklmnopqrstuvwxyz";
+    const controlQr = "legacy-control-qr-1234567890-abcdefghijklmnopqrstuvwxyz";
+    const state = createInitialGameState({ id: gameId, nowMs: 1_000 });
+    const legacyOperation = {
+      fingerprint: JSON.stringify([
+        "ad-hoc",
+        1_001,
+        { type: "change-score", team: "home", delta: 10, reason: "goal" },
+        [],
+      ]),
+      command: { type: "change-score", team: "home", delta: 10, reason: "goal" } as const,
+      acceptedAtMs: 1_001,
+      status: "accepted",
+    };
+    const acceptedState = applyGameCommand({
+      state,
+      command: legacyOperation.command,
+      nowMs: legacyOperation.acceptedAtMs,
+      idGenerator: () => "legacy-generated",
+    });
+    const digest = (value: string) => createHash("sha256").update(value).digest("hex");
+    const legacyDb = new Database(databasePath, { create: true, strict: true });
+    legacyDb.run(
+      "CREATE TABLE adhoc_schema (id INTEGER PRIMARY KEY CHECK (id = 1), version INTEGER NOT NULL)",
+    );
+    legacyDb.run("INSERT INTO adhoc_schema (id, version) VALUES (1, 1)");
+    legacyDb.run(`CREATE TABLE adhoc_games (
+      game_id TEXT PRIMARY KEY,
+      created_at_ms INTEGER NOT NULL,
+      state_json TEXT NOT NULL,
+      control_qr TEXT NOT NULL,
+      control_qr_hash TEXT NOT NULL,
+      sessions_json TEXT NOT NULL,
+      operations_json TEXT NOT NULL
+    )`);
+    legacyDb.run(
+      "CREATE TABLE adhoc_creation_events (source_hash TEXT NOT NULL, successful INTEGER NOT NULL, occurred_at_ms INTEGER NOT NULL)",
+    );
+    legacyDb.run(
+      "INSERT INTO adhoc_games (game_id, created_at_ms, state_json, control_qr, control_qr_hash, sessions_json, operations_json) VALUES (?, ?, ?, ?, ?, ?, ?)",
+      [
+        gameId,
+        1_000,
+        JSON.stringify(acceptedState),
+        controlQr,
+        digest(controlQr),
+        JSON.stringify([
+          {
+            sessionHash: digest(sessionId),
+            browserId: null,
+            connected: false,
+            lastConnectedAtMs: 1_000,
+            lastDisconnectedAtMs: null,
+          },
+        ]),
+        JSON.stringify({ "legacy-operation": legacyOperation }),
+      ],
+    );
+    legacyDb.close();
+    try {
+      const firstStore = openSqliteAdHocStore(databasePath, "field-a");
+      const first = createAdHocGamesService({
+        store: firstStore,
+        environmentIdentity: "field-a",
+        now: () => 1_000,
+      });
+      const applied = await first.apply({
+        gameId,
+        sessionId,
+        operations: [
+          {
+            id: "new-operation",
+            clientSentAtMs: 1_002,
+            command: { type: "change-score", team: "home", delta: 10, reason: "goal" },
+          },
+        ],
+      });
+      expect(applied.status).toBe("accepted");
+      if (applied.status === "accepted")
+        expect(applied.game.state.score).toEqual({ home: 20, away: 0 });
+      first.close();
+      const restartedStore = openSqliteAdHocStore(databasePath, "field-a");
+      const restarted = createAdHocGamesService({
+        store: restartedStore,
+        environmentIdentity: "field-a",
+        now: () => 1_003,
+      });
+      const recovered = await restarted.read({ gameId, sessionId });
+      expect(recovered.status).toBe("accepted");
+      if (recovered.status === "accepted")
+        expect(recovered.game.state.score).toEqual({ home: 20, away: 0 });
+      expect(
+        (
+          await restarted.apply({
+            gameId,
+            sessionId,
+            operations: [
+              { id: "legacy-operation", clientSentAtMs: 1_001, command: legacyOperation.command },
+            ],
+          })
+        ).status,
+      ).toBe("duplicate");
+      const conflict = await restarted.apply({
+        gameId,
+        sessionId,
+        operations: [
+          {
+            id: "legacy-operation",
+            clientSentAtMs: 1_001,
+            command: { type: "set-running", running: true },
+          },
+        ],
+      });
+      expect(conflict).toMatchObject({ status: "rejected", reason: "conflict" });
+      restarted.close();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("fails closed on corrupt retained SQLite state without acknowledgement", async () => {
+    const root = await mkdtemp(join(tmpdir(), "quadball-timer-adhoc-corrupt-focused-"));
+    const databasePath = join(root, "ad-hoc.sqlite");
+    try {
+      const store = openSqliteAdHocStore(databasePath);
+      const games = createAdHocGamesService({ store, now: () => 1_000 });
+      const created = await games.create({ homeName: "Home", awayName: "Away" });
+      if (created.status !== "accepted") throw new Error("creation failed");
+      store.close();
+      const tamper = new Database(databasePath, { create: false, strict: true });
+      tamper.run("UPDATE adhoc_games SET state_json = ? WHERE game_id = ?", [
+        '{"score":null}',
+        created.gameId,
+      ]);
+      tamper.close();
+      const reopenedStore = openSqliteAdHocStore(databasePath);
+      const reopened = createAdHocGamesService({ store: reopenedStore, now: () => 1_001 });
+      expect(
+        (await reopened.read({ gameId: created.gameId, sessionId: created.sessionId })).status,
+      ).toBe("unavailable");
+      const unavailable = await reopened.apply({
+        gameId: created.gameId,
+        sessionId: created.sessionId,
+        operations: [
+          {
+            id: "must-not-ack",
+            clientSentAtMs: 1_001,
+            command: { type: "set-running", running: true },
+          },
+        ],
+      });
+      expect(unavailable).toMatchObject({ status: "rejected", reason: "unavailable" });
+      reopenedStore.close();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("fails closed when accepted SQLite history points at a missing predecessor", async () => {
+    const root = await mkdtemp(join(tmpdir(), "quadball-timer-adhoc-causal-corrupt-focused-"));
+    const databasePath = join(root, "ad-hoc.sqlite");
+    try {
+      const store = openSqliteAdHocStore(databasePath);
+      const games = createAdHocGamesService({ store, now: () => 1_000 });
+      const created = await games.create({ homeName: "Home", awayName: "Away" });
+      if (created.status !== "accepted") throw new Error("creation failed");
+      const applied = await games.apply({
+        gameId: created.gameId,
+        sessionId: created.sessionId,
+        operations: [
+          {
+            id: "accepted",
+            clientSentAtMs: 1_001,
+            command: { type: "set-running", running: true },
+          },
+        ],
+      });
+      expect(applied.status).toBe("accepted");
+      store.close();
+      const tamper = new Database(databasePath, { create: false, strict: true });
+      const row = tamper
+        .query("SELECT operations_json FROM adhoc_games WHERE game_id = ?")
+        .get(created.gameId) as { operations_json: string };
+      const operations = JSON.parse(row.operations_json) as Record<string, Record<string, unknown>>;
+      operations.accepted!.causalPredecessorIds = ["missing-predecessor"];
+      tamper.run("UPDATE adhoc_games SET operations_json = ? WHERE game_id = ?", [
+        JSON.stringify(operations),
+        created.gameId,
+      ]);
+      tamper.close();
+      const reopenedStore = openSqliteAdHocStore(databasePath);
+      const reopened = createAdHocGamesService({ store: reopenedStore, now: () => 1_002 });
+      expect(
+        (await reopened.read({ gameId: created.gameId, sessionId: created.sessionId })).status,
+      ).toBe("unavailable");
+      reopenedStore.close();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("fails closed when blocked SQLite history has no retained rejected predecessor", async () => {
+    const root = await mkdtemp(join(tmpdir(), "quadball-timer-adhoc-blocked-corrupt-focused-"));
+    const databasePath = join(root, "ad-hoc.sqlite");
+    try {
+      const store = openSqliteAdHocStore(databasePath);
+      const games = createAdHocGamesService({ store, now: () => 1_000 });
+      const created = await games.create({ homeName: "Home", awayName: "Away" });
+      if (created.status !== "accepted") throw new Error("creation failed");
+      const applied = await games.apply({
+        gameId: created.gameId,
+        sessionId: created.sessionId,
+        operations: [
+          {
+            id: "missing-child",
+            clientSentAtMs: 1_001,
+            causalPredecessorIds: ["missing"],
+            command: { type: "set-running", running: true },
+          },
+          {
+            id: "blocked-child",
+            clientSentAtMs: 1_002,
+            causalPredecessorIds: ["missing-child"],
+            command: { type: "set-running", running: false },
+          },
+        ],
+      });
+      expect(applied.status).toBe("accepted");
+      store.close();
+
+      const tamper = new Database(databasePath, { create: false, strict: true });
+      const row = tamper
+        .query("SELECT operations_json FROM adhoc_games WHERE game_id = ?")
+        .get(created.gameId) as { operations_json: string };
+      const operations = JSON.parse(row.operations_json) as Record<string, Record<string, unknown>>;
+      operations["blocked-child"]!.causalPredecessorIds = ["missing-blocker"];
+      tamper.run("UPDATE adhoc_games SET operations_json = ? WHERE game_id = ?", [
+        JSON.stringify(operations),
+        created.gameId,
+      ]);
+      tamper.close();
+
+      const reopenedStore = openSqliteAdHocStore(databasePath);
+      const reopened = createAdHocGamesService({ store: reopenedStore, now: () => 1_003 });
+      expect(
+        (await reopened.read({ gameId: created.gameId, sessionId: created.sessionId })).status,
+      ).toBe("unavailable");
+      reopenedStore.close();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   test("migration, state, and operation identity survive a bounded process-boundary restart", async () => {
     const root = await mkdtemp(join(tmpdir(), "quadball-timer-adhoc-focused-"));
     const databasePath = join(root, "ad-hoc.sqlite");

--- a/src/lib/ad-hoc-games.test.ts
+++ b/src/lib/ad-hoc-games.test.ts
@@ -1,16 +1,13 @@
 import { describe, expect, test } from "bun:test";
-import { Database } from "bun:sqlite";
-import { createHash } from "node:crypto";
-import { mkdtempSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 import {
   createAdHocGamesService,
   createInMemoryAdHocStore,
-  openSqliteAdHocStore,
+  type AdHocStore,
   type AdHocGamesService,
 } from "@/lib/ad-hoc-games";
-import { createInitialGameState } from "@/lib/game-engine";
+import { applyGameCommand, createInitialGameState } from "@/lib/game-engine";
+import { deriveAdHocOptimisticState } from "@/lib/game-page-support";
+import type { AdHocPendingOperation } from "@/lib/ad-hoc-controller-session";
 
 function service(): AdHocGamesService {
   return createAdHocGamesService({
@@ -24,6 +21,133 @@ function service(): AdHocGamesService {
 }
 
 describe("Ad Hoc Games service", () => {
+  test("derives multiple offline operations once from the authoritative base and rebases on reconciliation", () => {
+    const authoritative = createInitialGameState({ id: "adhoc-optimistic", nowMs: 1_000 });
+    const pending: AdHocPendingOperation[] = [
+      {
+        id: "offline-1",
+        clientSentAtMs: 1_001,
+        workflow: "ad-hoc",
+        causalPredecessorIds: [],
+        command: { type: "change-score", team: "home", delta: 10, reason: "goal" },
+      },
+      {
+        id: "offline-2",
+        clientSentAtMs: 1_002,
+        workflow: "ad-hoc",
+        causalPredecessorIds: ["offline-1"],
+        command: { type: "change-score", team: "home", delta: 10, reason: "goal" },
+      },
+    ];
+    expect(deriveAdHocOptimisticState(authoritative, pending).score.home).toBe(20);
+    const reconciledBase = applyGameCommand({
+      state: authoritative,
+      command: pending[0]!.command,
+      nowMs: 1_001,
+      idGenerator: () => "server-1",
+    });
+    expect(
+      deriveAdHocOptimisticState(reconciledBase, pending.slice(1), { "offline-1": "accepted" })
+        .score.home,
+    ).toBe(20);
+  });
+
+  test("orders reordered causal batches, blocks only descendants, and rejects identity conflicts", async () => {
+    const games = service();
+    const created = await games.create({ homeName: "Home", awayName: "Away" });
+    if (created.status !== "accepted") throw new Error("creation failed");
+    const replay = await games.apply({
+      gameId: created.gameId,
+      sessionId: created.sessionId,
+      operations: [
+        {
+          id: "child",
+          clientSentAtMs: 1_002,
+          causalPredecessorIds: ["parent"],
+          command: { type: "change-score", team: "home", delta: 10, reason: "goal" },
+        },
+        {
+          id: "unrelated",
+          clientSentAtMs: 1_000,
+          command: { type: "change-score", team: "away", delta: 10, reason: "goal" },
+        },
+        {
+          id: "parent",
+          clientSentAtMs: 1_001,
+          command: { type: "change-score", team: "home", delta: 10, reason: "goal" },
+        },
+      ],
+    });
+    expect(replay.status).toBe("accepted");
+    if (replay.status !== "accepted") return;
+    expect(replay.game.state.score).toEqual({ home: 20, away: 10 });
+    const missing = await games.apply({
+      gameId: created.gameId,
+      sessionId: created.sessionId,
+      operations: [
+        {
+          id: "blocked-child",
+          clientSentAtMs: 1_003,
+          causalPredecessorIds: ["missing"],
+          command: { type: "change-score", team: "home", delta: 10, reason: "goal" },
+        },
+        {
+          id: "still-unrelated",
+          clientSentAtMs: 1_004,
+          command: { type: "change-score", team: "away", delta: 10, reason: "goal" },
+        },
+      ],
+    });
+    expect(missing.status).toBe("accepted");
+    if (missing.status === "accepted") {
+      expect(
+        missing.outcomes.find((outcome) => outcome.operationId === "blocked-child")?.status,
+      ).toBe("rejected");
+      expect(missing.game.state.score).toEqual({ home: 20, away: 20 });
+    }
+    const conflict = await games.apply({
+      gameId: created.gameId,
+      sessionId: created.sessionId,
+      operations: [
+        { id: "parent", clientSentAtMs: 1_001, command: { type: "set-running", running: true } },
+      ],
+    });
+    expect(conflict).toMatchObject({ status: "rejected", reason: "conflict" });
+    const cyclic = await games.apply({
+      gameId: created.gameId,
+      sessionId: created.sessionId,
+      operations: [
+        {
+          id: "cycle-a",
+          clientSentAtMs: 1_005,
+          causalPredecessorIds: ["cycle-b"],
+          command: { type: "change-score", team: "home", delta: 10, reason: "goal" },
+        },
+        {
+          id: "cycle-b",
+          clientSentAtMs: 1_006,
+          causalPredecessorIds: ["cycle-a"],
+          command: { type: "change-score", team: "away", delta: 10, reason: "goal" },
+        },
+      ],
+    });
+    expect(cyclic).toMatchObject({ status: "rejected", reason: "invalid-operation" });
+    const reusedAfterRejectedBatch = await games.apply({
+      gameId: created.gameId,
+      sessionId: created.sessionId,
+      operations: [
+        {
+          id: "cycle-a",
+          clientSentAtMs: 1_005,
+          command: { type: "change-score", team: "home", delta: 10, reason: "goal" },
+        },
+      ],
+    });
+    expect(reusedAfterRejectedBatch.status).toBe("accepted");
+    if (reusedAfterRejectedBatch.status === "accepted") {
+      expect(reusedAfterRejectedBatch.game.state.score).toEqual({ home: 30, away: 20 });
+    }
+  });
   test("normalizes bounded names and atomically admits the initially admitted Ad Hoc Controller", async () => {
     const games = service();
     const result = await games.create({
@@ -87,6 +211,44 @@ describe("Ad Hoc Games service", () => {
     ).toBe("accepted");
   });
 
+  test("uses the explicit Ad Hoc workflow and converges concurrent operations deterministically", async () => {
+    const first = service();
+    const created = await first.create({ homeName: "Home", awayName: "Away" });
+    if (created.status !== "accepted") throw new Error("creation failed");
+    const second = await first.admit({ gameId: created.gameId, controlQr: created.controlQr });
+    if (second.status !== "accepted") throw new Error("admission failed");
+    const replay = await first.apply({
+      gameId: created.gameId,
+      sessionId: second.game.sessionId,
+      operations: [
+        {
+          id: "later-operation",
+          clientSentAtMs: 1_002,
+          workflow: "ad-hoc",
+          command: { type: "change-score", team: "home", delta: 10, reason: "goal" },
+        },
+        {
+          id: "earlier-operation",
+          clientSentAtMs: 1_001,
+          workflow: "ad-hoc",
+          command: { type: "change-score", team: "away", delta: 10, reason: "goal" },
+        },
+      ],
+    });
+    expect(replay.status).toBe("accepted");
+    if (replay.status !== "accepted") return;
+    expect(replay.outcomes.every((outcome) => outcome.workflow === "ad-hoc")).toBe(true);
+    expect(replay.game.state.score).toEqual({ home: 10, away: 10 });
+    const restarted = createAdHocGamesService({ store: first.store, now: () => 1_003 });
+    const recovered = await restarted.read({
+      gameId: created.gameId,
+      sessionId: created.sessionId,
+    });
+    expect(recovered.status).toBe("accepted");
+    if (recovered.status === "accepted")
+      expect(recovered.game.state.score).toEqual({ home: 10, away: 10 });
+  });
+
   test("binds QR admission and retained sessions to the configured environment", async () => {
     const store = createInMemoryAdHocStore();
     const field = createAdHocGamesService({
@@ -116,103 +278,6 @@ describe("Ad Hoc Games service", () => {
     expect(
       (await copiedField.admit({ gameId: created.gameId, controlQr: created.controlQr })).status,
     ).toBe("unavailable");
-  });
-
-  test("migrates a retained #152 SQLite Game into the upgrading environment", async () => {
-    const root = mkdtempSync(join(tmpdir(), "quadball-timer-adhoc-migration-"));
-    const databasePath = join(root, "ad-hoc.sqlite");
-    const gameId = "adhoc-legacy-game-1234567890";
-    const sessionId = "legacy-session-1234567890-abcdefghijklmnopqrstuvwxyz";
-    const controlQr = "legacy-control-qr-1234567890-abcdefghijklmnopqrstuvwxyz";
-    const state = createInitialGameState({
-      id: gameId,
-      nowMs: 1_000,
-      homeName: "Home",
-      awayName: "Away",
-      homeColor: "#0f172a",
-      awayColor: "#f8fafc",
-    });
-    const digest = (value: string) => createHash("sha256").update(value).digest("hex");
-    const legacyDb = new Database(databasePath, { create: true, strict: true });
-    legacyDb.run(
-      "CREATE TABLE adhoc_schema (id INTEGER PRIMARY KEY CHECK (id = 1), version INTEGER NOT NULL)",
-    );
-    legacyDb.run("INSERT INTO adhoc_schema (id, version) VALUES (1, 1)");
-    legacyDb.run(`CREATE TABLE adhoc_games (
-      game_id TEXT PRIMARY KEY,
-      created_at_ms INTEGER NOT NULL,
-      state_json TEXT NOT NULL,
-      control_qr TEXT NOT NULL,
-      control_qr_hash TEXT NOT NULL,
-      sessions_json TEXT NOT NULL,
-      operations_json TEXT NOT NULL
-    )`);
-    legacyDb.run(`CREATE TABLE adhoc_creation_events (
-      source_hash TEXT NOT NULL,
-      successful INTEGER NOT NULL,
-      occurred_at_ms INTEGER NOT NULL
-    )`);
-    legacyDb.run(
-      "INSERT INTO adhoc_games (game_id, created_at_ms, state_json, control_qr, control_qr_hash, sessions_json, operations_json) VALUES (?, ?, ?, ?, ?, ?, ?)",
-      [
-        gameId,
-        1_000,
-        JSON.stringify(state),
-        controlQr,
-        digest(controlQr),
-        JSON.stringify([
-          {
-            sessionHash: digest(sessionId),
-            browserId: null,
-            connected: false,
-            lastConnectedAtMs: 1_000,
-            lastDisconnectedAtMs: null,
-          },
-        ]),
-        JSON.stringify({}),
-      ],
-    );
-    legacyDb.close();
-
-    try {
-      const firstStore = openSqliteAdHocStore(databasePath, "field-a");
-      const first = createAdHocGamesService({
-        store: firstStore,
-        environmentIdentity: "field-a",
-        now: () => 1_000,
-      });
-      const firstRead = await first.read({ gameId, sessionId });
-      expect(firstRead.status).toBe("accepted");
-      if (firstRead.status !== "accepted") return;
-      expect(firstRead.game.controlQr).toBe(controlQr);
-      first.close();
-
-      const secondStore = openSqliteAdHocStore(databasePath, "field-a");
-      const restarted = createAdHocGamesService({
-        store: secondStore,
-        environmentIdentity: "field-a",
-        now: () => 1_000,
-      });
-      const restartedRead = await restarted.read({ gameId, sessionId });
-      expect(restartedRead.status).toBe("accepted");
-      if (restartedRead.status === "accepted") {
-        expect(restartedRead.game.controlQr).toBe(controlQr);
-      }
-      const admitted = await restarted.admit({ gameId, controlQr });
-      expect(admitted.status).toBe("accepted");
-      restarted.close();
-
-      const copiedStore = openSqliteAdHocStore(databasePath, "field-b");
-      const copied = createAdHocGamesService({
-        store: copiedStore,
-        environmentIdentity: "field-b",
-        now: () => 1_000,
-      });
-      expect((await copied.read({ gameId, sessionId })).status).toBe("unavailable");
-      copied.close();
-    } finally {
-      rmSync(root, { recursive: true, force: true });
-    }
   });
 
   test("hands the unchanged QR to every Controller and replaces only a re-admitting browser", async () => {
@@ -342,6 +407,31 @@ describe("Ad Hoc Games service", () => {
     expect(rejected).toMatchObject({ status: "rejected", reason: "invalid-operation" });
     expect(read.status).toBe("accepted");
     if (read.status === "accepted") expect(read.game.state.isRunning).toBe(false);
+  });
+
+  test("retains pending work and emits no acknowledgement when durable mutation fails", async () => {
+    const base = createInMemoryAdHocStore();
+    const failingStore: AdHocStore = {
+      close: () => base.close(),
+      listGames: () => base.listGames(),
+      readGame: (gameId) => base.readGame(gameId),
+      createGame: (input) => base.createGame(input),
+      mutateGame: () => null,
+    };
+    const games = createAdHocGamesService({ store: failingStore, now: () => 1_000 });
+    expect(
+      await games.apply({
+        gameId: "adhoc-missing",
+        sessionId: "session-that-is-long-enough-to-pass-validation-123456",
+        operations: [
+          {
+            id: "durable-failure",
+            clientSentAtMs: 1_000,
+            command: { type: "set-running", running: true },
+          },
+        ],
+      }),
+    ).toMatchObject({ status: "rejected", reason: "unavailable" });
   });
 
   test("keeps capacity cleanup isolated and rejects protected saturation", async () => {

--- a/src/lib/ad-hoc-games.ts
+++ b/src/lib/ad-hoc-games.ts
@@ -2,9 +2,18 @@ import { Database } from "bun:sqlite";
 import { createHash, randomBytes } from "node:crypto";
 import { mkdirSync } from "node:fs";
 import { dirname } from "node:path";
-import { applyGameCommand, createInitialGameState, projectGameView } from "@/lib/game-engine";
+import { createInitialGameState } from "@/lib/game-engine";
 import type { GameCommand, GameState, GameView } from "@/lib/game-types";
 import { parseGameCommand } from "@/lib/ws-protocol";
+import { DEFAULT_IQA_SPORTING_RULES, type IqaSportingRules } from "@/lib/iqa-game-rules";
+import {
+  orderControllerOperations,
+  createControllerReplayAcknowledgement,
+  resolveControllerBatch,
+  validateControllerReplay,
+  type ControllerOperationOutcome,
+  type ControllerSynchronizationOperation,
+} from "@/lib/controller-synchronization";
 import { parseHexColor, DEFAULT_AWAY_TEAM_COLOR, DEFAULT_HOME_TEAM_COLOR } from "@/lib/team-colors";
 import {
   normalizeBoundedText,
@@ -18,8 +27,10 @@ export const AD_HOC_CREATION_SOURCE_WINDOW_MS = 10 * 60_000;
 export const AD_HOC_CREATION_GLOBAL_WINDOW_MS = 60 * 60_000;
 export const AD_HOC_MAX_CREATIONS_PER_SOURCE = 5;
 export const AD_HOC_MAX_CREATIONS_PER_HOUR = 30;
+export const AD_HOC_MAX_OPERATIONS_PER_SECOND_PER_CONTROLLER = 40;
+export const AD_HOC_MAX_OPERATIONS_PER_SECOND_PER_GAME = 100;
 
-const SCHEMA_VERSION = 2;
+const SCHEMA_VERSION = 3;
 const GENERIC_UNAVAILABLE = "Ad Hoc Game unavailable.";
 
 export type AdHocGameView = GameView & {
@@ -57,14 +68,22 @@ export type AdHocOperation = {
   id: string;
   clientSentAtMs: number;
   command: GameCommand;
+  workflow?: "ad-hoc";
+  causalPredecessorIds?: readonly string[];
 };
 
 export type AdHocActionResult =
-  | { status: "accepted" | "duplicate"; game: AdHocGameView; ackedOperationIds: string[] }
+  | {
+      status: "accepted" | "duplicate";
+      game: AdHocGameView;
+      ackedOperationIds: string[];
+      outcomes: readonly ControllerOperationOutcome[];
+    }
   | {
       status: "rejected";
-      reason: "unavailable" | "invalid-operation" | "conflict";
+      reason: "unavailable" | "invalid-operation" | "conflict" | "rate-limited";
       detail?: string;
+      outcomes?: readonly ControllerOperationOutcome[];
     };
 
 export type AdHocAccessResult =
@@ -83,6 +102,10 @@ type StoredOperation = {
   fingerprint: string;
   command: GameCommand;
   acceptedAtMs: number;
+  clientSentAtMs: number;
+  causalPredecessorIds: readonly string[];
+  status: "accepted" | "rejected" | "causally-blocked";
+  detail?: string;
 };
 
 export type StoredAdHocGame = {
@@ -90,6 +113,8 @@ export type StoredAdHocGame = {
   environmentIdentity: string;
   createdAtMs: number;
   state: GameState;
+  initialState?: GameState;
+  replayBaselineOperationIds?: readonly string[];
   controlQr: string;
   controlQrHash: string;
   sessions: StoredSession[];
@@ -99,8 +124,13 @@ export type StoredAdHocGame = {
 type AdHocApplyMutationResult =
   | false
   | { invalid: true; rollback: true }
-  | { conflict: true }
-  | { acknowledged: string[]; duplicate: boolean };
+  | { conflict: true; operationId: string }
+  | { rateLimited: true }
+  | {
+      acknowledged: string[];
+      duplicate: boolean;
+      outcomes: readonly ControllerOperationOutcome[];
+    };
 
 export type AdHocStore = {
   close(): void;
@@ -119,7 +149,13 @@ export type AdHocGamesServiceOptions = {
   now?: () => number;
   random?: () => string;
   environmentIdentity?: string;
+  iqaRules?: AdHocIqaGameRules;
 };
+
+/** Shared sporting interpretation consumed by both Controller workflows. */
+export type AdHocIqaGameRules = IqaSportingRules;
+
+export const DEFAULT_AD_HOC_IQA_RULES: AdHocIqaGameRules = DEFAULT_IQA_SPORTING_RULES;
 
 export type AdHocGamesService = ReturnType<typeof createAdHocGamesService>;
 
@@ -128,6 +164,9 @@ export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) 
   const now = options.now ?? (() => Date.now());
   const random = options.random ?? (() => randomBytes(32).toString("base64url"));
   const environmentIdentity = options.environmentIdentity?.trim() || "test";
+  const iqaRules = options.iqaRules ?? DEFAULT_AD_HOC_IQA_RULES;
+  const controllerActionTimes = new Map<string, number[]>();
+  const gameActionTimes = new Map<string, number[]>();
 
   return {
     async create(input: AdHocCreationInput): Promise<AdHocCreateResult> {
@@ -172,6 +211,8 @@ export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) 
         environmentIdentity,
         createdAtMs: nowMs,
         state,
+        initialState: structuredClone(state),
+        replayBaselineOperationIds: [],
         controlQr,
         controlQrHash: digest(controlQr),
         sessions: [
@@ -209,7 +250,7 @@ export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) 
         gameId,
         sessionId,
         controlQr,
-        game: projectAuthorizedGame(game, sessionId, controlQr, nowMs),
+        game: projectAuthorizedGame(game, sessionId, controlQr, nowMs, iqaRules),
       };
     },
 
@@ -235,7 +276,7 @@ export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) 
         return unavailable();
       return {
         status: "accepted",
-        game: projectAuthorizedGame(game, sessionId, null, input.nowMs ?? now()),
+        game: projectAuthorizedGame(game, sessionId, null, input.nowMs ?? now(), iqaRules),
       };
     },
 
@@ -288,7 +329,10 @@ export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) 
         return unavailable();
       }
       if (game === null) return unavailable();
-      return { status: "accepted", game: projectAuthorizedGame(game, sessionId, qr, nowMs) };
+      return {
+        status: "accepted",
+        game: projectAuthorizedGame(game, sessionId, qr, nowMs, iqaRules),
+      };
     },
 
     async apply(input: {
@@ -318,53 +362,142 @@ export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) 
           const next = structuredClone(game) as StoredAdHocGame;
           const acknowledged: string[] = [];
           let duplicate = false;
-          for (const operation of input.operations) {
-            if (typeof operation !== "object" || operation === null)
-              return { invalid: true, rollback: true } as const;
-            const operationId = validateOpaqueIdentifier(operation.id, "operationId");
-            if (
-              !operationId.ok ||
-              !Number.isSafeInteger(operation.clientSentAtMs) ||
-              operation.clientSentAtMs < 0
-            )
-              return { invalid: true, rollback: true } as const;
-            const id = operationId.value;
-            const parsedCommand =
-              typeof operation.command === "object" && operation.command !== null
-                ? parseGameCommand(operation.command as Record<string, unknown>)
-                : { ok: false as const, error: "command must be an object." };
-            if (!parsedCommand.ok) return { invalid: true, rollback: true } as const;
-            const normalizedOperation = { ...operation, command: parsedCommand.command };
-            const fingerprint = canonicalOperation(normalizedOperation);
-            const existing = next.operations[id];
+          const parsed = parseAdHocOperations(input.operations);
+          if (!parsed.ok) return { invalid: true, rollback: true } as const;
+          const incoming = parsed.operations;
+          const newOperationCount = incoming.filter(
+            (operation) => next.operations[operation.operationId] === undefined,
+          ).length;
+          const sessionKey = digest(sessionId);
+          const sessionTimes = (controllerActionTimes.get(sessionKey) ?? []).filter(
+            (timestamp) => timestamp > nowMs - 1_000,
+          );
+          const gameTimes = (gameActionTimes.get(gameId) ?? []).filter(
+            (timestamp) => timestamp > nowMs - 1_000,
+          );
+          if (
+            sessionTimes.length + newOperationCount >
+              AD_HOC_MAX_OPERATIONS_PER_SECOND_PER_CONTROLLER ||
+            gameTimes.length + newOperationCount > AD_HOC_MAX_OPERATIONS_PER_SECOND_PER_GAME
+          ) {
+            return { rateLimited: true } as const;
+          }
+          const outcomes: ControllerOperationOutcome[] = [];
+          for (const operation of incoming) {
+            const existing = next.operations[operation.operationId];
             if (existing !== undefined) {
-              if (existing.fingerprint !== fingerprint) return { conflict: true } as const;
-              acknowledged.push(id);
+              if (existing.fingerprint !== operationFingerprint(operation)) {
+                return { conflict: true, operationId: operation.operationId } as const;
+              }
+              acknowledged.push(operation.operationId);
               duplicate = true;
+              outcomes.push({
+                operationId: operation.operationId,
+                workflow: "ad-hoc",
+                status: existing.status === "accepted" ? "duplicate" : existing.status,
+                ...(existing.detail === undefined ? {} : { detail: existing.detail }),
+              });
               continue;
             }
-            next.state = applyGameCommand({
-              state: next.state,
-              command: parsedCommand.command,
-              nowMs: operation.clientSentAtMs,
-            });
-            next.operations[id] = {
-              fingerprint,
-              command: structuredClone(parsedCommand.command),
-              acceptedAtMs: nowMs,
-            };
-            acknowledged.push(id);
           }
+          const retainedStatuses = new Map(
+            Object.entries(next.operations).map(
+              ([operationId, operation]) => [operationId, operation.status] as const,
+            ),
+          );
+          const resolution = resolveControllerBatch({
+            operations: incoming.filter(
+              (operation) => next.operations[operation.operationId] === undefined,
+            ),
+            retainedStatuses,
+          });
+          for (const operation of resolution.ordered) {
+            const status = resolution.statuses.get(operation.operationId) ?? "rejected";
+            const detail = resolution.details.get(operation.operationId);
+            next.operations[operation.operationId] =
+              status === "accepted"
+                ? {
+                    fingerprint: operationFingerprint(operation),
+                    command: structuredClone(operation.payload),
+                    acceptedAtMs: nowMs,
+                    clientSentAtMs: operation.clientOriginAtMs,
+                    causalPredecessorIds: [...operation.causalPredecessorIds],
+                    status: "accepted",
+                  }
+                : rejectedOperation(operation, nowMs, detail ?? "Causal cycle.", status);
+            outcomes.push({
+              operationId: operation.operationId,
+              workflow: "ad-hoc",
+              status,
+              ...(detail === undefined ? {} : { detail }),
+            });
+            acknowledged.push(operation.operationId);
+          }
+          for (const operation of incoming) {
+            if (
+              next.operations[operation.operationId] !== undefined &&
+              acknowledged.includes(operation.operationId)
+            )
+              continue;
+            if (next.operations[operation.operationId] === undefined) {
+              const status = resolution.statuses.get(operation.operationId) ?? "rejected";
+              const detail = resolution.details.get(operation.operationId) ?? "Causal cycle.";
+              next.operations[operation.operationId] = rejectedOperation(
+                operation,
+                nowMs,
+                detail,
+                status === "accepted" ? "rejected" : status,
+              );
+              outcomes.push({
+                operationId: operation.operationId,
+                workflow: "ad-hoc",
+                status,
+                detail,
+              });
+              acknowledged.push(operation.operationId);
+            }
+          }
+          const rebuilt = rebuildAdHocState(next, iqaRules);
+          if (rebuilt === null) return { invalid: true, rollback: true } as const;
+          next.state = rebuilt;
           next.state.updatedAtMs = nowMs;
+          if (newOperationCount > 0) {
+            const acceptedTimes = Array.from({ length: newOperationCount }, () => nowMs);
+            controllerActionTimes.set(sessionKey, [...sessionTimes, ...acceptedTimes]);
+            gameActionTimes.set(gameId, [...gameTimes, ...acceptedTimes]);
+          }
           Object.assign(game, next);
-          return { acknowledged, duplicate };
+          const acknowledgement = createControllerReplayAcknowledgement({
+            workflow: "ad-hoc",
+            acknowledgedOperationIds: acknowledged,
+            outcomes,
+          });
+          return {
+            acknowledged: [...acknowledgement.acknowledgedOperationIds],
+            duplicate,
+            outcomes: acknowledgement.outcomes,
+          };
         });
       } catch {
         return { status: "rejected", reason: "unavailable" };
       }
       if (outcome === null || outcome === false)
         return { status: "rejected", reason: "unavailable" };
-      if ("conflict" in outcome) return { status: "rejected", reason: "conflict" };
+      if ("rateLimited" in outcome) return { status: "rejected", reason: "rate-limited" };
+      if ("conflict" in outcome) {
+        return {
+          status: "rejected",
+          reason: "conflict",
+          outcomes: [
+            {
+              operationId: outcome.operationId,
+              workflow: "ad-hoc",
+              status: "rejected",
+              detail: "The operation identity is already bound to different content.",
+            },
+          ],
+        };
+      }
       if ("invalid" in outcome) return { status: "rejected", reason: "invalid-operation" };
       let game: StoredAdHocGame | null;
       try {
@@ -376,7 +509,8 @@ export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) 
       return {
         status: outcome.duplicate ? "duplicate" : "accepted",
         ackedOperationIds: outcome.acknowledged,
-        game: projectAuthorizedGame(game, sessionId, null, nowMs),
+        outcomes: outcome.outcomes,
+        game: projectAuthorizedGame(game, sessionId, null, nowMs, iqaRules),
       };
     },
 
@@ -520,6 +654,8 @@ export function openSqliteAdHocStore(
     environment_identity TEXT NOT NULL DEFAULT '',
     created_at_ms INTEGER NOT NULL,
     state_json TEXT NOT NULL,
+    initial_state_json TEXT NOT NULL,
+    replay_baseline_operation_ids_json TEXT NOT NULL DEFAULT '[]',
     control_qr TEXT NOT NULL,
     control_qr_hash TEXT NOT NULL,
     sessions_json TEXT NOT NULL,
@@ -528,6 +664,25 @@ export function openSqliteAdHocStore(
   const columns = db.query("PRAGMA table_info(adhoc_games)").all() as { name?: string }[];
   if (!columns.some((column) => column.name === "environment_identity")) {
     db.run("ALTER TABLE adhoc_games ADD COLUMN environment_identity TEXT NOT NULL DEFAULT ''");
+  }
+  const legacyStateColumnWasMissing = !columns.some(
+    (column) => column.name === "initial_state_json",
+  );
+  if (legacyStateColumnWasMissing) {
+    db.run("ALTER TABLE adhoc_games ADD COLUMN initial_state_json TEXT NOT NULL DEFAULT '{}'");
+    db.run(
+      "UPDATE adhoc_games SET initial_state_json = state_json WHERE initial_state_json = '{}' ",
+    );
+  }
+  if (!columns.some((column) => column.name === "replay_baseline_operation_ids_json")) {
+    db.run(
+      "ALTER TABLE adhoc_games ADD COLUMN replay_baseline_operation_ids_json TEXT NOT NULL DEFAULT '[]'",
+    );
+    if (legacyStateColumnWasMissing) {
+      db.run(
+        "UPDATE adhoc_games SET replay_baseline_operation_ids_json = (SELECT json_group_array(key) FROM json_each(adhoc_games.operations_json))",
+      );
+    }
   }
   if (previousSchemaVersion < SCHEMA_VERSION) {
     const migrate = db.transaction(() => {
@@ -599,12 +754,14 @@ export function openSqliteAdHocStore(
           db.run("DELETE FROM adhoc_games WHERE game_id = ?", [victim.game_id]);
         }
         db.run(
-          "INSERT INTO adhoc_games (game_id, environment_identity, created_at_ms, state_json, control_qr, control_qr_hash, sessions_json, operations_json) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+          "INSERT INTO adhoc_games (game_id, environment_identity, created_at_ms, state_json, initial_state_json, replay_baseline_operation_ids_json, control_qr, control_qr_hash, sessions_json, operations_json) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
           [
             game.gameId,
             game.environmentIdentity,
             game.createdAtMs,
             JSON.stringify(game.state),
+            JSON.stringify(game.initialState ?? game.state),
+            JSON.stringify(game.replayBaselineOperationIds ?? []),
             game.controlQr,
             game.controlQrHash,
             JSON.stringify(game.sessions),
@@ -633,11 +790,12 @@ export function openSqliteAdHocStore(
           )
         ) {
           db.run(
-            "UPDATE adhoc_games SET state_json = ?, sessions_json = ?, operations_json = ? WHERE game_id = ?",
+            "UPDATE adhoc_games SET state_json = ?, sessions_json = ?, operations_json = ?, replay_baseline_operation_ids_json = ? WHERE game_id = ?",
             [
               JSON.stringify(game.state),
               JSON.stringify(game.sessions),
               JSON.stringify(game.operations),
+              JSON.stringify(game.replayBaselineOperationIds ?? []),
               gameId,
             ],
           );
@@ -649,16 +807,27 @@ export function openSqliteAdHocStore(
 }
 
 function parseStoredRow(row: Record<string, string | number>): StoredAdHocGame {
-  return {
+  const operations = JSON.parse(String(row.operations_json)) as Record<string, StoredOperation>;
+  for (const operation of Object.values(operations)) {
+    operation.clientSentAtMs ??= operation.acceptedAtMs;
+    operation.causalPredecessorIds ??= [];
+    operation.status ??= "accepted";
+  }
+  const parsed = {
     gameId: String(row.game_id),
     environmentIdentity: String(row.environment_identity ?? ""),
     createdAtMs: Number(row.created_at_ms),
     state: JSON.parse(String(row.state_json)) as GameState,
+    initialState: JSON.parse(String(row.initial_state_json ?? row.state_json)) as GameState,
+    replayBaselineOperationIds: JSON.parse(
+      String(row.replay_baseline_operation_ids_json ?? "[]"),
+    ) as string[],
     controlQr: String(row.control_qr),
     controlQrHash: String(row.control_qr_hash),
     sessions: JSON.parse(String(row.sessions_json)) as StoredSession[],
-    operations: JSON.parse(String(row.operations_json)) as Record<string, StoredOperation>,
+    operations,
   };
+  return validateStoredGame(parsed);
 }
 
 function projectAuthorizedGame(
@@ -666,14 +835,355 @@ function projectAuthorizedGame(
   sessionId: string,
   controlQr: string | null,
   nowMs: number,
+  rules: AdHocIqaGameRules = DEFAULT_AD_HOC_IQA_RULES,
 ): AdHocGameView {
-  const view = projectGameView(game.state, nowMs);
+  const view = rules.project(game.state, nowMs);
   return {
     ...view,
     gameId: game.gameId,
     sessionId,
     controlQr: view.state.isFinished ? null : (controlQr ?? game.controlQr),
   };
+}
+
+function validateStoredGame(game: StoredAdHocGame): StoredAdHocGame {
+  if (!isRecord(game)) throw new Error("Stored Ad Hoc Game must be an object.");
+  requireOpaque(game.gameId, "gameId");
+  if (!game.gameId.startsWith("adhoc-")) throw new Error("Stored Ad Hoc Game identity is invalid.");
+  if (typeof game.environmentIdentity !== "string" || game.environmentIdentity.length === 0)
+    throw new Error("Stored Ad Hoc environment identity is invalid.");
+  requireSafeNonNegative(game.createdAtMs, "createdAtMs");
+  validateGameState(game.state, game.gameId);
+  if (game.initialState !== undefined) validateGameState(game.initialState, game.gameId);
+  if (!Array.isArray(game.replayBaselineOperationIds))
+    throw new Error("Stored replay baseline is invalid.");
+  const baselineIds = new Set<string>();
+  for (const id of game.replayBaselineOperationIds) {
+    requireOpaque(id, "replay baseline operationId");
+    if (baselineIds.has(id)) throw new Error("Stored replay baseline contains duplicates.");
+    baselineIds.add(id);
+  }
+  if (typeof game.controlQr !== "string" || game.controlQr.length === 0)
+    throw new Error("Stored control QR is invalid.");
+  if (!/^[a-f0-9]{64}$/u.test(game.controlQrHash))
+    throw new Error("Stored control QR hash is invalid.");
+  if (!Array.isArray(game.sessions)) throw new Error("Stored sessions are invalid.");
+  for (const session of game.sessions) validateStoredSession(session);
+  if (!isRecord(game.operations)) throw new Error("Stored operations are invalid.");
+  const operationIds = new Set(Object.keys(game.operations));
+  for (const [operationId, operation] of Object.entries(game.operations)) {
+    requireOpaque(operationId, "operationId");
+    validateStoredOperation(operationId, operation);
+  }
+  for (const operation of Object.values(game.operations)) {
+    const predecessors = operation.causalPredecessorIds.map(
+      (predecessor) => game.operations[predecessor],
+    );
+    if (
+      operation.status === "accepted" &&
+      predecessors.some((predecessor) => predecessor?.status !== "accepted")
+    ) {
+      throw new Error("Stored accepted operation has a non-accepted predecessor.");
+    }
+    if (
+      operation.status === "causally-blocked" &&
+      (predecessors.length === 0 ||
+        predecessors.some((predecessor) => predecessor === undefined) ||
+        predecessors.every((predecessor) => predecessor?.status === "accepted"))
+    ) {
+      throw new Error("Stored causally blocked operation has no rejected predecessor.");
+    }
+    if (
+      operation.status === "rejected" &&
+      predecessors.some((predecessor) => predecessor === undefined) &&
+      operation.detail !== "Causal predecessor is not retained."
+    ) {
+      throw new Error("Stored rejected operation has inconsistent causal evidence.");
+    }
+  }
+  for (const baselineId of baselineIds) {
+    if (!operationIds.has(baselineId) || game.operations[baselineId]?.status !== "accepted")
+      throw new Error("Stored replay baseline does not match accepted history.");
+  }
+  const graph = new Map(
+    Object.entries(game.operations).map(([operationId, operation]) => [
+      operationId,
+      operation.causalPredecessorIds.filter((predecessor) => operationIds.has(predecessor)),
+    ]),
+  );
+  for (const operationId of operationIds) {
+    if (hasStoredCausalCycle(operationId, graph, new Set(), new Set()))
+      throw new Error("Stored operation causal graph contains a cycle.");
+  }
+  return game;
+}
+
+function validateGameState(value: unknown, expectedId: string): asserts value is GameState {
+  if (!isRecord(value) || value.id !== expectedId)
+    throw new Error("Stored GameState identity is invalid.");
+  requireSafeNonNegative(value.createdAtMs, "state.createdAtMs");
+  requireSafeNonNegative(value.updatedAtMs, "state.updatedAtMs");
+  requireText(value.homeName, SHARED_LIMITS.names.teamAndPitchMaxCodePoints, "state.homeName");
+  requireText(value.awayName, SHARED_LIMITS.names.teamAndPitchMaxCodePoints, "state.awayName");
+  if (typeof value.homeColor !== "string" || parseHexColor(value.homeColor) === null)
+    throw new Error("Stored home color is invalid.");
+  if (typeof value.awayColor !== "string" || parseHexColor(value.awayColor) === null)
+    throw new Error("Stored away color is invalid.");
+  for (const field of [
+    "displaySidesSwapped",
+    "isRunning",
+    "isFinished",
+    "isSuspended",
+    "isOvertime",
+  ])
+    if (typeof value[field] !== "boolean") throw new Error(`Stored ${field} is invalid.`);
+  if (value.suspendedAtMs !== null)
+    requireSafeNonNegative(value.suspendedAtMs, "state.suspendedAtMs");
+  if (value.winner !== null && value.winner !== "home" && value.winner !== "away")
+    throw new Error("Stored winner is invalid.");
+  if (
+    value.finishReason !== null &&
+    !["forfeit", "double-forfeit", "flag-catch", "target-score", "concede"].includes(
+      value.finishReason,
+    )
+  )
+    throw new Error("Stored finish reason is invalid.");
+  requireInteger(
+    value.gameClockMs,
+    SHARED_LIMITS.clock.minMs,
+    SHARED_LIMITS.clock.maxMs,
+    "state.gameClockMs",
+  );
+  if (!isRecord(value.score)) throw new Error("Stored score is invalid.");
+  requireInteger(
+    value.score.home,
+    SHARED_LIMITS.score.min,
+    SHARED_LIMITS.score.max,
+    "state.score.home",
+  );
+  requireInteger(
+    value.score.away,
+    SHARED_LIMITS.score.min,
+    SHARED_LIMITS.score.max,
+    "state.score.away",
+  );
+  if (
+    !Array.isArray(value.scoreEvents) ||
+    !Array.isArray(value.cardEvents) ||
+    !Array.isArray(value.pendingExpirations) ||
+    !Array.isArray(value.recentReleases)
+  )
+    throw new Error("Stored GameState collections are invalid.");
+  for (const event of value.scoreEvents) {
+    if (!isRecord(event)) throw new Error("Stored score event is invalid.");
+    requireOpaque(event.id, "score event id");
+    requireTeam(event.team);
+    requireInteger(
+      event.points,
+      -SHARED_LIMITS.score.max,
+      SHARED_LIMITS.score.max,
+      "score event points",
+    );
+    requireSafeNonNegative(event.createdAtMs, "score event createdAtMs");
+    if (event.reason !== "goal" && event.reason !== "flag-catch")
+      throw new Error("Stored score event reason is invalid.");
+    if (event.pendingExpirationId !== null)
+      requireOpaque(event.pendingExpirationId, "pendingExpirationId");
+    if (event.undoneAtMs !== null)
+      requireSafeNonNegative(event.undoneAtMs, "score event undoneAtMs");
+  }
+  for (const event of value.cardEvents) {
+    if (!isRecord(event)) throw new Error("Stored card event is invalid.");
+    requireOpaque(event.id, "card event id");
+    requireTeam(event.team);
+    if (event.playerKey !== null) requireOpaque(event.playerKey, "card event playerKey");
+    if (event.playerNumber !== null)
+      requireInteger(event.playerNumber, 0, 99, "card event playerNumber");
+    if (!["blue", "yellow", "red", "ejection"].includes(event.cardType))
+      throw new Error("Stored card type is invalid.");
+    requireSafeNonNegative(event.createdAtMs, "card event createdAtMs");
+  }
+  if (!isRecord(value.players)) throw new Error("Stored players are invalid.");
+  for (const [key, player] of Object.entries(value.players)) {
+    requireOpaque(key, "player key");
+    if (!isRecord(player) || player.key !== key || !["home", "away"].includes(player.team))
+      throw new Error("Stored player is invalid.");
+    if (player.playerNumber !== null) requireInteger(player.playerNumber, 0, 99, "player number");
+    if (!Array.isArray(player.segments)) throw new Error("Stored penalty segments are invalid.");
+    for (const segment of player.segments) {
+      if (!isRecord(segment)) throw new Error("Stored penalty segment is invalid.");
+      requireOpaque(segment.id, "penalty segment id");
+      if (!["blue", "yellow", "red"].includes(segment.cardType))
+        throw new Error("Stored penalty card type is invalid.");
+      requireInteger(segment.remainingMs, 0, SHARED_LIMITS.clock.maxMs, "penalty remainingMs");
+      if (typeof segment.expirableByScore !== "boolean")
+        throw new Error("Stored penalty expiration flag is invalid.");
+    }
+  }
+  for (const pending of value.pendingExpirations) {
+    if (
+      !isRecord(pending) ||
+      !["home", "away"].includes(pending.penalizedTeam) ||
+      !["home", "away"].includes(pending.benefitingTeam)
+    )
+      throw new Error("Stored pending expiration is invalid.");
+    requireOpaque(pending.id, "pending expiration id");
+    if (pending.reason !== "score" && pending.reason !== "flag-catch")
+      throw new Error("Stored pending expiration reason is invalid.");
+    requireSafeNonNegative(pending.createdAtMs, "pending expiration createdAtMs");
+    if (
+      !Array.isArray(pending.candidatePlayerKeys) ||
+      pending.candidatePlayerKeys.some(
+        (key) => !validateOpaqueIdentifier(key, "candidatePlayerKey").ok,
+      )
+    )
+      throw new Error("Stored candidate player keys are invalid.");
+    requireInteger(pending.expireMs, 0, SHARED_LIMITS.clock.maxMs, "pending expiration expireMs");
+    if (pending.resolvedAtMs !== null)
+      requireSafeNonNegative(pending.resolvedAtMs, "pending resolvedAtMs");
+    if (pending.resolvedPlayerKey !== null)
+      requireOpaque(pending.resolvedPlayerKey, "resolvedPlayerKey");
+  }
+  for (const release of value.recentReleases) {
+    if (!isRecord(release)) throw new Error("Stored release is invalid.");
+    requireOpaque(release.id, "release id");
+    requireTeam(release.team);
+    requireOpaque(release.playerKey, "release playerKey");
+    if (release.playerNumber !== null)
+      requireInteger(release.playerNumber, 0, 99, "release playerNumber");
+    requireSafeNonNegative(release.releasedAtMs, "release releasedAtMs");
+    if (release.reason !== "served" && release.reason !== "expired")
+      throw new Error("Stored release reason is invalid.");
+  }
+  if (value.flagCatch !== null) {
+    if (!isRecord(value.flagCatch)) throw new Error("Stored flag catch is invalid.");
+    requireTeam(value.flagCatch.team);
+    requireSafeNonNegative(value.flagCatch.createdAtMs, "flagCatch.createdAtMs");
+  }
+  if (!isRecord(value.timeouts) || !isRecord(value.timeouts.home) || !isRecord(value.timeouts.away))
+    throw new Error("Stored timeouts are invalid.");
+  if (
+    typeof value.timeouts.home.used !== "boolean" ||
+    typeof value.timeouts.away.used !== "boolean"
+  )
+    throw new Error("Stored timeout usage is invalid.");
+  if (value.timeouts.active !== null) {
+    if (
+      !isRecord(value.timeouts.active) ||
+      !["home", "away"].includes(value.timeouts.active.team) ||
+      typeof value.timeouts.active.running !== "boolean"
+    )
+      throw new Error("Stored active timeout is invalid.");
+    requireInteger(
+      value.timeouts.active.remainingMs,
+      0,
+      SHARED_LIMITS.clock.maxMs,
+      "active timeout remainingMs",
+    );
+  }
+  if (!isRecord(value.nextUnknownPlayerId)) throw new Error("Stored player counter is invalid.");
+  requireInteger(value.nextUnknownPlayerId.home, 0, Number.MAX_SAFE_INTEGER, "next home player id");
+  requireInteger(value.nextUnknownPlayerId.away, 0, Number.MAX_SAFE_INTEGER, "next away player id");
+}
+
+function validateStoredSession(value: unknown): asserts value is StoredSession {
+  if (
+    !isRecord(value) ||
+    typeof value.sessionHash !== "string" ||
+    !/^[a-f0-9]{64}$/u.test(value.sessionHash) ||
+    (value.browserId !== null && !validateOpaqueIdentifier(value.browserId, "browserId").ok) ||
+    typeof value.connected !== "boolean"
+  )
+    throw new Error("Stored session is invalid.");
+  requireSafeNonNegative(value.lastConnectedAtMs, "session lastConnectedAtMs");
+  if (value.lastDisconnectedAtMs !== null)
+    requireSafeNonNegative(value.lastDisconnectedAtMs, "session lastDisconnectedAtMs");
+}
+
+function validateStoredOperation(
+  operationId: string,
+  value: unknown,
+): asserts value is StoredOperation {
+  if (!isRecord(value) || typeof value.fingerprint !== "string" || value.fingerprint.length === 0)
+    throw new Error("Stored operation is invalid.");
+  if (
+    value.status !== "accepted" &&
+    value.status !== "rejected" &&
+    value.status !== "causally-blocked"
+  )
+    throw new Error("Stored operation status is invalid.");
+  const command = parseGameCommand(value.command);
+  if (!command.ok) throw new Error(`Stored operation command is invalid: ${command.error}`);
+  value.command = command.command;
+  requireSafeNonNegative(value.acceptedAtMs, "operation acceptedAtMs");
+  requireSafeNonNegative(value.clientSentAtMs, "operation clientSentAtMs");
+  if (!Array.isArray(value.causalPredecessorIds))
+    throw new Error("Stored operation causal references are invalid.");
+  const seen = new Set<string>();
+  for (const predecessor of value.causalPredecessorIds) {
+    requireOpaque(predecessor, "causalPredecessorId");
+    if (predecessor === operationId || seen.has(predecessor))
+      throw new Error("Stored operation causal references are invalid.");
+    seen.add(predecessor);
+  }
+  const expectedFingerprint = operationFingerprint({
+    operationId,
+    workflow: "ad-hoc",
+    clientOriginAtMs: value.clientSentAtMs,
+    causalPredecessorIds: value.causalPredecessorIds,
+    payload: value.command,
+  });
+  if (value.fingerprint !== expectedFingerprint)
+    throw new Error("Stored operation fingerprint is invalid.");
+}
+
+function hasStoredCausalCycle(
+  id: string,
+  graph: ReadonlyMap<string, readonly string[]>,
+  active: Set<string>,
+  visited: Set<string>,
+): boolean {
+  if (active.has(id)) return true;
+  if (visited.has(id)) return false;
+  active.add(id);
+  for (const predecessor of graph.get(id) ?? [])
+    if (graph.has(predecessor) && hasStoredCausalCycle(predecessor, graph, active, visited))
+      return true;
+  active.delete(id);
+  visited.add(id);
+  return false;
+}
+
+function requireOpaque(value: unknown, field: string): asserts value is string {
+  const result = validateOpaqueIdentifier(value, field);
+  if (!result.ok) throw new Error(result.error);
+}
+function requireSafeNonNegative(value: unknown, field: string): asserts value is number {
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0)
+    throw new Error(`${field} is invalid.`);
+}
+function requireInteger(
+  value: unknown,
+  minimum: number,
+  maximum: number,
+  field: string,
+): asserts value is number {
+  if (
+    typeof value !== "number" ||
+    !Number.isSafeInteger(value) ||
+    value < minimum ||
+    value > maximum
+  )
+    throw new Error(`${field} is invalid.`);
+}
+function requireText(value: unknown, max: number, field: string): asserts value is string {
+  if (!normalizeBoundedText(value, max, field).ok) throw new Error(`${field} is invalid.`);
+}
+function requireTeam(value: unknown): asserts value is "home" | "away" {
+  if (value !== "home" && value !== "away") throw new Error("Stored team is invalid.");
+}
+function isRecord(value: unknown): value is Record<string, any> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function hasSession(game: StoredAdHocGame, sessionId: string): boolean {
@@ -711,7 +1221,92 @@ function validateColor(value: unknown, fallback: string, field: string) {
 }
 
 function canonicalOperation(operation: AdHocOperation): string {
-  return JSON.stringify([operation.clientSentAtMs, operation.command]);
+  return JSON.stringify([
+    "ad-hoc",
+    operation.clientSentAtMs,
+    operation.command,
+    [...(operation.causalPredecessorIds ?? [])],
+  ]);
+}
+
+function operationFingerprint(operation: ControllerSynchronizationOperation<GameCommand>): string {
+  return canonicalOperation({
+    id: operation.operationId,
+    clientSentAtMs: operation.clientOriginAtMs,
+    command: operation.payload,
+    workflow: "ad-hoc",
+    causalPredecessorIds: operation.causalPredecessorIds,
+  });
+}
+
+function parseAdHocOperations(
+  operations: readonly AdHocOperation[],
+):
+  | { ok: true; operations: readonly ControllerSynchronizationOperation<GameCommand>[] }
+  | { ok: false; error: string } {
+  const transport = validateControllerReplay(operations, "ad-hoc");
+  if (!transport.ok) return transport;
+  const parsed: ControllerSynchronizationOperation<GameCommand>[] = [];
+  for (const operation of transport.operations) {
+    if (typeof operation.payload !== "object" || operation.payload === null) {
+      return { ok: false, error: "Replay command must be an object." };
+    }
+    const command = parseGameCommand(operation.payload as Record<string, unknown>);
+    if (!command.ok) return { ok: false, error: command.error };
+    parsed.push({ ...operation, payload: command.command });
+  }
+  return { ok: true, operations: parsed };
+}
+
+function rejectedOperation(
+  operation: ControllerSynchronizationOperation<GameCommand>,
+  nowMs: number,
+  detail: string,
+  status: "rejected" | "causally-blocked",
+): StoredOperation {
+  return {
+    fingerprint: operationFingerprint(operation),
+    command: structuredClone(operation.payload),
+    acceptedAtMs: nowMs,
+    clientSentAtMs: operation.clientOriginAtMs,
+    causalPredecessorIds: [...operation.causalPredecessorIds],
+    status,
+    detail,
+  };
+}
+
+function rebuildAdHocState(game: StoredAdHocGame, rules: AdHocIqaGameRules): GameState | null {
+  const baselineIds = new Set(game.replayBaselineOperationIds ?? []);
+  const accepted = Object.entries(game.operations)
+    .filter(([operationId]) => !baselineIds.has(operationId))
+    .filter(([, operation]) => operation.status === undefined || operation.status === "accepted")
+    .map(([operationId, operation]) => ({
+      operationId,
+      workflow: "ad-hoc" as const,
+      clientOriginAtMs: operation.clientSentAtMs ?? operation.acceptedAtMs,
+      causalPredecessorIds: [...(operation.causalPredecessorIds ?? [])],
+      payload: operation.command,
+    }));
+  const acceptedIds = new Set([
+    ...baselineIds,
+    ...accepted.map((operation) => operation.operationId),
+  ]);
+  const eligible = accepted.filter((operation) =>
+    operation.causalPredecessorIds.every((predecessor) => acceptedIds.has(predecessor)),
+  );
+  const ordered = orderControllerOperations(eligible);
+  if (!ordered.ok) return null;
+  let state = structuredClone(game.initialState ?? game.state) as GameState;
+  for (const operation of ordered.operations) {
+    let generated = 0;
+    state = rules.apply({
+      state,
+      command: operation.payload,
+      nowMs: operation.clientOriginAtMs,
+      idGenerator: () => `${operation.operationId}:${++generated}`,
+    });
+  }
+  return state;
 }
 
 function digest(value: string): string {
@@ -719,7 +1314,15 @@ function digest(value: string): string {
 }
 
 function cloneStoredGame(game: StoredAdHocGame): StoredAdHocGame {
-  return structuredClone(game) as StoredAdHocGame;
+  const cloned = structuredClone(game) as StoredAdHocGame;
+  cloned.replayBaselineOperationIds ??= [];
+  for (const [operationId, operation] of Object.entries(cloned.operations)) {
+    operation.clientSentAtMs ??= operation.acceptedAtMs;
+    operation.causalPredecessorIds ??= [];
+    operation.status ??= "accepted";
+    cloned.operations[operationId] = operation;
+  }
+  return validateStoredGame(cloned);
 }
 
 function unavailable(): AdHocAccessResult {

--- a/src/lib/controller-reconnect.ts
+++ b/src/lib/controller-reconnect.ts
@@ -20,6 +20,11 @@ import {
   validateIntegerInRange,
   validateOpaqueIdentifier,
 } from "@/lib/validation-policy";
+import {
+  projectControllerReplayRetry,
+  orderControllerOperations,
+  validateControllerReplay,
+} from "@/lib/controller-synchronization";
 
 export const CONTROLLER_REPLICA_VERSION = "controller-replica-v3" as const;
 export const CONTROLLER_REPLICA_STORAGE_KEY = "quadball:event-controller-replica";
@@ -40,6 +45,7 @@ export type ControllerActionOutcomeStatus =
   | "terminally-rejected";
 
 export type PendingControllerAction = {
+  workflow?: "event";
   eventGameId: string;
   intent: LiveEventControllerIntent;
   causalPredecessorIds: readonly string[];
@@ -55,6 +61,7 @@ export type PendingControllerAction = {
 
 export type ControllerReplicaState = {
   version: typeof CONTROLLER_REPLICA_VERSION;
+  workflow?: "event";
   eventGameId: string;
   authoritativeProjection: ControllerProjection;
   projection: ControllerProjection;
@@ -88,6 +95,7 @@ export type ControllerReplicaLoad = {
 };
 
 export type ControllerReplayBatch = {
+  workflow?: "event";
   batchId: string;
   replicaGeneration: string;
   session: ControllerSessionAttachment;
@@ -100,6 +108,7 @@ export type ControllerReplayBatch = {
 };
 
 export type ControllerReplayBatchResponse = {
+  workflow?: "event";
   batchId: string;
   replicaGeneration: string;
   session: ControllerSessionAttachment;
@@ -129,6 +138,7 @@ export function createControllerReplica(input: {
   requireIdentifier(deviceId, "deviceId");
   return {
     version: CONTROLLER_REPLICA_VERSION,
+    workflow: "event",
     eventGameId,
     authoritativeProjection: cloneProjection(input.projection),
     projection: cloneProjection(input.projection),
@@ -170,6 +180,7 @@ export function dispatchControllerAction(
   if (existing !== undefined) return { state, action: existing };
   const counter = state.identity.nextCounter;
   const action: PendingControllerAction = {
+    workflow: "event",
     eventGameId: state.eventGameId,
     intent: structuredClone(parsed.value),
     causalPredecessorIds: predecessors,
@@ -221,6 +232,7 @@ export function dispatchControllerClockAction(
   if (existing !== undefined) return { state, action: existing };
   const counter = state.identity.nextCounter;
   const action: PendingControllerAction = {
+    workflow: "event",
     eventGameId: state.eventGameId,
     intent: structuredClone(parsed.value),
     causalPredecessorIds: predecessors,
@@ -278,9 +290,21 @@ export function prepareControllerReplayBatch(
       actionOperationIds: selected.map((action) => action.intent.operationId),
     },
   };
+  const envelope = validateControllerReplay(
+    selected.map((action) => ({
+      id: action.intent.operationId,
+      workflow: "event" as const,
+      clientSentAtMs: action.dispatchedAtMs,
+      causalPredecessorIds: action.causalPredecessorIds,
+      intent: action.intent,
+    })),
+    "event",
+  );
+  if (!envelope.ok) return null;
   return {
     state: nextState,
     batch: {
+      workflow: "event",
       batchId,
       replicaGeneration: state.replicaGeneration,
       session: structuredClone(state.session),
@@ -352,12 +376,9 @@ export function reconcileControllerReplay(
     authoritativeProjection,
     outcomes,
     unacknowledgedBatch: null,
-    pendingActions: pendingActions.filter(
-      (action) =>
-        action.status === "pending" ||
-        action.status === "retryable" ||
-        action.status === "causally-blocked" ||
-        action.status === "held-for-correction",
+    pendingActions: projectControllerReplayRetry(
+      pendingActions,
+      new Set(["pending", "retryable", "causally-blocked", "held-for-correction"]),
     ),
   };
   return reapplyPendingOptimisticActions(reconciled);
@@ -444,6 +465,8 @@ export function parseControllerReplica(
   if (!isRecord(value)) throw new Error("Controller replica must be an object.");
   if (value.version !== CONTROLLER_REPLICA_VERSION)
     throw new Error("Controller replica version is unsupported.");
+  if (value.workflow !== undefined && value.workflow !== "event")
+    throw new Error("Controller replica workflow is invalid.");
   const eventGameId = requireIdentifier(value.eventGameId, "eventGameId");
   if (expectedEventGameId !== undefined && eventGameId !== expectedEventGameId) {
     throw new Error("Controller replica belongs to another Event Game.");
@@ -476,6 +499,7 @@ export function parseControllerReplica(
   }
   const state: ControllerReplicaState = {
     version: CONTROLLER_REPLICA_VERSION,
+    workflow: "event",
     eventGameId,
     authoritativeProjection,
     projection,
@@ -560,6 +584,8 @@ export function persistControllerReplica(
 export function validateControllerReplica(state: ControllerReplicaState): void {
   if (state.version !== CONTROLLER_REPLICA_VERSION)
     throw new Error("Controller replica version is unsupported.");
+  if (state.workflow !== undefined && state.workflow !== "event")
+    throw new Error("Controller replica workflow is invalid.");
   requireIdentifier(state.eventGameId, "eventGameId");
   parseProjection(state.authoritativeProjection);
   parseProjection(state.projection);
@@ -802,6 +828,17 @@ function validateCausalGraph(state: ControllerReplicaState) {
     if (hasCausalCycle(action.intent.operationId, state.pendingActions, new Set()))
       throw new Error("Controller causal graph contains a cycle.");
   }
+  const pendingIds = new Set(state.pendingActions.map((action) => action.intent.operationId));
+  const ordered = orderControllerOperations(
+    state.pendingActions.map((action) => ({
+      operationId: action.intent.operationId,
+      workflow: "event" as const,
+      clientOriginAtMs: action.dispatchedAtMs,
+      causalPredecessorIds: action.causalPredecessorIds.filter((id) => pendingIds.has(id)),
+      payload: action.intent,
+    })),
+  );
+  if (!ordered.ok) throw new Error(ordered.error);
 }
 
 function validateDerivedProjection(state: ControllerReplicaState) {
@@ -873,6 +910,8 @@ function parsePendingAction(
 ): PendingControllerAction {
   if (!isRecord(value) || value.eventGameId !== eventGameId)
     throw new Error("Pending action has the wrong Event Game.");
+  if (value.workflow !== undefined && value.workflow !== "event")
+    throw new Error("Pending action workflow is invalid.");
   const intent = parseLiveEventControllerIntent(value.intent);
   if (!intent.ok) throw new Error(intent.error);
   if (!Array.isArray(value.causalPredecessorIds))
@@ -902,6 +941,11 @@ function parsePendingAction(
   const predecessors = value.causalPredecessorIds.map((candidate) =>
     requireIdentifier(candidate, "causalPredecessorId"),
   );
+  if (
+    new Set(predecessors).size !== predecessors.length ||
+    predecessors.includes(intent.value.operationId)
+  )
+    throw new Error("Pending action causal predecessors are invalid.");
   if (!isRecord(value.identity)) throw new Error("Pending action identity is invalid.");
   const identityDeviceId = requireIdentifier(value.identity.deviceId, "action.identity.deviceId");
   const identityCounter = validateIntegerInRange(
@@ -915,6 +959,7 @@ function parsePendingAction(
     throw new Error("Pending action identity is inconsistent.");
   }
   return {
+    workflow: "event",
     eventGameId,
     intent: intent.value,
     causalPredecessorIds: predecessors,

--- a/src/lib/controller-synchronization.test.ts
+++ b/src/lib/controller-synchronization.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test } from "bun:test";
+import {
+  createControllerReplayAcknowledgement,
+  projectControllerReplayRetry,
+  resolveControllerBatch,
+  validateControllerReplay,
+  type ControllerSynchronizationOperation,
+} from "@/lib/controller-synchronization";
+
+type Payload = { value: number };
+const operation = (
+  id: string,
+  value: number,
+  predecessors: readonly string[] = [],
+): ControllerSynchronizationOperation<Payload> => ({
+  operationId: id,
+  workflow: "ad-hoc",
+  clientOriginAtMs: value,
+  causalPredecessorIds: predecessors,
+  payload: { value },
+});
+
+describe("shared Controller synchronization boundary", () => {
+  test("resolves causal order independently of incoming order and keeps unrelated work", () => {
+    const results = [
+      [operation("child", 2, ["parent"]), operation("unrelated", 1), operation("parent", 3)],
+      [operation("parent", 3), operation("unrelated", 1), operation("child", 2, ["parent"])],
+    ].map((operations) => resolveControllerBatch({ operations, retainedStatuses: new Map() }));
+    for (const resolution of results) {
+      expect(resolution.ordered.map((entry) => entry.operationId)).toEqual([
+        "unrelated",
+        "parent",
+        "child",
+      ]);
+      expect(resolution.statuses.get("child")).toBe("accepted");
+    }
+  });
+
+  test("rejects missing/cyclic predecessors and blocks only descendants of retained rejection", () => {
+    const operations = [
+      operation("missing-child", 1, ["missing"]),
+      operation("descendant", 2, ["missing-child"]),
+      operation("independent", 3),
+      operation("cycle-a", 4, ["cycle-b"]),
+      operation("cycle-b", 5, ["cycle-a"]),
+    ];
+    for (const resolution of [
+      resolveControllerBatch({ operations, retainedStatuses: new Map() }),
+      resolveControllerBatch({
+        operations: [...operations].reverse(),
+        retainedStatuses: new Map(),
+      }),
+    ]) {
+      expect(resolution.statuses.get("missing-child")).toBe("rejected");
+      expect(resolution.statuses.get("descendant")).toBe("causally-blocked");
+      expect(resolution.statuses.get("independent")).toBe("accepted");
+      expect(resolution.statuses.get("cycle-a")).toBe("rejected");
+      expect(resolution.statuses.get("cycle-b")).toBe("rejected");
+    }
+    const retained = resolveControllerBatch({
+      operations: [operation("descendant", 2, ["rejected"]), operation("independent", 3)],
+      retainedStatuses: new Map([["rejected", "rejected"]]),
+    });
+    expect(retained.statuses.get("descendant")).toBe("causally-blocked");
+    expect(retained.statuses.get("independent")).toBe("accepted");
+  });
+
+  test("uses one workflow-scoped envelope contract for Event and Ad Hoc", () => {
+    expect(
+      validateControllerReplay(
+        [{ id: "event-op", workflow: "event", clientSentAtMs: 1, intent: { type: "event" } }],
+        "event",
+      ).ok,
+    ).toBe(true);
+    expect(
+      validateControllerReplay(
+        [{ id: "adhoc-op", workflow: "ad-hoc", clientSentAtMs: 1, command: { type: "adhoc" } }],
+        "ad-hoc",
+      ).ok,
+    ).toBe(true);
+    expect(
+      validateControllerReplay(
+        [{ id: "event-op", workflow: "ad-hoc", clientSentAtMs: 1, intent: {} }],
+        "event",
+      ).ok,
+    ).toBe(false);
+    expect(
+      validateControllerReplay(
+        [
+          {
+            id: "cycle-a",
+            workflow: "ad-hoc",
+            clientSentAtMs: 1,
+            causalPredecessorIds: ["cycle-b"],
+            command: {},
+          },
+          {
+            id: "cycle-b",
+            workflow: "ad-hoc",
+            clientSentAtMs: 2,
+            causalPredecessorIds: ["cycle-a"],
+            command: {},
+          },
+          {
+            id: "cycle-descendant",
+            workflow: "ad-hoc",
+            clientSentAtMs: 3,
+            causalPredecessorIds: ["cycle-a"],
+            command: {},
+          },
+        ],
+        "ad-hoc",
+      ).ok,
+    ).toBe(false);
+  });
+
+  test("shares acknowledgement and retry projection semantics across workflows", () => {
+    const acknowledgement = createControllerReplayAcknowledgement({
+      workflow: "event",
+      acknowledgedOperationIds: ["event-op"],
+      outcomes: [{ operationId: "event-op", workflow: "event", status: "accepted" }],
+    });
+    expect(acknowledgement.acknowledgedOperationIds).toEqual(["event-op"]);
+    expect(
+      projectControllerReplayRetry(
+        [{ status: "accepted" }, { status: "retryable" }, { status: "causally-blocked" }],
+        new Set(["retryable", "causally-blocked"]),
+      ),
+    ).toHaveLength(2);
+  });
+});

--- a/src/lib/controller-synchronization.ts
+++ b/src/lib/controller-synchronization.ts
@@ -1,0 +1,312 @@
+import { SHARED_LIMITS, validateOpaqueIdentifier } from "@/lib/validation-policy";
+
+/** The workflow discriminator keeps Ad Hoc replay out of Event authority. */
+export const CONTROLLER_WORKFLOW_VERSION = "controller-workflow-v1" as const;
+export type ControllerWorkflowKind = "event" | "ad-hoc";
+
+export type ControllerOperationOutcomeStatus =
+  | "accepted"
+  | "duplicate"
+  | "rejected"
+  | "causally-blocked";
+
+export type ControllerOperationOutcome = {
+  operationId: string;
+  workflow: ControllerWorkflowKind;
+  status: ControllerOperationOutcomeStatus;
+  detail?: string;
+};
+
+export type ControllerSynchronizationOperation<T> = {
+  operationId: string;
+  workflow: ControllerWorkflowKind;
+  clientOriginAtMs: number;
+  causalPredecessorIds: readonly string[];
+  payload: T;
+};
+
+export type ControllerReplayValidation =
+  | { ok: true; operations: readonly ControllerSynchronizationOperation<unknown>[] }
+  | { ok: false; error: string };
+
+export type ControllerBatchResolution<T> = {
+  ordered: readonly ControllerSynchronizationOperation<T>[];
+  statuses: ReadonlyMap<string, "accepted" | "rejected" | "causally-blocked">;
+  details: ReadonlyMap<string, string>;
+};
+
+export type ControllerTopologyResult<T> = {
+  ordered: readonly ControllerSynchronizationOperation<T>[];
+  missingOperationIds: readonly string[];
+  cyclicOperationIds: readonly string[];
+};
+
+export type ControllerReplayAcknowledgement = {
+  workflow: ControllerWorkflowKind;
+  acknowledgedOperationIds: readonly string[];
+  outcomes: readonly ControllerOperationOutcome[];
+};
+
+export function createControllerReplayAcknowledgement(input: {
+  workflow: ControllerWorkflowKind;
+  acknowledgedOperationIds: readonly string[];
+  outcomes: readonly ControllerOperationOutcome[];
+}): ControllerReplayAcknowledgement {
+  const ids = new Set<string>();
+  for (const operationId of input.acknowledgedOperationIds) {
+    if (!validateOpaqueIdentifier(operationId, "operationId").ok || ids.has(operationId))
+      throw new Error("Controller acknowledgement identities are invalid.");
+    ids.add(operationId);
+  }
+  for (const outcome of input.outcomes) {
+    if (outcome.workflow !== input.workflow || !ids.has(outcome.operationId))
+      throw new Error("Controller acknowledgement workflow is invalid.");
+  }
+  return {
+    workflow: input.workflow,
+    acknowledgedOperationIds: [...input.acknowledgedOperationIds],
+    outcomes: structuredClone(input.outcomes),
+  };
+}
+
+export function projectControllerReplayRetry<T extends { status: string }>(
+  operations: readonly T[],
+  retryableStatuses: ReadonlySet<string>,
+): readonly T[] {
+  return operations.filter((operation) => retryableStatuses.has(operation.status));
+}
+
+/**
+ * Validate the transport-shaped part of a replay before a store mutation. The
+ * operation payload is intentionally left to the owning deep module.
+ */
+export function validateControllerReplay(
+  value: unknown,
+  workflow: ControllerWorkflowKind,
+): ControllerReplayValidation {
+  if (!Array.isArray(value)) return { ok: false, error: "Replay operations must be an array." };
+  if (value.length === 0) return { ok: false, error: "Replay operations must not be empty." };
+  if (value.length > SHARED_LIMITS.replay.maxControlActions) {
+    return { ok: false, error: "Replay operations exceed the configured limit." };
+  }
+
+  const operationIds = new Set<string>();
+  const operations: ControllerSynchronizationOperation<unknown>[] = [];
+  for (const candidate of value) {
+    if (!isRecord(candidate)) return { ok: false, error: "Replay operation must be an object." };
+    const operationId = validateOpaqueIdentifier(
+      candidate.id ?? candidate.operationId,
+      "operationId",
+    );
+    if (!operationId.ok) return { ok: false, error: operationId.error };
+    if (operationIds.has(operationId.value)) {
+      return { ok: false, error: "Replay operation identities must be unique." };
+    }
+    operationIds.add(operationId.value);
+    if (
+      typeof candidate.clientSentAtMs !== "number" ||
+      !Number.isSafeInteger(candidate.clientSentAtMs) ||
+      candidate.clientSentAtMs < 0
+    ) {
+      return { ok: false, error: "Replay operation timestamp is invalid." };
+    }
+    if (candidate.workflow !== undefined && candidate.workflow !== workflow) {
+      return { ok: false, error: "Replay workflow does not match the subscribed Controller." };
+    }
+    const predecessors = candidate.causalPredecessorIds ?? [];
+    if (
+      !Array.isArray(predecessors) ||
+      predecessors.length > SHARED_LIMITS.replay.maxControlActions ||
+      predecessors.some(
+        (predecessor) => !validateOpaqueIdentifier(predecessor, "causalPredecessorId").ok,
+      ) ||
+      new Set(predecessors).size !== predecessors.length ||
+      predecessors.includes(operationId.value)
+    ) {
+      return { ok: false, error: "Replay causal predecessors are invalid." };
+    }
+    operations.push({
+      operationId: operationId.value,
+      workflow,
+      clientOriginAtMs: candidate.clientSentAtMs,
+      causalPredecessorIds: [...predecessors],
+      payload: candidate.command ?? candidate.intent,
+    });
+  }
+  const externalPredecessors = new Set(
+    operations.flatMap((operation) =>
+      operation.causalPredecessorIds.filter((predecessor) => !operationIds.has(predecessor)),
+    ),
+  );
+  const topology = topologicallyOrderControllerOperations(operations, {
+    knownOperationIds: externalPredecessors,
+  });
+  if (topology.cyclicOperationIds.length > 0) {
+    return { ok: false, error: "Replay causal predecessors contain a cycle." };
+  }
+  return { ok: true, operations };
+}
+
+/**
+ * Resolve a complete incoming batch against retained workflow state. The
+ * caller supplies retained statuses; the incoming transport order is never
+ * used as causal order.
+ */
+export function resolveControllerBatch<T>(input: {
+  operations: readonly ControllerSynchronizationOperation<T>[];
+  retainedStatuses: ReadonlyMap<string, "accepted" | "rejected" | "causally-blocked">;
+}): ControllerBatchResolution<T> {
+  const statuses = new Map<string, "accepted" | "rejected" | "causally-blocked">();
+  const details = new Map<string, string>();
+  const byId = new Map(input.operations.map((operation) => [operation.operationId, operation]));
+  for (const operation of input.operations) {
+    const predecessors = new Set(operation.causalPredecessorIds);
+    if (predecessors.has(operation.operationId)) {
+      statuses.set(operation.operationId, "rejected");
+      details.set(operation.operationId, "Causal cycle.");
+    }
+    if (
+      [...predecessors].some(
+        (predecessor) => !byId.has(predecessor) && !input.retainedStatuses.has(predecessor),
+      )
+    ) {
+      statuses.set(operation.operationId, "rejected");
+      details.set(operation.operationId, "Causal predecessor is not retained.");
+    }
+  }
+  const topology = topologicallyOrderControllerOperations(input.operations, {
+    knownOperationIds: new Set(input.retainedStatuses.keys()),
+    excludedOperationIds: new Set(statuses.keys()),
+  });
+  for (const operationId of topology.cyclicOperationIds) {
+    statuses.set(operationId, "rejected");
+    details.set(operationId, "Causal cycle.");
+  }
+  for (const operation of topology.ordered) {
+    if (statuses.has(operation.operationId)) continue;
+    const blocked = operation.causalPredecessorIds.find((predecessor) => {
+      const incomingStatus = statuses.get(predecessor);
+      const retainedStatus = input.retainedStatuses.get(predecessor);
+      return (
+        incomingStatus === "rejected" ||
+        incomingStatus === "causally-blocked" ||
+        (incomingStatus === undefined && retainedStatus !== "accepted")
+      );
+    });
+    if (blocked !== undefined) {
+      statuses.set(operation.operationId, "causally-blocked");
+      details.set(operation.operationId, "Causal predecessor was rejected.");
+    } else {
+      statuses.set(operation.operationId, "accepted");
+    }
+  }
+  return { ordered: topology.ordered, statuses, details };
+}
+
+/** One deterministic Kahn traversal shared by Event and Ad Hoc policy layers. */
+export function topologicallyOrderControllerOperations<T>(
+  operations: readonly ControllerSynchronizationOperation<T>[],
+  options: {
+    knownOperationIds?: ReadonlySet<string>;
+    excludedOperationIds?: ReadonlySet<string>;
+  } = {},
+): ControllerTopologyResult<T> {
+  const knownOperationIds = options.knownOperationIds ?? new Set<string>();
+  const excludedOperationIds = options.excludedOperationIds ?? new Set<string>();
+  const byId = new Map(operations.map((operation) => [operation.operationId, operation]));
+  const missingOperationIds = operations
+    .filter(
+      (operation) =>
+        !excludedOperationIds.has(operation.operationId) &&
+        operation.causalPredecessorIds.some(
+          (predecessor) => !byId.has(predecessor) && !knownOperationIds.has(predecessor),
+        ),
+    )
+    .map((operation) => operation.operationId);
+  const failed = new Set([...excludedOperationIds, ...missingOperationIds]);
+  const indegree = new Map<string, number>();
+  const dependents = new Map<string, string[]>();
+  for (const operation of operations) {
+    if (failed.has(operation.operationId)) continue;
+    let count = 0;
+    for (const predecessor of new Set(operation.causalPredecessorIds)) {
+      if (!byId.has(predecessor) || failed.has(predecessor)) continue;
+      count += 1;
+      dependents.set(predecessor, [...(dependents.get(predecessor) ?? []), operation.operationId]);
+    }
+    indegree.set(operation.operationId, count);
+  }
+  const ready = operations
+    .filter(
+      (operation) =>
+        !failed.has(operation.operationId) && indegree.get(operation.operationId) === 0,
+    )
+    .sort(compareControllerOperations);
+  const ordered: ControllerSynchronizationOperation<T>[] = [];
+  while (ready.length > 0) {
+    const operation = ready.shift();
+    if (operation === undefined) break;
+    ordered.push(operation);
+    for (const dependentId of dependents.get(operation.operationId) ?? []) {
+      const remaining = (indegree.get(dependentId) ?? 0) - 1;
+      indegree.set(dependentId, remaining);
+      if (remaining === 0) {
+        const dependent = byId.get(dependentId);
+        if (dependent !== undefined) ready.push(dependent);
+        ready.sort(compareControllerOperations);
+      }
+    }
+  }
+  const orderedIds = new Set(ordered.map((operation) => operation.operationId));
+  return {
+    ordered,
+    missingOperationIds,
+    cyclicOperationIds: operations
+      .filter(
+        (operation) => !failed.has(operation.operationId) && !orderedIds.has(operation.operationId),
+      )
+      .map((operation) => operation.operationId),
+  };
+}
+
+/**
+ * Return a deterministic causal order. Independent operations are ordered by
+ * their content-bound origin timestamp and opaque identity, so two relays
+ * receiving the same accepted set rebuild the same current state.
+ */
+export function orderControllerOperations<T>(
+  operations: readonly ControllerSynchronizationOperation<T>[],
+):
+  | { ok: true; operations: readonly ControllerSynchronizationOperation<T>[] }
+  | { ok: false; operationIds: readonly string[]; error: string } {
+  const topology = topologicallyOrderControllerOperations(operations);
+  if (topology.missingOperationIds.length > 0) {
+    return {
+      ok: false,
+      operationIds: topology.missingOperationIds,
+      error: "Causal predecessor is not retained.",
+    };
+  }
+  if (topology.cyclicOperationIds.length > 0) {
+    return {
+      ok: false,
+      operationIds: topology.cyclicOperationIds,
+      error: "Causal cycle.",
+    };
+  }
+  return { ok: true, operations: topology.ordered };
+}
+
+function compareControllerOperations<T>(
+  left: ControllerSynchronizationOperation<T>,
+  right: ControllerSynchronizationOperation<T>,
+) {
+  return (
+    left.clientOriginAtMs - right.clientOriginAtMs ||
+    left.operationId.localeCompare(right.operationId)
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/lib/event-game-action-codecs.ts
+++ b/src/lib/event-game-action-codecs.ts
@@ -22,6 +22,7 @@ import type {
   OfficialOverrideMetadata,
 } from "@/lib/event-game-actions";
 import type { EventGameRecordRoot } from "@/lib/foundation-record-types";
+import { DEFAULT_IQA_SPORTING_RULES } from "@/lib/iqa-game-rules";
 
 const MAX_TIMESTAMP_MS = Number.MAX_SAFE_INTEGER;
 
@@ -53,6 +54,7 @@ export function createDefaultControlActionCodecs(): readonly ControlActionCodec[
 export function createDeterministicTestIqaInterpreter(version: string): IqaGameRulesInterpreter {
   return {
     version,
+    sporting: DEFAULT_IQA_SPORTING_RULES,
     rebuild({ canonicalActions, effectiveFacts }) {
       return {
         interpreterVersion: version,

--- a/src/lib/event-game-actions.ts
+++ b/src/lib/event-game-actions.ts
@@ -1,5 +1,6 @@
 import type { ValidationResult } from "@/lib/validation-policy";
 import type { EventGameLifecyclePhase, EventGameRecordRoot } from "@/lib/foundation-record-types";
+import type { IqaSportingRules } from "@/lib/iqa-game-rules";
 import { canonicalizeJson, sha256 } from "@/lib/event-game-action-json";
 import {
   invalid,
@@ -260,6 +261,7 @@ export type IqaGameRulesRebuildInput = {
 export type IqaGameRulesInterpreter = {
   version: string;
   rebuild(input: IqaGameRulesRebuildInput): unknown;
+  sporting?: IqaSportingRules;
 };
 
 export type ControlActionCodec<TPayload = unknown> = {

--- a/src/lib/game-page-support.ts
+++ b/src/lib/game-page-support.ts
@@ -1,9 +1,10 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
-  createPersistedControllerSession,
-  getControllerSessionStorageKey,
-  parsePersistedControllerSession,
-} from "@/lib/controller-session";
+  getAdHocControllerSessionStorageKey,
+  parseAdHocControllerSession,
+  serializeAdHocControllerSession,
+  type AdHocPendingOperation,
+} from "@/lib/ad-hoc-controller-session";
 import { applyGameCommand } from "@/lib/game-engine";
 import type {
   ControllerRole,
@@ -13,7 +14,8 @@ import type {
   PlayerPenaltyState,
   TeamId,
 } from "@/lib/game-types";
-import type { ClientCommandEnvelope, ServerWsMessage } from "@/lib/ws-protocol";
+import { orderControllerOperations } from "@/lib/controller-synchronization";
+import type { ServerWsMessage } from "@/lib/ws-protocol";
 
 export type ConnectionState = "connecting" | "online" | "offline" | "local-only";
 export type PendingReleaseAction = {
@@ -38,14 +40,15 @@ const RELEASE_EVENT_VISIBLE_MS = 30_000;
 export function useGameConnection({ gameId, role }: { gameId: string; role: ControllerRole }) {
   const wsUrl = useMemo(createWebSocketUrl, []);
   const [baseState, setBaseState] = useState<GameState | null>(null);
+  const authoritativeStateRef = useRef<GameState | null>(null);
   const [controlQr, setControlQr] = useState<string | null>(null);
   const [clockOffsetMs, setClockOffsetMs] = useState(0);
   const [connectionState, setConnectionState] = useState<ConnectionState>("connecting");
   const [error, setError] = useState<string | null>(null);
   const [pendingCommandsCount, setPendingCommandsCount] = useState(0);
   const [localOnlyMode, setLocalOnlyMode] = useState(false);
-
-  const pendingRef = useRef<ClientCommandEnvelope[]>([]);
+  const pendingRef = useRef<AdHocPendingOperation[]>([]);
+  const outcomesRef = useRef<AdHocControllerOutcomes>({});
   const reconnectTimeoutRef = useRef<number | null>(null);
   const wsRef = useRef<WebSocket | null>(null);
   const commandCounterRef = useRef(0);
@@ -57,47 +60,44 @@ export function useGameConnection({ gameId, role }: { gameId: string; role: Cont
     localOnlyModeRef.current = value;
     setLocalOnlyMode(value);
   }, []);
-
-  const setPendingCommands = useCallback((commands: ClientCommandEnvelope[]) => {
+  const setPendingCommands = useCallback((commands: AdHocPendingOperation[]) => {
     pendingRef.current = commands;
     setPendingCommandsCount(commands.length);
   }, []);
-
   const persistControllerSession = useCallback(
-    (state: GameState, pendingCommands: ClientCommandEnvelope[], commandCounter: number) => {
-      if (role !== "controller") {
-        return;
+    (state: GameState, pendingOperations: AdHocPendingOperation[], operationCounter: number) => {
+      if (role !== "controller") return;
+      try {
+        window.localStorage.setItem(
+          getAdHocControllerSessionStorageKey(gameId),
+          serializeAdHocControllerSession({
+            version: "ad-hoc-controller-session-v1",
+            workflow: "ad-hoc",
+            gameId,
+            state,
+            authoritativeState: authoritativeStateRef.current ?? state,
+            pendingOperations,
+            outcomes: outcomesRef.current,
+            operationCounter,
+            savedAtMs: Date.now(),
+          }),
+        );
+      } catch {
+        // Keep the in-memory replica useful when browser storage is unavailable.
       }
-
-      savePersistedControllerSession({
-        gameId,
-        state,
-        pendingCommands,
-        commandCounter,
-      });
     },
     [gameId, role],
   );
-
   const flushPendingCommands = useCallback(() => {
-    if (role !== "controller") {
+    if (
+      role !== "controller" ||
+      localOnlyModeRef.current ||
+      !subscribedToServerGameRef.current ||
+      wsRef.current?.readyState !== WebSocket.OPEN ||
+      pendingRef.current.length === 0
+    )
       return;
-    }
-
-    if (localOnlyModeRef.current) {
-      return;
-    }
-
-    if (!subscribedToServerGameRef.current) {
-      return;
-    }
-
-    const ws = wsRef.current;
-    if (ws === null || ws.readyState !== WebSocket.OPEN || pendingRef.current.length === 0) {
-      return;
-    }
-
-    ws.send(
+    wsRef.current.send(
       JSON.stringify({
         type: "apply-commands",
         gameId,
@@ -105,32 +105,31 @@ export function useGameConnection({ gameId, role }: { gameId: string; role: Cont
       }),
     );
   }, [gameId, role]);
-
   const reconcileWithServer = useCallback(
     ({
       state,
       serverNowMs,
       ackedCommandIds,
+      operationOutcomes = [],
     }: {
       state: GameState;
       serverNowMs: number;
       ackedCommandIds: string[];
+      operationOutcomes?: readonly AdHocOutcome[];
     }) => {
-      if (ackedCommandIds.length > 0) {
-        const ackedSet = new Set(ackedCommandIds);
-        setPendingCommands(pendingRef.current.filter((command) => !ackedSet.has(command.id)));
-      }
-
+      for (const outcome of operationOutcomes)
+        outcomesRef.current[outcome.operationId] = outcome.status;
+      const settled = new Set([
+        ...ackedCommandIds,
+        ...operationOutcomes.map((outcome) => outcome.operationId),
+      ]);
+      const pending = pendingRef.current.filter((operation) => !settled.has(operation.id));
+      setPendingCommands(pending);
       setClockOffsetMs(serverNowMs - Date.now());
-
-      let reconciled = state;
-
-      for (const command of pendingRef.current) {
-        reconciled = applyLocalEnvelope(reconciled, command);
-      }
-
+      authoritativeStateRef.current = state;
+      const reconciled = applyPendingOperations(state, pending, outcomesRef.current);
       setBaseState(reconciled);
-      persistControllerSession(reconciled, pendingRef.current, commandCounterRef.current);
+      persistControllerSession(reconciled, pending, commandCounterRef.current);
     },
     [persistControllerSession, setPendingCommands],
   );
@@ -138,19 +137,25 @@ export function useGameConnection({ gameId, role }: { gameId: string; role: Cont
   useEffect(() => {
     let cancelled = false;
     let recoveredFromLocal = false;
-
     if (role === "controller") {
       const persisted = loadPersistedControllerSession(gameId);
       if (persisted !== null) {
         recoveredFromLocal = true;
-        setPendingCommands(persisted.pendingCommands);
-        commandCounterRef.current = Math.max(commandCounterRef.current, persisted.commandCounter);
-        setBaseState(persisted.state);
+        setPendingCommands(persisted.pendingOperations);
+        outcomesRef.current = persisted.outcomes;
+        commandCounterRef.current = persisted.operationCounter;
+        authoritativeStateRef.current = persisted.authoritativeState ?? persisted.state;
+        setBaseState(
+          applyPendingOperations(
+            authoritativeStateRef.current,
+            persisted.pendingOperations,
+            persisted.outcomes,
+          ),
+        );
         setConnectionState("offline");
         setError("Recovered local game state. Reconnecting server...");
       }
     }
-
     const fetchInitialSnapshot = async () => {
       try {
         const response = await fetch(`/api/games/${gameId}`);
@@ -159,75 +164,46 @@ export function useGameConnection({ gameId, role }: { gameId: string; role: Cont
             setLocalOnlyState(true);
             setConnectionState("local-only");
             setError(LOCAL_ONLY_MESSAGE);
-            return;
-          }
-
-          setError("Ad Hoc Game unavailable.");
+          } else setError("Ad Hoc Game unavailable.");
           return;
         }
-
         const payload = (await response.json()) as {
           game?: GameView & { controlQr?: string | null };
         };
         if (!cancelled && payload.game !== undefined) {
           setError(null);
           setControlQr(payload.game.controlQr ?? null);
-
-          let reconciled = payload.game.state;
-          for (const command of pendingRef.current) {
-            reconciled = applyLocalEnvelope(reconciled, command);
-          }
-
+          authoritativeStateRef.current = payload.game.state;
+          const reconciled = applyPendingOperations(
+            authoritativeStateRef.current,
+            pendingRef.current,
+            outcomesRef.current,
+          );
           setLocalOnlyState(false);
           setBaseState(reconciled);
           persistControllerSession(reconciled, pendingRef.current, commandCounterRef.current);
         }
       } catch {
         if (!cancelled) {
-          if (role === "controller" && recoveredFromLocal) {
+          if (role === "controller" && recoveredFromLocal)
             setError("Unable to reach server. Continuing locally on this device.");
-            return;
-          }
-
-          setError("Ad Hoc Game unavailable.");
+          else setError("Ad Hoc Game unavailable.");
         }
       }
     };
-
     const connect = () => {
-      if (cancelled) {
-        return;
-      }
-
-      if (localOnlyModeRef.current) {
-        setConnectionState("local-only");
-      } else {
-        setConnectionState("connecting");
-      }
-
+      if (cancelled) return;
+      setConnectionState(localOnlyModeRef.current ? "local-only" : "connecting");
       const ws = new WebSocket(wsUrl);
       wsRef.current = ws;
       subscribedToServerGameRef.current = false;
-
       ws.onopen = () => {
-        if (!localOnlyModeRef.current) {
-          setConnectionState("online");
-        }
-
-        ws.send(
-          JSON.stringify({
-            type: "subscribe-game",
-            gameId,
-          }),
-        );
+        if (!localOnlyModeRef.current) setConnectionState("online");
+        ws.send(JSON.stringify({ type: "subscribe-game", gameId }));
       };
-
       ws.onmessage = (event) => {
         const parsed = parseServerMessage(event.data);
-        if (parsed === null) {
-          return;
-        }
-
+        if (parsed === null) return;
         if (parsed.type === "error") {
           if (role === "controller" && isServerGameUnavailableError(parsed.message)) {
             subscribedToServerGameRef.current = false;
@@ -235,13 +211,9 @@ export function useGameConnection({ gameId, role }: { gameId: string; role: Cont
             setConnectionState("local-only");
             setError(LOCAL_ONLY_MESSAGE);
             ws.close();
-            return;
-          }
-
-          setError(parsed.message);
+          } else setError(parsed.message);
           return;
         }
-
         if (parsed.type === "game-snapshot") {
           subscribedToServerGameRef.current = true;
           setLocalOnlyState(false);
@@ -252,45 +224,31 @@ export function useGameConnection({ gameId, role }: { gameId: string; role: Cont
             state: parsed.game.state,
             serverNowMs: parsed.serverNowMs,
             ackedCommandIds: parsed.ackedCommandIds,
+            operationOutcomes: parsed.operationOutcomes,
           });
           flushPendingCommands();
         }
       };
-
       ws.onclose = () => {
-        if (localOnlyModeRef.current) {
-          setConnectionState("local-only");
-        } else {
-          setConnectionState("offline");
-        }
-
+        setConnectionState(localOnlyModeRef.current ? "local-only" : "offline");
         wsRef.current = null;
         subscribedToServerGameRef.current = false;
         if (!cancelled) {
-          const retryDelay = localOnlyModeRef.current
-            ? LOCAL_ONLY_RETRY_DELAY_MS
-            : NORMAL_RECONNECT_DELAY_MS;
-          reconnectTimeoutRef.current = window.setTimeout(connect, retryDelay);
+          reconnectTimeoutRef.current = window.setTimeout(
+            connect,
+            localOnlyModeRef.current ? LOCAL_ONLY_RETRY_DELAY_MS : NORMAL_RECONNECT_DELAY_MS,
+          );
         }
       };
-
-      ws.onerror = () => {
-        ws.close();
-      };
+      ws.onerror = () => ws.close();
     };
-
     void fetchInitialSnapshot();
     connect();
-
     return () => {
       cancelled = true;
       subscribedToServerGameRef.current = false;
-      if (wsRef.current !== null) {
-        wsRef.current.close();
-      }
-      if (reconnectTimeoutRef.current !== null) {
-        window.clearTimeout(reconnectTimeoutRef.current);
-      }
+      wsRef.current?.close();
+      if (reconnectTimeoutRef.current !== null) window.clearTimeout(reconnectTimeoutRef.current);
     };
   }, [
     flushPendingCommands,
@@ -305,35 +263,31 @@ export function useGameConnection({ gameId, role }: { gameId: string; role: Cont
 
   const dispatchCommand = useCallback(
     (command: GameCommand) => {
-      if (role !== "controller") {
-        return;
-      }
-
+      if (role !== "controller") return;
       setBaseState((previous) => {
-        if (previous === null) {
-          return previous;
-        }
-
+        if (authoritativeStateRef.current === null && previous === null) return previous;
         commandCounterRef.current += 1;
-        const envelope: ClientCommandEnvelope = {
+        const operation: AdHocPendingOperation = {
           id: `${clientInstanceId.current}-${commandCounterRef.current}`,
           clientSentAtMs: Date.now() + clockOffsetMs,
           command,
+          workflow: "ad-hoc",
+          causalPredecessorIds: pendingRef.current.at(-1)?.id
+            ? [pendingRef.current.at(-1)!.id]
+            : [],
         };
-
-        const nextPendingCommands = [...pendingRef.current, envelope];
-        setPendingCommands(nextPendingCommands);
-        const next = applyLocalEnvelope(previous, envelope);
-        persistControllerSession(next, nextPendingCommands, commandCounterRef.current);
-
+        const pending = [...pendingRef.current, operation];
+        setPendingCommands(pending);
+        const authoritative = authoritativeStateRef.current ?? previous;
+        if (authoritative === null) return previous;
+        const next = applyPendingOperations(authoritative, pending, outcomesRef.current);
+        persistControllerSession(next, pending, commandCounterRef.current);
         window.setTimeout(flushPendingCommands, 0);
-
         return next;
       });
     },
     [clockOffsetMs, flushPendingCommands, persistControllerSession, role, setPendingCommands],
   );
-
   return {
     baseState,
     controlQr,
@@ -379,6 +333,7 @@ function parseServerMessage(input: unknown): ServerWsMessage | null {
 
 function isServerGameUnavailableError(message: string) {
   return (
+    message === "Ad Hoc Game unavailable." ||
     message === "Game not found." ||
     message === "Not subscribed to a game." ||
     message === "Command gameId mismatch."
@@ -387,54 +342,76 @@ function isServerGameUnavailableError(message: string) {
 
 function loadPersistedControllerSession(gameId: string) {
   try {
-    const raw = window.localStorage.getItem(getControllerSessionStorageKey(gameId));
+    const raw = window.localStorage.getItem(getAdHocControllerSessionStorageKey(gameId));
     if (raw === null) {
       return null;
     }
 
-    return parsePersistedControllerSession(raw, gameId);
+    const parsed = parseAdHocControllerSession(raw, gameId);
+    if (parsed === null)
+      window.localStorage.removeItem(getAdHocControllerSessionStorageKey(gameId));
+    return parsed;
   } catch {
+    try {
+      window.localStorage.removeItem(getAdHocControllerSessionStorageKey(gameId));
+    } catch {
+      /* best effort */
+    }
     return null;
   }
 }
 
-function savePersistedControllerSession({
-  gameId,
-  state,
-  pendingCommands,
-  commandCounter,
-}: {
-  gameId: string;
-  state: GameState;
-  pendingCommands: ClientCommandEnvelope[];
-  commandCounter: number;
-}) {
-  try {
-    const payload = createPersistedControllerSession({
-      gameId,
-      state,
-      pendingCommands,
-      commandCounter,
-      savedAtMs: Date.now(),
-    });
+type AdHocOutcome = {
+  operationId: string;
+  workflow: "ad-hoc" | "event";
+  status: "accepted" | "duplicate" | "rejected" | "causally-blocked";
+  detail?: string;
+};
+type AdHocControllerOutcomes = Record<string, AdHocOutcome["status"]>;
 
-    window.localStorage.setItem(getControllerSessionStorageKey(gameId), JSON.stringify(payload));
-  } catch {
-    // Best-effort persistence only; keep runtime behavior even if storage is unavailable.
-  }
+function applyPendingOperations(
+  state: GameState,
+  pending: readonly AdHocPendingOperation[],
+  outcomes: Readonly<AdHocControllerOutcomes>,
+): GameState {
+  const pendingIds = new Set(pending.map((operation) => operation.id));
+  const operations = pending
+    .filter((operation) => outcomes[operation.id] === undefined)
+    .filter((operation) =>
+      operation.causalPredecessorIds.every((predecessor) => {
+        if (pendingIds.has(predecessor)) return true;
+        const outcome = outcomes[predecessor];
+        return outcome === "accepted" || outcome === "duplicate";
+      }),
+    )
+    .map((operation) => ({
+      operationId: operation.id,
+      workflow: "ad-hoc" as const,
+      clientOriginAtMs: operation.clientSentAtMs,
+      causalPredecessorIds: operation.causalPredecessorIds.filter((predecessor) =>
+        pendingIds.has(predecessor),
+      ),
+      payload: operation.command,
+    }));
+  const ordered = orderControllerOperations(operations);
+  if (!ordered.ok) return state;
+  return ordered.operations.reduce((current, operation) => {
+    let generated = 0;
+    return applyGameCommand({
+      state: current,
+      command: operation.payload,
+      nowMs: operation.clientOriginAtMs,
+      idGenerator: () => `${operation.operationId}:${++generated}`,
+    });
+  }, state);
 }
 
-function applyLocalEnvelope(state: GameState, envelope: ClientCommandEnvelope): GameState {
-  let idCounter = 0;
-  return applyGameCommand({
-    state,
-    command: envelope.command,
-    nowMs: envelope.clientSentAtMs,
-    idGenerator: () => {
-      idCounter += 1;
-      return `${envelope.id}:${idCounter}`;
-    },
-  });
+export function deriveAdHocOptimisticState(
+  authoritative: GameState,
+  pending: readonly AdHocPendingOperation[],
+  outcomes: Readonly<AdHocControllerOutcomes> = {},
+) {
+  return applyPendingOperations(authoritative, pending, outcomes);
 }
 
 export function navigateTo(path: string) {

--- a/src/lib/iqa-game-rules.test.ts
+++ b/src/lib/iqa-game-rules.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import { createLiveEventGameIqaInterpreter } from "@/lib/live-event-game-control";
+import { DEFAULT_AD_HOC_IQA_RULES } from "@/lib/ad-hoc-games";
+import { createInitialGameState } from "@/lib/game-engine";
+
+describe("shared IQA sporting rules contract", () => {
+  test("Event and Ad Hoc use equivalent common sporting interpretations", () => {
+    const eventRules = createLiveEventGameIqaInterpreter().sporting;
+    if (eventRules === undefined) throw new Error("Event IQA sporting rules are missing");
+    const commands = [
+      { type: "change-score", team: "home", delta: 10, reason: "goal" } as const,
+      { type: "set-running", running: true } as const,
+      { type: "set-running", running: false } as const,
+      { type: "correct-to-unfinished" } as const,
+    ];
+    for (const [index, command] of commands.entries()) {
+      const state = createInitialGameState({ id: `adhoc-iqa-${index}`, nowMs: 1_000 });
+      const input = { state, command, nowMs: 1_000 + index, idGenerator: () => `iqa-${index}` };
+      expect(eventRules.apply(input)).toEqual(DEFAULT_AD_HOC_IQA_RULES.apply(input));
+    }
+  });
+});

--- a/src/lib/iqa-game-rules.ts
+++ b/src/lib/iqa-game-rules.ts
@@ -1,0 +1,20 @@
+import { applyGameCommand, projectGameView } from "@/lib/game-engine";
+import type { GameCommand, GameState, GameView } from "@/lib/game-types";
+
+/** Policy-neutral sporting interpretation shared by live Event and Ad Hoc Controllers. */
+export type IqaSportingRules = {
+  version: string;
+  apply(input: {
+    state: GameState;
+    command: GameCommand;
+    nowMs: number;
+    idGenerator: () => string;
+  }): GameState;
+  project(state: GameState, nowMs: number): GameView;
+};
+
+export const DEFAULT_IQA_SPORTING_RULES: IqaSportingRules = {
+  version: "iqa-game-rules-v1",
+  apply: applyGameCommand,
+  project: projectGameView,
+};

--- a/src/lib/live-event-game-control.ts
+++ b/src/lib/live-event-game-control.ts
@@ -11,6 +11,7 @@ import {
   rebuildControlActionHistory,
 } from "@/lib/event-game-actions";
 import { parseJsonValue, validateOverride } from "@/lib/event-game-action-codecs";
+import { DEFAULT_IQA_SPORTING_RULES } from "@/lib/iqa-game-rules";
 import {
   CLOCK_AUTHORITY_VERSION,
   deriveClockAuthority,
@@ -291,6 +292,7 @@ export function createLiveEventGameIqaInterpreter(
 ): IqaGameRulesInterpreter {
   return {
     version,
+    sporting: DEFAULT_IQA_SPORTING_RULES,
     rebuild({ root, canonicalActions, effectiveFacts }) {
       return deriveLiveEventGameState(
         root,

--- a/src/lib/ws-protocol.ts
+++ b/src/lib/ws-protocol.ts
@@ -15,6 +15,8 @@ export type ClientCommandEnvelope = {
   id: string;
   clientSentAtMs: number;
   command: GameCommand;
+  workflow?: "ad-hoc";
+  causalPredecessorIds?: string[];
 };
 
 export type SubscribeLobbyMessage = {
@@ -57,6 +59,12 @@ export type ServerWsMessage =
       };
       serverNowMs: number;
       ackedCommandIds: string[];
+      operationOutcomes?: readonly {
+        operationId: string;
+        workflow: "ad-hoc" | "event";
+        status: "accepted" | "duplicate" | "rejected" | "causally-blocked";
+        detail?: string;
+      }[];
     };
 
 export function parseClientWsMessage(
@@ -208,10 +216,27 @@ export function parseClientWsMessage(
         };
       }
 
+      if (entry.workflow !== undefined && entry.workflow !== "ad-hoc") {
+        return { ok: false, error: "Unsupported Controller workflow." };
+      }
+      if (
+        entry.causalPredecessorIds !== undefined &&
+        (!Array.isArray(entry.causalPredecessorIds) ||
+          entry.causalPredecessorIds.some((predecessor) => typeof predecessor !== "string"))
+      ) {
+        return { ok: false, error: "Invalid causal predecessor identities." };
+      }
+
       commands.push({
         id: commandId.value,
         clientSentAtMs: clientSentAtMs.value,
         command: parsedCommand.command,
+        ...(entry.workflow === undefined
+          ? {}
+          : { workflow: entry.workflow === "ad-hoc" ? "ad-hoc" : undefined }),
+        ...(entry.causalPredecessorIds === undefined
+          ? {}
+          : { causalPredecessorIds: entry.causalPredecessorIds as string[] }),
       });
       commandIds.add(commandId.value);
     }

--- a/src/pages/game-page.tsx
+++ b/src/pages/game-page.tsx
@@ -34,7 +34,7 @@ import {
   willFlagCatchWin,
 } from "@/lib/game-page-support";
 import { buildAdHocControlQrPayload } from "@/lib/ad-hoc-handoff";
-import { clearPersistedControllerSession } from "@/lib/controller-session";
+import { clearAdHocControllerSession } from "@/lib/ad-hoc-controller-session";
 import {
   DEFAULT_AWAY_TEAM_COLOR,
   DEFAULT_HOME_TEAM_COLOR,
@@ -125,7 +125,7 @@ export function GamePage({ gameId, role }: { gameId: string; role: ControllerRol
     try {
       const response = await fetch(`/api/games/${gameId}/leave`, { method: "POST" });
       if (!response.ok) throw new Error("leave failed");
-      clearPersistedControllerSession(gameId);
+      clearAdHocControllerSession(gameId);
       navigateTo("/");
     } catch {
       setLeaveMessage("Ad Hoc Game unavailable.");


### PR DESCRIPTION
## What

- add durable, content-bound Ad Hoc Controller operations with deterministic causal replay and explicit per-operation outcomes
- retain authoritative and pending browser state across disconnects, refreshes, browser restarts, and ordinary server restarts
- share policy-neutral Controller synchronization and IQA sporting-rules contracts while keeping Ad Hoc authority, persistence, and no-audit semantics separate from Event control
- validate browser and SQLite state deeply, including migration replay baselines and fail-closed corrupt causal history
- keep a removed server Game honestly local-only without recreating or acknowledging shared state

## Why

Equal Ad Hoc Controllers need to keep operating through short venue-network outages and then converge without duplicated effects, lost operation identities, or Event authority crossover.

## Impact

- Ad Hoc synchronization, operation identities, pending work, and deduplication survive ordinary restarts
- cyclic or malformed replay is rejected before durable mutation; rejected work blocks only causal descendants
- Ad Hoc action accounting remains physically separate from Event and Grant accounting
- no Event Game Record, permanent Control Action, Grant, Audit Trail, Game Lock, or Recovery Gap is created for Ad Hoc work

## Validation

- `bun run check`
- `bun run test` — 549 passing after restacking on current `main`
- `bun run test:focused:ad-hoc` — 5 passing
- `bun run test:focused:adhoc-browser`
- `bun run build`
- `git diff --check origin/main...HEAD`

Implements #154

Parent: #151
