### PR TITLE
Publish and hide an Event

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -185,7 +185,7 @@ A person holding the Event's shared Event Admin Grant. Event Admins create and m
 _Avoid_: Pitch Manager, Controller
 
 **Technical Admin**:
-The sole operator authorized to create Events, change event-level metadata and Publication Status, and manage Event Admin Grants. A Technical Admin may enter the Event Admin interface and exercise every Event Admin capability. Routine administration uses the passkey-authenticated browser interface; a host-local CLI additionally provides selected administration and recovery workflows.
+The sole operator authorized to create Events, change event-level metadata, and manage Event Admin Grants. A Technical Admin may enter the Event Admin interface and exercise every Event Admin capability, including managing Publication Status alongside an Event Admin. Routine administration uses the passkey-authenticated browser interface; a host-local CLI additionally provides selected administration and recovery workflows.
 _Avoid_: Event Admin, Pitch Manager
 
 **Technical Admin Passkey**:

--- a/scripts/test-technical-admin-browser.ts
+++ b/scripts/test-technical-admin-browser.ts
@@ -196,6 +196,30 @@ try {
     (event) => event.name === "Browser Event Updated",
   )?.eventId;
   if (!eventId) throw new Error("Browser Event was not returned by the catalog.");
+
+  const currentCsrfToken = (await context.cookies()).find(
+    (cookie) => cookie.name === "__Host-technical-admin-csrf",
+  )?.value;
+  if (!currentCsrfToken) throw new Error("Technical Admin CSRF cookie was not retained.");
+  const zeroDayResponse = await context.request.post(`${origin}/api/admin/events`, {
+    data: { name: "Zero Day Browser Event", timeZone: "UTC" },
+    headers: { origin, "x-technical-admin-csrf": currentCsrfToken },
+  });
+  const zeroDayPayload = (await zeroDayResponse.json()) as {
+    status: string;
+    value?: { eventId?: string };
+  };
+  const zeroDayEventId = zeroDayPayload.value?.eventId;
+  assert(
+    zeroDayResponse.status() === 201 && zeroDayEventId !== undefined,
+    "zero-Day browser Event creation failed",
+  );
+  await page.goto(`${origin}/event-admin?eventId=${zeroDayEventId}`);
+  await page.getByText("Event Hub", { exact: true }).waitFor();
+  await page.getByRole("button", { name: "Published Event", exact: true }).click();
+  await page.getByText("Publishing requires at least one Game Day.", { exact: true }).waitFor();
+  await page.goto(`${origin}/admin`);
+  await page.getByText("Technical Admin administration").waitFor();
   await page.getByRole("button", { name: /Browser Event Updated/ }).click();
   await page.getByRole("button", { name: "Create Grant" }).click();
   const revealResponsePromise = page.waitForResponse(
@@ -306,6 +330,54 @@ try {
   );
   await eventAdminPage.getByRole("button", { name: "Refresh Slot setup" }).click();
   await eventAdminPage.getByText("Opening", { exact: true }).waitFor();
+  await eventAdminPage.getByRole("button", { name: "Published Event", exact: true }).click();
+  const publicationWarning = eventAdminPage.getByText(/Published with incomplete schedule:/u);
+  await publicationWarning.waitFor();
+  const publicationWarningText = await publicationWarning.innerText();
+  assert(
+    publicationWarningText.includes("Gameplay Slots") &&
+      publicationWarningText.includes("Pitch Slots") &&
+      publicationWarningText.includes("Event Games"),
+    "publication warning did not identify incomplete schedule categories",
+  );
+  const publishedAudience = await eventAdminContext.request.get(
+    `${origin}/api/audience/events/${eventId}`,
+  );
+  assert(publishedAudience.status() === 200, "published Event was not anonymously available");
+  const publishedAudiencePayload = await publishedAudience.json();
+  assert(
+    publishedAudiencePayload.value?.auditTrail === undefined &&
+      publishedAudiencePayload.value?.publicationStatus === "published",
+    "anonymous projection leaked private publication history",
+  );
+  const unpublishedButton = eventAdminPage.getByRole("button", {
+    name: "Unpublished Event",
+    exact: true,
+  });
+  assert(await unpublishedButton.isDisabled(), "leaving Published was not gated by confirmation");
+  await eventAdminPage.getByLabel("Confirm leaving Published").check();
+  assert(!(await unpublishedButton.isDisabled()), "impact confirmation did not enable hiding");
+  await unpublishedButton.click();
+  await eventAdminPage.getByText("Publication Status updated.", { exact: true }).waitFor();
+  const unpublishedAudience = await eventAdminContext.request.get(
+    `${origin}/api/audience/events/${eventId}`,
+  );
+  assert(unpublishedAudience.status() === 404, "unpublished Event remained anonymously available");
+  await eventAdminPage.getByRole("button", { name: "Published Event", exact: true }).click();
+  await eventAdminPage.getByLabel("Confirm leaving Published").check();
+  await eventAdminPage.getByRole("button", { name: "Cancel Event", exact: true }).click();
+  const cancelledAudience = await eventAdminContext.request.get(
+    `${origin}/api/audience/events/${eventId}`,
+  );
+  assert(cancelledAudience.status() === 404, "cancelled Event remained anonymously available");
+  const unknownAudience = await eventAdminContext.request.get(
+    `${origin}/api/audience/events/unknown-event`,
+  );
+  assert(
+    unknownAudience.status() === cancelledAudience.status() &&
+      (await unknownAudience.text()) === (await cancelledAudience.text()),
+    "unknown Event did not use the same anonymous absence response",
+  );
   await eventAdminPage
     .getByText(/Slot 1.*10:00/u)
     .last()

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,11 @@ import {
   type CatalogOutcome,
 } from "@/lib/event-catalog";
 import {
+  createAudienceProjection,
+  PUBLIC_AUDIENCE_ABSENCE,
+  type AudienceProjectionReader,
+} from "@/lib/audience-projection";
+import {
   createEventAdministration,
   type EventAdministration,
   type EventAdministrationAuthority,
@@ -191,6 +196,7 @@ async function startServer() {
     }
 
     const eventCatalog = createEventCatalog(eventCatalogStorage, {});
+    const audienceProjection = createAudienceProjection(eventCatalogStorage);
     let eventAdministration: EventAdministration | null = null;
     if (foundationStorage !== undefined) {
       try {
@@ -309,6 +315,11 @@ async function startServer() {
               adHocService,
               requestSource(req, technicalAdminConfig.trustProxyHeaders),
             );
+          },
+        },
+        "/api/audience/events/:eventId": {
+          GET(req: Request) {
+            return readAudienceEvent(req, audienceProjection);
           },
         },
         "/api/games/:gameId": {
@@ -582,6 +593,30 @@ async function startServer() {
             return catalogResponse(await eventCatalog.removeEvent(eventId, token));
           },
         },
+        "/api/admin/events/:eventId/publication-status": {
+          async POST(req: Request) {
+            const token = requireTechnicalAdminMutationToken(req, technicalAdminAuth);
+            if (token === null) return genericAuthFailure(401);
+            const body = await readJsonRecord(req);
+            if (body === null)
+              return json(
+                {
+                  status: "rejected",
+                  reason: "invalid-input",
+                  detail: "JSON body must be an object.",
+                },
+                400,
+              );
+            const eventId = new URL(req.url).pathname.split("/").at(-2) ?? "";
+            return catalogResponse(
+              await eventCatalog.changePublicationStatus(
+                eventId,
+                { status: body.status, impactConfirmed: body.impactConfirmed },
+                token,
+              ),
+            );
+          },
+        },
         "/api/admin/events/:eventId/game-days": {
           async POST(req: Request) {
             const token = requireTechnicalAdminMutationToken(req, technicalAdminAuth);
@@ -741,6 +776,23 @@ async function startServer() {
               authority,
             });
             return sensitiveEventAdministrationResponse(result);
+          },
+        },
+        "/api/event-admin/events/:eventId/publication-status": {
+          async POST(req: Request) {
+            if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
+            const authority = resolveEventAdministrationAuthority(req, technicalAdminAuth);
+            const body = await readJsonRecord(req);
+            const eventId = new URL(req.url).pathname.split("/").at(-2) ?? "";
+            if (authority === null || body === null) return sensitiveGenericAuthFailure(401);
+            return sensitiveEventAdministrationMutationResponse(
+              await eventAdministration.changePublicationStatus(
+                eventId,
+                { status: body.status, impactConfirmed: body.impactConfirmed },
+                authority,
+              ),
+              authority,
+            );
           },
         },
         "/api/event-admin/events/:eventId/teams": {
@@ -1294,6 +1346,16 @@ export async function readGame(req: Request, service: AdHocGamesService = defaul
   return result.status === "accepted"
     ? sensitiveJson({ game: stripSession(result.game) })
     : adHocUnavailableResponse(service);
+}
+
+export async function readAudienceEvent(
+  req: Request,
+  projection: AudienceProjectionReader,
+): Promise<Response> {
+  const eventId = new URL(req.url).pathname.split("/").at(-1) ?? "";
+  const result = await projection.read(eventId);
+  if (result.status === "accepted") return sensitiveJson(result);
+  return sensitiveJson(PUBLIC_AUDIENCE_ABSENCE, 404);
 }
 
 export async function leaveGame(req: Request, service: AdHocGamesService = defaultAdHocService) {

--- a/src/lib/audience-projection.test.ts
+++ b/src/lib/audience-projection.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from "bun:test";
+import { createAudienceProjection, PUBLIC_AUDIENCE_ABSENCE } from "@/lib/audience-projection";
+import {
+  createEventCatalog,
+  createFoundationEventCatalogStorage,
+  createUnavailableEventCatalogStorage,
+} from "@/lib/event-catalog";
+import { createInMemoryFoundationStorage } from "@/lib/foundation-storage-memory";
+import {
+  MemoryTechnicalAdminAuthRepository,
+  createTechnicalAdminAuth,
+} from "@/lib/technical-admin-auth";
+import { readAudienceEvent } from "@/index";
+
+const authority = createTechnicalAdminAuth(
+  { environment: "test", origin: "https://timer.example", rpId: "timer.example" },
+  new MemoryTechnicalAdminAuthRepository(),
+).resolveHostLocalAuthority();
+
+describe("Audience Publication Projection", () => {
+  test("uses identical anonymous absence for unpublished, cancelled, nonexistent, and unknown Events", async () => {
+    const foundation = createInMemoryFoundationStorage();
+    const storage = createFoundationEventCatalogStorage(foundation);
+    const catalog = createEventCatalog(storage, {});
+    const audience = createAudienceProjection(storage);
+    const event = await catalog.createEvent({ name: "Private", timeZone: "UTC" }, authority);
+    if (event.status !== "accepted") throw new Error("Expected Event.");
+    await catalog.addGameDay(event.value.eventId, { date: "2026-08-14" }, authority);
+
+    const unpublished = await audience.read(event.value.eventId);
+    const unknown = await audience.read("event-does-not-exist");
+    expect(unpublished).toEqual(unknown);
+    expect(unpublished).toEqual({ status: "unavailable" });
+
+    await catalog.changePublicationStatus(event.value.eventId, { status: "published" }, authority);
+    await catalog.changePublicationStatus(
+      event.value.eventId,
+      { status: "cancelled", impactConfirmed: true },
+      authority,
+    );
+    expect(await audience.read(event.value.eventId)).toEqual(PUBLIC_AUDIENCE_ABSENCE);
+    expect(await audience.read("" as unknown)).toEqual({ status: "unavailable" });
+    foundation.close();
+  });
+
+  test("projects only current allowlisted state and has no publication history", async () => {
+    const foundation = createInMemoryFoundationStorage();
+    const storage = createFoundationEventCatalogStorage(foundation);
+    const catalog = createEventCatalog(storage, {});
+    const audience = createAudienceProjection(storage);
+    const event = await catalog.createEvent({ name: "Current", timeZone: "UTC" }, authority);
+    if (event.status !== "accepted") throw new Error("Expected Event.");
+    const day = await catalog.addGameDay(event.value.eventId, { date: "2026-08-14" }, authority);
+    if (day.status !== "accepted") throw new Error("Expected Game Day.");
+    await catalog.changePublicationStatus(event.value.eventId, { status: "published" }, authority);
+    await catalog.changePublicationStatus(
+      event.value.eventId,
+      { status: "cancelled", impactConfirmed: true },
+      authority,
+    );
+    await catalog.updateEvent(event.value.eventId, { name: "Current Renamed" }, authority);
+    await catalog.changePublicationStatus(event.value.eventId, { status: "published" }, authority);
+
+    const current = await audience.read(event.value.eventId);
+    expect(current).toMatchObject({
+      status: "accepted",
+      value: {
+        eventId: event.value.eventId,
+        name: "Current Renamed",
+        publicationStatus: "published",
+        gameDays: ["2026-08-14"],
+      },
+    });
+    if (current.status !== "accepted") return;
+    expect(current.value).not.toHaveProperty("auditTrail");
+    expect(current.value).not.toHaveProperty("createdAtMs");
+    expect(JSON.stringify(current.value)).not.toContain("event-publication-changed");
+    foundation.close();
+  });
+
+  test("collapses authoritative storage failure to the same public HTTP absence", async () => {
+    const projection = createAudienceProjection(
+      createUnavailableEventCatalogStorage("private storage detail"),
+    );
+    expect(await projection.read("published-event")).toEqual({ status: "retryable-failure" });
+
+    const failureResponse = await readAudienceEvent(
+      new Request("https://timer.example/api/audience/events/published-event"),
+      projection,
+    );
+    const absenceResponse = await readAudienceEvent(
+      new Request("https://timer.example/api/audience/events/unknown-event"),
+      { read: async () => PUBLIC_AUDIENCE_ABSENCE },
+    );
+    expect(failureResponse.status).toBe(404);
+    const failureBody = await failureResponse.text();
+    expect(failureBody).toBe(await absenceResponse.text());
+    expect(failureBody).not.toContain("private storage detail");
+  });
+});

--- a/src/lib/audience-projection.ts
+++ b/src/lib/audience-projection.ts
@@ -1,0 +1,67 @@
+import type {
+  EventCatalogFoundationStorage,
+  EventCatalogStorageSnapshot,
+  StoredEvent,
+} from "@/lib/event-catalog";
+
+/** The narrow publication contract consumed by the future public Event experience. */
+export type PublicAudienceEventProjection = {
+  eventId: string;
+  name: string;
+  timeZone: string;
+  publicationStatus: "published";
+  gameDays: readonly string[];
+};
+
+export type AudienceProjectionOutcome =
+  | { status: "accepted"; value: PublicAudienceEventProjection }
+  | { status: "unavailable" }
+  | { status: "retryable-failure" };
+
+export type AudienceProjectionReader = {
+  read(eventId: unknown): Promise<AudienceProjectionOutcome>;
+};
+
+export const PUBLIC_AUDIENCE_ABSENCE = Object.freeze({
+  status: "unavailable",
+} as const);
+
+/**
+ * Ineligible and unknown identifiers intentionally share one anonymous semantic absence.
+ * Public pages, Timeline composition, and transport fan-out remain owned by #131.
+ */
+export function createAudienceProjection(
+  storage: EventCatalogFoundationStorage,
+): AudienceProjectionReader {
+  return {
+    async read(eventId: unknown): Promise<AudienceProjectionOutcome> {
+      if (typeof eventId !== "string" || eventId.trim().length === 0)
+        return { status: "unavailable" };
+      try {
+        const snapshot = await storage.snapshot();
+        const event = snapshot.findEvent(eventId);
+        if (event === null || event.publicationStatus !== "published")
+          return { status: "unavailable" };
+        return { status: "accepted", value: projectPublicEvent(snapshot, event) };
+      } catch {
+        return { status: "retryable-failure" };
+      }
+    },
+  };
+}
+
+function projectPublicEvent(
+  snapshot: EventCatalogStorageSnapshot,
+  event: StoredEvent,
+): PublicAudienceEventProjection {
+  return {
+    eventId: event.eventId,
+    name: event.name,
+    timeZone: event.timeZone,
+    publicationStatus: "published",
+    gameDays: snapshot
+      .listGameDays(event.eventId)
+      .map(({ date }) => date)
+      .sort((left, right) => left.localeCompare(right)),
+  };
+}

--- a/src/lib/event-administration.test.ts
+++ b/src/lib/event-administration.test.ts
@@ -736,6 +736,64 @@ describe("Event Administration handoff", () => {
       ],
     });
   });
