### PR TITLE
Manage Control Grants and sessions

### DIFF
--- a/scripts/test-technical-admin-browser.ts
+++ b/scripts/test-technical-admin-browser.ts
@@ -598,6 +598,174 @@ try {
     .getByText(/Control Grant:/u)
     .first()
     .waitFor();
+
+  const controlSetupResponse = await eventAdminContext.request.get(
+    `${origin}/api/event-admin/slot-setup?eventId=${eventId}&gameDayId=${pitchManagerGameDayId}`,
+  );
+  const controlSetupPayload = (await controlSetupResponse.json()) as {
+    value?: {
+      pitchSlots?: Array<{ pitchSlotId: string; pitchId: string; gameDayId: string }>;
+    };
+  };
+  const controlSlot = controlSetupPayload.value?.pitchSlots?.find(
+    (slot) => slot.pitchId === pitchManagerPitchId && slot.gameDayId === pitchManagerGameDayId,
+  );
+  const pitchManagerControlSlot = controlSetupPayload.value?.pitchSlots?.find(
+    (slot) =>
+      slot.pitchId === pitchManagerPitchId &&
+      slot.gameDayId === pitchManagerGameDayId &&
+      slot.pitchSlotId !== controlSlot?.pitchSlotId,
+  );
+  assert(
+    controlSetupResponse.status() === 200 &&
+      controlSlot !== undefined &&
+      pitchManagerControlSlot !== undefined,
+    "Control Slot setup failed",
+  );
+  const controlGrantPath = `/api/event-admin/events/${eventId}/game-days/${pitchManagerGameDayId}/pitches/${pitchManagerPitchId}/pitch-slots/${controlSlot.pitchSlotId}/control-grant`;
+  const controlCreateResponse = await postJsonBodyFromPage(
+    eventAdminPage,
+    `${origin}${controlGrantPath}`,
+    {},
+  );
+  const controlCreatePayload = JSON.parse(controlCreateResponse.body) as {
+    value?: Record<string, unknown>;
+  };
+  assert(
+    controlCreateResponse.status === 201 &&
+      controlCreatePayload.value?.grantId !== undefined &&
+      controlCreatePayload.value?.qrCredential === undefined,
+    "Control Grant creation disclosed a credential or failed",
+  );
+  const eventAdminCookieBeforePitchManagerMutation = (await eventAdminContext.cookies()).find(
+    (cookie) => cookie.name === "__Host-event-admin-session",
+  );
+  if (eventAdminCookieBeforePitchManagerMutation === undefined)
+    throw new Error("Event Admin session cookie was not available for cookie isolation evidence.");
+  await pitchManagerContext.addCookies([eventAdminCookieBeforePitchManagerMutation]);
+  const pitchManagerControlPath = `/api/pitch-manager/events/${eventId}/game-days/${pitchManagerGameDayId}/pitches/${pitchManagerPitchId}/pitch-slots/${pitchManagerControlSlot.pitchSlotId}/control-grant`;
+  const pitchManagerControlCreateResponsePromise = pitchManagerPage.waitForResponse(
+    (response) =>
+      response
+        .url()
+        .endsWith(`/pitch-slots/${pitchManagerControlSlot.pitchSlotId}/control-grant`) &&
+      response.request().method() === "POST",
+  );
+  const pitchManagerControlCreateResponse = await pitchManagerPage.evaluate(async (requestUrl) => {
+    const response = await fetch(requestUrl, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    return response.status;
+  }, `${origin}${pitchManagerControlPath}`);
+  const pitchManagerControlCreateResponseHeaders = await pitchManagerControlCreateResponsePromise;
+  const pitchManagerControlCreateCookie = (
+    await pitchManagerControlCreateResponseHeaders.headersArray()
+  ).find((header) => header.name === "set-cookie")?.value;
+  assert(
+    pitchManagerControlCreateResponse === 201 &&
+      pitchManagerControlCreateCookie?.includes("__Host-pitch-manager-session=") === true &&
+      pitchManagerControlCreateCookie?.includes("__Host-event-admin-session=") !== true,
+    "Pitch Manager Control Grant creation did not refresh only its own cookie",
+  );
+  const eventAdminCookieAfterPitchManagerMutation = (await pitchManagerContext.cookies()).find(
+    (cookie) => cookie.name === "__Host-event-admin-session",
+  );
+  assert(
+    eventAdminCookieAfterPitchManagerMutation?.value ===
+      eventAdminCookieBeforePitchManagerMutation.value,
+    "Pitch Manager Control Grant mutation overwrote the Event Admin cookie",
+  );
+  const pitchManagerCreatedControlInspect = await pitchManagerContext.request.get(
+    `${origin}${pitchManagerControlPath}`,
+  );
+  assert(
+    pitchManagerCreatedControlInspect.status() === 200,
+    "Pitch Manager Control Grant inspection failed",
+  );
+  const pitchManagerControlSessions = await pitchManagerContext.request.get(
+    `${origin}${pitchManagerControlPath}/sessions`,
+  );
+  assert(
+    pitchManagerControlSessions.status() === 200 &&
+      pitchManagerControlSessions.headers()["set-cookie"] === undefined,
+    "Pitch Manager Control Grant session listing was not read-only",
+  );
+  const wrongPitchManagerControl = await pitchManagerContext.request.get(
+    `${origin}/api/pitch-manager/events/${eventId}/game-days/${pitchManagerGameDayId}/pitches/wrong-pitch/pitch-slots/${pitchManagerControlSlot.pitchSlotId}/control-grant`,
+  );
+  const wrongGameDayPitchManagerControl = await pitchManagerContext.request.get(
+    `${origin}/api/pitch-manager/events/${eventId}/game-days/wrong-game-day/pitches/${pitchManagerPitchId}/pitch-slots/${pitchManagerControlSlot.pitchSlotId}/control-grant`,
+  );
+  assert(
+    (wrongPitchManagerControl.status() === 401 || wrongPitchManagerControl.status() === 404) &&
+      (wrongGameDayPitchManagerControl.status() === 401 ||
+        wrongGameDayPitchManagerControl.status() === 404),
+    "Pitch Manager Control Grant scope accepted a wrong Pitch or Game Day",
+  );
+  await eventAdminPage.reload();
+  await eventAdminPage
+    .getByLabel("Game Day", { exact: true })
+    .selectOption({ value: pitchManagerGameDayId });
+  await eventAdminPage.getByRole("button", { name: "Pitch Main", exact: true }).click();
+  const controlInspectResponsePromise = eventAdminPage.waitForResponse(
+    (response) =>
+      response.url().endsWith(`/pitch-slots/${controlSlot.pitchSlotId}/control-grant`) &&
+      response.request().method() === "GET",
+  );
+  await eventAdminPage.getByRole("button", { name: "Inspect Control Grant" }).first().click();
+  assert((await controlInspectResponsePromise).status() === 200, "Control Grant inspection failed");
+  const pitchManagerControlInspect = await pitchManagerContext.request.get(
+    `${origin}/api/pitch-manager${controlGrantPath}`,
+  );
+  assert(
+    pitchManagerControlInspect.status() === 200,
+    "Pitch Manager could not inspect its exact Pitch and Game Day Control Grant",
+  );
+  const wrongPitchManagerControlInspect = await pitchManagerContext.request.get(
+    `${origin}/api/pitch-manager/events/${eventId}/game-days/wrong-game-day/pitches/${pitchManagerPitchId}/pitch-slots/${controlSlot.pitchSlotId}/control-grant`,
+  );
+  assert(
+    wrongPitchManagerControlInspect.status() === 401 ||
+      wrongPitchManagerControlInspect.status() === 404,
+    "Pitch Manager Control Grant scope was broader than its exact Game Day",
+  );
+  const controlRevealResponsePromise = eventAdminPage.waitForResponse(
+    (response) =>
+      response.url().endsWith(`/pitch-slots/${controlSlot.pitchSlotId}/control-grant/reveal`) &&
+      response.request().method() === "POST",
+  );
+  await eventAdminPage.getByRole("button", { name: "Reveal QR" }).first().click();
+  const controlRevealResponse = await controlRevealResponsePromise;
+  const controlRevealPayload = (await controlRevealResponse.json()) as {
+    status?: string;
+    reason?: string;
+    value?: { qrCredential?: string };
+  };
+  assert(
+    controlRevealResponse.status() === 401 &&
+      controlRevealPayload.value?.qrCredential === undefined &&
+      controlRevealPayload.reason === "unauthorized",
+    "ineligible Control Grant reveal was not generic and redacted",
+  );
+  const controlSessionsResponsePromise = eventAdminPage.waitForResponse(
+    (response) =>
+      response.url().endsWith(`/pitch-slots/${controlSlot.pitchSlotId}/control-grant/sessions`) &&
+      response.request().method() === "GET",
+  );
+  await eventAdminPage.getByRole("button", { name: "Sessions" }).first().click();
+  const controlSessionsResponse = await controlSessionsResponsePromise;
+  assert(controlSessionsResponse.status() === 200, "Control Grant session listing failed");
+  const controlRotateResponse = await postJsonFromPage(
+    eventAdminPage,
+    `${origin}${controlGrantPath}/rotate`,
+    {},
+  );
+  assert(
+    controlRotateResponse.status === 400 || controlRotateResponse.status === 401,
+    "ineligible Control Grant rotation did not fail generically",
+  );
   await pitchManagerPage.reload();
   await pitchManagerPage.getByText("Pitch Main", { exact: true }).waitFor();
   await pitchManagerPage.getByText(/2026-08-15 10:00 Europe\/Zurich/u).waitFor();
@@ -1007,6 +1175,12 @@ try {
       eventAdminRotationRevocationIsolation: true,
       pitchManagerHandoff: true,
       pitchManagerScopedView: true,
+      controlGrantManagement: true,
+      controlGrantRedaction: true,
+      controlGrantScopedView: true,
+      pitchManagerControlCookieIsolation: true,
+      pitchManagerControlReadOnly: true,
+      pitchManagerControlScopedView: true,
       forgedAuthorityRejected: true,
       revocationRevalidated: true,
     }),
@@ -1099,6 +1273,24 @@ async function postJsonFromPage(page: Page, url: string, body: Record<string, st
         status: response.status,
         cacheControl: response.headers.get("cache-control"),
         referrerPolicy: response.headers.get("referrer-policy"),
+        setCookie: response.headers.get("set-cookie"),
+      };
+    },
+    { requestUrl: url, requestBody: body },
+  );
+}
+
+async function postJsonBodyFromPage(page: Page, url: string, body: Record<string, string>) {
+  return page.evaluate(
+    async ({ requestUrl, requestBody }) => {
+      const response = await fetch(requestUrl, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(requestBody),
+      });
+      return {
+        status: response.status,
+        body: await response.text(),
         setCookie: response.headers.get("set-cookie"),
       };
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { parseClientWsMessage, type ServerWsMessage } from "@/lib/ws-protocol";
 import { createLiveEventGameControlTransport } from "@/lib/live-event-game-transport";
 import {
   openLiveEventGameRuntime,
+  createControlScopeResolver,
   readLiveEventGrantKeyRing,
   type LiveEventGameRuntime,
 } from "@/lib/live-event-game-runtime";
@@ -210,13 +211,15 @@ async function startServer() {
     let eventAdministration: EventAdministration | null = null;
     if (foundationStorage !== undefined) {
       try {
-        const grantAuthority = createGrantAuthority(
-          foundationStorage,
-          runtimeGrantOptions ?? readGrantAuthorityOptions(environment),
-        );
+        const grantOptions = {
+          ...(runtimeGrantOptions ?? readGrantAuthorityOptions(environment)),
+          controlScopeResolver: createControlScopeResolver(),
+        };
+        const grantAuthority = createGrantAuthority(foundationStorage, grantOptions);
         eventAdministration = createEventAdministration({
           storage: foundationStorage,
           grants: grantAuthority,
+          controlScopeResolver: grantOptions.controlScopeResolver,
         });
       } catch {
         // Grant keys are an Event Administration dependency, not a server-wide dependency.
@@ -307,8 +310,36 @@ async function startServer() {
                     authority,
                   );
       return sensitiveEventAdministrationMutationResponse<TypedGrantMutation | TypedGrantReveal>(
-        result,
+        result as EventAdministrationMutationOutcome<TypedGrantMutation | TypedGrantReveal>,
         authority,
+      );
+    };
+    const controlGrantMutation = async (
+      req: Request,
+      authorityResolver: (request: Request) => EventAdministrationAuthority | null,
+      operation: "reveal" | "rotate" | "revoke-session",
+      audience: "event-admin" | "pitch-manager" = "event-admin",
+    ) => {
+      if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
+      const authority = authorityResolver(req);
+      const path = new URL(req.url).pathname.split("/");
+      if (authority === null) return sensitiveGenericAuthFailure(401);
+      const common = [path[4] ?? "", path[6] ?? "", path[8] ?? "", path[10] ?? ""] as const;
+      const result =
+        operation === "reveal"
+          ? await eventAdministration.revealControlGrant(...common, authority)
+          : operation === "rotate"
+            ? await eventAdministration.rotateControlGrant(...common, authority)
+            : await eventAdministration.revokeControlGrantSession(
+                ...common,
+                (await readJsonRecord(req))?.sessionReference,
+                authority,
+              );
+      return sensitiveEventAdministrationMutationResponse<TypedGrantMutation | TypedGrantReveal>(
+        result as EventAdministrationMutationOutcome<TypedGrantMutation | TypedGrantReveal>,
+        authority,
+        200,
+        audience,
       );
     };
     const tls =
@@ -868,6 +899,86 @@ async function startServer() {
           {
             POST: (req: Request) => pitchManagerGrantMutation(req, "reactivatePitchManagerGrant"),
           },
+        "/api/event-admin/events/:eventId/game-days/:gameDayId/pitches/:pitchId/pitch-slots/:pitchSlotId/control-grant":
+          {
+            async GET(req: Request) {
+              if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
+              const authority = resolveEventAdministrationAuthority(req, technicalAdminAuth);
+              const path = new URL(req.url).pathname.split("/");
+              if (authority === null) return sensitiveGenericAuthFailure(401);
+              return sensitiveEventAdministrationResponse(
+                await eventAdministration.inspectControlGrant(
+                  path[4] ?? "",
+                  path[6] ?? "",
+                  path[8] ?? "",
+                  path[10] ?? "",
+                  authority,
+                ),
+              );
+            },
+            async POST(req: Request) {
+              if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
+              const authority = resolveEventAdministrationAuthority(req, technicalAdminAuth);
+              const path = new URL(req.url).pathname.split("/");
+              if (authority === null) return sensitiveGenericAuthFailure(401);
+              return sensitiveEventAdministrationMutationResponse(
+                await eventAdministration.createControlGrant(
+                  path[4] ?? "",
+                  path[6] ?? "",
+                  path[8] ?? "",
+                  path[10] ?? "",
+                  authority,
+                ),
+                authority,
+                201,
+              );
+            },
+          },
+        "/api/event-admin/events/:eventId/game-days/:gameDayId/pitches/:pitchId/pitch-slots/:pitchSlotId/control-grant/reveal":
+          {
+            POST: (req: Request) =>
+              controlGrantMutation(
+                req,
+                (request) => resolveEventAdministrationAuthority(request, technicalAdminAuth),
+                "reveal",
+              ),
+          },
+        "/api/event-admin/events/:eventId/game-days/:gameDayId/pitches/:pitchId/pitch-slots/:pitchSlotId/control-grant/rotate":
+          {
+            POST: (req: Request) =>
+              controlGrantMutation(
+                req,
+                (request) => resolveEventAdministrationAuthority(request, technicalAdminAuth),
+                "rotate",
+              ),
+          },
+        "/api/event-admin/events/:eventId/game-days/:gameDayId/pitches/:pitchId/pitch-slots/:pitchSlotId/control-grant/sessions":
+          {
+            async GET(req: Request) {
+              if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
+              const authority = resolveEventAdministrationAuthority(req, technicalAdminAuth);
+              const path = new URL(req.url).pathname.split("/");
+              if (authority === null) return sensitiveGenericAuthFailure(401);
+              return sensitiveEventAdministrationResponse(
+                await eventAdministration.listControlGrantSessions(
+                  path[4] ?? "",
+                  path[6] ?? "",
+                  path[8] ?? "",
+                  path[10] ?? "",
+                  authority,
+                ),
+              );
+            },
+          },
+        "/api/event-admin/events/:eventId/game-days/:gameDayId/pitches/:pitchId/pitch-slots/:pitchSlotId/control-grant/sessions/revoke":
+          {
+            POST: (req: Request) =>
+              controlGrantMutation(
+                req,
+                (request) => resolveEventAdministrationAuthority(request, technicalAdminAuth),
+                "revoke-session",
+              ),
+          },
         "/api/pitch-manager/admit": {
           async POST(req: Request) {
             if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
@@ -932,6 +1043,90 @@ async function startServer() {
             );
           },
         },
+        "/api/pitch-manager/events/:eventId/game-days/:gameDayId/pitches/:pitchId/pitch-slots/:pitchSlotId/control-grant":
+          {
+            async GET(req: Request) {
+              if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
+              const authority = resolvePitchManagerAuthority(req, technicalAdminAuth);
+              const path = new URL(req.url).pathname.split("/");
+              if (authority === null) return sensitiveGenericAuthFailure(401);
+              return sensitiveEventAdministrationResponse(
+                await eventAdministration.inspectControlGrant(
+                  path[4] ?? "",
+                  path[6] ?? "",
+                  path[8] ?? "",
+                  path[10] ?? "",
+                  authority,
+                ),
+              );
+            },
+            async POST(req: Request) {
+              if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
+              const authority = resolvePitchManagerAuthority(req, technicalAdminAuth);
+              const path = new URL(req.url).pathname.split("/");
+              if (authority === null) return sensitiveGenericAuthFailure(401);
+              return sensitiveEventAdministrationMutationResponse(
+                await eventAdministration.createControlGrant(
+                  path[4] ?? "",
+                  path[6] ?? "",
+                  path[8] ?? "",
+                  path[10] ?? "",
+                  authority,
+                ),
+                authority,
+                201,
+                "pitch-manager",
+              );
+            },
+          },
+        "/api/pitch-manager/events/:eventId/game-days/:gameDayId/pitches/:pitchId/pitch-slots/:pitchSlotId/control-grant/reveal":
+          {
+            POST: (req: Request) =>
+              controlGrantMutation(
+                req,
+                (request) => resolvePitchManagerAuthority(request, technicalAdminAuth),
+                "reveal",
+                "pitch-manager",
+              ),
+          },
+        "/api/pitch-manager/events/:eventId/game-days/:gameDayId/pitches/:pitchId/pitch-slots/:pitchSlotId/control-grant/rotate":
+          {
+            POST: (req: Request) =>
+              controlGrantMutation(
+                req,
+                (request) => resolvePitchManagerAuthority(request, technicalAdminAuth),
+                "rotate",
+                "pitch-manager",
+              ),
+          },
+        "/api/pitch-manager/events/:eventId/game-days/:gameDayId/pitches/:pitchId/pitch-slots/:pitchSlotId/control-grant/sessions":
+          {
+            async GET(req: Request) {
+              if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
+              const authority = resolvePitchManagerAuthority(req, technicalAdminAuth);
+              const path = new URL(req.url).pathname.split("/");
+              if (authority === null) return sensitiveGenericAuthFailure(401);
+              return sensitiveEventAdministrationResponse(
+                await eventAdministration.listControlGrantSessions(
+                  path[4] ?? "",
+                  path[6] ?? "",
+                  path[8] ?? "",
+                  path[10] ?? "",
+                  authority,
+                ),
+              );
+            },
+          },
+        "/api/pitch-manager/events/:eventId/game-days/:gameDayId/pitches/:pitchId/pitch-slots/:pitchSlotId/control-grant/sessions/revoke":
+          {
+            POST: (req: Request) =>
+              controlGrantMutation(
+                req,
+                (request) => resolvePitchManagerAuthority(request, technicalAdminAuth),
+                "revoke-session",
+                "pitch-manager",
+              ),
+          },
         "/api/pitch-manager/leave": {
           async POST(req: Request) {
             if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
@@ -2077,13 +2272,16 @@ function sensitiveEventAdministrationMutationResponse<T>(
   result: EventAdministrationMutationOutcome<T>,
   authority: EventAdministrationAuthority,
   acceptedStatus = 200,
+  audience: "event-admin" | "pitch-manager" = "event-admin",
 ) {
   const refreshHeaders: Array<[string, string]> =
     authority.kind === "grant-session" && result.status === "accepted"
       ? [
           [
             "set-cookie",
-            eventAdminSessionCookie(authority.sessionBearer, result.sessionExpiresAtMs),
+            audience === "pitch-manager"
+              ? pitchManagerSessionCookie(authority.sessionBearer, result.sessionExpiresAtMs)
+              : eventAdminSessionCookie(authority.sessionBearer, result.sessionExpiresAtMs),
           ],
         ]
       : [];

--- a/src/lib/control-grant-management.test.ts
+++ b/src/lib/control-grant-management.test.ts
@@ -1,0 +1,633 @@
+import { describe, expect, test } from "bun:test";
+import { createEventAdministration } from "@/lib/event-administration";
+import { createEventCatalog, createFoundationEventCatalogStorage } from "@/lib/event-catalog";
+import { createInMemoryFoundationStorage } from "@/lib/foundation-storage-memory";
+import { createGrantAuthority, createGrantAuthorityVerifier } from "@/lib/grant-authority";
+import type { ControlGrantScopeResolution, GrantKeyRing } from "@/lib/grant-types";
+import {
+  MemoryTechnicalAdminAuthRepository,
+  createTechnicalAdminAuth,
+  isTechnicalAdminAuthority,
+} from "@/lib/technical-admin-auth";
+
+const keyRing: GrantKeyRing = {
+  encryption: { currentVersion: "v1", keys: new Map([["v1", bytes(1)]]) },
+  lookup: { currentVersion: "v1", keys: new Map([["v1", bytes(2)]]) },
+  audit: { currentVersion: "v1", keys: new Map([["v1", bytes(3)]]) },
+};
+
+describe("Control Grant management", () => {
+  test("keeps creation separate from reveal and exposes only redacted session management", async () => {
+    const fixture = createFixture();
+    const event = await fixture.catalog.createEvent(
+      { name: "Control Grant Event", timeZone: "UTC" },
+      fixture.technical,
+    );
+    if (event.status !== "accepted") throw new Error("Expected Event.");
+    const day = await fixture.catalog.addGameDay(
+      event.value.eventId,
+      { date: "2026-08-14" },
+      fixture.technical,
+    );
+    const pitch = await fixture.catalog.createPitch(
+      event.value.eventId,
+      { name: "Pitch A" },
+      fixture.technical,
+    );
+    const wrongPitch = await fixture.catalog.createPitch(
+      event.value.eventId,
+      { name: "Pitch B" },
+      fixture.technical,
+    );
+    const wrongDay = await fixture.catalog.addGameDay(
+      event.value.eventId,
+      { date: "2026-08-15" },
+      fixture.technical,
+    );
+    if (
+      day.status !== "accepted" ||
+      pitch.status !== "accepted" ||
+      wrongPitch.status !== "accepted" ||
+      wrongDay.status !== "accepted"
+    )
+      throw new Error("Expected schedule structure.");
+    const gameplaySlot = await fixture.catalog.createGameplaySlot(
+      event.value.eventId,
+      day.value.gameDayId,
+      { sequence: 1, scheduledStart: "2026-08-14T10:00" },
+      fixture.technical,
+    );
+    if (gameplaySlot.status !== "accepted") throw new Error("Expected Gameplay Slot.");
+    const pitchSlot = await fixture.storage.transaction(
+      (transaction) => transaction.listPitchSlots(day.value.gameDayId, pitch.value.pitchId)[0],
+    );
+    if (pitchSlot === undefined) throw new Error("Expected Pitch Slot.");
+    const game = await fixture.catalog.createEventGame(
+      event.value.eventId,
+      day.value.gameDayId,
+      {
+        gameplaySlotId: gameplaySlot.value.gameplaySlotId,
+        pitchSlotId: pitchSlot.pitchSlotId,
+        sideA: { sourceLabel: "A" },
+        sideB: { sourceLabel: "B" },
+      },
+      fixture.technical,
+    );
+    if (game.status !== "accepted") throw new Error("Expected Event Game.");
+    fixture.resolution = { status: "eligible", eventGameId: game.value.eventGameId };
+
+    const eventGrant = await fixture.administration.createEventAdminGrant(
+      event.value.eventId,
+      fixture.technical,
+    );
+    if (eventGrant.status !== "accepted") throw new Error("Expected Event Admin Grant.");
+    const eventQr = await fixture.grants.revealGrant(eventGrant.value.grantId, fixture.technical);
+    if (eventQr.status !== "revealed") throw new Error("Expected Event Admin QR.");
+    const eventSession = await fixture.administration.admitEventAdmin({
+      qrCredential: eventQr.qrCredential,
+      browserContext: "event-admin",
+    });
+    if (eventSession.status !== "admitted") throw new Error("Expected Event Admin session.");
+    const eventAuthority = {
+      kind: "grant-session" as const,
+      sessionBearer: eventSession.sessionBearer,
+    };
+    const pitchManagerGrant = await fixture.administration.createPitchManagerGrant(
+      event.value.eventId,
+      day.value.gameDayId,
+      pitch.value.pitchId,
+      eventAuthority,
+    );
+    if (pitchManagerGrant.status !== "accepted") throw new Error("Expected Pitch Manager Grant.");
+    const pitchManagerQr = await fixture.grants.revealGrant(
+      pitchManagerGrant.value.grantId,
+      eventAuthority,
+    );
+    if (pitchManagerQr.status !== "revealed") throw new Error("Expected Pitch Manager QR.");
+    const pitchManagerSession = await fixture.administration.admitPitchManager({
+      qrCredential: pitchManagerQr.qrCredential,
+      browserContext: "pitch-manager",
+    });
+    if (pitchManagerSession.status !== "admitted")
+      throw new Error("Expected Pitch Manager session.");
+    const pitchManagerAuthority = {
+      kind: "grant-session" as const,
+      sessionBearer: pitchManagerSession.sessionBearer,
+    };
+
+    const created = await fixture.administration.createControlGrant(
+      event.value.eventId,
+      day.value.gameDayId,
+      pitch.value.pitchId,
+      pitchSlot.pitchSlotId,
+      pitchManagerAuthority,
+    );
+    expect(created).toMatchObject({
+      status: "accepted",
+      value: { status: "active", pitchSlotId: pitchSlot.pitchSlotId },
+    });
+    if (created.status !== "accepted") throw new Error("Expected Control Grant.");
+    expect(JSON.stringify(created)).not.toContain("qrCredential");
+    expect(
+      await fixture.administration.inspectControlGrant(
+        event.value.eventId,
+        day.value.gameDayId,
+        pitch.value.pitchId,
+        pitchSlot.pitchSlotId,
+        eventAuthority,
+      ),
+    ).toMatchObject({ status: "accepted", value: { grantId: created.value.grantId } });
+    expect(
+      await fixture.administration.inspectControlGrant(
+        event.value.eventId,
+        day.value.gameDayId,
+        wrongPitch.value.pitchId,
+        pitchSlot.pitchSlotId,
+        pitchManagerAuthority,
+      ),
+    ).toMatchObject({ status: "rejected", reason: "not-found" });
+    expect(
+      await fixture.administration.inspectControlGrant(
+        event.value.eventId,
+        wrongDay.value.gameDayId,
+        pitch.value.pitchId,
+        pitchSlot.pitchSlotId,
+        pitchManagerAuthority,
+      ),
+    ).toMatchObject({ status: "rejected", reason: "not-found" });
+
+    const inspected = await fixture.administration.inspectControlGrant(
+      event.value.eventId,
+      day.value.gameDayId,
+      pitch.value.pitchId,
+      pitchSlot.pitchSlotId,
+      pitchManagerAuthority,
+    );
+    expect(inspected).toMatchObject({
+      status: "accepted",
+      value: { status: "active", eligibility: "eligible", eventGameId: game.value.eventGameId },
+    });
+    const revealed = await fixture.administration.revealControlGrant(
+      event.value.eventId,
+      day.value.gameDayId,
+      pitch.value.pitchId,
+      pitchSlot.pitchSlotId,
+      pitchManagerAuthority,
+    );
+    if (revealed.status !== "accepted" || revealed.value.status !== "revealed")
+      throw new Error("Expected Control Grant QR.");
+
+    const firstController = await fixture.administration.admitControlGrant({
+      qrCredential: revealed.value.qrCredential,
+      browserContext: "controller-a",
+      deviceClass: "mobile",
+      browserClass: "safari",
+    });
+    const secondController = await fixture.administration.admitControlGrant({
+      qrCredential: revealed.value.qrCredential,
+      browserContext: "controller-b",
+      deviceClass: "desktop",
+      browserClass: "chrome",
+    });
+    if (firstController.status !== "admitted" || secondController.status !== "admitted")
+      throw new Error("Expected Controller sessions.");
+
+    const sessionStateBeforeList = await fixture.storage.transaction((transaction) =>
+      transaction.listGrantSessions(created.value.grantId),
+    );
+    const sessions = await fixture.administration.listControlGrantSessions(
+      event.value.eventId,
+      day.value.gameDayId,
+      pitch.value.pitchId,
+      pitchSlot.pitchSlotId,
+      pitchManagerAuthority,
+    );
+    expect(sessions).toMatchObject({ status: "accepted" });
+    if (sessions.status !== "accepted") throw new Error("Expected session summaries.");
+    expect(sessions.value).toEqual(
+      expect.arrayContaining([expect.objectContaining({ deviceClass: "mobile" })]),
+    );
+    expect(
+      await fixture.storage.transaction((transaction) =>
+        transaction.listGrantSessions(created.value.grantId),
+      ),
+    ).toEqual(sessionStateBeforeList);
+    expect(Object.keys(sessions.value[0] ?? {}).sort()).toEqual([
+      "browserClass",
+      "createdAtMs",
+      "deviceClass",
+      "label",
+      "lastActiveAtMs",
+    ]);
+    expect(sessions.value[0]).toEqual({
+      label: expect.stringMatching(/^session-/u),
+      createdAtMs: expect.any(Number),
+      lastActiveAtMs: expect.any(Number),
+      deviceClass: expect.any(String),
+      browserClass: expect.any(String),
+    });
+
+    const revoked = await fixture.administration.revokeControlGrantSession(
+      event.value.eventId,
+      day.value.gameDayId,
+      pitch.value.pitchId,
+      pitchSlot.pitchSlotId,
+      sessions.value[0]!.label,
+      pitchManagerAuthority,
+    );
+    expect(revoked).toMatchObject({ status: "accepted", value: { status: "updated" } });
+    const activeSessionsAfterRevoke = await fixture.administration.listControlGrantSessions(
+      event.value.eventId,
+      day.value.gameDayId,
+      pitch.value.pitchId,
+      pitchSlot.pitchSlotId,
+      pitchManagerAuthority,
+    );
+    expect(activeSessionsAfterRevoke).toMatchObject({
+      status: "accepted",
+      value: [{ label: expect.any(String) }],
+    });
+    if (activeSessionsAfterRevoke.status !== "accepted")
+      throw new Error("Expected active sessions.");
+    expect(activeSessionsAfterRevoke.value).toHaveLength(1);
+
+    const rotated = await fixture.administration.rotateControlGrant(
+      event.value.eventId,
+      day.value.gameDayId,
+      pitch.value.pitchId,
+      pitchSlot.pitchSlotId,
+      pitchManagerAuthority,
+    );
+    expect(rotated).toMatchObject({
+      status: "accepted",
+      value: { status: "updated", affectedSessionCount: 1 },
+    });
+    expect(
+      await fixture.administration.openEventHub({
+        eventId: event.value.eventId,
+        authority: eventAuthority,
+      }),
+    ).toMatchObject({ status: "accepted" });
+    expect(
+      await fixture.grants.authorizeGrant({
+        sessionBearer: secondController.sessionBearer,
+        eventGameId: game.value.eventGameId,
+      }),
+    ).toMatchObject({ status: "rejected" });
+  });
+
+  test("keeps the Control Grant on its Pitch Slot through reassignment and fails reveal generically when ineligible", async () => {
+    const fixture = createFixture();
+    const event = await fixture.catalog.createEvent(
+      { name: "Reassignment Event", timeZone: "UTC" },
+      fixture.technical,
+    );
+    if (event.status !== "accepted") throw new Error("Expected Event.");
+    const day = await fixture.catalog.addGameDay(
+      event.value.eventId,
+      { date: "2026-08-14" },
+      fixture.technical,
+    );
+    const pitch = await fixture.catalog.createPitch(
+      event.value.eventId,
+      { name: "Pitch A" },
+      fixture.technical,
+    );
+    if (day.status !== "accepted" || pitch.status !== "accepted")
+      throw new Error("Expected schedule structure.");
+    const firstSlot = await fixture.catalog.createGameplaySlot(
+      event.value.eventId,
+      day.value.gameDayId,
+      { sequence: 1, scheduledStart: "2026-08-14T10:00" },
+      fixture.technical,
+    );
+    const secondSlot = await fixture.catalog.createGameplaySlot(
+      event.value.eventId,
+      day.value.gameDayId,
+      { sequence: 2, scheduledStart: "2026-08-14T11:00" },
+      fixture.technical,
+    );
+    if (firstSlot.status !== "accepted" || secondSlot.status !== "accepted")
+      throw new Error("Expected Gameplay Slots.");
+    const slots = await fixture.storage.transaction((transaction) =>
+      transaction.listPitchSlots(day.value.gameDayId, pitch.value.pitchId),
+    );
+    const source = slots.find((slot) => slot.gameplaySlotId === firstSlot.value.gameplaySlotId);
+    const target = slots.find((slot) => slot.gameplaySlotId === secondSlot.value.gameplaySlotId);
+    if (source === undefined || target === undefined) throw new Error("Expected Pitch Slots.");
+    const game = await fixture.catalog.createEventGame(
+      event.value.eventId,
+      day.value.gameDayId,
+      {
+        gameplaySlotId: firstSlot.value.gameplaySlotId,
+        pitchSlotId: source.pitchSlotId,
+        sideA: { sourceLabel: "A" },
+        sideB: { sourceLabel: "B" },
+      },
+      fixture.technical,
+    );
+    if (game.status !== "accepted") throw new Error("Expected Event Game.");
+    fixture.resolution = { status: "eligible", eventGameId: game.value.eventGameId };
+    const grant = await fixture.administration.createControlGrant(
+      event.value.eventId,
+      day.value.gameDayId,
+      pitch.value.pitchId,
+      source.pitchSlotId,
+      fixture.technical,
+    );
+    if (grant.status !== "accepted") throw new Error("Expected Control Grant.");
+    const reassigned = await fixture.administration.reassignEventGame(
+      event.value.eventId,
+      day.value.gameDayId,
+      game.value.eventGameId,
+      { targetPitchSlotId: target.pitchSlotId },
+      fixture.technical,
+    );
+    expect(reassigned).toMatchObject({ status: "accepted" });
+    fixture.resolution = { status: "empty" };
+    const beforeRejectedReveal = await fixture.storage.transaction((transaction) => ({
+      grants: transaction.listGrants(),
+      sessions: transaction.listGrantSessions(grant.value.grantId),
+      audit: transaction.listGrantAudit(grant.value.grantId),
+    }));
+    expect(
+      await fixture.administration.revealControlGrant(
+        event.value.eventId,
+        day.value.gameDayId,
+        pitch.value.pitchId,
+        source.pitchSlotId,
+        fixture.technical,
+      ),
+    ).toMatchObject({ status: "rejected", reason: "unauthorized" });
+    expect(
+      await fixture.storage.transaction((transaction) => ({
+        grants: transaction.listGrants(),
+        sessions: transaction.listGrantSessions(grant.value.grantId),
+        audit: transaction.listGrantAudit(grant.value.grantId),
+      })),
+    ).toEqual(beforeRejectedReveal);
+    expect(
+      await fixture.storage.transaction((transaction) =>
+        transaction.findGrantById(grant.value.grantId),
+      ),
+    ).toMatchObject({ scope: { pitchSlotId: source.pitchSlotId } });
+  });
+
+  test("returns no session summaries for a disabled Control Grant without read mutation", async () => {
+    const { fixture, grantId } = await createControlGrantWithSession();
+    expect(await fixture.grants.disableGrant(grantId, fixture.technical)).toMatchObject({
+      status: "updated",
+    });
+    const before = await fixture.storage.transaction((transaction) => ({
+      grant: transaction.findGrantById(grantId),
+      sessions: transaction.listGrantSessions(grantId),
+      audit: transaction.listGrantAudit(grantId),
+    }));
+
+    expect(await fixture.grants.listGrantSessions(grantId, fixture.technical)).toEqual({
+      status: "ok",
+      value: [],
+    });
+    expect(
+      await fixture.storage.transaction((transaction) => ({
+        grant: transaction.findGrantById(grantId),
+        sessions: transaction.listGrantSessions(grantId),
+        audit: transaction.listGrantAudit(grantId),
+      })),
+    ).toEqual(before);
+  });
+
+  test("returns no session summaries at the exact Grant expiry boundary without read mutation", async () => {
+    const expiryAtMs = Date.parse("2026-08-14T12:00:01Z");
+    const { fixture, grantId } = await createControlGrantWithSession(expiryAtMs);
+    fixture.setNow(expiryAtMs);
+    const before = await fixture.storage.transaction((transaction) => ({
+      grant: transaction.findGrantById(grantId),
+      sessions: transaction.listGrantSessions(grantId),
+      audit: transaction.listGrantAudit(grantId),
+    }));
+
+    expect(await fixture.grants.listGrantSessions(grantId, fixture.technical)).toEqual({
+      status: "ok",
+      value: [],
+    });
+    expect(
+      await fixture.storage.transaction((transaction) => ({
+        grant: transaction.findGrantById(grantId),
+        sessions: transaction.listGrantSessions(grantId),
+        audit: transaction.listGrantAudit(grantId),
+      })),
+    ).toEqual(before);
+  });
+
+  test("rolls back management authority and Grant evidence when rotation fails inside its transaction", async () => {
+    const baseStorage = createInMemoryFoundationStorage();
+    let failAfterGrantUpdate = false;
+    const storage = new Proxy(baseStorage, {
+      get(target, property, receiver) {
+        if (property === "transaction") {
+          return (work: Parameters<typeof baseStorage.transaction>[0]) =>
+            target.transaction((transaction) => {
+              const transactionWithFailure = new Proxy(transaction, {
+                get(transactionTarget, transactionProperty, transactionReceiver) {
+                  if (transactionProperty === "updateGrant") {
+                    return (grant: Parameters<typeof transaction.updateGrant>[0]) => {
+                      transactionTarget.updateGrant(grant);
+                      if (failAfterGrantUpdate) {
+                        failAfterGrantUpdate = false;
+                        throw new Error("injected Control Grant rotation failure");
+                      }
+                    };
+                  }
+                  const value = Reflect.get(
+                    transactionTarget,
+                    transactionProperty,
+                    transactionReceiver,
+                  );
+                  return typeof value === "function" ? value.bind(transactionTarget) : value;
+                },
+              });
+              return work(transactionWithFailure);
+            });
+        }
+        const value = Reflect.get(target, property, receiver);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    }) as typeof baseStorage;
+    const fixture = createFixture(storage);
+    const event = await fixture.catalog.createEvent(
+      { name: "Atomic Control Grant Event", timeZone: "UTC" },
+      fixture.technical,
+    );
+    if (event.status !== "accepted") throw new Error("Expected event structure.");
+    const day = await fixture.catalog.addGameDay(
+      event.value.eventId,
+      { date: "2026-08-14" },
+      fixture.technical,
+    );
+    const pitch = await fixture.catalog.createPitch(
+      event.value.eventId,
+      { name: "Pitch A" },
+      fixture.technical,
+    );
+    if (event.status !== "accepted" || day.status !== "accepted" || pitch.status !== "accepted")
+      throw new Error("Expected schedule structure.");
+    const gameplaySlot = await fixture.catalog.createGameplaySlot(
+      event.value.eventId,
+      day.value.gameDayId,
+      { sequence: 1, scheduledStart: "2026-08-14T10:00" },
+      fixture.technical,
+    );
+    if (gameplaySlot.status !== "accepted") throw new Error("Expected Gameplay Slot.");
+    const pitchSlot = await fixture.storage.transaction(
+      (transaction) => transaction.listPitchSlots(day.value.gameDayId, pitch.value.pitchId)[0],
+    );
+    if (pitchSlot === undefined) throw new Error("Expected Pitch Slot.");
+    const game = await fixture.catalog.createEventGame(
+      event.value.eventId,
+      day.value.gameDayId,
+      {
+        gameplaySlotId: gameplaySlot.value.gameplaySlotId,
+        pitchSlotId: pitchSlot.pitchSlotId,
+        sideA: { sourceLabel: "A" },
+        sideB: { sourceLabel: "B" },
+      },
+      fixture.technical,
+    );
+    if (game.status !== "accepted") throw new Error("Expected Event Game.");
+    fixture.resolution = { status: "eligible", eventGameId: game.value.eventGameId };
+    const grant = await fixture.administration.createEventAdminGrant(
+      event.value.eventId,
+      fixture.technical,
+    );
+    if (grant.status !== "accepted") throw new Error("Expected Event Admin Grant.");
+    const qr = await fixture.grants.revealGrant(grant.value.grantId, fixture.technical);
+    if (qr.status !== "revealed") throw new Error("Expected Event Admin QR.");
+    const admission = await fixture.administration.admitEventAdmin({
+      qrCredential: qr.qrCredential,
+      browserContext: "atomic-event-admin",
+    });
+    if (admission.status !== "admitted") throw new Error("Expected Event Admin session.");
+    const authority = { kind: "grant-session" as const, sessionBearer: admission.sessionBearer };
+    const control = await fixture.administration.createControlGrant(
+      event.value.eventId,
+      day.value.gameDayId,
+      pitch.value.pitchId,
+      pitchSlot.pitchSlotId,
+      authority,
+    );
+    if (control.status !== "accepted") throw new Error("Expected Control Grant.");
+    const before = await baseStorage.transaction((transaction) => ({
+      grants: transaction.listGrants(),
+      sessions: transaction
+        .listGrantSessions(grant.value.grantId)
+        .concat(transaction.listGrantSessions(control.value.grantId)),
+      grantAudit: transaction.listGrantAudit(grant.value.grantId),
+      controlAudit: transaction.listGrantAudit(control.value.grantId),
+    }));
+    failAfterGrantUpdate = true;
+    expect(
+      await fixture.administration.rotateControlGrant(
+        event.value.eventId,
+        day.value.gameDayId,
+        pitch.value.pitchId,
+        pitchSlot.pitchSlotId,
+        authority,
+      ),
+    ).toMatchObject({ status: "retryable-failure" });
+    expect(
+      await baseStorage.transaction((transaction) => ({
+        grants: transaction.listGrants(),
+        sessions: transaction
+          .listGrantSessions(grant.value.grantId)
+          .concat(transaction.listGrantSessions(control.value.grantId)),
+        grantAudit: transaction.listGrantAudit(grant.value.grantId),
+        controlAudit: transaction.listGrantAudit(control.value.grantId),
+      })),
+    ).toEqual(before);
+  });
+});
+
+function createFixture(storage = createInMemoryFoundationStorage()) {
+  let nowMs = Date.parse("2026-08-14T12:00:00Z");
+  let entropy = 9;
+  let resolution: ControlGrantScopeResolution = { status: "unavailable" };
+  const technical = createTechnicalAdminAuth(
+    { environment: "test", origin: "https://timer.example", rpId: "timer.example" },
+    new MemoryTechnicalAdminAuthRepository(),
+  ).resolveHostLocalAuthority();
+  const catalog = createEventCatalog(createFoundationEventCatalogStorage(storage), {
+    clock: { nowMs: () => nowMs },
+  });
+  const grants = createGrantAuthority(storage, {
+    environmentId: "test",
+    clock: { nowMs: () => nowMs },
+    randomness: {
+      bytes: (length: number) => {
+        const seed = entropy++;
+        return Uint8Array.from({ length }, (_, index) => ((seed + index * 31) % 240) + 1);
+      },
+    },
+    keyRing,
+    controlScopeResolver: { resolve: () => resolution },
+    privilegedAuthorityVerifier: createGrantAuthorityVerifier((input) => {
+      if (isTechnicalAdminAuthority(input)) return { kind: "technical-admin", id: input.sessionId };
+      if (
+        isRecord(input) &&
+        input.kind === "grant-session" &&
+        typeof input.sessionBearer === "string"
+      )
+        return { kind: "grant-session", sessionBearer: input.sessionBearer, sessionId: "session" };
+      return null;
+    }),
+  });
+  return {
+    storage,
+    catalog,
+    grants,
+    technical,
+    administration: createEventAdministration({
+      storage,
+      grants,
+      catalog,
+      nowMs: () => nowMs,
+      controlScopeResolver: { resolve: () => resolution },
+    }),
+    set resolution(value: ControlGrantScopeResolution) {
+      resolution = value;
+    },
+    setNow(value: number) {
+      nowMs = value;
+    },
+  };
+}
+
+async function createControlGrantWithSession(expiresAtMs?: number) {
+  const fixture = createFixture();
+  fixture.resolution = { status: "eligible", eventGameId: "event-game-1" };
+  const created = await fixture.grants.createControlGrant({
+    scope: {
+      eventId: "event-1",
+      gameDayId: "game-day-1",
+      pitchId: "pitch-1",
+      pitchSlotId: "pitch-slot-1",
+    },
+    authority: fixture.technical,
+    ...(expiresAtMs === undefined ? {} : { expiresAtMs }),
+  });
+  if (created.status !== "created") throw new Error("Expected Control Grant.");
+  const admitted = await fixture.grants.admitGrant({
+    qrCredential: created.qrCredential,
+    browserContext: "controller-1",
+  });
+  if (admitted.status !== "admitted") throw new Error("Expected Control Grant session.");
+  return { fixture, grantId: created.grantId };
+}
+
+function bytes(value: number): Uint8Array {
+  return new Uint8Array(32).fill(value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/lib/event-administration.ts
+++ b/src/lib/event-administration.ts
@@ -27,10 +27,14 @@ import type {
   TypedGrantAuthority,
   TypedGrantMutation,
   TypedGrantReveal,
+  TypedSessionSummary,
 } from "@/lib/grant-management";
 import {
   EVENT_ADMIN_GRANT_TYPE,
+  GRANT_TYPE,
   PITCH_MANAGER_GRANT_TYPE,
+  type ControlGrantScope,
+  type ControlGrantScopeResolver,
   type PitchManagerGrantScope,
   type StoredGrant,
   validateControlGrantScope,
@@ -70,6 +74,21 @@ export type PitchManagerGrantProjection = {
   status: StoredGrant["status"];
   createdAtMs: number;
   expiresAtMs: number | null;
+};
+
+export type ControlGrantProjection = {
+  grantId: string;
+  grantVersion: string;
+  grantType: typeof GRANT_TYPE;
+  eventId: string;
+  gameDayId: string;
+  pitchId: string;
+  pitchSlotId: string;
+  status: StoredGrant["status"];
+  createdAtMs: number;
+  expiresAtMs: number | null;
+  eligibility: "eligible" | "empty" | "conflict" | "mismatch" | "unavailable" | "terminal";
+  eventGameId: string | null;
 };
 
 export type EventHubProjection = {
@@ -136,6 +155,7 @@ export type EventAdministrationOptions = {
   grants: TypedGrantAuthority;
   catalog?: EventCatalog;
   nowMs?: () => number;
+  controlScopeResolver?: ControlGrantScopeResolver;
 };
 
 export type EventAdministration = {
@@ -185,6 +205,49 @@ export type EventAdministration = {
     pitchId: unknown,
     authority: EventAdministrationAuthority,
   ): Promise<EventAdministrationMutationOutcome<TypedGrantMutation>>;
+  createControlGrant(
+    eventId: unknown,
+    gameDayId: unknown,
+    pitchId: unknown,
+    pitchSlotId: unknown,
+    authority: EventAdministrationAuthority,
+  ): Promise<EventAdministrationMutationOutcome<ControlGrantProjection>>;
+  inspectControlGrant(
+    eventId: unknown,
+    gameDayId: unknown,
+    pitchId: unknown,
+    pitchSlotId: unknown,
+    authority: EventAdministrationAuthority,
+  ): Promise<EventAdministrationOutcome<ControlGrantProjection | null>>;
+  revealControlGrant(
+    eventId: unknown,
+    gameDayId: unknown,
+    pitchId: unknown,
+    pitchSlotId: unknown,
+    authority: EventAdministrationAuthority,
+  ): Promise<EventAdministrationMutationOutcome<TypedGrantReveal>>;
+  listControlGrantSessions(
+    eventId: unknown,
+    gameDayId: unknown,
+    pitchId: unknown,
+    pitchSlotId: unknown,
+    authority: EventAdministrationAuthority,
+  ): Promise<EventAdministrationOutcome<readonly TypedSessionSummary[]>>;
+  revokeControlGrantSession(
+    eventId: unknown,
+    gameDayId: unknown,
+    pitchId: unknown,
+    pitchSlotId: unknown,
+    sessionReference: unknown,
+    authority: EventAdministrationAuthority,
+  ): Promise<EventAdministrationMutationOutcome<TypedGrantMutation>>;
+  rotateControlGrant(
+    eventId: unknown,
+    gameDayId: unknown,
+    pitchId: unknown,
+    pitchSlotId: unknown,
+    authority: EventAdministrationAuthority,
+  ): Promise<EventAdministrationMutationOutcome<TypedGrantMutation>>;
   inspectEventAdminGrant(
     eventId: unknown,
     authority: EventAdministrationAuthority,
@@ -216,6 +279,12 @@ export type EventAdministration = {
     browserClass?: unknown;
   }): Promise<TypedGrantAdmission | TypedGrantAdmissionThrottled>;
   admitPitchManager(input: {
+    qrCredential: unknown;
+    browserContext: unknown;
+    deviceClass?: unknown;
+    browserClass?: unknown;
+  }): Promise<TypedGrantAdmission | TypedGrantAdmissionThrottled>;
+  admitControlGrant(input: {
     qrCredential: unknown;
     browserContext: unknown;
     deviceClass?: unknown;
@@ -510,6 +579,291 @@ export function createEventAdministration(
       );
     },
 
+    async createControlGrant(
+      eventIdInput,
+      gameDayIdInput,
+      pitchIdInput,
+      pitchSlotIdInput,
+      authority,
+    ) {
+      const ids = validateControlScopeIds(
+        eventIdInput,
+        gameDayIdInput,
+        pitchIdInput,
+        pitchSlotIdInput,
+      );
+      if (!ids.ok) return invalid(ids.error);
+      try {
+        return await options.storage.transaction((transaction) => {
+          const scope = readControlGrantScope(transaction, ids.value);
+          if (scope === null) return notFound("Pitch Slot was not found.");
+          const authorized = authorizeControlManagementInTransaction(
+            options,
+            transaction,
+            ids.value,
+            authority,
+          );
+          if (authorized === null) return unauthorized();
+          if (findControlGrantInTransaction(transaction, scope) !== null)
+            return invalid("A Control Grant already exists for this Pitch Slot.");
+          const result = options.grants.createControlGrantInTransaction(transaction, {
+            authority,
+            scope,
+          });
+          if (result.status !== "created") return grantMutationRejection(result);
+          const stored = transaction.findGrantById(result.grantId);
+          if (stored === null) return unavailable();
+          return {
+            ...accepted(projectControlGrant(stored, options, transaction)),
+            sessionExpiresAtMs: authorized.sessionExpiresAtMs,
+          };
+        });
+      } catch {
+        return unavailable();
+      }
+    },
+
+    async inspectControlGrant(
+      eventIdInput,
+      gameDayIdInput,
+      pitchIdInput,
+      pitchSlotIdInput,
+      authority,
+    ) {
+      const ids = validateControlScopeIds(
+        eventIdInput,
+        gameDayIdInput,
+        pitchIdInput,
+        pitchSlotIdInput,
+      );
+      if (!ids.ok) return invalid(ids.error);
+      try {
+        return await options.storage.transaction((transaction) => {
+          const scope = readControlGrantScope(transaction, ids.value);
+          if (scope === null) return notFound("Pitch Slot was not found.");
+          if (
+            authorizeControlManagementInTransaction(
+              options,
+              transaction,
+              ids.value,
+              authority,
+              true,
+            ) === null
+          )
+            return unauthorized();
+          const grant = findControlGrantInTransaction(transaction, scope);
+          return accepted(grant === null ? null : projectControlGrant(grant, options, transaction));
+        });
+      } catch {
+        return unavailable();
+      }
+    },
+
+    async revealControlGrant(
+      eventIdInput,
+      gameDayIdInput,
+      pitchIdInput,
+      pitchSlotIdInput,
+      authority,
+    ) {
+      const ids = validateControlScopeIds(
+        eventIdInput,
+        gameDayIdInput,
+        pitchIdInput,
+        pitchSlotIdInput,
+      );
+      if (!ids.ok) return invalid(ids.error);
+      try {
+        return await options.storage.transaction((transaction) => {
+          const scope = readControlGrantScope(transaction, ids.value);
+          if (scope === null) return notFound("Pitch Slot was not found.");
+          const grant = findControlGrantInTransaction(transaction, scope);
+          if (grant === null) return notFound("Control Grant was not found.");
+          const authorization = authorizeControlManagementInTransaction(
+            options,
+            transaction,
+            ids.value,
+            authority,
+            true,
+          );
+          if (authorization === null) return unauthorized();
+          const result = options.grants.revealGrantInTransaction(
+            transaction,
+            grant.grantId,
+            authority,
+          );
+          if (result.status !== "revealed") return grantRevealRejection(result);
+          const refreshed = authorizeControlManagementInTransaction(
+            options,
+            transaction,
+            ids.value,
+            authority,
+            true,
+          );
+          return {
+            ...accepted(result),
+            sessionExpiresAtMs: refreshed?.sessionExpiresAtMs ?? authorization.sessionExpiresAtMs,
+          };
+        });
+      } catch {
+        return unavailable();
+      }
+    },
+
+    async listControlGrantSessions(
+      eventIdInput,
+      gameDayIdInput,
+      pitchIdInput,
+      pitchSlotIdInput,
+      authority,
+    ) {
+      const ids = validateControlScopeIds(
+        eventIdInput,
+        gameDayIdInput,
+        pitchIdInput,
+        pitchSlotIdInput,
+      );
+      if (!ids.ok) return invalid(ids.error);
+      try {
+        return await options.storage.transaction((transaction) => {
+          const scope = readControlGrantScope(transaction, ids.value);
+          if (scope === null) return notFound("Pitch Slot was not found.");
+          const grant = findControlGrantInTransaction(transaction, scope);
+          if (grant === null) return notFound("Control Grant was not found.");
+          if (
+            authorizeControlManagementInTransaction(
+              options,
+              transaction,
+              ids.value,
+              authority,
+              true,
+            ) === null
+          )
+            return unauthorized();
+          const result = options.grants.listGrantSessionsInTransaction(
+            transaction,
+            grant.grantId,
+            authority,
+          );
+          return result.status === "ok" ? accepted(result.value) : unavailable();
+        });
+      } catch {
+        return unavailable();
+      }
+    },
+
+    async revokeControlGrantSession(
+      eventIdInput,
+      gameDayIdInput,
+      pitchIdInput,
+      pitchSlotIdInput,
+      sessionReference,
+      authority,
+    ) {
+      if (typeof sessionReference !== "string" || sessionReference.length === 0)
+        return invalid("Grant Session reference is invalid.");
+      const ids = validateControlScopeIds(
+        eventIdInput,
+        gameDayIdInput,
+        pitchIdInput,
+        pitchSlotIdInput,
+      );
+      if (!ids.ok) return invalid(ids.error);
+      try {
+        return await options.storage.transaction((transaction) => {
+          const scope = readControlGrantScope(transaction, ids.value);
+          if (scope === null) return notFound("Pitch Slot was not found.");
+          const grant = findControlGrantInTransaction(transaction, scope);
+          if (grant === null) return notFound("Control Grant was not found.");
+          const authorization = authorizeControlManagementInTransaction(
+            options,
+            transaction,
+            ids.value,
+            authority,
+            true,
+          );
+          if (authorization === null) return unauthorized();
+          const result = options.grants.revokeGrantSessionInTransaction(
+            transaction,
+            grant.grantId,
+            sessionReference,
+            authority,
+          );
+          if (result.status !== "updated") return grantMutationRejection(result);
+          const refreshed = authorizeControlManagementInTransaction(
+            options,
+            transaction,
+            ids.value,
+            authority,
+            true,
+          );
+          return {
+            ...accepted(result),
+            sessionExpiresAtMs: refreshed?.sessionExpiresAtMs ?? authorization.sessionExpiresAtMs,
+          };
+        });
+      } catch {
+        return unavailable();
+      }
+    },
+
+    async rotateControlGrant(
+      eventIdInput,
+      gameDayIdInput,
+      pitchIdInput,
+      pitchSlotIdInput,
+      authority,
+    ) {
+      const ids = validateControlScopeIds(
+        eventIdInput,
+        gameDayIdInput,
+        pitchIdInput,
+        pitchSlotIdInput,
+      );
+      if (!ids.ok) return invalid(ids.error);
+      try {
+        return await options.storage.transaction((transaction) => {
+          const scope = readControlGrantScope(transaction, ids.value);
+          if (scope === null) return notFound("Pitch Slot was not found.");
+          const grant = findControlGrantInTransaction(transaction, scope);
+          if (grant === null) return notFound("Control Grant was not found.");
+          const authorization = authorizeControlManagementInTransaction(
+            options,
+            transaction,
+            ids.value,
+            authority,
+            true,
+          );
+          if (authorization === null) return unauthorized();
+          const result = options.grants.rotateGrantInTransaction(
+            transaction,
+            grant.grantId,
+            authority,
+          );
+          if (result.status !== "updated") return grantMutationRejection(result);
+          const refreshed = authorizeControlManagementInTransaction(
+            options,
+            transaction,
+            ids.value,
+            authority,
+            true,
+          );
+          return {
+            ...accepted({
+              status: "updated" as const,
+              grantId: result.grantId,
+              grantVersion: result.grantVersion,
+              affectedSessionCount:
+                "affectedSessionCount" in result ? result.affectedSessionCount : 0,
+            }),
+            sessionExpiresAtMs: refreshed?.sessionExpiresAtMs ?? authorization.sessionExpiresAtMs,
+          };
+        });
+      } catch {
+        return unavailable();
+      }
+    },
+
     async inspectEventAdminGrant(eventIdInput, authority) {
       const eventId = validateEventId(eventIdInput);
       if (!eventId.ok) return invalid(eventId.error);
@@ -591,6 +945,22 @@ export function createEventAdministration(
       )
         return options.grants.admitGrant({ qrCredential: "", browserContext: "" });
       return options.grants.admitPitchManagerGrant({
+        qrCredential: input.qrCredential,
+        browserContext: input.browserContext,
+        deviceClass: typeof input.deviceClass === "string" ? input.deviceClass : undefined,
+        browserClass: typeof input.browserClass === "string" ? input.browserClass : undefined,
+      });
+    },
+
+    async admitControlGrant(input) {
+      if (
+        typeof input.qrCredential !== "string" ||
+        typeof input.browserContext !== "string" ||
+        input.qrCredential.length === 0 ||
+        input.browserContext.length === 0
+      )
+        return options.grants.admitGrant({ qrCredential: "", browserContext: "" });
+      return options.grants.admitGrant({
         qrCredential: input.qrCredential,
         browserContext: input.browserContext,
         deviceClass: typeof input.deviceClass === "string" ? input.deviceClass : undefined,
@@ -918,6 +1288,8 @@ async function runCatalogMutation<T>(
 
 type ScopeIds = { eventId: string; gameDayId: string; pitchId: string };
 
+type ControlScopeIds = ScopeIds & { pitchSlotId: string };
+
 function validateScopeIds(
   eventIdInput: unknown,
   gameDayIdInput: unknown,
@@ -932,6 +1304,149 @@ function validateScopeIds(
   return {
     ok: true,
     value: { eventId: eventId.value, gameDayId: gameDayId.value, pitchId: pitchId.value },
+  };
+}
+
+function validateControlScopeIds(
+  eventIdInput: unknown,
+  gameDayIdInput: unknown,
+  pitchIdInput: unknown,
+  pitchSlotIdInput: unknown,
+): { ok: true; value: ControlScopeIds } | { ok: false; error: string } {
+  const ids = validateScopeIds(eventIdInput, gameDayIdInput, pitchIdInput);
+  const pitchSlotId = validateEventId(pitchSlotIdInput);
+  if (!ids.ok) return ids;
+  if (!pitchSlotId.ok) return pitchSlotId;
+  return { ok: true, value: { ...ids.value, pitchSlotId: pitchSlotId.value } };
+}
+
+function readControlGrantScope(
+  transaction: FoundationStorageTransaction,
+  ids: ControlScopeIds,
+): ControlGrantScope | null {
+  const event = transaction.findEvent(ids.eventId);
+  const gameDay = transaction
+    .listGameDays(ids.eventId)
+    .find((candidate) => candidate.gameDayId === ids.gameDayId);
+  const pitch = transaction.findPitch(ids.pitchId);
+  const pitchSlot = transaction.findPitchSlot(ids.pitchSlotId);
+  if (
+    event === null ||
+    gameDay === undefined ||
+    pitch === null ||
+    pitchSlot === null ||
+    pitch.eventId !== event.eventId ||
+    pitchSlot.eventId !== event.eventId ||
+    pitchSlot.gameDayId !== gameDay.gameDayId ||
+    pitchSlot.pitchId !== pitch.pitchId
+  )
+    return null;
+  return {
+    eventId: event.eventId,
+    gameDayId: gameDay.gameDayId,
+    pitchId: pitch.pitchId,
+    pitchSlotId: pitchSlot.pitchSlotId,
+  };
+}
+
+function sameControlGrantScope(value: unknown, expected: ControlGrantScope): boolean {
+  const scope = validateControlGrantScope(value);
+  return (
+    scope.ok &&
+    scope.value.eventId === expected.eventId &&
+    scope.value.gameDayId === expected.gameDayId &&
+    scope.value.pitchId === expected.pitchId &&
+    scope.value.pitchSlotId === expected.pitchSlotId
+  );
+}
+
+function findControlGrantInTransaction(
+  transaction: FoundationStorageTransaction,
+  scope: ControlGrantScope,
+): StoredGrant | null {
+  return (
+    transaction
+      .listGrants()
+      .filter(
+        (grant) => grant.grantType === GRANT_TYPE && sameControlGrantScope(grant.scope, scope),
+      )
+      .sort((left, right) => right.createdAtMs - left.createdAtMs)[0] ?? null
+  );
+}
+
+function authorizeControlManagementInTransaction(
+  options: EventAdministrationOptions,
+  transaction: FoundationStorageTransaction,
+  ids: ControlScopeIds,
+  authority: EventAdministrationAuthority,
+  readOnly = false,
+): { sessionExpiresAtMs: number | null } | null {
+  const eventAuthority = authorizeEventScopeInTransaction(
+    options,
+    transaction,
+    ids.eventId,
+    authority,
+    readOnly,
+  );
+  if (eventAuthority !== null) return { sessionExpiresAtMs: eventAuthority.sessionExpiresAtMs };
+  if (
+    !isRecord(authority) ||
+    authority.kind !== "grant-session" ||
+    typeof authority.sessionBearer !== "string"
+  )
+    return null;
+  const result = options.grants.authorizeGrantInTransaction(transaction, {
+    sessionBearer: authority.sessionBearer,
+    readOnly,
+  });
+  if (result.status !== "authorized" || result.grantType !== PITCH_MANAGER_GRANT_TYPE) return null;
+  const scope = validatePitchManagerGrantScope(result.scope);
+  if (
+    !scope.ok ||
+    scope.value.eventId !== ids.eventId ||
+    scope.value.gameDayId !== ids.gameDayId ||
+    scope.value.pitchId !== ids.pitchId
+  )
+    return null;
+  return { sessionExpiresAtMs: result.sessionExpiresAtMs ?? null };
+}
+
+function projectControlGrant(
+  grant: StoredGrant,
+  options: EventAdministrationOptions,
+  transaction: FoundationStorageTransaction,
+): ControlGrantProjection {
+  const scope = validateControlGrantScope(grant.scope);
+  if (!scope.ok) throw new Error("Control Grant scope is invalid.");
+  let eligibility: ControlGrantProjection["eligibility"] = "unavailable";
+  let eventGameId: string | null = null;
+  try {
+    const current = options.controlScopeResolver?.resolve(scope.value, transaction);
+    if (current?.status === "eligible") {
+      eligibility = "eligible";
+      eventGameId = current.eventGameId;
+    } else if (current?.status === "terminal") {
+      eligibility = "terminal";
+      eventGameId = current.eventGameId ?? null;
+    } else if (current !== undefined) {
+      eligibility = current.status;
+    }
+  } catch {
+    // The projection remains generic when the live resolver is unavailable.
+  }
+  return {
+    grantId: grant.grantId,
+    grantVersion: grant.grantVersion,
+    grantType: GRANT_TYPE,
+    eventId: scope.value.eventId,
+    gameDayId: scope.value.gameDayId,
+    pitchId: scope.value.pitchId,
+    pitchSlotId: scope.value.pitchSlotId,
+    status: grant.status,
+    createdAtMs: grant.createdAtMs,
+    expiresAtMs: grant.expiresAtMs,
+    eligibility,
+    eventGameId,
   };
 }
 
@@ -1316,6 +1831,13 @@ function grantMutationRejection(result: TypedGrantMutation): EventAdministration
   if (result.reason === "not-found") return notFound(result.detail ?? "Grant was not found.");
   if (result.reason === "unavailable") return unavailable();
   return invalid(result.detail ?? "Grant operation was rejected.");
+}
+
+function grantRevealRejection(result: TypedGrantReveal): EventAdministrationOutcome<never> {
+  if (result.status === "revealed") return invalid("Grant reveal returned an invalid outcome.");
+  if (result.reason === "unauthorized") return unauthorized();
+  if (result.reason === "not-found") return notFound(result.detail);
+  return unavailable();
 }
 
 async function manageEventAdminGrant(

--- a/src/lib/grant-authority-contract.ts
+++ b/src/lib/grant-authority-contract.ts
@@ -124,9 +124,7 @@ export function registerGrantAuthorityContract(
       ).toMatchObject({ status: "authorized", grantSessionId: replacement.grantSessionId });
 
       const sessions = await readGrantSessions(authority, created.grantId);
-      expect(sessions).toHaveLength(3);
-      expect(sessions.filter((session) => session.status === "revoked")).toHaveLength(1);
-      expect(sessions.filter((session) => session.status === "active")).toHaveLength(2);
+      expect(sessions).toHaveLength(2);
       expect(sessions.every((session) => /^session-[A-Za-z0-9_-]{12}$/.test(session.label))).toBe(
         true,
       );

--- a/src/lib/grant-authority.focused.ts
+++ b/src/lib/grant-authority.focused.ts
@@ -826,7 +826,7 @@ describe("focused SQLite Grant authority boundary", () => {
       if (controlSession.status !== "admitted") throw new Error("Expected Control Session.");
       const summaries = await authority.listGrantSessions(control.grantId, eventAuthority);
       if (summaries.status !== "ok") throw new Error("Expected session summaries.");
-      const label = summaries.value.find((summary) => summary.status === "active")?.label;
+      const label = summaries.value[0]?.label;
       if (label === undefined) throw new Error("Expected active session label.");
       expect(
         await authority.revokeGrantSession(control.grantId, label, eventAuthority),
@@ -1214,7 +1214,7 @@ describe("focused SQLite Grant authority boundary", () => {
       });
       expect(sessions).toMatchObject({ status: "ok" });
       if (sessions.status !== "ok") throw new Error("Expected terminal session evidence.");
-      expect(sessions.value.filter((session) => session.status === "active")).toHaveLength(0);
+      expect(sessions.value).toHaveLength(0);
       const audit = await authority.listGrantAudit(control.grantId, {
         kind: "technical-admin",
         id: "technical-admin-fixture",
@@ -1483,7 +1483,7 @@ describe("focused SQLite Grant authority boundary", () => {
           expect(sessionsResult.status).toBe("ok");
           if (sessionsResult.status !== "ok") throw new Error("Expected session read evidence.");
           const sessions = sessionsResult.value;
-          const active = sessions.filter((session) => session.status === "active");
+          const active = sessions;
           expect(active).toHaveLength(1);
           expect(Object.keys(sessions[0] ?? {}).sort()).toEqual([
             "browserClass",
@@ -1491,8 +1491,6 @@ describe("focused SQLite Grant authority boundary", () => {
             "deviceClass",
             "label",
             "lastActiveAtMs",
-            "revokedAtMs",
-            "status",
           ]);
           expect(JSON.stringify(sessions)).not.toMatch(
             /sessionId|grantId|bearer|verifier|digest|keyVersion|eventGameId|grantVersion/i,
@@ -1500,8 +1498,6 @@ describe("focused SQLite Grant authority boundary", () => {
           const admittedIds = new Set([leftResult.grantSessionId, rightResult.grantSessionId]);
           expect(admittedIds).toHaveLength(2);
           expect(active[0]?.label).toMatch(/^session-[A-Za-z0-9_-]{12}$/);
-          const revoked = sessions.find((session) => session.status === "revoked");
-          expect(revoked).toBeDefined();
           const auditResult = await readerAuthority.listGrantAudit(created.grantId, createActor());
           expect(auditResult.status).toBe("ok");
           if (auditResult.status !== "ok") throw new Error("Expected audit read evidence.");

--- a/src/lib/grant-management-credentials.ts
+++ b/src/lib/grant-management-credentials.ts
@@ -4,7 +4,11 @@ import {
   decryptCredential,
   encryptCredential,
 } from "@/lib/grant-crypto";
-import { requireGrantStorageTransaction, type FoundationStorage } from "@/lib/foundation-storage";
+import {
+  requireGrantStorageTransaction,
+  type FoundationStorage,
+  type FoundationStorageTransaction,
+} from "@/lib/foundation-storage";
 import type { GrantAuthorityOptions } from "@/lib/grant-authority";
 import {
   GRANT_CREDENTIAL_FORMAT_VERSION,
@@ -19,6 +23,7 @@ import {
   credentialMatches,
   hasCurrentAdmissionEligibility,
   refreshEventAdminSession,
+  refreshGrantManagementSession,
   resolveManagementAuthority,
   revokeAllSessions,
 } from "@/lib/grant-management-policy";
@@ -44,57 +49,68 @@ export async function revealGrant(
   grantId: string,
   authority: GrantManagementAuthority,
 ): Promise<TypedGrantReveal> {
-  const trustedAuthority = verifyGrantAuthority(options.privilegedAuthorityVerifier, authority);
-  if (trustedAuthority === null)
-    return { status: "rejected", reason: "unauthorized", detail: "The Grant cannot be revealed." };
   try {
-    return await storage.transaction((transaction) => {
-      const grantTransaction = requireGrantStorageTransaction(transaction);
-      const stored = grantTransaction.findGrantById(grantId);
-      if (stored === null)
-        return { status: "rejected", reason: "not-found", detail: "The Grant cannot be revealed." };
-      const grant = expireGrantIfDue(transaction, options, stored);
-      const resolvedAuthority = resolveManagementAuthority(transaction, options, trustedAuthority);
-      if (
-        grant.status !== "active" ||
-        resolvedAuthority === null ||
-        !canManageInTransaction(transaction, options, grant, resolvedAuthority, "reveal")
-      )
-        return {
-          status: "rejected",
-          reason: "unauthorized",
-          detail: "The Grant cannot be revealed.",
-        };
-      const token = decryptCredential(
-        grant.credential,
-        bindingFor(options, grant),
-        options.keyRing,
-      );
-      if (token === null || !credentialMatches(grant, options, token))
-        return {
-          status: "rejected",
-          reason: "unavailable",
-          detail: "The Grant cannot be revealed.",
-        };
-      grantTransaction.appendGrantAudit(
-        createAuditEntry(
-          options,
-          auditInput("credential-revealed", grant, resolvedAuthority, grant.status),
-        ),
-      );
-      refreshEventAdminSession(transaction, options, resolvedAuthority);
-      return {
-        status: "revealed",
-        grantId,
-        grantVersion: grant.grantVersion,
-        grantType: grant.grantType,
-        qrCredential: token,
-        credentialFormatVersion: GRANT_CREDENTIAL_FORMAT_VERSION,
-      };
-    });
+    return await storage.transaction((transaction) =>
+      revealGrantInTransaction(transaction, options, grantId, authority),
+    );
   } catch {
     return { status: "rejected", reason: "unavailable", detail: "The Grant cannot be revealed." };
   }
+}
+
+export function revealGrantInTransaction(
+  transaction: FoundationStorageTransaction,
+  options: GrantAuthorityOptions,
+  grantId: string,
+  authority: GrantManagementAuthority,
+): TypedGrantReveal {
+  const trustedAuthority = verifyGrantAuthority(options.privilegedAuthorityVerifier, authority);
+  if (trustedAuthority === null)
+    return { status: "rejected", reason: "unauthorized", detail: "The Grant cannot be revealed." };
+  const grantTransaction = requireGrantStorageTransaction(transaction);
+  const stored = grantTransaction.findGrantById(grantId);
+  if (stored === null)
+    return { status: "rejected", reason: "not-found", detail: "The Grant cannot be revealed." };
+  const grant = expireGrantIfDue(transaction, options, stored);
+  if (grant.grantType === "control" && !hasCurrentAdmissionEligibility(options, grant, transaction))
+    return {
+      status: "rejected",
+      reason: "unauthorized",
+      detail: "The Grant cannot be revealed.",
+    };
+  const resolvedAuthority = resolveManagementAuthority(transaction, options, trustedAuthority);
+  if (
+    grant.status !== "active" ||
+    resolvedAuthority === null ||
+    !canManageInTransaction(transaction, options, grant, resolvedAuthority, "reveal")
+  )
+    return {
+      status: "rejected",
+      reason: "unauthorized",
+      detail: "The Grant cannot be revealed.",
+    };
+  const token = decryptCredential(grant.credential, bindingFor(options, grant), options.keyRing);
+  if (token === null || !credentialMatches(grant, options, token))
+    return {
+      status: "rejected",
+      reason: "unavailable",
+      detail: "The Grant cannot be revealed.",
+    };
+  grantTransaction.appendGrantAudit(
+    createAuditEntry(
+      options,
+      auditInput("credential-revealed", grant, resolvedAuthority, grant.status),
+    ),
+  );
+  refreshGrantManagementSession(transaction, options, resolvedAuthority);
+  return {
+    status: "revealed",
+    grantId,
+    grantVersion: grant.grantVersion,
+    grantType: grant.grantType,
+    qrCredential: token,
+    credentialFormatVersion: GRANT_CREDENTIAL_FORMAT_VERSION,
+  };
 }
 
 export async function rotateGrant(
@@ -103,114 +119,124 @@ export async function rotateGrant(
   grantId: string,
   authority: GrantManagementAuthority,
 ): Promise<TypedGrantRotated | TypedGrantMutation> {
-  const trustedAuthority = verifyGrantAuthority(options.privilegedAuthorityVerifier, authority);
-  if (trustedAuthority === null) return unauthorizedGrant();
   try {
-    return await storage.transaction((transaction) => {
-      const grantTransaction = requireGrantStorageTransaction(transaction);
-      const stored = grantTransaction.findGrantById(grantId);
-      if (stored === null) return { status: "rejected", reason: "not-found" };
-      const resolvedAuthority = resolveManagementAuthority(transaction, options, trustedAuthority);
-      if (
-        resolvedAuthority === null ||
-        !canManageInTransaction(transaction, options, stored, resolvedAuthority, "manage")
-      )
-        return unauthorizedGrant();
-      const grant = expireGrantIfDue(transaction, options, stored);
-      if (grant.status !== "active") return unauthorizedGrant();
-      if (!hasCurrentAdmissionEligibility(options, grant))
-        return {
-          status: "rejected",
-          reason: "invalid-state",
-          detail: "Grant admission is not currently eligible.",
-        };
-      const version = createRandomIdentifier("grant-version", options.randomness);
-      const binding = { ...bindingFor(options, grant), grantVersion: version };
-      const token = createCredentialToken(binding, options.randomness);
-      let rotatedCode: StoredGrantCode | null = null;
-      let replacementCode: string | null = null;
-      for (let attempt = 0; attempt < 8; attempt += 1) {
-        const candidate = generateGrantCode(options.randomness);
-        if (
-          grantTransaction.findGrantByCodeLookupDigest === undefined ||
-          grantTransaction.findGrantByCodeLookupDigest(
-            grantCodeLookupDigest(candidate, options.keyRing),
-          ) === null
-        ) {
-          replacementCode = candidate;
-          rotatedCode = encryptGrantCode(
-            candidate,
-            { ...binding, grantVersion: version },
-            options.randomness,
-            options.keyRing,
-          );
-          break;
-        }
-      }
-      if (rotatedCode === null || replacementCode === null) return unavailableGrant();
-      const rotated = {
-        ...grant,
-        grantVersion: version,
-        credential: encryptCredential(token, binding, options.randomness, options.keyRing),
-        code: rotatedCode,
-      };
-      revokeAllSessions(transaction, grantId, readGrantNow(options));
-      grantTransaction.updateGrant(rotated);
-      grantTransaction.appendGrantAudit(
-        createAuditEntry(
-          options,
-          auditInput(
-            "credential-rotated",
-            rotated,
-            resolvedAuthority,
-            "active",
-            null,
-            null,
-            null,
-            grant.status,
-          ),
-        ),
-      );
-      const codeAudit = createAuditEntry(
-        options,
-        auditInput(
-          grant.code?.state === "present" ? "grant-code-replaced" : "grant-code-created",
-          rotated,
-          resolvedAuthority,
-          "active",
-          null,
-          null,
-          null,
-          grant.status,
-        ),
-      );
-      grantTransaction.appendGrantAudit({
-        ...codeAudit,
-        credentialKind: GRANT_CODE_KIND,
-        credentialFingerprint: rotated.code.fingerprint,
-        codeFormatVersion: rotated.code.formatVersion,
-        codeEncryptionKeyVersion: rotated.code.encryptionKeyVersion,
-        codeLookupKeyVersion: rotated.code.lookupKeyVersion,
-        codeStateBefore: grant.code?.state ?? "absent",
-        codeState: rotated.code.state,
-        previousCodeFingerprint: grant.code?.fingerprint ?? null,
-      });
-      refreshEventAdminSession(transaction, options, resolvedAuthority);
-      return {
-        status: "updated",
-        grantId,
-        grantVersion: version,
-        qrCredential: token,
-        credentialFormatVersion: GRANT_CREDENTIAL_FORMAT_VERSION,
-        code: replacementCode,
-        codeFormatVersion: 1 as const,
-        oneTime: true,
-        noStore: true,
-      };
-    });
+    return await storage.transaction((transaction) =>
+      rotateGrantInTransaction(transaction, options, grantId, authority),
+    );
   } catch {
     return unavailableGrant();
   }
+}
+
+export function rotateGrantInTransaction(
+  transaction: FoundationStorageTransaction,
+  options: GrantAuthorityOptions,
+  grantId: string,
+  authority: GrantManagementAuthority,
+): TypedGrantRotated | TypedGrantMutation {
+  const trustedAuthority = verifyGrantAuthority(options.privilegedAuthorityVerifier, authority);
+  if (trustedAuthority === null) return unauthorizedGrant();
+  const grantTransaction = requireGrantStorageTransaction(transaction);
+  const stored = grantTransaction.findGrantById(grantId);
+  if (stored === null) return { status: "rejected", reason: "not-found" };
+  const resolvedAuthority = resolveManagementAuthority(transaction, options, trustedAuthority);
+  if (
+    resolvedAuthority === null ||
+    !canManageInTransaction(transaction, options, stored, resolvedAuthority, "manage")
+  )
+    return unauthorizedGrant();
+  const grant = expireGrantIfDue(transaction, options, stored);
+  if (grant.status !== "active") return unauthorizedGrant();
+  if (!hasCurrentAdmissionEligibility(options, grant, transaction))
+    return {
+      status: "rejected",
+      reason: "invalid-state",
+      detail: "Grant admission is not currently eligible.",
+    };
+  const version = createRandomIdentifier("grant-version", options.randomness);
+  const binding = { ...bindingFor(options, grant), grantVersion: version };
+  const token = createCredentialToken(binding, options.randomness);
+  let rotatedCode: StoredGrantCode | null = null;
+  let replacementCode: string | null = null;
+  for (let attempt = 0; attempt < 8; attempt += 1) {
+    const candidate = generateGrantCode(options.randomness);
+    if (
+      grantTransaction.findGrantByCodeLookupDigest === undefined ||
+      grantTransaction.findGrantByCodeLookupDigest(
+        grantCodeLookupDigest(candidate, options.keyRing),
+      ) === null
+    ) {
+      replacementCode = candidate;
+      rotatedCode = encryptGrantCode(
+        candidate,
+        { ...binding, grantVersion: version },
+        options.randomness,
+        options.keyRing,
+      );
+      break;
+    }
+  }
+  if (rotatedCode === null || replacementCode === null) return unavailableGrant();
+  const rotated = {
+    ...grant,
+    grantVersion: version,
+    credential: encryptCredential(token, binding, options.randomness, options.keyRing),
+    code: rotatedCode,
+  };
+  const affectedSessionCount = revokeAllSessions(transaction, grantId, readGrantNow(options));
+  grantTransaction.updateGrant(rotated);
+  grantTransaction.appendGrantAudit(
+    createAuditEntry(
+      options,
+      auditInput(
+        "credential-rotated",
+        rotated,
+        resolvedAuthority,
+        "active",
+        null,
+        null,
+        null,
+        grant.status,
+      ),
+    ),
+  );
+  const codeAudit = createAuditEntry(
+    options,
+    auditInput(
+      grant.code?.state === "present" ? "grant-code-replaced" : "grant-code-created",
+      rotated,
+      resolvedAuthority,
+      "active",
+      null,
+      null,
+      null,
+      grant.status,
+    ),
+  );
+  grantTransaction.appendGrantAudit({
+    ...codeAudit,
+    credentialKind: GRANT_CODE_KIND,
+    credentialFingerprint: rotated.code.fingerprint,
+    codeFormatVersion: rotated.code.formatVersion,
+    codeEncryptionKeyVersion: rotated.code.encryptionKeyVersion,
+    codeLookupKeyVersion: rotated.code.lookupKeyVersion,
+    codeStateBefore: grant.code?.state ?? "absent",
+    codeState: rotated.code.state,
+    previousCodeFingerprint: grant.code?.fingerprint ?? null,
+  });
+  refreshGrantManagementSession(transaction, options, resolvedAuthority);
+  return {
+    status: "updated",
+    grantId,
+    grantVersion: version,
+    qrCredential: token,
+    credentialFormatVersion: GRANT_CREDENTIAL_FORMAT_VERSION,
+    code: replacementCode,
+    codeFormatVersion: 1 as const,
+    oneTime: true,
+    noStore: true,
+    affectedSessionCount,
+  };
 }
 
 export async function rotateGrantCredentialKeys(

--- a/src/lib/grant-management-policy.ts
+++ b/src/lib/grant-management-policy.ts
@@ -7,7 +7,10 @@ import {
   parseCredentialToken,
   sameSecret,
 } from "@/lib/grant-crypto";
-import type { FoundationStorageTransaction } from "@/lib/foundation-storage";
+import type {
+  FoundationStorageSnapshot,
+  FoundationStorageTransaction,
+} from "@/lib/foundation-storage";
 import type { GrantAuthorityOptions } from "@/lib/grant-authority";
 import { DAY_MS } from "@/lib/grant-calendar";
 import { createAuditEntry, expireGrantIfDue } from "@/lib/grant-lifecycle";
@@ -31,10 +34,14 @@ import { validateOpaqueIdentifier } from "@/lib/validation-policy";
 export function hasCurrentAdmissionEligibility(
   options: GrantAuthorityOptions,
   grant: StoredGrant,
+  snapshot?: FoundationStorageSnapshot,
 ): boolean {
   if (grant.grantType !== "control") return true;
   try {
-    const resolved = options.controlScopeResolver.resolve(grant.scope as ControlGrantScope);
+    const resolved = options.controlScopeResolver.resolve(
+      grant.scope as ControlGrantScope,
+      snapshot,
+    );
     return (
       resolved.status === "eligible" &&
       validateOpaqueIdentifier(resolved.eventGameId, "eventGameId").ok
@@ -78,7 +85,7 @@ export function canInspectSessionSummariesInTransaction(
   grant: StoredGrant,
   authority: TrustedGrantAuthority,
 ): boolean {
-  authority = resolveManagementAuthority(transaction, options, authority) ?? authority;
+  authority = resolveManagementAuthority(transaction, options, authority, true) ?? authority;
   if (authority.kind === "technical-admin" || authority.kind === "fixture") return true;
   if (authority.kind !== "grant-session") return false;
 
@@ -86,16 +93,16 @@ export function canInspectSessionSummariesInTransaction(
   if (session === null || session.status !== "active") return false;
   const storedCaller = transaction.findGrantById(session.grantId);
   if (storedCaller === null) return false;
-  const caller = expireGrantIfDue(transaction, options, storedCaller);
+  const caller = storedCaller;
   if (caller.status !== "active" || caller.grantVersion !== session.grantVersion) return false;
+  const nowMs = readNow(options);
+  if (caller.expiresAtMs !== null && nowMs >= caller.expiresAtMs) return false;
 
   if (caller.grantType === "event-admin") {
-    const nowMs = readNow(options);
     if (
       nowMs >=
       Math.min(caller.expiresAtMs ?? Number.MAX_SAFE_INTEGER, session.lastActiveAtMs + 30 * DAY_MS)
     ) {
-      expireSession(transaction, options, caller, session);
       return false;
     }
     return (caller.scope as EventAdminGrantScope).eventId === grant.scope.eventId;
@@ -135,6 +142,31 @@ export function refreshEventAdminSession(
   transaction.updateGrantSession({ ...session, lastActiveAtMs: nowMs });
 }
 
+/** Refresh a successful management caller without coupling the Grant facade to one audience. */
+export function refreshGrantManagementSession(
+  transaction: FoundationStorageTransaction,
+  options: GrantAuthorityOptions,
+  authority: TrustedGrantAuthority,
+): void {
+  if (authority.kind !== "grant-session") return;
+  const session = findSessionByBearer(transaction, options, authority.sessionBearer);
+  if (session === null || session.status !== "active") return;
+  const storedGrant = transaction.findGrantById(session.grantId);
+  if (storedGrant === null) return;
+  const grant = expireGrantIfDue(transaction, options, storedGrant);
+  if (grant.status !== "active" || grant.grantVersion !== session.grantVersion) return;
+  const nowMs = readNow(options);
+  if (
+    grant.grantType === "event-admin" &&
+    nowMs >=
+      Math.min(grant.expiresAtMs ?? Number.MAX_SAFE_INTEGER, session.lastActiveAtMs + 30 * DAY_MS)
+  ) {
+    expireSession(transaction, options, grant, session);
+    return;
+  }
+  transaction.updateGrantSession({ ...session, lastActiveAtMs: nowMs });
+}
+
 export function canManageInTransaction(
   transaction: FoundationStorageTransaction,
   options: GrantAuthorityOptions,
@@ -143,8 +175,7 @@ export function canManageInTransaction(
   operation: "manage" | "reveal",
 ): boolean {
   authority = resolveManagementAuthority(transaction, options, authority) ?? authority;
-  if (authority.kind === "technical-admin")
-    return grant.grantType === "event-admin" || grant.grantType === "pitch-manager";
+  if (authority.kind === "technical-admin") return true;
   if (authority.kind === "fixture") return true;
   if (authority.kind !== "grant-session") return false;
   const session = findSessionByBearer(transaction, options, authority.sessionBearer);
@@ -167,6 +198,7 @@ export function canManageInTransaction(
     expireSession(transaction, options, caller, session);
     return false;
   }
+  if (caller.expiresAtMs !== null && nowMs >= caller.expiresAtMs) return false;
   if (caller.grantType === "control") {
     const resolved = options.controlScopeResolver.resolve(
       caller.scope as ControlGrantScope,
@@ -211,8 +243,7 @@ export function canCreateInTransaction(
 ): boolean {
   authority = resolveManagementAuthority(transaction, options, authority) ?? authority;
   if (authority.kind === "fixture") return true;
-  if (authority.kind === "technical-admin")
-    return grant.grantType === "event-admin" || grant.grantType === "pitch-manager";
+  if (authority.kind === "technical-admin") return true;
   if (authority.kind !== "grant-session") return false;
   const session = findSessionByBearer(transaction, options, authority.sessionBearer);
   if (session === null || session.status !== "active") return false;
@@ -351,23 +382,28 @@ export function revokeAllSessions(
   transaction: FoundationStorageTransaction,
   grantId: string,
   nowMs: number,
-): void {
+): number {
+  let affected = 0;
   for (const session of transaction.listGrantSessions(grantId))
-    if (session.status === "active")
+    if (session.status === "active") {
       transaction.updateGrantSession({ ...session, status: "revoked", revokedAtMs: nowMs });
+      affected += 1;
+    }
+  return affected;
 }
 
 export function resolveManagementAuthority(
   transaction: FoundationStorageTransaction,
   options: GrantAuthorityOptions,
   authority: TrustedGrantAuthority,
+  readOnly = false,
 ): TrustedGrantAuthority | null {
   if (authority.kind !== "grant-session") return authority;
   const session = findSessionByBearer(transaction, options, authority.sessionBearer);
   if (session === null || session.status !== "active") return null;
   const storedGrant = transaction.findGrantById(session.grantId);
   if (storedGrant === null) return null;
-  const grant = expireGrantIfDue(transaction, options, storedGrant);
+  const grant = readOnly ? storedGrant : expireGrantIfDue(transaction, options, storedGrant);
   if (grant.status !== "active" || grant.grantVersion !== session.grantVersion) return null;
   return bindTrustedGrantSession(authority, session.sessionId, session.browserContextKeyVersion);
 }

--- a/src/lib/grant-management-queries.ts
+++ b/src/lib/grant-management-queries.ts
@@ -1,4 +1,4 @@
-import type { FoundationStorage } from "@/lib/foundation-storage";
+import type { FoundationStorage, FoundationStorageTransaction } from "@/lib/foundation-storage";
 import type { GrantAuthorityOptions } from "@/lib/grant-authority";
 import { GENERIC_GRANT_STORAGE_FAILURE } from "@/lib/grant-authority-types";
 import type { GrantManagementAuthority, TypedSessionSummary } from "@/lib/grant-management-types";
@@ -11,6 +11,7 @@ import {
   refreshEventAdminSession,
 } from "@/lib/grant-management-policy";
 import { verifyGrantAuthority } from "@/lib/grant-authority-trust";
+import { readGrantNow } from "@/lib/grant-management-results";
 
 export async function listSessions(
   storage: FoundationStorage,
@@ -18,35 +19,45 @@ export async function listSessions(
   grantId: string,
   authority: GrantManagementAuthority,
 ): Promise<{ status: "ok"; value: TypedSessionSummary[] } | typeof GENERIC_GRANT_STORAGE_FAILURE> {
-  const trustedAuthority = verifyGrantAuthority(options.privilegedAuthorityVerifier, authority);
-  if (trustedAuthority === null) return GENERIC_GRANT_STORAGE_FAILURE;
   try {
-    return await storage.transaction((transaction) => {
-      const grant = transaction.findGrantById(grantId);
-      if (
-        grant === null ||
-        !canInspectSessionSummariesInTransaction(transaction, options, grant, trustedAuthority)
-      )
-        return GENERIC_GRANT_STORAGE_FAILURE;
-      expireGrantIfDue(transaction, options, grant);
-      const result = {
-        status: "ok" as const,
-        value: transaction.listGrantSessions(grantId).map((session) => ({
-          label: sessionLabel(options, session),
-          status: session.status,
-          createdAtMs: session.createdAtMs,
-          lastActiveAtMs: session.lastActiveAtMs,
-          revokedAtMs: session.revokedAtMs,
-          deviceClass: session.deviceClass ?? "unknown",
-          browserClass: session.browserClass ?? "unknown",
-        })),
-      };
-      refreshEventAdminSession(transaction, options, trustedAuthority);
-      return result;
-    });
+    return await storage.transaction((transaction) =>
+      listSessionsInTransaction(transaction, options, grantId, authority),
+    );
   } catch {
     return GENERIC_GRANT_STORAGE_FAILURE;
   }
+}
+
+export function listSessionsInTransaction(
+  transaction: FoundationStorageTransaction,
+  options: GrantAuthorityOptions,
+  grantId: string,
+  authority: GrantManagementAuthority,
+): { status: "ok"; value: TypedSessionSummary[] } | typeof GENERIC_GRANT_STORAGE_FAILURE {
+  const trustedAuthority = verifyGrantAuthority(options.privilegedAuthorityVerifier, authority);
+  if (trustedAuthority === null) return GENERIC_GRANT_STORAGE_FAILURE;
+  const grant = transaction.findGrantById(grantId);
+  if (
+    grant === null ||
+    !canInspectSessionSummariesInTransaction(transaction, options, grant, trustedAuthority)
+  )
+    return GENERIC_GRANT_STORAGE_FAILURE;
+  const nowMs = readGrantNow(options);
+  if (grant.status !== "active" || (grant.expiresAtMs !== null && nowMs >= grant.expiresAtMs))
+    return { status: "ok", value: [] };
+  return {
+    status: "ok",
+    value: transaction
+      .listGrantSessions(grantId)
+      .filter((session) => session.status === "active")
+      .map((session) => ({
+        label: sessionLabel(options, session),
+        createdAtMs: session.createdAtMs,
+        lastActiveAtMs: session.lastActiveAtMs,
+        deviceClass: session.deviceClass ?? "unknown",
+        browserClass: session.browserClass ?? "unknown",
+      })),
+  };
 }
 
 export async function listAudit(

--- a/src/lib/grant-management-sessions.ts
+++ b/src/lib/grant-management-sessions.ts
@@ -39,7 +39,7 @@ import {
   findActiveContext,
   findGrantByCredential,
   findSessionByBearer,
-  refreshEventAdminSession,
+  refreshGrantManagementSession,
   resolveManagementAuthority,
   terminateControlSessionForEventGame,
 } from "@/lib/grant-management-policy";
@@ -727,49 +727,59 @@ export async function revokeGrantSession(
   sessionReference: string,
   authority: GrantManagementAuthority,
 ): Promise<TypedGrantMutation> {
-  const trustedAuthority = verifyGrantAuthority(options.privilegedAuthorityVerifier, authority);
-  if (trustedAuthority === null) return unauthorizedGrant();
   try {
-    return await storage.transaction((transaction) => {
-      const storedGrant = transaction.findGrantById(grantId);
-      if (storedGrant === null) return { status: "rejected", reason: "not-found" };
-      const grant = expireGrantIfDue(transaction, options, storedGrant);
-      const resolvedAuthority = resolveManagementAuthority(transaction, options, trustedAuthority);
-      if (
-        grant.status !== "active" ||
-        resolvedAuthority === null ||
-        !canManageInTransaction(transaction, options, grant, resolvedAuthority, "manage")
-      )
-        return unauthorizedGrant();
-      const matches = transaction
-        .listGrantSessions(grantId)
-        .filter((candidate) => sessionLabel(options, candidate) === sessionReference);
-      if (matches.length !== 1) return { status: "rejected", reason: "not-found" };
-      const session = matches[0];
-      if (session === undefined) return { status: "rejected", reason: "not-found" };
-      if (session.status !== "active")
-        return {
-          status: "rejected",
-          reason: "invalid-state",
-          detail: "Grant Session is already inactive.",
-        };
-      transaction.updateGrantSession({
-        ...session,
-        status: "revoked",
-        revokedAtMs: readGrantNow(options),
-      });
-      transaction.appendGrantAudit(
-        createAuditEntry(
-          options,
-          auditInput("session-revoked", grant, resolvedAuthority, grant.status, session.sessionId),
-        ),
-      );
-      refreshEventAdminSession(transaction, options, resolvedAuthority);
-      return { status: "updated", grantId, grantVersion: grant.grantVersion };
-    });
+    return await storage.transaction((transaction) =>
+      revokeGrantSessionInTransaction(transaction, options, grantId, sessionReference, authority),
+    );
   } catch {
     return unavailableGrant();
   }
+}
+
+export function revokeGrantSessionInTransaction(
+  transaction: FoundationStorageTransaction,
+  options: GrantAuthorityOptions,
+  grantId: string,
+  sessionReference: string,
+  authority: GrantManagementAuthority,
+): TypedGrantMutation {
+  const trustedAuthority = verifyGrantAuthority(options.privilegedAuthorityVerifier, authority);
+  if (trustedAuthority === null) return unauthorizedGrant();
+  const storedGrant = transaction.findGrantById(grantId);
+  if (storedGrant === null) return { status: "rejected", reason: "not-found" };
+  const grant = expireGrantIfDue(transaction, options, storedGrant);
+  const resolvedAuthority = resolveManagementAuthority(transaction, options, trustedAuthority);
+  if (
+    grant.status !== "active" ||
+    resolvedAuthority === null ||
+    !canManageInTransaction(transaction, options, grant, resolvedAuthority, "manage")
+  )
+    return unauthorizedGrant();
+  const matches = transaction
+    .listGrantSessions(grantId)
+    .filter((candidate) => sessionLabel(options, candidate) === sessionReference);
+  if (matches.length !== 1) return { status: "rejected", reason: "not-found" };
+  const session = matches[0];
+  if (session === undefined) return { status: "rejected", reason: "not-found" };
+  if (session.status !== "active")
+    return {
+      status: "rejected",
+      reason: "invalid-state",
+      detail: "Grant Session is already inactive.",
+    };
+  transaction.updateGrantSession({
+    ...session,
+    status: "revoked",
+    revokedAtMs: readGrantNow(options),
+  });
+  transaction.appendGrantAudit(
+    createAuditEntry(
+      options,
+      auditInput("session-revoked", grant, resolvedAuthority, grant.status, session.sessionId),
+    ),
+  );
+  refreshGrantManagementSession(transaction, options, resolvedAuthority);
+  return { status: "updated", grantId, grantVersion: grant.grantVersion };
 }
 
 export async function leaveGrantSession(

--- a/src/lib/grant-management-types.ts
+++ b/src/lib/grant-management-types.ts
@@ -7,7 +7,6 @@ import {
   type GrantType,
   type PitchManagerGrantScope,
   type StoredGrantAuditEntry,
-  type StoredGrantSession,
 } from "@/lib/grant-types";
 import {
   GENERIC_GRANT_ADMISSION_FAILURE,
@@ -78,6 +77,7 @@ export type TypedGrantRotated = {
   codeFormatVersion: 1;
   oneTime: true;
   noStore: true;
+  affectedSessionCount: number;
 };
 
 export type TypedGrantAuthorization =
@@ -147,10 +147,8 @@ export type TypedGrantReveal =
 
 export type TypedSessionSummary = {
   label: string;
-  status: StoredGrantSession["status"];
   createdAtMs: number;
   lastActiveAtMs: number;
-  revokedAtMs: number | null;
   deviceClass: string;
   browserClass: string;
 };
@@ -178,6 +176,10 @@ export type TypedGrantAuthority = {
   createControlGrant(
     input: Omit<CreateTypedGrantInput, "grantType"> & { scope: ControlGrantScope },
   ): Promise<TypedGrantCreated | TypedGrantMutation>;
+  createControlGrantInTransaction(
+    transaction: FoundationStorageTransaction,
+    input: Omit<CreateTypedGrantInput, "grantType"> & { scope: ControlGrantScope },
+  ): TypedGrantCreated | TypedGrantMutation;
   createGrantCode(
     grantId: string,
     authority: GrantManagementAuthority,
@@ -235,6 +237,11 @@ export type TypedGrantAuthority = {
     replayEvidenceId: string;
   }): Promise<TypedGrantReplayAuthorization>;
   revealGrant(grantId: string, authority: GrantManagementAuthority): Promise<TypedGrantReveal>;
+  revealGrantInTransaction(
+    transaction: FoundationStorageTransaction,
+    grantId: string,
+    authority: GrantManagementAuthority,
+  ): TypedGrantReveal;
   disableGrant(grantId: string, authority: GrantManagementAuthority): Promise<TypedGrantMutation>;
   revokeGrant(grantId: string, authority: GrantManagementAuthority): Promise<TypedGrantMutation>;
   reactivateGrant(
@@ -245,6 +252,11 @@ export type TypedGrantAuthority = {
     grantId: string,
     authority: GrantManagementAuthority,
   ): Promise<TypedGrantRotated | TypedGrantMutation>;
+  rotateGrantInTransaction(
+    transaction: FoundationStorageTransaction,
+    grantId: string,
+    authority: GrantManagementAuthority,
+  ): TypedGrantRotated | TypedGrantMutation;
   rotateGrantCredentialKeys(
     grantId: string,
     authority: GrantManagementAuthority,
@@ -259,11 +271,22 @@ export type TypedGrantAuthority = {
     sessionReference: string,
     authority: GrantManagementAuthority,
   ): Promise<TypedGrantMutation>;
+  revokeGrantSessionInTransaction(
+    transaction: FoundationStorageTransaction,
+    grantId: string,
+    sessionReference: string,
+    authority: GrantManagementAuthority,
+  ): TypedGrantMutation;
   leaveGrantSession(sessionBearer: string): Promise<TypedGrantMutation>;
   listGrantSessions(
     grantId: string,
     authority: GrantManagementAuthority,
   ): Promise<{ status: "ok"; value: TypedSessionSummary[] } | typeof GENERIC_GRANT_STORAGE_FAILURE>;
+  listGrantSessionsInTransaction(
+    transaction: FoundationStorageTransaction,
+    grantId: string,
+    authority: GrantManagementAuthority,
+  ): { status: "ok"; value: TypedSessionSummary[] } | typeof GENERIC_GRANT_STORAGE_FAILURE;
   listGrantAudit(
     grantId: string,
     authority: GrantManagementAuthority,

--- a/src/lib/grant-management.test.ts
+++ b/src/lib/grant-management.test.ts
@@ -130,7 +130,7 @@ describe("typed Grant management", () => {
         sessionBearer: session.sessionBearer,
       });
       if (summaries.status !== "ok") throw new Error("Expected session summaries.");
-      const label = summaries.value.find((summary) => summary.status === "active")?.label;
+      const label = summaries.value[0]?.label;
       if (label === undefined) throw new Error("Expected active session label.");
       expect(
         await authority.revokeGrantSession(control.grantId, label, {
@@ -317,9 +317,7 @@ describe("typed Grant management", () => {
     });
     expect(managerSummaries.status).toBe("ok");
     if (managerSummaries.status !== "ok") throw new Error("Expected manager session summaries.");
-    const managerControllerSummary = managerSummaries.value.find(
-      (summary) => summary.status === "active",
-    );
+    const managerControllerSummary = managerSummaries.value[0];
     if (managerControllerSummary === undefined)
       throw new Error("Expected a manager-visible controller summary.");
     expect(JSON.stringify(managerSummaries)).not.toContain(controllerSession.sessionBearer);
@@ -399,7 +397,7 @@ describe("typed Grant management", () => {
     const sessions = await authority.listGrantSessions(control.grantId, technical);
     expect(sessions).toMatchObject({ status: "ok" });
     if (sessions.status !== "ok") throw new Error("Expected session summaries.");
-    expect(sessions.value[0]).toMatchObject({ deviceClass: "unknown", browserClass: "unknown" });
+    expect(sessions.value).toHaveLength(0);
     expect(JSON.stringify(sessions)).not.toContain(controllerSession.sessionBearer);
     storage.close();
   });
@@ -777,8 +775,6 @@ describe("typed Grant management", () => {
       "deviceClass",
       "label",
       "lastActiveAtMs",
-      "revokedAtMs",
-      "status",
     ]);
     expect(JSON.stringify(sessions)).not.toMatch(
       /bearer|digest|verifier|keyVersion|grantId|sessionId/i,

--- a/src/lib/grant-management.ts
+++ b/src/lib/grant-management.ts
@@ -9,11 +9,13 @@ import {
 } from "@/lib/grant-management-commands";
 import {
   revealGrant,
+  revealGrantInTransaction,
   rotateGrant,
+  rotateGrantInTransaction,
   rotateGrantCredentialKeys,
 } from "@/lib/grant-management-credentials";
 import { recalculateExpiry } from "@/lib/grant-management-lifecycle";
-import { listAudit, listSessions } from "@/lib/grant-management-queries";
+import { listAudit, listSessions, listSessionsInTransaction } from "@/lib/grant-management-queries";
 import { admitGrantCode, createGrantCode, disableGrantCode } from "@/lib/grant-management-code";
 import {
   admitGrant,
@@ -23,6 +25,7 @@ import {
   authorizeControlGrantReplay,
   leaveGrantSession,
   revokeGrantSession,
+  revokeGrantSessionInTransaction,
 } from "@/lib/grant-management-sessions";
 import type { TypedGrantAuthority } from "@/lib/grant-management-types";
 
@@ -73,6 +76,11 @@ export function createTypedGrantAuthority(
       }),
     createControlGrant: (input) =>
       createGrant(storage, options, { ...input, grantType: GRANT_TYPE }),
+    createControlGrantInTransaction: (transaction, input) =>
+      createGrantInTransaction(transaction, options, {
+        ...input,
+        grantType: GRANT_TYPE,
+      }),
     createGrantCode: (grantId, authority) =>
       createGrantCode(storage, options, grantId, authority, false),
     replaceGrantCode: (grantId, authority) =>
@@ -91,20 +99,28 @@ export function createTypedGrantAuthority(
       acceptControlGrantSessionSwitch(storage, options, input.sessionBearer),
     authorizeControlGrantReplay: (input) => authorizeControlGrantReplay(storage, options, input),
     revealGrant: (grantId, authority) => revealGrant(storage, options, grantId, authority),
+    revealGrantInTransaction: (transaction, grantId, authority) =>
+      revealGrantInTransaction(transaction, options, grantId, authority),
     disableGrant: (grantId, authority) =>
       updateGrantStatus(storage, options, grantId, authority, "disabled", "grant-disabled"),
     revokeGrant: (grantId, authority) =>
       updateGrantStatus(storage, options, grantId, authority, "revoked", "grant-revoked"),
     reactivateGrant: (grantId, authority) => reactivateGrant(storage, options, grantId, authority),
     rotateGrant: (grantId, authority) => rotateGrant(storage, options, grantId, authority),
+    rotateGrantInTransaction: (transaction, grantId, authority) =>
+      rotateGrantInTransaction(transaction, options, grantId, authority),
     rotateGrantCredentialKeys: (grantId, authority) =>
       rotateGrantCredentialKeys(storage, options, grantId, authority),
     recalculateGrantExpiry: (grantId, correction, authority) =>
       recalculateExpiry(storage, options, grantId, correction, authority),
     revokeGrantSession: (grantId, sessionReference, authority) =>
       revokeGrantSession(storage, options, grantId, sessionReference, authority),
+    revokeGrantSessionInTransaction: (transaction, grantId, sessionReference, authority) =>
+      revokeGrantSessionInTransaction(transaction, options, grantId, sessionReference, authority),
     leaveGrantSession: (sessionBearer) => leaveGrantSession(storage, options, sessionBearer),
     listGrantSessions: (grantId, authority) => listSessions(storage, options, grantId, authority),
+    listGrantSessionsInTransaction: (transaction, grantId, authority) =>
+      listSessionsInTransaction(transaction, options, grantId, authority),
     listGrantAudit: (grantId, authority) => listAudit(storage, options, grantId, authority),
   };
 }

--- a/src/lib/grant-types.ts
+++ b/src/lib/grant-types.ts
@@ -279,10 +279,8 @@ export type StoredGrantAuditEntry = {
 
 export type GrantSessionSummary = {
   label: string;
-  status: StoredGrantSessionStatus;
   createdAtMs: number;
   lastActiveAtMs: number;
-  revokedAtMs: number | null;
   deviceClass: string;
   browserClass: string;
 };

--- a/src/pages/event-admin-page.tsx
+++ b/src/pages/event-admin-page.tsx
@@ -80,6 +80,20 @@ type PitchManagerGrantResponse = {
     expiresAtMs: number | null;
   };
 };
+type ControlGrantResponse = {
+  status: "accepted";
+  value: {
+    grantId: string;
+    status: string;
+    eligibility: string;
+    eventGameId: string | null;
+  } | null;
+};
+type ControlSession = {
+  label: string;
+  deviceClass: string;
+  browserClass: string;
+};
 
 class EventPublicationValidationError extends Error {}
 
@@ -156,6 +170,11 @@ export function EventAdminPage() {
     PitchManagerGrantResponse["value"] | null
   >(null);
   const [pitchManagerQrDataUrl, setPitchManagerQrDataUrl] = useState<string | null>(null);
+  const [controlGrants, setControlGrants] = useState<Record<string, ControlGrantResponse["value"]>>(
+    {},
+  );
+  const [controlQrDataUrls, setControlQrDataUrls] = useState<Record<string, string>>({});
+  const [controlSessions, setControlSessions] = useState<Record<string, ControlSession[]>>({});
   const [publicationImpactConfirmed, setPublicationImpactConfirmed] = useState(false);
 
   const loadHub = async (nextGameDayId = selectedGameDayId) => {
@@ -232,6 +251,68 @@ export function EventAdminPage() {
     if (!response.ok || payload.status !== "accepted")
       throw new Error("Unable to load Pitch view.");
     setPitchView(payload.value);
+  };
+
+  const controlGrantUrl = (pitchSlotId: string) =>
+    `/api/event-admin/events/${eventId}/game-days/${selectedGameDayId}/pitches/${selectedPitchId}/pitch-slots/${pitchSlotId}/control-grant`;
+
+  const inspectControlGrant = async (pitchSlotId: string) => {
+    const response = await fetch(controlGrantUrl(pitchSlotId));
+    const payload = (await response.json()) as ControlGrantResponse;
+    if (!response.ok || payload.status !== "accepted")
+      throw new Error("Control Grant lookup failed.");
+    setControlGrants((current) => ({ ...current, [pitchSlotId]: payload.value }));
+    setControlQrDataUrls((current) => ({ ...current, [pitchSlotId]: "" }));
+  };
+
+  const createControlGrant = async (pitchSlotId: string) => {
+    const response = await fetch(controlGrantUrl(pitchSlotId), { method: "POST" });
+    if (!response.ok) throw new Error("Control Grant creation failed.");
+    await inspectControlGrant(pitchSlotId);
+  };
+
+  const revealControlGrant = async (pitchSlotId: string) => {
+    const response = await fetch(`${controlGrantUrl(pitchSlotId)}/reveal`, { method: "POST" });
+    const payload = (await response.json()) as {
+      status: string;
+      value?: { qrCredential?: string };
+    };
+    if (!response.ok || payload.status !== "accepted" || payload.value?.qrCredential === undefined)
+      throw new Error("Control Grant QR reveal failed.");
+    const dataUrl = await QRCode.toDataURL(payload.value.qrCredential);
+    setControlQrDataUrls((current) => ({ ...current, [pitchSlotId]: dataUrl }));
+  };
+
+  const loadControlSessions = async (pitchSlotId: string) => {
+    const response = await fetch(`${controlGrantUrl(pitchSlotId)}/sessions`);
+    const payload = (await response.json()) as { status: string; value?: ControlSession[] };
+    if (!response.ok || payload.status !== "accepted") throw new Error("Session list failed.");
+    setControlSessions((current) => ({ ...current, [pitchSlotId]: payload.value ?? [] }));
+  };
+
+  const rotateControlGrant = async (pitchSlotId: string) => {
+    const response = await fetch(`${controlGrantUrl(pitchSlotId)}/rotate`, { method: "POST" });
+    const payload = (await response.json()) as {
+      status: string;
+      value?: { affectedSessionCount?: number };
+    };
+    if (!response.ok || payload.status !== "accepted")
+      throw new Error("Control Grant rotation failed.");
+    setMessage(
+      `Control Grant rotated; ${payload.value?.affectedSessionCount ?? 0} session(s) revoked.`,
+    );
+    await inspectControlGrant(pitchSlotId);
+    await loadControlSessions(pitchSlotId);
+  };
+
+  const revokeControlSession = async (pitchSlotId: string, label: string) => {
+    const response = await fetch(`${controlGrantUrl(pitchSlotId)}/sessions/revoke`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ sessionReference: label }),
+    });
+    if (!response.ok) throw new Error("Control session revocation failed.");
+    await loadControlSessions(pitchSlotId);
   };
 
   const loadPitchManagerGrant = async () => {
@@ -1154,6 +1235,7 @@ export function EventAdminPage() {
                       const games = pitchView.eventGames.filter(
                         (candidate) => candidate.pitchSlotId === slot.pitchSlotId,
                       );
+                      const controlGrant = controlGrants[slot.pitchSlotId];
                       return (
                         <div className="rounded border p-2 text-sm" key={slot.pitchSlotId}>
                           <div className="flex flex-wrap justify-between gap-2">
@@ -1272,6 +1354,93 @@ export function EventAdminPage() {
                               </div>
                             ))
                           )}
+                          <div className="mt-3 space-y-2 border-t pt-2">
+                            <div className="flex flex-wrap gap-2">
+                              <Button
+                                size="sm"
+                                variant="outline"
+                                onClick={() =>
+                                  void run(() => inspectControlGrant(slot.pitchSlotId))
+                                }
+                              >
+                                Inspect Control Grant
+                              </Button>
+                              {controlGrant === undefined || controlGrant === null ? (
+                                <Button
+                                  size="sm"
+                                  onClick={() =>
+                                    void run(() => createControlGrant(slot.pitchSlotId))
+                                  }
+                                >
+                                  Create Control Grant
+                                </Button>
+                              ) : (
+                                <>
+                                  <Button
+                                    size="sm"
+                                    variant="outline"
+                                    onClick={() =>
+                                      void run(() => revealControlGrant(slot.pitchSlotId))
+                                    }
+                                  >
+                                    Reveal QR
+                                  </Button>
+                                  <Button
+                                    size="sm"
+                                    variant="outline"
+                                    onClick={() =>
+                                      void run(() => loadControlSessions(slot.pitchSlotId))
+                                    }
+                                  >
+                                    Sessions
+                                  </Button>
+                                  <Button
+                                    size="sm"
+                                    variant="outline"
+                                    onClick={() =>
+                                      void run(() => rotateControlGrant(slot.pitchSlotId))
+                                    }
+                                  >
+                                    Rotate Grant
+                                  </Button>
+                                </>
+                              )}
+                            </div>
+                            {controlGrant ? (
+                              <p className="text-xs text-muted-foreground">
+                                {controlGrant.status} · {controlGrant.eligibility}
+                                {controlGrant.eventGameId ? ` · ${controlGrant.eventGameId}` : ""}
+                              </p>
+                            ) : null}
+                            {controlQrDataUrls[slot.pitchSlotId] ? (
+                              <img
+                                alt={`Control Grant QR for Pitch Slot ${slot.sequence}`}
+                                className="h-40 w-40 rounded border bg-white p-2"
+                                src={controlQrDataUrls[slot.pitchSlotId]}
+                              />
+                            ) : null}
+                            {(controlSessions[slot.pitchSlotId] ?? []).map((session) => (
+                              <div
+                                className="flex items-center justify-between gap-2 text-xs"
+                                key={session.label}
+                              >
+                                <span>
+                                  {session.label} · {session.deviceClass}/{session.browserClass}
+                                </span>
+                                <Button
+                                  size="sm"
+                                  variant="outline"
+                                  onClick={() =>
+                                    void run(() =>
+                                      revokeControlSession(slot.pitchSlotId, session.label),
+                                    )
+                                  }
+                                >
+                                  Revoke
+                                </Button>
+                              </div>
+                            ))}
+                          </div>
                         </div>
                       );
                     })}

--- a/src/pages/pitch-manager-page.tsx
+++ b/src/pages/pitch-manager-page.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
+import QRCode from "qrcode/lib/browser";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -36,12 +37,31 @@ type View = {
   grantSessionExpiresAt: string | null;
 };
 
+type ControlGrant = {
+  grantId: string;
+  status: string;
+  eligibility: string;
+  eventGameId: string | null;
+  affectedSessionCount?: number;
+};
+
+type ControlSession = {
+  label: string;
+  createdAtMs: number;
+  lastActiveAtMs: number;
+  deviceClass: string;
+  browserClass: string;
+};
+
 export function PitchManagerPage() {
   const [credential, setCredential] = useState("");
   const [scope, setScope] = useState<Scope | null>(null);
   const [view, setView] = useState<View | null>(null);
   const [message, setMessage] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
+  const [controlGrants, setControlGrants] = useState<Record<string, ControlGrant | null>>({});
+  const [controlQr, setControlQr] = useState<Record<string, string>>({});
+  const [controlSessions, setControlSessions] = useState<Record<string, ControlSession[]>>({});
 
   const loadCurrent = useCallback(async () => {
     const response = await fetch("/api/pitch-manager/current");
@@ -88,6 +108,69 @@ export function PitchManagerPage() {
     await fetch("/api/pitch-manager/leave", { method: "POST" });
     setScope(null);
     setView(null);
+  };
+
+  const controlGrantUrl = (pitchSlotId: string) =>
+    `/api/pitch-manager/events/${scope?.eventId}/game-days/${scope?.gameDayId}/pitches/${scope?.pitchId}/pitch-slots/${pitchSlotId}/control-grant`;
+
+  const inspectControlGrant = async (pitchSlotId: string) => {
+    const response = await fetch(controlGrantUrl(pitchSlotId));
+    const payload = (await response.json()) as { status: string; value?: ControlGrant | null };
+    if (!response.ok || payload.status !== "accepted")
+      throw new Error("Control Grant lookup failed.");
+    setControlGrants((current) => ({ ...current, [pitchSlotId]: payload.value ?? null }));
+    setControlQr((current) => ({ ...current, [pitchSlotId]: "" }));
+    return payload.value ?? null;
+  };
+
+  const createControlGrant = async (pitchSlotId: string) => {
+    const response = await fetch(controlGrantUrl(pitchSlotId), { method: "POST" });
+    if (!response.ok) throw new Error("Control Grant creation failed.");
+    await inspectControlGrant(pitchSlotId);
+  };
+
+  const revealControlGrant = async (pitchSlotId: string) => {
+    const response = await fetch(`${controlGrantUrl(pitchSlotId)}/reveal`, { method: "POST" });
+    const payload = (await response.json()) as {
+      status: string;
+      value?: { qrCredential?: string };
+    };
+    if (!response.ok || payload.status !== "accepted" || payload.value?.qrCredential === undefined)
+      throw new Error("Control Grant QR reveal failed.");
+    const dataUrl = await QRCode.toDataURL(payload.value.qrCredential);
+    setControlQr((current) => ({ ...current, [pitchSlotId]: dataUrl }));
+  };
+
+  const loadControlSessions = async (pitchSlotId: string) => {
+    const response = await fetch(`${controlGrantUrl(pitchSlotId)}/sessions`);
+    const payload = (await response.json()) as { status: string; value?: ControlSession[] };
+    if (!response.ok || payload.status !== "accepted") throw new Error("Session list failed.");
+    setControlSessions((current) => ({ ...current, [pitchSlotId]: payload.value ?? [] }));
+  };
+
+  const rotateControlGrant = async (pitchSlotId: string) => {
+    const response = await fetch(`${controlGrantUrl(pitchSlotId)}/rotate`, { method: "POST" });
+    const payload = (await response.json()) as {
+      status: string;
+      value?: { affectedSessionCount?: number };
+    };
+    if (!response.ok || payload.status !== "accepted")
+      throw new Error("Control Grant rotation failed.");
+    setMessage(
+      `Control Grant rotated; ${payload.value?.affectedSessionCount ?? 0} session(s) revoked.`,
+    );
+    await inspectControlGrant(pitchSlotId);
+    await loadControlSessions(pitchSlotId);
+  };
+
+  const revokeControlSession = async (pitchSlotId: string, label: string) => {
+    const response = await fetch(`${controlGrantUrl(pitchSlotId)}/sessions/revoke`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ sessionReference: label }),
+    });
+    if (!response.ok) throw new Error("Control session revocation failed.");
+    await loadControlSessions(pitchSlotId);
   };
 
   if (view === null || scope === null) {
@@ -143,6 +226,7 @@ export function PitchManagerPage() {
           <div className="space-y-2" aria-label="Pitch schedule">
             {view.schedule.map((slot) => {
               const game = slot.eventGame;
+              const controlGrant = controlGrants[slot.pitchSlotId];
               return (
                 <div
                   className={`rounded border p-3 ${slot.conflictEventGameIds.length > 1 ? "border-destructive" : ""}`}
@@ -161,6 +245,104 @@ export function PitchManagerPage() {
                     Control Grant: {slot.controlGrantStatus}
                     {slot.conflictEventGameIds.length > 1 ? " · Schedule conflict" : ""}
                   </p>
+                  <div className="mt-3 space-y-2 border-t pt-2">
+                    <div className="flex flex-wrap gap-2">
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={() =>
+                          void inspectControlGrant(slot.pitchSlotId).catch(() =>
+                            setMessage("Control Grant lookup failed."),
+                          )
+                        }
+                      >
+                        Inspect Control Grant
+                      </Button>
+                      {controlGrant === undefined || controlGrant === null ? (
+                        <Button
+                          size="sm"
+                          onClick={() =>
+                            void createControlGrant(slot.pitchSlotId).catch(() =>
+                              setMessage("Control Grant creation failed."),
+                            )
+                          }
+                        >
+                          Create Control Grant
+                        </Button>
+                      ) : null}
+                      {controlGrant ? (
+                        <>
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            onClick={() =>
+                              void revealControlGrant(slot.pitchSlotId).catch(() =>
+                                setMessage("Control Grant QR reveal failed."),
+                              )
+                            }
+                          >
+                            Reveal QR
+                          </Button>
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            onClick={() =>
+                              void loadControlSessions(slot.pitchSlotId).catch(() =>
+                                setMessage("Session list failed."),
+                              )
+                            }
+                          >
+                            Sessions
+                          </Button>
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            onClick={() =>
+                              void rotateControlGrant(slot.pitchSlotId).catch(() =>
+                                setMessage("Control Grant rotation failed."),
+                              )
+                            }
+                          >
+                            Rotate Grant
+                          </Button>
+                        </>
+                      ) : null}
+                    </div>
+                    {controlGrant ? (
+                      <p className="text-xs text-muted-foreground">
+                        {controlGrant.status} · {controlGrant.eligibility}
+                        {controlGrant.eventGameId ? ` · ${controlGrant.eventGameId}` : ""}
+                      </p>
+                    ) : null}
+                    {controlQr[slot.pitchSlotId] ? (
+                      <img
+                        alt={`Control Grant QR for Pitch Slot ${slot.sequence}`}
+                        className="h-40 w-40 rounded border bg-white p-2"
+                        src={controlQr[slot.pitchSlotId]}
+                      />
+                    ) : null}
+                    {(controlSessions[slot.pitchSlotId] ?? []).map((session) => (
+                      <div
+                        className="flex items-center justify-between gap-2 text-xs"
+                        key={session.label}
+                      >
+                        <span>
+                          {session.label} · {session.deviceClass}/{session.browserClass}
+                        </span>
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() =>
+                            void revokeControlSession(slot.pitchSlotId, session.label).catch(() =>
+                              setMessage("Control session revocation failed."),
+                            )
+                          }
+                        >
+                          Revoke
+                        </Button>
+                      </div>
+                    ))}
+                  </div>
                 </div>
               );
             })}


### PR DESCRIPTION
## What changed

Manage Control Grants and their admitted sessions for Event Administration and Pitch Managers.

- Event Admins manage Event-wide Control Grants; Pitch Managers manage only their exact Pitch and Game Day.
- Control Grants remain attached to their Pitch Slot through schedule reassignment.
- Operators can inspect status, reveal QR credentials, list redacted active sessions, revoke one session, and rotate credentials with an affected-session count.
- Session summaries expose only generated labels, created/activity times, and coarse browser/device classes.
- Read-only session listing evaluates effective Grant lifecycle without persisting expiry, activity, or audit changes.

## Why

The feature gives authorized event operators a small recovery and access-management surface while keeping credentials, pseudonymous session evidence, and authority boundaries private. Reveal, targeted revoke, and rotation validate scope and current authority and commit Grant, session, audit, admission relation, and projections through one Foundation transaction.

## Impact and boundaries

Users gain reliable Event Admin and exact-scope Pitch Manager Control Grant management. Developers get typed Grant/Event Administration seams for atomic operations and read-only projections. Session data remains strictly allowlisted and currently revocable only; unrelated cookies are not overwritten by Pitch Manager responses.

Grant Codes, Access Sheets, the audit browser, removal, public Timeline, Controller workflow, deployment, migrations, and Qualification Tests are out of scope.

Parent Spec: #105  
Implementation issue: #116

## Validation

- `bun run check` — pass; only existing await-thenable warnings remain.
- Focused deterministic/composed Grant and Event Administration tests — 28 pass, 0 fail.
- Focused browser evidence — pass, including exact Pitch/Game Day scope, redaction, read-only session listing, and cookie isolation.
- `bun run test` — 603 pass, 0 fail on current `main` (`c6e7db7`).
- `bun run build` — pass.
- `git diff --check` — pass.

The focused SQLite Grant suite has one known nonblocking repaired-base harness mismatch: its schema-006 readiness assertion expects migrations through `022`, while the repaired base applies current migrations `023`–`026`. No migrations were changed for #116.
