### PR TITLE
Pin deployment CI to ShellCheck v0.11.0

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -39,10 +39,29 @@ jobs:
           bun-version-file: package.json
 
       - name: Install ShellCheck
+        env:
+          SHELLCHECK_VERSION: 0.11.0
+          SHELLCHECK_SHA256: 8c3be12b05d5c177a04c29e3c78ce89ac86f1595681cab149b65b97c4e227198
         run: |
           set -euo pipefail
-          sudo apt-get update
-          sudo apt-get install --yes --no-install-recommends shellcheck
+          archive="${RUNNER_TEMP}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz"
+          install_dir="${RUNNER_TEMP}/shellcheck-v${SHELLCHECK_VERSION}"
+          curl \
+            --fail \
+            --location \
+            --retry 3 \
+            --show-error \
+            --silent \
+            --proto '=https' \
+            --tlsv1.2 \
+            --output "$archive" \
+            "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz"
+          printf '%s  %s\n' "$SHELLCHECK_SHA256" "$archive" | sha256sum --check --status
+          tar --extract --file "$archive" --directory "$RUNNER_TEMP"
+          shellcheck_path="${install_dir}/shellcheck"
+          test -x "$shellcheck_path"
+          "$shellcheck_path" --version | grep -Fqx "version: ${SHELLCHECK_VERSION}"
+          echo "$install_dir" >> "$GITHUB_PATH"
 
       - name: Install dependencies
         run: bun install --frozen-lockfile


### PR DESCRIPTION
## Summary

- Pin deployment CI to the official ShellCheck v0.11.0 Linux x86_64 release used by local validation.
- Verify the official release SHA-256 before extraction and verify the installed binary reports exactly v0.11.0.
- Remove the unpinned Ubuntu apt installation that resolved to ShellCheck 0.9.

## Why

The deployment workflow introduced by #191 failed in its build gate before either environment could deploy. Ubuntu's ShellCheck 0.9 reports `SC2317` for cleanup functions invoked through EXIT traps, while the locally used ShellCheck 0.11.0 accepts the same scripts. The later deployment after #184 inherited the same failure.

This keeps CI and local shell validation on the same explicit version without suppressing the diagnostic.

Relates to #161 and parent spec #158.

## Verification

- Official release asset digest confirmed as `8c3be12b05d5c177a04c29e3c78ce89ac86f1595681cab149b65b97c4e227198`.
- `bun run check`
- `bun test --isolate` — 598 passed, 0 failed
- `git diff --check`
- Independent review found no correctness, workflow, or supply-chain issues.

## Operational impact

The failed runs stopped during linting, so neither Production nor Test was mutated. After merge, the next eligible `main` push or an explicit workflow dispatch can run the corrected deployment path. No deployment, server, or secret mutation is performed by this PR itself.
