### PR TITLE
Publish Event discovery through Audience Projections

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "event:catalog": "bun scripts/event-catalog.ts",
     "event:admin": "bun scripts/event-admin.ts",
     "test:focused:technical-admin-browser": "bun scripts/test-technical-admin-browser.ts",
+    "test:focused:public-event-browser": "bun scripts/test-public-event-browser.ts",
     "test:focused:technical-admin": "bun test --isolate ./src/lib/technical-admin-auth-sqlite.focused.ts",
     "test:focused:startup": "bun test --isolate ./src/index-startup.focused.ts",
     "build": "bun run build.ts",

--- a/scripts/test-public-event-browser.ts
+++ b/scripts/test-public-event-browser.ts
@@ -1,0 +1,290 @@
+import { chromium, type Page } from "playwright";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createEventCatalog, createFoundationEventCatalogStorage } from "@/lib/event-catalog";
+import { openSqliteFoundationStorage } from "@/lib/foundation-storage-sqlite";
+import {
+  MemoryTechnicalAdminAuthRepository,
+  createTechnicalAdminAuth,
+  type TechnicalAdminAuthority,
+} from "@/lib/technical-admin-auth";
+
+const directory = mkdtempSync(join(tmpdir(), "quadball-timer-public-browser-"));
+const foundationDatabase = join(directory, "foundation.sqlite");
+const technicalAdminDatabase = join(directory, "technical-admin.sqlite");
+const port = 38_000 + Math.floor(Math.random() * 1_000);
+const origin = `http://127.0.0.1:${port}`;
+const environment = {
+  ...process.env,
+  NODE_ENV: "test",
+  QUADBALL_ENVIRONMENT: "test",
+  PUBLIC_ORIGIN: "https://timer.example",
+  FOUNDATION_DATABASE: foundationDatabase,
+  TECHNICAL_ADMIN_DATABASE: technicalAdminDatabase,
+  PORT: String(port),
+  HOST: "127.0.0.1",
+};
+
+let server: Bun.Subprocess | null = null;
+let serverStderr: Promise<string> | null = null;
+let browser: Awaited<ReturnType<typeof chromium.launch>> | null = null;
+let browserPage: Page | null = null;
+
+try {
+  const seeded = await seedDatabase();
+  server = Bun.spawn(["bun", "run", "src/index.ts"], {
+    cwd: process.cwd(),
+    env: environment,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  serverStderr = new Response(server.stderr as unknown as BodyInit).text();
+  await waitForServer(`${origin}/internal/healthz`);
+
+  browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  page.setDefaultTimeout(5_000);
+  browserPage = page;
+  const consoleErrors: string[] = [];
+  page.on("pageerror", (error) => consoleErrors.push(error.message));
+  page.on("console", (message) => {
+    if (message.type() === "error" && !message.text().includes("Failed to load resource")) {
+      consoleErrors.push(message.text());
+    }
+  });
+
+  const listResponse = await context.request.get(`${origin}/api/audience/events`);
+  assert(listResponse.status() === 200, "seeded Audience list was unavailable");
+  const listPayload = (await listResponse.json()) as {
+    status: string;
+    value: { events: Array<PublicEventFixture> };
+  };
+  assert(listPayload.status === "accepted", "seeded Audience list was not accepted");
+  const current = listPayload.value.events.find((event) => event.eventId === seeded.currentId);
+  if (!current) throw new Error("seeded current Event was not listed");
+
+  await page.goto(`${origin}/events`);
+  await page.waitForURL(`${origin}${current.canonicalPath}`);
+  await page.getByRole("heading", { name: "Published Current" }).waitFor();
+
+  const canonicalResponse = await page.goto(`${origin}${current.canonicalPath}`);
+  await page.getByRole("heading", { name: "Published Current" }).waitFor();
+  assert(
+    canonicalResponse?.headers()["x-robots-tag"] === undefined,
+    "Published canonical page was noindex",
+  );
+
+  await page.getByRole("button", { name: "All events" }).click();
+  await page.waitForURL(`${origin}/events?view=all`);
+  await page.getByRole("heading", { name: "Current Events" }).waitFor();
+  await page.getByRole("link", { name: "Published Current" }).click();
+  await page.waitForURL(`${origin}${current.canonicalPath}`);
+  await page.getByRole("heading", { name: "Published Current" }).waitFor();
+  await page.getByRole("button", { name: "All events" }).click();
+  await page.waitForURL(`${origin}/events?view=all`);
+
+  await page.route(`${origin}/api/audience/events`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        status: "accepted",
+        value: {
+          events: [
+            { ...current, lifecycle: "future", gameDays: [futureDate()] },
+            {
+              ...current,
+              eventId: "event-unscheduled",
+              name: "Unscheduled Event",
+              lifecycle: "unscheduled",
+              gameDays: [],
+              canonicalPath: "/events/event-unscheduled",
+            },
+          ],
+        },
+      }),
+    });
+  });
+  await page.goto(`${origin}/events`);
+  await page.getByRole("heading", { name: "Current Events" }).waitFor();
+  assert(page.url() === `${origin}/events`, "zero-current discovery auto-opened an Event");
+  await page.getByText("No Event is current today.").waitFor();
+  await page.unroute(`${origin}/api/audience/events`);
+
+  await page.route(`${origin}/api/audience/events`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        status: "accepted",
+        value: {
+          events: [
+            current,
+            {
+              ...current,
+              eventId: "event-current-two",
+              name: "Second Current",
+              canonicalPath: "/events/event-current-two",
+            },
+          ],
+        },
+      }),
+    });
+  });
+  await page.goto(`${origin}/events`);
+  await page.getByRole("heading", { name: "Current Events" }).waitFor();
+  assert(page.url() === `${origin}/events`, "multiple-current discovery auto-opened an Event");
+  await page.getByRole("link", { name: "Second Current" }).waitFor();
+  await page.unroute(`${origin}/api/audience/events`);
+
+  const sitemap = await context.request.get(`${origin}/sitemap.xml`);
+  const sitemapBody = await sitemap.text();
+  assert(sitemap.status() === 200, "sitemap was unavailable");
+  assert(sitemapBody.includes(current.canonicalPath), "Published Event was omitted from sitemap");
+  assert(!sitemapBody.includes(seeded.hiddenId), "hidden Event was included in sitemap");
+
+  for (const eventId of [seeded.hiddenId, "unknown-event"]) {
+    const response = await page.goto(`${origin}/events/${eventId}`);
+    await page.getByRole("heading", { name: "Event unavailable" }).waitFor();
+    assert(response?.headers()["x-robots-tag"] === "noindex", `${eventId} page was indexable`);
+    assert(
+      (await page
+        .getByText("The Event may be hidden, unknown, or temporarily unavailable.")
+        .count()) === 1,
+      `${eventId} did not render the generic unavailable experience`,
+    );
+    await page.getByRole("button", { name: "Back to Home" }).click();
+    await page.waitForURL(`${origin}/events?view=all`);
+  }
+
+  await page.route(`${origin}/api/audience/events/database-failure`, async (route) => {
+    await route.fulfill({
+      status: 503,
+      contentType: "application/json",
+      body: JSON.stringify({ status: "unavailable" }),
+    });
+  });
+  const databaseFailureResponse = await page.goto(`${origin}/events/database-failure`);
+  await page.getByRole("heading", { name: "Event unavailable" }).waitFor();
+  assert(
+    databaseFailureResponse?.headers()["x-robots-tag"] === "noindex",
+    "database-failure page was indexable",
+  );
+  await page.getByRole("button", { name: "Back to Home" }).click();
+  await page.waitForURL(`${origin}/events?view=all`);
+  await page.unroute(`${origin}/api/audience/events/database-failure`);
+
+  await page.getByRole("button", { name: /Start an Ad Hoc Game/ }).click();
+  await page.waitForURL(new RegExp(`${origin}/game/adhoc-[a-zA-Z0-9_-]+$`));
+  assert(consoleErrors.length === 0, `browser console errors: ${consoleErrors.join(" | ")}`);
+  console.log(
+    JSON.stringify({
+      status: "passed",
+      zeroCurrent: true,
+      oneCurrentAutoOpen: true,
+      multipleCurrentDiscovery: true,
+      canonicalNavigation: true,
+      unavailableHiddenUnknown: true,
+      unavailableDatabaseFailure: true,
+      publishedSitemapExclusion: true,
+      adHocHandoff: true,
+    }),
+  );
+} catch (error) {
+  console.error(error instanceof Error ? (error.stack ?? error.message) : String(error));
+  if (browserPage) {
+    console.error(`browser_url=${browserPage.url()}`);
+    console.error(
+      `browser_text=${(await browserPage.locator("body").innerText()).slice(0, 1_000)}`,
+    );
+  }
+  process.exitCode = 1;
+} finally {
+  if (browser) await browser.close();
+  if (server) {
+    server.kill();
+    await server.exited;
+    const diagnostics = serverStderr ? await serverStderr : "";
+    if (diagnostics.trim().length > 0) console.error(diagnostics.trim());
+  }
+  rmSync(directory, { recursive: true, force: true });
+}
+
+type PublicEventFixture = {
+  eventId: string;
+  name: string;
+  lifecycle: "unscheduled" | "current" | "future" | "past";
+  gameDays: string[];
+  canonicalPath: string;
+};
+
+async function seedDatabase() {
+  const foundation = openSqliteFoundationStorage(foundationDatabase);
+  await foundation.applyMigrations();
+  const catalog = createEventCatalog(createFoundationEventCatalogStorage(foundation), {});
+  const hostAuth = createTechnicalAdminAuth(
+    { environment: "test", origin: "https://timer.example", rpId: "timer.example" },
+    new MemoryTechnicalAdminAuthRepository(),
+  );
+  const authority = hostAuth.resolveHostLocalAuthority();
+  try {
+    const current = await createPublishedEvent(catalog, authority, "Published Current", 0);
+    await createPublishedEvent(catalog, authority, "Published Future", 1);
+    await createPublishedEvent(catalog, authority, "Published Past", -1);
+    const hidden = await catalog.createEvent({ name: "Hidden Event", timeZone: "UTC" }, authority);
+    if (hidden.status !== "accepted") throw new Error("hidden Event creation failed");
+    return { currentId: current, hiddenId: hidden.value.eventId };
+  } finally {
+    hostAuth.close();
+    foundation.close();
+  }
+}
+
+async function createPublishedEvent(
+  catalog: ReturnType<typeof createEventCatalog>,
+  authority: TechnicalAdminAuthority,
+  name: string,
+  dayOffset: number,
+) {
+  const event = await catalog.createEvent({ name, timeZone: "UTC" }, authority);
+  if (event.status !== "accepted") throw new Error(`${name} creation failed`);
+  const day = await catalog.addGameDay(
+    event.value.eventId,
+    { date: dateOffset(dayOffset) },
+    authority,
+  );
+  if (day.status !== "accepted") throw new Error(`${name} Game Day creation failed`);
+  const published = await catalog.changePublicationStatus(
+    event.value.eventId,
+    { status: "published", impactConfirmed: true },
+    authority,
+  );
+  if (published.status !== "accepted") throw new Error(`${name} publication failed`);
+  return event.value.eventId;
+}
+
+function dateOffset(offset: number) {
+  const date = new Date();
+  date.setUTCDate(date.getUTCDate() + offset);
+  return date.toISOString().slice(0, 10);
+}
+
+function futureDate() {
+  return dateOffset(1);
+}
+
+async function waitForServer(url: string) {
+  const deadline = Date.now() + 15_000;
+  while (Date.now() < deadline) {
+    const response = Bun.spawnSync(["curl", "-k", "-sSf", "-H", `host: localhost:${port}`, url]);
+    if (response.exitCode === 0) return;
+    await Bun.sleep(100);
+  }
+  throw new Error("Public Event browser server did not become ready.");
+}
+
+function assert(condition: boolean, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -139,6 +139,14 @@ describe("App", () => {
     });
   });
 
