### PR TITLE
Browse administrative audit evidence

### DIFF
--- a/scripts/test-technical-admin-browser.ts
+++ b/scripts/test-technical-admin-browser.ts
@@ -232,6 +232,15 @@ try {
   await page.goto(`${origin}/admin`);
   await page.getByText("Technical Admin administration").waitFor();
   await page.getByRole("button", { name: /Browser Event Updated/ }).click();
+  await page.getByText("Administrative audit evidence", { exact: true }).waitFor();
+  const technicalAuditResponse = await context.request.get(
+    `${origin}/api/admin/events/${eventId}/audit?projection=event-administration&limit=1`,
+  );
+  assert(
+    technicalAuditResponse.status() === 200 &&
+      technicalAuditResponse.headers()["set-cookie"] === undefined,
+    "Technical Admin audit projection was not a read-only response",
+  );
   await page.getByRole("button", { name: "Create Grant" }).click();
   const revealResponsePromise = page.waitForResponse(
     (response) =>
@@ -262,7 +271,33 @@ try {
   await eventAdminPage.goto(`${origin}/event-admin?eventId=${eventId}`);
   await eventAdminPage.getByLabel("Scanned Event Admin QR value").fill(revealedCredential);
   await eventAdminPage.getByRole("button", { name: "Admit Event Admin" }).click();
-  await eventAdminPage.getByText(/event-admin/u).waitFor();
+  await eventAdminPage.getByText("Event Hub", { exact: true }).waitFor();
+  await eventAdminPage.getByText("Administrative audit evidence", { exact: true }).waitFor();
+  await eventAdminPage.getByText("Event Administration", { exact: true }).waitFor();
+  await eventAdminPage.getByText("Grant Audit", { exact: true }).waitFor();
+  const eventAdminAuditResponse = await eventAdminContext.request.get(
+    `${origin}/api/event-admin/audit?eventId=${eventId}&projection=grant&limit=1`,
+  );
+  assert(
+    eventAdminAuditResponse.status() === 200 &&
+      eventAdminAuditResponse.headers()["set-cookie"] === undefined &&
+      !(await eventAdminAuditResponse.text()).includes(revealedCredential),
+    "Event Admin audit projection was not read-only and redacted",
+  );
+  const unsupportedEventAuditFilter = await eventAdminContext.request.get(
+    `${origin}/api/event-admin/audit?eventId=${eventId}&projection=event-administration&grantId=unsupported`,
+  );
+  assert(
+    unsupportedEventAuditFilter.status() === 400 &&
+      unsupportedEventAuditFilter.headers()["set-cookie"] === undefined,
+    "Event Administration silently accepted its unsupported grantId filter",
+  );
+  const anonymousContext = await browser.newContext({ ignoreHTTPSErrors: true });
+  const anonymousAuditResponse = await anonymousContext.request.get(
+    `${origin}/api/event-admin/audit?eventId=${eventId}&projection=grant`,
+  );
+  assert(anonymousAuditResponse.status() === 401, "anonymous audit enumeration was accepted");
+  await anonymousContext.close();
   const eventAdminGameDaySelector = eventAdminPage.getByLabel("Game Day", { exact: true });
   const firstDayHubResponsePromise = eventAdminPage.waitForResponse(
     (response) =>
@@ -529,7 +564,7 @@ try {
       duplicatePitchManagerGrant.headers()["set-cookie"] === undefined,
     "invalid duplicate Pitch Manager Grant response was not generic and uncached",
   );
-  await eventAdminPage.getByText(/active.*expires/u).waitFor();
+  await eventAdminPage.getByText(/^active · expires/u).waitFor();
   const pitchManagerRevealResponsePromise = eventAdminPage.waitForResponse(
     (response) =>
       response.url().includes("/pitch-manager-grant/reveal") &&
@@ -594,6 +629,14 @@ try {
   await pitchManagerPage.getByText("Pitch Main", { exact: true }).waitFor();
   await pitchManagerPage.getByText(/Pitch Manager.*Game Day/u).waitFor();
   await pitchManagerPage.getByText(/2026-08-15 10:00 Europe\/Zurich/u).waitFor();
+  const pitchManagerAuditResponse = await pitchManagerContext.request.get(
+    `${origin}/api/event-admin/audit?eventId=${eventId}&projection=grant`,
+  );
+  assert(
+    pitchManagerAuditResponse.status() === 401 &&
+      pitchManagerAuditResponse.headers()["set-cookie"] === undefined,
+    "admitted Pitch Manager was not generically denied administrative audit evidence",
+  );
   await pitchManagerPage
     .getByText(/Control Grant:/u)
     .first()
@@ -605,10 +648,17 @@ try {
   const controlSetupPayload = (await controlSetupResponse.json()) as {
     value?: {
       pitchSlots?: Array<{ pitchSlotId: string; pitchId: string; gameDayId: string }>;
+      eventGames?: Array<{ eventGameId: string; pitchSlotId: string; gameCode: string | null }>;
     };
   };
+  const assignedControlSlotId = controlSetupPayload.value?.eventGames?.find(
+    (game) => game.gameCode === "G-01",
+  )?.pitchSlotId;
   const controlSlot = controlSetupPayload.value?.pitchSlots?.find(
-    (slot) => slot.pitchId === pitchManagerPitchId && slot.gameDayId === pitchManagerGameDayId,
+    (slot) =>
+      slot.pitchSlotId === assignedControlSlotId &&
+      slot.pitchId === pitchManagerPitchId &&
+      slot.gameDayId === pitchManagerGameDayId,
   );
   const pitchManagerControlSlot = controlSetupPayload.value?.pitchSlots?.find(
     (slot) =>
@@ -898,7 +948,7 @@ try {
       reactivatedPitchManagerVersion !== rotatedPitchManagerVersion,
     "Pitch Manager reactivation did not settle an active new Grant version",
   );
-  await expect(eventAdminPage.getByText(/active.*expires/u)).toBeVisible();
+  await expect(eventAdminPage.getByText(/^active · expires/u)).toBeVisible();
   const reactivatedPitchManagerRevealResponsePromise = eventAdminPage.waitForResponse(
     (response) =>
       response.url().includes("/pitch-manager-grant/reveal") &&
@@ -1034,6 +1084,57 @@ try {
   );
   await eventAdminPage.reload();
   await eventAdminPage.getByText(/event-admin/u).waitFor();
+  const eventAuditProbe = await eventAdminContext.request.get(
+    `${origin}/api/event-admin/audit?eventId=${eventId}&projection=event-administration&limit=100`,
+  );
+  const eventAuditProbePayload = (await eventAuditProbe.json()) as {
+    status?: string;
+    value?: { entries?: unknown[] };
+  };
+  assert(
+    eventAuditProbe.status() === 200 && (eventAuditProbePayload.value?.entries?.length ?? 0) > 10,
+    `Event Admin audit fixture did not cross ten entries (${eventAuditProbe.status()}: ${eventAuditProbePayload.value?.entries?.length ?? 0})`,
+  );
+  const eventAuditPanel = eventAdminPage.getByLabel("Event Administration audit projection");
+  const eventAuditBeforeLoadMore = await eventAuditPanel.textContent();
+  const eventLoadMore = eventAdminPage.getByRole("button", {
+    name: "Load more Event Administration",
+  });
+  assert(
+    (await eventLoadMore.count()) === 1,
+    "Event Admin audit did not expose bounded pagination",
+  );
+  const eventLoadMoreResponsePromise = eventAdminPage.waitForResponse(
+    (response) =>
+      response.url().includes("/api/event-admin/audit") &&
+      response.url().includes("cursor=") &&
+      response.request().method() === "GET",
+  );
+  await eventLoadMore.click();
+  assert(
+    (await eventLoadMoreResponsePromise).status() === 200 &&
+      (await eventAuditPanel.textContent()) !== eventAuditBeforeLoadMore,
+    "Event Admin audit did not cross its first bounded page",
+  );
+  const eventDirectionResponsePromise = eventAdminPage.waitForResponse(
+    (response) =>
+      response.url().includes("/api/event-admin/audit") &&
+      response.url().includes("direction=ascending") &&
+      response.request().method() === "GET",
+  );
+  await eventAdminPage.getByLabel("Audit ordering").selectOption("ascending");
+  assert(
+    (await eventDirectionResponsePromise).status() === 200,
+    "Event Admin ordering change failed",
+  );
+  const eventFilterResponsePromise = eventAdminPage.waitForResponse(
+    (response) =>
+      response.url().includes("/api/event-admin/audit") &&
+      response.url().includes("action=event-created") &&
+      response.request().method() === "GET",
+  );
+  await eventAdminPage.getByLabel("Audit action filter").fill("event-created");
+  assert((await eventFilterResponsePromise).status() === 200, "Event Admin filter change failed");
   const sessionCookieAfterRefresh = (await eventAdminContext.cookies()).find(
     (cookie) => cookie.name === "__Host-event-admin-session",
   );
@@ -1051,6 +1152,43 @@ try {
   assert(wrongEventResponse.status === 401, "wrong-Event Event Admin authority was accepted");
   await page.goto(`${origin}/admin`);
   await page.getByRole("button", { name: /Browser Event Updated/ }).click();
+  await page.getByText("Administrative audit evidence", { exact: true }).waitFor();
+  const technicalAuditPanel = page.getByLabel("Event Administration audit projection");
+  const technicalLoadMore = technicalAuditPanel.getByRole("button", {
+    name: "Load more Event Administration",
+  });
+  await technicalLoadMore.waitFor();
+  assert(
+    (await technicalLoadMore.count()) === 1,
+    "Technical Admin audit did not expose bounded pagination",
+  );
+  const technicalAuditBeforeLoadMore = await technicalAuditPanel.textContent();
+  assert(
+    technicalAuditBeforeLoadMore?.includes("Load more Event Administration") === true,
+    "Technical Admin audit pagination control was not rendered",
+  );
+  const technicalDirectionResponsePromise = page.waitForResponse(
+    (response) =>
+      response.url().includes(`/api/admin/events/${eventId}/audit`) &&
+      response.url().includes("direction=ascending") &&
+      response.request().method() === "GET",
+  );
+  await page.getByLabel("Audit ordering").selectOption("ascending");
+  assert(
+    (await technicalDirectionResponsePromise).status() === 200,
+    "Technical Admin ordering change failed",
+  );
+  const technicalFilterResponsePromise = page.waitForResponse(
+    (response) =>
+      response.url().includes(`/api/admin/events/${eventId}/audit`) &&
+      response.url().includes("action=event-created") &&
+      response.request().method() === "GET",
+  );
+  await page.getByLabel("Audit action filter").fill("event-created");
+  assert(
+    (await technicalFilterResponsePromise).status() === 200,
+    "Technical Admin filter change failed",
+  );
   const rotateResponsePromise = page.waitForResponse(
     (response) =>
       response.url().includes(`/api/admin/events/${eventId}/event-admin-grant/rotate`) &&
@@ -1085,7 +1223,10 @@ try {
   await revokedEventAdminPage.goto(`${origin}/event-admin?eventId=${eventId}`);
   await revokedEventAdminPage.getByLabel("Scanned Event Admin QR value").fill(freshCredential);
   await revokedEventAdminPage.getByRole("button", { name: "Admit Event Admin" }).click();
-  await revokedEventAdminPage.getByText(/event-admin/u).waitFor();
+  await revokedEventAdminPage
+    .getByText("Europe/Zurich · event-admin", { exact: false })
+    .first()
+    .waitFor();
   const validFreshSession = await fetchFromPage(
     revokedEventAdminPage,
     `${origin}/api/event-admin/hub?eventId=${eventId}`,
@@ -1172,6 +1313,11 @@ try {
       eventAdminGrantHandoff: true,
       qrRender: true,
       eventHubDelegation: true,
+      administrativeAuditPagination: true,
+      administrativeAuditFiltersAndDirection: true,
+      administrativeAuditProjectionFilterValidation: true,
+      pitchManagerAuditDenied: true,
+      anonymousAuditDenied: true,
       eventAdminRotationRevocationIsolation: true,
       pitchManagerHandoff: true,
       pitchManagerScopedView: true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,11 @@ import {
   type EventAdministrationMutationOutcome,
   type EventAdministrationOutcome,
 } from "@/lib/event-administration";
+import {
+  createAdministrativeAuditProjection,
+  type AdministrativeAuditProjection,
+  type AdministrativeAuditProjectionKind,
+} from "@/lib/administrative-audit";
 import { createGrantAuthority } from "@/lib/grant-authority";
 import { readGrantAuthorityOptions } from "@/lib/grant-runtime";
 import type { TypedGrantMutation, TypedGrantReveal } from "@/lib/grant-management";
@@ -209,6 +214,7 @@ async function startServer() {
     const eventCatalog = createEventCatalog(eventCatalogStorage, {});
     const audienceProjection = createAudienceProjection(eventCatalogStorage);
     let eventAdministration: EventAdministration | null = null;
+    let administrativeAuditProjection: AdministrativeAuditProjection | null = null;
     if (foundationStorage !== undefined) {
       try {
         const grantOptions = {
@@ -220,6 +226,10 @@ async function startServer() {
           storage: foundationStorage,
           grants: grantAuthority,
           controlScopeResolver: grantOptions.controlScopeResolver,
+        });
+        administrativeAuditProjection = createAdministrativeAuditProjection({
+          storage: foundationStorage,
+          grants: grantAuthority,
         });
       } catch {
         // Grant keys are an Event Administration dependency, not a server-wide dependency.
@@ -692,6 +702,19 @@ async function startServer() {
             return catalogResponse(await eventCatalog.removeEvent(eventId, token));
           },
         },
+        "/api/admin/events/:eventId/audit": {
+          async GET(req: Request) {
+            const token = requireTechnicalAdminToken(req, technicalAdminAuth);
+            if (token === null) return sensitiveGenericAuthFailure(401);
+            if (administrativeAuditProjection === null) return sensitiveGenericAuthFailure(503);
+            const eventId = new URL(req.url).pathname.split("/").at(-2) ?? "";
+            return administrativeAuditResponse(
+              await administrativeAuditProjection.read(
+                administrativeAuditQuery(new URL(req.url), eventId, token),
+              ),
+            );
+          },
+        },
         "/api/admin/events/:eventId/publication-status": {
           async POST(req: Request) {
             const token = requireTechnicalAdminMutationToken(req, technicalAdminAuth);
@@ -1152,6 +1175,19 @@ async function startServer() {
               authority,
             });
             return sensitiveEventAdministrationResponse(result);
+          },
+        },
+        "/api/event-admin/audit": {
+          async GET(req: Request) {
+            if (administrativeAuditProjection === null) return sensitiveGenericAuthFailure(503);
+            const authority = resolveEventAdministrationAuthority(req, technicalAdminAuth);
+            if (authority === null) return sensitiveGenericAuthFailure(401);
+            const url = new URL(req.url);
+            return administrativeAuditResponse(
+              await administrativeAuditProjection.read(
+                administrativeAuditQuery(url, url.searchParams.get("eventId") ?? "", authority),
+              ),
+            );
           },
         },
         "/api/event-admin/catalog": {
@@ -2266,6 +2302,38 @@ function sensitiveEventAdministrationResponse<T>(
     result.reason === "unauthorized" ? 401 : result.reason === "not-found" ? 404 : 400,
     extraHeaders,
   );
+}
+
+function administrativeAuditResponse<T>(
+  result: import("@/lib/administrative-audit").AdministrativeAuditOutcome<T>,
+) {
+  if (result.status === "accepted") return sensitiveJson(result);
+  if (result.status === "unavailable") return sensitiveJson(result, 503);
+  return sensitiveJson(result, result.reason === "unauthorized" ? 401 : 400);
+}
+
+function administrativeAuditQuery(
+  url: URL,
+  eventId: string,
+  authority: EventAdministrationAuthority,
+) {
+  const projection = url.searchParams.get("projection");
+  return {
+    projection: (projection === null
+      ? "event-administration"
+      : projection) as AdministrativeAuditProjectionKind,
+    eventId,
+    authority,
+    cursor: url.searchParams.get("cursor") ?? undefined,
+    limit: url.searchParams.get("limit") ?? undefined,
+    direction: url.searchParams.get("direction") ?? undefined,
+    action: url.searchParams.get("action") ?? undefined,
+    grantId: url.searchParams.get("grantId") ?? undefined,
+    eventGameId: url.searchParams.get("eventGameId") ?? undefined,
+    gameDayId: url.searchParams.get("gameDayId") ?? undefined,
+    pitchId: url.searchParams.get("pitchId") ?? undefined,
+    pitchSlotId: url.searchParams.get("pitchSlotId") ?? undefined,
+  };
 }
 
 function sensitiveEventAdministrationMutationResponse<T>(

--- a/src/lib/administrative-audit.test.ts
+++ b/src/lib/administrative-audit.test.ts
@@ -1,0 +1,471 @@
+import { describe, expect, test } from "bun:test";
+import { createAdministrativeAuditProjection } from "@/lib/administrative-audit";
+import { createEventAdministration } from "@/lib/event-administration";
+import { createEventCatalog, createFoundationEventCatalogStorage } from "@/lib/event-catalog";
+import { createInMemoryFoundationStorage } from "@/lib/foundation-storage-memory";
+import { createGrantAuthority, createGrantAuthorityVerifier } from "@/lib/grant-authority";
+import type { FoundationStorage } from "@/lib/foundation-storage";
+import type { ControlGrantScopeResolver, GrantKeyRing } from "@/lib/grant-types";
+import {
+  MemoryTechnicalAdminAuthRepository,
+  createTechnicalAdminAuth,
+  isTechnicalAdminAuthority,
+} from "@/lib/technical-admin-auth";
+
+const keyRing: GrantKeyRing = {
+  encryption: { currentVersion: "v1", keys: new Map([["v1", bytes(1)]]) },
+  lookup: { currentVersion: "v1", keys: new Map([["v1", bytes(2)]]) },
+  audit: { currentVersion: "v1", keys: new Map([["v1", bytes(3)]]) },
+};
+
+describe("privileged administrative audit projections", () => {
+  test("exposes separate allowlisted Event and Grant evidence without secrets", async () => {
+    const fixture = createFixture();
+    const event = await fixture.catalog.createEvent(
+      { name: "Audit Event", timeZone: "Europe/Zurich" },
+      fixture.technical,
+    );
+    if (event.status !== "accepted") throw new Error("Expected Event.");
+    const day = await fixture.catalog.addGameDay(
+      event.value.eventId,
+      { date: "2026-08-14" },
+      fixture.technical,
+    );
+    if (day.status !== "accepted") throw new Error("Expected Game Day.");
+    await fixture.catalog.addGameDay(
+      event.value.eventId,
+      { date: "2026-08-15" },
+      fixture.technical,
+    );
+    const created = await fixture.administration.createEventAdminGrant(
+      event.value.eventId,
+      fixture.technical,
+    );
+    if (created.status !== "accepted") throw new Error("Expected Event Admin Grant.");
+    const revealed = await fixture.grants.revealGrant(created.value.grantId, fixture.technical);
+    if (revealed.status !== "revealed")
+      throw new Error(`Expected Grant reveal: ${JSON.stringify(revealed)}`);
+    const admitted = await fixture.administration.admitEventAdmin({
+      qrCredential: revealed.qrCredential,
+      browserContext: "audit-browser",
+    });
+    if (admitted.status !== "admitted") throw new Error("Expected Event Admin session.");
+
+    const eventAudit = await fixture.projection.read({
+      projection: "event-administration",
+      eventId: event.value.eventId,
+      authority: fixture.technical,
+    });
+    expect(eventAudit.status).toBe("accepted");
+    if (eventAudit.status !== "accepted") throw new Error("Expected Event audit.");
+    expect(eventAudit.value.entries.length).toBeGreaterThan(0);
+    expect(eventAudit.value.entries[0]?.evidenceType).toBe("event-administration");
+    expect(JSON.stringify(eventAudit)).not.toContain("qrCredential");
+    expect(JSON.stringify(eventAudit)).not.toContain("ciphertext");
+    expect(eventAudit.value.entries[0]).toHaveProperty("before");
+    expect(eventAudit.value.entries[0]).toHaveProperty("after");
+
+    const grantAudit = await fixture.projection.read({
+      projection: "grant",
+      eventId: event.value.eventId,
+      authority: { kind: "grant-session", sessionBearer: admitted.sessionBearer },
+    });
+    expect(grantAudit.status).toBe("accepted");
+    if (grantAudit.status !== "accepted") throw new Error("Expected Grant audit.");
+    expect(grantAudit.value.entries.length).toBeGreaterThan(0);
+    expect(grantAudit.value.entries[0]).toMatchObject({
+      evidenceType: "grant",
+      grantId: created.value.grantId,
+    });
+    expect(JSON.stringify(grantAudit)).not.toContain(revealed.qrCredential);
+    expect(JSON.stringify(grantAudit)).not.toContain("lookupDigest");
+    expect(JSON.stringify(grantAudit)).not.toContain("encryptionKeyVersion");
+    expect(grantAudit.value.entries[0]).toHaveProperty("links");
+
+    const stateBefore = await snapshotGrantState(fixture.storage, created.value.grantId);
+    fixture.setNow(Date.parse("2026-08-14T12:00:05Z"));
+    const readAfterClockAdvance = await fixture.projection.read({
+      projection: "grant",
+      eventId: event.value.eventId,
+      authority: { kind: "grant-session", sessionBearer: admitted.sessionBearer },
+    });
+    expect(readAfterClockAdvance.status).toBe("accepted");
+    const stateAfter = await snapshotGrantState(fixture.storage, created.value.grantId);
+    expect(stateAfter).toEqual(stateBefore);
+    expect(stateAfter.sessions[0]?.lastActiveAtMs).toBe(stateBefore.sessions[0]?.lastActiveAtMs);
+  });
+
+  test("keeps pagination stable and rejects lower audiences without evidence enumeration", async () => {
+    const fixture = createFixture();
+    const event = await fixture.catalog.createEvent(
+      { name: "Paged Audit Event", timeZone: "UTC" },
+      fixture.technical,
+    );
+    if (event.status !== "accepted") throw new Error("Expected Event.");
+    const day = await fixture.catalog.addGameDay(
+      event.value.eventId,
+      { date: "2026-08-14" },
+      fixture.technical,
+    );
+    if (day.status !== "accepted") throw new Error("Expected Game Day.");
+    const grant = await fixture.administration.createEventAdminGrant(
+      event.value.eventId,
+      fixture.technical,
+    );
+    if (grant.status !== "accepted") throw new Error("Expected Grant.");
+    await fixture.catalog.changePublicationStatus(
+      event.value.eventId,
+      { status: "published" },
+      fixture.technical,
+    );
+
+    const first = await fixture.projection.read({
+      projection: "event-administration",
+      eventId: event.value.eventId,
+      authority: fixture.technical,
+      limit: 1,
+    });
+    expect(first).toMatchObject({ status: "accepted", value: { entries: [{}], hasMore: true } });
+    if (first.status !== "accepted" || first.value.nextCursor === null)
+      throw new Error("Expected an opaque next cursor.");
+    expect(first.value.nextCursor).not.toContain(event.value.eventId);
+    const second = await fixture.projection.read({
+      projection: "event-administration",
+      eventId: event.value.eventId,
+      authority: fixture.technical,
+      limit: 1,
+      cursor: first.value.nextCursor,
+    });
+    expect(second).toMatchObject({ status: "accepted", value: { entries: [{}] } });
+    if (second.status !== "accepted") throw new Error("Expected second page.");
+    expect(second.value.entries[0]?.evidenceId).not.toBe(first.value.entries[0]?.evidenceId);
+    const cursor = first.value.nextCursor;
+    if (cursor === null) throw new Error("Expected an opaque cursor.");
+    for (const mismatchedQuery of [
+      { eventId: "different-event" },
+      { eventId: event.value.eventId, action: "event-created" },
+      { eventId: event.value.eventId, direction: "ascending" },
+    ]) {
+      expect(
+        await fixture.projection.read({
+          projection: "event-administration",
+          eventId: mismatchedQuery.eventId,
+          authority: fixture.technical,
+          limit: 1,
+          cursor,
+          action: mismatchedQuery.action,
+          direction: mismatchedQuery.direction,
+        }),
+      ).toEqual({
+        status: "rejected",
+        reason: "invalid-input",
+        detail: "Audit cursor is invalid.",
+      });
+    }
+    expect(
+      await fixture.projection.read({
+        projection: "grant",
+        eventId: event.value.eventId,
+        authority: fixture.technical,
+        limit: 1,
+        cursor,
+      }),
+    ).toEqual({
+      status: "rejected",
+      reason: "invalid-input",
+      detail: "Audit cursor is invalid.",
+    });
+
+    const filtered = await fixture.projection.read({
+      projection: "event-administration",
+      eventId: event.value.eventId,
+      authority: fixture.technical,
+      action: "event-created",
+      limit: "100",
+    });
+    expect(filtered).toMatchObject({
+      status: "accepted",
+      value: { entries: [{ action: "event-created" }] },
+    });
+    const bounded = await fixture.projection.read({
+      projection: "event-administration",
+      eventId: event.value.eventId,
+      authority: fixture.technical,
+      limit: 101,
+    });
+    expect(bounded).toEqual({
+      status: "rejected",
+      reason: "invalid-input",
+      detail: "Audit page size is invalid.",
+    });
+    expect(
+      await fixture.projection.read({
+        projection: "event-administration",
+        eventId: event.value.eventId,
+        authority: fixture.technical,
+        grantId: "unsupported",
+      }),
+    ).toEqual({
+      status: "rejected",
+      reason: "invalid-input",
+      detail: "Audit filter is unsupported for this projection.",
+    });
+
+    const completeAscending = await fixture.projection.read({
+      projection: "event-administration",
+      eventId: event.value.eventId,
+      authority: fixture.technical,
+      direction: "ascending",
+      limit: 100,
+    });
+    expect(completeAscending.status).toBe("accepted");
+    if (completeAscending.status !== "accepted") throw new Error("Expected complete page.");
+    expect(new Set(completeAscending.value.entries.map((entry) => entry.occurredAtMs)).size).toBe(
+      1,
+    );
+    const pagedAscending: string[] = [];
+    let ascendingCursor: string | null = null;
+    do {
+      const page = await fixture.projection.read({
+        projection: "event-administration",
+        eventId: event.value.eventId,
+        authority: fixture.technical,
+        direction: "ascending",
+        limit: 1,
+        cursor: ascendingCursor ?? undefined,
+      });
+      expect(page.status).toBe("accepted");
+      if (page.status !== "accepted") throw new Error("Expected ascending page.");
+      pagedAscending.push(...page.value.entries.map((entry) => entry.evidenceId));
+      ascendingCursor = page.value.nextCursor;
+    } while (ascendingCursor !== null);
+    expect(pagedAscending).toEqual(
+      completeAscending.value.entries.map((entry) => entry.evidenceId),
+    );
+
+    const rejected = await fixture.projection.read({
+      projection: "event-administration",
+      eventId: event.value.eventId,
+      authority: { kind: "grant-session", sessionBearer: "pitch-manager-bearer" },
+    });
+    expect(rejected).toEqual({
+      status: "rejected",
+      reason: "unauthorized",
+      detail: "Unable to read administrative evidence.",
+    });
+  });
+
+  test("collapses stale authority and read failures to safe outcomes", async () => {
+    const fixture = createFixture();
+    const event = await fixture.catalog.createEvent(
+      { name: "Stale Audit Event", timeZone: "Europe/Zurich" },
+      fixture.technical,
+    );
+    if (event.status !== "accepted") throw new Error("Expected Event.");
+    await fixture.catalog.addGameDay(
+      event.value.eventId,
+      { date: "2026-08-14" },
+      fixture.technical,
+    );
+    await fixture.catalog.addGameDay(
+      event.value.eventId,
+      { date: "2026-08-15" },
+      fixture.technical,
+    );
+    const grant = await fixture.administration.createEventAdminGrant(
+      event.value.eventId,
+      fixture.technical,
+    );
+    if (grant.status !== "accepted") throw new Error("Expected Grant.");
+    const qr = await fixture.grants.revealGrant(grant.value.grantId, fixture.technical);
+    if (qr.status !== "revealed") throw new Error("Expected Grant reveal.");
+    const session = await fixture.administration.admitEventAdmin({
+      qrCredential: qr.qrCredential,
+      browserContext: "stale-audit-browser",
+    });
+    if (session.status !== "admitted") throw new Error("Expected session.");
+    fixture.setNow(Date.parse("2026-08-22T03:00:00Z"));
+    expect(
+      await fixture.projection.read({
+        projection: "grant",
+        eventId: event.value.eventId,
+        authority: { kind: "grant-session", sessionBearer: session.sessionBearer },
+      }),
+    ).toEqual({
+      status: "rejected",
+      reason: "unauthorized",
+      detail: "Unable to read administrative evidence.",
+    });
+
+    const failedFixture = createFixture();
+    failedFixture.storage.close();
+    expect(
+      await failedFixture.projection.read({
+        projection: "event-administration",
+        eventId: "event-read-failure",
+        authority: failedFixture.technical,
+      }),
+    ).toEqual({ status: "unavailable", detail: "Administrative evidence is unavailable." });
+  });
+
+  test("denies real admitted Pitch Manager and Controller authorities generically", async () => {
+    const fixture = createFixture(undefined, {
+      resolve: () => ({ status: "eligible", eventGameId: "controller-game" }),
+    });
+    const event = await fixture.catalog.createEvent(
+      { name: "Authority Boundary Event", timeZone: "UTC" },
+      fixture.technical,
+    );
+    if (event.status !== "accepted") throw new Error("Expected Event.");
+    const day = await fixture.catalog.addGameDay(
+      event.value.eventId,
+      { date: "2026-08-14" },
+      fixture.technical,
+    );
+    const pitch = await fixture.catalog.createPitch(
+      event.value.eventId,
+      { name: "Pitch A" },
+      fixture.technical,
+    );
+    if (day.status !== "accepted" || pitch.status !== "accepted")
+      throw new Error("Expected schedule structure.");
+    const eventGrant = await fixture.administration.createEventAdminGrant(
+      event.value.eventId,
+      fixture.technical,
+    );
+    if (eventGrant.status !== "accepted") throw new Error("Expected Event Admin Grant.");
+    const eventQr = await fixture.grants.revealGrant(eventGrant.value.grantId, fixture.technical);
+    if (eventQr.status !== "revealed") throw new Error("Expected Event Admin QR.");
+    const eventSession = await fixture.administration.admitEventAdmin({
+      qrCredential: eventQr.qrCredential,
+      browserContext: "authority-event-admin",
+    });
+    if (eventSession.status !== "admitted") throw new Error("Expected Event Admin session.");
+    const eventAuthority = {
+      kind: "grant-session" as const,
+      sessionBearer: eventSession.sessionBearer,
+    };
+    const managerGrant = await fixture.administration.createPitchManagerGrant(
+      event.value.eventId,
+      day.value.gameDayId,
+      pitch.value.pitchId,
+      eventAuthority,
+    );
+    if (managerGrant.status !== "accepted") throw new Error("Expected Pitch Manager Grant.");
+    const managerQr = await fixture.grants.revealGrant(managerGrant.value.grantId, eventAuthority);
+    if (managerQr.status !== "revealed") throw new Error("Expected Pitch Manager QR.");
+    const managerSession = await fixture.administration.admitPitchManager({
+      qrCredential: managerQr.qrCredential,
+      browserContext: "authority-pitch-manager",
+    });
+    if (managerSession.status !== "admitted") throw new Error("Expected Pitch Manager session.");
+    const slot = await fixture.catalog.createGameplaySlot(
+      event.value.eventId,
+      day.value.gameDayId,
+      { sequence: 1, scheduledStart: "2026-08-14T10:00" },
+      fixture.technical,
+    );
+    if (slot.status !== "accepted") throw new Error("Expected Gameplay Slot.");
+    const pitchSlot = await fixture.storage.transaction(
+      (transaction) => transaction.listPitchSlots(day.value.gameDayId, pitch.value.pitchId)[0],
+    );
+    if (pitchSlot === undefined) throw new Error("Expected Pitch Slot.");
+    const control = await fixture.grants.createControlGrant({
+      authority: { kind: "grant-session", sessionBearer: managerSession.sessionBearer },
+      scope: {
+        eventId: event.value.eventId,
+        gameDayId: day.value.gameDayId,
+        pitchId: pitch.value.pitchId,
+        pitchSlotId: pitchSlot.pitchSlotId,
+      },
+    });
+    if (control.status !== "created") throw new Error("Expected Control Grant.");
+    const controlQr = await fixture.grants.revealGrant(control.grantId, fixture.technical);
+    if (controlQr.status !== "revealed") throw new Error("Expected Control Grant QR.");
+    const controllerSession = await fixture.administration.admitControlGrant({
+      qrCredential: controlQr.qrCredential,
+      browserContext: "authority-controller",
+    });
+    if (controllerSession.status !== "admitted") throw new Error("Expected Controller session.");
+    for (const authority of [managerSession.sessionBearer, controllerSession.sessionBearer]) {
+      expect(
+        await fixture.projection.read({
+          projection: "grant",
+          eventId: event.value.eventId,
+          authority: { kind: "grant-session", sessionBearer: authority },
+        }),
+      ).toEqual({
+        status: "rejected",
+        reason: "unauthorized",
+        detail: "Unable to read administrative evidence.",
+      });
+    }
+  });
+});
+
+function createFixture(
+  storage: FoundationStorage = createInMemoryFoundationStorage(),
+  controlScopeResolver: ControlGrantScopeResolver = {
+    resolve: () => ({ status: "unavailable" as const }),
+  },
+) {
+  let nowMs = Date.parse("2026-08-14T12:00:00Z");
+  let entropy = 7;
+  const technical = createTechnicalAdminAuth(
+    { environment: "test", origin: "https://timer.example", rpId: "timer.example" },
+    new MemoryTechnicalAdminAuthRepository(),
+  ).resolveHostLocalAuthority();
+  const catalog = createEventCatalog(createFoundationEventCatalogStorage(storage), {
+    clock: { nowMs: () => nowMs },
+  });
+  const grants = createGrantAuthority(storage, {
+    environmentId: "test",
+    clock: { nowMs: () => nowMs },
+    randomness: {
+      bytes: (length: number) => {
+        const seed = entropy++;
+        return Uint8Array.from({ length }, (_, index) => ((seed + index * 37) % 240) + 1);
+      },
+    },
+    keyRing,
+    controlScopeResolver,
+    privilegedAuthorityVerifier: createGrantAuthorityVerifier((input) => {
+      if (isTechnicalAdminAuthority(input)) return { kind: "technical-admin", id: input.sessionId };
+      if (
+        typeof input === "object" &&
+        input !== null &&
+        (input as { kind?: unknown }).kind === "grant-session" &&
+        typeof (input as { sessionBearer?: unknown }).sessionBearer === "string"
+      )
+        return {
+          kind: "grant-session",
+          sessionBearer: (input as { sessionBearer: string }).sessionBearer,
+          sessionId: "audit-session",
+        };
+      return null;
+    }),
+  });
+  const administration = createEventAdministration({ storage, grants });
+  const projection = createAdministrativeAuditProjection({ storage, grants });
+  return {
+    storage,
+    technical,
+    catalog,
+    grants,
+    administration,
+    projection,
+    setNow: (value: number) => (nowMs = value),
+  };
+}
+
+function bytes(value: number): Uint8Array {
+  return new Uint8Array(32).fill(value);
+}
+
+async function snapshotGrantState(storage: FoundationStorage, grantId: string) {
+  return storage.transaction((transaction) => ({
+    grants: transaction.listGrants().filter((grant) => grant.grantId === grantId),
+    sessions: transaction.listGrantSessions(grantId),
+    audit: transaction.listGrantAudit(grantId),
+  }));
+}

--- a/src/lib/administrative-audit.ts
+++ b/src/lib/administrative-audit.ts
@@ -1,0 +1,605 @@
+import type {
+  EventCatalogAuditEntry,
+  FoundationStorage,
+  FoundationStorageTransaction,
+} from "@/lib/foundation-storage";
+import type { EventAdministrationAuthority } from "@/lib/event-administration";
+import type { TypedGrantAuthority } from "@/lib/grant-management";
+import {
+  EVENT_ADMIN_GRANT_TYPE,
+  GRANT_TYPE,
+  PITCH_MANAGER_GRANT_TYPE,
+  type GrantAuditAction,
+  type GrantScope,
+  type StoredGrantAuditEntry,
+} from "@/lib/grant-types";
+import { isTechnicalAdminAuthority } from "@/lib/technical-admin-auth";
+import { validateOpaqueIdentifier } from "@/lib/validation-policy";
+
+const DEFAULT_PAGE_SIZE = 25;
+const MAX_PAGE_SIZE = 100;
+const MAX_CURSOR_LENGTH = 2048;
+
+export type AdministrativeAuditProjectionKind = "event-administration" | "grant";
+export type AdministrativeAuditDirection = "ascending" | "descending";
+
+export type AdministrativeAuditEntry = EventAdministrativeAuditProjection | GrantAuditProjection;
+
+export type EventAdministrativeAuditProjection = {
+  evidenceType: "event-administration";
+  evidenceId: string;
+  operationId: string;
+  action: EventCatalogAuditEntry["action"];
+  occurredAtMs: number;
+  scope: { eventId: string; gameDayId: string | null };
+  authority: { reference: string };
+  before: Record<string, unknown> | null;
+  after: Record<string, unknown> | null;
+  links: { eventGameId: string | null; grantId: string | null };
+};
+
+export type GrantAuditProjection = {
+  evidenceType: "grant";
+  evidenceId: string;
+  action: GrantAuditAction;
+  occurredAtMs: number;
+  grantId: string;
+  grantType: typeof EVENT_ADMIN_GRANT_TYPE | typeof PITCH_MANAGER_GRANT_TYPE | typeof GRANT_TYPE;
+  grantVersion: string;
+  scope: Record<string, string>;
+  authority: { reference: string };
+  before: Record<string, unknown> | null;
+  after: Record<string, unknown> | null;
+  reason?: string;
+  links: {
+    eventGameId: string | null;
+    previousEventGameId: string | null;
+    controlAuditId: string | null;
+    controlActionId: string | null;
+    acceptanceId: string | null;
+    replayEvidenceId: string | null;
+  };
+};
+
+export type AdministrativeAuditPage = {
+  entries: readonly AdministrativeAuditEntry[];
+  direction: AdministrativeAuditDirection;
+  hasMore: boolean;
+  nextCursor: string | null;
+};
+
+export type AdministrativeAuditReadInput = {
+  projection: AdministrativeAuditProjectionKind;
+  eventId: unknown;
+  authority: EventAdministrationAuthority;
+  cursor?: unknown;
+  limit?: unknown;
+  direction?: unknown;
+  action?: unknown;
+  grantId?: unknown;
+  eventGameId?: unknown;
+  gameDayId?: unknown;
+  pitchId?: unknown;
+  pitchSlotId?: unknown;
+};
+
+export type AdministrativeAuditOutcome<T> =
+  | { status: "accepted"; value: T }
+  | { status: "rejected"; reason: "invalid-input" | "unauthorized"; detail: string }
+  | { status: "unavailable"; detail: "Administrative evidence is unavailable." };
+
+export type AdministrativeAuditProjection = {
+  read(
+    input: AdministrativeAuditReadInput,
+  ): Promise<AdministrativeAuditOutcome<AdministrativeAuditPage>>;
+};
+
+type ParsedRead = {
+  eventId: string;
+  cursor: AuditCursor | null;
+  limit: number;
+  direction: AdministrativeAuditDirection;
+  action: string | null;
+  grantId: string | null;
+  eventGameId: string | null;
+  gameDayId: string | null;
+  pitchId: string | null;
+  pitchSlotId: string | null;
+};
+
+type SortKey = {
+  occurredAtMs: number;
+  evidenceType: AdministrativeAuditProjectionKind;
+  evidenceId: string;
+};
+
+type AuditCursor = SortKey & {
+  version: 1;
+  direction: AdministrativeAuditDirection;
+  projection: AdministrativeAuditProjectionKind;
+  queryFingerprint: string;
+};
+
+export function createAdministrativeAuditProjection(options: {
+  storage: FoundationStorage;
+  grants: Pick<TypedGrantAuthority, "authorizeGrantInTransaction">;
+}): AdministrativeAuditProjection {
+  return {
+    async read(input) {
+      const parsed = parseRead(input);
+      if (!parsed.ok) return parsed;
+      try {
+        return await options.storage.transaction((transaction) => {
+          if (!authorize(transaction, parsed.value.eventId, input.authority, options.grants))
+            return unauthorized();
+
+          const entries =
+            input.projection === "event-administration"
+              ? readEventEntries(transaction, parsed.value)
+              : readGrantEntries(transaction, parsed.value);
+          return accepted(pageEntries(input.projection, entries, parsed.value));
+        });
+      } catch {
+        return unavailable();
+      }
+    },
+  };
+}
+
+function parseRead(
+  input: AdministrativeAuditReadInput,
+):
+  | { ok: true; value: ParsedRead }
+  | { ok: false; status: "rejected"; reason: "invalid-input"; detail: string } {
+  if (input.projection !== "event-administration" && input.projection !== "grant")
+    return invalid("Administrative evidence projection is invalid.");
+  const eventId = validateOpaqueIdentifier(input.eventId, "eventId");
+  if (!eventId.ok) return invalid("Event identifier is invalid.");
+  const limit = parsePageSize(input.limit);
+  if (limit === null) return invalid("Audit page size is invalid.");
+  const direction =
+    input.direction === undefined
+      ? "descending"
+      : input.direction === "ascending"
+        ? "ascending"
+        : input.direction === "descending"
+          ? "descending"
+          : null;
+  if (direction === null) return invalid("Audit direction is invalid.");
+  if (input.projection === "event-administration" && input.grantId !== undefined)
+    return invalid("Audit filter is unsupported for this projection.");
+  const fields = [
+    ["action", input.action],
+    ["grantId", input.grantId],
+    ["eventGameId", input.eventGameId],
+    ["gameDayId", input.gameDayId],
+    ["pitchId", input.pitchId],
+    ["pitchSlotId", input.pitchSlotId],
+  ] as const;
+  const values: Record<string, string | null> = {};
+  for (const [name, value] of fields) {
+    if (value === undefined) {
+      values[name] = null;
+      continue;
+    }
+    if (typeof value !== "string" || value.length === 0 || value.length > 128)
+      return invalid("Audit filter is invalid.");
+    values[name] = typeof value === "string" ? value : null;
+  }
+  const filters = {
+    action: values.action ?? null,
+    grantId: values.grantId ?? null,
+    eventGameId: values.eventGameId ?? null,
+    gameDayId: values.gameDayId ?? null,
+    pitchId: values.pitchId ?? null,
+    pitchSlotId: values.pitchSlotId ?? null,
+  };
+  const cursor = decodeCursor(
+    input.cursor,
+    input.projection,
+    direction,
+    queryFingerprint(eventId.value, input.projection, direction, filters),
+  );
+  if (!cursor.ok) return cursor;
+  return {
+    ok: true,
+    value: {
+      eventId: eventId.value,
+      cursor: cursor.value,
+      limit,
+      direction,
+      ...filters,
+    },
+  };
+}
+
+function parsePageSize(value: unknown): number | null {
+  if (value === undefined) return DEFAULT_PAGE_SIZE;
+  if (typeof value === "number")
+    return Number.isSafeInteger(value) && value >= 1 && value <= MAX_PAGE_SIZE ? value : null;
+  if (typeof value !== "string" || !/^[0-9]{1,3}$/u.test(value)) return null;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed >= 1 && parsed <= MAX_PAGE_SIZE ? parsed : null;
+}
+
+function decodeCursor(
+  value: unknown,
+  projection: AdministrativeAuditProjectionKind,
+  direction: AdministrativeAuditDirection,
+  expectedQueryFingerprint: string,
+):
+  | { ok: true; value: AuditCursor | null }
+  | { ok: false; status: "rejected"; reason: "invalid-input"; detail: string } {
+  if (value === undefined) return { ok: true, value: null };
+  if (typeof value !== "string" || value.length === 0 || value.length > MAX_CURSOR_LENGTH)
+    return invalid("Audit cursor is invalid.");
+  try {
+    const decoded = JSON.parse(Buffer.from(value, "base64url").toString("utf8")) as unknown;
+    if (!isRecord(decoded)) return invalid("Audit cursor is invalid.");
+    if (
+      decoded.version !== 1 ||
+      decoded.projection !== projection ||
+      decoded.direction !== direction ||
+      decoded.queryFingerprint !== expectedQueryFingerprint ||
+      !Number.isSafeInteger(decoded.occurredAtMs) ||
+      (decoded.evidenceType !== "event-administration" && decoded.evidenceType !== "grant") ||
+      typeof decoded.evidenceId !== "string" ||
+      decoded.evidenceId.length === 0
+    )
+      return invalid("Audit cursor is invalid.");
+    return { ok: true, value: decoded as unknown as AuditCursor };
+  } catch {
+    return invalid("Audit cursor is invalid.");
+  }
+}
+
+function queryFingerprint(
+  eventId: string,
+  projection: AdministrativeAuditProjectionKind,
+  direction: AdministrativeAuditDirection,
+  filters: {
+    action: string | null;
+    grantId: string | null;
+    eventGameId: string | null;
+    gameDayId: string | null;
+    pitchId: string | null;
+    pitchSlotId: string | null;
+  },
+): string {
+  return Buffer.from(JSON.stringify({ eventId, projection, direction, filters }), "utf8").toString(
+    "base64url",
+  );
+}
+
+function authorize(
+  transaction: FoundationStorageTransaction,
+  eventId: string,
+  authority: EventAdministrationAuthority,
+  grants: Pick<TypedGrantAuthority, "authorizeGrantInTransaction">,
+): boolean {
+  if (isTechnicalAdminAuthority(authority)) return true;
+  if (
+    !isRecord(authority) ||
+    authority.kind !== "grant-session" ||
+    typeof authority.sessionBearer !== "string" ||
+    authority.sessionBearer.length === 0
+  )
+    return false;
+  const result = grants.authorizeGrantInTransaction(transaction, {
+    sessionBearer: authority.sessionBearer,
+    readOnly: true,
+  });
+  return (
+    result.status === "authorized" &&
+    result.grantType === EVENT_ADMIN_GRANT_TYPE &&
+    isRecord(result.scope) &&
+    result.scope.eventId === eventId
+  );
+}
+
+function readEventEntries(
+  transaction: FoundationStorageTransaction,
+  query: ParsedRead,
+): EventAdministrativeAuditProjection[] {
+  return transaction
+    .listEventAuditTrail(query.eventId)
+    .filter((entry) => query.action === null || entry.action === query.action)
+    .filter((entry) => query.gameDayId === null || entry.gameDayId === query.gameDayId)
+    .filter((entry) =>
+      query.eventGameId === null
+        ? true
+        : containsValue(entry.before, query.eventGameId) ||
+          containsValue(entry.after, query.eventGameId),
+    )
+    .filter((entry) =>
+      query.pitchId === null
+        ? true
+        : containsValue(entry.before, query.pitchId) || containsValue(entry.after, query.pitchId),
+    )
+    .filter((entry) =>
+      query.pitchSlotId === null
+        ? true
+        : containsValue(entry.before, query.pitchSlotId) ||
+          containsValue(entry.after, query.pitchSlotId),
+    )
+    .map(projectEventEntry);
+}
+
+function readGrantEntries(
+  transaction: FoundationStorageTransaction,
+  query: ParsedRead,
+): GrantAuditProjection[] {
+  const grantIds = transaction
+    .listGrants()
+    .filter((grant) => grantBelongsToEvent(grant.scope, query.eventId))
+    .filter((grant) => query.grantId === null || grant.grantId === query.grantId)
+    .map((grant) => grant.grantId);
+  return grantIds
+    .flatMap((grantId) => transaction.listGrantAudit(grantId))
+    .filter((entry) => query.action === null || entry.action === query.action)
+    .filter((entry) => query.grantId === null || entry.grantId === query.grantId)
+    .filter((entry) => query.eventGameId === null || entry.eventGameId === query.eventGameId)
+    .filter((entry) => scopeMatches(entry.scope, query))
+    .map(projectGrantEntry);
+}
+
+function projectEventEntry(entry: EventCatalogAuditEntry): EventAdministrativeAuditProjection {
+  const before = redactCatalogSnapshot(entry.before);
+  const after = redactCatalogSnapshot(entry.after);
+  return {
+    evidenceType: "event-administration",
+    evidenceId: entry.auditId,
+    operationId: entry.operationId,
+    action: entry.action,
+    occurredAtMs: entry.occurredAtMs,
+    scope: { eventId: entry.eventId, gameDayId: entry.gameDayId },
+    authority: { reference: entry.actorReference },
+    before,
+    after,
+    links: {
+      eventGameId: findString(after, "eventGameId") ?? findString(before, "eventGameId"),
+      grantId: null,
+    },
+  };
+}
+
+function projectGrantEntry(entry: StoredGrantAuditEntry): GrantAuditProjection {
+  const before = grantLifecycleSummary(
+    entry.beforeStatus,
+    entry.beforeExpiresAtMs,
+    entry.codeStateBefore,
+  );
+  const after = grantLifecycleSummary(entry.afterStatus, entry.afterExpiresAtMs, entry.codeState);
+  return {
+    evidenceType: "grant",
+    evidenceId: entry.auditId,
+    action: entry.action,
+    occurredAtMs: entry.createdAtMs,
+    grantId: entry.grantId,
+    grantType: entry.grantType,
+    grantVersion: entry.grantVersion,
+    scope: redactGrantScope(entry.scope),
+    authority: { reference: entry.actorReference },
+    before,
+    after,
+    ...(entry.terminalReason === null || entry.terminalReason === undefined
+      ? {}
+      : { reason: entry.terminalReason }),
+    links: {
+      eventGameId: entry.eventGameId,
+      previousEventGameId: entry.previousEventGameId ?? null,
+      controlAuditId: entry.controlAuditId ?? null,
+      controlActionId: entry.controlActionId ?? null,
+      acceptanceId: entry.acceptanceId ?? null,
+      replayEvidenceId: entry.replayEvidenceId ?? null,
+    },
+  };
+}
+
+function pageEntries(
+  projection: AdministrativeAuditProjectionKind,
+  entries: readonly AdministrativeAuditEntry[],
+  query: ParsedRead,
+): AdministrativeAuditPage {
+  const sorted = [...entries].sort((left, right) =>
+    compareSortKey(sortKey(left), sortKey(right), query.direction),
+  );
+  const afterCursor =
+    query.cursor === null
+      ? sorted
+      : sorted.filter((entry) =>
+          isAfterCursor(sortKey(entry), query.cursor as AuditCursor, query.direction),
+        );
+  const page = afterCursor.slice(0, query.limit);
+  const hasMore = afterCursor.length > query.limit;
+  const last = page.at(-1);
+  return {
+    entries: page,
+    direction: query.direction,
+    hasMore,
+    nextCursor:
+      hasMore && last !== undefined
+        ? encodeCursor({
+            version: 1,
+            projection,
+            direction: query.direction,
+            queryFingerprint: queryFingerprint(query.eventId, projection, query.direction, {
+              action: query.action,
+              grantId: query.grantId,
+              eventGameId: query.eventGameId,
+              gameDayId: query.gameDayId,
+              pitchId: query.pitchId,
+              pitchSlotId: query.pitchSlotId,
+            }),
+            ...sortKey(last),
+          })
+        : null,
+  };
+}
+
+function sortKey(entry: AdministrativeAuditEntry): SortKey {
+  return {
+    occurredAtMs: entry.occurredAtMs,
+    evidenceType: entry.evidenceType,
+    evidenceId: entry.evidenceId,
+  };
+}
+
+function compareSortKey(left: SortKey, right: SortKey, direction: AdministrativeAuditDirection) {
+  const base =
+    left.occurredAtMs - right.occurredAtMs ||
+    left.evidenceType.localeCompare(right.evidenceType) ||
+    left.evidenceId.localeCompare(right.evidenceId);
+  return direction === "ascending" ? base : -base;
+}
+
+function isAfterCursor(
+  value: SortKey,
+  cursor: AuditCursor,
+  direction: AdministrativeAuditDirection,
+) {
+  return compareSortKey(value, cursor, direction) > 0;
+}
+
+function encodeCursor(cursor: AuditCursor): string {
+  return Buffer.from(JSON.stringify(cursor), "utf8").toString("base64url");
+}
+
+function redactCatalogSnapshot(value: unknown): Record<string, unknown> | null {
+  if (value === null) return null;
+  if (!isRecord(value)) return {};
+  const allowed = new Set([
+    "eventId",
+    "gameDayId",
+    "eventTeamId",
+    "rosterEntryId",
+    "pitchId",
+    "gameplaySlotId",
+    "pitchSlotId",
+    "eventGameId",
+    "name",
+    "timeZone",
+    "publicationStatus",
+    "date",
+    "defaultColor",
+    "playerNumber",
+    "publicName",
+    "sequence",
+    "scheduledStartMs",
+    "expectedDelayMs",
+    "gameCode",
+    "gameDesignation",
+    "sideA",
+    "sideB",
+    "sideId",
+    "eventTeamName",
+    "sourceLabel",
+    "confirmedAtMs",
+  ]);
+  const result: Record<string, unknown> = {};
+  for (const key of allowed) {
+    if (!(key in value)) continue;
+    const current = value[key];
+    if (key === "sideA" || key === "sideB") {
+      result[key] = redactCatalogSnapshot(current);
+    } else if (
+      current === null ||
+      typeof current === "string" ||
+      typeof current === "number" ||
+      typeof current === "boolean"
+    ) {
+      result[key] = current;
+    }
+  }
+  return result;
+}
+
+function redactGrantScope(scope: GrantScope): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const key of [
+    "eventId",
+    "gameDayId",
+    "gameDayDate",
+    "eventTimeZone",
+    "finalGameDayDate",
+    "pitchId",
+    "pitchSlotId",
+  ]) {
+    const value = scope[key as keyof GrantScope];
+    if (typeof value === "string") result[key] = value;
+  }
+  return result;
+}
+
+function grantLifecycleSummary(
+  status: StoredGrantAuditEntry["beforeStatus"],
+  expiresAtMs: number | null,
+  codeState: StoredGrantAuditEntry["codeStateBefore"],
+): Record<string, unknown> | null {
+  if (status === null && expiresAtMs === null && codeState === undefined) return null;
+  return {
+    status,
+    expiresAtMs,
+    ...(codeState === undefined ? {} : { codeState }),
+  };
+}
+
+function grantBelongsToEvent(scope: GrantScope, eventId: string): boolean {
+  return "eventId" in scope && scope.eventId === eventId;
+}
+
+function scopeMatches(scope: GrantScope, query: ParsedRead): boolean {
+  return (
+    (query.gameDayId === null || ("gameDayId" in scope && scope.gameDayId === query.gameDayId)) &&
+    (query.pitchId === null || ("pitchId" in scope && scope.pitchId === query.pitchId)) &&
+    (query.pitchSlotId === null ||
+      ("pitchSlotId" in scope && scope.pitchSlotId === query.pitchSlotId))
+  );
+}
+
+function containsValue(value: unknown, expected: string): boolean {
+  if (value === expected) return true;
+  if (Array.isArray(value)) return value.some((item) => containsValue(item, expected));
+  if (!isRecord(value)) return false;
+  return Object.values(value).some((item) => containsValue(item, expected));
+}
+
+function findString(value: Record<string, unknown> | null, key: string): string | null {
+  const candidate = value?.[key];
+  return typeof candidate === "string" ? candidate : null;
+}
+
+function accepted<T>(value: T): { status: "accepted"; value: T } {
+  return { status: "accepted", value };
+}
+
+function invalid(detail: string): {
+  ok: false;
+  status: "rejected";
+  reason: "invalid-input";
+  detail: string;
+};
+function invalid(detail: string): {
+  status: "rejected";
+  reason: "invalid-input";
+  detail: string;
+};
+function invalid(detail: string) {
+  return { status: "rejected" as const, reason: "invalid-input" as const, detail };
+}
+
+function unauthorized(): AdministrativeAuditOutcome<never> {
+  return {
+    status: "rejected",
+    reason: "unauthorized",
+    detail: "Unable to read administrative evidence.",
+  };
+}
+
+function unavailable(): AdministrativeAuditOutcome<never> {
+  return { status: "unavailable", detail: "Administrative evidence is unavailable." };
+}
+
+function isRecord(value: unknown): value is Record<string, any> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/pages/administrative-audit-browser.test.tsx
+++ b/src/pages/administrative-audit-browser.test.tsx
@@ -1,0 +1,320 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { Window } from "happy-dom";
+import { AdministrativeAuditBrowser } from "@/pages/administrative-audit-browser";
+
+describe("shared administrative audit browser seam", () => {
+  const originalWindow = globalThis.window;
+  const originalDocument = globalThis.document;
+  const originalActEnvironment = (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean })
+    .IS_REACT_ACT_ENVIRONMENT;
+  let testWindow: Window;
+  let container: HTMLDivElement;
+  let root: Root;
+  let requests: string[];
+
+  beforeEach(() => {
+    testWindow = new Window({ url: "http://timer.quadball.app/event-admin?eventId=event-1" });
+    Object.assign(globalThis, {
+      window: testWindow,
+      document: testWindow.document,
+      IS_REACT_ACT_ENVIRONMENT: true,
+    });
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    requests = [];
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+      await Promise.resolve();
+    });
+    container.remove();
+    testWindow.close();
+    Object.assign(globalThis, {
+      window: originalWindow,
+      document: originalDocument,
+      IS_REACT_ACT_ENVIRONMENT: originalActEnvironment,
+    });
+  });
+
+  test("loads both projections, crosses a bounded page, and resets on filter and direction changes", async () => {
+    const request = async (input: RequestInfo | URL) => {
+      const rawInput =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      const url = new URL(rawInput, testWindow.location.href);
+      requests.push(url.toString());
+      const projection = url.searchParams.get("projection") ?? "";
+      const cursor = url.searchParams.get("cursor");
+      const direction = url.searchParams.get("direction");
+      const action = url.searchParams.get("action");
+      const page = cursor === null ? 1 : 2;
+      return new Response(
+        JSON.stringify({
+          status: "accepted",
+          value: {
+            entries: [
+              {
+                evidenceId: `${projection}-${direction}-${action ?? "all"}-${page}`,
+                evidenceType: projection,
+                action: action ?? "event-created",
+                occurredAtMs: page,
+                authority: { reference: "actor" },
+                scope: {},
+                before: null,
+                after: null,
+                links: {},
+              },
+            ],
+            direction,
+            hasMore: page === 1,
+            nextCursor: page === 1 ? `${projection}-cursor` : null,
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    };
+
+    await act(async () => {
+      root.render(
+        <AdministrativeAuditBrowser eventId="event-1" route="event-admin" request={request} />,
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(container.textContent).toContain("event-administration-descending-all-1");
+    expect(container.textContent).toContain("grant-descending-all-1");
+    expect(requests).toHaveLength(2);
+
+    await act(async () => {
+      const button = Array.from(container.querySelectorAll("button")).find((candidate) =>
+        candidate.textContent?.includes("Load more Event Administration"),
+      );
+      if (button === undefined) throw new Error("Expected Event load-more button.");
+      button.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(container.textContent).toContain("event-administration-descending-all-2");
+
+    await act(async () => {
+      const button = Array.from(container.querySelectorAll("button")).find((candidate) =>
+        candidate.textContent?.includes("Load more Grant Audit"),
+      );
+      if (button === undefined) throw new Error("Expected Grant load-more button.");
+      button.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(container.textContent).toContain("grant-descending-all-2");
+
+    await act(async () => {
+      const direction = container.querySelector(
+        'select[aria-label="Audit ordering"]',
+      ) as HTMLSelectElement | null;
+      if (direction === null) throw new Error("Expected ordering control.");
+      direction.value = "ascending";
+      direction.dispatchEvent(
+        new testWindow.Event("change", { bubbles: true }) as unknown as Event,
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(container.textContent).not.toContain("event-administration-descending-all-2");
+    expect(container.textContent).toContain("event-administration-ascending-all-1");
+
+    await act(async () => {
+      const action = container.querySelector(
+        'input[aria-label="Audit action filter"]',
+      ) as HTMLInputElement | null;
+      if (action === null) throw new Error("Expected action filter.");
+      action.value = "event-created";
+      action.dispatchEvent(new testWindow.Event("input", { bubbles: true }) as unknown as Event);
+      action.dispatchEvent(new testWindow.Event("change", { bubbles: true }) as unknown as Event);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    expect(container.textContent).toContain("event-administration-ascending-event-created-1");
+    expect(requests.at(-1)).toContain("action=event-created");
+  });
+
+  test("keeps stale load-more success and rejected responses out of newer queries", async () => {
+    type PendingRequest = {
+      url: string;
+      resolve: (response: Response) => void;
+    };
+    const pending: PendingRequest[] = [];
+    const response = (label: string, hasMore = true) =>
+      new Response(
+        JSON.stringify({
+          status: "accepted",
+          value: {
+            entries: [
+              {
+                evidenceId: label,
+                evidenceType: "event-administration",
+                action: "event-created",
+                occurredAtMs: 1,
+                authority: { reference: "actor" },
+                scope: {},
+                before: null,
+                after: null,
+                links: {},
+              },
+            ],
+            direction: "descending",
+            hasMore,
+            nextCursor: hasMore ? `${label}-next` : null,
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    const rejectedAuditResponse = () =>
+      new Response(
+        JSON.stringify({ status: "rejected", detail: "Unable to load audit evidence." }),
+        {
+          status: 400,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    const request = (input: RequestInfo | URL) => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      return new Promise<Response>((resolve) => {
+        pending.push({ url, resolve });
+      });
+    };
+    const flush = async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    };
+    const findPending = (predicate: (request: PendingRequest) => boolean) => {
+      const found = pending.find(predicate);
+      if (found === undefined) throw new Error("Expected deferred request.");
+      return found;
+    };
+    const resolveInitial = async (eventId: string, label: string, action?: string) => {
+      for (const request of pending.filter(
+        (candidate) =>
+          candidate.url.includes(`eventId=${eventId}`) &&
+          !candidate.url.includes("cursor=") &&
+          (action === undefined
+            ? !candidate.url.includes("action=")
+            : candidate.url.includes(`action=${action}`)),
+      )) {
+        request.resolve(response(label));
+      }
+      await flush();
+    };
+
+    await act(async () => {
+      root.render(
+        <AdministrativeAuditBrowser eventId="event-a" route="event-admin" request={request} />,
+      );
+      await flush();
+    });
+    await act(async () => resolveInitial("event-a", "event-a-page-1"));
+    expect(container.textContent).toContain("event-a-page-1");
+
+    await act(async () => {
+      const button = Array.from(container.querySelectorAll("button")).find((candidate) =>
+        candidate.textContent?.includes("Load more Event Administration"),
+      );
+      if (button === undefined) throw new Error("Expected Event load-more button.");
+      button.click();
+      await flush();
+    });
+    const staleSuccess = findPending(
+      (candidate) => candidate.url.includes("eventId=event-a") && candidate.url.includes("cursor="),
+    );
+
+    await act(async () => {
+      root.render(
+        <AdministrativeAuditBrowser eventId="event-b" route="event-admin" request={request} />,
+      );
+      await flush();
+    });
+    await act(async () => resolveInitial("event-b", "event-b-page-1"));
+    expect(container.textContent).toContain("event-b-page-1");
+    expect(container.textContent).not.toContain("event-a-page-2");
+    staleSuccess.resolve(response("event-a-page-2"));
+    await act(flush);
+    expect(container.textContent).toContain("event-b-page-1");
+    expect(container.textContent).not.toContain("event-a-page-2");
+
+    await act(async () => {
+      const action = container.querySelector(
+        'input[aria-label="Audit action filter"]',
+      ) as HTMLInputElement | null;
+      if (action === null) throw new Error("Expected action filter.");
+      action.value = "filter-a";
+      action.dispatchEvent(new testWindow.Event("input", { bubbles: true }) as unknown as Event);
+      action.dispatchEvent(new testWindow.Event("change", { bubbles: true }) as unknown as Event);
+      await flush();
+    });
+    await act(async () => resolveInitial("event-b", "event-b-filter-a-page-1", "filter-a"));
+    expect(container.textContent).toContain("event-b-filter-a-page-1");
+
+    await act(async () => {
+      const button = Array.from(container.querySelectorAll("button")).find((candidate) =>
+        candidate.textContent?.includes("Load more Event Administration"),
+      );
+      if (button === undefined) throw new Error("Expected filtered Event load-more button.");
+      button.click();
+      await flush();
+    });
+    const staleRejectedResponse = findPending(
+      (candidate) =>
+        candidate.url.includes("eventId=event-b") &&
+        candidate.url.includes("action=filter-a") &&
+        candidate.url.includes("cursor="),
+    );
+
+    await act(async () => {
+      const action = container.querySelector(
+        'input[aria-label="Audit action filter"]',
+      ) as HTMLInputElement | null;
+      if (action === null) throw new Error("Expected action filter.");
+      action.value = "filter-b";
+      action.dispatchEvent(new testWindow.Event("input", { bubbles: true }) as unknown as Event);
+      action.dispatchEvent(new testWindow.Event("change", { bubbles: true }) as unknown as Event);
+      await flush();
+    });
+    await act(async () => resolveInitial("event-b", "event-b-filter-b-page-1", "filter-b"));
+    expect(container.textContent).toContain("event-b-filter-b-page-1");
+    expect(container.textContent).not.toContain("event-b-filter-a-page-1");
+    const filterBLoadMore = Array.from(container.querySelectorAll("button")).find((candidate) =>
+      candidate.textContent?.includes("Load more Event Administration"),
+    );
+    if (filterBLoadMore === undefined) throw new Error("Expected filter-B load-more button.");
+    expect(filterBLoadMore.textContent).toBe("Load more Event Administration");
+
+    staleRejectedResponse.resolve(rejectedAuditResponse());
+    await act(flush);
+    const stableFilterBState = container.textContent;
+    await act(flush);
+    expect(container.textContent).toBe(stableFilterBState);
+    expect(container.textContent).toContain("event-b-filter-b-page-1");
+    expect(container.textContent).not.toContain("Unable to load audit evidence.");
+    expect(container.textContent).not.toContain("event-a-page-2");
+
+    await act(async () => {
+      filterBLoadMore.click();
+      await flush();
+    });
+    const filterBNextPage = findPending(
+      (candidate) =>
+        candidate.url.includes("eventId=event-b") &&
+        candidate.url.includes("action=filter-b") &&
+        candidate.url.includes("cursor="),
+    );
+    expect(filterBNextPage.url).toContain("cursor=event-b-filter-b-page-1-next");
+  });
+});

--- a/src/pages/administrative-audit-browser.tsx
+++ b/src/pages/administrative-audit-browser.tsx
@@ -1,0 +1,361 @@
+import { useEffect, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+
+export type AdministrativeAuditBrowserRoute = "event-admin" | "technical-admin";
+export type AdministrativeAuditBrowserRequest = (
+  input: RequestInfo | URL,
+  init?: RequestInit,
+) => Promise<Response>;
+
+type AuditEntry = {
+  evidenceId: string;
+  evidenceType: "event-administration" | "grant";
+  action: string;
+  occurredAtMs: number;
+  authority: { reference: string };
+  scope?: Record<string, string | null>;
+  before: Record<string, unknown> | null;
+  after: Record<string, unknown> | null;
+  grantId?: string;
+  reason?: string;
+  links: Record<string, string | null>;
+};
+
+type AuditResponse =
+  | {
+      status: "accepted";
+      value: {
+        entries: AuditEntry[];
+        direction: "ascending" | "descending";
+        hasMore: boolean;
+        nextCursor: string | null;
+      };
+    }
+  | { status: "rejected" | "unavailable"; detail?: string };
+
+type AuditFilters = {
+  action: string;
+  grantId: string;
+  eventGameId: string;
+  gameDayId: string;
+  pitchId: string;
+  pitchSlotId: string;
+};
+
+type ProjectionState = {
+  entries: AuditEntry[];
+  hasMore: boolean;
+  nextCursor: string | null;
+  loading: boolean;
+};
+
+const PROJECTIONS = ["event-administration", "grant"] as const;
+const EMPTY_FILTERS: AuditFilters = {
+  action: "",
+  grantId: "",
+  eventGameId: "",
+  gameDayId: "",
+  pitchId: "",
+  pitchSlotId: "",
+};
+
+export function AdministrativeAuditBrowser({
+  eventId,
+  route,
+  request = (input, init) => fetch(input, init),
+}: {
+  eventId: string;
+  route: AdministrativeAuditBrowserRoute;
+  request?: AdministrativeAuditBrowserRequest;
+}) {
+  const [direction, setDirection] = useState<"ascending" | "descending">("descending");
+  const [filters, setFilters] = useState<AuditFilters>(EMPTY_FILTERS);
+  const [pages, setPages] =
+    useState<Record<(typeof PROJECTIONS)[number], ProjectionState>>(emptyPages());
+  const [error, setError] = useState<string | null>(null);
+  const generation = useRef(0);
+  const mounted = useRef(true);
+  const requestRef = useRef(request);
+  requestRef.current = request;
+  const queryKey = JSON.stringify({ eventId, direction, filters });
+  const queryKeyRef = useRef(queryKey);
+  queryKeyRef.current = queryKey;
+
+  useEffect(() => {
+    const currentGeneration = generation.current + 1;
+    generation.current = currentGeneration;
+    mounted.current = true;
+    setPages(emptyPages());
+    setError(null);
+    let cancelled = false;
+    const isCurrent = () =>
+      mounted.current &&
+      generation.current === currentGeneration &&
+      queryKeyRef.current === queryKey;
+
+    const loadInitialPages = async () => {
+      await Promise.all(
+        PROJECTIONS.map((projection) =>
+          loadPage({
+            eventId,
+            route,
+            projection,
+            direction,
+            filters,
+            cursor: null,
+            append: false,
+            isCurrent,
+            cancelled: () => cancelled,
+            setPages,
+            setError,
+            requestRef,
+          }),
+        ),
+      );
+    };
+    void loadInitialPages().catch(() => undefined);
+    return () => {
+      cancelled = true;
+      generation.current += 1;
+      mounted.current = false;
+    };
+  }, [eventId, route, queryKey]);
+
+  const loadMore = (projection: (typeof PROJECTIONS)[number]) => {
+    const page = pages[projection];
+    if (!page.hasMore || page.loading || page.nextCursor === null) return;
+    const loadGeneration = generation.current;
+    const loadQueryKey = queryKey;
+    void loadPage({
+      eventId,
+      route,
+      projection,
+      direction,
+      filters,
+      cursor: page.nextCursor,
+      append: true,
+      isCurrent: () =>
+        mounted.current &&
+        generation.current === loadGeneration &&
+        queryKeyRef.current === loadQueryKey,
+      cancelled: () => false,
+      setPages,
+      setError,
+      requestRef,
+    }).catch(() => undefined);
+  };
+
+  const updateFilter = (name: keyof AuditFilters, value: string) => {
+    setFilters((current) => ({ ...current, [name]: value }));
+  };
+
+  return (
+    <div className="space-y-3 rounded-lg border p-3">
+      <div>
+        <p className="font-semibold">Administrative audit evidence</p>
+        <p className="text-sm text-muted-foreground">
+          Privileged Event Administration and Grant lifecycle evidence; credentials, sporting
+          detail, and Technical Admin operational logs remain separate.
+        </p>
+      </div>
+      <div className="grid gap-2 sm:grid-cols-2">
+        <label className="text-xs">
+          Audit ordering
+          <select
+            aria-label="Audit ordering"
+            className="mt-1 block w-full rounded border bg-background p-2"
+            value={direction}
+            onChange={(event) => setDirection(event.target.value as typeof direction)}
+          >
+            <option value="descending">Newest first</option>
+            <option value="ascending">Oldest first</option>
+          </select>
+        </label>
+        <AuditFilter
+          label="Audit action filter"
+          value={filters.action}
+          onChange={(value) => updateFilter("action", value)}
+        />
+        <AuditFilter
+          label="Event Game ID filter"
+          value={filters.eventGameId}
+          onChange={(value) => updateFilter("eventGameId", value)}
+        />
+        <AuditFilter
+          label="Game Day ID filter"
+          value={filters.gameDayId}
+          onChange={(value) => updateFilter("gameDayId", value)}
+        />
+        <AuditFilter
+          label="Pitch ID filter"
+          value={filters.pitchId}
+          onChange={(value) => updateFilter("pitchId", value)}
+        />
+        <AuditFilter
+          label="Pitch Slot ID filter"
+          value={filters.pitchSlotId}
+          onChange={(value) => updateFilter("pitchSlotId", value)}
+        />
+        <AuditFilter
+          label="Grant ID filter (Grant Audit only)"
+          value={filters.grantId}
+          onChange={(value) => updateFilter("grantId", value)}
+        />
+      </div>
+      {error ? <p className="text-sm text-destructive">Unable to load audit evidence.</p> : null}
+      <div className="grid gap-2 sm:grid-cols-2">
+        <AuditProjectionCard
+          label="Event Administration"
+          projection="event-administration"
+          page={pages["event-administration"]}
+          onLoadMore={() => loadMore("event-administration")}
+        />
+        <AuditProjectionCard
+          label="Grant Audit"
+          projection="grant"
+          page={pages.grant}
+          onLoadMore={() => loadMore("grant")}
+        />
+      </div>
+      <p className="text-xs text-muted-foreground">
+        Changing the Event, projection, filters, or ordering starts a fresh bounded result set.
+      </p>
+    </div>
+  );
+}
+
+function AuditFilter({
+  label,
+  value,
+  onChange,
+}: {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+}) {
+  return (
+    <label className="text-xs">
+      {label}
+      <input
+        aria-label={label}
+        className="mt-1 block w-full rounded border bg-background p-2"
+        value={value}
+        onInput={(event) => onChange(event.currentTarget.value)}
+        onChange={(event) => onChange(event.target.value)}
+      />
+    </label>
+  );
+}
+
+function AuditProjectionCard({
+  label,
+  projection,
+  page,
+  onLoadMore,
+}: {
+  label: string;
+  projection: (typeof PROJECTIONS)[number];
+  page: ProjectionState;
+  onLoadMore: () => void;
+}) {
+  return (
+    <div aria-label={`${label} audit projection`} className="rounded border p-2">
+      <p className="text-xs font-semibold">{label}</p>
+      {page.entries.length === 0 && !page.loading ? (
+        <p className="text-xs text-muted-foreground">No evidence.</p>
+      ) : (
+        page.entries.map((entry) => (
+          <div className="border-b py-2 text-xs last:border-0" key={entry.evidenceId}>
+            <p className="font-mono text-[10px]">Evidence: {entry.evidenceId}</p>
+            <p className="font-medium">{entry.action}</p>
+            <p className="text-muted-foreground">
+              {new Date(entry.occurredAtMs).toLocaleString()} · {entry.authority.reference}
+            </p>
+            <p className="text-muted-foreground">Scope: {JSON.stringify(entry.scope ?? {})}</p>
+            <p className="text-muted-foreground">
+              {projection === "grant" ? "Lifecycle" : "Before → after"}:{" "}
+              {JSON.stringify(entry.before)} → {JSON.stringify(entry.after)}
+            </p>
+            {entry.reason ? <p className="text-muted-foreground">Reason: {entry.reason}</p> : null}
+            <p className="text-muted-foreground">Links: {JSON.stringify(entry.links)}</p>
+          </div>
+        ))
+      )}
+      {page.hasMore ? (
+        <Button disabled={page.loading} onClick={onLoadMore} size="sm" variant="outline">
+          {page.loading ? "Loading…" : `Load more ${label}`}
+        </Button>
+      ) : null}
+    </div>
+  );
+}
+
+function emptyPages(): Record<(typeof PROJECTIONS)[number], ProjectionState> {
+  return {
+    "event-administration": { entries: [], hasMore: false, nextCursor: null, loading: false },
+    grant: { entries: [], hasMore: false, nextCursor: null, loading: false },
+  };
+}
+
+async function loadPage({
+  eventId,
+  route,
+  projection,
+  direction,
+  filters,
+  cursor,
+  append,
+  isCurrent,
+  cancelled,
+  setPages,
+  setError,
+  requestRef,
+}: {
+  eventId: string;
+  route: AdministrativeAuditBrowserRoute;
+  projection: (typeof PROJECTIONS)[number];
+  direction: "ascending" | "descending";
+  filters: AuditFilters;
+  cursor: string | null;
+  append: boolean;
+  isCurrent: () => boolean;
+  cancelled: () => boolean;
+  setPages: React.Dispatch<
+    React.SetStateAction<Record<(typeof PROJECTIONS)[number], ProjectionState>>
+  >;
+  setError: React.Dispatch<React.SetStateAction<string | null>>;
+  requestRef: React.MutableRefObject<AdministrativeAuditBrowserRequest>;
+}) {
+  setPages((current) => ({
+    ...current,
+    [projection]: { ...current[projection], loading: true },
+  }));
+  const params = new URLSearchParams({ projection, limit: "10", direction });
+  if (route === "event-admin") params.set("eventId", eventId);
+  for (const [name, value] of Object.entries(filters)) {
+    if (value.length > 0 && (projection === "grant" || name !== "grantId")) params.set(name, value);
+  }
+  if (cursor !== null) params.set("cursor", cursor);
+  const path =
+    route === "event-admin"
+      ? `/api/event-admin/audit?${params}`
+      : `/api/admin/events/${encodeURIComponent(eventId)}/audit?${params}`;
+  const response = await requestRef.current(path);
+  const payload = (await response.json()) as AuditResponse;
+  if (!response.ok || payload.status !== "accepted") {
+    if (!cancelled() && isCurrent()) setError("Unable to load audit evidence.");
+    throw new Error("Unable to load audit evidence.");
+  }
+  if (cancelled() || !isCurrent()) return;
+  setPages((current) => ({
+    ...current,
+    [projection]: {
+      entries: append
+        ? [...current[projection].entries, ...payload.value.entries]
+        : payload.value.entries,
+      hasMore: payload.value.hasMore,
+      nextCursor: payload.value.nextCursor,
+      loading: false,
+    },
+  }));
+}

--- a/src/pages/event-admin-page.tsx
+++ b/src/pages/event-admin-page.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { AdministrativeAuditBrowser } from "@/pages/administrative-audit-browser";
 
 type HubResponse = {
   status: "accepted";
@@ -600,6 +601,7 @@ export function EventAdminPage() {
                   {hub.event.timeZone} · {hub.authority} · {hub.event.publicationStatus}
                 </p>
               </div>
+              <AdministrativeAuditBrowser eventId={hub.event.eventId} route="event-admin" />
               <div className="space-y-3 rounded-lg border p-3">
                 <p className="font-semibold">Publication Status</p>
                 <p className="text-sm text-muted-foreground">

--- a/src/pages/technical-admin-page.tsx
+++ b/src/pages/technical-admin-page.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { AdministrativeAuditBrowser } from "@/pages/administrative-audit-browser";
 
 type AdminSession = {
   authenticated: true;
@@ -477,6 +478,11 @@ function EventCatalogPanel() {
                   Open Event Hub
                 </Button>
               </div>
+              <AdministrativeAuditBrowser
+                eventId={selected.eventId}
+                route="technical-admin"
+                request={adminFetch}
+              />
               <div className="space-y-3 rounded-lg border p-3">
                 <div>
                   <h3 className="font-semibold">Event Admin Grant</h3>


### PR DESCRIPTION
## Summary

Implements #119, “Browse administrative audit evidence,” as the accepted child of Spec #105.

This PR adds privileged, independently allowlisted audit projections for Event Administration and Grant lifecycle evidence, with browser panels for Event Admin and Technical Admin. It preserves the accepted #116 Grant/session management behavior and composes the canonical Foundation, Event Catalog, and Grant interfaces without adding a second authority or storage system.

## Behavior

- Event Admin and Technical Admin receive separate projections with scope, lifecycle, timestamps, pseudonymous authority references, canonical reasons where required, linked references, and independently allowlisted before/after summaries.
- Raw credentials, cryptographic material, sporting detail duplication, Technical Admin operational logs, and lower-audience inference remain excluded.
- Authority is resolved afresh at the read boundary. Reads are genuinely read-only: no Grant activity refresh, session-cookie emission, or `Set-Cookie` response.
- Pagination is bounded and stable with opaque cursors tied to event, projection, direction, and every normalized filter. Cross-query cursor reuse rejects generically.
- Filters are projection-valid: `grantId` is supported only for Grant Audit and explicitly rejected for Event Administration rather than silently ignored.
- The shared browser seam provides both panels with bounded load-more, direction, and filters. Query changes reset accumulated pages and stale load-more responses cannot alter the replacement query.
- Anonymous, Pitch Manager, Controller, stale, wrong-scope, unavailable, invalid, and read-failure outcomes remain generic and non-enumerating with sensitive headers.

## Scope and exclusions

Included: the privileged Event Administration and Grant Audit projections, their HTTP seams, the shared Event Admin/Technical Admin browser surface, pagination/filter/ordering behavior, and deterministic authority/redaction/read-only evidence.

Excluded: Controller workflows, public Timeline/audience behavior, deployment, Qualification Tests, schema/migration changes, Technical Admin operational-log browsing, and unrelated #105 tickets.

## Validation

- Exact publication base: `cd6a61d0ae243e5e6606ac01388919a321ec21b4` (`main`), containing accepted #116 commit `3cb930bcfbebacb8861c845e4441ecc2d204304a`.
- One commit above `main`: `0209c882df3a3081a38233604478ad86d7193513` (`Browse administrative audit evidence`).
- `git range-diff` of the accepted four-commit range onto current `main`: all four commits equivalent.
- Focused module/adjacent suite: 36 tests, 288 expectations, passing.
- Real browser flow: passing, including privileged panels, page-boundary pagination, filters/direction, redaction, authority denial, sensitive headers, and no `Set-Cookie`.
- `bun run check`: passing with seven pre-existing `await-thenable` warnings in unrelated Grant files.
- `bun run test`: 609 tests, 17,433 expectations, passing.
- `bun run build`: passing.
- `git diff --check`: passing.
- Qualification Tests were not run.