+
+  test("lets Technical and Event Admin authority publish and hide without revoking the Grant", async () => {
+    const fixture = createFixture();
+    const event = await fixture.catalog.createEvent(
+      { name: "Publication Event", timeZone: "UTC" },
+      fixture.technical,
+    );
+    if (event.status !== "accepted") throw new Error("Expected Event.");
+    await fixture.catalog.addGameDay(
+      event.value.eventId,
+      { date: "2026-08-14" },
+      fixture.technical,
+    );
+    const grant = await fixture.administration.createEventAdminGrant(
+      event.value.eventId,
+      fixture.technical,
+    );
+    if (grant.status !== "accepted") throw new Error("Expected Grant.");
+    const revealed = await fixture.grants.revealGrant(grant.value.grantId, fixture.technical);
+    if (revealed.status !== "revealed") throw new Error("Expected Grant reveal.");
+    const admission = await fixture.administration.admitEventAdmin({
+      qrCredential: revealed.qrCredential,
+      browserContext: "publication-browser",
+    });
+    if (admission.status !== "admitted") throw new Error("Expected Event Admin admission.");
+    const eventAdmin = { kind: "grant-session" as const, sessionBearer: admission.sessionBearer };
+
+    expect(
+      await fixture.administration.changePublicationStatus(
+        event.value.eventId,
+        { status: "published" },
+        eventAdmin,
+      ),
+    ).toMatchObject({ status: "accepted", value: { publicationStatus: "published" } });
+    expect(
+      await fixture.administration.changePublicationStatus(
+        event.value.eventId,
+        { status: "cancelled" },
+        eventAdmin,
+      ),
+    ).toMatchObject({ status: "rejected", reason: "invalid-input" });
+    expect(
+      await fixture.administration.changePublicationStatus(
+        event.value.eventId,
+        { status: "cancelled", impactConfirmed: true },
+        eventAdmin,
+      ),
+    ).toMatchObject({ status: "accepted", value: { publicationStatus: "cancelled" } });
+    expect(
+      await fixture.administration.openEventHub({
+        eventId: event.value.eventId,
+        authority: eventAdmin,
+      }),
+    ).toMatchObject({ status: "accepted", value: { event: { publicationStatus: "cancelled" } } });
+    expect(
+      await fixture.administration.inspectEventAdminGrant(event.value.eventId, fixture.technical),
+    ).toMatchObject({ status: "accepted", value: { status: "active" } });
+  });
 });
 
 function createFixture(storage: FoundationStorage = createInMemoryFoundationStorage()) {

--- a/src/lib/event-administration.ts
+++ b/src/lib/event-administration.ts
@@ -8,6 +8,7 @@ import {
   type EventCatalogMutationOperations,
   type EventTeamProjection,
   type EventProjection,
+  type EventPublicationStatusChange,
   type StoredPitch,
   type StoredRosterEntry,
   type GameplaySlot,
@@ -128,6 +129,11 @@ export type EventAdministration = {
     gameDayId?: unknown;
     authority: EventAdministrationAuthority;
   }): Promise<EventAdministrationOutcome<EventHubProjection>>;
+  changePublicationStatus(
+    eventId: unknown,
+    input: { status: unknown; impactConfirmed?: unknown },
+    authority: EventAdministrationAuthority,
+  ): Promise<EventAdministrationMutationOutcome<EventPublicationStatusChange>>;
   createEventTeam(
     eventId: unknown,
     input: { name: unknown; defaultColor?: unknown },
@@ -369,6 +375,12 @@ export function createEventAdministration(
       } catch {
         return unavailable();
       }
+    },
+
+    async changePublicationStatus(eventId, input, authority) {
+      return runCatalogMutation(catalog, options, eventId, authority, (operations) =>
+        operations.changePublicationStatus(eventId, input),
+      );
     },
 
     async createEventTeam(eventId, input, authority) {

--- a/src/lib/event-catalog.test.ts
+++ b/src/lib/event-catalog.test.ts
@@ -103,6 +103,169 @@ describe("Event operations catalog", () => {
     ]);
   });
 