+  test("parses the stable public Event route", () => {
+    expect(parseRoute("/events/event-123", "")).toEqual({
+      type: "event",
+      eventId: "event-123",
+    });
+    expect(parseRoute("/events", "?view=all")).toEqual({ type: "home", showAll: true });
+  });
+
   beforeEach(() => {
     testWindow = new Window({
       url: "http://localhost:3000/game/test-game?mode=controller",
@@ -912,5 +920,258 @@ describe("App", () => {
       (section) => section.getAttribute("data-color-preview") === "true",
     );
     expect(previews).toHaveLength(100);
+  });
+
+  test("lists public Events with the Ad Hoc handoff between upcoming and past content", async () => {
+    testWindow.history.replaceState(null, "", "/events");
+    (globalThis.fetch as typeof fetch) = (async (input: string | URL | Request) => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      if (!url.endsWith("/api/audience/events")) return new Response("Not found", { status: 404 });
+      return new Response(
+        JSON.stringify({
+          status: "accepted",
+          value: {
+            events: [
+              {
+                eventId: "current",
+                name: "Current Event",
+                timeZone: "UTC",
+                publicationStatus: "published",
+                gameDays: ["2026-08-14"],
+                lifecycle: "current",
+                canonicalPath: "/events/current",
+                teams: [],
+                pitches: [],
+              },
+              {
+                eventId: "future",
+                name: "Future Event",
+                timeZone: "UTC",
+                publicationStatus: "published",
+                gameDays: ["2026-08-15"],
+                lifecycle: "future",
+                canonicalPath: "/events/future",
+                teams: [],
+                pitches: [],
+              },
+              {
+                eventId: "unscheduled",
+                name: "Unscheduled Event",
+                timeZone: "UTC",
+                publicationStatus: "published",
+                gameDays: [],
+                lifecycle: "unscheduled",
+                canonicalPath: "/events/unscheduled",
+                teams: [],
+                pitches: [],
+              },
+              {
+                eventId: "current-two",
+                name: "Another Current Event",
+                timeZone: "UTC",
+                publicationStatus: "published",
+                gameDays: ["2026-08-14"],
+                lifecycle: "current",
+                canonicalPath: "/events/current-two",
+                teams: [],
+                pitches: [],
+              },
+              {
+                eventId: "past",
+                name: "Past Event",
+                timeZone: "UTC",
+                publicationStatus: "published",
+                gameDays: ["2026-08-13"],
+                lifecycle: "past",
+                canonicalPath: "/events/past",
+                teams: [],
+                pitches: [],
+              },
+            ],
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as typeof fetch;
+
+    await act(async () => {
+      root.render(<App />);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const text = container.textContent ?? "";
+    expect(text).toContain("Current Event");
+    expect(text).toContain("Future Event");
+    expect(text).toContain("Unscheduled Events");
+    expect(text).toContain("Start Ad Hoc Game");
+    expect(text).toContain("Past Event");
+    expect(text.indexOf("Future Event")).toBeLessThan(text.indexOf("Start Ad Hoc Game"));
+    expect(text.indexOf("Start Ad Hoc Game")).toBeLessThan(text.indexOf("Past Event"));
+  });
+
+  test("opens the sole current Published Event from Home", async () => {
+    testWindow.history.replaceState(null, "", "/events");
+    (globalThis.fetch as typeof fetch) = (async (input: string | URL | Request) => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      if (!url.endsWith("/api/audience/events")) return new Response("Not found", { status: 404 });
+      return new Response(
+        JSON.stringify({
+          status: "accepted",
+          value: {
+            events: [
+              {
+                eventId: "only-current",
+                name: "Only Current Event",
+                timeZone: "UTC",
+                publicationStatus: "published",
+                gameDays: ["2026-08-14"],
+                lifecycle: "current",
+                canonicalPath: "/events/only-current",
+                teams: [],
+                pitches: [],
+              },
+            ],
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as typeof fetch;
+
+    await act(async () => {
+      root.render(<App />);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(testWindow.location.pathname).toBe("/events/only-current");
+  });
+
+  test("shows the discovery list when no Event is current", async () => {
+    testWindow.history.replaceState(null, "", "/events");
+    (globalThis.fetch as typeof fetch) = (async () =>
+      new Response(
+        JSON.stringify({
+          status: "accepted",
+          value: {
+            events: [
+              {
+                eventId: "future-only",
+                name: "Future Only Event",
+                timeZone: "UTC",
+                publicationStatus: "published",
+                gameDays: ["2026-08-15"],
+                lifecycle: "future",
+                canonicalPath: "/events/future-only",
+                teams: [],
+                pitches: [],
+              },
+            ],
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      )) as unknown as typeof fetch;
+
+    await act(async () => {
+      root.render(<App />);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(testWindow.location.pathname).toBe("/events");
+    expect(container.textContent).toContain("No Event is current today.");
+    expect(container.textContent).toContain("Future Only Event");
+  });
+
+  test("renders a navigable generic page for a direct unavailable Event visit", async () => {
+    testWindow.history.replaceState(null, "", "/events/hidden-event");
+    (globalThis.fetch as typeof fetch) = (async () =>
+      new Response('{"status":"unavailable"}', {
+        status: 404,
+        headers: { "content-type": "application/json" },
+      })) as unknown as typeof fetch;
+
+    await act(async () => {
+      root.render(<App />);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain("Event unavailable");
+    expect(container.textContent).toContain("Back to Home");
+    expect(container.textContent).not.toContain('{"status":"unavailable"}');
+  });
+
+  test("uses the canonical Event link and escapes to the full list without redirecting", async () => {
+    testWindow.history.replaceState(null, "", "/events/visible-event");
+    (globalThis.fetch as typeof fetch) = (async (input: string | URL | Request) => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      if (url.endsWith("/api/audience/events/visible-event")) {
+        return new Response(
+          JSON.stringify({
+            status: "accepted",
+            value: {
+              eventId: "visible-event",
+              name: "Visible Event",
+              timeZone: "UTC",
+              publicationStatus: "published",
+              gameDays: ["2026-08-14"],
+              lifecycle: "current",
+              canonicalPath: "/events/visible-event",
+              teams: [],
+              pitches: [],
+            },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      return new Response(
+        JSON.stringify({
+          status: "accepted",
+          value: {
+            events: [
+              {
+                eventId: "visible-event",
+                name: "Visible Event",
+                timeZone: "UTC",
+                publicationStatus: "published",
+                gameDays: ["2026-08-14"],
+                lifecycle: "current",
+                canonicalPath: "/events/visible-event",
+                teams: [],
+                pitches: [],
+              },
+            ],
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as typeof fetch;
+
+    await act(async () => {
+      root.render(<App />);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const allEvents = Array.from(container.getElementsByTagName("button")).find((button) =>
+      (button.textContent ?? "").includes("All events"),
+    );
+    expect(allEvents).not.toBeNull();
+    await act(async () => {
+      allEvents?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(testWindow.location.pathname).toBe("/events");
+    expect(testWindow.location.search).toBe("?view=all");
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,6 @@
-import { useCallback, useEffect, useState } from "react";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
+import { useEffect, useState } from "react";
+import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import type { ControllerRole } from "@/lib/game-types";
-import { DEFAULT_AWAY_TEAM_COLOR, DEFAULT_HOME_TEAM_COLOR } from "@/lib/team-colors";
 import { ColorTestPage } from "@/pages/color-test-page";
 import { EventOperationsPrototypePage } from "@/pages/event-operations-prototype-page";
 import { EventAdminPage } from "@/pages/event-admin-page";
@@ -16,12 +12,18 @@ import {
   parseAdHocHandoffHash,
   type AdHocHandoff,
 } from "@/lib/ad-hoc-handoff";
+import { PublicEventHomePage, PublicEventPage } from "@/pages/public-event-page";
 import { TechnicalAdminPage } from "@/pages/technical-admin-page";
 import "./index.css";
 
 type Route =
   | {
       type: "home";
+      showAll?: boolean;
+    }
+  | {
+      type: "event";
+      eventId: string;
     }
   | {
       type: "color-test";
@@ -62,7 +64,11 @@ export function App({
   const route = useRoute(initialAdHocHandoff, initialAdHocHandoffAttempted);
 
   if (route.type === "home") {
-    return <HomePage />;
+    return <PublicEventHomePage showAll={route.showAll} />;
+  }
+
+  if (route.type === "event") {
+    return <PublicEventPage eventId={route.eventId} />;
   }
 
   if (route.type === "color-test") {
@@ -105,126 +111,6 @@ export function App({
   }
 
   return <GamePage gameId={route.gameId} role={route.role} />;
-}
-
-function HomePage() {
-  const [homeName, setHomeName] = useState("Home");
-  const [awayName, setAwayName] = useState("Away");
-  const [homeColor, setHomeColor] = useState(DEFAULT_HOME_TEAM_COLOR);
-  const [awayColor, setAwayColor] = useState(DEFAULT_AWAY_TEAM_COLOR);
-
-  const handleCreateGame = useCallback(async () => {
-    const response = await fetch("/api/games", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({
-        homeName,
-        awayName,
-        homeColor,
-        awayColor,
-        browserId: getAdHocBrowserId(),
-      }),
-    });
-
-    if (!response.ok) {
-      return;
-    }
-
-    const payload = (await response.json()) as { gameId?: string };
-    if (typeof payload.gameId === "string") {
-      navigateTo(`/game/${payload.gameId}`);
-    }
-  }, [awayColor, awayName, homeColor, homeName]);
-
-  return (
-    <div className="mx-auto w-full max-w-5xl p-4 pb-12 sm:p-6">
-      <header className="mb-6 rounded-2xl border bg-card/80 p-5 shadow-sm backdrop-blur">
-        <p className="text-xs font-semibold tracking-widest text-muted-foreground uppercase">
-          Quadball Timer
-        </p>
-        <h1 className="mt-2 text-3xl font-semibold tracking-tight">
-          Live Scorekeeper + Timekeeper
-        </h1>
-        <p className="mt-2 text-sm text-muted-foreground">
-          Mobile-first control for game time, scores, cards, penalty timers, and spectator sync.
-        </p>
-        <div className="mt-3">
-          <Button size="sm" variant="outline" onClick={() => navigateTo("/color-test")}>
-            Open color test page
-          </Button>
-        </div>
-      </header>
-
-      <div className="grid gap-4 lg:grid-cols-[1fr_2fr]">
-        <Card>
-          <CardHeader>
-            <CardTitle>Start an Ad Hoc Game</CardTitle>
-            <CardDescription>
-              You are admitted as an equal Ad Hoc Controller. Share the reusable Control QR from the
-              game screen with another device.
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-3">
-            <div className="space-y-2">
-              <Label htmlFor="home-name">Home team</Label>
-              <Input
-                id="home-name"
-                value={homeName}
-                onChange={(event) => setHomeName(event.target.value)}
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="away-name">Away team</Label>
-              <Input
-                id="away-name"
-                value={awayName}
-                onChange={(event) => setAwayName(event.target.value)}
-              />
-            </div>
-            <div className="grid grid-cols-2 gap-3">
-              <div className="space-y-2">
-                <Label htmlFor="home-color">Home color</Label>
-                <Input
-                  id="home-color"
-                  type="color"
-                  value={homeColor}
-                  onChange={(event) => setHomeColor(event.target.value)}
-                  className="h-10 cursor-pointer p-1"
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="away-color">Away color</Label>
-                <Input
-                  id="away-color"
-                  type="color"
-                  value={awayColor}
-                  onChange={(event) => setAwayColor(event.target.value)}
-                  className="h-10 cursor-pointer p-1"
-                />
-              </div>
-            </div>
-            <Button className="w-full" onClick={handleCreateGame}>
-              Start an Ad Hoc Game <span className="sr-only">Create new game</span>
-            </Button>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle>Private Controller access</CardTitle>
-            <CardDescription>
-              Retained Ad Hoc Games are never listed or spectated publicly.
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <p className="text-sm text-muted-foreground">
-              Control starts immediately after atomic creation and admission.
-            </p>
-          </CardContent>
-        </Card>
-      </div>
-    </div>
-  );
 }
 
 function AdHocHandoffPage({ handoff }: { handoff: AdHocHandoff }) {
@@ -287,7 +173,7 @@ function useRoute(
   return route;
 }
 
-export function parseRoute(pathname: string, _search: string, hash = ""): Route {
+export function parseRoute(pathname: string, search: string, hash = ""): Route {
   const handoff = parseAdHocHandoffHash(hash);
   if (handoff !== null) {
     return { type: "ad-hoc-handoff", handoff };
@@ -295,7 +181,6 @@ export function parseRoute(pathname: string, _search: string, hash = ""): Route 
   if (hasAdHocHandoffAttempt(hash)) {
     return { type: "ad-hoc-unavailable" };
   }
-
   if (pathname === "/admin" || pathname === "/admin/") {
     return { type: "technical-admin", enrollment: false };
   }
@@ -305,7 +190,19 @@ export function parseRoute(pathname: string, _search: string, hash = ""): Route 
   }
 
   if (pathname === "/events" || pathname === "/events/") {
-    return { type: "home" };
+    return {
+      type: "home",
+      ...(new URLSearchParams(search).get("view") === "all" ? { showAll: true } : {}),
+    };
+  }
+
+  const eventMatch = pathname.match(/^\/events\/([^/]+)$/);
+  if (eventMatch !== null) {
+    try {
+      return { type: "event", eventId: decodeURIComponent(eventMatch[1] ?? "") };
+    } catch {
+      return { type: "home" };
+    }
   }
 
   if (pathname === "/color-test") {

--- a/src/index-public-event.test.ts
+++ b/src/index-public-event.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import { readPublicAudienceEventPage } from "./index";
+
+const publishedEvent = {
+  eventId: "event-published",
+  name: "Published Event",
+  timeZone: "UTC",
+  publicationStatus: "published" as const,
+  gameDays: ["2026-08-15"],
+  lifecycle: "current" as const,
+  canonicalPath: "/events/event-published",
+  teams: [],
+  pitches: [],
+};
+
+describe("public Event browser responses", () => {
+  test("keeps an authoritative Published Event page indexable", async () => {
+    const response = await readPublicAudienceEventPage(
+      new Request("http://localhost/events/event-published"),
+      { read: async () => ({ status: "accepted", value: publishedEvent }) },
+      () =>
+        new Response('<!doctype html><html><body><div id="root"></div></body></html>', {
+          headers: { "content-type": "text/html; charset=utf-8" },
+        }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-robots-tag")).toBeNull();
+    expect(response.headers.get("content-type")).toContain("text/html");
+    expect(await response.text()).not.toContain('"status":"unavailable"');
+  });
+
+  test.each([
+    ["unknown", { status: "unavailable" as const }],
+    ["unpublished", { status: "unavailable" as const }],
+    ["database failure", { status: "retryable-failure" as const }],
+  ])("marks %s browser pages noindex while keeping the HTML experience", async (_, result) => {
+    const response = await readPublicAudienceEventPage(
+      new Request("http://localhost/events/event-hidden"),
+      { read: async () => result },
+      () =>
+        new Response('<!doctype html><html><body><div id="root"></div></body></html>', {
+          headers: { "content-type": "text/html; charset=utf-8" },
+        }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-robots-tag")).toBe("noindex");
+    expect(response.headers.get("content-type")).toContain("text/html");
+    expect(await response.text()).not.toContain('"status":"unavailable"');
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,7 @@ import {
 import {
   createAudienceProjection,
   PUBLIC_AUDIENCE_ABSENCE,
+  type AudienceProjectionListOutcome,
   type AudienceProjectionReader,
 } from "@/lib/audience-projection";
 import {
@@ -320,6 +321,11 @@ async function startServer() {
         "/api/audience/events/:eventId": {
           GET(req: Request) {
             return readAudienceEvent(req, audienceProjection);
+          },
+        },
+        "/api/audience/events": {
+          GET(req: Request) {
+            return readAudienceEvents(req, audienceProjection);
           },
         },
         "/api/games/:gameId": {
@@ -1027,6 +1033,23 @@ async function startServer() {
         },
         "/game/:gameId": htmlRoute,
         "/": htmlRoute,
+        "/events/:eventId": {
+          async GET(req: Request, routeServer: Bun.Server<SessionData>) {
+            return readPublicAudienceEventPage(req, audienceProjection, () =>
+              fetch(new URL("/", routeServer.url)),
+            );
+          },
+        },
+        "/sitemap.xml": {
+          GET(req: Request) {
+            return readAudienceSitemap(req, audienceProjection);
+          },
+        },
+        "/robots.txt": {
+          GET(req: Request) {
+            return audienceRobotsResponse(req);
+          },
+        },
         "/events": htmlRoute,
         "/events/": htmlRoute,
         "/admin": htmlRoute,
@@ -1350,12 +1373,47 @@ export async function readGame(req: Request, service: AdHocGamesService = defaul
 
 export async function readAudienceEvent(
   req: Request,
-  projection: AudienceProjectionReader,
+  projection: Pick<AudienceProjectionReader, "read">,
 ): Promise<Response> {
-  const eventId = new URL(req.url).pathname.split("/").at(-1) ?? "";
+  const eventId = readPathSegment(req.url);
   const result = await projection.read(eventId);
   if (result.status === "accepted") return sensitiveJson(result);
-  return sensitiveJson(PUBLIC_AUDIENCE_ABSENCE, 404);
+  return publicAudienceUnavailableResponse();
+}
+
+export async function readPublicAudienceEventPage(
+  req: Request,
+  projection: Pick<AudienceProjectionReader, "read">,
+  readIndex: () => Response | Promise<Response>,
+): Promise<Response> {
+  const result = await projection.read(readPathSegment(req.url));
+  const response = await readIndex();
+  if (result.status !== "accepted") response.headers.set("x-robots-tag", "noindex");
+  return response;
+}
+
+export async function readAudienceEvents(
+  _req: Request,
+  projection: Pick<AudienceProjectionReader, "list">,
+): Promise<Response> {
+  const result = await projection.list();
+  if (result.status === "accepted") return sensitiveJson(result);
+  return publicAudienceUnavailableResponse();
+}
+
+export async function readAudienceSitemap(
+  req: Request,
+  projection: Pick<AudienceProjectionReader, "list">,
+): Promise<Response> {
+  const result = await projection.list();
+  if (result.status !== "accepted") return publicAudienceUnavailableResponse();
+  return new Response(renderAudienceSitemap(new URL(req.url), result), {
+    headers: {
+      "cache-control": "no-store",
+      "content-type": "application/xml; charset=utf-8",
+      "referrer-policy": "no-referrer",
+    },
+  });
 }
 
 export async function leaveGame(req: Request, service: AdHocGamesService = defaultAdHocService) {
@@ -1487,7 +1545,9 @@ type HtmlRoute = typeof index | ((req: Request) => Response);
 
 function adHocFallbackRouteFor(req: Request, htmlRoute: HtmlRoute) {
   const pathname = new URL(req.url).pathname;
-  return isAdHocPath(pathname) ? adHocUnavailableResponse() : resolveHtmlRoute(req, htmlRoute);
+  if (isAdHocPath(pathname)) return adHocUnavailableResponse();
+  if (isPublicEventPath(pathname)) return publicAudienceUnavailableResponse();
+  return resolveHtmlRoute(req, htmlRoute);
 }
 
 function resolveHtmlRoute(req: Request, htmlRoute: HtmlRoute) {
@@ -1501,6 +1561,79 @@ function isAdHocPath(pathname: string): boolean {
     pathname === "/api/games" ||
     pathname.startsWith("/api/games/")
   );
+}
+
+function isPublicEventPath(pathname: string): boolean {
+  return pathname === "/events/" || pathname.startsWith("/events/");
+}
+
+function readPathSegment(url: string): string {
+  const segment = new URL(url).pathname.split("/").at(-1) ?? "";
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return "";
+  }
+}
+
+function publicAudienceUnavailableResponse() {
+  return sensitiveJson(PUBLIC_AUDIENCE_ABSENCE, 404);
+}
+
+function audienceRobotsResponse(req: Request): Response {
+  const origin = new URL(req.url).origin;
+  return new Response(
+    [
+      "User-agent: *",
+      "Allow: /",
+      "Disallow: /admin",
+      "Disallow: /event-admin",
+      "Disallow: /event-control",
+      "Disallow: /api/",
+      `Sitemap: ${origin}/sitemap.xml`,
+      "",
+    ].join("\n"),
+    {
+      headers: {
+        "content-type": "text/plain; charset=utf-8",
+        "referrer-policy": "no-referrer",
+      },
+    },
+  );
+}
+
+function renderAudienceSitemap(
+  origin: URL,
+  result: AudienceProjectionListOutcome & { status: "accepted" },
+): string {
+  const locations = [
+    new URL("/", origin).toString(),
+    ...result.value.events.map((event) => new URL(event.canonicalPath, origin).toString()),
+  ];
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    ...locations.map((location) => `  <url><loc>${escapeXml(location)}</loc></url>`),
+    "</urlset>",
+    "",
+  ].join("\n");
+}
+
+function escapeXml(value: string): string {
+  return value.replace(/[&<>'"]/g, (character) => {
+    switch (character) {
+      case "&":
+        return "&amp;";
+      case "<":
+        return "&lt;";
+      case ">":
+        return "&gt;";
+      case "'":
+        return "&apos;";
+      default:
+        return "&quot;";
+    }
+  });
 }
 
 function json(payload: unknown, status = 200, extraHeaders: Iterable<[string, string]> = []) {

--- a/src/lib/audience-projection.test.ts
+++ b/src/lib/audience-projection.test.ts
@@ -4,13 +4,16 @@ import {
   createEventCatalog,
   createFoundationEventCatalogStorage,
   createUnavailableEventCatalogStorage,
+  type EventCatalogFoundationStorage,
+  type EventCatalogStorageSnapshot,
+  type StoredEvent,
 } from "@/lib/event-catalog";
 import { createInMemoryFoundationStorage } from "@/lib/foundation-storage-memory";
 import {
   MemoryTechnicalAdminAuthRepository,
   createTechnicalAdminAuth,
 } from "@/lib/technical-admin-auth";
-import { readAudienceEvent } from "@/index";
+import { readAudienceEvent, readAudienceEvents, readAudienceSitemap } from "@/index";
 
 const authority = createTechnicalAdminAuth(
   { environment: "test", origin: "https://timer.example", rpId: "timer.example" },
@@ -18,6 +21,150 @@ const authority = createTechnicalAdminAuth(
 ).resolveHostLocalAuthority();
 
 describe("Audience Publication Projection", () => {
+  test("keeps a zero-Day Published Event explicitly unscheduled", async () => {
+    const event: StoredEvent = {
+      eventId: "event-unscheduled",
+      name: "Unscheduled",
+      timeZone: "UTC",
+      publicationStatus: "published",
+      createdAtMs: 1,
+      updatedAtMs: 1,
+    };
+    const snapshot = {
+      listEvents: () => [event],
+      findEvent: () => event,
+      listGameDays: () => [],
+      listEventTeams: () => [],
+      listPitches: () => [],
+    } as unknown as EventCatalogStorageSnapshot;
+    const audience = createAudienceProjection(
+      { snapshot: async () => snapshot } as unknown as EventCatalogFoundationStorage,
+      { now: () => Date.parse("2026-08-14T12:00:00.000Z") },
+    );
+
+    const result = await audience.list();
+    expect(result).toMatchObject({
+      status: "accepted",
+      value: { events: [{ name: "Unscheduled", lifecycle: "unscheduled" }] },
+    });
+  });
+
+  test("lists only Published Events and classifies them in each Event timezone", async () => {
+    const foundation = createInMemoryFoundationStorage();
+    const storage = createFoundationEventCatalogStorage(foundation);
+    const catalog = createEventCatalog(storage, {});
+    const audience = createAudienceProjection(storage, {
+      now: () => Date.parse("2026-08-14T00:30:00.000Z"),
+    });
+    const current = await catalog.createEvent(
+      { name: "Current", timeZone: "Europe/Zurich" },
+      authority,
+    );
+    const future = await catalog.createEvent({ name: "Future", timeZone: "UTC" }, authority);
+    const past = await catalog.createEvent({ name: "Past", timeZone: "UTC" }, authority);
+    if (current.status !== "accepted" || future.status !== "accepted" || past.status !== "accepted")
+      throw new Error("Expected Events.");
+    await catalog.addGameDay(current.value.eventId, { date: "2026-08-14" }, authority);
+    await catalog.addGameDay(future.value.eventId, { date: "2026-08-15" }, authority);
+    await catalog.addGameDay(past.value.eventId, { date: "2026-08-13" }, authority);
+    await catalog.changePublicationStatus(
+      current.value.eventId,
+      { status: "published" },
+      authority,
+    );
+    await catalog.changePublicationStatus(future.value.eventId, { status: "published" }, authority);
+    await catalog.changePublicationStatus(past.value.eventId, { status: "published" }, authority);
+
+    const result = await audience.list();
+    expect(result).toMatchObject({ status: "accepted" });
+    if (result.status !== "accepted") return;
+    expect(result.value.events.map((event) => [event.name, event.lifecycle])).toEqual([
+      ["Current", "current"],
+      ["Future", "future"],
+      ["Past", "past"],
+    ]);
+    expect(result.value.events[0]).toMatchObject({
+      canonicalPath: `/events/${encodeURIComponent(current.value.eventId)}`,
+      teams: [],
+      pitches: [],
+    });
+    foundation.close();
+  });
+
+  test("adapts the allowlisted list and sitemap without exposing hidden Event names", async () => {
+    const projection = {
+      list: async () => ({
+        status: "accepted" as const,
+        value: {
+          events: [
+            {
+              eventId: "event-public",
+              name: "Public Event",
+              timeZone: "UTC",
+              publicationStatus: "published" as const,
+              gameDays: ["2026-08-14"],
+              lifecycle: "current" as const,
+              canonicalPath: "/events/event-public",
+              teams: [],
+              pitches: [],
+            },
+          ],
+        },
+      }),
+    };
+    const listResponse = await readAudienceEvents(
+      new Request("https://timer.example/api/audience/events"),
+      projection,
+    );
+    expect(listResponse.status).toBe(200);
+    expect(await listResponse.text()).toContain("Public Event");
+
+    const sitemapResponse = await readAudienceSitemap(
+      new Request("https://timer.example/sitemap.xml"),
+      projection,
+    );
+    const sitemap = await sitemapResponse.text();
+    expect(sitemapResponse.status).toBe(200);
+    expect(sitemap).toContain("https://timer.example/events/event-public");
+    expect(sitemap).not.toContain("unpublished");
+  });
+
+  test("excludes a real Unpublished Event from discovery and its sitemap", async () => {
+    const foundation = createInMemoryFoundationStorage();
+    const storage = createFoundationEventCatalogStorage(foundation);
+    const catalog = createEventCatalog(storage, {});
+    const audience = createAudienceProjection(storage, {
+      now: () => Date.parse("2026-08-14T12:00:00.000Z"),
+    });
+    const hidden = await catalog.createEvent({ name: "Hidden Event", timeZone: "UTC" }, authority);
+    const visible = await catalog.createEvent(
+      { name: "Visible Event", timeZone: "UTC" },
+      authority,
+    );
+    if (hidden.status !== "accepted" || visible.status !== "accepted")
+      throw new Error("Expected Events.");
+    await catalog.addGameDay(hidden.value.eventId, { date: "2026-08-14" }, authority);
+    await catalog.addGameDay(visible.value.eventId, { date: "2026-08-14" }, authority);
+    await catalog.changePublicationStatus(
+      visible.value.eventId,
+      { status: "published" },
+      authority,
+    );
+
+    const list = await audience.list();
+    if (list.status !== "accepted") throw new Error("Expected discovery list.");
+    expect(list.value.events.map((event) => event.name)).toEqual(["Visible Event"]);
+
+    const sitemap = await readAudienceSitemap(
+      new Request("https://timer.example/sitemap.xml"),
+      audience,
+    );
+    const sitemapBody = await sitemap.text();
+    expect(sitemapBody).toContain(encodeURIComponent(visible.value.eventId));
+    expect(sitemapBody).not.toContain(encodeURIComponent(hidden.value.eventId));
+    foundation.close();
+  });
+
   test("uses identical anonymous absence for unpublished, cancelled, nonexistent, and unknown Events", async () => {
     const foundation = createInMemoryFoundationStorage();
     const storage = createFoundationEventCatalogStorage(foundation);
@@ -40,6 +187,20 @@ describe("Audience Publication Projection", () => {
     );
     expect(await audience.read(event.value.eventId)).toEqual(PUBLIC_AUDIENCE_ABSENCE);
     expect(await audience.read("" as unknown)).toEqual({ status: "unavailable" });
+    const anonymousResponses = await Promise.all(
+      [event.value.eventId, "event-does-not-exist", ""].map((eventId) =>
+        readAudienceEvent(
+          new Request(`https://timer.example/api/audience/events/${eventId}`),
+          audience,
+        ),
+      ),
+    );
+    expect(anonymousResponses.map((response) => response.status)).toEqual([404, 404, 404]);
+    expect(await Promise.all(anonymousResponses.map((response) => response.text()))).toEqual([
+      '{"status":"unavailable"}',
+      '{"status":"unavailable"}',
+      '{"status":"unavailable"}',
+    ]);
     foundation.close();
   });
 

--- a/src/lib/audience-projection.ts
+++ b/src/lib/audience-projection.ts
@@ -4,6 +4,17 @@ import type {
   StoredEvent,
 } from "@/lib/event-catalog";
 
+export type PublicAudienceEventLifecycle = "unscheduled" | "current" | "future" | "past";
+
+export type PublicAudienceEventTeam = {
+  name: string;
+  color: string;
+};
+
+export type PublicAudiencePitch = {
+  name: string;
+};
+
 /** The narrow publication contract consumed by the future public Event experience. */
 export type PublicAudienceEventProjection = {
   eventId: string;
@@ -11,6 +22,14 @@ export type PublicAudienceEventProjection = {
   timeZone: string;
   publicationStatus: "published";
   gameDays: readonly string[];
+  lifecycle: PublicAudienceEventLifecycle;
+  canonicalPath: string;
+  teams: readonly PublicAudienceEventTeam[];
+  pitches: readonly PublicAudiencePitch[];
+};
+
+export type PublicAudienceEventList = {
+  events: readonly PublicAudienceEventProjection[];
 };
 
 export type AudienceProjectionOutcome =
@@ -18,8 +37,17 @@ export type AudienceProjectionOutcome =
   | { status: "unavailable" }
   | { status: "retryable-failure" };
 
+export type AudienceProjectionListOutcome =
+  | { status: "accepted"; value: PublicAudienceEventList }
+  | { status: "retryable-failure" };
+
+export type AudienceProjectionOptions = {
+  now?: () => number;
+};
+
 export type AudienceProjectionReader = {
   read(eventId: unknown): Promise<AudienceProjectionOutcome>;
+  list(): Promise<AudienceProjectionListOutcome>;
 };
 
 export const PUBLIC_AUDIENCE_ABSENCE = Object.freeze({
@@ -32,7 +60,9 @@ export const PUBLIC_AUDIENCE_ABSENCE = Object.freeze({
  */
 export function createAudienceProjection(
   storage: EventCatalogFoundationStorage,
+  options: AudienceProjectionOptions = {},
 ): AudienceProjectionReader {
+  const now = options.now ?? Date.now;
   return {
     async read(eventId: unknown): Promise<AudienceProjectionOutcome> {
       if (typeof eventId !== "string" || eventId.trim().length === 0)
@@ -42,7 +72,23 @@ export function createAudienceProjection(
         const event = snapshot.findEvent(eventId);
         if (event === null || event.publicationStatus !== "published")
           return { status: "unavailable" };
-        return { status: "accepted", value: projectPublicEvent(snapshot, event) };
+        return { status: "accepted", value: projectPublicEvent(snapshot, event, now()) };
+      } catch {
+        return { status: "retryable-failure" };
+      }
+    },
+    async list(): Promise<AudienceProjectionListOutcome> {
+      try {
+        const snapshot = await storage.snapshot();
+        const nowMs = now();
+        const events = snapshot
+          .listEvents()
+          .filter((event) => event.publicationStatus === "published")
+          .map((event) => projectPublicEvent(snapshot, event, nowMs));
+        return {
+          status: "accepted",
+          value: { events: sortPublicEvents(events) },
+        };
       } catch {
         return { status: "retryable-failure" };
       }
@@ -53,15 +99,74 @@ export function createAudienceProjection(
 function projectPublicEvent(
   snapshot: EventCatalogStorageSnapshot,
   event: StoredEvent,
+  nowMs: number,
 ): PublicAudienceEventProjection {
+  const gameDays = snapshot
+    .listGameDays(event.eventId)
+    .map(({ date }) => date)
+    .sort();
   return {
     eventId: event.eventId,
     name: event.name,
     timeZone: event.timeZone,
     publicationStatus: "published",
-    gameDays: snapshot
-      .listGameDays(event.eventId)
-      .map(({ date }) => date)
-      .sort((left, right) => left.localeCompare(right)),
+    gameDays,
+    lifecycle: classifyLifecycle(gameDays, event.timeZone, nowMs),
+    canonicalPath: `/events/${encodeURIComponent(event.eventId)}`,
+    teams: snapshot.listEventTeams(event.eventId).map(({ name, defaultColor }) => ({
+      name,
+      color: defaultColor,
+    })),
+    pitches: snapshot.listPitches(event.eventId).map(({ name }) => ({ name })),
   };
+}
+
+function classifyLifecycle(
+  gameDays: readonly string[],
+  timeZone: string,
+  nowMs: number,
+): PublicAudienceEventLifecycle {
+  if (gameDays.length === 0) return "unscheduled";
+  const today = localDate(nowMs, timeZone);
+  if (gameDays.includes(today)) return "current";
+  return gameDays.some((date) => date > today) ? "future" : "past";
+}
+
+function localDate(nowMs: number, timeZone: string): string {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(new Date(nowMs));
+  const values = new Map(parts.map((part) => [part.type, part.value]));
+  return `${values.get("year")}-${values.get("month")}-${values.get("day")}`;
+}
+
+function sortPublicEvents(
+  events: readonly PublicAudienceEventProjection[],
+): readonly PublicAudienceEventProjection[] {
+  return [...events].sort((left, right) => {
+    const lifecycle = lifecycleOrder(left.lifecycle) - lifecycleOrder(right.lifecycle);
+    if (lifecycle !== 0) return lifecycle;
+    const leftDate = left.gameDays[0] ?? "9999-99-99";
+    const rightDate = right.gameDays[0] ?? "9999-99-99";
+    const date =
+      left.lifecycle === "past"
+        ? rightDate.localeCompare(leftDate)
+        : leftDate.localeCompare(rightDate);
+    return date === 0
+      ? left.name.localeCompare(right.name) || left.eventId.localeCompare(right.eventId)
+      : date;
+  });
+}
+
+function lifecycleOrder(lifecycle: PublicAudienceEventLifecycle): number {
+  return lifecycle === "current"
+    ? 0
+    : lifecycle === "future"
+      ? 1
+      : lifecycle === "unscheduled"
+        ? 2
+        : 3;
 }

--- a/src/pages/public-event-page.tsx
+++ b/src/pages/public-event-page.tsx
@@ -1,0 +1,371 @@
+import { useCallback, useEffect, useState, type ReactNode } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import type { PublicAudienceEventProjection } from "@/lib/audience-projection";
+import { DEFAULT_AWAY_TEAM_COLOR, DEFAULT_HOME_TEAM_COLOR } from "@/lib/team-colors";
+
+export function PublicEventHomePage({ showAll = false }: { showAll?: boolean }) {
+  const [events, setEvents] = useState<readonly PublicAudienceEventProjection[] | null>(null);
+  const [discoveryUnavailable, setDiscoveryUnavailable] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    void fetch("/api/audience/events")
+      .then(async (response) => {
+        if (!response.ok) throw new Error("Audience discovery unavailable");
+        const payload = (await response.json()) as AudienceEventsResponse;
+        if (payload.status !== "accepted") throw new Error("Audience discovery unavailable");
+        return payload.value.events;
+      })
+      .then((nextEvents) => {
+        if (!active) return;
+        const current = nextEvents.filter((event) => event.lifecycle === "current");
+        if (!showAll && current.length === 1) {
+          navigateTo(current[0]!.canonicalPath);
+          return;
+        }
+        setEvents(nextEvents);
+      })
+      .catch(() => {
+        if (active) setDiscoveryUnavailable(true);
+      });
+    return () => {
+      active = false;
+    };
+  }, [showAll]);
+
+  return (
+    <PublicShell
+      title="Public Event discovery"
+      description="Find a Published Event and follow its public schedule. No sign-in is required."
+    >
+      {events === null && !discoveryUnavailable ? (
+        <div className="space-y-6">
+          <p className="rounded-2xl border bg-card/80 p-5 text-sm text-muted-foreground">
+            Loading Published Events…
+          </p>
+          <StartAdHocGame />
+        </div>
+      ) : discoveryUnavailable ? (
+        <div className="space-y-6">
+          <p className="rounded-2xl border bg-card/80 p-5 text-sm text-muted-foreground">
+            Event discovery is unavailable.
+          </p>
+          <StartAdHocGame />
+        </div>
+      ) : (
+        <EventDiscovery events={events ?? []} />
+      )}
+    </PublicShell>
+  );
+}
+
+export function PublicEventPage({ eventId }: { eventId: string }) {
+  const [event, setEvent] = useState<PublicAudienceEventProjection | null>(null);
+  const [unavailable, setUnavailable] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    setEvent(null);
+    setUnavailable(false);
+    void fetch(`/api/audience/events/${encodeURIComponent(eventId)}`)
+      .then(async (response) => {
+        if (!response.ok) throw new Error("Event unavailable");
+        const payload = (await response.json()) as AudienceEventResponse;
+        if (payload.status !== "accepted") throw new Error("Event unavailable");
+        return payload.value;
+      })
+      .then((nextEvent) => {
+        if (active) setEvent(nextEvent);
+      })
+      .catch(() => {
+        if (active) setUnavailable(true);
+      });
+    return () => {
+      active = false;
+    };
+  }, [eventId]);
+
+  if (unavailable) return <UnavailablePanel />;
+  if (event === null) {
+    return (
+      <PublicShell title="Published Event" description="Loading public Event information…">
+        <p className="rounded-2xl border bg-card/80 p-5 text-sm text-muted-foreground">Loading…</p>
+      </PublicShell>
+    );
+  }
+
+  return (
+    <PublicShell title={event.name} description={`Published Event · ${event.timeZone}`}>
+      <div className="space-y-4">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <p className="text-sm text-muted-foreground">{lifecycleLabel(event.lifecycle)}</p>
+          <Button variant="outline" onClick={() => navigateTo("/events?view=all")}>
+            All events
+          </Button>
+        </div>
+        <Card>
+          <CardHeader>
+            <CardTitle>Game Days</CardTitle>
+            <CardDescription>
+              Published Event information from the authoritative catalog.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {event.gameDays.length === 0 ? (
+              <p className="text-sm text-muted-foreground">No Game Days have been scheduled.</p>
+            ) : (
+              <ul className="grid gap-2 sm:grid-cols-2">
+                {event.gameDays.map((date) => (
+                  <li key={date} className="rounded-xl border px-3 py-2 text-sm">
+                    {date}
+                  </li>
+                ))}
+              </ul>
+            )}
+            {event.teams.length > 0 && (
+              <div>
+                <h2 className="text-sm font-semibold">Event Teams</h2>
+                <ul className="mt-2 grid gap-2 sm:grid-cols-2">
+                  {event.teams.map((team) => (
+                    <li
+                      key={`${team.name}-${team.color}`}
+                      className="rounded-xl border px-3 py-2 text-sm"
+                    >
+                      {team.name}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            {event.pitches.length > 0 && (
+              <div>
+                <h2 className="text-sm font-semibold">Pitches</h2>
+                <ul className="mt-2 flex flex-wrap gap-2">
+                  {event.pitches.map((pitch) => (
+                    <li key={pitch.name} className="rounded-full border px-3 py-1 text-sm">
+                      {pitch.name}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </PublicShell>
+  );
+}
+
+function EventDiscovery({ events }: { events: readonly PublicAudienceEventProjection[] }) {
+  const current = events.filter((event) => event.lifecycle === "current");
+  const future = events.filter((event) => event.lifecycle === "future");
+  const unscheduled = events.filter((event) => event.lifecycle === "unscheduled");
+  const past = events.filter((event) => event.lifecycle === "past");
+
+  return (
+    <div className="space-y-6">
+      <EventGroup title="Current Events" events={current} empty="No Event is current today." />
+      <EventGroup title="Upcoming Events" events={future} empty="No upcoming Published Events." />
+      <EventGroup
+        title="Unscheduled Events"
+        events={unscheduled}
+        empty="No unscheduled Published Events."
+      />
+      <StartAdHocGame />
+      <EventGroup title="Past Events" events={past} empty="No past Published Events." />
+    </div>
+  );
+}
+
+function EventGroup({
+  title,
+  events,
+  empty,
+}: {
+  title: string;
+  events: readonly PublicAudienceEventProjection[];
+  empty: string;
+}) {
+  return (
+    <section aria-labelledby={title.toLowerCase().replaceAll(" ", "-")}>
+      <h2 id={title.toLowerCase().replaceAll(" ", "-")} className="mb-3 text-xl font-semibold">
+        {title}
+      </h2>
+      {events.length === 0 ? (
+        <p className="rounded-2xl border border-dashed p-4 text-sm text-muted-foreground">
+          {empty}
+        </p>
+      ) : (
+        <div className="grid gap-3 sm:grid-cols-2">
+          {events.map((event) => (
+            <a
+              key={event.eventId}
+              href={event.canonicalPath}
+              className="rounded-2xl border bg-card/80 p-4 shadow-sm transition hover:border-primary focus:outline-none focus:ring-2 focus:ring-ring"
+              onClick={(click) => {
+                if (
+                  click.button !== 0 ||
+                  click.metaKey ||
+                  click.ctrlKey ||
+                  click.shiftKey ||
+                  click.altKey
+                )
+                  return;
+                click.preventDefault();
+                navigateTo(event.canonicalPath);
+              }}
+            >
+              <span className="font-semibold">{event.name}</span>
+              <span className="mt-1 block text-sm text-muted-foreground">
+                {event.gameDays.length > 0 ? event.gameDays.join(" · ") : "Unscheduled"}
+              </span>
+            </a>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function StartAdHocGame() {
+  const [homeName, setHomeName] = useState("Home");
+  const [awayName, setAwayName] = useState("Away");
+  const [homeColor, setHomeColor] = useState(DEFAULT_HOME_TEAM_COLOR);
+  const [awayColor, setAwayColor] = useState(DEFAULT_AWAY_TEAM_COLOR);
+
+  const handleCreateGame = useCallback(async () => {
+    const response = await fetch("/api/games", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        homeName,
+        awayName,
+        homeColor,
+        awayColor,
+      }),
+    });
+
+    if (!response.ok) return;
+
+    const payload = (await response.json()) as { gameId?: string };
+    if (typeof payload.gameId === "string") navigateTo(`/game/${payload.gameId}`);
+  }, [awayColor, awayName, homeColor, homeName]);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Start Ad Hoc Game</CardTitle>
+        <CardDescription>
+          Need an unscheduled Game? Start one here. You are admitted as the initially admitted Ad
+          Hoc Controller.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div className="space-y-2">
+          <Label htmlFor="home-name">Home team</Label>
+          <Input
+            id="home-name"
+            value={homeName}
+            onChange={(event) => setHomeName(event.target.value)}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="away-name">Away team</Label>
+          <Input
+            id="away-name"
+            value={awayName}
+            onChange={(event) => setAwayName(event.target.value)}
+          />
+        </div>
+        <div className="grid grid-cols-2 gap-3">
+          <div className="space-y-2">
+            <Label htmlFor="home-color">Home color</Label>
+            <Input
+              id="home-color"
+              type="color"
+              value={homeColor}
+              onChange={(event) => setHomeColor(event.target.value)}
+              className="h-10 cursor-pointer p-1"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="away-color">Away color</Label>
+            <Input
+              id="away-color"
+              type="color"
+              value={awayColor}
+              onChange={(event) => setAwayColor(event.target.value)}
+              className="h-10 cursor-pointer p-1"
+            />
+          </div>
+        </div>
+        <Button className="w-full" onClick={handleCreateGame}>
+          Start an Ad Hoc Game <span className="sr-only">Create new game</span>
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}
+
+function PublicShell({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="mx-auto w-full max-w-5xl p-4 pb-12 sm:p-6">
+      <header className="mb-6 rounded-2xl border bg-card/80 p-5 shadow-sm backdrop-blur">
+        <p className="text-xs font-semibold tracking-widest text-muted-foreground uppercase">
+          Quadball Timer
+        </p>
+        <h1 className="mt-2 text-3xl font-semibold tracking-tight">{title}</h1>
+        <p className="mt-2 text-sm text-muted-foreground">{description}</p>
+      </header>
+      {children}
+    </div>
+  );
+}
+
+function UnavailablePanel() {
+  return (
+    <PublicShell title="Event unavailable" description="This Published Event is not available.">
+      <Card>
+        <CardContent className="space-y-4 pt-6">
+          <p className="text-sm text-muted-foreground">
+            The Event may be hidden, unknown, or temporarily unavailable.
+          </p>
+          <Button onClick={() => navigateTo("/events?view=all")}>Back to Home</Button>
+        </CardContent>
+      </Card>
+    </PublicShell>
+  );
+}
+
+function lifecycleLabel(lifecycle: PublicAudienceEventProjection["lifecycle"]): string {
+  return lifecycle === "current"
+    ? "Current Event"
+    : lifecycle === "future"
+      ? "Upcoming Event"
+      : lifecycle === "unscheduled"
+        ? "Unscheduled Event"
+        : "Past Event";
+}
+
+type AudienceEventResponse =
+  | { status: "accepted"; value: PublicAudienceEventProjection }
+  | { status: "unavailable" };
+type AudienceEventsResponse =
+  | { status: "accepted"; value: { events: readonly PublicAudienceEventProjection[] } }
+  | { status: "unavailable" };
+
+function navigateTo(path: string) {
+  window.history.pushState(null, "", path);
+  window.dispatchEvent(new PopStateEvent("popstate"));
+}


### PR DESCRIPTION
## Summary

- establish the database-backed Audience Projections contract for published Event discovery, canonical public Event routes, and semantic absence
- add public Home/Event discovery with sole-current auto-open, explicit all-Events escape, Ad Hoc handoff, and generic unavailable recovery
- keep hidden and failed Event routes non-indexable while generating sitemap entries only for Published Events
- add focused HTTP, projection, interaction, and Playwright coverage for the complete #133 discovery boundary

## Testing

- `bun run check`
- `bun run test` (592 tests, 17,266 expectations)
- `bun run build`
- `bun run test:focused:public-event-browser`
- `git diff --check`

This replaces #183, which was merged into an intermediate dependency branch instead of `main`.

Closes #133