### PR TITLE
Remove unused Event catalog entries

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -22,6 +22,7 @@
         "@types/qrcode": "^1.5.6",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
+        "@zxing/browser": "0.2.1",
         "happy-dom": "20.11.2",
         "oxfmt": "^0.63.0",
         "oxlint": "^1.78.0",
@@ -229,6 +230,12 @@
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
+    "@zxing/browser": ["@zxing/browser@0.2.1", "", { "optionalDependencies": { "@zxing/text-encoding": "^0.9.0" }, "peerDependencies": { "@zxing/library": "^0.23.0" } }, "sha512-92pVfVDUXbc15xu9vIEmhNyqIEASMEkDF92CwT6T+7sg2EHXJRktH9CQKoQSXe51UtbNsj+Fm09H/JBWHMs/Sw=="],
+
+    "@zxing/library": ["@zxing/library@0.23.0", "", { "dependencies": { "ts-custom-error": "^3.3.1" }, "optionalDependencies": { "@zxing/text-encoding": "~0.9.0" } }, "sha512-6fkkoFwP8CHxl6ugnPsj74PLJgX2iRv5zczGAyt5OBzQgxFhuhF0NCEc4t4OvSr8xAv2MRLlI0Iu9ZGDZQ2urA=="],
+
+    "@zxing/text-encoding": ["@zxing/text-encoding@0.9.0", "", {}, "sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA=="],
+
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
@@ -332,6 +339,8 @@
     "tailwindcss": ["tailwindcss@4.2.4", "", {}, "sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA=="],
 
     "tinypool": ["tinypool@2.1.0", "", {}, "sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw=="],
+
+    "ts-custom-error": ["ts-custom-error@3.3.1", "", {}, "sha512-5OX1tzOjxWEgsr/YEUWSuPrQ00deKLh6D7OTWcvNHm12/7QPyRh8SYpyWvA4IZv8H/+GQWQEh/kwo95Q9OVW1A=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@types/qrcode": "^1.5.6",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
+    "@zxing/browser": "0.2.1",
     "happy-dom": "20.11.2",
     "oxfmt": "^0.63.0",
     "oxlint": "^1.78.0",

--- a/scripts/event-catalog.ts
+++ b/scripts/event-catalog.ts
@@ -15,17 +15,7 @@ import { readRuntimeConfig } from "@/lib/runtime-config";
 
 const args = process.argv.slice(2);
 const databasePath = option("--db") ?? process.env.EVENT_CATALOG_DATABASE?.trim() ?? null;
-const commands = new Set([
-  "list",
-  "inspect",
-  "create",
-  "update",
-  "add-day",
-  "update-day",
-  "remove-day",
-  "remove-event",
-  "audit",
-]);
+const commands = new Set(["list", "inspect", "create", "update", "add-day", "update-day", "audit"]);
 const command = args.find((arg) => commands.has(arg)) ?? "help";
 let foundationStorage: ReturnType<typeof openSqliteFoundationStorage> | null = null;
 let hostAuth: ReturnType<typeof createTechnicalAdminAuth> | null = null;
@@ -95,10 +85,6 @@ async function run(
         { date: required("date") },
         authority,
       );
-    case "remove-day":
-      return catalog.removeGameDay(required("event-id"), required("game-day-id"), authority);
-    case "remove-event":
-      return catalog.removeEvent(required("event-id"), authority);
     case "audit":
       return catalog.listAuditTrail(required("event-id"), authority);
     default:
@@ -106,7 +92,7 @@ async function run(
         status: "rejected",
         reason: "invalid-input",
         detail:
-          "Usage: list | inspect --event-id ID | create --name NAME --timezone ZONE | update --event-id ID [--name NAME] [--timezone ZONE] | add-day --event-id ID --date YYYY-MM-DD | update-day --event-id ID --game-day-id ID --date YYYY-MM-DD | remove-day --event-id ID --game-day-id ID | remove-event --event-id ID | audit --event-id ID",
+          "Usage: list | inspect --event-id ID | create --name NAME --timezone ZONE | update --event-id ID [--name NAME] [--timezone ZONE] | add-day --event-id ID --date YYYY-MM-DD | update-day --event-id ID --game-day-id ID --date YYYY-MM-DD | audit --event-id ID",
       };
   }
 }

--- a/scripts/test-technical-admin-browser.ts
+++ b/scripts/test-technical-admin-browser.ts
@@ -207,11 +207,65 @@ try {
     (event) => event.name === "Browser Event Updated",
   )?.eventId;
   if (!eventId) throw new Error("Browser Event was not returned by the catalog.");
-
   const currentCsrfToken = (await context.cookies()).find(
     (cookie) => cookie.name === "__Host-technical-admin-csrf",
   )?.value;
   if (!currentCsrfToken) throw new Error("Technical Admin CSRF cookie was not retained.");