+  test("publishes with a schedule warning, requires impact confirmation, and keeps private audit evidence", async () => {
+    const fixture = createFixture();
+    const event = await fixture.catalog.createEvent(
+      { name: "Publication", timeZone: "UTC" },
+      authority,
+    );
+    if (event.status !== "accepted") throw new Error("Expected Event.");
+
+    expect(
+      await fixture.catalog.changePublicationStatus(
+        event.value.eventId,
+        { status: "published" },
+        authority,
+      ),
+    ).toMatchObject({ status: "rejected", reason: "invalid-input" });
+    await fixture.catalog.addGameDay(event.value.eventId, { date: "2026-08-14" }, authority);
+    const published = await fixture.catalog.changePublicationStatus(
+      event.value.eventId,
+      { status: "published" },
+      authority,
+    );
+    expect(published).toMatchObject({
+      status: "accepted",
+      value: {
+        previousStatus: "unpublished",
+        publicationStatus: "published",
+        warnings: [
+          "missing-event-teams",
+          "missing-pitches",
+          "missing-gameplay-slots",
+          "missing-pitch-slots",
+          "missing-event-games",
+        ],
+        event: { publicationStatus: "published" },
+      },
+    });
+    expect(
+      await fixture.catalog.changePublicationStatus(
+        event.value.eventId,
+        { status: "unpublished" },
+        authority,
+      ),
+    ).toMatchObject({ status: "rejected", reason: "invalid-input" });
+    expect(
+      await fixture.catalog.changePublicationStatus(
+        event.value.eventId,
+        { status: "unpublished", impactConfirmed: true },
+        authority,
+      ),
+    ).toMatchObject({ status: "accepted", value: { event: { publicationStatus: "unpublished" } } });
+    expect(
+      await fixture.catalog.changePublicationStatus(
+        event.value.eventId,
+        { status: "cancelled" },
+        authority,
+      ),
+    ).toMatchObject({ status: "accepted", value: { event: { publicationStatus: "cancelled" } } });
+
+    const audit = await fixture.catalog.listAuditTrail(event.value.eventId, authority);
+    if (audit.status !== "accepted") throw new Error("Expected audit trail.");
+    const publicationAudits = audit.value.filter(
+      (entry) => entry.action === "event-publication-changed",
+    );
+    expect(publicationAudits).toHaveLength(3);
+    const firstPublication = publicationAudits.find(
+      (entry) => (entry.after as { publicationStatus?: string }).publicationStatus === "published",
+    );
+    expect(firstPublication).toMatchObject({
+      before: { publicationStatus: "unpublished" },
+      after: { publicationStatus: "published" },
+    });
+    expect(firstPublication?.after).not.toHaveProperty("reason");
+  });
+
+  test("rolls back a publication transition when the catalog transaction fails", async () => {
+    const fixture = createFixture();
+    const event = await fixture.catalog.createEvent({ name: "Atomic", timeZone: "UTC" }, authority);
+    if (event.status !== "accepted") throw new Error("Expected Event.");
+    await fixture.catalog.addGameDay(event.value.eventId, { date: "2026-08-14" }, authority);
+    fixture.storage.failNextTransaction(new Error("commit failed"));
+    expect(
+      await fixture.catalog.changePublicationStatus(
+        event.value.eventId,
+        { status: "published" },
+        authority,
+      ),
+    ).toMatchObject({ status: "retryable-failure" });
+    expect(await fixture.catalog.inspectEvent(event.value.eventId, authority)).toMatchObject({
+      status: "accepted",
+      value: { publicationStatus: "unpublished" },
+    });
+  });
+
+  test("warns about unresolved matchups after the Event schedule categories exist", async () => {
+    const fixture = createFixture();
+    const event = await fixture.catalog.createEvent(
+      { name: "Unresolved", timeZone: "UTC" },
+      authority,
+    );
+    if (event.status !== "accepted") throw new Error("Expected Event.");
+    const day = await fixture.catalog.addGameDay(
+      event.value.eventId,
+      { date: "2026-08-14" },
+      authority,
+    );
+    const pitch = await fixture.catalog.createPitch(
+      event.value.eventId,
+      { name: "Pitch" },
+      authority,
+    );
+    const blue = await fixture.catalog.createEventTeam(
+      event.value.eventId,
+      { name: "Blue" },
+      authority,
+    );
+    const red = await fixture.catalog.createEventTeam(
+      event.value.eventId,
+      { name: "Red" },
+      authority,
+    );
+    if (
+      day.status !== "accepted" ||
+      pitch.status !== "accepted" ||
+      blue.status !== "accepted" ||
+      red.status !== "accepted"
+    )
+      throw new Error("Expected Event schedule setup.");
+    const slot = await fixture.catalog.createGameplaySlot(
+      event.value.eventId,
+      day.value.gameDayId,
+      { sequence: 1, scheduledStart: "2026-08-14T10:00" },
+      authority,
+    );
+    if (slot.status !== "accepted") throw new Error("Expected Gameplay Slot.");
+    const pitchSlot = (await fixture.storage.snapshot()).listPitchSlots(
+      day.value.gameDayId,
+      pitch.value.pitchId,
+    )[0];
+    if (pitchSlot === undefined) throw new Error("Expected Pitch Slot.");
+    const game = await fixture.catalog.createEventGame(
+      event.value.eventId,
+      day.value.gameDayId,
+      {
+        gameplaySlotId: slot.value.gameplaySlotId,
+        pitchSlotId: pitchSlot.pitchSlotId,
+        sideA: { sourceLabel: "Winner A" },
+        sideB: { sourceLabel: "Winner B" },
+      },
+      authority,
+    );
+    if (game.status !== "accepted") throw new Error("Expected Event Game.");
+    expect(
+      await fixture.catalog.changePublicationStatus(
+        event.value.eventId,
+        { status: "published" },
+        authority,
+      ),
+    ).toMatchObject({
+      status: "accepted",
+      value: { warnings: ["unresolved-matchups"] },
+    });
+  });
+
   test("only the verified Technical Admin can mutate metadata and Game Days", async () => {
     const fixture = createFixture();
     expect(

--- a/src/lib/event-catalog.ts
+++ b/src/lib/event-catalog.ts
@@ -36,7 +36,14 @@ import type {
 import type { EventGameRecordRoot } from "@/lib/foundation-record-types";
 import { createInMemoryFoundationStorage } from "@/lib/foundation-storage-memory";
 
-export type EventPublicationStatus = "unpublished";
+export type EventPublicationStatus = "unpublished" | "published" | "cancelled";
+export type EventPublicationWarning =
+  | "missing-event-teams"
+  | "missing-pitches"
+  | "missing-gameplay-slots"
+  | "missing-pitch-slots"
+  | "missing-event-games"
+  | "unresolved-matchups";
 export type EventLifecycle = "unscheduled" | "future" | "current" | "past";
 export type GameDayClassification = "future" | "current" | "past";
 
@@ -73,6 +80,13 @@ export type EventProjection = StoredEvent & {
   pitchSlots: readonly PitchSlot[];
   eventGames: readonly EventGame[];
   auditTrail: readonly EventAdministrationAuditEntry[];
+};
+
+export type EventPublicationStatusChange = {
+  event: EventProjection;
+  previousStatus: EventPublicationStatus;
+  publicationStatus: EventPublicationStatus;
+  warnings: readonly EventPublicationWarning[];
 };
 
 /** Shared projection seam for composed Event Administration workflows. */
@@ -140,6 +154,10 @@ export type EventCatalogOptions = {
 };
 
 export type EventCatalogMutationOperations = {
+  changePublicationStatus(
+    eventId: unknown,
+    input: { status: unknown; impactConfirmed?: unknown },
+  ): CatalogOutcome<EventPublicationStatusChange>;
   createEventTeam(
     eventId: unknown,
     input: { name: unknown; defaultColor?: unknown },
@@ -263,6 +281,11 @@ export type EventCatalog = {
     input: { name?: unknown; timeZone?: unknown },
     authority: TechnicalAdminAuthority,
   ): Promise<CatalogOutcome<EventProjection>>;
+  changePublicationStatus(
+    eventId: unknown,
+    input: { status: unknown; impactConfirmed?: unknown },
+    authority: TechnicalAdminAuthority,
+  ): Promise<CatalogOutcome<EventPublicationStatusChange>>;
   addGameDay(
     eventId: unknown,
     input: { date: unknown },
@@ -532,6 +555,20 @@ export function createEventCatalog(
           ),
         );
       });
+    },
+
+    async changePublicationStatus(eventIdInput, input, authority) {
+      if (!isTechnicalAdminAuthority(authority)) return unauthorized();
+      return commit(storage, (transaction) =>
+        changePublicationStatusOperation(
+          transaction,
+          clock,
+          ids,
+          eventIdInput,
+          input,
+          authorityActor(authority),
+        ),
+      );
     },
 
     async addGameDay(eventIdInput, input, authority) {
@@ -941,6 +978,14 @@ function validateEventName(value: unknown) {
   );
 }
 
+function validatePublicationStatus(
+  value: unknown,
+): { ok: true; value: EventPublicationStatus } | { ok: false; error: string } {
+  if (value === "unpublished" || value === "published" || value === "cancelled")
+    return { ok: true, value };
+  return { ok: false, error: "Publication Status must be unpublished, published, or cancelled." };
+}
+
 function validateId(value: unknown, field: string) {
   return validateOpaqueIdentifier(value, field);
 }
@@ -1072,6 +1117,28 @@ function project(
   };
 }
 
+function projectEventFromTransaction(
+  transaction: EventCatalogStorageTransaction,
+  event: StoredEvent,
+  nowMs: number,
+): EventProjection {
+  const gameDays = transaction.listGameDays(event.eventId);
+  return project(
+    event,
+    gameDays,
+    transaction.listAuditTrail(event.eventId),
+    nowMs,
+    transaction.listEventTeams(event.eventId),
+    transaction
+      .listEventTeams(event.eventId)
+      .flatMap((team) => transaction.listRoster(team.eventTeamId)),
+    transaction.listPitches(event.eventId),
+    gameDays.flatMap((day) => transaction.listGameplaySlots(day.gameDayId)),
+    gameDays.flatMap((day) => transaction.listPitchSlots(day.gameDayId)),
+    gameDays.flatMap((day) => transaction.listEventGames(day.gameDayId)),
+  );
+}
+
 function projectDay(day: StoredGameDay, timeZone: string, nowMs: number): EventGameDay {
   const today = localDate(nowMs, timeZone);
   return {
@@ -1123,6 +1190,8 @@ function createMutationOperations(
   actorReference: string,
 ): EventCatalogMutationOperations {
   return {
+    changePublicationStatus: (eventId, input) =>
+      changePublicationStatusOperation(transaction, clock, ids, eventId, input, actorReference),
     createEventTeam: (eventId, input) =>
       createEventTeamOperation(transaction, clock, ids, eventId, input, actorReference),
     updateEventTeam: (eventId, eventTeamId, input) =>
@@ -1165,6 +1234,93 @@ function createMutationOperations(
         actorReference,
       ),
   };
+}
+
+function changePublicationStatusOperation(
+  transaction: EventCatalogStorageTransaction,
+  clock: EventCatalogClock,
+  ids: EventCatalogIds,
+  eventIdInput: unknown,
+  input: { status: unknown; impactConfirmed?: unknown },
+  actorReference: string,
+): CatalogOutcome<EventPublicationStatusChange> {
+  const eventId = validateId(eventIdInput, "eventId");
+  if (!eventId.ok) return invalid(eventId.error);
+  const status = validatePublicationStatus(input.status);
+  if (!status.ok) return invalid(status.error);
+  if (input.impactConfirmed !== undefined && typeof input.impactConfirmed !== "boolean")
+    return invalid("Publication impact confirmation must be a boolean.");
+  const nowMs = validNow(clock);
+  if (nowMs === null) return invalid("Event clock returned an invalid timestamp.");
+  const existing = transaction.findEvent(eventId.value);
+  if (existing === null) return notFound("Event was not found.");
+  if (existing.publicationStatus === status.value)
+    return noChange("Publication Status is unchanged.");
+  if (
+    existing.publicationStatus === "published" &&
+    status.value !== "published" &&
+    input.impactConfirmed !== true
+  )
+    return invalid("Impact confirmation is required before leaving Published.");
+  const gameDays = transaction.listGameDays(existing.eventId);
+  if (status.value === "published") {
+    if (existing.name.trim().length === 0 || existing.timeZone.trim().length === 0)
+      return invalid("Publishing requires an Event name and timezone.");
+    if (gameDays.length === 0) return invalid("Publishing requires at least one Game Day.");
+  }
+  const teams = transaction.listEventTeams(existing.eventId);
+  const pitches = transaction.listPitches(existing.eventId);
+  const daySchedules = gameDays.map((day) => ({
+    gameplaySlots: transaction.listGameplaySlots(day.gameDayId),
+    pitchSlots: transaction.listPitchSlots(day.gameDayId),
+    eventGames: transaction.listEventGames(day.gameDayId),
+  }));
+  const gameplaySlots = daySchedules.flatMap((day) => day.gameplaySlots);
+  const pitchSlots = daySchedules.flatMap((day) => day.pitchSlots);
+  const eventGames = daySchedules.flatMap((day) => day.eventGames);
+  const warnings: EventPublicationWarning[] = [];
+  if (teams.length === 0) warnings.push("missing-event-teams");
+  if (pitches.length === 0) warnings.push("missing-pitches");
+  if (gameplaySlots.length === 0 || daySchedules.some((day) => day.gameplaySlots.length === 0))
+    warnings.push("missing-gameplay-slots");
+  if (pitchSlots.length === 0 || daySchedules.some((day) => day.pitchSlots.length === 0))
+    warnings.push("missing-pitch-slots");
+  if (eventGames.length === 0 || daySchedules.some((day) => day.eventGames.length === 0))
+    warnings.push("missing-event-games");
+  if (
+    eventGames.some(
+      (game) =>
+        game.sideA.eventTeamId === null ||
+        game.sideB.eventTeamId === null ||
+        game.sideA.confirmedAtMs === null ||
+        game.sideB.confirmedAtMs === null,
+    )
+  )
+    warnings.push("unresolved-matchups");
+  const updated: StoredEvent = {
+    ...existing,
+    publicationStatus: status.value,
+    updatedAtMs: nowMs,
+  };
+  const audit = createAudit(
+    ids,
+    "event-publication-changed",
+    existing.eventId,
+    null,
+    actorReference,
+    nowMs,
+    existing,
+    updated,
+  );
+  transaction.updateEvent(updated);
+  transaction.appendAudit(audit);
+  const event = projectEventFromTransaction(transaction, updated, nowMs);
+  return accepted({
+    event,
+    previousStatus: existing.publicationStatus,
+    publicationStatus: updated.publicationStatus,
+    warnings: status.value === "published" ? warnings : [],
+  });
 }
 
 function createEventTeamOperation(

--- a/src/lib/foundation-grant-erasure-migration.test.ts
+++ b/src/lib/foundation-grant-erasure-migration.test.ts
@@ -210,7 +210,7 @@ describe("Grant cryptographic erasure migration", () => {
 
       const current = openSqliteFoundationStorage(databasePath);
       await current.applyMigrations({ requireCandidate: false });
-      expect(await current.readiness()).toMatchObject({ ok: true, schemaVersion: "24" });
+      expect(await current.readiness()).toMatchObject({ ok: true, schemaVersion: "25" });
       current.close();
 
       const raw = new Database(databasePath);
@@ -330,7 +330,7 @@ describe("Grant cryptographic erasure migration", () => {
       raw.close();
 
       const reopened = openSqliteFoundationStorage(databasePath);
-      expect(await reopened.readiness()).toMatchObject({ ok: true, schemaVersion: "24" });
+      expect(await reopened.readiness()).toMatchObject({ ok: true, schemaVersion: "25" });
       const restartedAudit = await reopened.transaction((transaction) =>
         transaction.listGrantAudit("grant-expired"),
       );

--- a/src/lib/foundation-migrations.test.ts
+++ b/src/lib/foundation-migrations.test.ts
@@ -13,7 +13,7 @@ const migrations: readonly FoundationMigration[] = [
 ];
 
 describe("foundation migration ledger compatibility", () => {
-  test("keeps accepted migrations 001 through 023 byte-for-byte immutable and pins 024", () => {
+  test("keeps accepted migrations 001 through 024 byte-for-byte immutable and pins 025", () => {
     expect(FOUNDATION_MIGRATIONS.map(({ id, checksum }) => ({ id, checksum }))).toEqual([
       {
         id: "001-foundation-event-game-record-roots",
@@ -110,6 +110,10 @@ describe("foundation migration ledger compatibility", () => {
       {
         id: "024-event-schedule-slots-and-games",
         checksum: "aaf67baece0503c2c7ac91f3f26ca69b65e416e2514ef8a3889d7739679ae175",
+      },
+      {
+        id: "025-event-publication-status",
+        checksum: "c53a6d6d178217ed050086d40dad7a281f3ecd071ef6ab3e429fdef8787637ee",
       },
     ]);
   });

--- a/src/lib/foundation-migrations.ts
+++ b/src/lib/foundation-migrations.ts
@@ -1506,6 +1506,12 @@ export const FOUNDATION_EVENT_CATALOG_EVENTS_TABLE_SQL = `
   ) STRICT
 `;
 
+const FOUNDATION_EVENT_CATALOG_EVENTS_TABLE_V25_SQL =
+  FOUNDATION_EVENT_CATALOG_EVENTS_TABLE_SQL.replace(
+    "publication_status TEXT NOT NULL CHECK (publication_status = 'unpublished')",
+    "publication_status TEXT NOT NULL CHECK (publication_status IN ('unpublished', 'published', 'cancelled'))",
+  );
+
 export const FOUNDATION_EVENT_CATALOG_GAME_DAYS_TABLE_SQL = `
   CREATE TABLE foundation_event_catalog_game_days (
     game_day_id TEXT PRIMARY KEY,
@@ -1729,6 +1735,101 @@ export const FOUNDATION_EVENT_SCHEDULE_MIGRATION_SQL = `
   ${FOUNDATION_EVENT_CATALOG_GAMES_INDEX_SQL};
 `;
 
+function foundationEventCatalogV25Sql(sql: string): string {
+  return sql.replaceAll("foundation_event_catalog_", "foundation_event_catalog_v25_");
+}
+
+const FOUNDATION_EVENT_PUBLICATION_MIGRATION_SQL = `
+  ${foundationEventCatalogV25Sql(FOUNDATION_EVENT_CATALOG_EVENTS_TABLE_V25_SQL)};
+  ${foundationEventCatalogV25Sql(FOUNDATION_EVENT_CATALOG_GAME_DAYS_TABLE_SQL)};
+  ${foundationEventCatalogV25Sql(FOUNDATION_EVENT_CATALOG_TEAMS_TABLE_SQL)};
+  ${foundationEventCatalogV25Sql(FOUNDATION_EVENT_CATALOG_ROSTER_TABLE_SQL)};
+  ${foundationEventCatalogV25Sql(FOUNDATION_EVENT_CATALOG_PITCHES_TABLE_SQL)};
+  ${foundationEventCatalogV25Sql(FOUNDATION_EVENT_CATALOG_GAMEPLAY_SLOTS_TABLE_SQL)};
+  ${foundationEventCatalogV25Sql(FOUNDATION_EVENT_CATALOG_PITCH_SLOTS_TABLE_SQL)};
+  ${foundationEventCatalogV25Sql(FOUNDATION_EVENT_CATALOG_GAMES_TABLE_SQL)};
+  INSERT INTO foundation_event_catalog_v25_events
+    (event_id, name, time_zone, publication_status, created_at_ms, updated_at_ms)
+  SELECT event_id, name, time_zone, publication_status, created_at_ms, updated_at_ms
+  FROM foundation_event_catalog_events;
+  INSERT INTO foundation_event_catalog_v25_game_days
+    (game_day_id, event_id, game_day_date, created_at_ms, updated_at_ms)
+  SELECT game_day_id, event_id, game_day_date, created_at_ms, updated_at_ms
+  FROM foundation_event_catalog_game_days;
+  INSERT INTO foundation_event_catalog_v25_teams
+    (event_team_id, event_id, name, default_color, created_at_ms, updated_at_ms)
+  SELECT event_team_id, event_id, name, default_color, created_at_ms, updated_at_ms
+  FROM foundation_event_catalog_teams;
+  INSERT INTO foundation_event_catalog_v25_roster
+    (roster_entry_id, event_id, event_team_id, player_number, public_name, created_at_ms, updated_at_ms)
+  SELECT roster_entry_id, event_id, event_team_id, player_number, public_name, created_at_ms, updated_at_ms
+  FROM foundation_event_catalog_roster;
+  INSERT INTO foundation_event_catalog_v25_pitches
+    (pitch_id, event_id, name, created_at_ms, updated_at_ms)
+  SELECT pitch_id, event_id, name, created_at_ms, updated_at_ms
+  FROM foundation_event_catalog_pitches;
+  INSERT INTO foundation_event_catalog_v25_gameplay_slots
+    (gameplay_slot_id, event_id, game_day_id, sequence_number, scheduled_start_ms, created_at_ms, updated_at_ms)
+  SELECT gameplay_slot_id, event_id, game_day_id, sequence_number, scheduled_start_ms, created_at_ms, updated_at_ms
+  FROM foundation_event_catalog_gameplay_slots;
+  INSERT INTO foundation_event_catalog_v25_pitch_slots
+    (pitch_slot_id, event_id, game_day_id, pitch_id, gameplay_slot_id, sequence_number, created_at_ms, updated_at_ms)
+  SELECT pitch_slot_id, event_id, game_day_id, pitch_id, gameplay_slot_id, sequence_number, created_at_ms, updated_at_ms
+  FROM foundation_event_catalog_pitch_slots;
+  INSERT INTO foundation_event_catalog_v25_games
+    (event_game_id, event_id, game_day_id, gameplay_slot_id, pitch_slot_id,
+     game_code, game_designation, side_a_id, side_a_event_team_id, side_a_event_team_name,
+     side_a_source_label, side_a_confirmed_at_ms, side_b_id, side_b_event_team_id,
+     side_b_event_team_name, side_b_source_label, side_b_confirmed_at_ms, created_at_ms, updated_at_ms)
+  SELECT event_game_id, event_id, game_day_id, gameplay_slot_id, pitch_slot_id,
+     game_code, game_designation, side_a_id, side_a_event_team_id, side_a_event_team_name,
+     side_a_source_label, side_a_confirmed_at_ms, side_b_id, side_b_event_team_id,
+     side_b_event_team_name, side_b_source_label, side_b_confirmed_at_ms, created_at_ms, updated_at_ms
+  FROM foundation_event_catalog_games;
+
+  DROP TABLE foundation_event_catalog_games;
+  DROP TABLE foundation_event_catalog_pitch_slots;
+  DROP TABLE foundation_event_catalog_gameplay_slots;
+  DROP TABLE foundation_event_catalog_roster;
+  DROP TABLE foundation_event_catalog_pitches;
+  DROP TABLE foundation_event_catalog_teams;
+  DROP TABLE foundation_event_catalog_game_days;
+  DROP TABLE foundation_event_catalog_events;
+  ALTER TABLE foundation_event_catalog_v25_events RENAME TO foundation_event_catalog_events;
+  ALTER TABLE foundation_event_catalog_v25_game_days RENAME TO foundation_event_catalog_game_days;
+  ALTER TABLE foundation_event_catalog_v25_teams RENAME TO foundation_event_catalog_teams;
+  ALTER TABLE foundation_event_catalog_v25_roster RENAME TO foundation_event_catalog_roster;
+  ALTER TABLE foundation_event_catalog_v25_pitches RENAME TO foundation_event_catalog_pitches;
+  ALTER TABLE foundation_event_catalog_v25_gameplay_slots RENAME TO foundation_event_catalog_gameplay_slots;
+  ALTER TABLE foundation_event_catalog_v25_pitch_slots RENAME TO foundation_event_catalog_pitch_slots;
+  ALTER TABLE foundation_event_catalog_v25_games RENAME TO foundation_event_catalog_games;
+  ${FOUNDATION_EVENT_CATALOG_GAME_DAYS_EVENT_INDEX_SQL};
+  ${FOUNDATION_EVENT_CATALOG_ROSTER_TEAM_INDEX_SQL};
+  ${FOUNDATION_EVENT_CATALOG_PITCHES_EVENT_INDEX_SQL};
+  ${FOUNDATION_EVENT_CATALOG_GAMEPLAY_SLOTS_INDEX_SQL};
+  ${FOUNDATION_EVENT_CATALOG_PITCH_SLOTS_INDEX_SQL};
+  ${FOUNDATION_EVENT_CATALOG_GAMES_INDEX_SQL};
+
+  CREATE TABLE foundation_event_catalog_audit_v25 AS SELECT * FROM foundation_event_catalog_audit;
+  DROP TABLE foundation_event_catalog_audit;
+  ${FOUNDATION_EVENT_CATALOG_AUDIT_TABLE_V3_SQL.replace(
+    "CREATE TABLE foundation_event_catalog_audit",
+    "CREATE TABLE foundation_event_catalog_audit_rebuilt",
+  ).replace(
+    "'event-game-teams-confirmed'",
+    "'event-game-teams-confirmed', 'event-publication-changed'",
+  )};
+  INSERT INTO foundation_event_catalog_audit_rebuilt
+    (audit_id, operation_id, action, event_id, game_day_id, actor_reference,
+     occurred_at_ms, before_json, after_json)
+  SELECT audit_id, operation_id, action, event_id, game_day_id, actor_reference,
+         occurred_at_ms, before_json, after_json
+  FROM foundation_event_catalog_audit_v25;
+  DROP TABLE foundation_event_catalog_audit_v25;
+  ALTER TABLE foundation_event_catalog_audit_rebuilt RENAME TO foundation_event_catalog_audit;
+  ${FOUNDATION_EVENT_CATALOG_AUDIT_EVENT_INDEX_SQL};
+`;
+
 export const FOUNDATION_MIGRATIONS: readonly FoundationMigration[] = Object.freeze([
   createMigration({
     id: "001-foundation-event-game-record-roots",
@@ -1873,6 +1974,12 @@ export const FOUNDATION_MIGRATIONS: readonly FoundationMigration[] = Object.free
     ordinal: 24,
     schemaVersion: 24,
     sql: FOUNDATION_EVENT_SCHEDULE_MIGRATION_SQL,
+  }),
+  createMigration({
+    id: "025-event-publication-status",
+    ordinal: 25,
+    schemaVersion: 25,
+    sql: FOUNDATION_EVENT_PUBLICATION_MIGRATION_SQL,
   }),
 ]);
 

--- a/src/lib/foundation-storage-sqlite.test.ts
+++ b/src/lib/foundation-storage-sqlite.test.ts
@@ -546,7 +546,7 @@ describe("SQLite foundation storage", () => {
       expect(await reopenedRecord.registerRoot(root)).toMatchObject({ status: "idempotent" });
       expect(await reopened.readiness()).toMatchObject({
         ok: true,
-        schemaVersion: "24",
+        schemaVersion: "25",
         evidence: { replay: { result: "passed", rootCount: 1, durationMs: expect.any(Number) } },
       });
       reopened.close();
@@ -594,12 +594,12 @@ describe("SQLite foundation storage", () => {
       const storage = openSqliteFoundationStorage(databasePath);
       const candidate = await storage.validateCandidate();
       expect(candidate.ready).toBe(true);
-      expect(candidate.readiness).toMatchObject({ ok: true, schemaVersion: "24" });
+      expect(candidate.readiness).toMatchObject({ ok: true, schemaVersion: "25" });
       expect(existsSync(candidate.candidatePath)).toBe(false);
       expect(await storage.readiness()).toMatchObject({ ok: false, status: "pending" });
 
       const migration = await storage.applyMigrations({ requireCandidate: true });
-      expect(migration.schemaVersion).toBe(24);
+      expect(migration.schemaVersion).toBe(25);
       expect(await storage.readiness()).toMatchObject({ ok: true });
       storage.close();
     });
@@ -690,8 +690,9 @@ describe("SQLite foundation storage", () => {
         controlSessionStayMigration.id,
         eventTeamsMigration.id,
         "024-event-schedule-slots-and-games",
+        "025-event-publication-status",
       ]);
-      expect(await current.readiness()).toMatchObject({ ok: true, schemaVersion: "24" });
+      expect(await current.readiness()).toMatchObject({ ok: true, schemaVersion: "25" });
       current.close();
     });
   });
@@ -700,9 +701,9 @@ describe("SQLite foundation storage", () => {
     await withDatabase(async (databasePath) => {
       const baseMigrations = FOUNDATION_MIGRATIONS;
       const failingMigration = createMigration(
-        "025-failing-test-migration",
-        25,
-        25,
+        "026-failing-test-migration",
+        26,
+        26,
         "CREATE TABLE migration_failure_probe (id TEXT) STRICT; THIS IS NOT SQL;",
       );
       const store = openSqliteFoundationStorage(databasePath, {
@@ -722,7 +723,7 @@ describe("SQLite foundation storage", () => {
       });
       expect(await priorBinary.readiness()).toMatchObject({
         ok: true,
-        schemaVersion: "24",
+        schemaVersion: "25",
       });
       priorBinary.close();
 
@@ -794,7 +795,7 @@ describe("SQLite foundation storage", () => {
         .query(
           "INSERT INTO foundation_migration_ledger (migration_id, ordinal, schema_version, checksum, status, applied_at_ms) VALUES (?, ?, ?, ?, ?, ?)",
         )
-        .run("future-999", 25, 25, "future-checksum", "complete", 2_000);
+        .run("future-999", 26, 26, "future-checksum", "complete", 2_000);
       futureDatabase.close();
       const future = openSqliteFoundationStorage(databasePath);
       expect(await future.readiness()).toMatchObject({ ok: false });

--- a/src/lib/foundation-storage-sqlite.ts
+++ b/src/lib/foundation-storage-sqlite.ts
@@ -273,7 +273,9 @@ function readEvent(value: unknown): StoredEventCatalogEvent | null {
     eventId: String(row.eventId),
     name: String(row.name),
     timeZone: String(row.timeZone),
-    publicationStatus: "unpublished",
+    publicationStatus: String(
+      row.publicationStatus,
+    ) as StoredEventCatalogEvent["publicationStatus"],
     createdAtMs: Number(row.createdAtMs),
     updatedAtMs: Number(row.updatedAtMs),
   };

--- a/src/lib/foundation-storage.ts
+++ b/src/lib/foundation-storage.ts
@@ -127,7 +127,7 @@ export type StoredEventCatalogEvent = {
   eventId: string;
   name: string;
   timeZone: string;
-  publicationStatus: "unpublished";
+  publicationStatus: "unpublished" | "published" | "cancelled";
   createdAtMs: number;
   updatedAtMs: number;
 };
@@ -228,7 +228,8 @@ export type EventCatalogAuditEntry = {
     | "gameplay-slot-created"
     | "pitch-slot-created"
     | "event-game-created"
-    | "event-game-teams-confirmed";
+    | "event-game-teams-confirmed"
+    | "event-publication-changed";
   eventId: string;
   gameDayId: string | null;
   actorReference: string;

--- a/src/lib/ws-protocol.test.ts
+++ b/src/lib/ws-protocol.test.ts
@@ -321,6 +321,12 @@ describe("ws-protocol", () => {
     expect(parsed.error).toContain("Unsupported event type");
   });
 
+  test("keeps Audience publication outside the existing game WebSocket contract", () => {
+    expect(
+      parseClientWsMessage(JSON.stringify({ type: "subscribe-audience-event", eventId: "event" })),
+    ).toMatchObject({ ok: false });
+  });
+
   test("rejects unsupported command types in apply-commands", () => {
     const parsed = parseClientWsMessage(
       JSON.stringify({

--- a/src/pages/event-admin-page.tsx
+++ b/src/pages/event-admin-page.tsx
@@ -12,6 +12,7 @@ type HubResponse = {
       name: string;
       timeZone: string;
       lifecycle: string;
+      publicationStatus: "unpublished" | "published" | "cancelled";
       gameDays: Array<{ gameDayId: string; date: string; classification: string }>;
       teams: Array<{
         eventTeamId: string;
@@ -61,6 +62,17 @@ type ScheduleResponse = {
   };
 };
 
+class EventPublicationValidationError extends Error {}
+
+const publicationWarningLabels: Record<string, string> = {
+  "missing-event-teams": "Event Teams",
+  "missing-pitches": "Pitches",
+  "missing-gameplay-slots": "Gameplay Slots",
+  "missing-pitch-slots": "Pitch Slots",
+  "missing-event-games": "Event Games",
+  "unresolved-matchups": "unresolved matchups or confirmed sides",
+};
+
 export function EventAdminPage() {
   const queryEventId = new URLSearchParams(window.location.search).get("eventId") ?? "";
   const [eventId, setEventId] = useState(queryEventId);
@@ -96,6 +108,7 @@ export function EventAdminPage() {
     pitchSlots: HubResponse["value"]["event"]["pitchSlots"];
     eventGames: HubResponse["value"]["event"]["eventGames"];
   } | null>(null);
+  const [publicationImpactConfirmed, setPublicationImpactConfirmed] = useState(false);
 
   const loadHub = async (nextGameDayId = selectedGameDayId) => {
     if (eventId.trim().length === 0) return;
@@ -173,6 +186,44 @@ export function EventAdminPage() {
     setPitchView(payload.value);
   };
 
+  const changePublicationStatus = async (status: "unpublished" | "published" | "cancelled") => {
+    if (hub === null) return;
+    const leavingPublished = hub.event.publicationStatus === "published" && status !== "published";
+    const response = await fetch(`/api/event-admin/events/${eventId}/publication-status`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        status,
+        impactConfirmed: leavingPublished ? publicationImpactConfirmed : undefined,
+      }),
+    });
+    const payload = (await response.json()) as {
+      status: "accepted" | "rejected" | "retryable-failure";
+      reason?: string;
+      detail?: string;
+      value?: { warnings?: readonly string[] };
+    };
+    if (
+      response.status === 400 &&
+      payload.status === "rejected" &&
+      payload.reason === "invalid-input" &&
+      typeof payload.detail === "string"
+    )
+      throw new EventPublicationValidationError(payload.detail);
+    if (!response.ok || payload.status !== "accepted")
+      throw new Error("Publication update failed.");
+    setPublicationImpactConfirmed(false);
+    const warningLabels = (payload.value?.warnings ?? []).map(
+      (warning) => publicationWarningLabels[warning] ?? "incomplete schedule content",
+    );
+    setMessage(
+      warningLabels.length > 0
+        ? `Published with incomplete schedule: ${warningLabels.join(", ")}.`
+        : "Publication Status updated.",
+    );
+    await loadHub(selectedGameDayId);
+  };
+
   const confirmGameplaySlot = async (
     gameplaySlotId: string,
     games: HubResponse["value"]["event"]["eventGames"],
@@ -205,8 +256,12 @@ export function EventAdminPage() {
     setMessage(null);
     try {
       await action();
-    } catch {
-      setMessage("Unable to authorize the Event Hub.");
+    } catch (error) {
+      setMessage(
+        error instanceof EventPublicationValidationError
+          ? error.message
+          : "Unable to authorize the Event Hub.",
+      );
     } finally {
       setBusy(false);
     }
@@ -275,8 +330,47 @@ export function EventAdminPage() {
               <div>
                 <p className="font-semibold">{hub.event.name}</p>
                 <p className="text-sm text-muted-foreground">
-                  {hub.event.timeZone} · {hub.authority}
+                  {hub.event.timeZone} · {hub.authority} · {hub.event.publicationStatus}
                 </p>
+              </div>
+              <div className="space-y-3 rounded-lg border p-3">
+                <p className="font-semibold">Publication Status</p>
+                <p className="text-sm text-muted-foreground">
+                  Only Published Events are visible to anonymous audiences.
+                </p>
+                {hub.event.publicationStatus === "published" ? (
+                  <label className="flex items-start gap-2 text-sm">
+                    <input
+                      aria-label="Confirm leaving Published"
+                      checked={publicationImpactConfirmed}
+                      onChange={(event) => setPublicationImpactConfirmed(event.target.checked)}
+                      type="checkbox"
+                    />
+                    <span>I understand that leaving Published removes public availability.</span>
+                  </label>
+                ) : null}
+                <div className="flex flex-wrap gap-2">
+                  {(["unpublished", "published", "cancelled"] as const).map((status) => {
+                    const leavingPublished =
+                      hub.event.publicationStatus === "published" && status !== "published";
+                    return (
+                      <Button
+                        key={status}
+                        disabled={
+                          busy ||
+                          hub.event.publicationStatus === status ||
+                          (leavingPublished && !publicationImpactConfirmed)
+                        }
+                        onClick={() => void run(() => changePublicationStatus(status))}
+                        variant={status === "published" ? "default" : "outline"}
+                      >
+                        {status === "cancelled"
+                          ? "Cancel Event"
+                          : `${status[0]?.toUpperCase()}${status.slice(1)} Event`}
+                      </Button>
+                    );
+                  })}
+                </div>
               </div>
               <div className="space-y-2">
                 <Label htmlFor="game-day-selector">Game Day</Label>


### PR DESCRIPTION
> Stack repair: this replaces merged PR #175, which targeted an intermediate branch and was therefore not reachable from `main`. This replacement preserves the accepted ticket layer and is stacked on its correct immediate dependency.

## What changed

Implemented GitHub issue #113, “Publish and hide an Event,” as one ready-to-review layer on the rebased Spec #105 integration branch.

- Added direct `Unpublished`, `Published`, and `Event Cancelled` transitions for Event Admin and Technical Admin authorities.
- Publishing requires Event name, timezone, and at least one Game Day; incomplete two-day schedule categories warn with concise evidence for missing Teams, Pitches, Gameplay Slots, Pitch Slots, Event Games, or confirmed matchups.
- Leaving Published requires explicit impact confirmation.
- Retained permanent private before/after publication audit evidence without a reason field, with catalog/projection/HTTP changes atomic through the existing transaction seam.
- Kept Grants and private administration active, stable Event identifiers, current-state republishing, and the existing game WebSocket transport unchanged.
- Added migration 025 for publication status and audit action support.
- Clarified `CONTEXT.md`: Event Admin and Technical Admin may both manage Publication Status; Technical Admin retains sole Event creation, event-level metadata, and Event Admin Grant responsibilities.

## Why

The Event needs an explicit two-day publication lifecycle while anonymous audiences must remain fail-closed and unable to distinguish unpublished, cancelled, nonexistent, invalid, or authoritative storage-failure Events.

## Impact

Only Published Events are exposed to the narrow #131 consumer contract. The public adapter returns the same generic 404 semantic absence for hidden, cancelled, unknown, invalid, and storage-failure cases. No public pages, Timeline, publication history, or WebSocket subscription transport are included.

## Parent and follow-up boundaries

- Parent Spec: #105
- Implementation: #113
- #131 consumer contract: `createAudienceProjection(storage).read(eventId)` returns an allowlisted current published projection, internal unavailable/retryable outcomes, and no private audit/history or internal schedule detail. Public HTTP collapses retryable storage failure to the generic absence response.

## Validation

- `bun run check` passed with only existing unrelated await-thenable warnings.
- `bun run build` passed.
- Full suite: 520 passed, 0 failed, 16,966 expectations.
- Focused catalog, administration, migration, SQLite storage, projection/HTTP failure, and WebSocket coverage: 90 passed, 0 failed, 494 expectations.
- Browser flow passed with zero-Day validation messaging, category-specific schedule warnings, hide/cancel absence, republish, and impact-confirmation gating.
- `git diff --check` passed.