+
+  assert(
+    (await page.getByRole("button", { name: "Remove", exact: true }).count()) === 0 &&
+      (await page.getByRole("button", { name: "Remove empty Event", exact: true }).count()) === 1,
+    "Technical Admin exposed child-structure removal UI",
+  );
+  const eventProjectionResponse = await context.request.get(
+    `${origin}/api/admin/events/${eventId}`,
+  );
+  const eventProjectionPayload = (await eventProjectionResponse.json()) as {
+    value?: { gameDays?: Array<{ gameDayId: string }> };
+  };
+  const technicalGameDayId = eventProjectionPayload.value?.gameDays?.[0]?.gameDayId;
+  if (!technicalGameDayId) throw new Error("Technical browser Event has no Game Day.");
+  const technicalChildPreview = await context.request.post(
+    `${origin}/api/admin/events/${eventId}/catalog-removal/preview`,
+    { data: { kind: "game-day", targetId: technicalGameDayId } },
+  );
+  assert(
+    technicalChildPreview.status() === 401,
+    "Technical Admin child-removal preview was not unauthorized",
+  );
+  const technicalChildRemoval = await context.request.delete(
+    `${origin}/api/admin/events/${eventId}/catalog-removal`,
+    {
+      data: {
+        kind: "game-day",
+        targetId: technicalGameDayId,
+        previewFingerprint: "event-catalog-removal-v1:" + "0".repeat(64),
+      },
+      headers: { "x-technical-admin-csrf": currentCsrfToken ?? "" },
+    },
+  );
+  assert(
+    technicalChildRemoval.status() === 401,
+    "Technical Admin child-removal acceptance was not unauthorized",
+  );
+
+  const removalDayResponse = await context.request.post(
+    `${origin}/api/admin/events/${eventId}/game-days`,
+    {
+      data: { date: "2026-08-16" },
+      headers: { origin, "x-technical-admin-csrf": currentCsrfToken },
+    },
+  );
+  const removalDayPayload = (await removalDayResponse.json()) as {
+    status: string;
+    value?: { gameDayId?: string };
+  };
+  const removalGameDayId = removalDayPayload.value?.gameDayId;
+  assert(
+    removalDayResponse.status() === 201 && removalGameDayId !== undefined,
+    "removal browser Game Day creation failed",
+  );
+
   const zeroDayResponse = await context.request.post(`${origin}/api/admin/events`, {
     data: { name: "Zero Day Browser Event", timeZone: "UTC" },
     headers: { origin, "x-technical-admin-csrf": currentCsrfToken },
@@ -314,6 +368,119 @@ try {
   await secondDayHubResponsePromise;
   const secondSelectedGameDay = await expectSelectValue(eventAdminGameDaySelector, 2);
   assert(firstSelectedGameDay !== secondSelectedGameDay, "Game Day selector reused one option");
+  const removalPreviewResponsePromise = eventAdminPage.waitForResponse(
+    (response) =>
+      response.url().endsWith("/catalog-removal/preview") && response.request().method() === "POST",
+  );
+  const removalDayHubResponsePromise = eventAdminPage.waitForResponse(
+    (response) =>
+      response.url().includes("/api/event-admin/hub?") && response.request().method() === "GET",
+  );
+  await eventAdminGameDaySelector.selectOption({ index: 3 });
+  await removalDayHubResponsePromise;
+  await eventAdminPage.getByLabel("Preview removal Game Day 2026-08-16").click();
+  const removalPreviewResponse = await removalPreviewResponsePromise;
+  const removalPreviewPayload = (await removalPreviewResponse.json()) as {
+    status: string;
+    value?: {
+      eligible: boolean;
+      fingerprint?: string;
+      impact?: {
+        descendantCount: number;
+        retainedEventGameCount: number;
+        retainedControlActionCount: number;
+        retiredAuthorityCount: number;
+        retiredAuthorityCategories: {
+          eventAdmin: number;
+          pitchManager: number;
+          control: number;
+        };
+      };
+    };
+  };
+  assert(
+    removalPreviewResponse.status() === 200 &&
+      removalPreviewPayload.status === "accepted" &&
+      removalPreviewPayload.value?.eligible === true &&
+      removalPreviewPayload.value.fingerprint?.startsWith("event-catalog-removal-v1:") === true,
+    "Event Admin Game Day removal preview failed",
+  );
+  const removalStatusText = await eventAdminPage.getByRole("status").innerText();
+  assert(
+    removalStatusText.includes("catalog descendants 0") &&
+      removalStatusText.includes("retained Event Game Records 0") &&
+      removalStatusText.includes("accepted Control Actions 0") &&
+      removalStatusText.includes("retiring 0 authority item") &&
+      removalStatusText.includes("Authority categories") &&
+      !/grantId|session|credential|secret|code/iu.test(removalStatusText),
+    "removal preview did not show only bounded safe impact",
+  );
+  const eventAdminCookieBeforeRemoval = (await eventAdminContext.cookies()).find(
+    (cookie) => cookie.name === "__Host-event-admin-session",
+  );
+  const missingFingerprintResponse = await eventAdminContext.request.delete(
+    `${origin}/api/event-admin/events/${eventId}/catalog-removal`,
+    { data: { kind: "game-day", targetId: removalGameDayId } },
+  );
+  assert(
+    missingFingerprintResponse.status() === 400 &&
+      missingFingerprintResponse.headers()["set-cookie"] === undefined,
+    "missing removal fingerprint was accepted or refreshed the Event Admin session",
+  );
+  const eventAdminCookieAfterRejectedRemoval = (await eventAdminContext.cookies()).find(
+    (cookie) => cookie.name === "__Host-event-admin-session",
+  );
+  assert(
+    eventAdminCookieBeforeRemoval?.value === eventAdminCookieAfterRejectedRemoval?.value &&
+      eventAdminCookieBeforeRemoval?.expires === eventAdminCookieAfterRejectedRemoval?.expires,
+    "rejected removal changed the Event Admin session",
+  );
+  const removalAcceptedResponsePromise = eventAdminPage.waitForResponse(
+    (response) =>
+      response.url().endsWith("/catalog-removal") && response.request().method() === "DELETE",
+  );
+  const repairedGameDayHubResponsePromise = eventAdminPage.waitForResponse(
+    (response) =>
+      response.url().includes("/api/event-admin/hub?") &&
+      response.url().includes("gameDayId=") &&
+      response.request().method() === "GET",
+  );
+  await eventAdminPage.getByRole("button", { name: "Confirm", exact: true }).click();
+  const removalAcceptedResponse = await removalAcceptedResponsePromise;
+  await repairedGameDayHubResponsePromise;
+  const removalAcceptedPayload = (await removalAcceptedResponse.json()) as {
+    status: string;
+    sessionExpiresAtMs?: number;
+  };
+  assert(
+    removalAcceptedResponse.status() === 200 &&
+      removalAcceptedPayload.status === "accepted" &&
+      typeof removalAcceptedPayload.sessionExpiresAtMs === "number",
+    "Event Admin Game Day removal was not accepted with session activity",
+  );
+  const refreshedEventAdminCookie = (await eventAdminContext.cookies()).find(
+    (cookie) => cookie.name === "__Host-event-admin-session",
+  );
+  assert(
+    refreshedEventAdminCookie !== undefined &&
+      refreshedEventAdminCookie.expires > 0 &&
+      Math.abs(
+        refreshedEventAdminCookie.expires * 1_000 -
+          (removalAcceptedPayload.sessionExpiresAtMs ?? 0),
+      ) < 2_000,
+    "Event Admin removal cookie expiry did not match the returned capped expiry",
+  );
+  await eventAdminPage.getByText("Event Hub", { exact: true }).waitFor();
+  const repairedGameDayValue = await eventAdminGameDaySelector.inputValue();
+  const repairedGameDayOptions = await eventAdminGameDaySelector
+    .locator("option")
+    .allTextContents();
+  assert(
+    repairedGameDayValue.length > 0 &&
+      repairedGameDayValue !== removalGameDayId &&
+      repairedGameDayOptions.includes("2026-08-14 · past"),
+    `selected Game Day was not repaired to a surviving scope (value=${repairedGameDayValue}, options=${repairedGameDayOptions.join("|")})`,
+  );
   await eventAdminPage.getByLabel("New Event Team name").fill("Blue");
   await eventAdminPage.getByRole("button", { name: "Add Team" }).click();
   await eventAdminPage.getByText("Blue", { exact: true }).first().waitFor();
@@ -339,6 +506,81 @@ try {
   await eventAdminPage.getByLabel("Pitch Pitch One name").fill("Pitch Main");
   await eventAdminPage.getByRole("button", { name: "Save Pitch" }).click();
   await eventAdminPage.getByLabel("Pitch Pitch Main name").waitFor();
+  await eventAdminPage.getByLabel("New Pitch name").fill("Pitch Temporary");
+  const temporaryPitchResponsePromise = eventAdminPage.waitForResponse(
+    (response) =>
+      response.url().includes(`/api/event-admin/events/${eventId}/pitches`) &&
+      response.request().method() === "POST",
+  );
+  await eventAdminPage.getByRole("button", { name: "Add Pitch" }).click();
+  assert(
+    (await temporaryPitchResponsePromise).status() === 201,
+    "temporary removal Pitch creation failed",
+  );
+  await eventAdminPage.getByLabel("Pitch Pitch Temporary name").waitFor();
+  const removalHubPayload = (await (
+    await eventAdminContext.request.get(`${origin}/api/event-admin/hub?eventId=${eventId}`)
+  ).json()) as {
+    status: string;
+    value?: { event?: { pitches?: Array<{ pitchId: string; name: string }> } };
+  };
+  const removalPitchId = removalHubPayload.value?.event?.pitches?.find(
+    (pitch) => pitch.name === "Pitch Temporary",
+  )?.pitchId;
+  assert(removalPitchId !== undefined, "temporary removal Pitch was not projected");
+  const temporaryPitchViewResponsePromise = eventAdminPage.waitForResponse(
+    (response) =>
+      response.url().includes("/api/event-admin/pitch-view?") &&
+      response.request().method() === "GET",
+  );
+  await eventAdminPage.getByRole("button", { name: "Pitch Temporary", exact: true }).click();
+  await temporaryPitchViewResponsePromise;
+  await eventAdminPage.getByLabel("Preview removal Pitch Pitch Temporary").click();
+  await eventAdminPage.getByRole("status").filter({ hasText: "catalog descendants 0" }).waitFor();
+  const pitchRemovalResponsePromise = eventAdminPage.waitForResponse(
+    (response) =>
+      response.url().endsWith("/catalog-removal") && response.request().method() === "DELETE",
+  );
+  const survivingPitchViewResponsePromise = eventAdminPage.waitForResponse(
+    (response) =>
+      response.url().includes("/api/event-admin/pitch-view?") &&
+      response.request().method() === "GET",
+  );
+  await eventAdminPage.getByRole("button", { name: "Confirm", exact: true }).click();
+  const pitchRemovalResponse = await pitchRemovalResponsePromise;
+  const pitchRemovalPayload = (await pitchRemovalResponse.json()) as {
+    status: string;
+    sessionExpiresAtMs?: number;
+  };
+  assert(
+    pitchRemovalResponse.status() === 200 &&
+      pitchRemovalPayload.status === "accepted" &&
+      typeof pitchRemovalPayload.sessionExpiresAtMs === "number",
+    "Event Admin Pitch removal was not accepted with session activity",
+  );
+  const refreshedPitchEventAdminCookie = (await eventAdminContext.cookies()).find(
+    (cookie) => cookie.name === "__Host-event-admin-session",
+  );
+  assert(
+    refreshedPitchEventAdminCookie !== undefined &&
+      refreshedPitchEventAdminCookie.expires > 0 &&
+      Math.abs(
+        refreshedPitchEventAdminCookie.expires * 1_000 -
+          (pitchRemovalPayload.sessionExpiresAtMs ?? 0),
+      ) < 2_000,
+    "Pitch removal did not refresh the Event Admin session cookie",
+  );
+  const survivingPitchViewResponse = await survivingPitchViewResponsePromise;
+  assert(
+    !survivingPitchViewResponse.url().includes(removalPitchId),
+    "Pitch removal refetched the deleted Pitch view",
+  );
+  await eventAdminPage.getByRole("button", { name: "Pitch Main", exact: true }).waitFor();
+  assert(
+    (await eventAdminPage.getByRole("button", { name: "Pitch Temporary", exact: true }).count()) ===
+      0,
+    "removed Pitch remained selected or visible",
+  );
   const firstDayScheduleHubResponsePromise = eventAdminPage.waitForResponse(
     (response) =>
       response.url().includes("/api/event-admin/hub?") && response.request().method() === "GET",
@@ -1069,7 +1311,7 @@ try {
     .getByText(/Expected Delay 1m/u)
     .last()
     .waitFor();
-  await eventAdminPage.getByRole("button", { name: "Pitch Main" }).click();
+  await eventAdminPage.getByRole("button", { name: "Pitch Main", exact: true }).click();
   await eventAdminPage.getByLabel("Pitch Slot 1 Expected Delay minutes").waitFor();
   await eventAdminPage.getByLabel("Pitch Slot 1 Expected Delay minutes").fill("3");
   const pitchPreviewResponsePromise = eventAdminPage.waitForResponse(
@@ -1117,7 +1359,7 @@ try {
   assert((await thirdGameResponsePromise).status() === 201, "third Event Game creation failed");
   await eventAdminPage.getByRole("button", { name: "Refresh Slot setup" }).click();
   await eventAdminPage.getByText("Third", { exact: true }).waitFor();
-  await eventAdminPage.getByRole("button", { name: "Pitch Main" }).click();
+  await eventAdminPage.getByRole("button", { name: "Pitch Main", exact: true }).click();
   await eventAdminPage.getByLabel("Pitch Slot 1 Expected Delay minutes").waitFor();
   const lastTargetSelector = eventAdminPage
     .locator('select[aria-label$="target Pitch Slot"]')
@@ -1372,11 +1614,113 @@ try {
     "explicitly revoked live Event Admin session remained live",
   );
   await pitchManagerCodeContext.close();
+  const finalRemovalEventResponse = await context.request.post(`${origin}/api/admin/events`, {
+    data: { name: "Final Removal Browser Event", timeZone: "UTC" },
+    headers: { origin, "x-technical-admin-csrf": currentCsrfToken },
+  });
+  const finalRemovalEventPayload = (await finalRemovalEventResponse.json()) as {
+    status: string;
+    value?: { eventId?: string };
+  };
+  const finalRemovalEventId = finalRemovalEventPayload.value?.eventId;
+  assert(
+    finalRemovalEventResponse.status() === 201 && finalRemovalEventId !== undefined,
+    "final removal browser Event creation failed",
+  );
+  for (const date of ["2026-08-17", "2026-08-18"]) {
+    const finalRemovalDayResponse = await context.request.post(
+      `${origin}/api/admin/events/${finalRemovalEventId}/game-days`,
+      {
+        data: { date },
+        headers: { origin, "x-technical-admin-csrf": currentCsrfToken },
+      },
+    );
+    assert(finalRemovalDayResponse.status() === 201, `final removal Game Day ${date} failed`);
+  }
+  await page.goto(`${origin}/admin`);
+  await page.getByText("Technical Admin administration").waitFor();
+  await page.getByRole("button", { name: /Final Removal Browser Event/ }).click();
+  await page.getByRole("button", { name: "Create Grant" }).click();
+  const finalRevealResponsePromise = page.waitForResponse(
+    (response) =>
+      response
+        .url()
+        .includes(`/api/admin/events/${finalRemovalEventId}/event-admin-grant/reveal`) &&
+      response.request().method() === "POST",
+  );
+  await page.getByRole("button", { name: "Reveal QR credential" }).click();
+  const finalRevealResponse = await finalRevealResponsePromise;
+  const finalRevealPayload = (await finalRevealResponse.json()) as {
+    status: string;
+    value?: { qrCredential?: string };
+  };
+  const finalCredential = finalRevealPayload.value?.qrCredential ?? "";
+  assert(
+    finalRevealResponse.status() === 200 && finalCredential.length > 0,
+    "final QR reveal failed",
+  );
+  const finalRemovalContext = await browser.newContext({ ignoreHTTPSErrors: true });
+  const finalRemovalPage = await finalRemovalContext.newPage();
+  finalRemovalPage.setDefaultTimeout(5_000);
+  await finalRemovalPage.goto(`${origin}/event-admin?eventId=${finalRemovalEventId}`);
+  await finalRemovalPage.getByLabel("Scanned Event Admin QR value").fill(finalCredential);
+  await finalRemovalPage.getByRole("button", { name: "Admit Event Admin" }).click();
+  await finalRemovalPage.getByText(/event-admin/u).waitFor();
+  const finalRemovalSelector = finalRemovalPage.getByLabel("Game Day", { exact: true });
+  const finalFirstDayHubResponsePromise = finalRemovalPage.waitForResponse(
+    (response) =>
+      response.url().includes("/api/event-admin/hub?") && response.request().method() === "GET",
+  );
+  await finalRemovalSelector.selectOption({ index: 1 });
+  await finalFirstDayHubResponsePromise;
+  assert(
+    (await finalRemovalSelector.inputValue()).length > 0,
+    "final removal Game Day was not selected",
+  );
+  await finalRemovalPage.getByLabel("New Pitch name").fill("Final Pitch");
+  await finalRemovalPage.getByRole("button", { name: "Add Pitch" }).click();
+  await finalRemovalPage.getByRole("button", { name: "Final Pitch", exact: true }).waitFor();
+  await finalRemovalPage.getByLabel("Preview removal Pitch Final Pitch").click();
+  const finalPitchHubResponsePromise = finalRemovalPage.waitForResponse(
+    (response) =>
+      response.url().includes("/api/event-admin/hub?") &&
+      response.url().includes("gameDayId=") &&
+      response.request().method() === "GET",
+  );
+  await finalRemovalPage.getByRole("button", { name: "Confirm", exact: true }).click();
+  await finalRemovalPage.getByRole("button", { name: "Final Pitch", exact: true }).waitFor({
+    state: "detached",
+  });
+  await finalPitchHubResponsePromise;
+  assert(
+    (await finalRemovalPage.getByRole("button", { name: "Final Pitch", exact: true }).count()) ===
+      0,
+    "final Pitch removal did not leave the UI in an empty state",
+  );
+  const firstFinalDayValue = await finalRemovalSelector.inputValue();
+  await finalRemovalPage.getByLabel(/Preview removal Game Day 2026-08-17/u).click();
+  const survivingFinalDayHubResponsePromise = finalRemovalPage.waitForResponse(
+    (response) =>
+      response.url().includes("/api/event-admin/hub?") &&
+      response.url().includes("gameDayId=") &&
+      response.request().method() === "GET",
+  );
+  await finalRemovalPage.getByRole("button", { name: "Confirm", exact: true }).click();
+  await survivingFinalDayHubResponsePromise;
+  assert(
+    (await finalRemovalSelector.inputValue()) !== firstFinalDayValue,
+    "selected Game Day was not changed after removing it",
+  );
+  await finalRemovalPage.getByLabel(/Preview removal Game Day 2026-08-18/u).click();
+  await finalRemovalPage.getByRole("button", { name: "Confirm", exact: true }).click();
+  await expectValue(finalRemovalSelector, "");
+  await finalRemovalPage
+    .getByText("Choose a Game Day to schedule Games.", { exact: true })
+    .waitFor();
+  await finalRemovalContext.close();
   await pitchManagerContext.close();
   await eventAdminContext.close();
   await revokedEventAdminContext.close();
-  const removeButtons = page.getByRole("button", { name: "Remove", exact: true });
-  await removeButtons.nth(0).click();
   const attachedGrantRemoval = await page.evaluate(async (url) => {
     const csrf = document.cookie
       .split(";")

--- a/scripts/test-technical-admin-browser.ts
+++ b/scripts/test-technical-admin-browser.ts
@@ -211,7 +211,6 @@ try {
     (cookie) => cookie.name === "__Host-technical-admin-csrf",
   )?.value;
   if (!currentCsrfToken) throw new Error("Technical Admin CSRF cookie was not retained.");
-
   assert(
     (await page.getByRole("button", { name: "Remove", exact: true }).count()) === 0 &&
       (await page.getByRole("button", { name: "Remove empty Event", exact: true }).count()) === 1,
@@ -266,6 +265,55 @@ try {
     "removal browser Game Day creation failed",
   );
 
+  const futureEventResponse = await postJsonWithHeadersFromPage(
+    page,
+    `${origin}/api/admin/events`,
+    { name: "Future Sheet Event", timeZone: "UTC" },
+    { origin, "x-technical-admin-csrf": currentCsrfToken },
+  );
+  const futureEventPayload = JSON.parse(futureEventResponse.body) as {
+    value?: { eventId?: string };
+  };
+  const futureEventId = futureEventPayload.value?.eventId;
+  assert(
+    futureEventResponse.status === 201 && futureEventId !== undefined,
+    "future Event creation failed",
+  );
+  const futureGameDayResponse = await postJsonWithHeadersFromPage(
+    page,
+    `${origin}/api/admin/events/${futureEventId}/game-days`,
+    { date: "2026-08-16" },
+    { origin, "x-technical-admin-csrf": currentCsrfToken },
+  );
+  const futureGameDayPayload = JSON.parse(futureGameDayResponse.body) as {
+    value?: { gameDayId?: string };
+  };
+  const futureGameDayId = futureGameDayPayload.value?.gameDayId;
+  assert(
+    futureGameDayResponse.status === 201 && futureGameDayId !== undefined,
+    "future Game Day creation failed",
+  );
+  const futureEventGrantCreateResponse = await postJsonWithHeadersFromPage(
+    page,
+    `${origin}/api/admin/events/${futureEventId}/event-admin-grant`,
+    {},
+    { origin, "x-technical-admin-csrf": currentCsrfToken },
+  );
+  assert(futureEventGrantCreateResponse.status === 201, "future Event Admin Grant creation failed");
+  const futureEventGrantRevealResponse = await postJsonWithHeadersFromPage(
+    page,
+    `${origin}/api/admin/events/${futureEventId}/event-admin-grant/reveal`,
+    {},
+    { origin, "x-technical-admin-csrf": currentCsrfToken },
+  );
+  const futureEventGrantRevealPayload = JSON.parse(futureEventGrantRevealResponse.body) as {
+    value?: { qrCredential?: string };
+  };
+  const futureEventCredential = futureEventGrantRevealPayload.value?.qrCredential;
+  assert(
+    futureEventGrantRevealResponse.status === 200 && futureEventCredential !== undefined,
+    "future Event Admin QR reveal failed",
+  );
   const zeroDayResponse = await context.request.post(`${origin}/api/admin/events`, {
     data: { name: "Zero Day Browser Event", timeZone: "UTC" },
     headers: { origin, "x-technical-admin-csrf": currentCsrfToken },
@@ -352,6 +400,163 @@ try {
   );
   assert(anonymousAuditResponse.status() === 401, "anonymous audit enumeration was accepted");
   await anonymousContext.close();
+  await eventAdminPage.getByText(/event-admin/u).waitFor();
+  const accessSheetResponsePromise = eventAdminPage.waitForResponse(
+    (response) =>
+      response.url().endsWith(`/api/event-admin/events/${eventId}/access-sheets`) &&
+      response.request().method() === "POST",
+  );
+  await eventAdminPage.getByLabel("Access Sheet type").selectOption("event-admin");
+  await eventAdminPage.getByRole("button", { name: "Generate Access Sheet" }).click();
+  const accessSheetResponse = await accessSheetResponsePromise;
+  const accessSheetPayload = (await accessSheetResponse.json()) as {
+    status?: string;
+    value?: { body?: string; version?: { testMark?: boolean } };
+  };
+  assert(
+    accessSheetResponse.status() === 200 &&
+      accessSheetPayload.status === "accepted" &&
+      accessSheetPayload.value?.version?.testMark === true &&
+      accessSheetPayload.value.body?.includes("TEST ENVIRONMENT") === true &&
+      accessSheetPayload.value.body.includes(revealedCredential) === false,
+    "Access Sheet generation did not return a marked, redacted printable artifact",
+  );
+  const accessSheetPreview = eventAdminPage.locator(
+    'iframe[title="Generated Grant Access Sheet preview"]',
+  );
+  await accessSheetPreview.waitFor();
+  await expect(accessSheetPreview).toHaveCount(1);
+  await eventAdminPage.addScriptTag({
+    path: join(process.cwd(), "node_modules/@zxing/browser/umd/zxing-browser.min.js"),
+  });
+  const decodedAccessSheetCredential = await accessSheetPreview.evaluate(async (iframe) => {
+    const preview = iframe as HTMLIFrameElement;
+    const svg = preview.contentDocument?.querySelector("svg.qr");
+    if (svg === null || svg === undefined) throw new Error("Access Sheet QR SVG was not rendered.");
+    const image = new Image();
+    image.src = `data:image/svg+xml;base64,${btoa(new XMLSerializer().serializeToString(svg))}`;
+    await new Promise<void>((resolve, reject) => {
+      image.addEventListener("load", () => resolve(), { once: true });
+      image.addEventListener("error", () => reject(new Error("Access Sheet QR image failed.")), {
+        once: true,
+      });
+    });
+    const browserWindow = window as typeof window & {
+      ZXingBrowser: {
+        BrowserQRCodeReader: new () => {
+          decodeFromImageElement(source: HTMLImageElement): Promise<{ getText(): string }>;
+        };
+      };
+    };
+    const result =
+      await new browserWindow.ZXingBrowser.BrowserQRCodeReader().decodeFromImageElement(image);
+    return result.getText();
+  });
+  assert(
+    decodedAccessSheetCredential === revealedCredential,
+    "independent browser QR decode did not recover the canonical Event Admin credential",
+  );
+  await eventAdminPage.evaluate(() => {
+    const frame = document.getElementById(
+      "generated-access-sheet-preview",
+    ) as HTMLIFrameElement | null;
+    if (frame?.contentWindow === null)
+      throw new Error("Access Sheet print frame was not available.");
+    if (frame?.contentWindow !== undefined)
+      frame.contentWindow.print = () => {
+        document.body.dataset.accessSheetPrintInvoked = "true";
+      };
+  });
+  await eventAdminPage.getByRole("button", { name: "Print Access Sheet" }).focus();
+  await eventAdminPage.getByRole("button", { name: "Print Access Sheet" }).press("Enter");
+  await expect(eventAdminPage.locator("body")).toHaveAttribute(
+    "data-access-sheet-print-invoked",
+    "true",
+  );
+  await eventAdminPage.setViewportSize({ width: 360, height: 900 });
+  const narrowPrintableStructure = await accessSheetPreview.evaluate((iframe) => {
+    const preview = iframe as HTMLIFrameElement;
+    const document = preview.contentDocument;
+    if (document === null) throw new Error("Access Sheet preview document was not available.");
+    return {
+      title: document.title,
+      main: document.querySelector("main[aria-labelledby='access-sheet-title']") !== null,
+      qrLabels: document.querySelectorAll("svg[aria-label='QR credential']").length,
+      fits: document.documentElement.scrollWidth <= document.documentElement.clientWidth,
+      printCss: Array.from(document.styleSheets as StyleSheetList).some((sheet) => {
+        try {
+          return Array.from((sheet as CSSStyleSheet).cssRules).some((rule) =>
+            rule.cssText.includes("@media print"),
+          );
+        } catch {
+          return false;
+        }
+      }),
+    };
+  });
+  assert(
+    narrowPrintableStructure.title.includes("Event Admin Access Sheet") &&
+      narrowPrintableStructure.main &&
+      narrowPrintableStructure.qrLabels === 1 &&
+      narrowPrintableStructure.fits &&
+      narrowPrintableStructure.printCss,
+    `Access Sheet printable structure was not accessible and 360px-safe: ${JSON.stringify(narrowPrintableStructure)}`,
+  );
+  await eventAdminPage.setViewportSize({ width: 1280, height: 900 });
+  assert(
+    (await accessSheetPreview.getAttribute("srcdoc"))?.includes("TEST ENVIRONMENT") === true,
+    "Access Sheet preview did not preserve the visible TEST marking",
+  );
+  const assertAccessSheetAbsent = async (detail: string) => {
+    await expect(accessSheetPreview, detail).toHaveCount(0);
+  };
+  const inFlightAccessSheetGate = Promise.withResolvers<void>();
+  const inFlightAccessSheet = inFlightAccessSheetGate.promise;
+  await eventAdminPage.route(
+    `${origin}/api/event-admin/events/${eventId}/access-sheets`,
+    async (route) => {
+      await inFlightAccessSheet;
+      await route.continue();
+    },
+  );
+  const inFlightAccessSheetRequestPromise = eventAdminPage.waitForRequest(
+    (request) =>
+      request.url().endsWith(`/api/event-admin/events/${eventId}/access-sheets`) &&
+      request.method() === "POST",
+  );
+  const inFlightAccessSheetResponsePromise = eventAdminPage.waitForResponse(
+    (response) =>
+      response.url().endsWith(`/api/event-admin/events/${eventId}/access-sheets`) &&
+      response.request().method() === "POST",
+  );
+  await eventAdminPage.getByRole("button", { name: "Generate Access Sheet" }).click();
+  await inFlightAccessSheetRequestPromise;
+  await eventAdminPage.getByLabel("Event ID").fill(zeroDayEventId);
+  await assertAccessSheetAbsent("Event transition did not clear the live Access Sheet artifact");
+  inFlightAccessSheetGate.resolve();
+  const inFlightAccessSheetResponse = await inFlightAccessSheetResponsePromise;
+  assert(inFlightAccessSheetResponse.status() === 200, "in-flight Access Sheet generation failed");
+  await assertAccessSheetAbsent("stale in-flight Access Sheet response was displayed");
+  await eventAdminPage.unroute(`${origin}/api/event-admin/events/${eventId}/access-sheets`);
+  await eventAdminPage.getByLabel("Event ID").fill(eventId);
+
+  const currentEventHubResponsePromise = eventAdminPage.waitForResponse(
+    (response) =>
+      response.url().includes(`/api/event-admin/hub?eventId=${eventId}`) &&
+      response.request().method() === "GET",
+  );
+  await eventAdminPage.getByRole("button", { name: "Open as Technical Admin" }).click();
+  const currentEventHubResponse = await currentEventHubResponsePromise;
+  assert(currentEventHubResponse.status() === 200, "current Event Hub reload failed");
+  await eventAdminPage.getByText("Event Hub", { exact: true }).waitFor();
+  await eventAdminPage.getByText("Administrative audit evidence", { exact: true }).waitFor();
+  await eventAdminPage.getByText("Event Administration", { exact: true }).waitFor();
+  await eventAdminPage.getByText("Grant Audit", { exact: true }).waitFor();
+  await eventAdminPage.getByRole("button", { name: "Change authority" }).click();
+  await assertAccessSheetAbsent("authority transition did not clear the Access Sheet artifact");
+  await eventAdminPage.getByLabel("Scanned Event Admin QR value").fill(revealedCredential);
+  await eventAdminPage.getByRole("button", { name: "Admit Event Admin" }).click();
+  await eventAdminPage.getByText("Europe/Zurich · event-admin", { exact: false }).first().waitFor();
   const eventAdminGameDaySelector = eventAdminPage.getByLabel("Game Day", { exact: true });
   const firstDayHubResponsePromise = eventAdminPage.waitForResponse(
     (response) =>
@@ -359,6 +564,7 @@ try {
   );
   await eventAdminGameDaySelector.selectOption({ index: 1 });
   await firstDayHubResponsePromise;
+  await assertAccessSheetAbsent("Game Day transition did not clear the Access Sheet artifact");
   const firstSelectedGameDay = await expectSelectValue(eventAdminGameDaySelector, 1);
   const secondDayHubResponsePromise = eventAdminPage.waitForResponse(
     (response) =>
@@ -581,6 +787,16 @@ try {
       0,
     "removed Pitch remained selected or visible",
   );
+  const pitchViewResponsePromise = eventAdminPage.waitForResponse(
+    (response) =>
+      response.url().includes("/api/event-admin/pitch-view?") &&
+      response.request().method() === "GET",
+  );
+  await eventAdminPage.getByRole("button", { name: "Pitch Main", exact: true }).click();
+  assert((await pitchViewResponsePromise).status() === 200, "Pitch view transition failed");
+  await assertAccessSheetAbsent("Pitch transition did not clear the Access Sheet artifact");
+  await eventAdminPage.getByLabel("Access Sheet type").selectOption("control-grant");
+  await assertAccessSheetAbsent("sheet-type transition did not clear the Access Sheet artifact");
   const firstDayScheduleHubResponsePromise = eventAdminPage.waitForResponse(
     (response) =>
       response.url().includes("/api/event-admin/hub?") && response.request().method() === "GET",
@@ -604,6 +820,18 @@ try {
     .getByText(/Slot 1.*10:00/u)
     .last()
     .waitFor();
+  const failedReplacementResponsePromise = eventAdminPage.waitForResponse(
+    (response) =>
+      response.url().endsWith(`/api/event-admin/events/${eventId}/access-sheets`) &&
+      response.request().method() === "POST",
+  );
+  await eventAdminPage.getByRole("button", { name: "Generate Access Sheet" }).click();
+  const failedReplacementResponse = await failedReplacementResponsePromise;
+  assert(
+    failedReplacementResponse.status() === 404,
+    "failed Access Sheet replacement unexpectedly succeeded",
+  );
+  await assertAccessSheetAbsent("failed Access Sheet replacement restored an old artifact");
   await eventAdminPage.getByLabel("Gameplay Slot 1 Expected Delay minutes").fill("2");
   const firstDayPreviewResponsePromise = eventAdminPage.waitForResponse(
     (response) =>
@@ -741,21 +969,6 @@ try {
     `${origin}/api/audience/events/${eventId}`,
   );
   assert(unpublishedAudience.status() === 404, "unpublished Event remained anonymously available");
-  await eventAdminPage.getByRole("button", { name: "Published Event", exact: true }).click();
-  await eventAdminPage.getByLabel("Confirm leaving Published").check();
-  await eventAdminPage.getByRole("button", { name: "Cancel Event", exact: true }).click();
-  const cancelledAudience = await eventAdminContext.request.get(
-    `${origin}/api/audience/events/${eventId}`,
-  );
-  assert(cancelledAudience.status() === 404, "cancelled Event remained anonymously available");
-  const unknownAudience = await eventAdminContext.request.get(
-    `${origin}/api/audience/events/unknown-event`,
-  );
-  assert(
-    unknownAudience.status() === cancelledAudience.status() &&
-      (await unknownAudience.text()) === (await cancelledAudience.text()),
-    "unknown Event did not use the same anonymous absence response",
-  );
   await eventAdminPage
     .getByText(/Slot 1.*10:00/u)
     .last()
@@ -884,6 +1097,95 @@ try {
     .first()
     .waitFor();
 
+  const futureEventAdminContext = await browser.newContext({ ignoreHTTPSErrors: true });
+  const futureEventAdminPage = await futureEventAdminContext.newPage();
+  futureEventAdminPage.setDefaultTimeout(5_000);
+  browserPage = futureEventAdminPage;
+  await futureEventAdminPage.goto(`${origin}/event-admin?eventId=${futureEventId}`, {
+    waitUntil: "domcontentloaded",
+    timeout: 5_000,
+  });
+  const futureAdmissionResponsePromise = futureEventAdminPage.waitForResponse(
+    (response) =>
+      response.url().endsWith("/api/event-admin/admit") && response.request().method() === "POST",
+  );
+  await futureEventAdminPage.getByLabel("Scanned Event Admin QR value").fill(futureEventCredential);
+  await futureEventAdminPage.getByRole("button", { name: "Admit Event Admin" }).click();
+  const futureAdmissionResponse = await futureAdmissionResponsePromise;
+  assert(
+    futureAdmissionResponse.status() === 200,
+    `future Event Admin admission failed (${futureAdmissionResponse.status()})`,
+  );
+  await futureEventAdminPage.goto(`${origin}/event-admin?eventId=${futureEventId}`, {
+    waitUntil: "domcontentloaded",
+    timeout: 5_000,
+  });
+  await futureEventAdminPage.getByText("Event Hub", { exact: true }).waitFor();
+  const futurePitchCreateResponse = await postJsonBodyFromPage(
+    futureEventAdminPage,
+    `${origin}/api/event-admin/events/${futureEventId}/pitches`,
+    { name: "Future Pitch" },
+  );
+  const futurePitchPayload = JSON.parse(futurePitchCreateResponse.body) as {
+    value?: { pitchId?: string };
+  };
+  const futurePitchId = futurePitchPayload.value?.pitchId;
+  assert(
+    futurePitchCreateResponse.status === 201 && futurePitchId !== undefined,
+    "future Pitch creation failed",
+  );
+  await futureEventAdminPage.reload();
+  await futureEventAdminPage.getByRole("button", { name: "Future Pitch", exact: true }).waitFor();
+  const futurePitchManagerCreateResponse = await postJsonBodyFromPage(
+    futureEventAdminPage,
+    `${origin}/api/event-admin/events/${futureEventId}/game-days/${futureGameDayId}/pitches/${futurePitchId}/pitch-manager-grant`,
+    {},
+  );
+  assert(
+    futurePitchManagerCreateResponse.status === 201,
+    "future Pitch Manager Grant creation failed",
+  );
+  const futureAccessSheetResponsePromise = futureEventAdminPage.waitForResponse(
+    (response) =>
+      response.url().endsWith(`/api/event-admin/events/${futureEventId}/access-sheets`) &&
+      response.request().method() === "POST",
+  );
+  await futureEventAdminPage.getByLabel("Access Sheet type").selectOption("pitch-manager");
+  await futureEventAdminPage.getByRole("button", { name: "Generate Access Sheet" }).click();
+  const futureAccessSheetResponse = await futureAccessSheetResponsePromise;
+  const futureAccessSheetPayload = (await futureAccessSheetResponse.json()) as {
+    status?: string;
+    value?: { body?: string; version?: { type?: string } };
+  };
+  const futureAccessSheetBody = futureAccessSheetPayload.value?.body ?? "";
+  assert(
+    futureAccessSheetResponse.status() === 200 &&
+      futureAccessSheetPayload.status === "accepted" &&
+      futureAccessSheetPayload.value?.version?.type === "pitch-manager" &&
+      (futureAccessSheetBody.match(/class="entry"/gu) ?? []).length === 1 &&
+      futureAccessSheetBody.includes("TEST ENVIRONMENT") &&
+      futureAccessSheetBody.includes("Grant Code") === false,
+    "Pitch Manager Access Sheet generation did not return the complete printable artifact",
+  );
+  await futureEventAdminPage
+    .locator('iframe[title="Generated Grant Access Sheet preview"]')
+    .waitFor();
+  await futureEventAdminContext.close();
+  browserPage = eventAdminPage;
+
+  const currentGameDayHubResponsePromise = eventAdminPage.waitForResponse(
+    (response) =>
+      response.url().includes(`/api/event-admin/hub?eventId=${eventId}`) &&
+      response.url().includes("gameDayId=") &&
+      response.request().method() === "GET",
+  );
+  await eventAdminPage
+    .getByLabel("Game Day", { exact: true })
+    .selectOption({ value: pitchManagerGameDayId });
+  assert(
+    (await currentGameDayHubResponsePromise).status() === 200,
+    "current Game Day reload failed",
+  );
   const controlSetupResponse = await eventAdminContext.request.get(
     `${origin}/api/event-admin/slot-setup?eventId=${eventId}&gameDayId=${pitchManagerGameDayId}`,
   );
@@ -960,6 +1262,137 @@ try {
       pitchManagerControlCreateCookie?.includes("__Host-pitch-manager-session=") === true &&
       pitchManagerControlCreateCookie?.includes("__Host-event-admin-session=") !== true,
     "Pitch Manager Control Grant creation did not refresh only its own cookie",
+  );
+  const controlGameDayResponsePromise = eventAdminPage.waitForResponse(
+    (response) =>
+      response.url().includes(`/api/event-admin/hub?eventId=${eventId}`) &&
+      response.url().includes(`gameDayId=${pitchManagerGameDayId}`) &&
+      response.request().method() === "GET",
+  );
+  await eventAdminPage.getByLabel("Game Day", { exact: true }).selectOption(pitchManagerGameDayId);
+  assert(
+    (await controlGameDayResponsePromise).status() === 200,
+    "Control Game Day selection failed",
+  );
+  const controlPitchViewResponsePromise = eventAdminPage.waitForResponse(
+    (response) =>
+      response.url().includes("/api/event-admin/pitch-view?") &&
+      response.request().method() === "GET",
+  );
+  await eventAdminPage.getByRole("button", { name: "Pitch Main", exact: true }).click();
+  assert(
+    (await controlPitchViewResponsePromise).status() === 200,
+    "Control Pitch selection failed",
+  );
+  const controlGrantInspectForSheet = await eventAdminContext.request.get(
+    `${origin}${controlGrantPath}`,
+  );
+  const pitchManagerControlInspectForSheet = await pitchManagerContext.request.get(
+    `${origin}${pitchManagerControlPath}`,
+  );
+  const controlGrantInspectForSheetPayload = (await controlGrantInspectForSheet.json()) as {
+    value?: {
+      status?: string;
+      eligibility?: string;
+      grantVersion?: string;
+      expiresAtMs?: number | null;
+    };
+  };
+  const pitchManagerControlInspectForSheetPayload =
+    (await pitchManagerControlInspectForSheet.json()) as {
+      value?: {
+        status?: string;
+        eligibility?: string;
+        grantVersion?: string;
+        expiresAtMs?: number | null;
+      };
+    };
+  assert(
+    controlGrantInspectForSheetPayload.value?.eligibility === "empty" &&
+      pitchManagerControlInspectForSheetPayload.value?.eligibility === "empty",
+    "Control Grant unavailable-state fixture did not remain safely unavailable before registration",
+  );
+  await eventAdminPage.getByLabel("Access Sheet type").selectOption("control-grant");
+  const controlAccessSheetResponsePromise = eventAdminPage.waitForResponse(
+    (response) =>
+      response.url().endsWith(`/api/event-admin/events/${eventId}/access-sheets`) &&
+      response.request().method() === "POST",
+  );
+  await eventAdminPage.getByRole("button", { name: "Generate Access Sheet" }).click();
+  const controlAccessSheetResponse = await controlAccessSheetResponsePromise;
+  const controlAccessSheetPayload = (await controlAccessSheetResponse.json()) as {
+    status?: string;
+    value?: { body?: string; version?: { type?: string; scope?: Record<string, unknown> } };
+  };
+  assert(
+    controlAccessSheetResponse.status() === 200 &&
+      controlAccessSheetPayload.status === "accepted" &&
+      controlAccessSheetPayload.value?.version?.type === "control-grant" &&
+      controlAccessSheetPayload.value.body?.includes("control-grant") === true &&
+      controlAccessSheetPayload.value.body.includes("Grant Code") === false,
+    `new-scope Control Access Sheet generation did not return the new artifact (${controlAccessSheetResponse.status()}, grants=${controlGrantInspectForSheet.status()}/${pitchManagerControlInspectForSheet.status()}, states=${controlGrantInspectForSheetPayload.value?.status}/${pitchManagerControlInspectForSheetPayload.value?.status}, eligibility=${controlGrantInspectForSheetPayload.value?.eligibility}/${pitchManagerControlInspectForSheetPayload.value?.eligibility}): ${JSON.stringify(controlAccessSheetPayload).slice(0, 300)}`,
+  );
+  await accessSheetPreview.waitFor();
+  await expect(accessSheetPreview).toHaveCount(1);
+  const decodedControlCredentials = await accessSheetPreview.evaluate(async (iframe) => {
+    const preview = iframe as HTMLIFrameElement;
+    const document = preview.contentDocument;
+    if (document === null) throw new Error("Control Access Sheet preview was not available.");
+    const browserWindow = window as typeof window & {
+      ZXingBrowser: {
+        BrowserQRCodeReader: new () => {
+          decodeFromImageElement(source: HTMLImageElement): Promise<{ getText(): string }>;
+        };
+      };
+    };
+    const reader = new browserWindow.ZXingBrowser.BrowserQRCodeReader();
+    return Promise.all(
+      Array.from(document.querySelectorAll("svg.qr")).map(async (svg) => {
+        const image = new Image();
+        image.src = `data:image/svg+xml;base64,${btoa(new XMLSerializer().serializeToString(svg))}`;
+        await new Promise<void>((resolve, reject) => {
+          image.addEventListener("load", () => resolve(), { once: true });
+          image.addEventListener(
+            "error",
+            () => reject(new Error("Control Access Sheet QR failed.")),
+            {
+              once: true,
+            },
+          );
+        });
+        return (await reader.decodeFromImageElement(image)).getText();
+      }),
+    );
+  });
+  const controlSheetEntryCount = (
+    controlAccessSheetPayload.value.body?.match(/class="entry"/gu) ?? []
+  ).length;
+  assert(
+    decodedControlCredentials.length === controlSheetEntryCount &&
+      decodedControlCredentials.length === 2 &&
+      decodedControlCredentials.every(
+        (credential) => credential.length > 0 && credential.includes("Grant Code") === false,
+      ),
+    `independent browser QR decode did not recover every Control credential (${decodedControlCredentials.length}/${controlSheetEntryCount})`,
+  );
+  assert(
+    (await accessSheetPreview.getAttribute("srcdoc"))?.includes("control-grant") === true,
+    "new-scope Access Sheet preview did not display only the new artifact",
+  );
+  await eventAdminPage.getByRole("button", { name: "Published Event", exact: true }).click();
+  await eventAdminPage.getByLabel("Confirm leaving Published").check();
+  await eventAdminPage.getByRole("button", { name: "Cancel Event", exact: true }).click();
+  const cancelledAudience = await eventAdminContext.request.get(
+    `${origin}/api/audience/events/${eventId}`,
+  );
+  assert(cancelledAudience.status() === 404, "cancelled Event remained anonymously available");
+  const unknownAudience = await eventAdminContext.request.get(
+    `${origin}/api/audience/events/unknown-event`,
+  );
+  assert(
+    unknownAudience.status() === cancelledAudience.status() &&
+      (await unknownAudience.text()) === (await cancelledAudience.text()),
+    "unknown Event did not use the same anonymous absence response",
   );
   const eventAdminCookieAfterPitchManagerMutation = (await pitchManagerContext.cookies()).find(
     (cookie) => cookie.name === "__Host-event-admin-session",
@@ -1915,6 +2348,25 @@ async function postJsonBodyFromPage(page: Page, url: string, body: Record<string
       };
     },
     { requestUrl: url, requestBody: body },
+  );
+}
+
+async function postJsonWithHeadersFromPage(
+  page: Page,
+  url: string,
+  body: Record<string, string>,
+  headers: Record<string, string>,
+) {
+  return page.evaluate(
+    async ({ requestUrl, requestBody, requestHeaders }) => {
+      const response = await fetch(requestUrl, {
+        method: "POST",
+        headers: { ...requestHeaders, "content-type": "application/json" },
+        body: JSON.stringify(requestBody),
+      });
+      return { status: response.status, body: await response.text() };
+    },
+    { requestUrl: url, requestBody: body, requestHeaders: headers },
   );
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -855,8 +855,82 @@ async function startServer() {
           async DELETE(req: Request) {
             const token = requireTechnicalAdminMutationToken(req, technicalAdminAuth);
             if (token === null) return genericAuthFailure(401);
+            if (eventAdministration === null) return genericAuthFailure(503);
             const eventId = new URL(req.url).pathname.split("/").at(-1) ?? "";
-            return catalogResponse(await eventCatalog.removeEvent(eventId, token));
+            const body = await readJsonRecord(req);
+            if (body === null)
+              return json(
+                {
+                  status: "rejected",
+                  reason: "in-use",
+                  detail: "Event Catalog removal requires a fresh preview and confirmation.",
+                },
+                409,
+              );
+            return eventAdministrationResponse(
+              await eventAdministration.removeEventCatalogEntry(
+                {
+                  kind: "event",
+                  eventId,
+                  targetId: eventId,
+                  previewFingerprint: body?.previewFingerprint,
+                },
+                token,
+              ),
+            );
+          },
+        },
+        "/api/admin/events/:eventId/catalog-removal/preview": {
+          async POST(req: Request) {
+            const token = requireTechnicalAdminToken(req, technicalAdminAuth);
+            if (token === null) return genericAuthFailure(401);
+            if (eventAdministration === null) return genericAuthFailure(503);
+            const body = await readJsonRecord(req);
+            const eventId = new URL(req.url).pathname.split("/").at(-3) ?? "";
+            if (body === null)
+              return json(
+                {
+                  status: "rejected",
+                  reason: "invalid-input",
+                  detail: "JSON body must be an object.",
+                },
+                400,
+              );
+            return eventAdministrationResponse(
+              await eventAdministration.previewEventCatalogRemoval(
+                { kind: body.kind, eventId, targetId: body.targetId ?? eventId },
+                token,
+              ),
+            );
+          },
+        },
+        "/api/admin/events/:eventId/catalog-removal": {
+          async DELETE(req: Request) {
+            const token = requireTechnicalAdminMutationToken(req, technicalAdminAuth);
+            if (token === null) return genericAuthFailure(401);
+            if (eventAdministration === null) return genericAuthFailure(503);
+            const body = await readJsonRecord(req);
+            const eventId = new URL(req.url).pathname.split("/").at(-2) ?? "";
+            if (body === null)
+              return json(
+                {
+                  status: "rejected",
+                  reason: "invalid-input",
+                  detail: "JSON body must be an object.",
+                },
+                400,
+              );
+            return eventAdministrationResponse(
+              await eventAdministration.removeEventCatalogEntry(
+                {
+                  kind: body.kind,
+                  eventId,
+                  targetId: body.targetId ?? eventId,
+                  previewFingerprint: body.previewFingerprint,
+                },
+                token,
+              ),
+            );
           },
         },
         "/api/admin/events/:eventId/audit": {
@@ -942,10 +1016,31 @@ async function startServer() {
           async DELETE(req: Request) {
             const token = requireTechnicalAdminMutationToken(req, technicalAdminAuth);
             if (token === null) return genericAuthFailure(401);
+            if (eventAdministration === null) return genericAuthFailure(503);
             const path = new URL(req.url).pathname.split("/");
             const eventId = path.at(-3) ?? "";
             const gameDayId = path.at(-1) ?? "";
-            return catalogResponse(await eventCatalog.removeGameDay(eventId, gameDayId, token));
+            const body = await readJsonRecord(req);
+            if (body === null)
+              return json(
+                {
+                  status: "rejected",
+                  reason: "in-use",
+                  detail: "Event Catalog removal requires a fresh preview and confirmation.",
+                },
+                409,
+              );
+            return eventAdministrationResponse(
+              await eventAdministration.removeEventCatalogEntry(
+                {
+                  kind: "game-day",
+                  eventId,
+                  targetId: gameDayId,
+                  previewFingerprint: body?.previewFingerprint,
+                },
+                token,
+              ),
+            );
           },
         },
         "/api/admin/events/:eventId/event-admin-grant": {
@@ -1478,6 +1573,44 @@ async function startServer() {
               await eventAdministration.changePublicationStatus(
                 eventId,
                 { status: body.status, impactConfirmed: body.impactConfirmed },
+                authority,
+              ),
+              authority,
+            );
+          },
+        },
+        "/api/event-admin/events/:eventId/catalog-removal/preview": {
+          async POST(req: Request) {
+            if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
+            const authority = resolveEventAdministrationAuthority(req, technicalAdminAuth);
+            const body = await readJsonRecord(req);
+            const eventId = new URL(req.url).pathname.split("/").at(-3) ?? "";
+            if (authority === null) return sensitiveGenericAuthFailure(401);
+            if (body === null) return sensitiveEventAdministrationResponse(invalidEventBody());
+            return sensitiveEventAdministrationResponse(
+              await eventAdministration.previewEventCatalogRemoval(
+                { kind: body.kind, eventId, targetId: body.targetId },
+                authority,
+              ),
+            );
+          },
+        },
+        "/api/event-admin/events/:eventId/catalog-removal": {
+          async DELETE(req: Request) {
+            if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
+            const authority = resolveEventAdministrationAuthority(req, technicalAdminAuth);
+            const body = await readJsonRecord(req);
+            const eventId = new URL(req.url).pathname.split("/").at(-2) ?? "";
+            if (authority === null) return sensitiveGenericAuthFailure(401);
+            if (body === null) return sensitiveEventAdministrationResponse(invalidEventBody());
+            return sensitiveEventAdministrationMutationResponse(
+              await eventAdministration.removeEventCatalogEntry(
+                {
+                  kind: body.kind,
+                  eventId,
+                  targetId: body.targetId,
+                  previewFingerprint: body.previewFingerprint,
+                },
                 authority,
               ),
               authority,
@@ -2658,8 +2791,23 @@ function eventAdministrationResponse<T>(
 ) {
   if (result.status === "accepted") return json(result, acceptedStatus, extraHeaders);
   if (result.status === "retryable-failure") return json(result, 503, extraHeaders);
-  const status = result.reason === "unauthorized" ? 401 : result.reason === "not-found" ? 404 : 400;
+  const status =
+    result.reason === "unauthorized"
+      ? 401
+      : result.reason === "not-found"
+        ? 404
+        : result.reason === "in-use"
+          ? 409
+          : 400;
   return json(result, status, extraHeaders);
+}
+
+function invalidEventBody(): EventAdministrationOutcome<never> {
+  return {
+    status: "rejected",
+    reason: "invalid-input",
+    detail: "JSON body must be an object.",
+  };
 }
 
 function sensitiveEventAdministrationResponse<T>(
@@ -2671,7 +2819,13 @@ function sensitiveEventAdministrationResponse<T>(
   if (result.status === "retryable-failure") return sensitiveJson(result, 503, extraHeaders);
   return sensitiveJson(
     result,
-    result.reason === "unauthorized" ? 401 : result.reason === "not-found" ? 404 : 400,
+    result.reason === "unauthorized"
+      ? 401
+      : result.reason === "not-found"
+        ? 404
+        : result.reason === "in-use"
+          ? 409
+          : 400,
     extraHeaders,
   );
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,6 +66,7 @@ import type {
   TypedGrantReveal,
   TypedGrantRotated,
 } from "@/lib/grant-management";
+import type { AccessSheetRequest } from "@/lib/access-sheet";
 import { createInMemoryFoundationStorage } from "@/lib/foundation-storage-memory";
 import { openSqliteFoundationStorage } from "@/lib/foundation-storage-sqlite";
 import type { FoundationStorage } from "@/lib/foundation-storage";
@@ -280,6 +281,7 @@ async function startServer() {
           storage: foundationStorage,
           grants: grantAuthority,
           controlScopeResolver: grantOptions.controlScopeResolver,
+          environmentId: environment,
         });
         administrativeAuditProjection = createAdministrativeAuditProjection({
           storage: foundationStorage,
@@ -1560,6 +1562,27 @@ async function startServer() {
               authority,
             });
             return sensitiveEventAdministrationResponse(result);
+          },
+        },
+        "/api/event-admin/events/:eventId/access-sheets": {
+          async POST(req: Request) {
+            if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
+            const authority = resolveEventAdministrationAuthority(req, technicalAdminAuth);
+            const body = await readJsonRecord(req);
+            const eventId = new URL(req.url).pathname.split("/").at(-2) ?? "";
+            if (authority === null || body === null) return sensitiveGenericAuthFailure(401);
+            const input = {
+              type: body.type,
+              scope: {
+                eventId,
+                gameDayId: body.gameDayId,
+                pitchId: body.pitchId,
+              },
+            } as AccessSheetRequest;
+            return sensitiveEventAdministrationMutationResponse(
+              await eventAdministration.generateAccessSheet(input, authority),
+              authority,
+            );
           },
         },
         "/api/event-admin/events/:eventId/publication-status": {

--- a/src/lib/access-sheet.test.ts
+++ b/src/lib/access-sheet.test.ts
@@ -1,0 +1,890 @@
+import { describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import QRCode from "qrcode";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createEventAdministration } from "@/lib/event-administration";
+import { createEventCatalog, createFoundationEventCatalogStorage } from "@/lib/event-catalog";
+import { createInMemoryFoundationStorage } from "@/lib/foundation-storage-memory";
+import type { FoundationStorage } from "@/lib/foundation-storage";
+import {
+  openSqliteFoundationStorage,
+  SqliteFoundationFault,
+} from "@/lib/foundation-storage-sqlite";
+import { createPrintableAccessSheetRenderer } from "@/lib/access-sheet";
+import {
+  createGrantAuthority,
+  createGrantAuthorityVerifier,
+  type ControlGrantScopeResolver,
+} from "@/lib/grant-authority";
+import type { GrantKeyRing } from "@/lib/grant-types";
+import {
+  MemoryTechnicalAdminAuthRepository,
+  createTechnicalAdminAuth,
+  isTechnicalAdminAuthority,
+} from "@/lib/technical-admin-auth";
+
+const keyRing: GrantKeyRing = {
+  encryption: { currentVersion: "v1", keys: new Map([["v1", bytes(1)]]) },
+  lookup: { currentVersion: "v1", keys: new Map([["v1", bytes(2)]]) },
+  audit: { currentVersion: "v1", keys: new Map([["v1", bytes(3)]]) },
+};
+
+describe("Grant Access Sheets", () => {
+  test("generates all three QR-only sheets from one catalog snapshot", async () => {
+    const fixture = await createFixture();
+    const eventAdmin = await fixture.administration.createEventAdminGrant(
+      fixture.eventId,
+      fixture.technical,
+    );
+    if (eventAdmin.status !== "accepted") throw new Error("Expected Event Admin Grant.");
+    const pitchManager = await fixture.administration.createPitchManagerGrant(
+      fixture.eventId,
+      fixture.gameDayId,
+      fixture.pitchId,
+      fixture.technical,
+    );
+    if (pitchManager.status !== "accepted") throw new Error("Expected Pitch Manager Grant.");
+    const secondPitchManager = await fixture.administration.createPitchManagerGrant(
+      fixture.eventId,
+      fixture.gameDayId,
+      fixture.secondPitchId,
+      fixture.technical,
+    );
+    expect(secondPitchManager.status).toBe("accepted");
+    const secondDayPitchManager = await fixture.administration.createPitchManagerGrant(
+      fixture.eventId,
+      fixture.secondGameDayId,
+      fixture.pitchId,
+      fixture.technical,
+    );
+    const secondDaySecondPitchManager = await fixture.administration.createPitchManagerGrant(
+      fixture.eventId,
+      fixture.secondGameDayId,
+      fixture.secondPitchId,
+      fixture.technical,
+    );
+    expect(secondDayPitchManager.status).toBe("accepted");
+    expect(secondDaySecondPitchManager.status).toBe("accepted");
+    const slots = await fixture.storage.transaction((transaction) =>
+      transaction.listPitchSlots(fixture.gameDayId, fixture.pitchId),
+    );
+    const firstPitchSlot = slots[0];
+    if (firstPitchSlot === undefined) throw new Error("Expected a first Pitch Slot.");
+    await fixture.storage.transaction((transaction) => {
+      const existing = transaction
+        .listEventGames(fixture.gameDayId)
+        .find((game) => game.pitchSlotId === firstPitchSlot.pitchSlotId);
+      if (existing === undefined) throw new Error("Expected the fixture Event Game.");
+      transaction.insertEventGame({
+        ...existing,
+        eventGameId: "conflicting-event-game",
+        gameCode: "G-CONFLICT",
+        gameDesignation: "Conflicting snapshot",
+        sideA: { ...existing.sideA, sideId: "conflicting-event-game-side-a" },
+        sideB: { ...existing.sideB, sideId: "conflicting-event-game-side-b" },
+      });
+    });
+    for (const slot of slots) {
+      const control = await fixture.administration.createControlGrant(
+        fixture.eventId,
+        fixture.gameDayId,
+        fixture.pitchId,
+        slot.pitchSlotId,
+        fixture.technical,
+      );
+      expect(control.status).toBe("accepted");
+    }
+
+    const eventSheet = await fixture.administration.generateAccessSheet(
+      { type: "event-admin", scope: { eventId: fixture.eventId } },
+      fixture.technical,
+    );
+    const pitchSheet = await fixture.administration.generateAccessSheet(
+      {
+        type: "pitch-manager",
+        scope: { eventId: fixture.eventId },
+      },
+      fixture.technical,
+    );
+    const controlSheet = await fixture.administration.generateAccessSheet(
+      {
+        type: "control-grant",
+        scope: {
+          eventId: fixture.eventId,
+          gameDayId: fixture.gameDayId,
+          pitchId: fixture.pitchId,
+        },
+      },
+      fixture.technical,
+    );
+
+    expect(eventSheet).toMatchObject({
+      status: "accepted",
+      value: { version: { environmentId: "test", type: "event-admin", testMark: true } },
+    });
+    expect(pitchSheet).toMatchObject({
+      status: "accepted",
+      value: { version: { type: "pitch-manager" } },
+    });
+    expect(controlSheet).toMatchObject({
+      status: "accepted",
+      value: { version: { type: "control-grant" } },
+    });
+    if (
+      eventSheet.status !== "accepted" ||
+      pitchSheet.status !== "accepted" ||
+      controlSheet.status !== "accepted"
+    )
+      throw new Error("Expected all sheets.");
+    expect(eventSheet.value.body).toContain("TEST ENVIRONMENT");
+    expect((pitchSheet.value.body.match(/class="entry"/g) ?? []).length).toBe(4);
+    expect((controlSheet.value.body.match(/class="entry"/g) ?? []).length).toBe(slots.length);
+    expect(controlSheet.value.body).toContain("Pitch A · Pitch Slot 1");
+    expect(controlSheet.value.body).toContain("Pitch A · Pitch Slot 2");
+    expect(controlSheet.value.body).toContain("North");
+    expect(controlSheet.value.body).toContain("South");
+    expect(controlSheet.value.body).toContain("Conflicting snapshot");
+    expect(controlSheet.value.body).not.toContain("grant-code");
+    expect(controlSheet.value.body).not.toContain("Grant Code");
+
+    const credentials = await fixture.storage.transaction((transaction) =>
+      transaction.listGrants().map((grant) => grant.grantId),
+    );
+    for (const grantId of credentials) {
+      const reveal = await fixture.grants.revealGrant(grantId, fixture.technical);
+      if (reveal.status === "revealed")
+        expect(controlSheet.value.body).not.toContain(reveal.qrCredential);
+    }
+    const audits = await fixture.catalog.listAuditTrail(fixture.eventId, fixture.technical);
+    expect(audits).toMatchObject({ status: "accepted" });
+    if (audits.status !== "accepted") throw new Error("Expected audit trail.");
+    const sheetAudits = audits.value.filter((audit) => audit.action === "access-sheet-generated");
+    expect(sheetAudits).toHaveLength(3);
+    expect(JSON.stringify(sheetAudits)).not.toContain("qrCredential");
+    expect(eventSheet.value.body).toContain('role="img" aria-label="QR credential"');
+    expect(eventSheet.value.body).toContain(
+      '<main class="sheet" aria-labelledby="access-sheet-title">',
+    );
+    expect(eventSheet.value.body).toContain('lang="en"');
+  });
+
+  test("rotation invalidates only the embedded QR for the rotated Grant", async () => {
+    const renderedCredentials = new Map<string, string[]>();
+    const renderer = createPrintableAccessSheetRenderer();
+    const fixture = await createFixture({
+      accessSheetRenderer: {
+        render(input) {
+          renderedCredentials.set(
+            input.version.type,
+            input.entries.map((entry) => entry.qrCredential),
+          );
+          return renderer.render(input);
+        },
+      },
+    });
+    const eventAdmin = await fixture.administration.createEventAdminGrant(
+      fixture.eventId,
+      fixture.technical,
+    );
+    const pitchManager = await fixture.administration.createPitchManagerGrant(
+      fixture.eventId,
+      fixture.gameDayId,
+      fixture.pitchId,
+      fixture.technical,
+    );
+    const secondPitchManager = await fixture.administration.createPitchManagerGrant(
+      fixture.eventId,
+      fixture.gameDayId,
+      fixture.secondPitchId,
+      fixture.technical,
+    );
+    expect(eventAdmin.status).toBe("accepted");
+    expect(pitchManager.status).toBe("accepted");
+    expect(secondPitchManager.status).toBe("accepted");
+    const secondDayPitchManager = await fixture.administration.createPitchManagerGrant(
+      fixture.eventId,
+      fixture.secondGameDayId,
+      fixture.pitchId,
+      fixture.technical,
+    );
+    expect(secondDayPitchManager.status).toBe("accepted");
+    const secondDaySecondPitchManager = await fixture.administration.createPitchManagerGrant(
+      fixture.eventId,
+      fixture.secondGameDayId,
+      fixture.secondPitchId,
+      fixture.technical,
+    );
+    expect(secondDaySecondPitchManager.status).toBe("accepted");
+    expect(
+      await fixture.administration.generateAccessSheet(
+        { type: "event-admin", scope: { eventId: fixture.eventId } },
+        fixture.technical,
+      ),
+    ).toMatchObject({ status: "accepted" });
+    expect(
+      await fixture.administration.generateAccessSheet(
+        { type: "pitch-manager", scope: { eventId: fixture.eventId } },
+        fixture.technical,
+      ),
+    ).toMatchObject({ status: "accepted" });
+    const oldEventCredential = renderedCredentials.get("event-admin")?.[0];
+    const unaffectedPitchCredential = renderedCredentials.get("pitch-manager")?.[0];
+    if (oldEventCredential === undefined || unaffectedPitchCredential === undefined)
+      throw new Error("Expected generated sheet credentials.");
+    const rotated = await fixture.administration.rotateEventAdminGrant(
+      fixture.eventId,
+      fixture.technical,
+    );
+    expect(rotated).toMatchObject({ status: "accepted" });
+    expect(
+      await fixture.administration.admitEventAdmin({
+        qrCredential: oldEventCredential,
+        browserContext: "rotated-sheet-credential",
+      }),
+    ).toMatchObject({ status: "rejected" });
+    expect(
+      await fixture.administration.admitPitchManager({
+        qrCredential: unaffectedPitchCredential,
+        browserContext: "unaffected-sheet-credential",
+      }),
+    ).toMatchObject({ status: "admitted" });
+  });
+
+  test("includes empty and conflicted Control QRs while canonical admission rejects them", async () => {
+    let emptySlotId: string | undefined;
+    let conflictedSlotId: string | undefined;
+    const renderedCredentials: string[] = [];
+    const renderer = createPrintableAccessSheetRenderer();
+    const controlScopeResolver: ControlGrantScopeResolver = {
+      resolve(scope) {
+        if (scope.pitchSlotId === emptySlotId) return { status: "empty" };
+        if (scope.pitchSlotId === conflictedSlotId) return { status: "conflict" };
+        return { status: "eligible", eventGameId: "game-1" };
+      },
+    };
+    const fixture = await createFixture({
+      controlScopeResolver,
+      accessSheetRenderer: {
+        render(input) {
+          if (input.version.type === "control-grant")
+            renderedCredentials.push(...input.entries.map((entry) => entry.qrCredential));
+          return renderer.render(input);
+        },
+      },
+    });
+    const slots = await fixture.storage.transaction((transaction) =>
+      transaction.listPitchSlots(fixture.gameDayId, fixture.pitchId),
+    );
+    const emptySlot = slots[1];
+    const conflictedSlot = slots[0];
+    if (emptySlot === undefined || conflictedSlot === undefined)
+      throw new Error("Expected empty and conflicted Pitch Slots.");
+    emptySlotId = emptySlot.pitchSlotId;
+    conflictedSlotId = conflictedSlot.pitchSlotId;
+    await fixture.storage.transaction((transaction) => {
+      const existing = transaction
+        .listEventGames(fixture.gameDayId)
+        .find((game) => game.pitchSlotId === conflictedSlotId);
+      if (existing === undefined) throw new Error("Expected the conflicted fixture Event Game.");
+      transaction.insertEventGame({
+        ...existing,
+        eventGameId: "access-sheet-conflict",
+        gameCode: "G-CONFLICT-ACCESS-SHEET",
+        gameDesignation: "Access Sheet conflict snapshot",
+        sideA: { ...existing.sideA, sideId: "access-sheet-conflict-side-a" },
+        sideB: { ...existing.sideB, sideId: "access-sheet-conflict-side-b" },
+      });
+    });
+    for (const slot of slots) {
+      const grant = await fixture.administration.createControlGrant(
+        fixture.eventId,
+        fixture.gameDayId,
+        fixture.pitchId,
+        slot.pitchSlotId,
+        fixture.technical,
+      );
+      expect(grant.status).toBe("accepted");
+    }
+
+    const beforeAudit = await fixture.catalog.listAuditTrail(fixture.eventId, fixture.technical);
+    const result = await fixture.administration.generateAccessSheet(
+      {
+        type: "control-grant",
+        scope: {
+          eventId: fixture.eventId,
+          gameDayId: fixture.gameDayId,
+          pitchId: fixture.pitchId,
+        },
+      },
+      fixture.technical,
+    );
+    expect(result).toMatchObject({ status: "accepted" });
+    expect(renderedCredentials).toHaveLength(slots.length);
+    const emptyIndex = slots.findIndex((slot) => slot.pitchSlotId === emptySlotId);
+    const conflictIndex = slots.findIndex((slot) => slot.pitchSlotId === conflictedSlotId);
+    expect(emptyIndex).toBeGreaterThanOrEqual(0);
+    expect(conflictIndex).toBeGreaterThanOrEqual(0);
+    for (const credential of renderedCredentials) {
+      expect(
+        await fixture.administration.admitControlGrant({
+          qrCredential: credential,
+          browserContext: `unavailable-control-${credential.slice(0, 8)}`,
+        }),
+      ).toMatchObject({ status: "rejected" });
+    }
+    const afterAudit = await fixture.catalog.listAuditTrail(fixture.eventId, fixture.technical);
+    expect(afterAudit).not.toEqual(beforeAudit);
+  });
+
+  test("does not resolve a disabled Grant into an Access Sheet", async () => {
+    const fixture = await createFixture();
+    const grant = await fixture.administration.createEventAdminGrant(
+      fixture.eventId,
+      fixture.technical,
+    );
+    expect(grant.status).toBe("accepted");
+    const disabled = await fixture.administration.disableEventAdminGrant(
+      fixture.eventId,
+      fixture.technical,
+    );
+    expect(disabled.status).toBe("accepted");
+    const beforeAudit = await fixture.catalog.listAuditTrail(fixture.eventId, fixture.technical);
+    expect(
+      await fixture.administration.generateAccessSheet(
+        { type: "event-admin", scope: { eventId: fixture.eventId } },
+        fixture.technical,
+      ),
+    ).toMatchObject({ status: "rejected" });
+    const afterAudit = await fixture.catalog.listAuditTrail(fixture.eventId, fixture.technical);
+    expect(afterAudit).toEqual(beforeAudit);
+  });
+
+  test("expires an Access Sheet Grant before resolution without an artifact or sheet audit", async () => {
+    const fixture = await createFixture();
+    const grant = await fixture.administration.createEventAdminGrant(
+      fixture.eventId,
+      fixture.technical,
+    );
+    expect(grant.status).toBe("accepted");
+    fixture.setNow(Date.parse("2026-08-23T14:00:00Z"));
+    const beforeAudit = await fixture.catalog.listAuditTrail(fixture.eventId, fixture.technical);
+    const result = await fixture.administration.generateAccessSheet(
+      { type: "event-admin", scope: { eventId: fixture.eventId } },
+      fixture.technical,
+    );
+    expect(result).toMatchObject({ status: "rejected" });
+    const afterAudit = await fixture.catalog.listAuditTrail(fixture.eventId, fixture.technical);
+    expect(afterAudit).toEqual(beforeAudit);
+  });
+
+  test("rolls back authority and catalog race mutations before returning a sheet", async () => {
+    const authorityRace = await createFixture();
+    const eventAdmin = await authorityRace.administration.createEventAdminGrant(
+      authorityRace.eventId,
+      authorityRace.technical,
+    );
+    expect(eventAdmin.status).toBe("accepted");
+    const beforeAuthorityRace = await authorityRace.storage.transaction((transaction) => ({
+      grant: transaction.findGrantById(
+        eventAdmin.status === "accepted" ? eventAdmin.value.grantId : "",
+      ),
+      audits: transaction.listEventAuditTrail(authorityRace.eventId),
+    }));
+    authorityRace.grants.resolveAccessSheetQrCredentialInTransaction = (transaction, input) => {
+      const grantId = input.grantId;
+      const grant = transaction.findGrantById(grantId);
+      if (grant !== null) transaction.updateGrant({ ...grant, status: "revoked" });
+      throw new Error("authority race");
+    };
+    expect(
+      await authorityRace.administration.generateAccessSheet(
+        { type: "event-admin", scope: { eventId: authorityRace.eventId } },
+        authorityRace.technical,
+      ),
+    ).toMatchObject({ status: "retryable-failure" });
+    const afterAuthorityRace = await authorityRace.storage.transaction((transaction) => ({
+      grant: transaction.findGrantById(
+        eventAdmin.status === "accepted" ? eventAdmin.value.grantId : "",
+      ),
+      audits: transaction.listEventAuditTrail(authorityRace.eventId),
+    }));
+    expect(afterAuthorityRace.grant?.status).toBe("active");
+    expect(afterAuthorityRace.audits).toEqual(beforeAuthorityRace.audits);
+
+    const catalogRace = await createFixture();
+    const catalogGrant = await catalogRace.administration.createEventAdminGrant(
+      catalogRace.eventId,
+      catalogRace.technical,
+    );
+    expect(catalogGrant.status).toBe("accepted");
+    const beforeCatalogRace = await catalogRace.storage.transaction((transaction) => ({
+      pitch: transaction.findPitch(catalogRace.pitchId),
+      audits: transaction.listEventAuditTrail(catalogRace.eventId),
+    }));
+    const racedPitch = beforeCatalogRace.pitch;
+    if (racedPitch === null) throw new Error("Expected catalog Pitch.");
+    catalogRace.grants.resolveAccessSheetQrCredentialInTransaction = (transaction) => {
+      transaction.updatePitch({ ...racedPitch, name: "Raced Pitch" });
+      throw new Error("catalog race");
+    };
+    expect(
+      await catalogRace.administration.generateAccessSheet(
+        { type: "event-admin", scope: { eventId: catalogRace.eventId } },
+        catalogRace.technical,
+      ),
+    ).toMatchObject({ status: "retryable-failure" });
+    const afterCatalogRace = await catalogRace.storage.transaction((transaction) => ({
+      pitch: transaction.findPitch(catalogRace.pitchId),
+      audits: transaction.listEventAuditTrail(catalogRace.eventId),
+    }));
+    expect(afterCatalogRace.pitch?.name).toBe(racedPitch.name);
+    expect(afterCatalogRace.audits).toEqual(beforeCatalogRace.audits);
+  });
+
+  test("serializes concurrent generations without sharing version or audit identities", async () => {
+    const fixture = await createFixture();
+    const grant = await fixture.administration.createEventAdminGrant(
+      fixture.eventId,
+      fixture.technical,
+    );
+    expect(grant.status).toBe("accepted");
+    const results = await Promise.all([
+      fixture.administration.generateAccessSheet(
+        { type: "event-admin", scope: { eventId: fixture.eventId } },
+        fixture.technical,
+      ),
+      fixture.administration.generateAccessSheet(
+        { type: "event-admin", scope: { eventId: fixture.eventId } },
+        fixture.technical,
+      ),
+    ]);
+    expect(results.every((result) => result.status === "accepted")).toBe(true);
+    if (results[0]?.status !== "accepted" || results[1]?.status !== "accepted")
+      throw new Error("Expected concurrent Access Sheet generations.");
+    expect(results[0].value.version.versionId).not.toBe(results[1].value.version.versionId);
+    const audits = await fixture.catalog.listAuditTrail(fixture.eventId, fixture.technical);
+    if (audits.status !== "accepted") throw new Error("Expected audit trail.");
+    expect(audits.value.filter((audit) => audit.action === "access-sheet-generated")).toHaveLength(
+      2,
+    );
+  });
+
+  test("escapes structure and keeps the production QR matrix inside the printable SVG", () => {
+    const credential = "qr-credential-for-structural-decode";
+    const expected = QRCode.create(credential, { errorCorrectionLevel: "M" });
+    const rendered = createPrintableAccessSheetRenderer().render({
+      version: {
+        versionId: "version-qr-structure",
+        environmentId: "test",
+        type: "event-admin",
+        scope: { eventId: "event-qr-structure" },
+        generatedAtMs: 1_000,
+        testMark: true,
+      },
+      title: "<script>bad</script>",
+      entries: [{ label: "<img src=x>", qrCredential: credential }],
+    });
+    expect(rendered.body).toContain("&lt;script&gt;bad&lt;/script&gt;");
+    expect(rendered.body).not.toContain("<script>bad</script>");
+    expect(rendered.body).toContain("&lt;img src=x&gt;");
+    expect(rendered.body).toContain(
+      `viewBox="0 0 ${expected.modules.size} ${expected.modules.size}"`,
+    );
+    expect(rendered.body).toContain('aria-label="QR credential"');
+    expect(rendered.body).toContain("@media print");
+  });
+
+  test("allows an Event Admin session and rejects a wrong Event scope", async () => {
+    const fixture = await createFixture();
+    const grant = await fixture.administration.createEventAdminGrant(
+      fixture.eventId,
+      fixture.technical,
+    );
+    if (grant.status !== "accepted") throw new Error("Expected Event Admin Grant.");
+    const reveal = await fixture.grants.revealGrant(grant.value.grantId, fixture.technical);
+    if (reveal.status !== "revealed") throw new Error("Expected QR.");
+    const admitted = await fixture.administration.admitEventAdmin({
+      qrCredential: reveal.qrCredential,
+      browserContext: "access-sheet-browser",
+    });
+    if (admitted.status !== "admitted") throw new Error("Expected Event Admin Session.");
+    expect(
+      await fixture.grants.revealGrant(grant.value.grantId, {
+        kind: "grant-session",
+        sessionBearer: admitted.sessionBearer,
+      }),
+    ).toMatchObject({ status: "rejected", reason: "unauthorized" });
+    const sessionResult = await fixture.administration.generateAccessSheet(
+      { type: "event-admin", scope: { eventId: fixture.eventId } },
+      { kind: "grant-session", sessionBearer: admitted.sessionBearer },
+    );
+    expect(sessionResult.status).toBe("accepted");
+    expect(
+      await fixture.administration.generateAccessSheet(
+        { type: "event-admin", scope: { eventId: "wrong-event" } },
+        { kind: "grant-session", sessionBearer: admitted.sessionBearer },
+      ),
+    ).toMatchObject({ status: "rejected", reason: "unauthorized" });
+  });
+
+  test("returns no artifact or audit when rendering fails", async () => {
+    const fixture = await createFixture({
+      accessSheetRenderer: {
+        render() {
+          throw new Error("renderer failed");
+        },
+      },
+    });
+    const grant = await fixture.administration.createEventAdminGrant(
+      fixture.eventId,
+      fixture.technical,
+    );
+    expect(grant.status).toBe("accepted");
+    const before = await fixture.catalog.listAuditTrail(fixture.eventId, fixture.technical);
+    const result = await fixture.administration.generateAccessSheet(
+      { type: "event-admin", scope: { eventId: fixture.eventId } },
+      fixture.technical,
+    );
+    expect(result).toMatchObject({ status: "retryable-failure" });
+    const after = await fixture.catalog.listAuditTrail(fixture.eventId, fixture.technical);
+    expect(after).toEqual(before);
+  });
+
+  test("does not return an artifact when the redacted audit commit fails", async () => {
+    const fixture = await createFixture({
+      accessSheetIds: {
+        next(kind) {
+          return kind === "audit" ? "existing-audit-id" : `new-${kind}`;
+        },
+      },
+    });
+    const grant = await fixture.administration.createEventAdminGrant(
+      fixture.eventId,
+      fixture.technical,
+    );
+    expect(grant.status).toBe("accepted");
+    await fixture.storage.transaction((transaction) => {
+      transaction.appendEventAudit({
+        auditId: "existing-audit-id",
+        operationId: "existing-operation-id",
+        action: "event-updated",
+        eventId: fixture.eventId,
+        gameDayId: null,
+        actorReference: "technical-admin:test",
+        occurredAtMs: 1,
+        before: null,
+        after: null,
+      });
+    });
+    const result = await fixture.administration.generateAccessSheet(
+      { type: "event-admin", scope: { eventId: fixture.eventId } },
+      fixture.technical,
+    );
+    expect(result).toMatchObject({ status: "retryable-failure" });
+    const audits = await fixture.catalog.listAuditTrail(fixture.eventId, fixture.technical);
+    if (audits.status !== "accepted") throw new Error("Expected audit trail.");
+    expect(audits.value.filter((audit) => audit.action === "access-sheet-generated")).toHaveLength(
+      0,
+    );
+  });
+
+  test("uses SQLite transaction boundaries for success and every failure path", async () => {
+    await withSqliteStorage(async (storage) => {
+      const successful = await createFixture({}, storage);
+      const grant = await successful.administration.createEventAdminGrant(
+        successful.eventId,
+        successful.technical,
+      );
+      expect(grant.status).toBe("accepted");
+      const artifact = await successful.administration.generateAccessSheet(
+        { type: "event-admin", scope: { eventId: successful.eventId } },
+        successful.technical,
+      );
+      expect(artifact).toMatchObject({ status: "accepted", value: { contentType: "text/html" } });
+      const audit = await successful.catalog.listAuditTrail(
+        successful.eventId,
+        successful.technical,
+      );
+      expect(audit).toMatchObject({ status: "accepted" });
+      if (audit.status !== "accepted") throw new Error("Expected SQLite audit trail.");
+      expect(audit.value.filter((entry) => entry.action === "access-sheet-generated")).toHaveLength(
+        1,
+      );
+    });
+
+    await withSqliteStorage(async (storage) => {
+      const failedRender = await createFixture(
+        {
+          accessSheetRenderer: {
+            render() {
+              throw new Error("renderer failed");
+            },
+          },
+        },
+        storage,
+      );
+      const grant = await failedRender.administration.createEventAdminGrant(
+        failedRender.eventId,
+        failedRender.technical,
+      );
+      expect(grant.status).toBe("accepted");
+      const result = await failedRender.administration.generateAccessSheet(
+        { type: "event-admin", scope: { eventId: failedRender.eventId } },
+        failedRender.technical,
+      );
+      expect(result).toMatchObject({ status: "retryable-failure" });
+      const audit = await failedRender.catalog.listAuditTrail(
+        failedRender.eventId,
+        failedRender.technical,
+      );
+      if (audit.status !== "accepted") throw new Error("Expected SQLite audit trail.");
+      expect(audit.value.filter((entry) => entry.action === "access-sheet-generated")).toHaveLength(
+        0,
+      );
+    });
+
+    await withSqliteStorage(async (storage) => {
+      const failedAudit = await createFixture(
+        {
+          accessSheetIds: {
+            next(kind) {
+              return kind === "audit" ? "existing-audit-id" : `new-${kind}`;
+            },
+          },
+        },
+        storage,
+      );
+      const grant = await failedAudit.administration.createEventAdminGrant(
+        failedAudit.eventId,
+        failedAudit.technical,
+      );
+      expect(grant.status).toBe("accepted");
+      await storage.transaction((transaction) => {
+        transaction.appendEventAudit({
+          auditId: "existing-audit-id",
+          operationId: "existing-operation-id",
+          action: "event-updated",
+          eventId: failedAudit.eventId,
+          gameDayId: null,
+          actorReference: "technical-admin:test",
+          occurredAtMs: 1,
+          before: null,
+          after: null,
+        });
+      });
+      const result = await failedAudit.administration.generateAccessSheet(
+        { type: "event-admin", scope: { eventId: failedAudit.eventId } },
+        failedAudit.technical,
+      );
+      expect(result).toMatchObject({ status: "retryable-failure" });
+      const audit = await failedAudit.catalog.listAuditTrail(
+        failedAudit.eventId,
+        failedAudit.technical,
+      );
+      if (audit.status !== "accepted") throw new Error("Expected SQLite audit trail.");
+      expect(audit.value.filter((entry) => entry.action === "access-sheet-generated")).toHaveLength(
+        0,
+      );
+    });
+
+    let injectCommitFailure = false;
+    await withSqliteStorage(
+      async (storage, databasePath) => {
+        const failedCommit = await createFixture({}, storage);
+        const grant = await failedCommit.administration.createEventAdminGrant(
+          failedCommit.eventId,
+          failedCommit.technical,
+        );
+        expect(grant.status).toBe("accepted");
+        injectCommitFailure = true;
+        const result = await failedCommit.administration.generateAccessSheet(
+          { type: "event-admin", scope: { eventId: failedCommit.eventId } },
+          failedCommit.technical,
+        );
+        expect(result).toMatchObject({ status: "retryable-failure" });
+        const database = new Database(databasePath);
+        expect(
+          database
+            .query(
+              "SELECT COUNT(*) AS count FROM foundation_event_catalog_audit WHERE action = 'access-sheet-generated'",
+            )
+            .get(),
+        ).toEqual({ count: 0 });
+        database.close();
+      },
+      () => injectCommitFailure,
+    );
+  });
+});
+
+async function withSqliteStorage<T>(
+  work: (storage: FoundationStorage, databasePath: string) => Promise<T>,
+  shouldFailCommit: () => boolean = () => false,
+): Promise<T> {
+  const directory = await mkdtemp(join(tmpdir(), "quadball-timer-access-sheet-"));
+  const databasePath = join(directory, "foundation.sqlite");
+  const storage = openSqliteFoundationStorage(databasePath, {
+    grantKeyRing: keyRing,
+    faultInjector(phase) {
+      if (shouldFailCommit() && phase === "before-commit")
+        throw new SqliteFoundationFault("commit-failure");
+    },
+  });
+  try {
+    await storage.applyMigrations({ requireCandidate: false });
+    return await work(storage, databasePath);
+  } finally {
+    storage.close();
+    await rm(directory, { recursive: true, force: true });
+  }
+}
+
+async function createFixture(
+  options: {
+    controlScopeResolver?: Parameters<typeof createGrantAuthority>[1]["controlScopeResolver"];
+    accessSheetRenderer?: Parameters<typeof createEventAdministration>[0]["accessSheetRenderer"];
+    accessSheetIds?: Parameters<typeof createEventAdministration>[0]["accessSheetIds"];
+  } = {},
+  storage: FoundationStorage = createInMemoryFoundationStorage(),
+) {
+  let nowMs = Date.parse("2026-08-14T12:00:00Z");
+  let entropy = 9;
+  const technical = createTechnicalAdminAuth(
+    { environment: "test", origin: "https://timer.example", rpId: "timer.example" },
+    new MemoryTechnicalAdminAuthRepository(),
+  ).resolveHostLocalAuthority();
+  const catalog = createEventCatalog(createFoundationEventCatalogStorage(storage), {
+    clock: { nowMs: () => nowMs },
+  });
+  const grants = createGrantAuthority(storage, {
+    environmentId: "test",
+    clock: { nowMs: () => nowMs },
+    randomness: {
+      bytes: (length) => {
+        const seed = entropy++;
+        return Uint8Array.from({ length }, (_, index) => ((seed + index * 31) % 240) + 1);
+      },
+    },
+    keyRing,
+    controlScopeResolver: options.controlScopeResolver ?? {
+      resolve: () => ({ status: "eligible", eventGameId: "game-1" }),
+    },
+    privilegedAuthorityVerifier: createGrantAuthorityVerifier((input) => {
+      if (isTechnicalAdminAuthority(input)) return { kind: "technical-admin", id: input.sessionId };
+      if (
+        isRecord(input) &&
+        input.kind === "grant-session" &&
+        typeof input.sessionBearer === "string"
+      )
+        return { kind: "grant-session", sessionBearer: input.sessionBearer, sessionId: "session" };
+      return null;
+    }),
+  });
+  const administration = createEventAdministration({
+    storage,
+    grants,
+    catalog,
+    nowMs: () => nowMs,
+    environmentId: "test",
+    ...options,
+  });
+  const event = await catalog.createEvent(
+    { name: "Access Sheet Event", timeZone: "UTC" },
+    technical,
+  );
+  if (event.status !== "accepted") throw new Error("Expected Event.");
+  const day = await catalog.addGameDay(event.value.eventId, { date: "2026-08-14" }, technical);
+  const secondDay = await catalog.addGameDay(
+    event.value.eventId,
+    { date: "2026-08-15" },
+    technical,
+  );
+  const pitchA = await catalog.createPitch(event.value.eventId, { name: "Pitch A" }, technical);
+  const pitchB = await catalog.createPitch(event.value.eventId, { name: "Pitch B" }, technical);
+  const slotA = await catalog.createGameplaySlot(
+    event.value.eventId,
+    day.status === "accepted" ? day.value.gameDayId : "",
+    { sequence: 1, scheduledStart: "2026-08-14T10:00" },
+    technical,
+  );
+  const slotB = await catalog.createGameplaySlot(
+    event.value.eventId,
+    day.status === "accepted" ? day.value.gameDayId : "",
+    { sequence: 2, scheduledStart: "2026-08-14T10:30" },
+    technical,
+  );
+  if (
+    day.status !== "accepted" ||
+    secondDay.status !== "accepted" ||
+    pitchA.status !== "accepted" ||
+    pitchB.status !== "accepted" ||
+    slotA.status !== "accepted" ||
+    slotB.status !== "accepted"
+  )
+    throw new Error("Expected schedule.");
+  const teams = await Promise.all([
+    catalog.createEventTeam(event.value.eventId, { name: "North" }, technical),
+    catalog.createEventTeam(event.value.eventId, { name: "South" }, technical),
+  ]);
+  if (teams.some((team) => team.status !== "accepted")) throw new Error("Expected teams.");
+  const slots = await storage.transaction((transaction) =>
+    transaction.listPitchSlots(day.value.gameDayId, pitchA.value.pitchId),
+  );
+  const firstSlot = slots[0];
+  if (firstSlot === undefined) throw new Error("Expected Pitch Slot.");
+  const game = await catalog.createEventGame(
+    event.value.eventId,
+    day.value.gameDayId,
+    {
+      gameplaySlotId: slotA.value.gameplaySlotId,
+      pitchSlotId: firstSlot.pitchSlotId,
+      gameCode: "G-1",
+      gameDesignation: "Opening Game",
+      sideA: { sourceLabel: "North" },
+      sideB: { sourceLabel: "South" },
+    },
+    technical,
+  );
+  if (game.status !== "accepted") throw new Error("Expected Event Game.");
+  const confirmed = await catalog.confirmGameplaySlotTeams(
+    event.value.eventId,
+    day.value.gameDayId,
+    slotA.value.gameplaySlotId,
+    {
+      games: [
+        {
+          eventGameId: game.value.eventGameId,
+          sideAEventTeamId: teams[0].status === "accepted" ? teams[0].value.eventTeamId : "",
+          sideBEventTeamId: teams[1].status === "accepted" ? teams[1].value.eventTeamId : "",
+        },
+      ],
+    },
+    technical,
+  );
+  if (confirmed.status !== "accepted") throw new Error("Expected confirmed teams.");
+  return {
+    storage,
+    catalog,
+    grants,
+    administration,
+    technical,
+    eventId: event.value.eventId,
+    gameDayId: day.value.gameDayId,
+    secondGameDayId: secondDay.value.gameDayId,
+    pitchId: pitchA.value.pitchId,
+    secondPitchId: pitchB.value.pitchId,
+    setNow(value: number) {
+      nowMs = value;
+    },
+  };
+}
+
+function bytes(value: number): Uint8Array {
+  return new Uint8Array(32).fill(value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/lib/access-sheet.ts
+++ b/src/lib/access-sheet.ts
@@ -1,0 +1,373 @@
+import QRCode from "qrcode";
+import type {
+  FoundationStorageTransaction,
+  EventCatalogAuditEntry,
+} from "@/lib/foundation-storage";
+import { projectExpectedStartMs, type EventGame, type PitchSlot } from "@/lib/event-catalog";
+import type { GrantManagementAuthority, TypedGrantAuthority } from "@/lib/grant-management";
+import {
+  EVENT_ADMIN_GRANT_TYPE,
+  GRANT_TYPE,
+  PITCH_MANAGER_GRANT_TYPE,
+  type StoredGrant,
+} from "@/lib/grant-types";
+
+export type AccessSheetType = "event-admin" | "pitch-manager" | "control-grant";
+
+export type AccessSheetScope = {
+  eventId: string;
+  gameDayId?: string;
+  pitchId?: string;
+};
+
+export type AccessSheetRequest = {
+  type: AccessSheetType;
+  scope: AccessSheetScope;
+};
+
+export type AccessSheetVersion = {
+  versionId: string;
+  environmentId: string;
+  type: AccessSheetType;
+  scope: AccessSheetScope;
+  generatedAtMs: number;
+  testMark: boolean;
+};
+
+export type AccessSheetArtifact = {
+  contentType: "text/html";
+  body: string;
+  version: AccessSheetVersion;
+};
+
+export type AccessSheetRejectedReason = "invalid-input" | "not-found" | "unauthorized";
+
+export type AccessSheetOutcome =
+  | { status: "accepted"; value: AccessSheetArtifact }
+  | { status: "rejected"; reason: AccessSheetRejectedReason; detail: string }
+  | { status: "retryable-failure"; detail: string };
+
+export type AccessSheetIds = {
+  next(kind: "version" | "audit" | "operation"): string;
+};
+
+export type AccessSheetRendererInput = {
+  version: AccessSheetVersion;
+  title: string;
+  entries: readonly AccessSheetEntry[];
+};
+
+export type AccessSheetEntry = {
+  label: string;
+  qrCredential: string;
+  game?: AccessSheetGameSnapshot | null;
+};
+
+export type AccessSheetGameSnapshot = {
+  scheduledStartMs: number;
+  expectedStartMs: number;
+  sideA: string | null;
+  sideB: string | null;
+  gameCode: string | null;
+  gameDesignation: string | null;
+};
+
+export type AccessSheetRenderer = {
+  render(input: AccessSheetRendererInput): { contentType: "text/html"; body: string };
+};
+
+export type AccessSheetOptions = {
+  environmentId: string;
+  nowMs: () => number;
+  grants: TypedGrantAuthority;
+  authority: GrantManagementAuthority;
+  renderer?: AccessSheetRenderer;
+  ids?: AccessSheetIds;
+};
+
+const DEFAULT_IDS: AccessSheetIds = {
+  next: (kind) => `access-sheet-${kind}-${crypto.randomUUID()}`,
+};
+
+export const ACCESS_SHEET_AUDIT_ACTION: EventCatalogAuditEntry["action"] = "access-sheet-generated";
+
+export function createPrintableAccessSheetRenderer(): AccessSheetRenderer {
+  return { render: renderPrintableAccessSheet };
+}
+
+export function generateAccessSheetInTransaction(
+  transaction: FoundationStorageTransaction,
+  request: AccessSheetRequest,
+  actorReference: string,
+  options: AccessSheetOptions,
+): AccessSheetOutcome {
+  const requestError = validateRequest(request);
+  if (requestError !== null) return requestError;
+  const event = transaction.findEvent(request.scope.eventId);
+  if (event === null) return rejected("not-found", "Event was not found.");
+  const nowMs = options.nowMs();
+  if (!Number.isSafeInteger(nowMs) || nowMs < 0)
+    return rejected("invalid-input", "Generation time is invalid.");
+  const version: AccessSheetVersion = {
+    versionId: (options.ids ?? DEFAULT_IDS).next("version"),
+    environmentId: options.environmentId,
+    type: request.type,
+    scope: { ...request.scope },
+    generatedAtMs: nowMs,
+    testMark: options.environmentId !== "production",
+  };
+  const entries = readEntries(transaction, request, options);
+  if (!entries.ok) return entries.outcome;
+  const renderer = options.renderer ?? createPrintableAccessSheetRenderer();
+  const rendered = renderer.render({
+    version,
+    title: titleFor(request.type, event.name),
+    entries: entries.value,
+  });
+  const ids = options.ids ?? DEFAULT_IDS;
+  transaction.appendEventAudit({
+    auditId: ids.next("audit"),
+    operationId: ids.next("operation"),
+    action: ACCESS_SHEET_AUDIT_ACTION,
+    eventId: event.eventId,
+    gameDayId: request.scope.gameDayId ?? null,
+    actorReference,
+    occurredAtMs: nowMs,
+    before: null,
+    after: {
+      versionId: version.versionId,
+      environmentId: version.environmentId,
+      type: version.type,
+      scope: version.scope,
+      generatedAtMs: version.generatedAtMs,
+      testMark: version.testMark,
+    },
+  });
+  return {
+    status: "accepted",
+    value: { contentType: rendered.contentType, body: rendered.body, version },
+  };
+}
+
+function readEntries(
+  transaction: FoundationStorageTransaction,
+  request: AccessSheetRequest,
+  options: AccessSheetOptions,
+): { ok: true; value: AccessSheetEntry[] } | { ok: false; outcome: AccessSheetOutcome } {
+  const { grants, authority } = options;
+  if (request.type === "event-admin") {
+    const grant = findGrant(transaction, EVENT_ADMIN_GRANT_TYPE, request.scope.eventId);
+    if (grant === null) return missingGrant();
+    const credential = reveal(grants, transaction, grant, authority);
+    return credential === null
+      ? missingGrant()
+      : { ok: true, value: [{ label: "Event Admin Grant", qrCredential: credential }] };
+  }
+  if (request.type === "pitch-manager") {
+    const days = transaction
+      .listGameDays(request.scope.eventId)
+      .sort(
+        (left, right) =>
+          left.date.localeCompare(right.date) || left.gameDayId.localeCompare(right.gameDayId),
+      );
+    const pitches = transaction
+      .listPitches(request.scope.eventId)
+      .sort((left, right) => left.pitchId.localeCompare(right.pitchId));
+    const entries: AccessSheetEntry[] = [];
+    for (const day of days) {
+      for (const pitch of pitches) {
+        const grant = findGrant(transaction, PITCH_MANAGER_GRANT_TYPE, {
+          eventId: request.scope.eventId,
+          gameDayId: day.gameDayId,
+          pitchId: pitch.pitchId,
+        });
+        if (grant === null) return missingGrant();
+        const credential = reveal(grants, transaction, grant, authority);
+        if (credential === null) return missingGrant();
+        entries.push({ label: `${pitch.name} · ${day.date}`, qrCredential: credential });
+      }
+    }
+    return { ok: true, value: entries };
+  }
+  const day = transaction
+    .listGameDays(request.scope.eventId)
+    .find((candidate) => candidate.gameDayId === request.scope.gameDayId);
+  const pitch = transaction.findPitch(request.scope.pitchId ?? "");
+  if (day === undefined || pitch === null)
+    return { ok: false, outcome: rejected("not-found", "Pitch scope was not found.") };
+  const pitchSlots = transaction
+    .listPitchSlots(day.gameDayId, pitch.pitchId)
+    .sort(
+      (left, right) =>
+        left.sequence - right.sequence || left.pitchSlotId.localeCompare(right.pitchSlotId),
+    );
+  const games = transaction.listEventGames(day.gameDayId);
+  const entries: AccessSheetEntry[] = [];
+  for (const pitchSlot of pitchSlots) {
+    const grant = findGrant(transaction, GRANT_TYPE, {
+      eventId: request.scope.eventId,
+      gameDayId: day.gameDayId,
+      pitchId: pitch.pitchId,
+      pitchSlotId: pitchSlot.pitchSlotId,
+    });
+    if (grant === null) return missingGrant();
+    const credential = reveal(grants, transaction, grant, authority);
+    if (credential === null) return missingGrant();
+    entries.push({
+      label: `${pitch.name} · Pitch Slot ${pitchSlot.sequence}`,
+      qrCredential: credential,
+      game: readGameSnapshot(transaction, pitchSlot, games),
+    });
+  }
+  return { ok: true, value: entries };
+}
+
+function readGameSnapshot(
+  transaction: FoundationStorageTransaction,
+  pitchSlot: PitchSlot,
+  games: readonly EventGame[],
+): AccessSheetGameSnapshot | null {
+  const game = games.find((candidate) => candidate.pitchSlotId === pitchSlot.pitchSlotId);
+  if (game === undefined) return null;
+  const gameplaySlot = transaction.findGameplaySlot(game.gameplaySlotId);
+  if (gameplaySlot === null) return null;
+  return {
+    scheduledStartMs: gameplaySlot.scheduledStartMs,
+    expectedStartMs: projectExpectedStartMs(gameplaySlot, pitchSlot),
+    sideA: game.sideA.eventTeamName,
+    sideB: game.sideB.eventTeamName,
+    gameCode: game.gameCode,
+    gameDesignation: game.gameDesignation,
+  };
+}
+
+function findGrant(
+  transaction: FoundationStorageTransaction,
+  grantType: typeof EVENT_ADMIN_GRANT_TYPE | typeof PITCH_MANAGER_GRANT_TYPE | typeof GRANT_TYPE,
+  scope: string | { eventId: string; gameDayId: string; pitchId: string; pitchSlotId?: string },
+): StoredGrant | null {
+  const grants = transaction.listGrants().filter((grant) => {
+    if (grant.grantType !== grantType || grant.status !== "active") return false;
+    if (typeof scope === "string") return grant.scope.eventId === scope;
+    return Object.entries(scope).every(
+      ([key, value]) => (grant.scope as Record<string, unknown>)[key] === value,
+    );
+  });
+  return grants.sort((left, right) => right.createdAtMs - left.createdAtMs)[0] ?? null;
+}
+
+function reveal(
+  grants: TypedGrantAuthority,
+  transaction: FoundationStorageTransaction,
+  grant: StoredGrant,
+  authority: GrantManagementAuthority,
+): string | null {
+  const result = grants.resolveAccessSheetQrCredentialInTransaction(transaction, {
+    grantId: grant.grantId,
+    grantType: grant.grantType,
+    scope: grant.scope,
+    authority,
+  });
+  return result.status === "resolved" ? result.qrCredential : null;
+}
+
+function validateRequest(request: AccessSheetRequest): AccessSheetOutcome | null {
+  if (!isType(request.type) || !isScope(request.scope))
+    return rejected("invalid-input", "Access Sheet scope is invalid.");
+  if (
+    request.type === "event-admin" &&
+    (request.scope.gameDayId !== undefined || request.scope.pitchId !== undefined)
+  )
+    return rejected("invalid-input", "Event Admin sheets cannot include Pitch scope.");
+  if (
+    request.type === "pitch-manager" &&
+    (request.scope.gameDayId !== undefined || request.scope.pitchId !== undefined)
+  )
+    return rejected("invalid-input", "Pitch Manager sheets cover the whole Event.");
+  if (
+    request.type === "control-grant" &&
+    (request.scope.gameDayId === undefined || request.scope.pitchId === undefined)
+  )
+    return rejected("invalid-input", "Control sheets require one Game Day and Pitch.");
+  return null;
+}
+
+function renderPrintableAccessSheet(input: AccessSheetRendererInput): {
+  contentType: "text/html";
+  body: string;
+} {
+  const marker = input.version.testMark
+    ? '<p class="test-mark" aria-label="Test environment">TEST ENVIRONMENT</p>'
+    : "";
+  const entries = input.entries
+    .map((entry, index) => {
+      const game = entry.game === undefined ? "" : renderGameSnapshot(entry.game);
+      const headingId = `access-sheet-entry-${index + 1}-title`;
+      return `<section class="entry" aria-labelledby="${headingId}"><h2 id="${headingId}">${escapeHtml(entry.label)}</h2>${renderQrSvg(entry.qrCredential)}${game}</section>`;
+    })
+    .join("\n");
+  const body = `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>${escapeHtml(input.title)}</title><style>@page{margin:1rem}*{box-sizing:border-box}html,body{max-width:100%;overflow-x:hidden}body{font-family:system-ui,sans-serif;margin:1rem;color:#111;overflow-wrap:anywhere;word-break:break-word}.sheet{width:100%;max-width:52rem;margin:auto}.test-mark{border:.25rem solid #b91c1c;color:#b91c1c;font-size:1.5rem;font-weight:800;padding:.75rem;text-align:center}.version{font-size:.8rem;color:#555}.entries{display:grid;grid-template-columns:repeat(auto-fit,minmax(min(14rem,100%),1fr));gap:1rem}.entry{break-inside:avoid;border:1px solid #aaa;padding:1rem;text-align:center;min-width:0}.qr{width:12rem;height:12rem;max-width:100%}.snapshot{font-size:.85rem;text-align:left}.snapshot dt{font-weight:700}.snapshot dd{margin:0 0 .25rem}@media print{body{margin:0}.entry{border:0;page-break-inside:avoid}.test-mark{break-inside:avoid}}</style></head><body><main class="sheet" aria-labelledby="access-sheet-title"><h1 id="access-sheet-title">${escapeHtml(input.title)}</h1>${marker}<p class="version">Access Sheet Version ${escapeHtml(input.version.versionId)} · ${escapeHtml(input.version.environmentId)} · ${escapeHtml(input.version.type)} · scope ${escapeHtml(JSON.stringify(input.version.scope))} · generated ${new Date(input.version.generatedAtMs).toISOString()}</p><div class="entries" aria-label="Access Sheet credentials">${entries}</div></main></body></html>`;
+  return { contentType: "text/html", body };
+}
+
+function renderGameSnapshot(game: AccessSheetGameSnapshot | null): string {
+  if (game === null) return "";
+  return `<dl class="snapshot"><dt>Scheduled start</dt><dd>${escapeHtml(new Date(game.scheduledStartMs).toISOString())}</dd><dt>Expected start</dt><dd>${escapeHtml(new Date(game.expectedStartMs).toISOString())}</dd><dt>Teams</dt><dd>${escapeHtml(game.sideA ?? "TBD")} vs ${escapeHtml(game.sideB ?? "TBD")}</dd>${optionalSnapshot("Game code", game.gameCode)}${optionalSnapshot("Game designation", game.gameDesignation)}</dl>`;
+}
+
+function optionalSnapshot(label: string, value: string | null): string {
+  return value === null ? "" : `<dt>${escapeHtml(label)}</dt><dd>${escapeHtml(value)}</dd>`;
+}
+
+function renderQrSvg(value: string): string {
+  const qr = QRCode.create(value, { errorCorrectionLevel: "M" });
+  const size = qr.modules.size;
+  const cells: string[] = [];
+  for (let y = 0; y < size; y += 1) {
+    for (let x = 0; x < size; x += 1) {
+      if (qr.modules.data[y * size + x]) cells.push(`M${x},${y}h1v1H${x}z`);
+    }
+  }
+  return `<svg class="qr" role="img" aria-label="QR credential" width="${size}" height="${size}" viewBox="0 0 ${size} ${size}" xmlns="http://www.w3.org/2000/svg"><path fill="#000" d="${cells.join("")}"/></svg>`;
+}
+
+function escapeHtml(value: string): string {
+  return value.replace(
+    /[&<>"']/g,
+    (character) =>
+      ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[character] ??
+      character,
+  );
+}
+
+function isType(value: unknown): value is AccessSheetType {
+  return value === "event-admin" || value === "pitch-manager" || value === "control-grant";
+}
+
+function isScope(value: unknown): value is AccessSheetScope {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  const scope = value as Record<string, unknown>;
+  return (
+    typeof scope.eventId === "string" &&
+    scope.eventId.length > 0 &&
+    (scope.gameDayId === undefined || typeof scope.gameDayId === "string") &&
+    (scope.pitchId === undefined || typeof scope.pitchId === "string")
+  );
+}
+
+function titleFor(type: AccessSheetType, eventName: string): string {
+  if (type === "event-admin") return `${eventName} · Event Admin Access Sheet`;
+  if (type === "pitch-manager") return `${eventName} · Pitch Manager Access Sheet`;
+  return `${eventName} · Control Grant Access Sheet`;
+}
+
+function missingGrant(): { ok: false; outcome: AccessSheetOutcome } {
+  return {
+    ok: false,
+    outcome: rejected("not-found", "A current QR Grant is not available for this sheet."),
+  };
+}
+
+function rejected(reason: AccessSheetRejectedReason, detail: string): AccessSheetOutcome {
+  return { status: "rejected", reason, detail };
+}

--- a/src/lib/event-administration.test.ts
+++ b/src/lib/event-administration.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { createAudienceProjection } from "@/lib/audience-projection";
 import { createEventAdministration } from "@/lib/event-administration";
 import { createEventCatalog, createFoundationEventCatalogStorage } from "@/lib/event-catalog";
 import type { FoundationStorage } from "@/lib/foundation-storage";
@@ -18,6 +19,815 @@ const keyRing: GrantKeyRing = {
 };
 
 describe("Event Administration handoff", () => {
+  test("previews and atomically removes an empty Event with its Event Admin authority", async () => {
+    const fixture = createFixture();
+    const event = await fixture.catalog.createEvent(
+      { name: "Remove Event", timeZone: "UTC" },
+      fixture.technical,
+    );
+    if (event.status !== "accepted") throw new Error("Expected Event.");
+    const day = await fixture.catalog.addGameDay(
+      event.value.eventId,
+      { date: "2026-08-14" },
+      fixture.technical,
+    );
+    if (day.status !== "accepted") throw new Error("Expected Game Day.");
+    const grant = await fixture.administration.createEventAdminGrant(
+      event.value.eventId,
+      fixture.technical,
+    );
+    if (grant.status !== "accepted") throw new Error("Expected Event Admin Grant.");
+    const revealed = await fixture.grants.revealGrant(grant.value.grantId, fixture.technical);
+    if (revealed.status !== "revealed") throw new Error("Expected Grant reveal.");
+    const admission = await fixture.administration.admitEventAdmin({
+      qrCredential: revealed.qrCredential,
+      browserContext: "removal-browser",
+    });
+    if (admission.status !== "admitted") throw new Error("Expected Grant Session.");
+    const eventAdmin = { kind: "grant-session" as const, sessionBearer: admission.sessionBearer };
+    const beforeAudit = await fixture.storage.transaction((transaction) =>
+      transaction.listEventAuditTrail(event.value.eventId),
+    );
+
+    const preview = await fixture.administration.previewEventCatalogRemoval(
+      { kind: "game-day", eventId: event.value.eventId, targetId: day.value.gameDayId },
+      eventAdmin,
+    );
+    expect(preview).toMatchObject({
+      status: "accepted",
+      value: {
+        eligible: true,
+        target: { kind: "game-day", targetId: day.value.gameDayId },
+        impact: { retiredAuthorityCount: 0 },
+      },
+    });
+    if (preview.status !== "accepted") throw new Error("Expected removal preview.");
+    const afterPreviewGrant = await fixture.storage.transaction((transaction) =>
+      transaction.findGrantById(grant.value.grantId),
+    );
+    expect(afterPreviewGrant?.status).toBe("active");
+    const sessionBeforeRemoval = await fixture.storage.transaction(
+      (transaction) => transaction.listGrantSessions(grant.value.grantId)[0],
+    );
+    if (sessionBeforeRemoval === undefined)
+      throw new Error("Expected persisted Event Admin session.");
+    const removedDay = await fixture.administration.removeEventCatalogEntry(
+      {
+        kind: "game-day",
+        eventId: event.value.eventId,
+        targetId: day.value.gameDayId,
+        previewFingerprint: preview.value.fingerprint,
+      },
+      eventAdmin,
+    );
+    expect(removedDay).toMatchObject({ status: "accepted", value: { removed: true } });
+    expect(removedDay.sessionExpiresAtMs).toBeTypeOf("number");
+    const sessionAfterRemoval = await fixture.storage.transaction(
+      (transaction) => transaction.listGrantSessions(grant.value.grantId)[0],
+    );
+    expect(sessionAfterRemoval?.lastActiveAtMs).toBeGreaterThanOrEqual(
+      sessionBeforeRemoval.lastActiveAtMs,
+    );
+    expect(removedDay.sessionExpiresAtMs).toBe(
+      Math.min(
+        afterPreviewGrant?.expiresAtMs ?? Number.MAX_SAFE_INTEGER,
+        (sessionAfterRemoval?.lastActiveAtMs ?? 0) + 30 * 24 * 60 * 60 * 1000,
+      ),
+    );
+
+    const eventRemovalPreview = await fixture.administration.previewEventCatalogRemoval(
+      {
+        kind: "event",
+        eventId: event.value.eventId,
+        targetId: event.value.eventId,
+      },
+      fixture.technical,
+    );
+    if (eventRemovalPreview.status !== "accepted") throw new Error("Expected Event preview.");
+    const removed = await fixture.administration.removeEventCatalogEntry(
+      {
+        kind: "event",
+        eventId: event.value.eventId,
+        targetId: event.value.eventId,
+        previewFingerprint: eventRemovalPreview.value.fingerprint,
+      },
+      fixture.technical,
+    );
+    expect(removed).toMatchObject({ status: "accepted", value: { removed: true } });
+    const retiredGrant = await fixture.storage.transaction((transaction) =>
+      transaction.findGrantById(grant.value.grantId),
+    );
+    expect(retiredGrant).toMatchObject({
+      status: "expired",
+      credential: { materialState: "erased", ciphertext: null, lookupDigest: null },
+    });
+    expect(
+      (
+        await fixture.storage.transaction((transaction) =>
+          transaction.listGrantSessions(grant.value.grantId),
+        )
+      )[0],
+    ).toMatchObject({ status: "expired", bearerMaterialState: "erased" });
+    const afterAudit = await fixture.storage.transaction((transaction) =>
+      transaction.listEventAuditTrail(event.value.eventId),
+    );
+    expect(afterAudit.length).toBeGreaterThan(beforeAudit.length);
+    const removalAudit = afterAudit.find(
+      (entry) =>
+        entry.action === "event-catalog-entry-removed" &&
+        entry.before !== null &&
+        typeof entry.before === "object" &&
+        "kind" in entry.before &&
+        entry.before.kind === "event",
+    );
+    expect(removalAudit).toMatchObject({
+      before: {
+        kind: "event",
+        eventId: event.value.eventId,
+        targetId: event.value.eventId,
+      },
+      after: null,
+    });
+    expect(JSON.stringify(removalAudit)).not.toMatch(
+      /credential|code|session|gameCode|gameDesignation|sideA|sideB/i,
+    );
+    expect(
+      await fixture.administration.openEventHub({
+        eventId: event.value.eventId,
+        authority: fixture.technical,
+      }),
+    ).toMatchObject({ status: "rejected", reason: "unauthorized" });
+  });
+
+  test("rejects a stale removal acceptance without changing the target", async () => {
+    const fixture = createFixture();
+    const event = await fixture.catalog.createEvent(
+      { name: "Stale Removal", timeZone: "UTC" },
+      fixture.technical,
+    );
+    if (event.status !== "accepted") throw new Error("Expected Event.");
+    const first = event;
+    const preview = await fixture.administration.previewEventCatalogRemoval(
+      { kind: "event", eventId: event.value.eventId, targetId: first.value.eventId },
+      fixture.technical,
+    );
+    if (preview.status !== "accepted") throw new Error("Expected preview.");
+    await fixture.catalog.updateEvent(
+      event.value.eventId,
+      { name: "Stale Removal Updated" },
+      fixture.technical,
+    );
+    expect(
+      await fixture.administration.removeEventCatalogEntry(
+        {
+          kind: "event",
+          eventId: event.value.eventId,
+          targetId: first.value.eventId,
+          previewFingerprint: preview.value.fingerprint,
+        },
+        fixture.technical,
+      ),
+    ).toMatchObject({ status: "rejected", reason: "invalid-input" });
+    expect(
+      await fixture.catalog.inspectEvent(event.value.eventId, fixture.technical),
+    ).toMatchObject({
+      status: "accepted",
+      value: { name: "Stale Removal Updated" },
+    });
+  });
+
+  test("requires an opaque nonempty fingerprint and binds acceptance to complete authority impact", async () => {
+    const fixture = createFixture();
+    const event = await fixture.catalog.createEvent(
+      { name: "Fingerprint Removal", timeZone: "UTC" },
+      fixture.technical,
+    );
+    if (event.status !== "accepted") throw new Error("Expected Event.");
+    const day = await fixture.catalog.addGameDay(
+      event.value.eventId,
+      { date: "2026-08-14" },
+      fixture.technical,
+    );
+    const pitch = await fixture.catalog.createPitch(
+      event.value.eventId,
+      { name: "Fingerprint Pitch" },
+      fixture.technical,
+    );
+    if (day.status !== "accepted" || pitch.status !== "accepted")
+      throw new Error("Expected catalog structure.");
+    const eventGrant = await fixture.administration.createEventAdminGrant(
+      event.value.eventId,
+      fixture.technical,
+    );
+    if (eventGrant.status !== "accepted") throw new Error("Expected Event Admin Grant.");
+    const revealed = await fixture.grants.revealGrant(eventGrant.value.grantId, fixture.technical);
+    if (revealed.status !== "revealed") throw new Error("Expected Event Admin credential.");
+    const admission = await fixture.administration.admitEventAdmin({
+      qrCredential: revealed.qrCredential,
+      browserContext: "fingerprint-removal-browser",
+    });
+    if (admission.status !== "admitted") throw new Error("Expected Event Admin session.");
+    const authority = { kind: "grant-session" as const, sessionBearer: admission.sessionBearer };
+    const preview = await fixture.administration.previewEventCatalogRemoval(
+      { kind: "pitch", eventId: event.value.eventId, targetId: pitch.value.pitchId },
+      authority,
+    );
+    if (preview.status !== "accepted") throw new Error("Expected removal preview.");
+    expect(preview.value.fingerprint).toMatch(/^event-catalog-removal-v1:[A-Za-z0-9_-]+$/u);
+    const beforeMissing = await fixture.storage.transaction((transaction) => ({
+      pitch: transaction.findPitch(pitch.value.pitchId),
+      grants: transaction.listGrants(),
+      grantAudit: transaction.listGrantAudit(eventGrant.value.grantId),
+      catalogAudit: transaction.listEventAuditTrail(event.value.eventId),
+    }));
+    for (const suppliedFingerprint of [undefined, "", "not-a-valid-removal-fingerprint"]) {
+      expect(
+        await fixture.administration.removeEventCatalogEntry(
+          {
+            kind: "pitch",
+            eventId: event.value.eventId,
+            targetId: pitch.value.pitchId,
+            ...(suppliedFingerprint === undefined
+              ? {}
+              : { previewFingerprint: suppliedFingerprint }),
+          },
+          authority,
+        ),
+      ).toMatchObject({ status: "rejected", reason: "invalid-input" });
+    }
+    const afterMissing = await fixture.storage.transaction((transaction) => ({
+      pitch: transaction.findPitch(pitch.value.pitchId),
+      grants: transaction.listGrants(),
+      grantAudit: transaction.listGrantAudit(eventGrant.value.grantId),
+      catalogAudit: transaction.listEventAuditTrail(event.value.eventId),
+    }));
+    expect(afterMissing).toEqual(beforeMissing);
+
+    const pitchGrant = await fixture.administration.createPitchManagerGrant(
+      event.value.eventId,
+      day.value.gameDayId,
+      pitch.value.pitchId,
+      authority,
+    );
+    if (pitchGrant.status !== "accepted") throw new Error("Expected Pitch Manager Grant.");
+    const beforeCreateRace = await fixture.storage.transaction((transaction) => ({
+      sessions: transaction.listGrantSessions(eventGrant.value.grantId),
+      grantAudit: transaction.listGrantAudit(eventGrant.value.grantId),
+      catalogAudit: transaction.listEventAuditTrail(event.value.eventId),
+    }));
+    expect(
+      await fixture.administration.removeEventCatalogEntry(
+        {
+          kind: "pitch",
+          eventId: event.value.eventId,
+          targetId: pitch.value.pitchId,
+          previewFingerprint: preview.value.fingerprint,
+        },
+        authority,
+      ),
+    ).toMatchObject({ status: "rejected", reason: "invalid-input" });
+    expect(
+      await fixture.storage.transaction((transaction) => ({
+        pitch: transaction.findPitch(pitch.value.pitchId),
+        grant: transaction.findGrantById(pitchGrant.value.grantId),
+      })),
+    ).toMatchObject({ pitch: { pitchId: pitch.value.pitchId }, grant: { status: "active" } });
+    const afterCreateRace = await fixture.storage.transaction((transaction) => ({
+      sessions: transaction.listGrantSessions(eventGrant.value.grantId),
+      grantAudit: transaction.listGrantAudit(eventGrant.value.grantId),
+      catalogAudit: transaction.listEventAuditTrail(event.value.eventId),
+    }));
+    expect(afterCreateRace).toEqual(beforeCreateRace);
+
+    const changedPitch = await fixture.catalog.createPitch(
+      event.value.eventId,
+      { name: "Changed Fingerprint Pitch" },
+      fixture.technical,
+    );
+    if (changedPitch.status !== "accepted") throw new Error("Expected changed Pitch.");
+    const changedGrant = await fixture.administration.createPitchManagerGrant(
+      event.value.eventId,
+      day.value.gameDayId,
+      changedPitch.value.pitchId,
+      authority,
+    );
+    if (changedGrant.status !== "accepted") throw new Error("Expected changed Pitch Grant.");
+    const changedPreview = await fixture.administration.previewEventCatalogRemoval(
+      { kind: "pitch", eventId: event.value.eventId, targetId: changedPitch.value.pitchId },
+      authority,
+    );
+    if (changedPreview.status !== "accepted") throw new Error("Expected changed Pitch preview.");
+    expect(
+      await fixture.administration.disablePitchManagerGrant(
+        event.value.eventId,
+        day.value.gameDayId,
+        changedPitch.value.pitchId,
+        authority,
+      ),
+    ).toMatchObject({ status: "accepted" });
+    expect(
+      await fixture.administration.removeEventCatalogEntry(
+        {
+          kind: "pitch",
+          eventId: event.value.eventId,
+          targetId: changedPitch.value.pitchId,
+          previewFingerprint: changedPreview.value.fingerprint,
+        },
+        authority,
+      ),
+    ).toMatchObject({ status: "rejected", reason: "invalid-input" });
+    expect(
+      await fixture.storage.transaction((transaction) => ({
+        pitch: transaction.findPitch(changedPitch.value.pitchId),
+        grant: transaction.findGrantById(changedGrant.value.grantId),
+      })),
+    ).toMatchObject({
+      pitch: { pitchId: changedPitch.value.pitchId },
+      grant: { status: "disabled" },
+    });
+  });
+
+  test("limits removal roles and retires only authority owned by the removed structure", async () => {
+    const fixture = createFixture();
+    const event = await fixture.catalog.createEvent(
+      { name: "Scoped Removal", timeZone: "UTC" },
+      fixture.technical,
+    );
+    if (event.status !== "accepted") throw new Error("Expected Event.");
+    const day = await fixture.catalog.addGameDay(
+      event.value.eventId,
+      { date: "2026-08-14" },
+      fixture.technical,
+    );
+    const pitch = await fixture.catalog.createPitch(
+      event.value.eventId,
+      { name: "Pitch A" },
+      fixture.technical,
+    );
+    if (day.status !== "accepted" || pitch.status !== "accepted")
+      throw new Error("Expected catalog structure.");
+    const eventGrant = await fixture.administration.createEventAdminGrant(
+      event.value.eventId,
+      fixture.technical,
+    );
+    if (eventGrant.status !== "accepted") throw new Error("Expected Event Admin Grant.");
+    const eventReveal = await fixture.grants.revealGrant(
+      eventGrant.value.grantId,
+      fixture.technical,
+    );
+    if (eventReveal.status !== "revealed") throw new Error("Expected Event Admin credential.");
+    const admission = await fixture.administration.admitEventAdmin({
+      qrCredential: eventReveal.qrCredential,
+      browserContext: "scoped-removal-browser",
+    });
+    if (admission.status !== "admitted") throw new Error("Expected Event Admin session.");
+    const authority = { kind: "grant-session" as const, sessionBearer: admission.sessionBearer };
+    expect(
+      await fixture.administration.previewEventCatalogRemoval(
+        { kind: "pitch", eventId: event.value.eventId, targetId: pitch.value.pitchId },
+        fixture.technical,
+      ),
+    ).toMatchObject({ status: "rejected", reason: "unauthorized" });
+    expect(
+      await fixture.administration.previewEventCatalogRemoval(
+        { kind: "event", eventId: event.value.eventId, targetId: event.value.eventId },
+        authority,
+      ),
+    ).toMatchObject({ status: "rejected", reason: "unauthorized" });
+    const pitchGrant = await fixture.administration.createPitchManagerGrant(
+      event.value.eventId,
+      day.value.gameDayId,
+      pitch.value.pitchId,
+      authority,
+    );
+    if (pitchGrant.status !== "accepted") throw new Error("Expected Pitch Manager Grant.");
+    const preview = await fixture.administration.previewEventCatalogRemoval(
+      { kind: "pitch", eventId: event.value.eventId, targetId: pitch.value.pitchId },
+      authority,
+    );
+    expect(preview).toMatchObject({
+      status: "accepted",
+      value: { eligible: true, impact: { retiredAuthorityCount: 1 } },
+    });
+    if (preview.status !== "accepted") throw new Error("Expected pitch preview.");
+    expect(
+      await fixture.administration.removeEventCatalogEntry(
+        {
+          kind: "pitch",
+          eventId: event.value.eventId,
+          targetId: pitch.value.pitchId,
+          previewFingerprint: preview.value.fingerprint,
+        },
+        authority,
+      ),
+    ).toMatchObject({ status: "accepted", value: { retiredAuthorityCount: 1 } });
+    expect(
+      await fixture.storage.transaction((transaction) => ({
+        eventGrant: transaction.findGrantById(eventGrant.value.grantId)?.status,
+        pitchGrant: transaction.findGrantById(pitchGrant.value.grantId)?.status,
+      })),
+    ).toEqual({ eventGrant: "active", pitchGrant: "expired" });
+  });
+
+  test("rejects removal after Grant Code or QR material changes without refreshing activity", async () => {
+    const fixture = createFixture();
+    const event = await fixture.catalog.createEvent(
+      { name: "Credential fingerprint removal", timeZone: "UTC" },
+      fixture.technical,
+    );
+    const day =
+      event.status === "accepted"
+        ? await fixture.catalog.addGameDay(
+            event.value.eventId,
+            { date: "2026-08-14" },
+            fixture.technical,
+          )
+        : null;
+    const pitch =
+      event.status === "accepted"
+        ? await fixture.catalog.createPitch(
+            event.value.eventId,
+            { name: "Fingerprint Pitch" },
+            fixture.technical,
+          )
+        : null;
+    if (event.status !== "accepted" || day?.status !== "accepted" || pitch?.status !== "accepted")
+      throw new Error("Expected removal structure.");
+    const eventGrant = await fixture.administration.createEventAdminGrant(
+      event.value.eventId,
+      fixture.technical,
+    );
+    if (eventGrant.status !== "accepted") throw new Error("Expected Event Admin Grant.");
+    const reveal = await fixture.grants.revealGrant(eventGrant.value.grantId, fixture.technical);
+    if (reveal.status !== "revealed") throw new Error("Expected Event Admin credential.");
+    const admission = await fixture.administration.admitEventAdmin({
+      qrCredential: reveal.qrCredential,
+      browserContext: "credential-fingerprint-browser",
+    });
+    if (admission.status !== "admitted") throw new Error("Expected Event Admin session.");
+    const eventAdmin = { kind: "grant-session" as const, sessionBearer: admission.sessionBearer };
+    const manager = await fixture.administration.createPitchManagerGrant(
+      event.value.eventId,
+      day.value.gameDayId,
+      pitch.value.pitchId,
+      eventAdmin,
+    );
+    if (manager.status !== "accepted") throw new Error("Expected Pitch Manager Grant.");
+    const code = await fixture.grants.createGrantCode(manager.value.grantId, eventAdmin);
+    if (code.status !== "created") throw new Error("Expected Grant Code.");
+
+    const codePreview = await fixture.administration.previewEventCatalogRemoval(
+      { kind: "pitch", eventId: event.value.eventId, targetId: pitch.value.pitchId },
+      eventAdmin,
+    );
+    if (codePreview.status !== "accepted") throw new Error("Expected code preview.");
+    const replace = await fixture.grants.replaceGrantCode(manager.value.grantId, eventAdmin);
+    expect(replace).toMatchObject({ status: "replaced" });
+    const afterCodeChange = await removalState(fixture, event.value.eventId, manager.value.grantId);
+    expect(
+      await fixture.administration.removeEventCatalogEntry(
+        {
+          kind: "pitch",
+          eventId: event.value.eventId,
+          targetId: pitch.value.pitchId,
+          previewFingerprint: codePreview.value.fingerprint,
+        },
+        eventAdmin,
+      ),
+    ).toMatchObject({ status: "rejected", reason: "invalid-input" });
+    expect(await removalState(fixture, event.value.eventId, manager.value.grantId)).toEqual(
+      afterCodeChange,
+    );
+
+    const qrPreview = await fixture.administration.previewEventCatalogRemoval(
+      { kind: "pitch", eventId: event.value.eventId, targetId: pitch.value.pitchId },
+      eventAdmin,
+    );
+    if (qrPreview.status !== "accepted") throw new Error("Expected QR preview.");
+    expect(await fixture.grants.rotateGrant(manager.value.grantId, eventAdmin)).toMatchObject({
+      status: "updated",
+    });
+    const afterQrChange = await removalState(fixture, event.value.eventId, manager.value.grantId);
+    expect(
+      await fixture.administration.removeEventCatalogEntry(
+        {
+          kind: "pitch",
+          eventId: event.value.eventId,
+          targetId: pitch.value.pitchId,
+          previewFingerprint: qrPreview.value.fingerprint,
+        },
+        eventAdmin,
+      ),
+    ).toMatchObject({ status: "rejected", reason: "invalid-input" });
+    expect(await removalState(fixture, event.value.eventId, manager.value.grantId)).toEqual(
+      afterQrChange,
+    );
+  });
+
+  test("rolls back typed retirement before catalog removal and allows a retry", async () => {
+    const fixture = createFixture();
+    const event = await fixture.catalog.createEvent(
+      { name: "Removal rollback", timeZone: "UTC" },
+      fixture.technical,
+    );
+    const day =
+      event.status === "accepted"
+        ? await fixture.catalog.addGameDay(
+            event.value.eventId,
+            { date: "2026-08-14" },
+            fixture.technical,
+          )
+        : null;
+    const pitch =
+      event.status === "accepted"
+        ? await fixture.catalog.createPitch(
+            event.value.eventId,
+            { name: "Rollback Pitch" },
+            fixture.technical,
+          )
+        : null;
+    if (event.status !== "accepted" || day?.status !== "accepted" || pitch?.status !== "accepted")
+      throw new Error("Expected removal structure.");
+    const eventGrant = await fixture.administration.createEventAdminGrant(
+      event.value.eventId,
+      fixture.technical,
+    );
+    if (eventGrant.status !== "accepted") throw new Error("Expected Event Admin Grant.");
+    const reveal = await fixture.grants.revealGrant(eventGrant.value.grantId, fixture.technical);
+    if (reveal.status !== "revealed") throw new Error("Expected Event Admin credential.");
+    const admission = await fixture.administration.admitEventAdmin({
+      qrCredential: reveal.qrCredential,
+      browserContext: "rollback-removal-browser",
+    });
+    if (admission.status !== "admitted") throw new Error("Expected Event Admin session.");
+    const eventAdmin = { kind: "grant-session" as const, sessionBearer: admission.sessionBearer };
+    const manager = await fixture.administration.createPitchManagerGrant(
+      event.value.eventId,
+      day.value.gameDayId,
+      pitch.value.pitchId,
+      eventAdmin,
+    );
+    if (manager.status !== "accepted") throw new Error("Expected Pitch Manager Grant.");
+    const code = await fixture.grants.createGrantCode(manager.value.grantId, eventAdmin);
+    if (code.status !== "created") throw new Error("Expected Grant Code.");
+    const preview = await fixture.administration.previewEventCatalogRemoval(
+      { kind: "pitch", eventId: event.value.eventId, targetId: pitch.value.pitchId },
+      eventAdmin,
+    );
+    if (preview.status !== "accepted") throw new Error("Expected removal preview.");
+    const before = await removalState(fixture, event.value.eventId, manager.value.grantId);
+    let inject = true;
+    const injectedAdministration = createEventAdministration({
+      storage: fixture.storage,
+      grants: fixture.grants,
+      nowMs: () => Date.parse("2026-08-14T12:00:00Z"),
+      removalFailureInjector: () => {
+        if (inject) {
+          inject = false;
+          throw new Error("injected removal failure after Grant retirement");
+        }
+      },
+    });
+    expect(
+      await injectedAdministration.removeEventCatalogEntry(
+        {
+          kind: "pitch",
+          eventId: event.value.eventId,
+          targetId: pitch.value.pitchId,
+          previewFingerprint: preview.value.fingerprint,
+        },
+        eventAdmin,
+      ),
+    ).toMatchObject({ status: "retryable-failure" });
+    expect(await removalState(fixture, event.value.eventId, manager.value.grantId)).toEqual(before);
+    expect(
+      await injectedAdministration.removeEventCatalogEntry(
+        {
+          kind: "pitch",
+          eventId: event.value.eventId,
+          targetId: pitch.value.pitchId,
+          previewFingerprint: preview.value.fingerprint,
+        },
+        eventAdmin,
+      ),
+    ).toMatchObject({ status: "accepted", value: { removed: true } });
+    expect(await removalState(fixture, event.value.eventId, manager.value.grantId)).toMatchObject({
+      event: { eventId: event.value.eventId },
+      grant: { status: "expired" },
+      pitches: [],
+    });
+  });
+
+  test("refreshes existing private and public readers after accepted removal", async () => {
+    const fixture = createFixture();
+    const event = await fixture.catalog.createEvent(
+      { name: "Projection removal", timeZone: "UTC" },
+      fixture.technical,
+    );
+    const day =
+      event.status === "accepted"
+        ? await fixture.catalog.addGameDay(
+            event.value.eventId,
+            { date: "2026-08-14" },
+            fixture.technical,
+          )
+        : null;
+    const pitch =
+      event.status === "accepted"
+        ? await fixture.catalog.createPitch(
+            event.value.eventId,
+            { name: "Projection Pitch" },
+            fixture.technical,
+          )
+        : null;
+    if (event.status !== "accepted" || day?.status !== "accepted" || pitch?.status !== "accepted")
+      throw new Error("Expected removal structure.");
+    expect(
+      await fixture.catalog.changePublicationStatus(
+        event.value.eventId,
+        { status: "published" },
+        fixture.technical,
+      ),
+    ).toMatchObject({ status: "accepted" });
+    const grant = await fixture.administration.createEventAdminGrant(
+      event.value.eventId,
+      fixture.technical,
+    );
+    if (grant.status !== "accepted") throw new Error("Expected Event Admin Grant.");
+    const reveal = await fixture.grants.revealGrant(grant.value.grantId, fixture.technical);
+    if (reveal.status !== "revealed") throw new Error("Expected Event Admin credential.");
+    const admission = await fixture.administration.admitEventAdmin({
+      qrCredential: reveal.qrCredential,
+      browserContext: "projection-removal-browser",
+    });
+    if (admission.status !== "admitted") throw new Error("Expected Event Admin session.");
+    const eventAdmin = { kind: "grant-session" as const, sessionBearer: admission.sessionBearer };
+    const preview = await fixture.administration.previewEventCatalogRemoval(
+      { kind: "pitch", eventId: event.value.eventId, targetId: pitch.value.pitchId },
+      eventAdmin,
+    );
+    if (preview.status !== "accepted") throw new Error("Expected removal preview.");
+    expect(
+      await fixture.administration.removeEventCatalogEntry(
+        {
+          kind: "pitch",
+          eventId: event.value.eventId,
+          targetId: pitch.value.pitchId,
+          previewFingerprint: preview.value.fingerprint,
+        },
+        eventAdmin,
+      ),
+    ).toMatchObject({ status: "accepted" });
+    expect(
+      await fixture.administration.openEventHub({
+        eventId: event.value.eventId,
+        gameDayId: day.value.gameDayId,
+        authority: eventAdmin,
+      }),
+    ).toMatchObject({ status: "accepted", value: { event: { pitches: [] } } });
+    expect(
+      await fixture.administration.openSlotSetup(
+        event.value.eventId,
+        day.value.gameDayId,
+        eventAdmin,
+      ),
+    ).toMatchObject({ status: "accepted", value: { pitches: [], eventGames: [] } });
+    expect(
+      await fixture.administration.openPitchView(
+        event.value.eventId,
+        day.value.gameDayId,
+        pitch.value.pitchId,
+        eventAdmin,
+      ),
+    ).toMatchObject({ status: "rejected", reason: "not-found" });
+    const audience = createAudienceProjection(
+      createFoundationEventCatalogStorage(fixture.storage),
+      {
+        now: () => Date.parse("2026-08-14T12:00:00Z"),
+      },
+    );
+    expect(await audience.read(event.value.eventId)).toMatchObject({
+      status: "accepted",
+      value: { publicationStatus: "published", pitches: [] },
+    });
+  });
+
+  test("fails closed when owned authority scope is malformed", async () => {
+    const fixture = createFixture();
+    const event = await fixture.catalog.createEvent(
+      { name: "Malformed authority removal", timeZone: "UTC" },
+      fixture.technical,
+    );
+    const day =
+      event.status === "accepted"
+        ? await fixture.catalog.addGameDay(
+            event.value.eventId,
+            { date: "2026-08-14" },
+            fixture.technical,
+          )
+        : null;
+    const pitch =
+      event.status === "accepted"
+        ? await fixture.catalog.createPitch(
+            event.value.eventId,
+            { name: "Malformed Pitch" },
+            fixture.technical,
+          )
+        : null;
+    if (event.status !== "accepted" || day?.status !== "accepted" || pitch?.status !== "accepted")
+      throw new Error("Expected removal structure.");
+    const eventGrant = await fixture.administration.createEventAdminGrant(
+      event.value.eventId,
+      fixture.technical,
+    );
+    if (eventGrant.status !== "accepted") throw new Error("Expected Event Admin Grant.");
+    const reveal = await fixture.grants.revealGrant(eventGrant.value.grantId, fixture.technical);
+    if (reveal.status !== "revealed") throw new Error("Expected Event Admin credential.");
+    const admission = await fixture.administration.admitEventAdmin({
+      qrCredential: reveal.qrCredential,
+      browserContext: "malformed-authority-browser",
+    });
+    if (admission.status !== "admitted") throw new Error("Expected Event Admin session.");
+    const eventAdmin = { kind: "grant-session" as const, sessionBearer: admission.sessionBearer };
+    const manager = await fixture.administration.createPitchManagerGrant(
+      event.value.eventId,
+      day.value.gameDayId,
+      pitch.value.pitchId,
+      eventAdmin,
+    );
+    if (manager.status !== "accepted") throw new Error("Expected Pitch Manager Grant.");
+    const malformedStorage = new Proxy(fixture.storage, {
+      get(target, property, receiver) {
+        if (property !== "transaction") return Reflect.get(target, property, receiver);
+        return (work: (transaction: unknown) => unknown) =>
+          target.transaction((transaction) => {
+            const wrapped = new Proxy(transaction, {
+              get(transactionTarget, transactionProperty, transactionReceiver) {
+                if (transactionProperty !== "listGrants")
+                  return Reflect.get(transactionTarget, transactionProperty, transactionReceiver);
+                return () => {
+                  const grants = transactionTarget.listGrants();
+                  const stored = grants.find((grant) => grant.grantId === manager.value.grantId);
+                  if (stored === undefined) return grants;
+                  return [
+                    ...grants.filter((grant) => grant.grantId !== manager.value.grantId),
+                    {
+                      ...stored,
+                      scope: { eventId: event.value.eventId, pitchId: pitch.value.pitchId },
+                    },
+                  ];
+                };
+              },
+            });
+            return work(wrapped);
+          });
+      },
+    }) as FoundationStorage;
+    const malformedAdministration = createEventAdministration({
+      storage: malformedStorage,
+      grants: fixture.grants,
+      nowMs: () => Date.parse("2026-08-14T12:00:00Z"),
+    });
+    const preview = await malformedAdministration.previewEventCatalogRemoval(
+      { kind: "pitch", eventId: event.value.eventId, targetId: pitch.value.pitchId },
+      eventAdmin,
+    );
+    expect(preview).toMatchObject({
+      status: "accepted",
+      value: {
+        eligible: false,
+        repairWorkflow: "Event Catalog removal is unavailable.",
+        impact: { retiredAuthorityCount: 0 },
+      },
+    });
+    if (preview.status !== "accepted") return;
+    const before = await fixture.storage.transaction((transaction) => ({
+      pitch: transaction.findPitch(pitch.value.pitchId),
+      grant: transaction.findGrantById(manager.value.grantId),
+      session: transaction.listGrantSessions(eventGrant.value.grantId),
+      audit: transaction.listEventAuditTrail(event.value.eventId),
+    }));
+    expect(
+      await malformedAdministration.removeEventCatalogEntry(
+        {
+          kind: "pitch",
+          eventId: event.value.eventId,
+          targetId: pitch.value.pitchId,
+          previewFingerprint: preview.value.fingerprint,
+        },
+        eventAdmin,
+      ),
+    ).toMatchObject({ status: "rejected", reason: "in-use" });
+    expect(
+      await fixture.storage.transaction((transaction) => ({
+        pitch: transaction.findPitch(pitch.value.pitchId),
+        grant: transaction.findGrantById(manager.value.grantId),
+        session: transaction.listGrantSessions(eventGrant.value.grantId),
+        audit: transaction.listEventAuditTrail(event.value.eventId),
+      })),
+    ).toEqual(before);
+  });
+
   test("creates a secret-free handoff, admits a pseudonymous session, and opens the same Hub", async () => {
     const fixture = createFixture();
     const event = await fixture.catalog.createEvent(
@@ -690,50 +1500,6 @@ describe("Event Administration handoff", () => {
         rotationAuthority,
       ),
     ).toMatchObject({ status: "rejected", reason: "unauthorized" });
-  });
-
-  test("preserves empty Event removal while rejecting removal of an attached Grant", async () => {
-    const fixture = createFixture();
-    const event = await fixture.catalog.createEvent(
-      { name: "Attached Grant Event", timeZone: "UTC" },
-      fixture.technical,
-    );
-    if (event.status !== "accepted") throw new Error("Expected Event.");
-    const day = await fixture.catalog.addGameDay(
-      event.value.eventId,
-      { date: "2026-08-14" },
-      fixture.technical,
-    );
-    if (day.status !== "accepted") throw new Error("Expected Game Day.");
-    const grant = await fixture.administration.createEventAdminGrant(
-      event.value.eventId,
-      fixture.technical,
-    );
-    if (grant.status !== "accepted") throw new Error("Expected Grant.");
-    expect(
-      await fixture.catalog.removeGameDay(
-        event.value.eventId,
-        day.value.gameDayId,
-        fixture.technical,
-      ),
-    ).toMatchObject({ status: "accepted" });
-    expect(await fixture.catalog.removeEvent(event.value.eventId, fixture.technical)).toMatchObject(
-      {
-        status: "rejected",
-        reason: "in-use",
-        detail: "Event has an attached Event Admin Grant.",
-      },
-    );
-    const empty = await fixture.catalog.createEvent(
-      { name: "No Grant Event", timeZone: "UTC" },
-      fixture.technical,
-    );
-    if (empty.status !== "accepted") throw new Error("Expected empty Event.");
-    expect(await fixture.catalog.removeEvent(empty.value.eventId, fixture.technical)).toMatchObject(
-      {
-        status: "accepted",
-      },
-    );
   });
 
   test("lets Event Administration configure Teams, public roster mappings, and Pitches", async () => {
@@ -1521,6 +2287,23 @@ function createFixture(
 
 function bytes(value: number): Uint8Array {
   return new Uint8Array(32).fill(value);
+}
+
+async function removalState(
+  fixture: ReturnType<typeof createFixture>,
+  eventId: string,
+  grantId: string,
+) {
+  return fixture.storage.transaction((transaction) => ({
+    event: transaction.findEvent(eventId),
+    grant: transaction.findGrantById(grantId),
+    grants: transaction.listGrants(),
+    sessions: transaction.listGrantSessions(grantId),
+    grantAudit: transaction.listGrantAudit(grantId),
+    eventAudit: transaction.listEventAuditTrail(eventId),
+    gameDays: transaction.listGameDays(eventId),
+    pitches: transaction.listPitches(eventId),
+  }));
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/lib/event-administration.ts
+++ b/src/lib/event-administration.ts
@@ -6,6 +6,9 @@ import {
   projectEventProjection,
   type CatalogOutcome,
   type EventCatalog,
+  type EventCatalogRemovalPreview,
+  type EventCatalogRemovalResult,
+  type EventCatalogRemovalTargetInput,
   type EventCatalogMutationOperations,
   type EventTeamProjection,
   type EventProjection,
@@ -40,9 +43,11 @@ import {
   type PitchManagerGrantScope,
   type StoredGrant,
   validateControlGrantScope,
+  validateEventAdminGrantScope,
   validatePitchManagerGrantScope,
 } from "@/lib/grant-types";
 import { isTechnicalAdminAuthority } from "@/lib/technical-admin-auth";
+import { canonicalizeJson, sha256 } from "@/lib/event-game-action-json";
 import { validateOpaqueIdentifier } from "@/lib/validation-policy";
 
 export const GENERIC_EVENT_HUB_AUTHORIZATION_FAILURE = Object.freeze({
@@ -152,7 +157,11 @@ export type PitchManagerViewProjection = {
 
 export type EventAdministrationOutcome<T> =
   | { status: "accepted"; value: T }
-  | { status: "rejected"; reason: "invalid-input" | "unauthorized" | "not-found"; detail: string }
+  | {
+      status: "rejected";
+      reason: "invalid-input" | "unauthorized" | "not-found" | "in-use";
+      detail: string;
+    }
   | { status: "retryable-failure"; detail: string };
 
 export type EventAdministrationMutationOutcome<T> = EventAdministrationOutcome<T> & {
@@ -165,9 +174,19 @@ export type EventAdministrationOptions = {
   catalog?: EventCatalog;
   nowMs?: () => number;
   controlScopeResolver?: ControlGrantScopeResolver;
+  /** Test-only composition seam for proving rollback after typed retirement. */
+  removalFailureInjector?: () => void;
 };
 
 export type EventAdministration = {
+  previewEventCatalogRemoval(
+    target: EventCatalogRemovalTargetInput,
+    authority: EventAdministrationAuthority,
+  ): Promise<EventAdministrationOutcome<EventCatalogRemovalPreview>>;
+  removeEventCatalogEntry(
+    target: EventCatalogRemovalTargetInput & { previewFingerprint?: unknown },
+    authority: EventAdministrationAuthority,
+  ): Promise<EventAdministrationMutationOutcome<EventCatalogRemovalResult>>;
   createEventAdminGrant(
     eventId: unknown,
     authority: TechnicalAdminAuthority,
@@ -513,6 +532,95 @@ export function createEventAdministration(
     });
 
   return {
+    async previewEventCatalogRemoval(target, authority) {
+      const eventId = validateEventId(target.eventId);
+      if (!eventId.ok) return invalid(eventId.error);
+      if (!removalAllowedForAuthority(target.kind, authority)) return unauthorized();
+      try {
+        return await options.storage.transaction((transaction) => {
+          const authorized = authorizeEventScopeInTransaction(
+            options,
+            transaction,
+            eventId.value,
+            authority,
+            true,
+          );
+          if (authorized === null) return unauthorized();
+          const result = catalog.runMutationInTransaction(
+            transaction,
+            eventId.value,
+            authorized.actorReference,
+            (operations) => operations.previewEventCatalogRemoval(target),
+          );
+          if (result.status !== "accepted") return catalogOutcomeToAdministration(result);
+          return accepted(addAuthorityImpact(transaction, result.value));
+        });
+      } catch {
+        return unavailable();
+      }
+    },
+
+    async removeEventCatalogEntry(target, authority) {
+      const eventId = validateEventId(target.eventId);
+      if (!eventId.ok) return invalid(eventId.error);
+      if (!removalAllowedForAuthority(target.kind, authority)) return unauthorized();
+      if (!isValidRemovalFingerprint(target.previewFingerprint))
+        return invalid("Event Catalog removal preview is invalid.");
+      try {
+        return await options.storage.transaction((transaction) => {
+          const authorized = authorizeEventScopeInTransaction(
+            options,
+            transaction,
+            eventId.value,
+            authority,
+          );
+          if (authorized === null) return rollbackRemovalMutation(unauthorized());
+          const preview = catalog.runMutationInTransaction(
+            transaction,
+            eventId.value,
+            authorized.actorReference,
+            (operations) => operations.previewEventCatalogRemoval(target),
+          );
+          if (preview.status !== "accepted")
+            return rollbackRemovalMutation(catalogOutcomeToAdministration(preview));
+          const impacted = addAuthorityImpact(transaction, preview.value);
+          if (target.previewFingerprint !== impacted.fingerprint)
+            return rollbackRemovalMutation(invalid("Event Catalog removal preview is stale."));
+          if (!impacted.eligible)
+            return rollbackRemovalMutation({
+              status: "rejected" as const,
+              reason: "in-use" as const,
+              detail: impacted.repairWorkflow ?? "Event Catalog removal is not eligible.",
+            });
+          const grants = grantsOwnedByRemovalTarget(transaction, impacted.target);
+          for (const grant of grants) {
+            const retired = options.grants.retireGrantInTransaction(transaction, {
+              grantId: grant.grantId,
+              actorReference: authorized.actorReference,
+              reason: "event-catalog-removal",
+            });
+            if (retired.status !== "updated")
+              return rollbackRemovalMutation(grantRetirementRejection(retired));
+          }
+          options.removalFailureInjector?.();
+          const result = catalog.runMutationInTransaction(
+            transaction,
+            eventId.value,
+            authorized.actorReference,
+            (operations) =>
+              operations.removeEventCatalogEntry(target, preview.value.fingerprint, grants.length),
+          );
+          if (result.status !== "accepted")
+            return rollbackRemovalMutation(catalogOutcomeToAdministration(result));
+          return { ...accepted(result.value), sessionExpiresAtMs: authorized.sessionExpiresAtMs };
+        });
+      } catch (error) {
+        if (error instanceof EventAdministrationRollback)
+          return error.outcome as EventAdministrationMutationOutcome<EventCatalogRemovalResult>;
+        return unavailable();
+      }
+    },
+
     async createEventAdminGrant(eventIdInput, authority) {
       if (!isTechnicalAdminAuthority(authority)) return unauthorized();
       const eventId = validateEventId(eventIdInput);
@@ -1475,6 +1583,279 @@ function authorizeEventScopeInTransaction(
     sessionExpiresAtMs: result.sessionExpiresAtMs ?? null,
     actorReference: `event-admin:${result.grantSessionId}`,
   };
+}
+
+function removalAllowedForAuthority(
+  kind: unknown,
+  authority: EventAdministrationAuthority,
+): boolean {
+  const isEventRemoval = kind === "event";
+  return isTechnicalAdminAuthority(authority) ? isEventRemoval : !isEventRemoval;
+}
+
+function addAuthorityImpact(
+  transaction: FoundationStorageTransaction,
+  preview: EventCatalogRemovalPreview,
+): EventCatalogRemovalPreview {
+  const authorityImpact = readRemovalAuthorityImpact(transaction, preview.target);
+  const malformed = authorityImpact.state !== "available";
+  return {
+    ...preview,
+    eligible: preview.eligible && !malformed,
+    rejectionCategory: malformed ? null : preview.rejectionCategory,
+    repairWorkflow: malformed ? "Event Catalog removal is unavailable." : preview.repairWorkflow,
+    impact: {
+      ...preview.impact,
+      retiredAuthorityCount: authorityImpact.grants.length,
+      retiredAuthorityCategories: authorityImpact.categories,
+    },
+    fingerprint: removalFingerprint(preview, authorityImpact),
+  };
+}
+
+type RemovalAuthorityDescriptor = {
+  grantId: string;
+  grantType: string;
+  grantVersion: string;
+  status: string;
+  expiresAtMs: number | null;
+  scopeState: "valid" | "malformed";
+  scope: unknown;
+  credentialMaterialState: string;
+  credentialFingerprint: string;
+  codeState: string | null;
+  codeFingerprint: string | null;
+  sessions: Array<{
+    sessionId: string;
+    grantVersion: string;
+    status: string;
+    bearerMaterialState: string;
+    revokedAtMs: number | null;
+  }>;
+};
+
+type RemovalAuthorityImpact = {
+  state: "available" | "malformed" | "unavailable";
+  descriptors: RemovalAuthorityDescriptor[];
+  grants: StoredGrant[];
+  categories: {
+    eventAdmin: number;
+    pitchManager: number;
+    control: number;
+  };
+};
+
+function readRemovalAuthorityImpact(
+  transaction: FoundationStorageTransaction,
+  target: EventCatalogRemovalPreview["target"],
+): RemovalAuthorityImpact {
+  const descriptors: RemovalAuthorityDescriptor[] = [];
+  const grants: StoredGrant[] = [];
+  try {
+    let malformed = false;
+    for (const grant of transaction.listGrants()) {
+      const ownership = classifyRemovalGrant(grant, target);
+      if (ownership === null) continue;
+      const scopeState = ownership === "malformed" ? "malformed" : "valid";
+      if (scopeState === "malformed") malformed = true;
+      else if (!hasReadableRemovalCredentialMaterial(grant)) malformed = true;
+      else grants.push(grant);
+      descriptors.push(removalGrantDescriptor(transaction, grant, scopeState));
+    }
+    descriptors.sort((left, right) => left.grantId.localeCompare(right.grantId));
+    const retiringGrants = grants.filter((grant) => grant.status !== "expired");
+    return {
+      state: malformed ? "malformed" : "available",
+      descriptors,
+      grants: retiringGrants,
+      categories: {
+        eventAdmin: retiringGrants.filter((grant) => grant.grantType === EVENT_ADMIN_GRANT_TYPE)
+          .length,
+        pitchManager: retiringGrants.filter((grant) => grant.grantType === PITCH_MANAGER_GRANT_TYPE)
+          .length,
+        control: retiringGrants.filter((grant) => grant.grantType === GRANT_TYPE).length,
+      },
+    };
+  } catch {
+    return {
+      state: "unavailable",
+      descriptors: [],
+      grants: [],
+      categories: { eventAdmin: 0, pitchManager: 0, control: 0 },
+    };
+  }
+}
+
+function hasReadableRemovalCredentialMaterial(grant: StoredGrant): boolean {
+  if (
+    typeof grant.credential?.fingerprint !== "string" ||
+    grant.credential.fingerprint.length === 0
+  )
+    return false;
+  if (grant.code === undefined || grant.code === null) return true;
+  return typeof grant.code.fingerprint === "string" && grant.code.fingerprint.length > 0;
+}
+
+function rawScopeMatchesRemovalTarget(
+  grant: StoredGrant,
+  target: EventCatalogRemovalPreview["target"],
+): boolean {
+  if (target.kind === "event") return true;
+  const rawScope = grant.scope as Record<string, unknown>;
+  if (target.kind === "game-day") return rawScope.gameDayId === target.targetId;
+  if (target.kind === "pitch") return rawScope.pitchId === target.targetId;
+  if (target.kind === "pitch-slot") return rawScope.pitchSlotId === target.targetId;
+  return false;
+}
+
+function classifyRemovalGrant(
+  grant: StoredGrant,
+  target: EventCatalogRemovalPreview["target"],
+): "valid" | "malformed" | null {
+  if (!isRecord(grant.scope)) return null;
+  const rawScope = grant.scope;
+  if (rawScope.eventId !== target.eventId || !rawScopeMatchesRemovalTarget(grant, target))
+    return null;
+  const scope =
+    target.kind === "event" && grant.grantType === EVENT_ADMIN_GRANT_TYPE
+      ? validateEventAdminGrantScope(grant.scope)
+      : grant.grantType === PITCH_MANAGER_GRANT_TYPE
+        ? validatePitchManagerGrantScope(grant.scope)
+        : grant.grantType === GRANT_TYPE
+          ? validateControlGrantScope(grant.scope)
+          : null;
+  if (scope !== null && scope.ok && scope.value.eventId === target.eventId) {
+    const scopeValue = scope.value as {
+      eventId: string;
+      gameDayId?: string;
+      pitchId?: string;
+      pitchSlotId?: string;
+    };
+    if (target.kind === "event") return "valid";
+    if (target.kind === "game-day" && scopeValue.gameDayId === target.targetId) return "valid";
+    if (target.kind === "pitch" && scopeValue.pitchId === target.targetId) return "valid";
+    if (target.kind === "pitch-slot" && scopeValue.pitchSlotId === target.targetId) return "valid";
+  }
+  return "malformed";
+}
+
+function removalGrantDescriptor(
+  transaction: FoundationStorageTransaction,
+  grant: StoredGrant,
+  scopeState: "valid" | "malformed",
+): RemovalAuthorityDescriptor {
+  const sessions = transaction
+    .listGrantSessions(grant.grantId)
+    .map((session) => ({
+      sessionId: session.sessionId,
+      grantVersion: session.grantVersion,
+      status: session.status,
+      bearerMaterialState: session.bearerMaterialState,
+      revokedAtMs: session.revokedAtMs,
+    }))
+    .sort((left, right) => left.sessionId.localeCompare(right.sessionId));
+  return {
+    grantId: grant.grantId,
+    grantType: grant.grantType,
+    grantVersion: grant.grantVersion,
+    status: grant.status,
+    expiresAtMs: grant.expiresAtMs,
+    scopeState,
+    scope: scopeState === "valid" ? grant.scope : null,
+    credentialMaterialState: grant.credential.materialState,
+    credentialFingerprint: grant.credential.fingerprint,
+    codeState: grant.code?.state ?? null,
+    codeFingerprint: grant.code?.fingerprint ?? null,
+    sessions,
+  };
+}
+
+function removalFingerprint(
+  preview: EventCatalogRemovalPreview,
+  authorityImpact: RemovalAuthorityImpact,
+): string {
+  return `event-catalog-removal-v1:${sha256(
+    canonicalizeJson({
+      catalogFingerprint: preview.fingerprint,
+      authorityImpact: {
+        state: authorityImpact.state,
+        descriptors: authorityImpact.descriptors,
+      },
+    }),
+  )}`;
+}
+
+function isValidRemovalFingerprint(value: unknown): value is string {
+  return typeof value === "string" && /^event-catalog-removal-v1:[0-9a-f]{64}$/u.test(value);
+}
+
+function grantsOwnedByRemovalTarget(
+  transaction: FoundationStorageTransaction,
+  target: EventCatalogRemovalPreview["target"],
+): StoredGrant[] {
+  return transaction.listGrants().filter((grant) => {
+    if (grant.status === "expired") return false;
+    const scope =
+      target.kind === "event" && grant.grantType === EVENT_ADMIN_GRANT_TYPE
+        ? validateEventAdminGrantScope(grant.scope)
+        : grant.grantType === PITCH_MANAGER_GRANT_TYPE
+          ? validatePitchManagerGrantScope(grant.scope)
+          : grant.grantType === GRANT_TYPE
+            ? validateControlGrantScope(grant.scope)
+            : null;
+    if (scope === null || !scope.ok || scope.value.eventId !== target.eventId) return false;
+    const scopeValue = scope.value as {
+      eventId: string;
+      gameDayId?: string;
+      pitchId?: string;
+      pitchSlotId?: string;
+    };
+    if (target.kind === "event") return true;
+    if (target.kind === "game-day")
+      return (
+        (grant.grantType === PITCH_MANAGER_GRANT_TYPE &&
+          scopeValue.gameDayId === target.targetId) ||
+        (grant.grantType === GRANT_TYPE && scopeValue.gameDayId === target.targetId)
+      );
+    if (target.kind === "pitch")
+      return (
+        (grant.grantType === PITCH_MANAGER_GRANT_TYPE && scopeValue.pitchId === target.targetId) ||
+        (grant.grantType === GRANT_TYPE && scopeValue.pitchId === target.targetId)
+      );
+    if (target.kind === "pitch-slot")
+      return grant.grantType === GRANT_TYPE && scopeValue.pitchSlotId === target.targetId;
+    return false;
+  });
+}
+
+function catalogOutcomeToAdministration<T>(
+  result: CatalogOutcome<T>,
+): EventAdministrationOutcome<T> {
+  if (result.status === "accepted") return accepted(result.value);
+  if (result.status === "retryable-failure") return unavailable();
+  if (result.reason === "unauthorized") return unauthorized();
+  if (result.reason === "not-found") return notFound(result.detail);
+  if (result.reason === "in-use")
+    return { status: "rejected", reason: "in-use", detail: result.detail };
+  return invalid(result.detail);
+}
+
+function grantRetirementRejection(result: TypedGrantMutation): EventAdministrationOutcome<never> {
+  if (result.status === "updated") return invalid("Grant retirement returned an invalid outcome.");
+  if (result.reason === "unauthorized") return unauthorized();
+  if (result.reason === "not-found") return notFound(result.detail ?? "Grant was not found.");
+  if (result.reason === "unavailable") return unavailable();
+  return invalid(result.detail ?? "Grant retirement was rejected.");
+}
+
+class EventAdministrationRollback extends Error {
+  constructor(readonly outcome: EventAdministrationOutcome<never>) {
+    super("Event Administration mutation rolled back.");
+  }
+}
+
+function rollbackRemovalMutation<T>(outcome: EventAdministrationOutcome<T>): never {
+  throw new EventAdministrationRollback(outcome as EventAdministrationOutcome<never>);
 }
 
 async function openScheduleProjection<T extends SlotSetupProjection | PitchViewProjection>(

--- a/src/lib/event-administration.ts
+++ b/src/lib/event-administration.ts
@@ -49,6 +49,13 @@ import {
 import { isTechnicalAdminAuthority } from "@/lib/technical-admin-auth";
 import { canonicalizeJson, sha256 } from "@/lib/event-game-action-json";
 import { validateOpaqueIdentifier } from "@/lib/validation-policy";
+import {
+  generateAccessSheetInTransaction,
+  type AccessSheetArtifact,
+  type AccessSheetRenderer,
+  type AccessSheetRequest,
+  type AccessSheetIds,
+} from "@/lib/access-sheet";
 
 export const GENERIC_EVENT_HUB_AUTHORIZATION_FAILURE = Object.freeze({
   status: "rejected",
@@ -176,6 +183,9 @@ export type EventAdministrationOptions = {
   controlScopeResolver?: ControlGrantScopeResolver;
   /** Test-only composition seam for proving rollback after typed retirement. */
   removalFailureInjector?: () => void;
+  environmentId?: string;
+  accessSheetRenderer?: AccessSheetRenderer;
+  accessSheetIds?: AccessSheetIds;
 };
 
 export type EventAdministration = {
@@ -405,6 +415,10 @@ export type EventAdministration = {
     gameDayId?: unknown;
     authority: EventAdministrationAuthority;
   }): Promise<EventAdministrationOutcome<EventHubProjection>>;
+  generateAccessSheet(
+    input: AccessSheetRequest,
+    authority: EventAdministrationAuthority,
+  ): Promise<EventAdministrationMutationOutcome<AccessSheetArtifact>>;
   changePublicationStatus(
     eventId: unknown,
     input: { status: unknown; impactConfirmed?: unknown },
@@ -1420,6 +1434,39 @@ export function createEventAdministration(
             grantSessionId: authorized.sessionId,
             grantSessionExpiresAtMs: authorized.sessionExpiresAtMs,
           });
+        });
+      } catch {
+        return unavailable();
+      }
+    },
+
+    async generateAccessSheet(input, authority) {
+      const eventId = validateEventId(input.scope.eventId);
+      if (!eventId.ok) return invalid(eventId.error);
+      try {
+        return await options.storage.transaction((transaction) => {
+          const authorized = authorizeEventScopeInTransaction(
+            options,
+            transaction,
+            eventId.value,
+            authority,
+          );
+          if (authorized === null) return unauthorized();
+          const result = generateAccessSheetInTransaction(
+            transaction,
+            input,
+            authorized.actorReference,
+            {
+              environmentId: options.environmentId ?? "test",
+              nowMs,
+              grants: options.grants,
+              authority,
+              renderer: options.accessSheetRenderer,
+              ids: options.accessSheetIds,
+            },
+          );
+          if (result.status !== "accepted") return result;
+          return { ...result, sessionExpiresAtMs: authorized.sessionExpiresAtMs };
         });
       } catch {
         return unavailable();

--- a/src/lib/event-catalog.focused.ts
+++ b/src/lib/event-catalog.focused.ts
@@ -162,6 +162,56 @@ describe("Event operations catalog through foundation SQLite", () => {
     }
   });
 
+  test("removes an eligible Team through the SQLite catalog transaction", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "quadball-event-catalog-removal-"));
+    const foundation = openSqliteFoundationStorage(join(directory, "catalog.sqlite"));
+    await foundation.applyMigrations();
+    try {
+      const catalog = createEventCatalog(createFoundationEventCatalogStorage(foundation), {
+        clock: { nowMs: () => Date.UTC(2026, 7, 14, 12) },
+      });
+      const event = await catalog.createEvent(
+        { name: "Removal Event", timeZone: "UTC" },
+        authority,
+      );
+      if (event.status !== "accepted") throw new Error("Expected Event.");
+      const team = await catalog.createEventTeam(event.value.eventId, { name: "Blue" }, authority);
+      if (team.status !== "accepted") throw new Error("Expected Team.");
+      const preview = await catalog.previewEventCatalogRemoval(
+        { kind: "event-team", eventId: event.value.eventId, targetId: team.value.eventTeamId },
+        authority,
+      );
+      expect(preview).toMatchObject({ status: "accepted", value: { eligible: true } });
+      if (preview.status !== "accepted") return;
+      expect(
+        await foundation.transaction((transaction) =>
+          catalog.runMutationInTransaction(
+            transaction,
+            event.value.eventId,
+            "technical-admin:test",
+            (operations) =>
+              operations.removeEventCatalogEntry(
+                {
+                  kind: "event-team",
+                  eventId: event.value.eventId,
+                  targetId: team.value.eventTeamId,
+                },
+                preview.value.fingerprint,
+                0,
+              ),
+          ),
+        ),
+      ).toMatchObject({ status: "accepted", value: { removed: true } });
+      expect(await catalog.inspectEvent(event.value.eventId, authority)).toMatchObject({
+        status: "accepted",
+        value: { teams: [] },
+      });
+    } finally {
+      foundation.close();
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
   test("keeps retained Game Facts unchanged across roster additions and corrections", async () => {
     const directory = await mkdtemp(join(tmpdir(), "quadball-event-catalog-facts-"));
     const foundation = openSqliteFoundationStorage(join(directory, "catalog.sqlite"));

--- a/src/lib/event-catalog.test.ts
+++ b/src/lib/event-catalog.test.ts
@@ -66,6 +66,379 @@ describe("Event operations catalog", () => {
     });
   });
 
+  test("covers eligibility and representative references for every catalog removal target kind", async () => {
+    const fixture = createFixture();
+    const emptyEvent = await fixture.catalog.createEvent(
+      { name: "Empty removal Event", timeZone: "UTC" },
+      authority,
+    );
+    expect(emptyEvent).toMatchObject({ status: "accepted" });
+    if (emptyEvent.status !== "accepted") return;
+    expect(
+      await fixture.catalog.previewEventCatalogRemoval(
+        { kind: "event", eventId: emptyEvent.value.eventId, targetId: emptyEvent.value.eventId },
+        authority,
+      ),
+    ).toMatchObject({ status: "accepted", value: { eligible: true } });
+    const event = await fixture.catalog.createEvent(
+      { name: "Removal Matrix", timeZone: "UTC" },
+      authority,
+    );
+    expect(event.status).toBe("accepted");
+    if (event.status !== "accepted") return;
+    const foreignEvent = await fixture.catalog.createEvent(
+      { name: "Foreign removal Event", timeZone: "UTC" },
+      authority,
+    );
+    if (foreignEvent.status !== "accepted") return;
+    const foreignTeam = await fixture.catalog.createEventTeam(
+      foreignEvent.value.eventId,
+      { name: "Foreign Team" },
+      authority,
+    );
+    if (foreignTeam.status !== "accepted") return;
+    expect(
+      await fixture.catalog.previewEventCatalogRemoval(
+        {
+          kind: "event-team",
+          eventId: event.value.eventId,
+          targetId: foreignTeam.value.eventTeamId,
+        },
+        authority,
+      ),
+    ).toMatchObject({ status: "rejected", reason: "not-found" });
+    const scheduledDay = await fixture.catalog.addGameDay(
+      event.value.eventId,
+      { date: "2026-08-14" },
+      authority,
+    );
+    const emptyDay = await fixture.catalog.addGameDay(
+      event.value.eventId,
+      { date: "2026-08-15" },
+      authority,
+    );
+    const slotOnlyDay = await fixture.catalog.addGameDay(
+      event.value.eventId,
+      { date: "2026-08-16" },
+      authority,
+    );
+    if (
+      scheduledDay.status !== "accepted" ||
+      emptyDay.status !== "accepted" ||
+      slotOnlyDay.status !== "accepted"
+    )
+      return;
+    const rosteredTeam = await fixture.catalog.createEventTeam(
+      event.value.eventId,
+      { name: "Rostered" },
+      authority,
+    );
+    const emptyTeam = await fixture.catalog.createEventTeam(
+      event.value.eventId,
+      { name: "Empty Team" },
+      authority,
+    );
+    if (rosteredTeam.status !== "accepted" || emptyTeam.status !== "accepted") return;
+    await fixture.catalog.upsertEventTeamRoster(
+      event.value.eventId,
+      rosteredTeam.value.eventTeamId,
+      { playerNumber: 1, publicName: "Player" },
+      authority,
+    );
+    expect(
+      await fixture.catalog.previewEventCatalogRemoval(
+        {
+          kind: "event-team",
+          eventId: event.value.eventId,
+          targetId: rosteredTeam.value.eventTeamId,
+        },
+        authority,
+      ),
+    ).toMatchObject({
+      status: "accepted",
+      value: { eligible: false, rejectionCategory: "referenced" },
+    });
+    expect(
+      await fixture.catalog.previewEventCatalogRemoval(
+        { kind: "event-team", eventId: event.value.eventId, targetId: emptyTeam.value.eventTeamId },
+        authority,
+      ),
+    ).toMatchObject({ status: "accepted", value: { eligible: true } });
+
+    const scheduledPitch = await fixture.catalog.createPitch(
+      event.value.eventId,
+      { name: "Scheduled Pitch" },
+      authority,
+    );
+    const sparePitch = await fixture.catalog.createPitch(
+      event.value.eventId,
+      { name: "Spare Pitch" },
+      authority,
+    );
+    if (scheduledPitch.status !== "accepted") return;
+    const scheduledSlot = await fixture.catalog.createGameplaySlot(
+      event.value.eventId,
+      scheduledDay.value.gameDayId,
+      { sequence: 1, scheduledStart: "2026-08-14T10:00" },
+      authority,
+    );
+    const slotOnlyEvent = await fixture.catalog.createEvent(
+      { name: "Gameplay-only removal Event", timeZone: "UTC" },
+      authority,
+    );
+    if (slotOnlyEvent.status !== "accepted") return;
+    const slotOnlyEventDay = await fixture.catalog.addGameDay(
+      slotOnlyEvent.value.eventId,
+      { date: "2026-08-16" },
+      authority,
+    );
+    if (slotOnlyEventDay.status !== "accepted") return;
+    const eligibleGameplaySlot = await fixture.catalog.createGameplaySlot(
+      slotOnlyEvent.value.eventId,
+      slotOnlyEventDay.value.gameDayId,
+      { sequence: 1, scheduledStart: "2026-08-16T10:00" },
+      authority,
+    );
+    if (
+      scheduledSlot.status !== "accepted" ||
+      eligibleGameplaySlot.status !== "accepted" ||
+      sparePitch.status !== "accepted"
+    )
+      return;
+    const pitchSlots = await fixture.storage.snapshot();
+    const scheduledPitchSlot = pitchSlots.listPitchSlots(
+      scheduledDay.value.gameDayId,
+      scheduledPitch.value.pitchId,
+    )[0];
+    const emptyPitchSlot = pitchSlots.listPitchSlots(
+      scheduledDay.value.gameDayId,
+      sparePitch.value.pitchId,
+    )[0];
+    if (scheduledPitchSlot === undefined || emptyPitchSlot === undefined) return;
+    const eventGame = await fixture.catalog.createEventGame(
+      event.value.eventId,
+      scheduledDay.value.gameDayId,
+      {
+        gameplaySlotId: scheduledSlot.value.gameplaySlotId,
+        pitchSlotId: scheduledPitchSlot.pitchSlotId,
+        sideA: { sourceLabel: "A" },
+        sideB: { sourceLabel: "B" },
+      },
+      authority,
+    );
+    if (eventGame.status !== "accepted") return;
+
+    const preview = async (
+      kind: "game-day" | "pitch" | "gameplay-slot" | "pitch-slot" | "event-game",
+      targetId: string,
+    ) =>
+      fixture.catalog.previewEventCatalogRemoval(
+        { kind, eventId: event.value.eventId, targetId },
+        authority,
+      );
+    expect(await preview("game-day", emptyDay.value.gameDayId)).toMatchObject({
+      status: "accepted",
+      value: { eligible: true },
+    });
+    expect(await preview("game-day", scheduledDay.value.gameDayId)).toMatchObject({
+      status: "accepted",
+      value: { eligible: false, rejectionCategory: "referenced" },
+    });
+    const pitchOnlyEvent = await fixture.catalog.createEvent(
+      { name: "Pitch-only removal Event", timeZone: "UTC" },
+      authority,
+    );
+    if (pitchOnlyEvent.status !== "accepted") return;
+    const emptyPitch = await fixture.catalog.createPitch(
+      pitchOnlyEvent.value.eventId,
+      { name: "Empty Pitch" },
+      authority,
+    );
+    if (emptyPitch.status !== "accepted") return;
+    expect(
+      await fixture.catalog.previewEventCatalogRemoval(
+        {
+          kind: "pitch",
+          eventId: pitchOnlyEvent.value.eventId,
+          targetId: emptyPitch.value.pitchId,
+        },
+        authority,
+      ),
+    ).toMatchObject({
+      status: "accepted",
+      value: { eligible: true },
+    });
+    expect(await preview("pitch", scheduledPitch.value.pitchId)).toMatchObject({
+      status: "accepted",
+      value: { eligible: false, rejectionCategory: "referenced" },
+    });
+    expect(
+      await fixture.catalog.previewEventCatalogRemoval(
+        {
+          kind: "gameplay-slot",
+          eventId: slotOnlyEvent.value.eventId,
+          targetId: eligibleGameplaySlot.value.gameplaySlotId,
+        },
+        authority,
+      ),
+    ).toMatchObject({ status: "accepted", value: { eligible: true } });
+    expect(await preview("gameplay-slot", scheduledSlot.value.gameplaySlotId)).toMatchObject({
+      status: "accepted",
+      value: { eligible: false, rejectionCategory: "referenced" },
+    });
+    expect(await preview("pitch-slot", emptyPitchSlot.pitchSlotId)).toMatchObject({
+      status: "accepted",
+      value: { eligible: true },
+    });
+    expect(await preview("pitch-slot", scheduledPitchSlot.pitchSlotId)).toMatchObject({
+      status: "accepted",
+      value: { eligible: false, rejectionCategory: "referenced" },
+    });
+    expect(await preview("event-game", eventGame.value.eventGameId)).toMatchObject({
+      status: "accepted",
+      value: {
+        eligible: true,
+        impact: { retainedEventGameCount: 0, retainedControlActionCount: 0 },
+      },
+    });
+  });
+
+  test("fails closed for commenced and accepted-action Event Game roots", async () => {
+    const foundation = createInMemoryFoundationStorage();
+    const catalog = createEventCatalog(createFoundationEventCatalogStorage(foundation), {
+      clock: { nowMs: () => Date.UTC(2026, 7, 14, 12) },
+    });
+    const event = await catalog.createEvent(
+      { name: "Lifecycle removal", timeZone: "UTC" },
+      authority,
+    );
+    if (event.status !== "accepted") return;
+    const day = await catalog.addGameDay(event.value.eventId, { date: "2026-08-14" }, authority);
+    const pitchA = await catalog.createPitch(event.value.eventId, { name: "A" }, authority);
+    const pitchB = await catalog.createPitch(event.value.eventId, { name: "B" }, authority);
+    if (day.status !== "accepted" || pitchA.status !== "accepted" || pitchB.status !== "accepted")
+      return;
+    const slot = await catalog.createGameplaySlot(
+      event.value.eventId,
+      day.value.gameDayId,
+      { sequence: 1, scheduledStart: "2026-08-14T10:00" },
+      authority,
+    );
+    if (slot.status !== "accepted") return;
+    const pitchSlots = await foundation.transaction((transaction) => ({
+      a: transaction.listPitchSlots(day.value.gameDayId, pitchA.value.pitchId)[0],
+      b: transaction.listPitchSlots(day.value.gameDayId, pitchB.value.pitchId)[0],
+    }));
+    if (pitchSlots.a === undefined || pitchSlots.b === undefined) return;
+    const commencedGame = await catalog.createEventGame(
+      event.value.eventId,
+      day.value.gameDayId,
+      {
+        gameplaySlotId: slot.value.gameplaySlotId,
+        pitchSlotId: pitchSlots.a.pitchSlotId,
+        sideA: { sourceLabel: "A" },
+        sideB: { sourceLabel: "B" },
+      },
+      authority,
+    );
+    const actionGame = await catalog.createEventGame(
+      event.value.eventId,
+      day.value.gameDayId,
+      {
+        gameplaySlotId: slot.value.gameplaySlotId,
+        pitchSlotId: pitchSlots.b.pitchSlotId,
+        sideA: { sourceLabel: "C" },
+        sideB: { sourceLabel: "D" },
+      },
+      authority,
+    );
+    if (commencedGame.status !== "accepted" || actionGame.status !== "accepted") return;
+    await foundation.transaction((transaction) => {
+      for (const [recordId, eventGameId, pitchId, pitchSlotId, commencedAtMs] of [
+        [
+          "commenced-record",
+          commencedGame.value.eventGameId,
+          pitchA.value.pitchId,
+          pitchSlots.a!.pitchSlotId,
+          1_500,
+        ],
+        [
+          "action-record",
+          actionGame.value.eventGameId,
+          pitchB.value.pitchId,
+          pitchSlots.b!.pitchSlotId,
+          null,
+        ],
+      ] as const) {
+        const root = {
+          recordId,
+          eventId: event.value.eventId,
+          eventGameId,
+          ownership: { eventId: event.value.eventId, eventGameId },
+          externalScope: {
+            eventId: event.value.eventId,
+            gameDayId: day.value.gameDayId,
+            pitchId,
+            pitchSlotId,
+          },
+          gameSides: [],
+          lifecycle: {
+            phase: commencedAtMs === null ? "scheduled" : "in-progress",
+            commencedAtMs,
+            finishedAtMs: null,
+            lockedAtMs: null,
+            lockReason: null,
+          },
+          compatibility: { recordVersion: "v1", schemaVersion: "v1", interpreterVersion: "v1" },
+          creationEvidence: {
+            operationId: `operation-${recordId}`,
+            actorReference: "test",
+            source: "event-game-registration",
+            createdAtMs: 1_000,
+          },
+        } as never;
+        transaction.insertRoot({ root, canonicalContent: "{}" });
+        if (commencedAtMs === null)
+          transaction.insertAction({
+            action: { recordId, eventGameId, operationId: "accepted" } as never,
+            canonicalContent: "{}",
+            contentFingerprint: "accepted-action",
+          });
+      }
+    });
+    expect(
+      await catalog.previewEventCatalogRemoval(
+        {
+          kind: "event-game",
+          eventId: event.value.eventId,
+          targetId: commencedGame.value.eventGameId,
+        },
+        authority,
+      ),
+    ).toMatchObject({
+      status: "accepted",
+      value: { eligible: false, rejectionCategory: "commenced" },
+    });
+    expect(
+      await catalog.previewEventCatalogRemoval(
+        {
+          kind: "event-game",
+          eventId: event.value.eventId,
+          targetId: actionGame.value.eventGameId,
+        },
+        authority,
+      ),
+    ).toMatchObject({
+      status: "accepted",
+      value: {
+        eligible: false,
+        rejectionCategory: "accepted-control-action",
+        impact: { retainedEventGameCount: 1, retainedControlActionCount: 1 },
+      },
+    });
+    foundation.close();
+  });
+
   test("creates a blank Unpublished Event and classifies Game Days in the Event timezone", async () => {
     const fixture = createFixture();
     const created = await fixture.catalog.createEvent(
@@ -524,37 +897,6 @@ describe("Event operations catalog", () => {
     if (after.status !== "accepted") return;
     expect(after.value.gameDays).toHaveLength(0);
     expect(after.value.auditTrail).toHaveLength(1);
-  });
-
-  test("removes only an empty Event and retains audit evidence", async () => {
-    const fixture = createFixture();
-    const created = await fixture.catalog.createEvent(
-      { name: "Remove me", timeZone: "UTC" },
-      authority,
-    );
-    if (created.status !== "accepted") throw new Error("Expected Event creation.");
-    const day = await fixture.catalog.addGameDay(
-      created.value.eventId,
-      { date: "2026-08-14" },
-      authority,
-    );
-    if (day.status !== "accepted") throw new Error("Expected Game Day.");
-    expect(await fixture.catalog.removeEvent(created.value.eventId, authority)).toMatchObject({
-      status: "rejected",
-      reason: "in-use",
-    });
-    expect(
-      await fixture.catalog.removeGameDay(created.value.eventId, day.value.gameDayId, authority),
-    ).toMatchObject({
-      status: "accepted",
-    });
-    expect(await fixture.catalog.removeEvent(created.value.eventId, authority)).toMatchObject({
-      status: "accepted",
-    });
-    expect(await fixture.catalog.inspectEvent(created.value.eventId, authority)).toMatchObject({
-      status: "rejected",
-      reason: "not-found",
-    });
   });
 
   test("configures stable Teams, current public rosters, and Pitches atomically", async () => {

--- a/src/lib/event-catalog.ts
+++ b/src/lib/event-catalog.ts
@@ -32,9 +32,11 @@ import type {
   StoredPitchSlot,
   StoredEventCatalogGame,
   StoredEventGameSide,
+  StoredControlAction,
 } from "@/lib/foundation-storage";
 import type { EventGameRecordRoot } from "@/lib/foundation-record-types";
 import { createInMemoryFoundationStorage } from "@/lib/foundation-storage-memory";
+import { canonicalizeJson, sha256 } from "@/lib/event-game-action-json";
 
 export type EventPublicationStatus = "unpublished" | "published" | "cancelled";
 export type EventPublicationWarning =
@@ -151,6 +153,56 @@ export type CatalogRejectedReason =
   | "no-change"
   | "in-use";
 
+export type EventCatalogRemovalKind =
+  | "event"
+  | "event-team"
+  | "game-day"
+  | "pitch"
+  | "gameplay-slot"
+  | "pitch-slot"
+  | "event-game";
+
+export type EventCatalogRemovalTargetInput = {
+  kind: unknown;
+  eventId: unknown;
+  targetId: unknown;
+};
+
+export type EventCatalogRemovalTarget = {
+  kind: EventCatalogRemovalKind;
+  eventId: string;
+  targetId: string;
+};
+
+export type EventCatalogRemovalImpact = {
+  descendantCount: number;
+  retiredAuthorityCount: number;
+  retiredAuthorityCategories: {
+    eventAdmin: number;
+    pitchManager: number;
+    control: number;
+  };
+  retainedEventGameCount: number;
+  retainedControlActionCount: number;
+};
+
+export type EventCatalogRemovalPreview = {
+  target: EventCatalogRemovalTarget;
+  eligible: boolean;
+  rejectionCategory: "referenced" | "commenced" | "accepted-control-action" | null;
+  repairWorkflow: string | null;
+  impact: EventCatalogRemovalImpact;
+  fingerprint: string;
+};
+
+export type EventCatalogRemovalResult = {
+  removed: true;
+  target: EventCatalogRemovalTarget;
+  retiredAuthorityCount: number;
+  retainedEventGameCount: number;
+  retainedControlActionCount: number;
+};
+
 export type CatalogOutcome<T> =
   | { status: "accepted"; value: T }
   | { status: "rejected"; reason: CatalogRejectedReason; detail: string }
@@ -180,6 +232,14 @@ export type EventCatalogOptions = {
 };
 
 export type EventCatalogMutationOperations = {
+  previewEventCatalogRemoval(
+    target: EventCatalogRemovalTargetInput,
+  ): CatalogOutcome<EventCatalogRemovalPreview>;
+  removeEventCatalogEntry(
+    target: EventCatalogRemovalTargetInput,
+    previewFingerprint: unknown,
+    retiredAuthorityCount: number,
+  ): CatalogOutcome<EventCatalogRemovalResult>;
   changePublicationStatus(
     eventId: unknown,
     input: { status: unknown; impactConfirmed?: unknown },
@@ -308,11 +368,11 @@ export type EventCatalogStorageSnapshot = {
   findEventGame(eventGameId: string): EventGame | null;
   listEventGames(gameDayId: string): EventGame[];
   findRootByEventGameId(eventGameId: string): EventGameRecordRoot | null;
+  listActions(recordId: string): StoredControlAction[];
   listAuditTrail(eventId: string): EventAdministrationAuditEntry[];
 };
 
 export type EventCatalogStorageTransaction = EventCatalogStorageSnapshot & {
-  hasAttachedEventAdminGrant(eventId: string): boolean;
   insertEvent(event: StoredEvent): void;
   updateEvent(event: StoredEvent): void;
   deleteEvent(eventId: string): void;
@@ -321,16 +381,21 @@ export type EventCatalogStorageTransaction = EventCatalogStorageSnapshot & {
   deleteGameDay(gameDayId: string): void;
   insertEventTeam(team: StoredEventTeam): void;
   updateEventTeam(team: StoredEventTeam): void;
+  deleteEventTeam(eventTeamId: string): void;
   insertRosterEntry(entry: StoredRosterEntry): void;
   updateRosterEntry(entry: StoredRosterEntry): void;
   insertPitch(pitch: StoredPitch): void;
   updatePitch(pitch: StoredPitch): void;
+  deletePitch(pitchId: string): void;
   insertGameplaySlot(slot: GameplaySlot): void;
   insertPitchSlot(slot: PitchSlot): void;
   updateGameplaySlot(slot: GameplaySlot): void;
   updatePitchSlot(slot: PitchSlot): void;
+  deleteGameplaySlot(gameplaySlotId: string): void;
+  deletePitchSlot(pitchSlotId: string): void;
   insertEventGame(game: EventGame): void;
   updateEventGame(game: EventGame): void;
+  deleteEventGame(eventGameId: string): void;
   appendAudit(entry: EventAdministrationAuditEntry): void;
 };
 
@@ -485,15 +550,10 @@ export type EventCatalog = {
     actorReference: string,
     work: (operations: EventCatalogMutationOperations) => CatalogOutcome<T>,
   ): CatalogOutcome<T>;
-  removeGameDay(
-    eventId: unknown,
-    gameDayId: unknown,
+  previewEventCatalogRemoval(
+    target: EventCatalogRemovalTargetInput,
     authority: TechnicalAdminAuthority,
-  ): Promise<CatalogOutcome<{ gameDayId: string }>>;
-  removeEvent(
-    eventId: unknown,
-    authority: TechnicalAdminAuthority,
-  ): Promise<CatalogOutcome<{ eventId: string }>>;
+  ): Promise<CatalogOutcome<EventCatalogRemovalPreview>>;
   listAuditTrail(
     eventId: unknown,
     authority: TechnicalAdminAuthority,
@@ -999,85 +1059,14 @@ export function createEventCatalog(
       );
     },
 
-    async removeGameDay(eventIdInput, gameDayIdInput, authority) {
+    async previewEventCatalogRemoval(target, authority) {
       if (!isTechnicalAdminAuthority(authority)) return unauthorized();
-      const actor = authorityActor(authority);
-      const eventId = validateId(eventIdInput, "eventId");
-      if (!eventId.ok) return invalid(eventId.error);
-      const gameDayId = validateId(gameDayIdInput, "gameDayId");
-      if (!gameDayId.ok) return invalid(gameDayId.error);
-      const nowMs = validNow(clock);
-      if (nowMs === null) return invalid("Event clock returned an invalid timestamp.");
-      return commit(storage, (transaction) => {
-        const event = transaction.findEvent(eventId.value);
-        if (event === null) return notFound("Event was not found.");
-        const gameDay = transaction
-          .listGameDays(event.eventId)
-          .find((day) => day.gameDayId === gameDayId.value);
-        if (gameDay === undefined) {
-          const elsewhere = transaction
-            .listEvents()
-            .some((candidate) =>
-              transaction
-                .listGameDays(candidate.eventId)
-                .some((day) => day.gameDayId === gameDayId.value),
-            );
-          return elsewhere
-            ? crossEvent("Game Day belongs to another Event.")
-            : notFound("Game Day was not found.");
-        }
-        const audit = createAudit(
-          ids,
-          "game-day-removed",
-          event.eventId,
-          gameDay.gameDayId,
-          actor,
-          nowMs,
-          gameDay,
-          null,
-        );
-        transaction.deleteGameDay(gameDay.gameDayId);
-        transaction.appendAudit(audit);
-        return accepted({ gameDayId: gameDay.gameDayId });
-      });
-    },
-
-    async removeEvent(eventIdInput, authority) {
-      if (!isTechnicalAdminAuthority(authority)) return unauthorized();
-      const actor = authorityActor(authority);
-      const eventId = validateId(eventIdInput, "eventId");
-      if (!eventId.ok) return invalid(eventId.error);
-      const nowMs = validNow(clock);
-      if (nowMs === null) return invalid("Event clock returned an invalid timestamp.");
-      return commit(storage, (transaction) => {
-        const event = transaction.findEvent(eventId.value);
-        if (event === null) return notFound("Event was not found.");
-        if (transaction.listGameDays(event.eventId).length > 0) {
-          return inUse("Event still contains Game Days.");
-        }
-        if (
-          transaction.listEventTeams(event.eventId).length > 0 ||
-          transaction.listPitches(event.eventId).length > 0
-        ) {
-          return inUse("Event still contains Teams or Pitches.");
-        }
-        if (transaction.hasAttachedEventAdminGrant(event.eventId)) {
-          return inUse("Event has an attached Event Admin Grant.");
-        }
-        const audit = createAudit(
-          ids,
-          "event-removed",
-          event.eventId,
-          null,
-          actor,
-          nowMs,
-          event,
-          null,
-        );
-        transaction.deleteEvent(event.eventId);
-        transaction.appendAudit(audit);
-        return accepted({ eventId: event.eventId });
-      });
+      try {
+        const snapshot = await storage.snapshot();
+        return previewEventCatalogRemovalOperation(snapshot, target);
+      } catch {
+        return unavailable();
+      }
     },
 
     async listAuditTrail(eventIdInput, authority) {
@@ -1387,6 +1376,18 @@ function createMutationOperations(
   actorReference: string,
 ): EventCatalogMutationOperations {
   return {
+    previewEventCatalogRemoval: (target) =>
+      previewEventCatalogRemovalOperation(transaction, target),
+    removeEventCatalogEntry: (target, previewFingerprint, retiredAuthorityCount) =>
+      removeEventCatalogEntryOperation(
+        transaction,
+        clock,
+        ids,
+        actorReference,
+        target,
+        previewFingerprint,
+        retiredAuthorityCount,
+      ),
     changePublicationStatus: (eventId, input) =>
       changePublicationStatusOperation(transaction, clock, ids, eventId, input, actorReference),
     createEventTeam: (eventId, input) =>
@@ -1474,6 +1475,302 @@ function createMutationOperations(
         actorReference,
       ),
   };
+}
+
+function previewEventCatalogRemovalOperation(
+  transaction: EventCatalogStorageSnapshot,
+  input: EventCatalogRemovalTargetInput,
+): CatalogOutcome<EventCatalogRemovalPreview> {
+  const target = parseRemovalTarget(input);
+  if (!target.ok) return invalid(target.error);
+  const event = transaction.findEvent(target.value.eventId);
+  if (event === null) return notFound("Event Catalog removal target was not found.");
+  const targetRecord = readRemovalTarget(transaction, target.value);
+  if (targetRecord === null) return notFound("Event Catalog removal target was not found.");
+
+  let eligible = true;
+  let rejectionCategory: EventCatalogRemovalPreview["rejectionCategory"] = null;
+  let repairWorkflow: string | null = null;
+  let descendantCount = 0;
+  let retainedEventGameCount = 0;
+  let retainedControlActionCount = 0;
+
+  if (target.value.kind === "event") {
+    descendantCount =
+      transaction.listGameDays(event.eventId).length +
+      transaction.listEventTeams(event.eventId).length +
+      transaction.listPitches(event.eventId).length;
+    for (const day of transaction.listGameDays(event.eventId)) {
+      descendantCount +=
+        transaction.listGameplaySlots(day.gameDayId).length +
+        transaction.listPitchSlots(day.gameDayId).length +
+        transaction.listEventGames(day.gameDayId).length;
+    }
+    if (descendantCount > 0) {
+      eligible = false;
+      rejectionCategory = "referenced";
+      repairWorkflow = "Remove or repair the remaining Event Catalog structure first.";
+    }
+  } else if (target.value.kind === "event-team") {
+    const team = transaction.findEventTeam(target.value.targetId);
+    if (team === null || team.eventId !== event.eventId)
+      return notFound("Event Catalog removal target was not found.");
+    descendantCount = transaction.listRoster(team.eventTeamId).length;
+    const referenced = transaction
+      .listGameDays(event.eventId)
+      .flatMap((day) => transaction.listEventGames(day.gameDayId))
+      .some(
+        (game) =>
+          game.sideA.eventTeamId === team.eventTeamId ||
+          game.sideB.eventTeamId === team.eventTeamId,
+      );
+    if (descendantCount > 0 || referenced) {
+      eligible = false;
+      rejectionCategory = "referenced";
+      repairWorkflow =
+        descendantCount > 0
+          ? "Remove the Event Team roster entries before removing the Event Team."
+          : "Use Event Team Assignment Correction or the ordinary schedule repair workflow.";
+    }
+  } else if (target.value.kind === "game-day") {
+    const day = transaction
+      .listGameDays(event.eventId)
+      .find((candidate) => candidate.gameDayId === target.value.targetId);
+    if (day === undefined) return notFound("Event Catalog removal target was not found.");
+    const childCount =
+      transaction.listGameplaySlots(day.gameDayId).length +
+      transaction.listPitchSlots(day.gameDayId).length +
+      transaction.listEventGames(day.gameDayId).length;
+    descendantCount = childCount;
+    if (childCount > 0) {
+      eligible = false;
+      rejectionCategory = "referenced";
+      repairWorkflow = "Repair or remove the Game Day's schedule structure first.";
+    }
+  } else if (target.value.kind === "pitch") {
+    const pitch = transaction.findPitch(target.value.targetId);
+    if (pitch === null || pitch.eventId !== event.eventId)
+      return notFound("Event Catalog removal target was not found.");
+    const slots = transaction
+      .listGameDays(event.eventId)
+      .flatMap((day) => transaction.listPitchSlots(day.gameDayId, pitch.pitchId));
+    descendantCount = slots.length;
+    if (slots.length > 0) {
+      eligible = false;
+      rejectionCategory = "referenced";
+      repairWorkflow = "Repair or remove the Pitch Schedule structure first.";
+    }
+  } else if (target.value.kind === "gameplay-slot") {
+    const slot = transaction.findGameplaySlot(target.value.targetId);
+    if (slot === null || slot.eventId !== event.eventId)
+      return notFound("Event Catalog removal target was not found.");
+    const pitchSlots = transaction
+      .listPitchSlots(slot.gameDayId)
+      .filter((pitchSlot) => pitchSlot.gameplaySlotId === slot.gameplaySlotId);
+    const games = transaction
+      .listEventGames(slot.gameDayId)
+      .filter((game) => game.gameplaySlotId === slot.gameplaySlotId);
+    descendantCount = pitchSlots.length + games.length;
+    if (descendantCount > 0) {
+      eligible = false;
+      rejectionCategory = "referenced";
+      repairWorkflow = "Repair or remove the Gameplay Slot's schedule structure first.";
+    }
+  } else if (target.value.kind === "pitch-slot") {
+    const slot = transaction.findPitchSlot(target.value.targetId);
+    if (slot === null || slot.eventId !== event.eventId)
+      return notFound("Event Catalog removal target was not found.");
+    const games = transaction
+      .listEventGames(slot.gameDayId)
+      .filter((game) => game.pitchSlotId === slot.pitchSlotId);
+    descendantCount = games.length;
+    if (games.length > 0) {
+      eligible = false;
+      rejectionCategory = "referenced";
+      repairWorkflow = "Use Pitch Reassignment or the ordinary Event Game repair workflow.";
+    }
+  } else {
+    const game = transaction.findEventGame(target.value.targetId);
+    if (game === null || game.eventId !== event.eventId)
+      return notFound("Event Catalog removal target was not found.");
+    const root = transaction.findRootByEventGameId(game.eventGameId);
+    retainedEventGameCount = root === null ? 0 : 1;
+    retainedControlActionCount = root === null ? 0 : transaction.listActions(root.recordId).length;
+    if (root?.lifecycle.commencedAtMs !== null && root !== null) {
+      eligible = false;
+      rejectionCategory = "commenced";
+      repairWorkflow = "Use the ordinary Event Game correction or reopening workflow.";
+    } else if (retainedControlActionCount > 0) {
+      eligible = false;
+      rejectionCategory = "accepted-control-action";
+      repairWorkflow =
+        "Use the ordinary Event Game correction workflow; accepted Control Actions remain durable.";
+    }
+  }
+
+  return accepted({
+    target: target.value,
+    eligible,
+    rejectionCategory,
+    repairWorkflow,
+    impact: {
+      descendantCount,
+      retiredAuthorityCount: 0,
+      retiredAuthorityCategories: { eventAdmin: 0, pitchManager: 0, control: 0 },
+      retainedEventGameCount,
+      retainedControlActionCount,
+    },
+    fingerprint: removalFingerprint(
+      target.value,
+      {
+        descendantCount,
+        retainedEventGameCount,
+        retainedControlActionCount,
+      },
+      targetRecord,
+    ),
+  });
+}
+
+function removeEventCatalogEntryOperation(
+  transaction: EventCatalogStorageTransaction,
+  clock: EventCatalogClock,
+  ids: EventCatalogIds,
+  actorReference: string,
+  input: EventCatalogRemovalTargetInput,
+  previewFingerprint: unknown,
+  retiredAuthorityCount: number,
+): CatalogOutcome<EventCatalogRemovalResult> {
+  if (typeof previewFingerprint !== "string")
+    return invalid("Event Catalog removal preview is required.");
+  const preview = previewEventCatalogRemovalOperation(transaction, input);
+  if (preview.status !== "accepted") return preview;
+  if (preview.value.fingerprint !== previewFingerprint)
+    return invalid("Event Catalog removal preview is stale.");
+  if (!preview.value.eligible)
+    return inUse(preview.value.repairWorkflow ?? "Event Catalog removal is not eligible.");
+  if (!Number.isSafeInteger(retiredAuthorityCount) || retiredAuthorityCount < 0)
+    return invalid("Event Catalog authority impact is invalid.");
+  const nowMs = validNow(clock);
+  if (nowMs === null) return invalid("Event clock returned an invalid timestamp.");
+  const target = preview.value.target;
+  const before = readRemovalTarget(transaction, target);
+  if (before === null) return notFound("Event Catalog removal target was not found.");
+  switch (target.kind) {
+    case "event":
+      transaction.deleteEvent(target.eventId);
+      break;
+    case "event-team":
+      transaction.deleteEventTeam(target.targetId);
+      break;
+    case "game-day":
+      transaction.deleteGameDay(target.targetId);
+      break;
+    case "pitch":
+      transaction.deletePitch(target.targetId);
+      break;
+    case "gameplay-slot":
+      transaction.deleteGameplaySlot(target.targetId);
+      break;
+    case "pitch-slot":
+      transaction.deletePitchSlot(target.targetId);
+      break;
+    case "event-game":
+      transaction.deleteEventGame(target.targetId);
+      break;
+  }
+  transaction.appendAudit(
+    createAudit(
+      ids,
+      "event-catalog-entry-removed",
+      target.eventId,
+      target.kind === "game-day" ? target.targetId : null,
+      actorReference,
+      nowMs,
+      removalAuditPayload(target),
+      null,
+    ),
+  );
+  return accepted({
+    removed: true,
+    target,
+    retiredAuthorityCount,
+    retainedEventGameCount: preview.value.impact.retainedEventGameCount,
+    retainedControlActionCount: preview.value.impact.retainedControlActionCount,
+  });
+}
+
+function removalAuditPayload(target: EventCatalogRemovalTarget): {
+  kind: EventCatalogRemovalKind;
+  eventId: string;
+  targetId: string;
+} {
+  return {
+    kind: target.kind,
+    eventId: target.eventId,
+    targetId: target.targetId,
+  };
+}
+
+function parseRemovalTarget(
+  input: EventCatalogRemovalTargetInput,
+): { ok: true; value: EventCatalogRemovalTarget } | { ok: false; error: string } {
+  if (!isRecord(input)) return { ok: false, error: "Event Catalog removal target is invalid." };
+  const kinds: readonly EventCatalogRemovalKind[] = [
+    "event",
+    "event-team",
+    "game-day",
+    "pitch",
+    "gameplay-slot",
+    "pitch-slot",
+    "event-game",
+  ];
+  if (!kinds.includes(input.kind as EventCatalogRemovalKind))
+    return { ok: false, error: "Event Catalog removal target is invalid." };
+  const eventId = validateId(input.eventId, "eventId");
+  const targetId = validateId(input.targetId, "targetId");
+  if (!eventId.ok || !targetId.ok)
+    return { ok: false, error: "Event Catalog removal target is invalid." };
+  if (input.kind === "event" && eventId.value !== targetId.value)
+    return { ok: false, error: "Event Catalog removal target is invalid." };
+  return {
+    ok: true,
+    value: {
+      kind: input.kind as EventCatalogRemovalKind,
+      eventId: eventId.value,
+      targetId: targetId.value,
+    },
+  };
+}
+
+function readRemovalTarget(
+  transaction: EventCatalogStorageSnapshot,
+  target: EventCatalogRemovalTarget,
+): unknown {
+  if (target.kind === "event") return transaction.findEvent(target.eventId);
+  if (target.kind === "event-team") return transaction.findEventTeam(target.targetId);
+  if (target.kind === "game-day")
+    return (
+      transaction.listGameDays(target.eventId).find((day) => day.gameDayId === target.targetId) ??
+      null
+    );
+  if (target.kind === "pitch") return transaction.findPitch(target.targetId);
+  if (target.kind === "gameplay-slot") return transaction.findGameplaySlot(target.targetId);
+  if (target.kind === "pitch-slot") return transaction.findPitchSlot(target.targetId);
+  return transaction.findEventGame(target.targetId);
+}
+
+function removalFingerprint(
+  target: EventCatalogRemovalTarget,
+  impact: Pick<
+    EventCatalogRemovalImpact,
+    "descendantCount" | "retainedEventGameCount" | "retainedControlActionCount"
+  >,
+  targetRecord: unknown,
+): string {
+  return `event-catalog-target-v1:${sha256(
+    canonicalizeJson({ version: 1, target, targetRecord, ...impact }),
+  )}`;
 }
 
 function changePublicationStatusOperation(
@@ -2864,6 +3161,7 @@ function eventCatalogSnapshot(transaction: FoundationStorageSnapshot): EventCata
     findEventGame: (eventGameId) => transaction.findEventGame?.(eventGameId) ?? null,
     listEventGames: (gameDayId) => transaction.listEventGames?.(gameDayId) ?? [],
     findRootByEventGameId: (eventGameId) => transaction.findRootByEventGameId(eventGameId),
+    listActions: (recordId) => transaction.listActions(recordId),
     listAuditTrail: (eventId) => transaction.listEventAuditTrail(eventId),
   };
 }
@@ -2873,10 +3171,6 @@ function eventCatalogTransaction(
 ): EventCatalogStorageTransaction {
   return {
     ...eventCatalogSnapshot(transaction),
-    hasAttachedEventAdminGrant: (eventId) =>
-      transaction
-        .listGrants()
-        .some((grant) => grant.grantType === "event-admin" && grant.scope.eventId === eventId),
     insertEvent: (event) => transaction.insertEvent(event),
     updateEvent: (event) => transaction.updateEvent(event),
     deleteEvent: (eventId) => transaction.deleteEvent(eventId),
@@ -2885,16 +3179,21 @@ function eventCatalogTransaction(
     deleteGameDay: (gameDayId) => transaction.deleteGameDay(gameDayId),
     insertEventTeam: (team) => transaction.insertEventTeam(team),
     updateEventTeam: (team) => transaction.updateEventTeam(team),
+    deleteEventTeam: (eventTeamId) => transaction.deleteEventTeam(eventTeamId),
     insertRosterEntry: (entry) => transaction.insertRosterEntry(entry),
     updateRosterEntry: (entry) => transaction.updateRosterEntry(entry),
     insertPitch: (pitch) => transaction.insertPitch(pitch),
     updatePitch: (pitch) => transaction.updatePitch(pitch),
+    deletePitch: (pitchId) => transaction.deletePitch(pitchId),
     insertGameplaySlot: (slot) => transaction.insertGameplaySlot(slot),
     insertPitchSlot: (slot) => transaction.insertPitchSlot(slot),
     updateGameplaySlot: (slot) => transaction.updateGameplaySlot(slot),
     updatePitchSlot: (slot) => transaction.updatePitchSlot(slot),
+    deleteGameplaySlot: (gameplaySlotId) => transaction.deleteGameplaySlot(gameplaySlotId),
+    deletePitchSlot: (pitchSlotId) => transaction.deletePitchSlot(pitchSlotId),
     insertEventGame: (game) => transaction.insertEventGame(game),
     updateEventGame: (game) => transaction.updateEventGame(game),
+    deleteEventGame: (eventGameId) => transaction.deleteEventGame(eventGameId),
     appendAudit: (entry) => transaction.appendEventAudit(entry),
   };
 }

--- a/src/lib/foundation-grant-erasure-migration.test.ts
+++ b/src/lib/foundation-grant-erasure-migration.test.ts
@@ -210,7 +210,7 @@ describe("Grant cryptographic erasure migration", () => {
 
       const current = openSqliteFoundationStorage(databasePath);
       await current.applyMigrations({ requireCandidate: false });
-      expect(await current.readiness()).toMatchObject({ ok: true, schemaVersion: "28" });
+      expect(await current.readiness()).toMatchObject({ ok: true, schemaVersion: "29" });
       current.close();
 
       const raw = new Database(databasePath);
@@ -330,7 +330,7 @@ describe("Grant cryptographic erasure migration", () => {
       raw.close();
 
       const reopened = openSqliteFoundationStorage(databasePath);
-      expect(await reopened.readiness()).toMatchObject({ ok: true, schemaVersion: "28" });
+      expect(await reopened.readiness()).toMatchObject({ ok: true, schemaVersion: "29" });
       const restartedAudit = await reopened.transaction((transaction) =>
         transaction.listGrantAudit("grant-expired"),
       );

--- a/src/lib/foundation-grant-erasure-migration.test.ts
+++ b/src/lib/foundation-grant-erasure-migration.test.ts
@@ -210,7 +210,7 @@ describe("Grant cryptographic erasure migration", () => {
 
       const current = openSqliteFoundationStorage(databasePath);
       await current.applyMigrations({ requireCandidate: false });
-      expect(await current.readiness()).toMatchObject({ ok: true, schemaVersion: "27" });
+      expect(await current.readiness()).toMatchObject({ ok: true, schemaVersion: "28" });
       current.close();
 
       const raw = new Database(databasePath);
@@ -330,7 +330,7 @@ describe("Grant cryptographic erasure migration", () => {
       raw.close();
 
       const reopened = openSqliteFoundationStorage(databasePath);
-      expect(await reopened.readiness()).toMatchObject({ ok: true, schemaVersion: "27" });
+      expect(await reopened.readiness()).toMatchObject({ ok: true, schemaVersion: "28" });
       const restartedAudit = await reopened.transaction((transaction) =>
         transaction.listGrantAudit("grant-expired"),
       );

--- a/src/lib/foundation-migrations.test.ts
+++ b/src/lib/foundation-migrations.test.ts
@@ -13,7 +13,7 @@ const migrations: readonly FoundationMigration[] = [
 ];
 
 describe("foundation migration ledger compatibility", () => {
-  test("keeps accepted migrations 001 through 027 byte-for-byte immutable and pins 028", () => {
+  test("keeps accepted migrations 001 through 028 byte-for-byte immutable and pins 029", () => {
     expect(FOUNDATION_MIGRATIONS.map(({ id, checksum }) => ({ id, checksum }))).toEqual([
       {
         id: "001-foundation-event-game-record-roots",
@@ -126,6 +126,10 @@ describe("foundation migration ledger compatibility", () => {
       {
         id: "028-event-catalog-removal-audit",
         checksum: "d5696e62b55e8ac83f9c73168508e5f748e68d0eeddd3eeef2cdea0a43f1fcea",
+      },
+      {
+        id: "029-access-sheet-generated-audit-action",
+        checksum: "80641922b9ab363831d290aec229b44d3477e02e828eddebdfdbf12064a76c3f",
       },
     ]);
   });

--- a/src/lib/foundation-migrations.test.ts
+++ b/src/lib/foundation-migrations.test.ts
@@ -13,7 +13,7 @@ const migrations: readonly FoundationMigration[] = [
 ];
 
 describe("foundation migration ledger compatibility", () => {
-  test("keeps accepted migrations 001 through 026 byte-for-byte immutable and pins 027", () => {
+  test("keeps accepted migrations 001 through 027 byte-for-byte immutable and pins 028", () => {
     expect(FOUNDATION_MIGRATIONS.map(({ id, checksum }) => ({ id, checksum }))).toEqual([
       {
         id: "001-foundation-event-game-record-roots",
@@ -122,6 +122,10 @@ describe("foundation migration ledger compatibility", () => {
       {
         id: "027-event-game-presentation-integrity",
         checksum: "d2d8b6d5000903573b5b143e5cbec0e05b3c672dc680e9c3058cd02d0a916d43",
+      },
+      {
+        id: "028-event-catalog-removal-audit",
+        checksum: "d5696e62b55e8ac83f9c73168508e5f748e68d0eeddd3eeef2cdea0a43f1fcea",
       },
     ]);
   });

--- a/src/lib/foundation-migrations.ts
+++ b/src/lib/foundation-migrations.ts
@@ -1974,6 +1974,28 @@ export const FOUNDATION_EVENT_CATALOG_REMOVAL_MIGRATION_SQL = `
   ${FOUNDATION_EVENT_CATALOG_AUDIT_EVENT_INDEX_SQL};
 `;
 
+/** Schema-29 adds the redacted Event Administration Access Sheet audit action. */
+export const FOUNDATION_ACCESS_SHEET_AUDIT_MIGRATION_SQL = `
+  CREATE TABLE foundation_event_catalog_audit_v29 AS SELECT * FROM foundation_event_catalog_audit;
+  DROP TABLE foundation_event_catalog_audit;
+  ${FOUNDATION_EVENT_CATALOG_AUDIT_TABLE_V3_SQL.replace(
+    "CREATE TABLE foundation_event_catalog_audit",
+    "CREATE TABLE foundation_event_catalog_audit_rebuilt",
+  ).replace(
+    "'event-game-teams-confirmed'",
+    "'event-game-teams-confirmed', 'event-publication-changed', 'event-catalog-entry-removed', 'access-sheet-generated'",
+  )};
+  INSERT INTO foundation_event_catalog_audit_rebuilt
+    (audit_id, operation_id, action, event_id, game_day_id, actor_reference,
+     occurred_at_ms, before_json, after_json)
+  SELECT audit_id, operation_id, action, event_id, game_day_id, actor_reference,
+         occurred_at_ms, before_json, after_json
+  FROM foundation_event_catalog_audit_v29;
+  DROP TABLE foundation_event_catalog_audit_v29;
+  ALTER TABLE foundation_event_catalog_audit_rebuilt RENAME TO foundation_event_catalog_audit;
+  ${FOUNDATION_EVENT_CATALOG_AUDIT_EVENT_INDEX_SQL};
+`;
+
 export const FOUNDATION_MIGRATIONS: readonly FoundationMigration[] = Object.freeze([
   createMigration({
     id: "001-foundation-event-game-record-roots",
@@ -2142,6 +2164,12 @@ export const FOUNDATION_MIGRATIONS: readonly FoundationMigration[] = Object.free
     ordinal: 28,
     schemaVersion: 28,
     sql: FOUNDATION_EVENT_CATALOG_REMOVAL_MIGRATION_SQL,
+  }),
+  createMigration({
+    id: "029-access-sheet-generated-audit-action",
+    ordinal: 29,
+    schemaVersion: 29,
+    sql: FOUNDATION_ACCESS_SHEET_AUDIT_MIGRATION_SQL,
   }),
 ]);
 

--- a/src/lib/foundation-migrations.ts
+++ b/src/lib/foundation-migrations.ts
@@ -1952,6 +1952,28 @@ export const FOUNDATION_PRESENTATION_INTEGRITY_MIGRATION_SQL = `
     BEGIN SELECT RAISE(ABORT, 'Game Presentation evidence anchors are immutable.'); END;
 `;
 
+/** Schema-28 adds the durable Event Catalog removal audit action. */
+export const FOUNDATION_EVENT_CATALOG_REMOVAL_MIGRATION_SQL = `
+  CREATE TABLE foundation_event_catalog_audit_v28 AS SELECT * FROM foundation_event_catalog_audit;
+  DROP TABLE foundation_event_catalog_audit;
+  ${FOUNDATION_EVENT_CATALOG_AUDIT_TABLE_V3_SQL.replace(
+    "CREATE TABLE foundation_event_catalog_audit",
+    "CREATE TABLE foundation_event_catalog_audit_rebuilt",
+  ).replace(
+    "'event-game-teams-confirmed'",
+    "'event-game-teams-confirmed', 'event-publication-changed', 'event-catalog-entry-removed'",
+  )};
+  INSERT INTO foundation_event_catalog_audit_rebuilt
+    (audit_id, operation_id, action, event_id, game_day_id, actor_reference,
+     occurred_at_ms, before_json, after_json)
+  SELECT audit_id, operation_id, action, event_id, game_day_id, actor_reference,
+         occurred_at_ms, before_json, after_json
+  FROM foundation_event_catalog_audit_v28;
+  DROP TABLE foundation_event_catalog_audit_v28;
+  ALTER TABLE foundation_event_catalog_audit_rebuilt RENAME TO foundation_event_catalog_audit;
+  ${FOUNDATION_EVENT_CATALOG_AUDIT_EVENT_INDEX_SQL};
+`;
+
 export const FOUNDATION_MIGRATIONS: readonly FoundationMigration[] = Object.freeze([
   createMigration({
     id: "001-foundation-event-game-record-roots",
@@ -2114,6 +2136,12 @@ export const FOUNDATION_MIGRATIONS: readonly FoundationMigration[] = Object.free
     ordinal: 27,
     schemaVersion: 27,
     sql: FOUNDATION_PRESENTATION_INTEGRITY_MIGRATION_SQL,
+  }),
+  createMigration({
+    id: "028-event-catalog-removal-audit",
+    ordinal: 28,
+    schemaVersion: 28,
+    sql: FOUNDATION_EVENT_CATALOG_REMOVAL_MIGRATION_SQL,
   }),
 ]);
 

--- a/src/lib/foundation-storage-memory.ts
+++ b/src/lib/foundation-storage-memory.ts
@@ -531,8 +531,8 @@ class InMemoryFoundationStorage implements FoundationStorage {
   eventCatalogStorageCapability() {
     return {
       name: "event-catalog-storage",
-      version: 1,
-      implementation: "event-teams-rosters-pitches-transaction-v1",
+      version: 2,
+      implementation: "event-catalog-removal-transaction-v2",
       transaction: [
         "findEventTeam",
         "listEventTeams",
@@ -542,10 +542,12 @@ class InMemoryFoundationStorage implements FoundationStorage {
         "listPitches",
         "insertEventTeam",
         "updateEventTeam",
+        "deleteEventTeam",
         "insertRosterEntry",
         "updateRosterEntry",
         "insertPitch",
         "updatePitch",
+        "deletePitch",
         "findGameplaySlot",
         "listGameplaySlots",
         "findPitchSlot",
@@ -556,8 +558,11 @@ class InMemoryFoundationStorage implements FoundationStorage {
         "insertPitchSlot",
         "updateGameplaySlot",
         "updatePitchSlot",
+        "deleteGameplaySlot",
+        "deletePitchSlot",
         "insertEventGame",
         "updateEventGame",
+        "deleteEventGame",
       ],
     } as const;
   }
@@ -1391,6 +1396,19 @@ function createTransaction(
       state.eventTeams.set(team.eventTeamId, structuredClone(team));
       undo.push(() => state.eventTeams.set(team.eventTeamId, previous));
     },
+    deleteEventTeam(eventTeamId) {
+      const previous = state.eventTeams.get(eventTeamId);
+      if (previous === undefined) throw new FoundationStorageConstraintError("event-team-id");
+      const roster = [...state.rosterEntries.values()].filter(
+        (entry) => entry.eventTeamId === eventTeamId,
+      );
+      state.eventTeams.delete(eventTeamId);
+      for (const entry of roster) state.rosterEntries.delete(entry.rosterEntryId);
+      undo.push(() => {
+        state.eventTeams.set(eventTeamId, previous);
+        for (const entry of roster) state.rosterEntries.set(entry.rosterEntryId, entry);
+      });
+    },
     insertRosterEntry(entry) {
       if (!state.eventTeams.has(entry.eventTeamId) || !state.events.has(entry.eventId))
         throw new FoundationStorageConstraintError("event-team-id");
@@ -1448,6 +1466,12 @@ function createTransaction(
         throw new FoundationStorageConstraintError("pitch-name");
       state.pitches.set(pitch.pitchId, structuredClone(pitch));
       undo.push(() => state.pitches.set(pitch.pitchId, previous));
+    },
+    deletePitch(pitchId) {
+      const previous = state.pitches.get(pitchId);
+      if (previous === undefined) throw new FoundationStorageConstraintError("pitch-id");
+      state.pitches.delete(pitchId);
+      undo.push(() => state.pitches.set(pitchId, previous));
     },
     appendEventAudit(entry) {
       if (state.eventAudits.has(entry.auditId)) {
@@ -1595,6 +1619,12 @@ function createTransaction(
       state.gameplaySlots.set(slot.gameplaySlotId, structuredClone(slot));
       undo.push(() => state.gameplaySlots.set(slot.gameplaySlotId, previous));
     },
+    deleteGameplaySlot(gameplaySlotId) {
+      const previous = state.gameplaySlots.get(gameplaySlotId);
+      if (previous === undefined) throw new FoundationStorageConstraintError("gameplay-slot-id");
+      state.gameplaySlots.delete(gameplaySlotId);
+      undo.push(() => state.gameplaySlots.set(gameplaySlotId, previous));
+    },
     insertPitchSlot(slot) {
       if (!state.events.has(slot.eventId)) throw new FoundationStorageConstraintError("event-id");
       const gameDay = state.gameDays.get(slot.gameDayId);
@@ -1634,6 +1664,12 @@ function createTransaction(
         throw new FoundationStorageConstraintError("pitch-slot-identity");
       state.pitchSlots.set(slot.pitchSlotId, structuredClone(slot));
       undo.push(() => state.pitchSlots.set(slot.pitchSlotId, previous));
+    },
+    deletePitchSlot(pitchSlotId) {
+      const previous = state.pitchSlots.get(pitchSlotId);
+      if (previous === undefined) throw new FoundationStorageConstraintError("pitch-slot-id");
+      state.pitchSlots.delete(pitchSlotId);
+      undo.push(() => state.pitchSlots.set(pitchSlotId, previous));
     },
     insertEventGame(game) {
       if (!state.events.has(game.eventId)) throw new FoundationStorageConstraintError("event-id");
@@ -1741,6 +1777,12 @@ function createTransaction(
       }
       state.eventGames.set(game.eventGameId, structuredClone(game));
       undo.push(() => state.eventGames.set(game.eventGameId, previous));
+    },
+    deleteEventGame(eventGameId) {
+      const previous = state.eventGames.get(eventGameId);
+      if (previous === undefined) throw new FoundationStorageConstraintError("event-game-id");
+      state.eventGames.delete(eventGameId);
+      undo.push(() => state.eventGames.set(eventGameId, previous));
     },
     appendAuditEntry(entry) {
       let audits = state.controlAudits.get(entry.recordId);

--- a/src/lib/foundation-storage-sqlite.test.ts
+++ b/src/lib/foundation-storage-sqlite.test.ts
@@ -564,7 +564,7 @@ describe("SQLite foundation storage", () => {
       expect(await reopenedRecord.registerRoot(root)).toMatchObject({ status: "idempotent" });
       expect(await reopened.readiness()).toMatchObject({
         ok: true,
-        schemaVersion: "28",
+        schemaVersion: "29",
         evidence: { replay: { result: "passed", rootCount: 1, durationMs: expect.any(Number) } },
       });
       reopened.close();
@@ -612,18 +612,18 @@ describe("SQLite foundation storage", () => {
       const storage = openSqliteFoundationStorage(databasePath);
       const candidate = await storage.validateCandidate();
       expect(candidate.ready).toBe(true);
-      expect(candidate.readiness).toMatchObject({ ok: true, schemaVersion: "28" });
+      expect(candidate.readiness).toMatchObject({ ok: true, schemaVersion: "29" });
       expect(existsSync(candidate.candidatePath)).toBe(false);
       expect(await storage.readiness()).toMatchObject({ ok: false, status: "pending" });
 
       const migration = await storage.applyMigrations({ requireCandidate: true });
-      expect(migration.schemaVersion).toBe(28);
+      expect(migration.schemaVersion).toBe(29);
       expect(await storage.readiness()).toMatchObject({ ok: true });
       storage.close();
     });
   });
 
-  test("preserves prior Event Catalog audit rows, shape, ordering, index, and FK behavior through removal migration", async () => {
+  test("preserves prior Event Catalog audit rows, shape, ordering, index, and FK behavior through Access Sheet migration", async () => {
     await withDatabase(async (databasePath) => {
       const prior = openSqliteFoundationStorage(databasePath, {
         migrations: FOUNDATION_MIGRATIONS.slice(0, 27),
@@ -845,9 +845,106 @@ describe("SQLite foundation storage", () => {
         "026-event-schedule-expected-delays-and-conflicts",
         "027-event-game-presentation-integrity",
         removalAuditMigration.id,
+        "029-access-sheet-generated-audit-action",
       ]);
-      expect(await current.readiness()).toMatchObject({ ok: true, schemaVersion: "28" });
+      expect(await current.readiness()).toMatchObject({ ok: true, schemaVersion: "29" });
       current.close();
+    });
+  });
+
+  test("adds the Access Sheet audit action while preserving prior audit rows and shape", async () => {
+    await withDatabase(async (databasePath) => {
+      const priorMigrations = FOUNDATION_MIGRATIONS.slice(0, -1);
+      const prior = openSqliteFoundationStorage(databasePath, { migrations: priorMigrations });
+      await prior.applyMigrations({ requireCandidate: false });
+      prior.close();
+
+      const database = new Database(databasePath);
+      const priorColumns = database
+        .query("PRAGMA table_info(foundation_event_catalog_audit)")
+        .all();
+      database
+        .query(
+          `INSERT INTO foundation_event_catalog_audit
+             (audit_id, operation_id, action, event_id, game_day_id, actor_reference,
+              occurred_at_ms, before_json, after_json)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          "audit-before-access-sheet-migration",
+          "operation-before-access-sheet-migration",
+          "event-created",
+          "event-before-access-sheet-migration",
+          null,
+          "actor-before-access-sheet-migration",
+          1_000,
+          null,
+          JSON.stringify({ name: "Before migration" }),
+        );
+      const priorIndexes = database
+        .query("PRAGMA index_list(foundation_event_catalog_audit)")
+        .all();
+      database.close();
+
+      const current = openSqliteFoundationStorage(databasePath);
+      expect(await current.applyMigrations({ requireCandidate: false })).toMatchObject({
+        appliedMigrationIds: ["029-access-sheet-generated-audit-action"],
+        schemaVersion: 29,
+      });
+      current.close();
+
+      const upgraded = new Database(databasePath);
+      expect(upgraded.query("PRAGMA table_info(foundation_event_catalog_audit)").all()).toEqual(
+        priorColumns,
+      );
+      expect(upgraded.query("PRAGMA index_list(foundation_event_catalog_audit)").all()).toEqual(
+        priorIndexes,
+      );
+      expect(
+        upgraded
+          .query(
+            `SELECT audit_id, operation_id, action, event_id, game_day_id, actor_reference,
+                    occurred_at_ms, before_json, after_json
+             FROM foundation_event_catalog_audit`,
+          )
+          .all(),
+      ).toEqual([
+        {
+          audit_id: "audit-before-access-sheet-migration",
+          operation_id: "operation-before-access-sheet-migration",
+          action: "event-created",
+          event_id: "event-before-access-sheet-migration",
+          game_day_id: null,
+          actor_reference: "actor-before-access-sheet-migration",
+          occurred_at_ms: 1_000,
+          before_json: null,
+          after_json: JSON.stringify({ name: "Before migration" }),
+        },
+      ]);
+      upgraded
+        .query(
+          `INSERT INTO foundation_event_catalog_audit
+             (audit_id, operation_id, action, event_id, game_day_id, actor_reference,
+              occurred_at_ms, before_json, after_json)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          "audit-after-access-sheet-migration",
+          "operation-after-access-sheet-migration",
+          "access-sheet-generated",
+          "event-after-access-sheet-migration",
+          null,
+          "actor-after-access-sheet-migration",
+          2_000,
+          null,
+          JSON.stringify({ versionId: "version-redacted" }),
+        );
+      expect(
+        upgraded
+          .query("SELECT action FROM foundation_event_catalog_audit WHERE audit_id = ?")
+          .get("audit-after-access-sheet-migration"),
+      ).toEqual({ action: "access-sheet-generated" });
+      upgraded.close();
     });
   });
 
@@ -855,9 +952,9 @@ describe("SQLite foundation storage", () => {
     await withDatabase(async (databasePath) => {
       const baseMigrations = FOUNDATION_MIGRATIONS;
       const failingMigration = createMigration(
-        "029-failing-test-migration",
-        29,
-        29,
+        "030-failing-test-migration",
+        30,
+        30,
         "CREATE TABLE migration_failure_probe (id TEXT) STRICT; THIS IS NOT SQL;",
       );
       const store = openSqliteFoundationStorage(databasePath, {
@@ -877,7 +974,7 @@ describe("SQLite foundation storage", () => {
       });
       expect(await priorBinary.readiness()).toMatchObject({
         ok: true,
-        schemaVersion: "28",
+        schemaVersion: "29",
       });
       priorBinary.close();
 
@@ -949,7 +1046,7 @@ describe("SQLite foundation storage", () => {
         .query(
           "INSERT INTO foundation_migration_ledger (migration_id, ordinal, schema_version, checksum, status, applied_at_ms) VALUES (?, ?, ?, ?, ?, ?)",
         )
-        .run("future-999", 29, 29, "future-checksum", "complete", 2_000);
+        .run("future-999", 30, 30, "future-checksum", "complete", 2_000);
       futureDatabase.close();
       const future = openSqliteFoundationStorage(databasePath);
       expect(await future.readiness()).toMatchObject({ ok: false });

--- a/src/lib/foundation-storage-sqlite.test.ts
+++ b/src/lib/foundation-storage-sqlite.test.ts
@@ -564,7 +564,7 @@ describe("SQLite foundation storage", () => {
       expect(await reopenedRecord.registerRoot(root)).toMatchObject({ status: "idempotent" });
       expect(await reopened.readiness()).toMatchObject({
         ok: true,
-        schemaVersion: "27",
+        schemaVersion: "28",
         evidence: { replay: { result: "passed", rootCount: 1, durationMs: expect.any(Number) } },
       });
       reopened.close();
@@ -612,14 +612,145 @@ describe("SQLite foundation storage", () => {
       const storage = openSqliteFoundationStorage(databasePath);
       const candidate = await storage.validateCandidate();
       expect(candidate.ready).toBe(true);
-      expect(candidate.readiness).toMatchObject({ ok: true, schemaVersion: "27" });
+      expect(candidate.readiness).toMatchObject({ ok: true, schemaVersion: "28" });
       expect(existsSync(candidate.candidatePath)).toBe(false);
       expect(await storage.readiness()).toMatchObject({ ok: false, status: "pending" });
 
       const migration = await storage.applyMigrations({ requireCandidate: true });
-      expect(migration.schemaVersion).toBe(27);
+      expect(migration.schemaVersion).toBe(28);
       expect(await storage.readiness()).toMatchObject({ ok: true });
       storage.close();
+    });
+  });
+
+  test("preserves prior Event Catalog audit rows, shape, ordering, index, and FK behavior through removal migration", async () => {
+    await withDatabase(async (databasePath) => {
+      const prior = openSqliteFoundationStorage(databasePath, {
+        migrations: FOUNDATION_MIGRATIONS.slice(0, 27),
+      });
+      await prior.applyMigrations({ requireCandidate: false });
+      prior.close();
+
+      const before = new Database(databasePath);
+      const insert = before.query(
+        `INSERT INTO foundation_event_catalog_audit
+           (audit_id, operation_id, action, event_id, game_day_id, actor_reference,
+            occurred_at_ms, before_json, after_json)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      );
+      for (const auditId of ["audit-b", "audit-a"]) {
+        insert.run(
+          auditId,
+          `operation-${auditId}`,
+          "event-publication-changed",
+          "event-prior",
+          null,
+          "actor-prior",
+          10_000,
+          JSON.stringify({ publicationStatus: "draft" }),
+          JSON.stringify({ publicationStatus: "public" }),
+        );
+      }
+      const priorColumns = (
+        before.query("PRAGMA table_info(foundation_event_catalog_audit)").all() as Array<{
+          name: string;
+          type: string;
+          notnull: number;
+          pk: number;
+        }>
+      ).map((row) => ({
+        name: row.name,
+        type: row.type,
+        notnull: row.notnull,
+        pk: row.pk,
+      }));
+      const priorForeignKeys = before
+        .query("PRAGMA foreign_key_list(foundation_event_catalog_audit)")
+        .all();
+      const priorIndexes = before
+        .query("PRAGMA index_list(foundation_event_catalog_audit)")
+        .all() as Array<{
+        name: string;
+      }>;
+      before.close();
+
+      const current = openSqliteFoundationStorage(databasePath);
+      await current.applyMigrations({ requireCandidate: false });
+      current.close();
+
+      const after = new Database(databasePath);
+      const currentColumns = (
+        after.query("PRAGMA table_info(foundation_event_catalog_audit)").all() as Array<{
+          name: string;
+          type: string;
+          notnull: number;
+          pk: number;
+        }>
+      ).map((row) => ({
+        name: row.name,
+        type: row.type,
+        notnull: row.notnull,
+        pk: row.pk,
+      }));
+      const currentForeignKeys = after
+        .query("PRAGMA foreign_key_list(foundation_event_catalog_audit)")
+        .all();
+      const currentIndexes = after
+        .query("PRAGMA index_list(foundation_event_catalog_audit)")
+        .all() as Array<{
+        name: string;
+      }>;
+      const indexColumns = (
+        after.query("PRAGMA index_info(foundation_event_catalog_audit_event_id)").all() as Array<{
+          name: string;
+        }>
+      ).map((row) => row.name);
+      after
+        .query(
+          `INSERT INTO foundation_event_catalog_audit
+             (audit_id, operation_id, action, event_id, game_day_id, actor_reference,
+              occurred_at_ms, before_json, after_json)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          "audit-removal",
+          "operation-removal",
+          "event-catalog-entry-removed",
+          "event-missing-parent-is-allowed",
+          null,
+          "actor-redacted",
+          10_001,
+          JSON.stringify({ kind: "event", eventId: "event-missing-parent-is-allowed" }),
+          JSON.stringify(null),
+        );
+      const rows = after
+        .query(
+          `SELECT audit_id AS auditId, action, event_id AS eventId, occurred_at_ms AS occurredAtMs
+             FROM foundation_event_catalog_audit
+            WHERE event_id = ?
+            ORDER BY occurred_at_ms, audit_id`,
+        )
+        .all("event-prior");
+      after.close();
+
+      expect(currentColumns).toEqual(priorColumns);
+      expect(currentForeignKeys).toEqual(priorForeignKeys);
+      expect(currentIndexes.map((row) => row.name)).toEqual(priorIndexes.map((row) => row.name));
+      expect(indexColumns).toEqual(["event_id", "occurred_at_ms", "audit_id"]);
+      expect(rows).toEqual([
+        {
+          auditId: "audit-a",
+          action: "event-publication-changed",
+          eventId: "event-prior",
+          occurredAtMs: 10_000,
+        },
+        {
+          auditId: "audit-b",
+          action: "event-publication-changed",
+          eventId: "event-prior",
+          occurredAtMs: 10_000,
+        },
+      ]);
     });
   });
 
@@ -648,6 +779,7 @@ describe("SQLite foundation storage", () => {
       const grantCodeLockMigration = FOUNDATION_MIGRATIONS[20];
       const controlSessionStayMigration = FOUNDATION_MIGRATIONS[21];
       const eventTeamsMigration = FOUNDATION_MIGRATIONS[22];
+      const removalAuditMigration = FOUNDATION_MIGRATIONS[27];
       if (
         initialMigration === undefined ||
         repairMigration === undefined ||
@@ -671,7 +803,8 @@ describe("SQLite foundation storage", () => {
         grantCodeMigration === undefined ||
         grantCodeLockMigration === undefined ||
         controlSessionStayMigration === undefined ||
-        eventTeamsMigration === undefined
+        eventTeamsMigration === undefined ||
+        removalAuditMigration === undefined
       ) {
         throw new Error("Expected the foundation migrations.");
       }
@@ -711,8 +844,9 @@ describe("SQLite foundation storage", () => {
         "025-event-publication-status",
         "026-event-schedule-expected-delays-and-conflicts",
         "027-event-game-presentation-integrity",
+        removalAuditMigration.id,
       ]);
-      expect(await current.readiness()).toMatchObject({ ok: true, schemaVersion: "27" });
+      expect(await current.readiness()).toMatchObject({ ok: true, schemaVersion: "28" });
       current.close();
     });
   });
@@ -721,9 +855,9 @@ describe("SQLite foundation storage", () => {
     await withDatabase(async (databasePath) => {
       const baseMigrations = FOUNDATION_MIGRATIONS;
       const failingMigration = createMigration(
-        "027-failing-test-migration",
-        27,
-        27,
+        "029-failing-test-migration",
+        29,
+        29,
         "CREATE TABLE migration_failure_probe (id TEXT) STRICT; THIS IS NOT SQL;",
       );
       const store = openSqliteFoundationStorage(databasePath, {
@@ -743,7 +877,7 @@ describe("SQLite foundation storage", () => {
       });
       expect(await priorBinary.readiness()).toMatchObject({
         ok: true,
-        schemaVersion: "27",
+        schemaVersion: "28",
       });
       priorBinary.close();
 
@@ -815,7 +949,7 @@ describe("SQLite foundation storage", () => {
         .query(
           "INSERT INTO foundation_migration_ledger (migration_id, ordinal, schema_version, checksum, status, applied_at_ms) VALUES (?, ?, ?, ?, ?, ?)",
         )
-        .run("future-999", 28, 28, "future-checksum", "complete", 2_000);
+        .run("future-999", 29, 29, "future-checksum", "complete", 2_000);
       futureDatabase.close();
       const future = openSqliteFoundationStorage(databasePath);
       expect(await future.readiness()).toMatchObject({ ok: false });

--- a/src/lib/foundation-storage-sqlite.ts
+++ b/src/lib/foundation-storage-sqlite.ts
@@ -510,16 +510,21 @@ type RootStatements = {
   insertEventAudit: SqlStatement;
   insertEventTeam: SqlStatement;
   updateEventTeam: SqlStatement;
+  deleteEventTeam: SqlStatement;
   insertRosterEntry: SqlStatement;
   updateRosterEntry: SqlStatement;
   insertPitch: SqlStatement;
   updatePitch: SqlStatement;
+  deletePitch: SqlStatement;
   insertGameplaySlot: SqlStatement;
   insertPitchSlot: SqlStatement;
   updateGameplaySlot: SqlStatement;
   updatePitchSlot: SqlStatement;
+  deleteGameplaySlot: SqlStatement;
+  deletePitchSlot: SqlStatement;
   insertEventGame: SqlStatement;
   updateEventGame: SqlStatement;
+  deleteEventGame: SqlStatement;
 };
 
 function assertGameplaySlotMembership(statements: RootStatements, slot: StoredGameplaySlot): void {
@@ -1003,8 +1008,8 @@ export class SqliteFoundationStorage implements FoundationStorage {
   eventCatalogStorageCapability() {
     return {
       name: "event-catalog-storage",
-      version: 1,
-      implementation: "event-teams-rosters-pitches-transaction-v1",
+      version: 2,
+      implementation: "event-catalog-removal-transaction-v2",
       transaction: [
         "findEventTeam",
         "listEventTeams",
@@ -1014,10 +1019,12 @@ export class SqliteFoundationStorage implements FoundationStorage {
         "listPitches",
         "insertEventTeam",
         "updateEventTeam",
+        "deleteEventTeam",
         "insertRosterEntry",
         "updateRosterEntry",
         "insertPitch",
         "updatePitch",
+        "deletePitch",
         "findGameplaySlot",
         "listGameplaySlots",
         "findPitchSlot",
@@ -1028,8 +1035,11 @@ export class SqliteFoundationStorage implements FoundationStorage {
         "insertPitchSlot",
         "updateGameplaySlot",
         "updatePitchSlot",
+        "deleteGameplaySlot",
+        "deletePitchSlot",
         "insertEventGame",
         "updateEventGame",
+        "deleteEventGame",
       ],
     } as const;
   }
@@ -1530,6 +1540,7 @@ export class SqliteFoundationStorage implements FoundationStorage {
           team.updatedAtMs,
           team.eventTeamId,
         ),
+      deleteEventTeam: (eventTeamId) => statements.deleteEventTeam.run(eventTeamId),
       insertRosterEntry: (entry) =>
         statements.insertRosterEntry.run(
           entry.rosterEntryId,
@@ -1552,6 +1563,7 @@ export class SqliteFoundationStorage implements FoundationStorage {
         ),
       updatePitch: (pitch) =>
         statements.updatePitch.run(pitch.name, pitch.updatedAtMs, pitch.pitchId),
+      deletePitch: (pitchId) => statements.deletePitch.run(pitchId),
       insertGameplaySlot: (slot) => {
         assertGameplaySlotMembership(statements, slot);
         statements.insertGameplaySlot.run(
@@ -1589,6 +1601,8 @@ export class SqliteFoundationStorage implements FoundationStorage {
       updatePitchSlot: (slot) => {
         statements.updatePitchSlot.run(slot.expectedDelayMs, slot.updatedAtMs, slot.pitchSlotId);
       },
+      deleteGameplaySlot: (gameplaySlotId) => statements.deleteGameplaySlot.run(gameplaySlotId),
+      deletePitchSlot: (pitchSlotId) => statements.deletePitchSlot.run(pitchSlotId),
       insertEventGame: (game) => {
         assertEventGameMembership(statements, game);
         statements.insertEventGame.run(
@@ -1634,6 +1648,7 @@ export class SqliteFoundationStorage implements FoundationStorage {
           game.eventGameId,
         );
       },
+      deleteEventGame: (eventGameId) => statements.deleteEventGame.run(eventGameId),
       writeGrantAdmissionTelemetry: (value) => {
         this.getGrantStatements().upsertTelemetry.run(
           value.mode,
@@ -2217,6 +2232,9 @@ export class SqliteFoundationStorage implements FoundationStorage {
         SET name = ?, default_color = ?, updated_at_ms = ?
         WHERE event_team_id = ?
       `),
+      deleteEventTeam: this.database.query(
+        `DELETE FROM foundation_event_catalog_teams WHERE event_team_id = ?`,
+      ),
       insertRosterEntry: this.database.query(`
         INSERT INTO foundation_event_catalog_roster
           (roster_entry_id, event_id, event_team_id, player_number, public_name, created_at_ms, updated_at_ms)
@@ -2237,6 +2255,9 @@ export class SqliteFoundationStorage implements FoundationStorage {
         SET name = ?, updated_at_ms = ?
         WHERE pitch_id = ?
       `),
+      deletePitch: this.database.query(
+        `DELETE FROM foundation_event_catalog_pitches WHERE pitch_id = ?`,
+      ),
       insertGameplaySlot: this.database.query(`
         INSERT INTO foundation_event_catalog_gameplay_slots
           (gameplay_slot_id, event_id, game_day_id, sequence_number, scheduled_start_ms, expected_delay_ms, created_at_ms, updated_at_ms)
@@ -2255,6 +2276,12 @@ export class SqliteFoundationStorage implements FoundationStorage {
         UPDATE foundation_event_catalog_pitch_slots SET expected_delay_ms = ?, updated_at_ms = ?
         WHERE pitch_slot_id = ?
       `),
+      deleteGameplaySlot: this.database.query(
+        `DELETE FROM foundation_event_catalog_gameplay_slots WHERE gameplay_slot_id = ?`,
+      ),
+      deletePitchSlot: this.database.query(
+        `DELETE FROM foundation_event_catalog_pitch_slots WHERE pitch_slot_id = ?`,
+      ),
       insertEventGame: this.database.query(`
         INSERT INTO foundation_event_catalog_games
           (event_game_id, event_id, game_day_id, gameplay_slot_id, pitch_slot_id,
@@ -2270,6 +2297,9 @@ export class SqliteFoundationStorage implements FoundationStorage {
           side_b_event_team_id = ?, side_b_event_team_name = ?, side_b_source_label = ?, side_b_confirmed_at_ms = ?,
           updated_at_ms = ? WHERE event_game_id = ?
       `),
+      deleteEventGame: this.database.query(
+        `DELETE FROM foundation_event_catalog_games WHERE event_game_id = ?`,
+      ),
       budgetById: this.database.query(
         `SELECT * FROM foundation_acceptance_budgets WHERE bucket_id = ?`,
       ),

--- a/src/lib/foundation-storage.ts
+++ b/src/lib/foundation-storage.ts
@@ -67,9 +67,9 @@ export const REQUIRED_GRANT_STORAGE_ANCHOR_METHODS = Object.freeze([
 ] as const);
 
 export const EVENT_CATALOG_STORAGE_CAPABILITY_NAME = "event-catalog-storage" as const;
-export const EVENT_CATALOG_STORAGE_CAPABILITY_VERSION = 1 as const;
+export const EVENT_CATALOG_STORAGE_CAPABILITY_VERSION = 2 as const;
 export const EVENT_CATALOG_STORAGE_CAPABILITY_IMPLEMENTATION =
-  "event-teams-rosters-pitches-transaction-v1" as const;
+  "event-catalog-removal-transaction-v2" as const;
 export type EventCatalogStorageCapability = {
   name: typeof EVENT_CATALOG_STORAGE_CAPABILITY_NAME;
   version: typeof EVENT_CATALOG_STORAGE_CAPABILITY_VERSION;
@@ -85,10 +85,12 @@ export const REQUIRED_EVENT_CATALOG_STORAGE_TRANSACTION_METHODS = Object.freeze(
   "listPitches",
   "insertEventTeam",
   "updateEventTeam",
+  "deleteEventTeam",
   "insertRosterEntry",
   "updateRosterEntry",
   "insertPitch",
   "updatePitch",
+  "deletePitch",
   "findGameplaySlot",
   "listGameplaySlots",
   "findPitchSlot",
@@ -99,8 +101,11 @@ export const REQUIRED_EVENT_CATALOG_STORAGE_TRANSACTION_METHODS = Object.freeze(
   "insertPitchSlot",
   "updateGameplaySlot",
   "updatePitchSlot",
+  "deleteGameplaySlot",
+  "deletePitchSlot",
   "insertEventGame",
   "updateEventGame",
+  "deleteEventGame",
 ] as const);
 
 export const DURABLE_EVIDENCE_PROVENANCE = Symbol("durable-evidence-provenance");
@@ -238,7 +243,8 @@ export type EventCatalogAuditEntry = {
     | "pitch-slot-created"
     | "event-game-created"
     | "event-game-teams-confirmed"
-    | "event-publication-changed";
+    | "event-publication-changed"
+    | "event-catalog-entry-removed";
   eventId: string;
   gameDayId: string | null;
   actorReference: string;
@@ -503,16 +509,21 @@ export type FoundationStorageTransaction = FoundationStorageSnapshot & {
   deleteGameDay(gameDayId: string): void;
   insertEventTeam(team: StoredEventCatalogTeam): void;
   updateEventTeam(team: StoredEventCatalogTeam): void;
+  deleteEventTeam(eventTeamId: string): void;
   insertRosterEntry(entry: StoredEventCatalogRosterEntry): void;
   updateRosterEntry(entry: StoredEventCatalogRosterEntry): void;
   insertPitch(pitch: StoredEventCatalogPitch): void;
   updatePitch(pitch: StoredEventCatalogPitch): void;
+  deletePitch(pitchId: string): void;
   insertGameplaySlot(slot: StoredGameplaySlot): void;
   insertPitchSlot(slot: StoredPitchSlot): void;
   updateGameplaySlot(slot: StoredGameplaySlot): void;
   updatePitchSlot(slot: StoredPitchSlot): void;
+  deleteGameplaySlot(gameplaySlotId: string): void;
+  deletePitchSlot(pitchSlotId: string): void;
   insertEventGame(game: StoredEventCatalogGame): void;
   updateEventGame(game: StoredEventCatalogGame): void;
+  deleteEventGame(eventGameId: string): void;
   appendEventAudit(entry: EventCatalogAuditEntry): void;
   writeGrantAdmissionTelemetry?(value: GrantAdmissionTelemetry): void;
   writeGrantAdmissionGlobalWindow?(value: GrantAdmissionGlobalWindow): void;

--- a/src/lib/foundation-storage.ts
+++ b/src/lib/foundation-storage.ts
@@ -244,7 +244,8 @@ export type EventCatalogAuditEntry = {
     | "event-game-created"
     | "event-game-teams-confirmed"
     | "event-publication-changed"
-    | "event-catalog-entry-removed";
+    | "event-catalog-entry-removed"
+    | "access-sheet-generated";
   eventId: string;
   gameDayId: string | null;
   actorReference: string;

--- a/src/lib/grant-lifecycle.ts
+++ b/src/lib/grant-lifecycle.ts
@@ -32,7 +32,8 @@ export function createAuditEntry(
     actor:
       | { kind: "authority"; value: GrantAuthorityActor }
       | { kind: "session"; sessionId: string; pseudonymKeyVersion: string }
-      | { kind: "system"; value: "grant-expiry" | "grant-session-termination" };
+      | { kind: "system"; value: "grant-expiry" | "grant-session-termination" }
+      | { kind: "external"; value: string };
     grant: StoredGrant;
     sessionId: string | null;
     replacedSessionId: string | null;
@@ -169,7 +170,9 @@ export function expireGrantIfDue(
   return expiredGrant;
 }
 
-function eraseGrantCredential(credential: StoredGrant["credential"]): StoredGrant["credential"] {
+export function eraseGrantCredential(
+  credential: StoredGrant["credential"],
+): StoredGrant["credential"] {
   return {
     materialState: "erased",
     formatVersion: credential.formatVersion,
@@ -190,14 +193,17 @@ function deriveAuditActorReference(
   actor:
     | { kind: "authority"; value: GrantAuthorityActor }
     | { kind: "session"; sessionId: string; pseudonymKeyVersion: string }
-    | { kind: "system"; value: "grant-expiry" | "grant-session-termination" },
+    | { kind: "system"; value: "grant-expiry" | "grant-session-termination" }
+    | { kind: "external"; value: string },
 ): string {
   const source =
     actor.kind === "authority"
       ? { source: actor.kind, authorityKind: actor.value.kind, authorityId: actor.value.id }
       : actor.kind === "session"
         ? { source: actor.kind, sessionId: actor.sessionId }
-        : { source: actor.kind, operation: actor.value };
+        : actor.kind === "external"
+          ? { source: actor.kind, actorReference: actor.value }
+          : { source: actor.kind, operation: actor.value };
   return `actor-${computeLookupDigest(
     JSON.stringify({ domain: "grant-audit", grantId, source }),
     options.keyRing,

--- a/src/lib/grant-management-audit.ts
+++ b/src/lib/grant-management-audit.ts
@@ -15,7 +15,8 @@ export function auditInput(
   authority:
     | TrustedGrantAuthority
     | GrantAuthorityActor
-    | { kind: "session"; sessionId: string; pseudonymKeyVersion: string },
+    | { kind: "session"; sessionId: string; pseudonymKeyVersion: string }
+    | { kind: "external"; value: string },
   afterStatus: StoredGrant["status"],
   sessionId: string | null = null,
   replacedSessionId: string | null = null,
@@ -29,7 +30,8 @@ export function auditInput(
 ) {
   let actor:
     | { kind: "authority"; value: GrantAuthorityActor }
-    | { kind: "session"; sessionId: string; pseudonymKeyVersion: string };
+    | { kind: "session"; sessionId: string; pseudonymKeyVersion: string }
+    | { kind: "external"; value: string };
   if (authority.kind === "grant-session") {
     if (authority.sessionId === undefined || authority.pseudonymKeyVersion === undefined)
       throw new Error("Grant Session authority was not resolved.");
@@ -39,6 +41,8 @@ export function auditInput(
       pseudonymKeyVersion: authority.pseudonymKeyVersion,
     };
   } else if (authority.kind === "session") {
+    actor = authority;
+  } else if (authority.kind === "external") {
     actor = authority;
   } else {
     actor = { kind: "authority", value: authorityToActor(authority) as GrantAuthorityActor };

--- a/src/lib/grant-management-credentials.ts
+++ b/src/lib/grant-management-credentials.ts
@@ -20,6 +20,7 @@ import { createAuditEntry, expireGrantIfDue } from "@/lib/grant-lifecycle";
 import {
   bindingFor,
   canManageInTransaction,
+  canResolveAccessSheetCredentialInTransaction,
   credentialMatches,
   hasCurrentAdmissionEligibility,
   refreshEventAdminSession,
@@ -37,6 +38,7 @@ import {
 import { auditInput } from "@/lib/grant-management-audit";
 import type {
   GrantManagementAuthority,
+  TypedAccessSheetQrCredentialResolution,
   TypedGrantMutation,
   TypedGrantReveal,
   TypedGrantRotated,
@@ -111,6 +113,89 @@ export function revealGrantInTransaction(
     qrCredential: token,
     credentialFormatVersion: GRANT_CREDENTIAL_FORMAT_VERSION,
   };
+}
+
+/**
+ * Resolve the current QR material for Access Sheet rendering inside its
+ * Foundation transaction. Unlike ordinary Grant reveal/admission, this does
+ * not require a Control Grant to have a live Event Game root: an Access Sheet
+ * intentionally includes empty and conflicted Pitch Slots. Admission keeps
+ * using the canonical live resolver separately.
+ */
+export function resolveAccessSheetQrCredentialInTransaction(
+  transaction: FoundationStorageTransaction,
+  options: GrantAuthorityOptions,
+  input: {
+    grantId: string;
+    grantType: StoredGrant["grantType"];
+    scope: StoredGrant["scope"];
+    authority: GrantManagementAuthority;
+  },
+): TypedAccessSheetQrCredentialResolution {
+  const trustedAuthority = verifyGrantAuthority(
+    options.privilegedAuthorityVerifier,
+    input.authority,
+  );
+  if (trustedAuthority === null)
+    return {
+      status: "rejected",
+      reason: "unauthorized",
+      detail: "The Access Sheet credential cannot be resolved.",
+    };
+  const grantTransaction = requireGrantStorageTransaction(transaction);
+  const stored = grantTransaction.findGrantById(input.grantId);
+  if (stored === null)
+    return {
+      status: "rejected",
+      reason: "not-found",
+      detail: "The Access Sheet credential cannot be resolved.",
+    };
+  const grant = expireGrantIfDue(transaction, options, stored);
+  const resolvedAuthority = resolveManagementAuthority(transaction, options, trustedAuthority);
+  if (
+    grant.grantId !== input.grantId ||
+    grant.grantType !== input.grantType ||
+    !sameGrantScope(grant.scope, input.scope) ||
+    grant.status !== "active" ||
+    resolvedAuthority === null ||
+    !canResolveAccessSheetCredentialInTransaction(transaction, options, grant, resolvedAuthority)
+  )
+    return {
+      status: "rejected",
+      reason: "unauthorized",
+      detail: "The Access Sheet credential cannot be resolved.",
+    };
+  const token = decryptCredential(grant.credential, bindingFor(options, grant), options.keyRing);
+  if (token === null || !credentialMatches(grant, options, token))
+    return {
+      status: "rejected",
+      reason: "unavailable",
+      detail: "The Access Sheet credential cannot be resolved.",
+    };
+  grantTransaction.appendGrantAudit(
+    createAuditEntry(
+      options,
+      auditInput("credential-revealed", grant, resolvedAuthority, grant.status),
+    ),
+  );
+  refreshGrantManagementSession(transaction, options, resolvedAuthority);
+  return {
+    status: "resolved",
+    grantId: grant.grantId,
+    grantVersion: grant.grantVersion,
+    grantType: grant.grantType,
+    qrCredential: token,
+    credentialFormatVersion: GRANT_CREDENTIAL_FORMAT_VERSION,
+  };
+}
+
+function sameGrantScope(left: StoredGrant["scope"], right: StoredGrant["scope"]): boolean {
+  const leftEntries = Object.entries(left);
+  const rightEntries = Object.entries(right);
+  return (
+    leftEntries.length === rightEntries.length &&
+    leftEntries.every(([key, value]) => (right as Record<string, unknown>)[key] === value)
+  );
 }
 
 export async function rotateGrant(

--- a/src/lib/grant-management-lifecycle.ts
+++ b/src/lib/grant-management-lifecycle.ts
@@ -14,7 +14,7 @@ import {
   validateGrantScope,
 } from "@/lib/grant-types";
 import { eraseGrantCode } from "@/lib/grant-code";
-import { createAuditEntry, expireGrantIfDue } from "@/lib/grant-lifecycle";
+import { createAuditEntry, eraseGrantCredential, expireGrantIfDue } from "@/lib/grant-lifecycle";
 import { grantExpiryCap, resolveGrantExpiry } from "@/lib/grant-calendar";
 import {
   bindingFor,
@@ -33,6 +33,78 @@ export type GrantLifecycleMetadataCorrection = {
   gameDayDate?: string;
   finalGameDayDate?: string;
 };
+
+export function retireGrantInTransaction(
+  transaction: import("@/lib/foundation-storage").FoundationStorageTransaction,
+  options: GrantAuthorityOptions,
+  input: {
+    grantId: string;
+    actorReference: string;
+    reason: "event-catalog-removal";
+  },
+): TypedGrantMutation {
+  const stored = transaction.findGrantById(input.grantId);
+  if (stored === null) return { status: "rejected", reason: "not-found" };
+  const current = expireGrantIfDue(transaction, options, stored);
+  if (current.status === "expired")
+    return { status: "updated", grantId: current.grantId, grantVersion: current.grantVersion };
+  const nowMs = readNow(options);
+  const retired: StoredGrant = {
+    ...current,
+    status: "expired",
+    credential: eraseGrantCredential(current.credential),
+    code:
+      current.code === undefined || current.code === null
+        ? null
+        : eraseGrantCode(current.code, "erased"),
+  };
+  transaction.updateGrant(retired);
+  for (const session of transaction.listGrantSessions(current.grantId)) {
+    transaction.updateGrantSession({
+      ...session,
+      status: "expired",
+      bearerMaterialState: "erased",
+      bearerLookupVerifier: null,
+      bearerLookupKeyVersion: null,
+      revokedAtMs: session.revokedAtMs ?? nowMs,
+    });
+  }
+  transaction.appendGrantAudit(
+    createAuditEntry(options, {
+      action: "grant-retired",
+      actor: { kind: "external", value: input.actorReference },
+      grant: current,
+      sessionId: null,
+      replacedSessionId: null,
+      eventGameId: null,
+      beforeStatus: current.status,
+      afterStatus: "expired",
+    }),
+  );
+  if (current.code?.state === "present" || current.code?.state === "disabled") {
+    transaction.appendGrantAudit({
+      ...createAuditEntry(options, {
+        action: "grant-code-erased-removal",
+        actor: { kind: "external", value: input.actorReference },
+        grant: current,
+        sessionId: null,
+        replacedSessionId: null,
+        eventGameId: null,
+        beforeStatus: current.status,
+        afterStatus: "expired",
+        credentialKind: GRANT_CODE_KIND,
+        codeFormatVersion: current.code.formatVersion,
+        codeEncryptionKeyVersion: current.code.encryptionKeyVersion,
+        codeLookupKeyVersion: current.code.lookupKeyVersion,
+        codeStateBefore: current.code.state,
+        codeState: "erased",
+        previousCodeFingerprint: current.code.fingerprint,
+      }),
+      credentialFingerprint: current.code.fingerprint,
+    });
+  }
+  return { status: "updated", grantId: retired.grantId, grantVersion: retired.grantVersion };
+}
 
 /**
  * A Grant Code is bound to the Grant version and scope. The public reactivation

--- a/src/lib/grant-management-policy.ts
+++ b/src/lib/grant-management-policy.ts
@@ -219,8 +219,9 @@ export function canManageInTransaction(
     if (resolved.status !== "eligible" || resolved.eventGameId !== session.eventGameId)
       return false;
   }
-  if (caller.grantType === "event-admin")
-    return grant.grantType !== "event-admin" && caller.scope.eventId === grant.scope.eventId;
+  if (caller.grantType === "event-admin") {
+    return caller.scope.eventId === grant.scope.eventId && grant.grantType !== "event-admin";
+  }
   if (caller.grantType === "pitch-manager" && grant.grantType === "control") {
     const callerScope = caller.scope as PitchManagerGrantScope;
     const targetScope = grant.scope as ControlGrantScope;
@@ -233,6 +234,49 @@ export function canManageInTransaction(
   return (
     operation === "reveal" && caller.grantType === "control" && caller.grantId === grant.grantId
   );
+}
+
+/**
+ * Access Sheet composition may render an Event Admin Grant for the exact
+ * Event Admin session that owns it. This exception is intentionally outside
+ * ordinary Grant reveal policy and rechecks the current session binding.
+ */
+export function canResolveAccessSheetCredentialInTransaction(
+  transaction: FoundationStorageTransaction,
+  options: GrantAuthorityOptions,
+  grant: StoredGrant,
+  authority: TrustedGrantAuthority,
+): boolean {
+  if (canManageInTransaction(transaction, options, grant, authority, "reveal")) return true;
+  if (authority.kind !== "grant-session" || grant.grantType !== "event-admin") return false;
+  const session = findSessionByBearer(transaction, options, authority.sessionBearer);
+  if (
+    session === null ||
+    session.status !== "active" ||
+    session.grantId !== grant.grantId ||
+    session.grantVersion !== grant.grantVersion
+  )
+    return false;
+  const storedCaller = transaction.findGrantById(session.grantId);
+  if (storedCaller === null) return false;
+  const caller = expireGrantIfDue(transaction, options, storedCaller);
+  if (
+    caller.status !== "active" ||
+    caller.grantId !== grant.grantId ||
+    caller.grantVersion !== session.grantVersion ||
+    caller.grantType !== "event-admin" ||
+    caller.scope.eventId !== grant.scope.eventId
+  )
+    return false;
+  const nowMs = readNow(options);
+  if (
+    nowMs >=
+    Math.min(caller.expiresAtMs ?? Number.MAX_SAFE_INTEGER, session.lastActiveAtMs + 30 * DAY_MS)
+  ) {
+    expireSession(transaction, options, caller, session);
+    return false;
+  }
+  return caller.expiresAtMs === null || nowMs < caller.expiresAtMs;
 }
 
 export function canCreateInTransaction(

--- a/src/lib/grant-management-types.ts
+++ b/src/lib/grant-management-types.ts
@@ -140,6 +140,12 @@ export type TypedGrantMutation =
       detail?: string;
     };
 
+export type GrantRetirementInput = {
+  grantId: string;
+  actorReference: string;
+  reason: "event-catalog-removal";
+};
+
 export type TypedGrantReveal =
   | {
       status: "revealed";
@@ -304,6 +310,10 @@ export type TypedGrantAuthority = {
     grantId: string,
     sessionReference: string,
     authority: GrantManagementAuthority,
+  ): TypedGrantMutation;
+  retireGrantInTransaction(
+    transaction: FoundationStorageTransaction,
+    input: GrantRetirementInput,
   ): TypedGrantMutation;
   leaveGrantSession(sessionBearer: string): Promise<TypedGrantMutation>;
   listGrantSessions(

--- a/src/lib/grant-management-types.ts
+++ b/src/lib/grant-management-types.ts
@@ -157,6 +157,22 @@ export type TypedGrantReveal =
     }
   | { status: "rejected"; reason: "not-found" | "unauthorized" | "unavailable"; detail: string };
 
+/**
+ * The Access Sheet composition may resolve only the current QR material for a
+ * Grant it already selected in the surrounding Foundation transaction. This
+ * deliberately has no Grant Code or session fields.
+ */
+export type TypedAccessSheetQrCredentialResolution =
+  | {
+      status: "resolved";
+      grantId: string;
+      grantVersion: string;
+      grantType: GrantType;
+      qrCredential: string;
+      credentialFormatVersion: typeof GRANT_CREDENTIAL_FORMAT_VERSION;
+    }
+  | { status: "rejected"; reason: "not-found" | "unauthorized" | "unavailable"; detail: string };
+
 export type TypedSessionSummary = {
   label: string;
   createdAtMs: number;
@@ -276,6 +292,15 @@ export type TypedGrantAuthority = {
     grantId: string,
     authority: GrantManagementAuthority,
   ): TypedGrantReveal;
+  resolveAccessSheetQrCredentialInTransaction(
+    transaction: FoundationStorageTransaction,
+    input: {
+      grantId: string;
+      grantType: GrantType;
+      scope: GrantScope;
+      authority: GrantManagementAuthority;
+    },
+  ): TypedAccessSheetQrCredentialResolution;
   disableGrant(grantId: string, authority: GrantManagementAuthority): Promise<TypedGrantMutation>;
   revokeGrant(grantId: string, authority: GrantManagementAuthority): Promise<TypedGrantMutation>;
   reactivateGrant(

--- a/src/lib/grant-management.ts
+++ b/src/lib/grant-management.ts
@@ -10,6 +10,7 @@ import {
 import {
   revealGrant,
   revealGrantInTransaction,
+  resolveAccessSheetQrCredentialInTransaction,
   rotateGrant,
   rotateGrantInTransaction,
   rotateGrantCredentialKeys,
@@ -40,6 +41,7 @@ export type {
   TypedGrantReplayAuthorization,
   TypedGrantMutation,
   TypedGrantReveal,
+  TypedAccessSheetQrCredentialResolution,
   TypedGrantRotated,
   TypedGrantAdmissionThrottled,
   TypedGrantCodeCreated,
@@ -127,6 +129,8 @@ export function createTypedGrantAuthority(
     revealGrant: (grantId, authority) => revealGrant(storage, options, grantId, authority),
     revealGrantInTransaction: (transaction, grantId, authority) =>
       revealGrantInTransaction(transaction, options, grantId, authority),
+    resolveAccessSheetQrCredentialInTransaction: (transaction, input) =>
+      resolveAccessSheetQrCredentialInTransaction(transaction, options, input),
     disableGrant: (grantId, authority) =>
       notifyLifecycleChange(
         updateGrantStatus(storage, options, grantId, authority, "disabled", "grant-disabled"),

--- a/src/lib/grant-management.ts
+++ b/src/lib/grant-management.ts
@@ -14,7 +14,7 @@ import {
   rotateGrantInTransaction,
   rotateGrantCredentialKeys,
 } from "@/lib/grant-management-credentials";
-import { recalculateExpiry } from "@/lib/grant-management-lifecycle";
+import { recalculateExpiry, retireGrantInTransaction } from "@/lib/grant-management-lifecycle";
 import { listAudit, listSessions, listSessionsInTransaction } from "@/lib/grant-management-queries";
 import { admitGrantCode, createGrantCode, disableGrantCode } from "@/lib/grant-management-code";
 import {
@@ -151,6 +151,8 @@ export function createTypedGrantAuthority(
       ),
     revokeGrantSessionInTransaction: (transaction, grantId, sessionReference, authority) =>
       revokeGrantSessionInTransaction(transaction, options, grantId, sessionReference, authority),
+    retireGrantInTransaction: (transaction, input) =>
+      retireGrantInTransaction(transaction, options, input),
     leaveGrantSession: (sessionBearer) =>
       notifyLifecycleChange(leaveGrantSession(storage, options, sessionBearer)),
     listGrantSessions: (grantId, authority) => listSessions(storage, options, grantId, authority),

--- a/src/lib/grant-state-validation.ts
+++ b/src/lib/grant-state-validation.ts
@@ -181,7 +181,9 @@ export function validateGrantState(
     if (completenessFailure !== null) return completenessFailure;
     if (grantAudits.filter((audit) => audit.action === "grant-created").length !== 1)
       return "Stored Grant Audit Trail is missing exactly one Grant creation record.";
-    const expiryCount = grantAudits.filter((audit) => audit.action === "grant-expired").length;
+    const expiryCount = grantAudits.filter(
+      (audit) => audit.action === "grant-expired" || audit.action === "grant-retired",
+    ).length;
     if (expiryCount !== (grant.status === "expired" ? 1 : 0))
       return "Stored Grant Audit Trail terminal expiry evidence is incomplete.";
   }
@@ -276,6 +278,7 @@ function validateGrantAuditCompleteness(
   const stateActions = new Set<StoredGrantAuditEntry["action"]>([
     "grant-disabled",
     "grant-revoked",
+    "grant-retired",
     "grant-reactivated",
     "grant-metadata-updated",
     "credential-rotated",
@@ -308,7 +311,8 @@ function validateGrantAuditCompleteness(
       }
       expectedExpiresAtMs = audit.afterExpiresAtMs;
     }
-    if (audit.action === "grant-expired") expiredEvidence = true;
+    if (audit.action === "grant-expired" || audit.action === "grant-retired")
+      expiredEvidence = true;
   }
   for (const audit of ordered) {
     if (
@@ -318,6 +322,7 @@ function validateGrantAuditCompleteness(
       audit.action === "grant-code-replaced" ||
       audit.action === "grant-code-disabled" ||
       audit.action === "grant-code-erased-expiry" ||
+      audit.action === "grant-code-erased-removal" ||
       audit.action === "grant-code-erased-game-lock" ||
       audit.action === "grant-code-admitted"
     )
@@ -388,7 +393,9 @@ function validateGrantAuditCompleteness(
       audit.codeState !== undefined ||
       audit.previousCodeFingerprint !== undefined;
     const isCodeErasure =
-      audit.action === "grant-code-erased-expiry" || audit.action === "grant-code-erased-game-lock";
+      audit.action === "grant-code-erased-expiry" ||
+      audit.action === "grant-code-erased-removal" ||
+      audit.action === "grant-code-erased-game-lock";
     if (isCodeAction) {
       if (audit.credentialKind !== GRANT_CODE_KIND)
         return "Stored Grant-Code Audit Trail credential kind is invalid.";
@@ -587,6 +594,7 @@ function validateGrantAuditCompleteness(
       if (
         audit.action === "grant-expired" ||
         audit.action === "grant-revoked" ||
+        audit.action === "grant-retired" ||
         audit.action === "grant-reactivated" ||
         audit.action === "grant-metadata-updated"
       )
@@ -1151,6 +1159,7 @@ function validateAudit(
     "grant-expired",
     "grant-disabled",
     "grant-revoked",
+    "grant-retired",
     "grant-reactivated",
     "grant-metadata-updated",
     "session-admitted",
@@ -1168,6 +1177,7 @@ function validateAudit(
     "grant-code-replaced",
     "grant-code-disabled",
     "grant-code-erased-expiry",
+    "grant-code-erased-removal",
     "grant-code-erased-game-lock",
     "grant-code-admitted",
   ];
@@ -1211,6 +1221,7 @@ function validateAudit(
     audit.action === "grant-code-replaced" ||
     audit.action === "grant-code-disabled" ||
     audit.action === "grant-code-erased-expiry" ||
+    audit.action === "grant-code-erased-removal" ||
     audit.action === "grant-code-erased-game-lock" ||
     audit.action === "grant-code-admitted";
   if (codeAction !== (audit.credentialKind === GRANT_CODE_KIND))

--- a/src/lib/grant-types.ts
+++ b/src/lib/grant-types.ts
@@ -220,6 +220,7 @@ export type GrantAuditAction =
   | "grant-expired"
   | "grant-disabled"
   | "grant-revoked"
+  | "grant-retired"
   | "grant-reactivated"
   | "grant-metadata-updated"
   | "session-revoked"
@@ -237,6 +238,7 @@ export type GrantAuditAction =
   | "grant-code-replaced"
   | "grant-code-disabled"
   | "grant-code-erased-expiry"
+  | "grant-code-erased-removal"
   | "grant-code-erased-game-lock"
   | "grant-code-admitted";
 

--- a/src/pages/event-admin-page.tsx
+++ b/src/pages/event-admin-page.tsx
@@ -103,6 +103,29 @@ type ControlSession = {
   browserClass: string;
 };
 
+type CatalogRemovalPreview = {
+  target: {
+    kind: "event-team" | "game-day" | "pitch" | "gameplay-slot" | "pitch-slot" | "event-game";
+    eventId: string;
+    targetId: string;
+  };
+  eligible: boolean;
+  rejectionCategory: string | null;
+  repairWorkflow: string | null;
+  impact: {
+    descendantCount: number;
+    retiredAuthorityCount: number;
+    retiredAuthorityCategories: {
+      eventAdmin: number;
+      pitchManager: number;
+      control: number;
+    };
+    retainedEventGameCount: number;
+    retainedControlActionCount: number;
+  };
+  fingerprint: string;
+};
+
 class EventPublicationValidationError extends Error {}
 
 export type GrantQrRenderer = (credential: string) => Promise<string>;
@@ -202,6 +225,7 @@ export function EventAdminPage({
   const [controlRotationCounts, setControlRotationCounts] = useState<Record<string, number>>({});
   const [secretWarning, setSecretWarning] = useState<string | null>(null);
   const [publicationImpactConfirmed, setPublicationImpactConfirmed] = useState(false);
+  const [removalPreview, setRemovalPreview] = useState<CatalogRemovalPreview | null>(null);
   const [secretOwner] = useState(createGrantSecretOwner);
 
   const secretScopeKey = (
@@ -371,6 +395,7 @@ export function EventAdminPage({
           ),
         );
       });
+      return payload.value;
     } catch (error) {
       if (secretOwner.current(token)) throw error;
     }
@@ -395,14 +420,17 @@ export function EventAdminPage({
     }
   };
 
-  const loadPitchView = async (pitchId: string, providedToken?: GrantSecretToken) => {
-    if (selectedGameDayId === null || pitchId.length === 0) return;
-    const token =
-      providedToken ?? secretOwner.capture(secretScopeKey(eventId, selectedGameDayId, pitchId));
+  const loadPitchView = async (
+    pitchId: string,
+    gameDayId = selectedGameDayId,
+    providedToken?: GrantSecretToken,
+  ) => {
+    if (gameDayId === null || pitchId.length === 0) return;
+    const token = providedToken ?? secretOwner.capture(secretScopeKey(eventId, gameDayId, pitchId));
     if (!secretOwner.current(token)) return;
     try {
       const response = await fetch(
-        `/api/event-admin/pitch-view?eventId=${encodeURIComponent(eventId)}&gameDayId=${encodeURIComponent(selectedGameDayId)}&pitchId=${encodeURIComponent(pitchId)}`,
+        `/api/event-admin/pitch-view?eventId=${encodeURIComponent(eventId)}&gameDayId=${encodeURIComponent(gameDayId)}&pitchId=${encodeURIComponent(pitchId)}`,
       );
       const payload = (await response.json()) as {
         status: string;
@@ -415,6 +443,97 @@ export function EventAdminPage({
     } catch (error) {
       if (secretOwner.current(token)) throw error;
     }
+  };
+
+  const previewCatalogRemoval = async (
+    kind: CatalogRemovalPreview["target"]["kind"],
+    targetId: string,
+  ) => {
+    const response = await fetch(
+      `/api/event-admin/events/${encodeURIComponent(eventId)}/catalog-removal/preview`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ kind, targetId }),
+      },
+    );
+    const payload = (await response.json()) as
+      | { status: "accepted"; value: CatalogRemovalPreview }
+      | { status: "rejected" | "retryable-failure"; detail?: string };
+    if (!response.ok || payload.status !== "accepted")
+      throw new Error(
+        "detail" in payload
+          ? (payload.detail ?? "Removal preview failed.")
+          : "Removal preview failed.",
+      );
+    setRemovalPreview(payload.value);
+  };
+
+  const acceptCatalogRemoval = async () => {
+    if (removalPreview === null || !removalPreview.eligible) return;
+    invalidateGrantSecrets();
+    const target = removalPreview.target;
+    const removedSelectedGameDay =
+      target.kind === "game-day" && target.targetId === selectedGameDayId;
+    const removedSelectedPitch = target.kind === "pitch" && target.targetId === selectedPitchId;
+    const preferredGameDayId = removedSelectedGameDay ? null : selectedGameDayId;
+    const preferredPitchId = removedSelectedPitch ? "" : selectedPitchId;
+    if (removedSelectedGameDay) {
+      setSelectedGameDayId(null);
+      setSchedule(null);
+      setSelectedPitchId("");
+      setPitchView(null);
+    } else if (removedSelectedPitch) {
+      setSelectedPitchId("");
+      setPitchView(null);
+    }
+    const response = await fetch(
+      `/api/event-admin/events/${encodeURIComponent(eventId)}/catalog-removal`,
+      {
+        method: "DELETE",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          kind: removalPreview.target.kind,
+          targetId: removalPreview.target.targetId,
+          previewFingerprint: removalPreview.fingerprint,
+        }),
+      },
+    );
+    const payload = (await response.json()) as { status: string; detail?: string };
+    if (!response.ok || payload.status !== "accepted")
+      throw new Error(payload.detail ?? "Event Catalog removal failed.");
+    setRemovalPreview(null);
+    const base = await loadHub(null);
+    if (base === undefined) return;
+    const nextGameDayId =
+      (preferredGameDayId !== null &&
+        base.event.gameDays.some((day) => day.gameDayId === preferredGameDayId) &&
+        preferredGameDayId) ||
+      base.event.gameDays[0]?.gameDayId ||
+      null;
+    if (nextGameDayId === null) {
+      setSelectedGameDayId(null);
+      setSchedule(null);
+      setSelectedPitchId("");
+      setPitchView(null);
+      return;
+    }
+    const selected = await loadHub(nextGameDayId);
+    if (selected === undefined) return;
+    await loadSchedule(nextGameDayId);
+    const nextPitchId =
+      (preferredPitchId.length > 0 &&
+        selected.event.pitches.some((pitch) => pitch.pitchId === preferredPitchId) &&
+        preferredPitchId) ||
+      selected.event.pitches[0]?.pitchId ||
+      "";
+    if (nextPitchId.length === 0) {
+      setSelectedPitchId("");
+      setPitchView(null);
+      return;
+    }
+    setSelectedPitchId(nextPitchId);
+    await loadPitchView(nextPitchId, nextGameDayId);
   };
 
   const controlGrantUrl = (pitchSlotId: string) =>
@@ -915,7 +1034,7 @@ export function EventAdminPage({
     );
     if (!response.ok) throw new Error(await responseError(response, "Delay apply failed."));
     await loadSchedule(selectedGameDayId, token);
-    if (selectedPitchId.length > 0) await loadPitchView(selectedPitchId, token);
+    if (selectedPitchId.length > 0) await loadPitchView(selectedPitchId, selectedGameDayId, token);
     setDelayPreviews((current) => {
       const next = { ...current };
       delete next[slotId];
@@ -942,7 +1061,7 @@ export function EventAdminPage({
     );
     if (!response.ok) throw new Error(await responseError(response, "Pitch Reassignment failed."));
     await loadSchedule(selectedGameDayId, token);
-    if (selectedPitchId.length > 0) await loadPitchView(selectedPitchId, token);
+    if (selectedPitchId.length > 0) await loadPitchView(selectedPitchId, selectedGameDayId, token);
   };
 
   const confirmGameplaySlot = async (
@@ -1070,7 +1189,11 @@ export function EventAdminPage({
                 <Button
                   variant="outline"
                   disabled={busy || eventId.trim().length === 0}
-                  onClick={() => void run(() => loadHub(null))}
+                  onClick={() =>
+                    void run(async () => {
+                      await loadHub(null);
+                    })
+                  }
                 >
                   Open as Technical Admin
                 </Button>
@@ -1085,6 +1208,101 @@ export function EventAdminPage({
                 </p>
               </div>
               <AdministrativeAuditBrowser eventId={hub.event.eventId} route="event-admin" />
+              <div className="space-y-3 rounded-lg border p-3">
+                <div>
+                  <p className="font-semibold">Unused catalog removal</p>
+                  <p className="text-xs text-muted-foreground">
+                    Preview validates references and lifecycle state. Accepted removal refetches the
+                    Event Hub and schedule projections.
+                  </p>
+                </div>
+                <div className="space-y-2">
+                  {[
+                    ...hub.event.teams.map((item) => ({
+                      kind: "event-team" as const,
+                      targetId: item.eventTeamId,
+                      label: `Event Team ${item.name}`,
+                    })),
+                    ...hub.event.gameDays.map((item) => ({
+                      kind: "game-day" as const,
+                      targetId: item.gameDayId,
+                      label: `Game Day ${item.date}`,
+                    })),
+                    ...hub.event.pitches.map((item) => ({
+                      kind: "pitch" as const,
+                      targetId: item.pitchId,
+                      label: `Pitch ${item.name}`,
+                    })),
+                    ...hub.event.gameplaySlots.map((item) => ({
+                      kind: "gameplay-slot" as const,
+                      targetId: item.gameplaySlotId,
+                      label: `Gameplay Slot ${item.sequence}`,
+                    })),
+                    ...hub.event.pitchSlots.map((item) => ({
+                      kind: "pitch-slot" as const,
+                      targetId: item.pitchSlotId,
+                      label: `Pitch Slot ${item.sequence}`,
+                    })),
+                    ...hub.event.eventGames.map((item) => ({
+                      kind: "event-game" as const,
+                      targetId: item.eventGameId,
+                      label: `Event Game ${item.eventGameId}`,
+                    })),
+                  ].map((item) => {
+                    const active =
+                      removalPreview?.target.kind === item.kind &&
+                      removalPreview.target.targetId === item.targetId;
+                    return (
+                      <div className="flex flex-wrap items-center gap-2" key={item.targetId}>
+                        <span className="min-w-40 text-sm">{item.label}</span>
+                        <Button
+                          aria-label={`Preview removal ${item.label}`}
+                          disabled={busy}
+                          onClick={() =>
+                            void run(() => previewCatalogRemoval(item.kind, item.targetId))
+                          }
+                          size="sm"
+                          type="button"
+                          variant="outline"
+                        >
+                          Preview removal
+                        </Button>
+                        {active && removalPreview !== null && removalPreview.eligible ? (
+                          <Button
+                            disabled={busy}
+                            onClick={() => void run(acceptCatalogRemoval)}
+                            size="sm"
+                            type="button"
+                            variant="destructive"
+                          >
+                            Confirm
+                          </Button>
+                        ) : null}
+                      </div>
+                    );
+                  })}
+                </div>
+                {removalPreview ? (
+                  <div className="rounded border p-2 text-sm" role="status">
+                    <p>
+                      {removalPreview.eligible ? "Eligible" : "Blocked"} · catalog descendants{" "}
+                      {removalPreview.impact.descendantCount}; retained Event Game Records{" "}
+                      {removalPreview.impact.retainedEventGameCount}; accepted Control Actions{" "}
+                      {removalPreview.impact.retainedControlActionCount}; retiring{" "}
+                      {removalPreview.impact.retiredAuthorityCount} authority item(s).
+                    </p>
+                    <p className="text-muted-foreground">
+                      Authority categories: Event Admin{" "}
+                      {removalPreview.impact.retiredAuthorityCategories.eventAdmin}, Pitch Manager{" "}
+                      {removalPreview.impact.retiredAuthorityCategories.pitchManager}, Control{" "}
+                      {removalPreview.impact.retiredAuthorityCategories.control}.
+                    </p>
+                    {!removalPreview.eligible && removalPreview.repairWorkflow ? (
+                      <p className="text-muted-foreground">{removalPreview.repairWorkflow}</p>
+                    ) : null}
+                  </div>
+                ) : null}
+              </div>
               <div className="space-y-3 rounded-lg border p-3">
                 <p className="font-semibold">Publication Status</p>
                 <p className="text-sm text-muted-foreground">
@@ -1134,7 +1352,9 @@ export function EventAdminPage({
                     const next = event.target.value || null;
                     invalidateGrantSecrets();
                     setSelectedGameDayId(next);
-                    void run(() => loadHub(next));
+                    void run(async () => {
+                      await loadHub(next);
+                    });
                   }}
                 >
                   <option value="">Choose a Game Day</option>
@@ -1709,7 +1929,7 @@ export function EventAdminPage({
                           secretScopeKey(eventId, selectedGameDayId, pitch.pitchId),
                         );
                         setSelectedPitchId(pitch.pitchId);
-                        void run(() => loadPitchView(pitch.pitchId, token));
+                        void run(() => loadPitchView(pitch.pitchId, selectedGameDayId, token));
                       }}
                     >
                       {pitch.name}

--- a/src/pages/event-admin-page.tsx
+++ b/src/pages/event-admin-page.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import QRCode from "qrcode/lib/browser";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -102,6 +102,21 @@ type ControlSession = {
   deviceClass: string;
   browserClass: string;
 };
+type AccessSheetType = "event-admin" | "pitch-manager" | "control-grant";
+type AccessSheetResponse = {
+  status: "accepted";
+  value: {
+    contentType: "text/html";
+    body: string;
+    version: {
+      versionId: string;
+      environmentId: string;
+      type: AccessSheetType;
+      generatedAtMs: number;
+      testMark: boolean;
+    };
+  };
+};
 
 type CatalogRemovalPreview = {
   target: {
@@ -140,6 +155,75 @@ const publicationWarningLabels: Record<string, string> = {
   "missing-event-games": "Event Games",
   "unresolved-matchups": "unresolved matchups or confirmed sides",
 };
+
+type AccessSheetArtifactScope = {
+  eventId: string;
+  authority: HubResponse["value"]["authority"] | "none";
+  gameDayId: string | null;
+  pitchId: string;
+  type: AccessSheetType;
+};
+
+type AccessSheetGenerationAttempt = {
+  sequence: number;
+  scopeKey: string;
+};
+
+function useAccessSheetArtifactOwner(scope: AccessSheetArtifactScope) {
+  const scopeKey = JSON.stringify(scope);
+  const sequenceRef = useRef(0);
+  const [stored, setStored] = useState<{
+    scopeKey: string;
+    artifact: AccessSheetResponse["value"];
+  } | null>(null);
+
+  useEffect(() => {
+    sequenceRef.current += 1;
+    setStored(null);
+  }, [scopeKey]);
+
+  useEffect(
+    () => () => {
+      sequenceRef.current += 1;
+    },
+    [],
+  );
+
+  const invalidate = () => {
+    sequenceRef.current += 1;
+    setStored(null);
+  };
+
+  const begin = (): AccessSheetGenerationAttempt => {
+    sequenceRef.current += 1;
+    setStored(null);
+    return { sequence: sequenceRef.current, scopeKey };
+  };
+
+  const matches = (attempt: AccessSheetGenerationAttempt) =>
+    attempt.sequence === sequenceRef.current && attempt.scopeKey === scopeKey;
+
+  const install = (
+    attempt: AccessSheetGenerationAttempt,
+    artifact: AccessSheetResponse["value"],
+  ) => {
+    if (!matches(attempt)) return false;
+    setStored({ scopeKey, artifact });
+    return true;
+  };
+
+  const fail = (attempt: AccessSheetGenerationAttempt) => {
+    if (matches(attempt)) setStored(null);
+  };
+
+  return {
+    artifact: stored?.scopeKey === scopeKey ? stored.artifact : null,
+    begin,
+    fail,
+    install,
+    invalidate,
+  };
+}
 
 type ScheduleDelayPreview = {
   dimension: "gameplay-slot" | "pitch-slot";
@@ -226,6 +310,14 @@ export function EventAdminPage({
   const [secretWarning, setSecretWarning] = useState<string | null>(null);
   const [publicationImpactConfirmed, setPublicationImpactConfirmed] = useState(false);
   const [removalPreview, setRemovalPreview] = useState<CatalogRemovalPreview | null>(null);
+  const [accessSheetType, setAccessSheetType] = useState<AccessSheetType>("event-admin");
+  const accessSheetOwner = useAccessSheetArtifactOwner({
+    eventId: eventId.trim(),
+    authority: hub?.authority ?? "none",
+    gameDayId: selectedGameDayId,
+    pitchId: selectedPitchId,
+    type: accessSheetType,
+  });
   const [secretOwner] = useState(createGrantSecretOwner);
 
   const secretScopeKey = (
@@ -252,6 +344,7 @@ export function EventAdminPage({
   };
 
   const invalidateGrantSecrets = () => {
+    accessSheetOwner.invalidate();
     secretOwner.invalidate(secretScopeKey());
     secretOwner.invalidate(hubScopeKey());
     clearGrantSecrets();
@@ -339,6 +432,7 @@ export function EventAdminPage({
   );
 
   const loadHub = async (nextGameDayId = selectedGameDayId, providedToken?: GrantSecretToken) => {
+    accessSheetOwner.invalidate();
     if (eventId.trim().length === 0) return;
     const token = providedToken ?? secretOwner.capture(hubScopeKey());
     if (!secretOwner.current(token)) return;
@@ -877,6 +971,37 @@ export function EventAdminPage({
         : "Publication Status updated.",
     );
     await loadHub(selectedGameDayId);
+  };
+
+  const generateAccessSheet = async () => {
+    const attempt = accessSheetOwner.begin();
+    const gameDayId = selectedGameDayId ?? "";
+    const pitchId = selectedPitchId;
+    try {
+      if (eventId.length === 0 || (accessSheetType === "control-grant" && gameDayId.length === 0))
+        throw new Error("Select a Game Day before generating this Access Sheet.");
+      if (accessSheetType === "control-grant" && pitchId.length === 0)
+        throw new Error("Select a Pitch before generating the Control Access Sheet.");
+      const response = await fetch(
+        `/api/event-admin/events/${encodeURIComponent(eventId)}/access-sheets`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            type: accessSheetType,
+            ...(accessSheetType === "control-grant" && gameDayId.length > 0 ? { gameDayId } : {}),
+            ...(accessSheetType === "control-grant" && pitchId.length > 0 ? { pitchId } : {}),
+          }),
+        },
+      );
+      const payload = (await response.json()) as AccessSheetResponse | { status: string };
+      if (!response.ok || payload.status !== "accepted")
+        throw new Error("Access Sheet generation failed.");
+      accessSheetOwner.install(attempt, (payload as AccessSheetResponse).value);
+    } catch (error) {
+      accessSheetOwner.fail(attempt);
+      throw error;
+    }
   };
 
   const managePitchManagerGrant = async (
@@ -2225,6 +2350,66 @@ export function EventAdminPage({
                         </div>
                       );
                     })}
+                  </div>
+                ) : null}
+              </div>
+              <div className="space-y-3 rounded-lg border p-3">
+                <div>
+                  <p className="font-semibold">Grant Access Sheets</p>
+                  <p className="text-xs text-muted-foreground">
+                    Generate a print-ready QR handoff. Grant Codes are never included. Test sheets
+                    are marked TEST in the artifact.
+                  </p>
+                </div>
+                <div className="grid gap-2 sm:grid-cols-3">
+                  <select
+                    aria-label="Access Sheet type"
+                    className="h-10 rounded-md border bg-background px-3 text-sm"
+                    value={accessSheetType}
+                    onChange={(event) => {
+                      accessSheetOwner.invalidate();
+                      setAccessSheetType(event.target.value as AccessSheetType);
+                    }}
+                  >
+                    <option value="event-admin">Event Admin</option>
+                    <option value="pitch-manager">Pitch Manager</option>
+                    <option value="control-grant">Control Grant</option>
+                  </select>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    disabled={busy || hub === null}
+                    onClick={() => void run(generateAccessSheet)}
+                  >
+                    Generate Access Sheet
+                  </Button>
+                </div>
+                {accessSheetOwner.artifact ? (
+                  <div className="space-y-2">
+                    <p className="text-xs text-muted-foreground">
+                      Version {accessSheetOwner.artifact.version.versionId} ·{" "}
+                      {accessSheetOwner.artifact.version.environmentId}
+                      {accessSheetOwner.artifact.version.testMark ? " · TEST" : ""}
+                    </p>
+                    <iframe
+                      id="generated-access-sheet-preview"
+                      title="Generated Grant Access Sheet preview"
+                      className="min-h-[28rem] w-full rounded border bg-white"
+                      srcDoc={accessSheetOwner.artifact.body}
+                    />
+                    <Button
+                      type="button"
+                      variant="outline"
+                      onClick={() => {
+                        const frame = document.getElementById(
+                          "generated-access-sheet-preview",
+                        ) as HTMLIFrameElement | null;
+                        frame?.contentWindow?.focus();
+                        frame?.contentWindow?.print();
+                      }}
+                    >
+                      Print Access Sheet
+                    </Button>
                   </div>
                 ) : null}
               </div>

--- a/src/pages/technical-admin-page.tsx
+++ b/src/pages/technical-admin-page.tsx
@@ -277,6 +277,24 @@ function EventCatalogPanel({
   clearSecretsRef: { current: () => void };
   qrRenderer: GrantQrRenderer;
 }) {
+  type EventCatalogRemovalPreview = {
+    target: { kind: "event"; eventId: string; targetId: string };
+    eligible: boolean;
+    rejectionCategory: string | null;
+    repairWorkflow: string | null;
+    impact: {
+      descendantCount: number;
+      retiredAuthorityCount: number;
+      retiredAuthorityCategories: {
+        eventAdmin: number;
+        pitchManager: number;
+        control: number;
+      };
+      retainedEventGameCount: number;
+      retainedControlActionCount: number;
+    };
+    fingerprint: string;
+  };
   const [events, setEvents] = useState<EventProjection[]>([]);
   const [selected, setSelected] = useState<EventProjection | null>(null);
   const [editedName, setEditedName] = useState("");
@@ -308,6 +326,7 @@ function EventCatalogPanel({
     setMessage(null);
     secretOwner.invalidate(secretScopeKey());
   };
+  const [removalPreview, setRemovalPreview] = useState<EventCatalogRemovalPreview | null>(null);
 
   useEffect(() => {
     clearSecretsRef.current = clearEventAdminSecrets;
@@ -419,6 +438,36 @@ function EventCatalogPanel({
     } finally {
       setBusy(false);
     }
+  };
+
+  const previewRemoval = async (kind: "event", targetId: string) => {
+    if (selected === null) return;
+    const preview = await request<EventCatalogRemovalPreview>(
+      `/api/admin/events/${selected.eventId}/catalog-removal/preview`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ kind, targetId }),
+      },
+    );
+    setRemovalPreview(preview);
+  };
+
+  const acceptRemoval = async () => {
+    if (selected === null || removalPreview === null || !removalPreview.eligible) return;
+    clearEventAdminSecrets();
+    await request(`/api/admin/events/${selected.eventId}/catalog-removal`, {
+      method: "DELETE",
+      headers: { "content-type": "application/json", "x-technical-admin-csrf": "1" },
+      body: JSON.stringify({
+        kind: removalPreview.target.kind,
+        targetId: removalPreview.target.targetId,
+        previewFingerprint: removalPreview.fingerprint,
+      }),
+    });
+    setRemovalPreview(null);
+    setSelected(null);
+    await refresh();
   };
 
   return (
@@ -541,22 +590,23 @@ function EventCatalogPanel({
                 </Button>
                 <Button
                   disabled={busy || selected.gameDays.length > 0}
-                  onClick={() =>
-                    void run(async () => {
-                      clearEventAdminSecrets();
-                      await request(`/api/admin/events/${selected.eventId}`, {
-                        method: "DELETE",
-                        headers: { "x-technical-admin-csrf": "1" },
-                      });
-                      setSelected(null);
-                      await refresh();
-                    })
-                  }
+                  onClick={() => void run(() => previewRemoval("event", selected.eventId))}
                   type="button"
                   variant="outline"
                 >
                   Remove empty Event
                 </Button>
+                {removalPreview?.target.kind === "event" &&
+                removalPreview.target.targetId === selected.eventId ? (
+                  <Button
+                    disabled={busy || !removalPreview.eligible}
+                    onClick={() => void run(acceptRemoval)}
+                    type="button"
+                    variant="destructive"
+                  >
+                    Confirm Event removal
+                  </Button>
+                ) : null}
                 <Button
                   variant="outline"
                   onClick={() => {
@@ -939,25 +989,6 @@ function EventCatalogPanel({
                       >
                         Save Game Day
                       </Button>
-                      <Button
-                        onClick={() =>
-                          void run(async () => {
-                            await request(
-                              `/api/admin/events/${selected.eventId}/game-days/${day.gameDayId}`,
-                              {
-                                method: "DELETE",
-                                headers: { "x-technical-admin-csrf": "1" },
-                              },
-                            );
-                            await refresh();
-                          })
-                        }
-                        size="sm"
-                        type="button"
-                        variant="ghost"
-                      >
-                        Remove
-                      </Button>
                     </div>
                   </li>
                 ))}
@@ -965,6 +996,26 @@ function EventCatalogPanel({
                   <li className="text-muted-foreground">No Game Days.</li>
                 ) : null}
               </ul>
+              {removalPreview ? (
+                <div className="rounded-md border p-3 text-sm" role="status">
+                  <p>
+                    Removal preview: {removalPreview.eligible ? "eligible" : "blocked"}; catalog
+                    descendants {removalPreview.impact.descendantCount}; retained Event Game Records{" "}
+                    {removalPreview.impact.retainedEventGameCount}; accepted Control Actions{" "}
+                    {removalPreview.impact.retainedControlActionCount}; retiring{" "}
+                    {removalPreview.impact.retiredAuthorityCount} authority item(s).
+                  </p>
+                  <p className="text-muted-foreground">
+                    Authority categories: Event Admin{" "}
+                    {removalPreview.impact.retiredAuthorityCategories.eventAdmin}, Pitch Manager{" "}
+                    {removalPreview.impact.retiredAuthorityCategories.pitchManager}, Control{" "}
+                    {removalPreview.impact.retiredAuthorityCategories.control}.
+                  </p>
+                  {!removalPreview.eligible && removalPreview.repairWorkflow ? (
+                    <p className="text-muted-foreground">{removalPreview.repairWorkflow}</p>
+                  ) : null}
+                </div>
+              ) : null}
             </div>
           ) : (
             <p className="text-sm text-muted-foreground">Select an Event to inspect it.</p>


### PR DESCRIPTION
#105/#120 Event catalog removal

Implements #120 within Spec #105:

- Read-only preview with a versioned opaque client fingerprint bound to the complete redacted catalog impact and owned Grant material/lifecycle.
- Technical Admin removes only an eligible empty Event; Event Admin removes eligible Event Team, Game Day, Pitch, Gameplay Slot, Pitch Slot, and safe pre-commencement/no-Control-Action Event Game targets.
- Typed Grant retirement occurs atomically with catalog removal and audit. Retained Grant, Control, and Event Administration evidence remains addressable by retained IDs; commenced or accepted-action roots remain intact.
- Legacy destructive CLI and public EventCatalog bypass methods are removed. UI clears a removed selection and refetches a surviving valid scope.
- Deterministic seven-kind eligibility, race, stale credential/code/QR, rollback, memory/SQLite, private/public projection, and browser evidence is included.

Migration ownership:

- #120 owns provisional `027-event-catalog-removal-audit`, checksum `f1c986ce481312d22f44f72746cbbc9bfa7d2eab5db513b8f495e644b9758565`.
- Sibling #118's later Access Sheet migration renumbering to 028 is intentionally not combined here.

Exclusions:

- No Foundation Event Game Record schema or deletion-semantics changes.
- No other #105 tickets, Controllers, public Timeline, deployment, Qualifications, issue auto-close, or issue mutation.

Checks after reconciliation onto current main:

- `bun run check` — passed (existing await-thenable warnings only).
- `bun run test` — 612 passed, 0 failed, 17,436 expectations.
- `bun run test:focused:event-catalog` — 7 passed.
- `bun run scripts/test-technical-admin-browser.ts` — passed.
- `bun run build` — passed.
- `git diff --check` — passed.
