### PR TITLE
Generate Grant Access Sheets

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -22,6 +22,7 @@
         "@types/qrcode": "^1.5.6",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
+        "@zxing/browser": "0.2.1",
         "happy-dom": "20.11.2",
         "oxfmt": "^0.63.0",
         "oxlint": "^1.78.0",
@@ -229,6 +230,12 @@
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
+    "@zxing/browser": ["@zxing/browser@0.2.1", "", { "optionalDependencies": { "@zxing/text-encoding": "^0.9.0" }, "peerDependencies": { "@zxing/library": "^0.23.0" } }, "sha512-92pVfVDUXbc15xu9vIEmhNyqIEASMEkDF92CwT6T+7sg2EHXJRktH9CQKoQSXe51UtbNsj+Fm09H/JBWHMs/Sw=="],
+
+    "@zxing/library": ["@zxing/library@0.23.0", "", { "dependencies": { "ts-custom-error": "^3.3.1" }, "optionalDependencies": { "@zxing/text-encoding": "~0.9.0" } }, "sha512-6fkkoFwP8CHxl6ugnPsj74PLJgX2iRv5zczGAyt5OBzQgxFhuhF0NCEc4t4OvSr8xAv2MRLlI0Iu9ZGDZQ2urA=="],
+
+    "@zxing/text-encoding": ["@zxing/text-encoding@0.9.0", "", {}, "sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA=="],
+
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
@@ -332,6 +339,8 @@
     "tailwindcss": ["tailwindcss@4.2.4", "", {}, "sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA=="],
 
     "tinypool": ["tinypool@2.1.0", "", {}, "sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw=="],
+
+    "ts-custom-error": ["ts-custom-error@3.3.1", "", {}, "sha512-5OX1tzOjxWEgsr/YEUWSuPrQ00deKLh6D7OTWcvNHm12/7QPyRh8SYpyWvA4IZv8H/+GQWQEh/kwo95Q9OVW1A=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@types/qrcode": "^1.5.6",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
+    "@zxing/browser": "0.2.1",
     "happy-dom": "20.11.2",
     "oxfmt": "^0.63.0",
     "oxlint": "^1.78.0",

--- a/scripts/test-technical-admin-browser.ts
+++ b/scripts/test-technical-admin-browser.ts
@@ -211,7 +211,6 @@ try {
     (cookie) => cookie.name === "__Host-technical-admin-csrf",
   )?.value;
   if (!currentCsrfToken) throw new Error("Technical Admin CSRF cookie was not retained.");
-
   assert(
     (await page.getByRole("button", { name: "Remove", exact: true }).count()) === 0 &&
       (await page.getByRole("button", { name: "Remove empty Event", exact: true }).count()) === 1,
@@ -266,6 +265,55 @@ try {
     "removal browser Game Day creation failed",
   );
 
+  const futureEventResponse = await postJsonWithHeadersFromPage(
+    page,
+    `${origin}/api/admin/events`,
+    { name: "Future Sheet Event", timeZone: "UTC" },
+    { origin, "x-technical-admin-csrf": currentCsrfToken },
+  );
+  const futureEventPayload = JSON.parse(futureEventResponse.body) as {
+    value?: { eventId?: string };
+  };
+  const futureEventId = futureEventPayload.value?.eventId;
+  assert(
+    futureEventResponse.status === 201 && futureEventId !== undefined,
+    "future Event creation failed",
+  );
+  const futureGameDayResponse = await postJsonWithHeadersFromPage(
+    page,
+    `${origin}/api/admin/events/${futureEventId}/game-days`,
+    { date: "2026-08-16" },
+    { origin, "x-technical-admin-csrf": currentCsrfToken },
+  );
+  const futureGameDayPayload = JSON.parse(futureGameDayResponse.body) as {
+    value?: { gameDayId?: string };
+  };
+  const futureGameDayId = futureGameDayPayload.value?.gameDayId;
+  assert(
+    futureGameDayResponse.status === 201 && futureGameDayId !== undefined,
+    "future Game Day creation failed",
+  );
+  const futureEventGrantCreateResponse = await postJsonWithHeadersFromPage(
+    page,
+    `${origin}/api/admin/events/${futureEventId}/event-admin-grant`,
+    {},
+    { origin, "x-technical-admin-csrf": currentCsrfToken },
+  );
+  assert(futureEventGrantCreateResponse.status === 201, "future Event Admin Grant creation failed");
+  const futureEventGrantRevealResponse = await postJsonWithHeadersFromPage(
+    page,
+    `${origin}/api/admin/events/${futureEventId}/event-admin-grant/reveal`,
+    {},
+    { origin, "x-technical-admin-csrf": currentCsrfToken },
+  );
+  const futureEventGrantRevealPayload = JSON.parse(futureEventGrantRevealResponse.body) as {
+    value?: { qrCredential?: string };
+  };
+  const futureEventCredential = futureEventGrantRevealPayload.value?.qrCredential;
+  assert(
+    futureEventGrantRevealResponse.status === 200 && futureEventCredential !== undefined,
+    "future Event Admin QR reveal failed",
+  );
   const zeroDayResponse = await context.request.post(`${origin}/api/admin/events`, {
     data: { name: "Zero Day Browser Event", timeZone: "UTC" },
     headers: { origin, "x-technical-admin-csrf": currentCsrfToken },
@@ -317,6 +365,150 @@ try {
   await eventAdminPage.getByLabel("Scanned Event Admin QR value").fill(revealedCredential);
   await eventAdminPage.getByRole("button", { name: "Admit Event Admin" }).click();
   await eventAdminPage.getByText(/event-admin/u).waitFor();
+  const accessSheetResponsePromise = eventAdminPage.waitForResponse(
+    (response) =>
+      response.url().endsWith(`/api/event-admin/events/${eventId}/access-sheets`) &&
+      response.request().method() === "POST",
+  );
+  await eventAdminPage.getByLabel("Access Sheet type").selectOption("event-admin");
+  await eventAdminPage.getByRole("button", { name: "Generate Access Sheet" }).click();
+  const accessSheetResponse = await accessSheetResponsePromise;
+  const accessSheetPayload = (await accessSheetResponse.json()) as {
+    status?: string;
+    value?: { body?: string; version?: { testMark?: boolean } };
+  };
+  assert(
+    accessSheetResponse.status() === 200 &&
+      accessSheetPayload.status === "accepted" &&
+      accessSheetPayload.value?.version?.testMark === true &&
+      accessSheetPayload.value.body?.includes("TEST ENVIRONMENT") === true &&
+      accessSheetPayload.value.body.includes(revealedCredential) === false,
+    "Access Sheet generation did not return a marked, redacted printable artifact",
+  );
+  const accessSheetPreview = eventAdminPage.locator(
+    'iframe[title="Generated Grant Access Sheet preview"]',
+  );
+  await accessSheetPreview.waitFor();
+  await expect(accessSheetPreview).toHaveCount(1);
+  await eventAdminPage.addScriptTag({
+    path: join(process.cwd(), "node_modules/@zxing/browser/umd/zxing-browser.min.js"),
+  });
+  const decodedAccessSheetCredential = await accessSheetPreview.evaluate(async (iframe) => {
+    const preview = iframe as HTMLIFrameElement;
+    const svg = preview.contentDocument?.querySelector("svg.qr");
+    if (svg === null || svg === undefined) throw new Error("Access Sheet QR SVG was not rendered.");
+    const image = new Image();
+    image.src = `data:image/svg+xml;base64,${btoa(new XMLSerializer().serializeToString(svg))}`;
+    await new Promise<void>((resolve, reject) => {
+      image.addEventListener("load", () => resolve(), { once: true });
+      image.addEventListener("error", () => reject(new Error("Access Sheet QR image failed.")), {
+        once: true,
+      });
+    });
+    const browserWindow = window as typeof window & {
+      ZXingBrowser: {
+        BrowserQRCodeReader: new () => {
+          decodeFromImageElement(source: HTMLImageElement): Promise<{ getText(): string }>;
+        };
+      };
+    };
+    const result =
+      await new browserWindow.ZXingBrowser.BrowserQRCodeReader().decodeFromImageElement(image);
+    return result.getText();
+  });
+  assert(
+    decodedAccessSheetCredential === revealedCredential,
+    "independent browser QR decode did not recover the canonical Event Admin credential",
+  );
+  await eventAdminPage.evaluate(() => {
+    const frame = document.getElementById(
+      "generated-access-sheet-preview",
+    ) as HTMLIFrameElement | null;
+    if (frame?.contentWindow === null)
+      throw new Error("Access Sheet print frame was not available.");
+    if (frame?.contentWindow !== undefined)
+      frame.contentWindow.print = () => {
+        document.body.dataset.accessSheetPrintInvoked = "true";
+      };
+  });
+  await eventAdminPage.getByRole("button", { name: "Print Access Sheet" }).focus();
+  await eventAdminPage.getByRole("button", { name: "Print Access Sheet" }).press("Enter");
+  await expect(eventAdminPage.locator("body")).toHaveAttribute(
+    "data-access-sheet-print-invoked",
+    "true",
+  );
+  await eventAdminPage.setViewportSize({ width: 360, height: 900 });
+  const narrowPrintableStructure = await accessSheetPreview.evaluate((iframe) => {
+    const preview = iframe as HTMLIFrameElement;
+    const document = preview.contentDocument;
+    if (document === null) throw new Error("Access Sheet preview document was not available.");
+    return {
+      title: document.title,
+      main: document.querySelector("main[aria-labelledby='access-sheet-title']") !== null,
+      qrLabels: document.querySelectorAll("svg[aria-label='QR credential']").length,
+      fits: document.documentElement.scrollWidth <= document.documentElement.clientWidth,
+      printCss: Array.from(document.styleSheets as StyleSheetList).some((sheet) => {
+        try {
+          return Array.from((sheet as CSSStyleSheet).cssRules).some((rule) =>
+            rule.cssText.includes("@media print"),
+          );
+        } catch {
+          return false;
+        }
+      }),
+    };
+  });
+  assert(
+    narrowPrintableStructure.title.includes("Event Admin Access Sheet") &&
+      narrowPrintableStructure.main &&
+      narrowPrintableStructure.qrLabels === 1 &&
+      narrowPrintableStructure.fits &&
+      narrowPrintableStructure.printCss,
+    `Access Sheet printable structure was not accessible and 360px-safe: ${JSON.stringify(narrowPrintableStructure)}`,
+  );
+  await eventAdminPage.setViewportSize({ width: 1280, height: 900 });
+  assert(
+    (await accessSheetPreview.getAttribute("srcdoc"))?.includes("TEST ENVIRONMENT") === true,
+    "Access Sheet preview did not preserve the visible TEST marking",
+  );
+  const assertAccessSheetAbsent = async (detail: string) => {
+    await expect(accessSheetPreview, detail).toHaveCount(0);
+  };
+  const inFlightAccessSheetGate = Promise.withResolvers<void>();
+  const inFlightAccessSheet = inFlightAccessSheetGate.promise;
+  await eventAdminPage.route(
+    `${origin}/api/event-admin/events/${eventId}/access-sheets`,
+    async (route) => {
+      await inFlightAccessSheet;
+      await route.continue();
+    },
+  );
+  const inFlightAccessSheetRequestPromise = eventAdminPage.waitForRequest(
+    (request) =>
+      request.url().endsWith(`/api/event-admin/events/${eventId}/access-sheets`) &&
+      request.method() === "POST",
+  );
+  const inFlightAccessSheetResponsePromise = eventAdminPage.waitForResponse(
+    (response) =>
+      response.url().endsWith(`/api/event-admin/events/${eventId}/access-sheets`) &&
+      response.request().method() === "POST",
+  );
+  await eventAdminPage.getByRole("button", { name: "Generate Access Sheet" }).click();
+  await inFlightAccessSheetRequestPromise;
+  await eventAdminPage.getByLabel("Event ID").fill(zeroDayEventId);
+  await assertAccessSheetAbsent("Event transition did not clear the live Access Sheet artifact");
+  inFlightAccessSheetGate.resolve();
+  const inFlightAccessSheetResponse = await inFlightAccessSheetResponsePromise;
+  assert(inFlightAccessSheetResponse.status() === 200, "in-flight Access Sheet generation failed");
+  await assertAccessSheetAbsent("stale in-flight Access Sheet response was displayed");
+  await eventAdminPage.unroute(`${origin}/api/event-admin/events/${eventId}/access-sheets`);
+  await eventAdminPage.getByLabel("Event ID").fill(eventId);
+
+  await eventAdminPage.getByRole("button", { name: "Change authority" }).click();
+  await assertAccessSheetAbsent("authority transition did not clear the Access Sheet artifact");
+  await eventAdminPage.getByLabel("Scanned Event Admin QR value").fill(revealedCredential);
+  await eventAdminPage.getByRole("button", { name: "Admit Event Admin" }).click();
+  await eventAdminPage.getByText(/event-admin/u).waitFor();
   const eventAdminGameDaySelector = eventAdminPage.getByLabel("Game Day", { exact: true });
   const firstDayHubResponsePromise = eventAdminPage.waitForResponse(
     (response) =>
@@ -324,6 +516,7 @@ try {
   );
   await eventAdminGameDaySelector.selectOption({ index: 1 });
   await firstDayHubResponsePromise;
+  await assertAccessSheetAbsent("Game Day transition did not clear the Access Sheet artifact");
   const firstSelectedGameDay = await expectSelectValue(eventAdminGameDaySelector, 1);
   const secondDayHubResponsePromise = eventAdminPage.waitForResponse(
     (response) =>
@@ -546,6 +739,16 @@ try {
       0,
     "removed Pitch remained selected or visible",
   );
+  const pitchViewResponsePromise = eventAdminPage.waitForResponse(
+    (response) =>
+      response.url().includes("/api/event-admin/pitch-view?") &&
+      response.request().method() === "GET",
+  );
+  await eventAdminPage.getByRole("button", { name: "Pitch Main", exact: true }).click();
+  assert((await pitchViewResponsePromise).status() === 200, "Pitch view transition failed");
+  await assertAccessSheetAbsent("Pitch transition did not clear the Access Sheet artifact");
+  await eventAdminPage.getByLabel("Access Sheet type").selectOption("control-grant");
+  await assertAccessSheetAbsent("sheet-type transition did not clear the Access Sheet artifact");
   const firstDayScheduleHubResponsePromise = eventAdminPage.waitForResponse(
     (response) =>
       response.url().includes("/api/event-admin/hub?") && response.request().method() === "GET",
@@ -569,6 +772,18 @@ try {
     .getByText(/Slot 1.*10:00/u)
     .last()
     .waitFor();
+  const failedReplacementResponsePromise = eventAdminPage.waitForResponse(
+    (response) =>
+      response.url().endsWith(`/api/event-admin/events/${eventId}/access-sheets`) &&
+      response.request().method() === "POST",
+  );
+  await eventAdminPage.getByRole("button", { name: "Generate Access Sheet" }).click();
+  const failedReplacementResponse = await failedReplacementResponsePromise;
+  assert(
+    failedReplacementResponse.status() === 404,
+    "failed Access Sheet replacement unexpectedly succeeded",
+  );
+  await assertAccessSheetAbsent("failed Access Sheet replacement restored an old artifact");
   await eventAdminPage.getByLabel("Gameplay Slot 1 Expected Delay minutes").fill("2");
   const firstDayPreviewResponsePromise = eventAdminPage.waitForResponse(
     (response) =>
@@ -706,21 +921,6 @@ try {
     `${origin}/api/audience/events/${eventId}`,
   );
   assert(unpublishedAudience.status() === 404, "unpublished Event remained anonymously available");
-  await eventAdminPage.getByRole("button", { name: "Published Event", exact: true }).click();
-  await eventAdminPage.getByLabel("Confirm leaving Published").check();
-  await eventAdminPage.getByRole("button", { name: "Cancel Event", exact: true }).click();
-  const cancelledAudience = await eventAdminContext.request.get(
-    `${origin}/api/audience/events/${eventId}`,
-  );
-  assert(cancelledAudience.status() === 404, "cancelled Event remained anonymously available");
-  const unknownAudience = await eventAdminContext.request.get(
-    `${origin}/api/audience/events/unknown-event`,
-  );
-  assert(
-    unknownAudience.status() === cancelledAudience.status() &&
-      (await unknownAudience.text()) === (await cancelledAudience.text()),
-    "unknown Event did not use the same anonymous absence response",
-  );
   await eventAdminPage
     .getByText(/Slot 1.*10:00/u)
     .last()
@@ -841,6 +1041,95 @@ try {
     .first()
     .waitFor();
 
+  const futureEventAdminContext = await browser.newContext({ ignoreHTTPSErrors: true });
+  const futureEventAdminPage = await futureEventAdminContext.newPage();
+  futureEventAdminPage.setDefaultTimeout(5_000);
+  browserPage = futureEventAdminPage;
+  await futureEventAdminPage.goto(`${origin}/event-admin?eventId=${futureEventId}`, {
+    waitUntil: "domcontentloaded",
+    timeout: 5_000,
+  });
+  const futureAdmissionResponsePromise = futureEventAdminPage.waitForResponse(
+    (response) =>
+      response.url().endsWith("/api/event-admin/admit") && response.request().method() === "POST",
+  );
+  await futureEventAdminPage.getByLabel("Scanned Event Admin QR value").fill(futureEventCredential);
+  await futureEventAdminPage.getByRole("button", { name: "Admit Event Admin" }).click();
+  const futureAdmissionResponse = await futureAdmissionResponsePromise;
+  assert(
+    futureAdmissionResponse.status() === 200,
+    `future Event Admin admission failed (${futureAdmissionResponse.status()})`,
+  );
+  await futureEventAdminPage.goto(`${origin}/event-admin?eventId=${futureEventId}`, {
+    waitUntil: "domcontentloaded",
+    timeout: 5_000,
+  });
+  await futureEventAdminPage.getByText("Event Hub", { exact: true }).waitFor();
+  const futurePitchCreateResponse = await postJsonBodyFromPage(
+    futureEventAdminPage,
+    `${origin}/api/event-admin/events/${futureEventId}/pitches`,
+    { name: "Future Pitch" },
+  );
+  const futurePitchPayload = JSON.parse(futurePitchCreateResponse.body) as {
+    value?: { pitchId?: string };
+  };
+  const futurePitchId = futurePitchPayload.value?.pitchId;
+  assert(
+    futurePitchCreateResponse.status === 201 && futurePitchId !== undefined,
+    "future Pitch creation failed",
+  );
+  await futureEventAdminPage.reload();
+  await futureEventAdminPage.getByRole("button", { name: "Future Pitch", exact: true }).waitFor();
+  const futurePitchManagerCreateResponse = await postJsonBodyFromPage(
+    futureEventAdminPage,
+    `${origin}/api/event-admin/events/${futureEventId}/game-days/${futureGameDayId}/pitches/${futurePitchId}/pitch-manager-grant`,
+    {},
+  );
+  assert(
+    futurePitchManagerCreateResponse.status === 201,
+    "future Pitch Manager Grant creation failed",
+  );
+  const futureAccessSheetResponsePromise = futureEventAdminPage.waitForResponse(
+    (response) =>
+      response.url().endsWith(`/api/event-admin/events/${futureEventId}/access-sheets`) &&
+      response.request().method() === "POST",
+  );
+  await futureEventAdminPage.getByLabel("Access Sheet type").selectOption("pitch-manager");
+  await futureEventAdminPage.getByRole("button", { name: "Generate Access Sheet" }).click();
+  const futureAccessSheetResponse = await futureAccessSheetResponsePromise;
+  const futureAccessSheetPayload = (await futureAccessSheetResponse.json()) as {
+    status?: string;
+    value?: { body?: string; version?: { type?: string } };
+  };
+  const futureAccessSheetBody = futureAccessSheetPayload.value?.body ?? "";
+  assert(
+    futureAccessSheetResponse.status() === 200 &&
+      futureAccessSheetPayload.status === "accepted" &&
+      futureAccessSheetPayload.value?.version?.type === "pitch-manager" &&
+      (futureAccessSheetBody.match(/class="entry"/gu) ?? []).length === 1 &&
+      futureAccessSheetBody.includes("TEST ENVIRONMENT") &&
+      futureAccessSheetBody.includes("Grant Code") === false,
+    "Pitch Manager Access Sheet generation did not return the complete printable artifact",
+  );
+  await futureEventAdminPage
+    .locator('iframe[title="Generated Grant Access Sheet preview"]')
+    .waitFor();
+  await futureEventAdminContext.close();
+  browserPage = eventAdminPage;
+
+  const currentGameDayHubResponsePromise = eventAdminPage.waitForResponse(
+    (response) =>
+      response.url().includes(`/api/event-admin/hub?eventId=${eventId}`) &&
+      response.url().includes("gameDayId=") &&
+      response.request().method() === "GET",
+  );
+  await eventAdminPage
+    .getByLabel("Game Day", { exact: true })
+    .selectOption({ value: pitchManagerGameDayId });
+  assert(
+    (await currentGameDayHubResponsePromise).status() === 200,
+    "current Game Day reload failed",
+  );
   const controlSetupResponse = await eventAdminContext.request.get(
     `${origin}/api/event-admin/slot-setup?eventId=${eventId}&gameDayId=${pitchManagerGameDayId}`,
   );
@@ -910,6 +1199,137 @@ try {
       pitchManagerControlCreateCookie?.includes("__Host-pitch-manager-session=") === true &&
       pitchManagerControlCreateCookie?.includes("__Host-event-admin-session=") !== true,
     "Pitch Manager Control Grant creation did not refresh only its own cookie",
+  );
+  const controlGameDayResponsePromise = eventAdminPage.waitForResponse(
+    (response) =>
+      response.url().includes(`/api/event-admin/hub?eventId=${eventId}`) &&
+      response.url().includes(`gameDayId=${pitchManagerGameDayId}`) &&
+      response.request().method() === "GET",
+  );
+  await eventAdminPage.getByLabel("Game Day", { exact: true }).selectOption(pitchManagerGameDayId);
+  assert(
+    (await controlGameDayResponsePromise).status() === 200,
+    "Control Game Day selection failed",
+  );
+  const controlPitchViewResponsePromise = eventAdminPage.waitForResponse(
+    (response) =>
+      response.url().includes("/api/event-admin/pitch-view?") &&
+      response.request().method() === "GET",
+  );
+  await eventAdminPage.getByRole("button", { name: "Pitch Main", exact: true }).click();
+  assert(
+    (await controlPitchViewResponsePromise).status() === 200,
+    "Control Pitch selection failed",
+  );
+  const controlGrantInspectForSheet = await eventAdminContext.request.get(
+    `${origin}${controlGrantPath}`,
+  );
+  const pitchManagerControlInspectForSheet = await pitchManagerContext.request.get(
+    `${origin}${pitchManagerControlPath}`,
+  );
+  const controlGrantInspectForSheetPayload = (await controlGrantInspectForSheet.json()) as {
+    value?: {
+      status?: string;
+      eligibility?: string;
+      grantVersion?: string;
+      expiresAtMs?: number | null;
+    };
+  };
+  const pitchManagerControlInspectForSheetPayload =
+    (await pitchManagerControlInspectForSheet.json()) as {
+      value?: {
+        status?: string;
+        eligibility?: string;
+        grantVersion?: string;
+        expiresAtMs?: number | null;
+      };
+    };
+  assert(
+    controlGrantInspectForSheetPayload.value?.eligibility === "empty" &&
+      pitchManagerControlInspectForSheetPayload.value?.eligibility === "empty",
+    "Control Grant unavailable-state fixture did not remain safely unavailable before registration",
+  );
+  await eventAdminPage.getByLabel("Access Sheet type").selectOption("control-grant");
+  const controlAccessSheetResponsePromise = eventAdminPage.waitForResponse(
+    (response) =>
+      response.url().endsWith(`/api/event-admin/events/${eventId}/access-sheets`) &&
+      response.request().method() === "POST",
+  );
+  await eventAdminPage.getByRole("button", { name: "Generate Access Sheet" }).click();
+  const controlAccessSheetResponse = await controlAccessSheetResponsePromise;
+  const controlAccessSheetPayload = (await controlAccessSheetResponse.json()) as {
+    status?: string;
+    value?: { body?: string; version?: { type?: string; scope?: Record<string, unknown> } };
+  };
+  assert(
+    controlAccessSheetResponse.status() === 200 &&
+      controlAccessSheetPayload.status === "accepted" &&
+      controlAccessSheetPayload.value?.version?.type === "control-grant" &&
+      controlAccessSheetPayload.value.body?.includes("control-grant") === true &&
+      controlAccessSheetPayload.value.body.includes("Grant Code") === false,
+    `new-scope Control Access Sheet generation did not return the new artifact (${controlAccessSheetResponse.status()}, grants=${controlGrantInspectForSheet.status()}/${pitchManagerControlInspectForSheet.status()}, states=${controlGrantInspectForSheetPayload.value?.status}/${pitchManagerControlInspectForSheetPayload.value?.status}, eligibility=${controlGrantInspectForSheetPayload.value?.eligibility}/${pitchManagerControlInspectForSheetPayload.value?.eligibility}): ${JSON.stringify(controlAccessSheetPayload).slice(0, 300)}`,
+  );
+  await accessSheetPreview.waitFor();
+  await expect(accessSheetPreview).toHaveCount(1);
+  const decodedControlCredentials = await accessSheetPreview.evaluate(async (iframe) => {
+    const preview = iframe as HTMLIFrameElement;
+    const document = preview.contentDocument;
+    if (document === null) throw new Error("Control Access Sheet preview was not available.");
+    const browserWindow = window as typeof window & {
+      ZXingBrowser: {
+        BrowserQRCodeReader: new () => {
+          decodeFromImageElement(source: HTMLImageElement): Promise<{ getText(): string }>;
+        };
+      };
+    };
+    const reader = new browserWindow.ZXingBrowser.BrowserQRCodeReader();
+    return Promise.all(
+      Array.from(document.querySelectorAll("svg.qr")).map(async (svg) => {
+        const image = new Image();
+        image.src = `data:image/svg+xml;base64,${btoa(new XMLSerializer().serializeToString(svg))}`;
+        await new Promise<void>((resolve, reject) => {
+          image.addEventListener("load", () => resolve(), { once: true });
+          image.addEventListener(
+            "error",
+            () => reject(new Error("Control Access Sheet QR failed.")),
+            {
+              once: true,
+            },
+          );
+        });
+        return (await reader.decodeFromImageElement(image)).getText();
+      }),
+    );
+  });
+  const controlSheetEntryCount = (
+    controlAccessSheetPayload.value.body?.match(/class="entry"/gu) ?? []
+  ).length;
+  assert(
+    decodedControlCredentials.length === controlSheetEntryCount &&
+      decodedControlCredentials.length === 2 &&
+      decodedControlCredentials.every(
+        (credential) => credential.length > 0 && credential.includes("Grant Code") === false,
+      ),
+    `independent browser QR decode did not recover every Control credential (${decodedControlCredentials.length}/${controlSheetEntryCount})`,
+  );
+  assert(
+    (await accessSheetPreview.getAttribute("srcdoc"))?.includes("control-grant") === true,
+    "new-scope Access Sheet preview did not display only the new artifact",
+  );
+  await eventAdminPage.getByRole("button", { name: "Published Event", exact: true }).click();
+  await eventAdminPage.getByLabel("Confirm leaving Published").check();
+  await eventAdminPage.getByRole("button", { name: "Cancel Event", exact: true }).click();
+  const cancelledAudience = await eventAdminContext.request.get(
+    `${origin}/api/audience/events/${eventId}`,
+  );
+  assert(cancelledAudience.status() === 404, "cancelled Event remained anonymously available");
+  const unknownAudience = await eventAdminContext.request.get(
+    `${origin}/api/audience/events/unknown-event`,
+  );
+  assert(
+    unknownAudience.status() === cancelledAudience.status() &&
+      (await unknownAudience.text()) === (await cancelledAudience.text()),
+    "unknown Event did not use the same anonymous absence response",
   );
   const eventAdminCookieAfterPitchManagerMutation = (await pitchManagerContext.cookies()).find(
     (cookie) => cookie.name === "__Host-event-admin-session",
@@ -1639,6 +2059,25 @@ async function postJsonBodyFromPage(page: Page, url: string, body: Record<string
       };
     },
     { requestUrl: url, requestBody: body },
+  );
+}
+
+async function postJsonWithHeadersFromPage(
+  page: Page,
+  url: string,
+  body: Record<string, string>,
+  headers: Record<string, string>,
+) {
+  return page.evaluate(
+    async ({ requestUrl, requestBody, requestHeaders }) => {
+      const response = await fetch(requestUrl, {
+        method: "POST",
+        headers: { ...requestHeaders, "content-type": "application/json" },
+        body: JSON.stringify(requestBody),
+      });
+      return { status: response.status, body: await response.text() };
+    },
+    { requestUrl: url, requestBody: body, requestHeaders: headers },
   );
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,7 @@ import {
 import { createGrantAuthority } from "@/lib/grant-authority";
 import { readGrantAuthorityOptions } from "@/lib/grant-runtime";
 import type { TypedGrantMutation, TypedGrantReveal } from "@/lib/grant-management";
+import type { AccessSheetRequest } from "@/lib/access-sheet";
 import { createInMemoryFoundationStorage } from "@/lib/foundation-storage-memory";
 import { openSqliteFoundationStorage } from "@/lib/foundation-storage-sqlite";
 import type { FoundationStorage } from "@/lib/foundation-storage";
@@ -220,6 +221,7 @@ async function startServer() {
           storage: foundationStorage,
           grants: grantAuthority,
           controlScopeResolver: grantOptions.controlScopeResolver,
+          environmentId: environment,
         });
       } catch {
         // Grant keys are an Event Administration dependency, not a server-wide dependency.
@@ -1262,6 +1264,27 @@ async function startServer() {
               authority,
             });
             return sensitiveEventAdministrationResponse(result);
+          },
+        },
+        "/api/event-admin/events/:eventId/access-sheets": {
+          async POST(req: Request) {
+            if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
+            const authority = resolveEventAdministrationAuthority(req, technicalAdminAuth);
+            const body = await readJsonRecord(req);
+            const eventId = new URL(req.url).pathname.split("/").at(-2) ?? "";
+            if (authority === null || body === null) return sensitiveGenericAuthFailure(401);
+            const input = {
+              type: body.type,
+              scope: {
+                eventId,
+                gameDayId: body.gameDayId,
+                pitchId: body.pitchId,
+              },
+            } as AccessSheetRequest;
+            return sensitiveEventAdministrationMutationResponse(
+              await eventAdministration.generateAccessSheet(input, authority),
+              authority,
+            );
           },
         },
         "/api/event-admin/events/:eventId/publication-status": {

--- a/src/lib/access-sheet.test.ts
+++ b/src/lib/access-sheet.test.ts
@@ -1,0 +1,890 @@
+import { describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import QRCode from "qrcode";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createEventAdministration } from "@/lib/event-administration";
+import { createEventCatalog, createFoundationEventCatalogStorage } from "@/lib/event-catalog";
+import { createInMemoryFoundationStorage } from "@/lib/foundation-storage-memory";
+import type { FoundationStorage } from "@/lib/foundation-storage";
+import {
+  openSqliteFoundationStorage,
+  SqliteFoundationFault,
+} from "@/lib/foundation-storage-sqlite";
+import { createPrintableAccessSheetRenderer } from "@/lib/access-sheet";
+import {
+  createGrantAuthority,
+  createGrantAuthorityVerifier,
+  type ControlGrantScopeResolver,
+} from "@/lib/grant-authority";
+import type { GrantKeyRing } from "@/lib/grant-types";
+import {
+  MemoryTechnicalAdminAuthRepository,
+  createTechnicalAdminAuth,
+  isTechnicalAdminAuthority,
+} from "@/lib/technical-admin-auth";
+
+const keyRing: GrantKeyRing = {
+  encryption: { currentVersion: "v1", keys: new Map([["v1", bytes(1)]]) },
+  lookup: { currentVersion: "v1", keys: new Map([["v1", bytes(2)]]) },
+  audit: { currentVersion: "v1", keys: new Map([["v1", bytes(3)]]) },
+};
+
+describe("Grant Access Sheets", () => {
+  test("generates all three QR-only sheets from one catalog snapshot", async () => {
+    const fixture = await createFixture();
+    const eventAdmin = await fixture.administration.createEventAdminGrant(
+      fixture.eventId,
+      fixture.technical,
+    );
+    if (eventAdmin.status !== "accepted") throw new Error("Expected Event Admin Grant.");
+    const pitchManager = await fixture.administration.createPitchManagerGrant(
+      fixture.eventId,
+      fixture.gameDayId,
+      fixture.pitchId,
+      fixture.technical,
+    );
+    if (pitchManager.status !== "accepted") throw new Error("Expected Pitch Manager Grant.");
+    const secondPitchManager = await fixture.administration.createPitchManagerGrant(
+      fixture.eventId,
+      fixture.gameDayId,
+      fixture.secondPitchId,
+      fixture.technical,
+    );
+    expect(secondPitchManager.status).toBe("accepted");
+    const secondDayPitchManager = await fixture.administration.createPitchManagerGrant(
+      fixture.eventId,
+      fixture.secondGameDayId,
+      fixture.pitchId,
+      fixture.technical,
+    );
+    const secondDaySecondPitchManager = await fixture.administration.createPitchManagerGrant(
+      fixture.eventId,
+      fixture.secondGameDayId,
+      fixture.secondPitchId,
+      fixture.technical,
+    );
+    expect(secondDayPitchManager.status).toBe("accepted");
+    expect(secondDaySecondPitchManager.status).toBe("accepted");
+    const slots = await fixture.storage.transaction((transaction) =>
+      transaction.listPitchSlots(fixture.gameDayId, fixture.pitchId),
+    );
+    const firstPitchSlot = slots[0];
+    if (firstPitchSlot === undefined) throw new Error("Expected a first Pitch Slot.");
+    await fixture.storage.transaction((transaction) => {
+      const existing = transaction
+        .listEventGames(fixture.gameDayId)
+        .find((game) => game.pitchSlotId === firstPitchSlot.pitchSlotId);
+      if (existing === undefined) throw new Error("Expected the fixture Event Game.");
+      transaction.insertEventGame({
+        ...existing,
+        eventGameId: "conflicting-event-game",
+        gameCode: "G-CONFLICT",
+        gameDesignation: "Conflicting snapshot",
+        sideA: { ...existing.sideA, sideId: "conflicting-event-game-side-a" },
+        sideB: { ...existing.sideB, sideId: "conflicting-event-game-side-b" },
+      });
+    });
+    for (const slot of slots) {
+      const control = await fixture.administration.createControlGrant(
+        fixture.eventId,
+        fixture.gameDayId,
+        fixture.pitchId,
+        slot.pitchSlotId,
+        fixture.technical,
+      );
+      expect(control.status).toBe("accepted");
+    }
+
+    const eventSheet = await fixture.administration.generateAccessSheet(
+      { type: "event-admin", scope: { eventId: fixture.eventId } },
+      fixture.technical,
+    );
+    const pitchSheet = await fixture.administration.generateAccessSheet(
+      {
+        type: "pitch-manager",
+        scope: { eventId: fixture.eventId },
+      },
+      fixture.technical,
+    );
+    const controlSheet = await fixture.administration.generateAccessSheet(
+      {
+        type: "control-grant",
+        scope: {
+          eventId: fixture.eventId,
+          gameDayId: fixture.gameDayId,
+          pitchId: fixture.pitchId,
+        },
+      },
+      fixture.technical,
+    );
+
+    expect(eventSheet).toMatchObject({
+      status: "accepted",
+      value: { version: { environmentId: "test", type: "event-admin", testMark: true } },
+    });
+    expect(pitchSheet).toMatchObject({
+      status: "accepted",
+      value: { version: { type: "pitch-manager" } },
+    });
+    expect(controlSheet).toMatchObject({
+      status: "accepted",
+      value: { version: { type: "control-grant" } },
+    });
+    if (
+      eventSheet.status !== "accepted" ||
+      pitchSheet.status !== "accepted" ||
+      controlSheet.status !== "accepted"
+    )
+      throw new Error("Expected all sheets.");
+    expect(eventSheet.value.body).toContain("TEST ENVIRONMENT");
+    expect((pitchSheet.value.body.match(/class="entry"/g) ?? []).length).toBe(4);
+    expect((controlSheet.value.body.match(/class="entry"/g) ?? []).length).toBe(slots.length);
+    expect(controlSheet.value.body).toContain("Pitch A · Pitch Slot 1");
+    expect(controlSheet.value.body).toContain("Pitch A · Pitch Slot 2");
+    expect(controlSheet.value.body).toContain("North");
+    expect(controlSheet.value.body).toContain("South");
+    expect(controlSheet.value.body).toContain("Conflicting snapshot");
+    expect(controlSheet.value.body).not.toContain("grant-code");
+    expect(controlSheet.value.body).not.toContain("Grant Code");
+
+    const credentials = await fixture.storage.transaction((transaction) =>
+      transaction.listGrants().map((grant) => grant.grantId),
+    );
+    for (const grantId of credentials) {
+      const reveal = await fixture.grants.revealGrant(grantId, fixture.technical);
+      if (reveal.status === "revealed")
+        expect(controlSheet.value.body).not.toContain(reveal.qrCredential);
+    }
+    const audits = await fixture.catalog.listAuditTrail(fixture.eventId, fixture.technical);
+    expect(audits).toMatchObject({ status: "accepted" });
+    if (audits.status !== "accepted") throw new Error("Expected audit trail.");
+    const sheetAudits = audits.value.filter((audit) => audit.action === "access-sheet-generated");
+    expect(sheetAudits).toHaveLength(3);
+    expect(JSON.stringify(sheetAudits)).not.toContain("qrCredential");
+    expect(eventSheet.value.body).toContain('role="img" aria-label="QR credential"');
+    expect(eventSheet.value.body).toContain(
+      '<main class="sheet" aria-labelledby="access-sheet-title">',
+    );
+    expect(eventSheet.value.body).toContain('lang="en"');
+  });
+
+  test("rotation invalidates only the embedded QR for the rotated Grant", async () => {
+    const renderedCredentials = new Map<string, string[]>();
+    const renderer = createPrintableAccessSheetRenderer();
+    const fixture = await createFixture({
+      accessSheetRenderer: {
+        render(input) {
+          renderedCredentials.set(
+            input.version.type,
+            input.entries.map((entry) => entry.qrCredential),
+          );
+          return renderer.render(input);
+        },
+      },
+    });
+    const eventAdmin = await fixture.administration.createEventAdminGrant(
+      fixture.eventId,
+      fixture.technical,
+    );
+    const pitchManager = await fixture.administration.createPitchManagerGrant(
+      fixture.eventId,
+      fixture.gameDayId,
+      fixture.pitchId,
+      fixture.technical,
+    );
+    const secondPitchManager = await fixture.administration.createPitchManagerGrant(
+      fixture.eventId,
+      fixture.gameDayId,
+      fixture.secondPitchId,
+      fixture.technical,
+    );
+    expect(eventAdmin.status).toBe("accepted");
+    expect(pitchManager.status).toBe("accepted");
+    expect(secondPitchManager.status).toBe("accepted");
+    const secondDayPitchManager = await fixture.administration.createPitchManagerGrant(
+      fixture.eventId,
+      fixture.secondGameDayId,
+      fixture.pitchId,
+      fixture.technical,
+    );
+    expect(secondDayPitchManager.status).toBe("accepted");
+    const secondDaySecondPitchManager = await fixture.administration.createPitchManagerGrant(
+      fixture.eventId,
+      fixture.secondGameDayId,
+      fixture.secondPitchId,
+      fixture.technical,
+    );
+    expect(secondDaySecondPitchManager.status).toBe("accepted");
+    expect(
+      await fixture.administration.generateAccessSheet(
+        { type: "event-admin", scope: { eventId: fixture.eventId } },
+        fixture.technical,
+      ),
+    ).toMatchObject({ status: "accepted" });
+    expect(
+      await fixture.administration.generateAccessSheet(
+        { type: "pitch-manager", scope: { eventId: fixture.eventId } },
+        fixture.technical,
+      ),
+    ).toMatchObject({ status: "accepted" });
+    const oldEventCredential = renderedCredentials.get("event-admin")?.[0];
+    const unaffectedPitchCredential = renderedCredentials.get("pitch-manager")?.[0];
+    if (oldEventCredential === undefined || unaffectedPitchCredential === undefined)
+      throw new Error("Expected generated sheet credentials.");
+    const rotated = await fixture.administration.rotateEventAdminGrant(
+      fixture.eventId,
+      fixture.technical,
+    );
+    expect(rotated).toMatchObject({ status: "accepted" });
+    expect(
+      await fixture.administration.admitEventAdmin({
+        qrCredential: oldEventCredential,
+        browserContext: "rotated-sheet-credential",
+      }),
+    ).toMatchObject({ status: "rejected" });
+    expect(
+      await fixture.administration.admitPitchManager({
+        qrCredential: unaffectedPitchCredential,
+        browserContext: "unaffected-sheet-credential",
+      }),
+    ).toMatchObject({ status: "admitted" });
+  });
+
+  test("includes empty and conflicted Control QRs while canonical admission rejects them", async () => {
+    let emptySlotId: string | undefined;
+    let conflictedSlotId: string | undefined;
+    const renderedCredentials: string[] = [];
+    const renderer = createPrintableAccessSheetRenderer();
+    const controlScopeResolver: ControlGrantScopeResolver = {
+      resolve(scope) {
+        if (scope.pitchSlotId === emptySlotId) return { status: "empty" };
+        if (scope.pitchSlotId === conflictedSlotId) return { status: "conflict" };
+        return { status: "eligible", eventGameId: "game-1" };
+      },
+    };
+    const fixture = await createFixture({
+      controlScopeResolver,
+      accessSheetRenderer: {
+        render(input) {
+          if (input.version.type === "control-grant")
+            renderedCredentials.push(...input.entries.map((entry) => entry.qrCredential));
+          return renderer.render(input);
+        },
+      },
+    });
+    const slots = await fixture.storage.transaction((transaction) =>
+      transaction.listPitchSlots(fixture.gameDayId, fixture.pitchId),
+    );
+    const emptySlot = slots[1];
+    const conflictedSlot = slots[0];
+    if (emptySlot === undefined || conflictedSlot === undefined)
+      throw new Error("Expected empty and conflicted Pitch Slots.");
+    emptySlotId = emptySlot.pitchSlotId;
+    conflictedSlotId = conflictedSlot.pitchSlotId;
+    await fixture.storage.transaction((transaction) => {
+      const existing = transaction
+        .listEventGames(fixture.gameDayId)
+        .find((game) => game.pitchSlotId === conflictedSlotId);
+      if (existing === undefined) throw new Error("Expected the conflicted fixture Event Game.");
+      transaction.insertEventGame({
+        ...existing,
+        eventGameId: "access-sheet-conflict",
+        gameCode: "G-CONFLICT-ACCESS-SHEET",
+        gameDesignation: "Access Sheet conflict snapshot",
+        sideA: { ...existing.sideA, sideId: "access-sheet-conflict-side-a" },
+        sideB: { ...existing.sideB, sideId: "access-sheet-conflict-side-b" },
+      });
+    });
+    for (const slot of slots) {
+      const grant = await fixture.administration.createControlGrant(
+        fixture.eventId,
+        fixture.gameDayId,
+        fixture.pitchId,
+        slot.pitchSlotId,
+        fixture.technical,
+      );
+      expect(grant.status).toBe("accepted");
+    }
+
+    const beforeAudit = await fixture.catalog.listAuditTrail(fixture.eventId, fixture.technical);
+    const result = await fixture.administration.generateAccessSheet(
+      {
+        type: "control-grant",
+        scope: {
+          eventId: fixture.eventId,
+          gameDayId: fixture.gameDayId,
+          pitchId: fixture.pitchId,
+        },
+      },
+      fixture.technical,
+    );
+    expect(result).toMatchObject({ status: "accepted" });
+    expect(renderedCredentials).toHaveLength(slots.length);
+    const emptyIndex = slots.findIndex((slot) => slot.pitchSlotId === emptySlotId);
+    const conflictIndex = slots.findIndex((slot) => slot.pitchSlotId === conflictedSlotId);
+    expect(emptyIndex).toBeGreaterThanOrEqual(0);
+    expect(conflictIndex).toBeGreaterThanOrEqual(0);
+    for (const credential of renderedCredentials) {
+      expect(
+        await fixture.administration.admitControlGrant({
+          qrCredential: credential,
+          browserContext: `unavailable-control-${credential.slice(0, 8)}`,
+        }),
+      ).toMatchObject({ status: "rejected" });
+    }
+    const afterAudit = await fixture.catalog.listAuditTrail(fixture.eventId, fixture.technical);
+    expect(afterAudit).not.toEqual(beforeAudit);
+  });
+
+  test("does not resolve a disabled Grant into an Access Sheet", async () => {
+    const fixture = await createFixture();
+    const grant = await fixture.administration.createEventAdminGrant(
+      fixture.eventId,
+      fixture.technical,
+    );
+    expect(grant.status).toBe("accepted");
+    const disabled = await fixture.administration.disableEventAdminGrant(
+      fixture.eventId,
+      fixture.technical,
+    );
+    expect(disabled.status).toBe("accepted");
+    const beforeAudit = await fixture.catalog.listAuditTrail(fixture.eventId, fixture.technical);
+    expect(
+      await fixture.administration.generateAccessSheet(
+        { type: "event-admin", scope: { eventId: fixture.eventId } },
+        fixture.technical,
+      ),
+    ).toMatchObject({ status: "rejected" });
+    const afterAudit = await fixture.catalog.listAuditTrail(fixture.eventId, fixture.technical);
+    expect(afterAudit).toEqual(beforeAudit);
+  });
+
+  test("expires an Access Sheet Grant before resolution without an artifact or sheet audit", async () => {
+    const fixture = await createFixture();
+    const grant = await fixture.administration.createEventAdminGrant(
+      fixture.eventId,
+      fixture.technical,
+    );
+    expect(grant.status).toBe("accepted");
+    fixture.setNow(Date.parse("2026-08-23T14:00:00Z"));
+    const beforeAudit = await fixture.catalog.listAuditTrail(fixture.eventId, fixture.technical);
+    const result = await fixture.administration.generateAccessSheet(
+      { type: "event-admin", scope: { eventId: fixture.eventId } },
+      fixture.technical,
+    );
+    expect(result).toMatchObject({ status: "rejected" });
+    const afterAudit = await fixture.catalog.listAuditTrail(fixture.eventId, fixture.technical);
+    expect(afterAudit).toEqual(beforeAudit);
+  });
+
+  test("rolls back authority and catalog race mutations before returning a sheet", async () => {
+    const authorityRace = await createFixture();
+    const eventAdmin = await authorityRace.administration.createEventAdminGrant(
+      authorityRace.eventId,
+      authorityRace.technical,
+    );
+    expect(eventAdmin.status).toBe("accepted");
+    const beforeAuthorityRace = await authorityRace.storage.transaction((transaction) => ({
+      grant: transaction.findGrantById(
+        eventAdmin.status === "accepted" ? eventAdmin.value.grantId : "",
+      ),
+      audits: transaction.listEventAuditTrail(authorityRace.eventId),
+    }));
+    authorityRace.grants.resolveAccessSheetQrCredentialInTransaction = (transaction, input) => {
+      const grantId = input.grantId;
+      const grant = transaction.findGrantById(grantId);
+      if (grant !== null) transaction.updateGrant({ ...grant, status: "revoked" });
+      throw new Error("authority race");
+    };
+    expect(
+      await authorityRace.administration.generateAccessSheet(
+        { type: "event-admin", scope: { eventId: authorityRace.eventId } },
+        authorityRace.technical,
+      ),
+    ).toMatchObject({ status: "retryable-failure" });
+    const afterAuthorityRace = await authorityRace.storage.transaction((transaction) => ({
+      grant: transaction.findGrantById(
+        eventAdmin.status === "accepted" ? eventAdmin.value.grantId : "",
+      ),
+      audits: transaction.listEventAuditTrail(authorityRace.eventId),
+    }));
+    expect(afterAuthorityRace.grant?.status).toBe("active");
+    expect(afterAuthorityRace.audits).toEqual(beforeAuthorityRace.audits);
+
+    const catalogRace = await createFixture();
+    const catalogGrant = await catalogRace.administration.createEventAdminGrant(
+      catalogRace.eventId,
+      catalogRace.technical,
+    );
+    expect(catalogGrant.status).toBe("accepted");
+    const beforeCatalogRace = await catalogRace.storage.transaction((transaction) => ({
+      pitch: transaction.findPitch(catalogRace.pitchId),
+      audits: transaction.listEventAuditTrail(catalogRace.eventId),
+    }));
+    const racedPitch = beforeCatalogRace.pitch;
+    if (racedPitch === null) throw new Error("Expected catalog Pitch.");
+    catalogRace.grants.resolveAccessSheetQrCredentialInTransaction = (transaction) => {
+      transaction.updatePitch({ ...racedPitch, name: "Raced Pitch" });
+      throw new Error("catalog race");
+    };
+    expect(
+      await catalogRace.administration.generateAccessSheet(
+        { type: "event-admin", scope: { eventId: catalogRace.eventId } },
+        catalogRace.technical,
+      ),
+    ).toMatchObject({ status: "retryable-failure" });
+    const afterCatalogRace = await catalogRace.storage.transaction((transaction) => ({
+      pitch: transaction.findPitch(catalogRace.pitchId),
+      audits: transaction.listEventAuditTrail(catalogRace.eventId),
+    }));
+    expect(afterCatalogRace.pitch?.name).toBe(racedPitch.name);
+    expect(afterCatalogRace.audits).toEqual(beforeCatalogRace.audits);
+  });
+
+  test("serializes concurrent generations without sharing version or audit identities", async () => {
+    const fixture = await createFixture();
+    const grant = await fixture.administration.createEventAdminGrant(
+      fixture.eventId,
+      fixture.technical,
+    );
+    expect(grant.status).toBe("accepted");
+    const results = await Promise.all([
+      fixture.administration.generateAccessSheet(
+        { type: "event-admin", scope: { eventId: fixture.eventId } },
+        fixture.technical,
+      ),
+      fixture.administration.generateAccessSheet(
+        { type: "event-admin", scope: { eventId: fixture.eventId } },
+        fixture.technical,
+      ),
+    ]);
+    expect(results.every((result) => result.status === "accepted")).toBe(true);
+    if (results[0]?.status !== "accepted" || results[1]?.status !== "accepted")
+      throw new Error("Expected concurrent Access Sheet generations.");
+    expect(results[0].value.version.versionId).not.toBe(results[1].value.version.versionId);
+    const audits = await fixture.catalog.listAuditTrail(fixture.eventId, fixture.technical);
+    if (audits.status !== "accepted") throw new Error("Expected audit trail.");
+    expect(audits.value.filter((audit) => audit.action === "access-sheet-generated")).toHaveLength(
+      2,
+    );
+  });
+
+  test("escapes structure and keeps the production QR matrix inside the printable SVG", () => {
+    const credential = "qr-credential-for-structural-decode";
+    const expected = QRCode.create(credential, { errorCorrectionLevel: "M" });
+    const rendered = createPrintableAccessSheetRenderer().render({
+      version: {
+        versionId: "version-qr-structure",
+        environmentId: "test",
+        type: "event-admin",
+        scope: { eventId: "event-qr-structure" },
+        generatedAtMs: 1_000,
+        testMark: true,
+      },
+      title: "<script>bad</script>",
+      entries: [{ label: "<img src=x>", qrCredential: credential }],
+    });
+    expect(rendered.body).toContain("&lt;script&gt;bad&lt;/script&gt;");
+    expect(rendered.body).not.toContain("<script>bad</script>");
+    expect(rendered.body).toContain("&lt;img src=x&gt;");
+    expect(rendered.body).toContain(
+      `viewBox="0 0 ${expected.modules.size} ${expected.modules.size}"`,
+    );
+    expect(rendered.body).toContain('aria-label="QR credential"');
+    expect(rendered.body).toContain("@media print");
+  });
+
+  test("allows an Event Admin session and rejects a wrong Event scope", async () => {
+    const fixture = await createFixture();
+    const grant = await fixture.administration.createEventAdminGrant(
+      fixture.eventId,
+      fixture.technical,
+    );
+    if (grant.status !== "accepted") throw new Error("Expected Event Admin Grant.");
+    const reveal = await fixture.grants.revealGrant(grant.value.grantId, fixture.technical);
+    if (reveal.status !== "revealed") throw new Error("Expected QR.");
+    const admitted = await fixture.administration.admitEventAdmin({
+      qrCredential: reveal.qrCredential,
+      browserContext: "access-sheet-browser",
+    });
+    if (admitted.status !== "admitted") throw new Error("Expected Event Admin Session.");
+    expect(
+      await fixture.grants.revealGrant(grant.value.grantId, {
+        kind: "grant-session",
+        sessionBearer: admitted.sessionBearer,
+      }),
+    ).toMatchObject({ status: "rejected", reason: "unauthorized" });
+    const sessionResult = await fixture.administration.generateAccessSheet(
+      { type: "event-admin", scope: { eventId: fixture.eventId } },
+      { kind: "grant-session", sessionBearer: admitted.sessionBearer },
+    );
+    expect(sessionResult.status).toBe("accepted");
+    expect(
+      await fixture.administration.generateAccessSheet(
+        { type: "event-admin", scope: { eventId: "wrong-event" } },
+        { kind: "grant-session", sessionBearer: admitted.sessionBearer },
+      ),
+    ).toMatchObject({ status: "rejected", reason: "unauthorized" });
+  });
+
+  test("returns no artifact or audit when rendering fails", async () => {
+    const fixture = await createFixture({
+      accessSheetRenderer: {
+        render() {
+          throw new Error("renderer failed");
+        },
+      },
+    });
+    const grant = await fixture.administration.createEventAdminGrant(
+      fixture.eventId,
+      fixture.technical,
+    );
+    expect(grant.status).toBe("accepted");
+    const before = await fixture.catalog.listAuditTrail(fixture.eventId, fixture.technical);
+    const result = await fixture.administration.generateAccessSheet(
+      { type: "event-admin", scope: { eventId: fixture.eventId } },
+      fixture.technical,
+    );
+    expect(result).toMatchObject({ status: "retryable-failure" });
+    const after = await fixture.catalog.listAuditTrail(fixture.eventId, fixture.technical);
+    expect(after).toEqual(before);
+  });
+
+  test("does not return an artifact when the redacted audit commit fails", async () => {
+    const fixture = await createFixture({
+      accessSheetIds: {
+        next(kind) {
+          return kind === "audit" ? "existing-audit-id" : `new-${kind}`;
+        },
+      },
+    });
+    const grant = await fixture.administration.createEventAdminGrant(
+      fixture.eventId,
+      fixture.technical,
+    );
+    expect(grant.status).toBe("accepted");
+    await fixture.storage.transaction((transaction) => {
+      transaction.appendEventAudit({
+        auditId: "existing-audit-id",
+        operationId: "existing-operation-id",
+        action: "event-updated",
+        eventId: fixture.eventId,
+        gameDayId: null,
+        actorReference: "technical-admin:test",
+        occurredAtMs: 1,
+        before: null,
+        after: null,
+      });
+    });
+    const result = await fixture.administration.generateAccessSheet(
+      { type: "event-admin", scope: { eventId: fixture.eventId } },
+      fixture.technical,
+    );
+    expect(result).toMatchObject({ status: "retryable-failure" });
+    const audits = await fixture.catalog.listAuditTrail(fixture.eventId, fixture.technical);
+    if (audits.status !== "accepted") throw new Error("Expected audit trail.");
+    expect(audits.value.filter((audit) => audit.action === "access-sheet-generated")).toHaveLength(
+      0,
+    );
+  });
+
+  test("uses SQLite transaction boundaries for success and every failure path", async () => {
+    await withSqliteStorage(async (storage) => {
+      const successful = await createFixture({}, storage);
+      const grant = await successful.administration.createEventAdminGrant(
+        successful.eventId,
+        successful.technical,
+      );
+      expect(grant.status).toBe("accepted");
+      const artifact = await successful.administration.generateAccessSheet(
+        { type: "event-admin", scope: { eventId: successful.eventId } },
+        successful.technical,
+      );
+      expect(artifact).toMatchObject({ status: "accepted", value: { contentType: "text/html" } });
+      const audit = await successful.catalog.listAuditTrail(
+        successful.eventId,
+        successful.technical,
+      );
+      expect(audit).toMatchObject({ status: "accepted" });
+      if (audit.status !== "accepted") throw new Error("Expected SQLite audit trail.");
+      expect(audit.value.filter((entry) => entry.action === "access-sheet-generated")).toHaveLength(
+        1,
+      );
+    });
+
+    await withSqliteStorage(async (storage) => {
+      const failedRender = await createFixture(
+        {
+          accessSheetRenderer: {
+            render() {
+              throw new Error("renderer failed");
+            },
+          },
+        },
+        storage,
+      );
+      const grant = await failedRender.administration.createEventAdminGrant(
+        failedRender.eventId,
+        failedRender.technical,
+      );
+      expect(grant.status).toBe("accepted");
+      const result = await failedRender.administration.generateAccessSheet(
+        { type: "event-admin", scope: { eventId: failedRender.eventId } },
+        failedRender.technical,
+      );
+      expect(result).toMatchObject({ status: "retryable-failure" });
+      const audit = await failedRender.catalog.listAuditTrail(
+        failedRender.eventId,
+        failedRender.technical,
+      );
+      if (audit.status !== "accepted") throw new Error("Expected SQLite audit trail.");
+      expect(audit.value.filter((entry) => entry.action === "access-sheet-generated")).toHaveLength(
+        0,
+      );
+    });
+
+    await withSqliteStorage(async (storage) => {
+      const failedAudit = await createFixture(
+        {
+          accessSheetIds: {
+            next(kind) {
+              return kind === "audit" ? "existing-audit-id" : `new-${kind}`;
+            },
+          },
+        },
+        storage,
+      );
+      const grant = await failedAudit.administration.createEventAdminGrant(
+        failedAudit.eventId,
+        failedAudit.technical,
+      );
+      expect(grant.status).toBe("accepted");
+      await storage.transaction((transaction) => {
+        transaction.appendEventAudit({
+          auditId: "existing-audit-id",
+          operationId: "existing-operation-id",
+          action: "event-updated",
+          eventId: failedAudit.eventId,
+          gameDayId: null,
+          actorReference: "technical-admin:test",
+          occurredAtMs: 1,
+          before: null,
+          after: null,
+        });
+      });
+      const result = await failedAudit.administration.generateAccessSheet(
+        { type: "event-admin", scope: { eventId: failedAudit.eventId } },
+        failedAudit.technical,
+      );
+      expect(result).toMatchObject({ status: "retryable-failure" });
+      const audit = await failedAudit.catalog.listAuditTrail(
+        failedAudit.eventId,
+        failedAudit.technical,
+      );
+      if (audit.status !== "accepted") throw new Error("Expected SQLite audit trail.");
+      expect(audit.value.filter((entry) => entry.action === "access-sheet-generated")).toHaveLength(
+        0,
+      );
+    });
+
+    let injectCommitFailure = false;
+    await withSqliteStorage(
+      async (storage, databasePath) => {
+        const failedCommit = await createFixture({}, storage);
+        const grant = await failedCommit.administration.createEventAdminGrant(
+          failedCommit.eventId,
+          failedCommit.technical,
+        );
+        expect(grant.status).toBe("accepted");
+        injectCommitFailure = true;
+        const result = await failedCommit.administration.generateAccessSheet(
+          { type: "event-admin", scope: { eventId: failedCommit.eventId } },
+          failedCommit.technical,
+        );
+        expect(result).toMatchObject({ status: "retryable-failure" });
+        const database = new Database(databasePath);
+        expect(
+          database
+            .query(
+              "SELECT COUNT(*) AS count FROM foundation_event_catalog_audit WHERE action = 'access-sheet-generated'",
+            )
+            .get(),
+        ).toEqual({ count: 0 });
+        database.close();
+      },
+      () => injectCommitFailure,
+    );
+  });
+});
+
+async function withSqliteStorage<T>(
+  work: (storage: FoundationStorage, databasePath: string) => Promise<T>,
+  shouldFailCommit: () => boolean = () => false,
+): Promise<T> {
+  const directory = await mkdtemp(join(tmpdir(), "quadball-timer-access-sheet-"));
+  const databasePath = join(directory, "foundation.sqlite");
+  const storage = openSqliteFoundationStorage(databasePath, {
+    grantKeyRing: keyRing,
+    faultInjector(phase) {
+      if (shouldFailCommit() && phase === "before-commit")
+        throw new SqliteFoundationFault("commit-failure");
+    },
+  });
+  try {
+    await storage.applyMigrations({ requireCandidate: false });
+    return await work(storage, databasePath);
+  } finally {
+    storage.close();
+    await rm(directory, { recursive: true, force: true });
+  }
+}
+
+async function createFixture(
+  options: {
+    controlScopeResolver?: Parameters<typeof createGrantAuthority>[1]["controlScopeResolver"];
+    accessSheetRenderer?: Parameters<typeof createEventAdministration>[0]["accessSheetRenderer"];
+    accessSheetIds?: Parameters<typeof createEventAdministration>[0]["accessSheetIds"];
+  } = {},
+  storage: FoundationStorage = createInMemoryFoundationStorage(),
+) {
+  let nowMs = Date.parse("2026-08-14T12:00:00Z");
+  let entropy = 9;
+  const technical = createTechnicalAdminAuth(
+    { environment: "test", origin: "https://timer.example", rpId: "timer.example" },
+    new MemoryTechnicalAdminAuthRepository(),
+  ).resolveHostLocalAuthority();
+  const catalog = createEventCatalog(createFoundationEventCatalogStorage(storage), {
+    clock: { nowMs: () => nowMs },
+  });
+  const grants = createGrantAuthority(storage, {
+    environmentId: "test",
+    clock: { nowMs: () => nowMs },
+    randomness: {
+      bytes: (length) => {
+        const seed = entropy++;
+        return Uint8Array.from({ length }, (_, index) => ((seed + index * 31) % 240) + 1);
+      },
+    },
+    keyRing,
+    controlScopeResolver: options.controlScopeResolver ?? {
+      resolve: () => ({ status: "eligible", eventGameId: "game-1" }),
+    },
+    privilegedAuthorityVerifier: createGrantAuthorityVerifier((input) => {
+      if (isTechnicalAdminAuthority(input)) return { kind: "technical-admin", id: input.sessionId };
+      if (
+        isRecord(input) &&
+        input.kind === "grant-session" &&
+        typeof input.sessionBearer === "string"
+      )
+        return { kind: "grant-session", sessionBearer: input.sessionBearer, sessionId: "session" };
+      return null;
+    }),
+  });
+  const administration = createEventAdministration({
+    storage,
+    grants,
+    catalog,
+    nowMs: () => nowMs,
+    environmentId: "test",
+    ...options,
+  });
+  const event = await catalog.createEvent(
+    { name: "Access Sheet Event", timeZone: "UTC" },
+    technical,
+  );
+  if (event.status !== "accepted") throw new Error("Expected Event.");
+  const day = await catalog.addGameDay(event.value.eventId, { date: "2026-08-14" }, technical);
+  const secondDay = await catalog.addGameDay(
+    event.value.eventId,
+    { date: "2026-08-15" },
+    technical,
+  );
+  const pitchA = await catalog.createPitch(event.value.eventId, { name: "Pitch A" }, technical);
+  const pitchB = await catalog.createPitch(event.value.eventId, { name: "Pitch B" }, technical);
+  const slotA = await catalog.createGameplaySlot(
+    event.value.eventId,
+    day.status === "accepted" ? day.value.gameDayId : "",
+    { sequence: 1, scheduledStart: "2026-08-14T10:00" },
+    technical,
+  );
+  const slotB = await catalog.createGameplaySlot(
+    event.value.eventId,
+    day.status === "accepted" ? day.value.gameDayId : "",
+    { sequence: 2, scheduledStart: "2026-08-14T10:30" },
+    technical,
+  );
+  if (
+    day.status !== "accepted" ||
+    secondDay.status !== "accepted" ||
+    pitchA.status !== "accepted" ||
+    pitchB.status !== "accepted" ||
+    slotA.status !== "accepted" ||
+    slotB.status !== "accepted"
+  )
+    throw new Error("Expected schedule.");
+  const teams = await Promise.all([
+    catalog.createEventTeam(event.value.eventId, { name: "North" }, technical),
+    catalog.createEventTeam(event.value.eventId, { name: "South" }, technical),
+  ]);
+  if (teams.some((team) => team.status !== "accepted")) throw new Error("Expected teams.");
+  const slots = await storage.transaction((transaction) =>
+    transaction.listPitchSlots(day.value.gameDayId, pitchA.value.pitchId),
+  );
+  const firstSlot = slots[0];
+  if (firstSlot === undefined) throw new Error("Expected Pitch Slot.");
+  const game = await catalog.createEventGame(
+    event.value.eventId,
+    day.value.gameDayId,
+    {
+      gameplaySlotId: slotA.value.gameplaySlotId,
+      pitchSlotId: firstSlot.pitchSlotId,
+      gameCode: "G-1",
+      gameDesignation: "Opening Game",
+      sideA: { sourceLabel: "North" },
+      sideB: { sourceLabel: "South" },
+    },
+    technical,
+  );
+  if (game.status !== "accepted") throw new Error("Expected Event Game.");
+  const confirmed = await catalog.confirmGameplaySlotTeams(
+    event.value.eventId,
+    day.value.gameDayId,
+    slotA.value.gameplaySlotId,
+    {
+      games: [
+        {
+          eventGameId: game.value.eventGameId,
+          sideAEventTeamId: teams[0].status === "accepted" ? teams[0].value.eventTeamId : "",
+          sideBEventTeamId: teams[1].status === "accepted" ? teams[1].value.eventTeamId : "",
+        },
+      ],
+    },
+    technical,
+  );
+  if (confirmed.status !== "accepted") throw new Error("Expected confirmed teams.");
+  return {
+    storage,
+    catalog,
+    grants,
+    administration,
+    technical,
+    eventId: event.value.eventId,
+    gameDayId: day.value.gameDayId,
+    secondGameDayId: secondDay.value.gameDayId,
+    pitchId: pitchA.value.pitchId,
+    secondPitchId: pitchB.value.pitchId,
+    setNow(value: number) {
+      nowMs = value;
+    },
+  };
+}
+
+function bytes(value: number): Uint8Array {
+  return new Uint8Array(32).fill(value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/lib/access-sheet.ts
+++ b/src/lib/access-sheet.ts
@@ -1,0 +1,373 @@
+import QRCode from "qrcode";
+import type {
+  FoundationStorageTransaction,
+  EventCatalogAuditEntry,
+} from "@/lib/foundation-storage";
+import { projectExpectedStartMs, type EventGame, type PitchSlot } from "@/lib/event-catalog";
+import type { GrantManagementAuthority, TypedGrantAuthority } from "@/lib/grant-management";
+import {
+  EVENT_ADMIN_GRANT_TYPE,
+  GRANT_TYPE,
+  PITCH_MANAGER_GRANT_TYPE,
+  type StoredGrant,
+} from "@/lib/grant-types";
+
+export type AccessSheetType = "event-admin" | "pitch-manager" | "control-grant";
+
+export type AccessSheetScope = {
+  eventId: string;
+  gameDayId?: string;
+  pitchId?: string;
+};
+
+export type AccessSheetRequest = {
+  type: AccessSheetType;
+  scope: AccessSheetScope;
+};
+
+export type AccessSheetVersion = {
+  versionId: string;
+  environmentId: string;
+  type: AccessSheetType;
+  scope: AccessSheetScope;
+  generatedAtMs: number;
+  testMark: boolean;
+};
+
+export type AccessSheetArtifact = {
+  contentType: "text/html";
+  body: string;
+  version: AccessSheetVersion;
+};
+
+export type AccessSheetRejectedReason = "invalid-input" | "not-found" | "unauthorized";
+
+export type AccessSheetOutcome =
+  | { status: "accepted"; value: AccessSheetArtifact }
+  | { status: "rejected"; reason: AccessSheetRejectedReason; detail: string }
+  | { status: "retryable-failure"; detail: string };
+
+export type AccessSheetIds = {
+  next(kind: "version" | "audit" | "operation"): string;
+};
+
+export type AccessSheetRendererInput = {
+  version: AccessSheetVersion;
+  title: string;
+  entries: readonly AccessSheetEntry[];
+};
+
+export type AccessSheetEntry = {
+  label: string;
+  qrCredential: string;
+  game?: AccessSheetGameSnapshot | null;
+};
+
+export type AccessSheetGameSnapshot = {
+  scheduledStartMs: number;
+  expectedStartMs: number;
+  sideA: string | null;
+  sideB: string | null;
+  gameCode: string | null;
+  gameDesignation: string | null;
+};
+
+export type AccessSheetRenderer = {
+  render(input: AccessSheetRendererInput): { contentType: "text/html"; body: string };
+};
+
+export type AccessSheetOptions = {
+  environmentId: string;
+  nowMs: () => number;
+  grants: TypedGrantAuthority;
+  authority: GrantManagementAuthority;
+  renderer?: AccessSheetRenderer;
+  ids?: AccessSheetIds;
+};
+
+const DEFAULT_IDS: AccessSheetIds = {
+  next: (kind) => `access-sheet-${kind}-${crypto.randomUUID()}`,
+};
+
+export const ACCESS_SHEET_AUDIT_ACTION: EventCatalogAuditEntry["action"] = "access-sheet-generated";
+
+export function createPrintableAccessSheetRenderer(): AccessSheetRenderer {
+  return { render: renderPrintableAccessSheet };
+}
+
+export function generateAccessSheetInTransaction(
+  transaction: FoundationStorageTransaction,
+  request: AccessSheetRequest,
+  actorReference: string,
+  options: AccessSheetOptions,
+): AccessSheetOutcome {
+  const requestError = validateRequest(request);
+  if (requestError !== null) return requestError;
+  const event = transaction.findEvent(request.scope.eventId);
+  if (event === null) return rejected("not-found", "Event was not found.");
+  const nowMs = options.nowMs();
+  if (!Number.isSafeInteger(nowMs) || nowMs < 0)
+    return rejected("invalid-input", "Generation time is invalid.");
+  const version: AccessSheetVersion = {
+    versionId: (options.ids ?? DEFAULT_IDS).next("version"),
+    environmentId: options.environmentId,
+    type: request.type,
+    scope: { ...request.scope },
+    generatedAtMs: nowMs,
+    testMark: options.environmentId !== "production",
+  };
+  const entries = readEntries(transaction, request, options);
+  if (!entries.ok) return entries.outcome;
+  const renderer = options.renderer ?? createPrintableAccessSheetRenderer();
+  const rendered = renderer.render({
+    version,
+    title: titleFor(request.type, event.name),
+    entries: entries.value,
+  });
+  const ids = options.ids ?? DEFAULT_IDS;
+  transaction.appendEventAudit({
+    auditId: ids.next("audit"),
+    operationId: ids.next("operation"),
+    action: ACCESS_SHEET_AUDIT_ACTION,
+    eventId: event.eventId,
+    gameDayId: request.scope.gameDayId ?? null,
+    actorReference,
+    occurredAtMs: nowMs,
+    before: null,
+    after: {
+      versionId: version.versionId,
+      environmentId: version.environmentId,
+      type: version.type,
+      scope: version.scope,
+      generatedAtMs: version.generatedAtMs,
+      testMark: version.testMark,
+    },
+  });
+  return {
+    status: "accepted",
+    value: { contentType: rendered.contentType, body: rendered.body, version },
+  };
+}
+
+function readEntries(
+  transaction: FoundationStorageTransaction,
+  request: AccessSheetRequest,
+  options: AccessSheetOptions,
+): { ok: true; value: AccessSheetEntry[] } | { ok: false; outcome: AccessSheetOutcome } {
+  const { grants, authority } = options;
+  if (request.type === "event-admin") {
+    const grant = findGrant(transaction, EVENT_ADMIN_GRANT_TYPE, request.scope.eventId);
+    if (grant === null) return missingGrant();
+    const credential = reveal(grants, transaction, grant, authority);
+    return credential === null
+      ? missingGrant()
+      : { ok: true, value: [{ label: "Event Admin Grant", qrCredential: credential }] };
+  }
+  if (request.type === "pitch-manager") {
+    const days = transaction
+      .listGameDays(request.scope.eventId)
+      .sort(
+        (left, right) =>
+          left.date.localeCompare(right.date) || left.gameDayId.localeCompare(right.gameDayId),
+      );
+    const pitches = transaction
+      .listPitches(request.scope.eventId)
+      .sort((left, right) => left.pitchId.localeCompare(right.pitchId));
+    const entries: AccessSheetEntry[] = [];
+    for (const day of days) {
+      for (const pitch of pitches) {
+        const grant = findGrant(transaction, PITCH_MANAGER_GRANT_TYPE, {
+          eventId: request.scope.eventId,
+          gameDayId: day.gameDayId,
+          pitchId: pitch.pitchId,
+        });
+        if (grant === null) return missingGrant();
+        const credential = reveal(grants, transaction, grant, authority);
+        if (credential === null) return missingGrant();
+        entries.push({ label: `${pitch.name} · ${day.date}`, qrCredential: credential });
+      }
+    }
+    return { ok: true, value: entries };
+  }
+  const day = transaction
+    .listGameDays(request.scope.eventId)
+    .find((candidate) => candidate.gameDayId === request.scope.gameDayId);
+  const pitch = transaction.findPitch(request.scope.pitchId ?? "");
+  if (day === undefined || pitch === null)
+    return { ok: false, outcome: rejected("not-found", "Pitch scope was not found.") };
+  const pitchSlots = transaction
+    .listPitchSlots(day.gameDayId, pitch.pitchId)
+    .sort(
+      (left, right) =>
+        left.sequence - right.sequence || left.pitchSlotId.localeCompare(right.pitchSlotId),
+    );
+  const games = transaction.listEventGames(day.gameDayId);
+  const entries: AccessSheetEntry[] = [];
+  for (const pitchSlot of pitchSlots) {
+    const grant = findGrant(transaction, GRANT_TYPE, {
+      eventId: request.scope.eventId,
+      gameDayId: day.gameDayId,
+      pitchId: pitch.pitchId,
+      pitchSlotId: pitchSlot.pitchSlotId,
+    });
+    if (grant === null) return missingGrant();
+    const credential = reveal(grants, transaction, grant, authority);
+    if (credential === null) return missingGrant();
+    entries.push({
+      label: `${pitch.name} · Pitch Slot ${pitchSlot.sequence}`,
+      qrCredential: credential,
+      game: readGameSnapshot(transaction, pitchSlot, games),
+    });
+  }
+  return { ok: true, value: entries };
+}
+
+function readGameSnapshot(
+  transaction: FoundationStorageTransaction,
+  pitchSlot: PitchSlot,
+  games: readonly EventGame[],
+): AccessSheetGameSnapshot | null {
+  const game = games.find((candidate) => candidate.pitchSlotId === pitchSlot.pitchSlotId);
+  if (game === undefined) return null;
+  const gameplaySlot = transaction.findGameplaySlot(game.gameplaySlotId);
+  if (gameplaySlot === null) return null;
+  return {
+    scheduledStartMs: gameplaySlot.scheduledStartMs,
+    expectedStartMs: projectExpectedStartMs(gameplaySlot, pitchSlot),
+    sideA: game.sideA.eventTeamName,
+    sideB: game.sideB.eventTeamName,
+    gameCode: game.gameCode,
+    gameDesignation: game.gameDesignation,
+  };
+}
+
+function findGrant(
+  transaction: FoundationStorageTransaction,
+  grantType: typeof EVENT_ADMIN_GRANT_TYPE | typeof PITCH_MANAGER_GRANT_TYPE | typeof GRANT_TYPE,
+  scope: string | { eventId: string; gameDayId: string; pitchId: string; pitchSlotId?: string },
+): StoredGrant | null {
+  const grants = transaction.listGrants().filter((grant) => {
+    if (grant.grantType !== grantType || grant.status !== "active") return false;
+    if (typeof scope === "string") return grant.scope.eventId === scope;
+    return Object.entries(scope).every(
+      ([key, value]) => (grant.scope as Record<string, unknown>)[key] === value,
+    );
+  });
+  return grants.sort((left, right) => right.createdAtMs - left.createdAtMs)[0] ?? null;
+}
+
+function reveal(
+  grants: TypedGrantAuthority,
+  transaction: FoundationStorageTransaction,
+  grant: StoredGrant,
+  authority: GrantManagementAuthority,
+): string | null {
+  const result = grants.resolveAccessSheetQrCredentialInTransaction(transaction, {
+    grantId: grant.grantId,
+    grantType: grant.grantType,
+    scope: grant.scope,
+    authority,
+  });
+  return result.status === "resolved" ? result.qrCredential : null;
+}
+
+function validateRequest(request: AccessSheetRequest): AccessSheetOutcome | null {
+  if (!isType(request.type) || !isScope(request.scope))
+    return rejected("invalid-input", "Access Sheet scope is invalid.");
+  if (
+    request.type === "event-admin" &&
+    (request.scope.gameDayId !== undefined || request.scope.pitchId !== undefined)
+  )
+    return rejected("invalid-input", "Event Admin sheets cannot include Pitch scope.");
+  if (
+    request.type === "pitch-manager" &&
+    (request.scope.gameDayId !== undefined || request.scope.pitchId !== undefined)
+  )
+    return rejected("invalid-input", "Pitch Manager sheets cover the whole Event.");
+  if (
+    request.type === "control-grant" &&
+    (request.scope.gameDayId === undefined || request.scope.pitchId === undefined)
+  )
+    return rejected("invalid-input", "Control sheets require one Game Day and Pitch.");
+  return null;
+}
+
+function renderPrintableAccessSheet(input: AccessSheetRendererInput): {
+  contentType: "text/html";
+  body: string;
+} {
+  const marker = input.version.testMark
+    ? '<p class="test-mark" aria-label="Test environment">TEST ENVIRONMENT</p>'
+    : "";
+  const entries = input.entries
+    .map((entry, index) => {
+      const game = entry.game === undefined ? "" : renderGameSnapshot(entry.game);
+      const headingId = `access-sheet-entry-${index + 1}-title`;
+      return `<section class="entry" aria-labelledby="${headingId}"><h2 id="${headingId}">${escapeHtml(entry.label)}</h2>${renderQrSvg(entry.qrCredential)}${game}</section>`;
+    })
+    .join("\n");
+  const body = `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>${escapeHtml(input.title)}</title><style>@page{margin:1rem}*{box-sizing:border-box}html,body{max-width:100%;overflow-x:hidden}body{font-family:system-ui,sans-serif;margin:1rem;color:#111;overflow-wrap:anywhere;word-break:break-word}.sheet{width:100%;max-width:52rem;margin:auto}.test-mark{border:.25rem solid #b91c1c;color:#b91c1c;font-size:1.5rem;font-weight:800;padding:.75rem;text-align:center}.version{font-size:.8rem;color:#555}.entries{display:grid;grid-template-columns:repeat(auto-fit,minmax(min(14rem,100%),1fr));gap:1rem}.entry{break-inside:avoid;border:1px solid #aaa;padding:1rem;text-align:center;min-width:0}.qr{width:12rem;height:12rem;max-width:100%}.snapshot{font-size:.85rem;text-align:left}.snapshot dt{font-weight:700}.snapshot dd{margin:0 0 .25rem}@media print{body{margin:0}.entry{border:0;page-break-inside:avoid}.test-mark{break-inside:avoid}}</style></head><body><main class="sheet" aria-labelledby="access-sheet-title"><h1 id="access-sheet-title">${escapeHtml(input.title)}</h1>${marker}<p class="version">Access Sheet Version ${escapeHtml(input.version.versionId)} · ${escapeHtml(input.version.environmentId)} · ${escapeHtml(input.version.type)} · scope ${escapeHtml(JSON.stringify(input.version.scope))} · generated ${new Date(input.version.generatedAtMs).toISOString()}</p><div class="entries" aria-label="Access Sheet credentials">${entries}</div></main></body></html>`;
+  return { contentType: "text/html", body };
+}
+
+function renderGameSnapshot(game: AccessSheetGameSnapshot | null): string {
+  if (game === null) return "";
+  return `<dl class="snapshot"><dt>Scheduled start</dt><dd>${escapeHtml(new Date(game.scheduledStartMs).toISOString())}</dd><dt>Expected start</dt><dd>${escapeHtml(new Date(game.expectedStartMs).toISOString())}</dd><dt>Teams</dt><dd>${escapeHtml(game.sideA ?? "TBD")} vs ${escapeHtml(game.sideB ?? "TBD")}</dd>${optionalSnapshot("Game code", game.gameCode)}${optionalSnapshot("Game designation", game.gameDesignation)}</dl>`;
+}
+
+function optionalSnapshot(label: string, value: string | null): string {
+  return value === null ? "" : `<dt>${escapeHtml(label)}</dt><dd>${escapeHtml(value)}</dd>`;
+}
+
+function renderQrSvg(value: string): string {
+  const qr = QRCode.create(value, { errorCorrectionLevel: "M" });
+  const size = qr.modules.size;
+  const cells: string[] = [];
+  for (let y = 0; y < size; y += 1) {
+    for (let x = 0; x < size; x += 1) {
+      if (qr.modules.data[y * size + x]) cells.push(`M${x},${y}h1v1H${x}z`);
+    }
+  }
+  return `<svg class="qr" role="img" aria-label="QR credential" width="${size}" height="${size}" viewBox="0 0 ${size} ${size}" xmlns="http://www.w3.org/2000/svg"><path fill="#000" d="${cells.join("")}"/></svg>`;
+}
+
+function escapeHtml(value: string): string {
+  return value.replace(
+    /[&<>"']/g,
+    (character) =>
+      ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[character] ??
+      character,
+  );
+}
+
+function isType(value: unknown): value is AccessSheetType {
+  return value === "event-admin" || value === "pitch-manager" || value === "control-grant";
+}
+
+function isScope(value: unknown): value is AccessSheetScope {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  const scope = value as Record<string, unknown>;
+  return (
+    typeof scope.eventId === "string" &&
+    scope.eventId.length > 0 &&
+    (scope.gameDayId === undefined || typeof scope.gameDayId === "string") &&
+    (scope.pitchId === undefined || typeof scope.pitchId === "string")
+  );
+}
+
+function titleFor(type: AccessSheetType, eventName: string): string {
+  if (type === "event-admin") return `${eventName} · Event Admin Access Sheet`;
+  if (type === "pitch-manager") return `${eventName} · Pitch Manager Access Sheet`;
+  return `${eventName} · Control Grant Access Sheet`;
+}
+
+function missingGrant(): { ok: false; outcome: AccessSheetOutcome } {
+  return {
+    ok: false,
+    outcome: rejected("not-found", "A current QR Grant is not available for this sheet."),
+  };
+}
+
+function rejected(reason: AccessSheetRejectedReason, detail: string): AccessSheetOutcome {
+  return { status: "rejected", reason, detail };
+}

--- a/src/lib/event-administration.ts
+++ b/src/lib/event-administration.ts
@@ -47,6 +47,13 @@ import {
 import { isTechnicalAdminAuthority } from "@/lib/technical-admin-auth";
 import { canonicalizeJson, sha256 } from "@/lib/event-game-action-json";
 import { validateOpaqueIdentifier } from "@/lib/validation-policy";
+import {
+  generateAccessSheetInTransaction,
+  type AccessSheetArtifact,
+  type AccessSheetRenderer,
+  type AccessSheetRequest,
+  type AccessSheetIds,
+} from "@/lib/access-sheet";
 
 export const GENERIC_EVENT_HUB_AUTHORIZATION_FAILURE = Object.freeze({
   status: "rejected",
@@ -167,6 +174,9 @@ export type EventAdministrationOptions = {
   controlScopeResolver?: ControlGrantScopeResolver;
   /** Test-only composition seam for proving rollback after typed retirement. */
   removalFailureInjector?: () => void;
+  environmentId?: string;
+  accessSheetRenderer?: AccessSheetRenderer;
+  accessSheetIds?: AccessSheetIds;
 };
 
 export type EventAdministration = {
@@ -316,6 +326,10 @@ export type EventAdministration = {
     gameDayId?: unknown;
     authority: EventAdministrationAuthority;
   }): Promise<EventAdministrationOutcome<EventHubProjection>>;
+  generateAccessSheet(
+    input: AccessSheetRequest,
+    authority: EventAdministrationAuthority,
+  ): Promise<EventAdministrationMutationOutcome<AccessSheetArtifact>>;
   changePublicationStatus(
     eventId: unknown,
     input: { status: unknown; impactConfirmed?: unknown },
@@ -1138,6 +1152,39 @@ export function createEventAdministration(
             grantSessionId: authorized.sessionId,
             grantSessionExpiresAtMs: authorized.sessionExpiresAtMs,
           });
+        });
+      } catch {
+        return unavailable();
+      }
+    },
+
+    async generateAccessSheet(input, authority) {
+      const eventId = validateEventId(input.scope.eventId);
+      if (!eventId.ok) return invalid(eventId.error);
+      try {
+        return await options.storage.transaction((transaction) => {
+          const authorized = authorizeEventScopeInTransaction(
+            options,
+            transaction,
+            eventId.value,
+            authority,
+          );
+          if (authorized === null) return unauthorized();
+          const result = generateAccessSheetInTransaction(
+            transaction,
+            input,
+            authorized.actorReference,
+            {
+              environmentId: options.environmentId ?? "test",
+              nowMs,
+              grants: options.grants,
+              authority,
+              renderer: options.accessSheetRenderer,
+              ids: options.accessSheetIds,
+            },
+          );
+          if (result.status !== "accepted") return result;
+          return { ...result, sessionExpiresAtMs: authorized.sessionExpiresAtMs };
         });
       } catch {
         return unavailable();

--- a/src/lib/foundation-grant-erasure-migration.test.ts
+++ b/src/lib/foundation-grant-erasure-migration.test.ts
@@ -210,7 +210,7 @@ describe("Grant cryptographic erasure migration", () => {
 
       const current = openSqliteFoundationStorage(databasePath);
       await current.applyMigrations({ requireCandidate: false });
-      expect(await current.readiness()).toMatchObject({ ok: true, schemaVersion: "27" });
+      expect(await current.readiness()).toMatchObject({ ok: true, schemaVersion: "28" });
       current.close();
 
       const raw = new Database(databasePath);
@@ -330,7 +330,7 @@ describe("Grant cryptographic erasure migration", () => {
       raw.close();
 
       const reopened = openSqliteFoundationStorage(databasePath);
-      expect(await reopened.readiness()).toMatchObject({ ok: true, schemaVersion: "27" });
+      expect(await reopened.readiness()).toMatchObject({ ok: true, schemaVersion: "28" });
       const restartedAudit = await reopened.transaction((transaction) =>
         transaction.listGrantAudit("grant-expired"),
       );

--- a/src/lib/foundation-migrations.test.ts
+++ b/src/lib/foundation-migrations.test.ts
@@ -13,7 +13,7 @@ const migrations: readonly FoundationMigration[] = [
 ];
 
 describe("foundation migration ledger compatibility", () => {
-  test("keeps accepted migrations 001 through 026 byte-for-byte immutable and pins 027", () => {
+  test("keeps accepted migrations 001 through 027 byte-for-byte immutable and pins 028", () => {
     expect(FOUNDATION_MIGRATIONS.map(({ id, checksum }) => ({ id, checksum }))).toEqual([
       {
         id: "001-foundation-event-game-record-roots",
@@ -122,6 +122,10 @@ describe("foundation migration ledger compatibility", () => {
       {
         id: "027-event-catalog-removal-audit",
         checksum: "f1c986ce481312d22f44f72746cbbc9bfa7d2eab5db513b8f495e644b9758565",
+      },
+      {
+        id: "028-access-sheet-generated-audit-action",
+        checksum: "52e52022edfddcf8e3cfb7a6addca8cdfddc2a84bf60649d9ce6d3f3787785c4",
       },
     ]);
   });

--- a/src/lib/foundation-migrations.ts
+++ b/src/lib/foundation-migrations.ts
@@ -1905,6 +1905,28 @@ export const FOUNDATION_EVENT_CATALOG_REMOVAL_MIGRATION_SQL = `
   ${FOUNDATION_EVENT_CATALOG_AUDIT_EVENT_INDEX_SQL};
 `;
 
+/** Schema-28 adds the redacted Event Administration Access Sheet audit action. */
+export const FOUNDATION_ACCESS_SHEET_AUDIT_MIGRATION_SQL = `
+  CREATE TABLE foundation_event_catalog_audit_v28 AS SELECT * FROM foundation_event_catalog_audit;
+  DROP TABLE foundation_event_catalog_audit;
+  ${FOUNDATION_EVENT_CATALOG_AUDIT_TABLE_V3_SQL.replace(
+    "CREATE TABLE foundation_event_catalog_audit",
+    "CREATE TABLE foundation_event_catalog_audit_rebuilt",
+  ).replace(
+    "'event-game-teams-confirmed'",
+    "'event-game-teams-confirmed', 'event-publication-changed', 'event-catalog-entry-removed', 'access-sheet-generated'",
+  )};
+  INSERT INTO foundation_event_catalog_audit_rebuilt
+    (audit_id, operation_id, action, event_id, game_day_id, actor_reference,
+     occurred_at_ms, before_json, after_json)
+  SELECT audit_id, operation_id, action, event_id, game_day_id, actor_reference,
+         occurred_at_ms, before_json, after_json
+  FROM foundation_event_catalog_audit_v28;
+  DROP TABLE foundation_event_catalog_audit_v28;
+  ALTER TABLE foundation_event_catalog_audit_rebuilt RENAME TO foundation_event_catalog_audit;
+  ${FOUNDATION_EVENT_CATALOG_AUDIT_EVENT_INDEX_SQL};
+`;
+
 export const FOUNDATION_MIGRATIONS: readonly FoundationMigration[] = Object.freeze([
   createMigration({
     id: "001-foundation-event-game-record-roots",
@@ -2067,6 +2089,12 @@ export const FOUNDATION_MIGRATIONS: readonly FoundationMigration[] = Object.free
     ordinal: 27,
     schemaVersion: 27,
     sql: FOUNDATION_EVENT_CATALOG_REMOVAL_MIGRATION_SQL,
+  }),
+  createMigration({
+    id: "028-access-sheet-generated-audit-action",
+    ordinal: 28,
+    schemaVersion: 28,
+    sql: FOUNDATION_ACCESS_SHEET_AUDIT_MIGRATION_SQL,
   }),
 ]);
 

--- a/src/lib/foundation-storage-sqlite.test.ts
+++ b/src/lib/foundation-storage-sqlite.test.ts
@@ -546,7 +546,7 @@ describe("SQLite foundation storage", () => {
       expect(await reopenedRecord.registerRoot(root)).toMatchObject({ status: "idempotent" });
       expect(await reopened.readiness()).toMatchObject({
         ok: true,
-        schemaVersion: "27",
+        schemaVersion: "28",
         evidence: { replay: { result: "passed", rootCount: 1, durationMs: expect.any(Number) } },
       });
       reopened.close();
@@ -594,21 +594,21 @@ describe("SQLite foundation storage", () => {
       const storage = openSqliteFoundationStorage(databasePath);
       const candidate = await storage.validateCandidate();
       expect(candidate.ready).toBe(true);
-      expect(candidate.readiness).toMatchObject({ ok: true, schemaVersion: "27" });
+      expect(candidate.readiness).toMatchObject({ ok: true, schemaVersion: "28" });
       expect(existsSync(candidate.candidatePath)).toBe(false);
       expect(await storage.readiness()).toMatchObject({ ok: false, status: "pending" });
 
       const migration = await storage.applyMigrations({ requireCandidate: true });
-      expect(migration.schemaVersion).toBe(27);
+      expect(migration.schemaVersion).toBe(28);
       expect(await storage.readiness()).toMatchObject({ ok: true });
       storage.close();
     });
   });
 
-  test("preserves prior Event Catalog audit rows, shape, ordering, index, and FK behavior through removal migration", async () => {
+  test("preserves prior Event Catalog audit rows, shape, ordering, index, and FK behavior through Access Sheet migration", async () => {
     await withDatabase(async (databasePath) => {
       const prior = openSqliteFoundationStorage(databasePath, {
-        migrations: FOUNDATION_MIGRATIONS.slice(0, 26),
+        migrations: FOUNDATION_MIGRATIONS.slice(0, 27),
       });
       await prior.applyMigrations({ requireCandidate: false });
       prior.close();
@@ -826,9 +826,106 @@ describe("SQLite foundation storage", () => {
         "025-event-publication-status",
         "026-event-schedule-expected-delays-and-conflicts",
         removalAuditMigration.id,
+        "028-access-sheet-generated-audit-action",
       ]);
-      expect(await current.readiness()).toMatchObject({ ok: true, schemaVersion: "27" });
+      expect(await current.readiness()).toMatchObject({ ok: true, schemaVersion: "28" });
       current.close();
+    });
+  });
+
+  test("adds the Access Sheet audit action while preserving prior audit rows and shape", async () => {
+    await withDatabase(async (databasePath) => {
+      const priorMigrations = FOUNDATION_MIGRATIONS.slice(0, -1);
+      const prior = openSqliteFoundationStorage(databasePath, { migrations: priorMigrations });
+      await prior.applyMigrations({ requireCandidate: false });
+      prior.close();
+
+      const database = new Database(databasePath);
+      const priorColumns = database
+        .query("PRAGMA table_info(foundation_event_catalog_audit)")
+        .all();
+      database
+        .query(
+          `INSERT INTO foundation_event_catalog_audit
+             (audit_id, operation_id, action, event_id, game_day_id, actor_reference,
+              occurred_at_ms, before_json, after_json)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          "audit-before-access-sheet-migration",
+          "operation-before-access-sheet-migration",
+          "event-created",
+          "event-before-access-sheet-migration",
+          null,
+          "actor-before-access-sheet-migration",
+          1_000,
+          null,
+          JSON.stringify({ name: "Before migration" }),
+        );
+      const priorIndexes = database
+        .query("PRAGMA index_list(foundation_event_catalog_audit)")
+        .all();
+      database.close();
+
+      const current = openSqliteFoundationStorage(databasePath);
+      expect(await current.applyMigrations({ requireCandidate: false })).toMatchObject({
+        appliedMigrationIds: ["028-access-sheet-generated-audit-action"],
+        schemaVersion: 28,
+      });
+      current.close();
+
+      const upgraded = new Database(databasePath);
+      expect(upgraded.query("PRAGMA table_info(foundation_event_catalog_audit)").all()).toEqual(
+        priorColumns,
+      );
+      expect(upgraded.query("PRAGMA index_list(foundation_event_catalog_audit)").all()).toEqual(
+        priorIndexes,
+      );
+      expect(
+        upgraded
+          .query(
+            `SELECT audit_id, operation_id, action, event_id, game_day_id, actor_reference,
+                    occurred_at_ms, before_json, after_json
+             FROM foundation_event_catalog_audit`,
+          )
+          .all(),
+      ).toEqual([
+        {
+          audit_id: "audit-before-access-sheet-migration",
+          operation_id: "operation-before-access-sheet-migration",
+          action: "event-created",
+          event_id: "event-before-access-sheet-migration",
+          game_day_id: null,
+          actor_reference: "actor-before-access-sheet-migration",
+          occurred_at_ms: 1_000,
+          before_json: null,
+          after_json: JSON.stringify({ name: "Before migration" }),
+        },
+      ]);
+      upgraded
+        .query(
+          `INSERT INTO foundation_event_catalog_audit
+             (audit_id, operation_id, action, event_id, game_day_id, actor_reference,
+              occurred_at_ms, before_json, after_json)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          "audit-after-access-sheet-migration",
+          "operation-after-access-sheet-migration",
+          "access-sheet-generated",
+          "event-after-access-sheet-migration",
+          null,
+          "actor-after-access-sheet-migration",
+          2_000,
+          null,
+          JSON.stringify({ versionId: "version-redacted" }),
+        );
+      expect(
+        upgraded
+          .query("SELECT action FROM foundation_event_catalog_audit WHERE audit_id = ?")
+          .get("audit-after-access-sheet-migration"),
+      ).toEqual({ action: "access-sheet-generated" });
+      upgraded.close();
     });
   });
 
@@ -836,9 +933,9 @@ describe("SQLite foundation storage", () => {
     await withDatabase(async (databasePath) => {
       const baseMigrations = FOUNDATION_MIGRATIONS;
       const failingMigration = createMigration(
-        "028-failing-test-migration",
-        28,
-        28,
+        "029-failing-test-migration",
+        29,
+        29,
         "CREATE TABLE migration_failure_probe (id TEXT) STRICT; THIS IS NOT SQL;",
       );
       const store = openSqliteFoundationStorage(databasePath, {
@@ -858,7 +955,7 @@ describe("SQLite foundation storage", () => {
       });
       expect(await priorBinary.readiness()).toMatchObject({
         ok: true,
-        schemaVersion: "27",
+        schemaVersion: "28",
       });
       priorBinary.close();
 
@@ -930,7 +1027,7 @@ describe("SQLite foundation storage", () => {
         .query(
           "INSERT INTO foundation_migration_ledger (migration_id, ordinal, schema_version, checksum, status, applied_at_ms) VALUES (?, ?, ?, ?, ?, ?)",
         )
-        .run("future-999", 28, 28, "future-checksum", "complete", 2_000);
+        .run("future-999", 29, 29, "future-checksum", "complete", 2_000);
       futureDatabase.close();
       const future = openSqliteFoundationStorage(databasePath);
       expect(await future.readiness()).toMatchObject({ ok: false });

--- a/src/lib/foundation-storage.ts
+++ b/src/lib/foundation-storage.ts
@@ -239,7 +239,8 @@ export type EventCatalogAuditEntry = {
     | "event-game-created"
     | "event-game-teams-confirmed"
     | "event-publication-changed"
-    | "event-catalog-entry-removed";
+    | "event-catalog-entry-removed"
+    | "access-sheet-generated";
   eventId: string;
   gameDayId: string | null;
   actorReference: string;

--- a/src/lib/grant-management-credentials.ts
+++ b/src/lib/grant-management-credentials.ts
@@ -20,6 +20,7 @@ import { createAuditEntry, expireGrantIfDue } from "@/lib/grant-lifecycle";
 import {
   bindingFor,
   canManageInTransaction,
+  canResolveAccessSheetCredentialInTransaction,
   credentialMatches,
   hasCurrentAdmissionEligibility,
   refreshEventAdminSession,
@@ -37,6 +38,7 @@ import {
 import { auditInput } from "@/lib/grant-management-audit";
 import type {
   GrantManagementAuthority,
+  TypedAccessSheetQrCredentialResolution,
   TypedGrantMutation,
   TypedGrantReveal,
   TypedGrantRotated,
@@ -111,6 +113,89 @@ export function revealGrantInTransaction(
     qrCredential: token,
     credentialFormatVersion: GRANT_CREDENTIAL_FORMAT_VERSION,
   };
+}
+
+/**
+ * Resolve the current QR material for Access Sheet rendering inside its
+ * Foundation transaction. Unlike ordinary Grant reveal/admission, this does
+ * not require a Control Grant to have a live Event Game root: an Access Sheet
+ * intentionally includes empty and conflicted Pitch Slots. Admission keeps
+ * using the canonical live resolver separately.
+ */
+export function resolveAccessSheetQrCredentialInTransaction(
+  transaction: FoundationStorageTransaction,
+  options: GrantAuthorityOptions,
+  input: {
+    grantId: string;
+    grantType: StoredGrant["grantType"];
+    scope: StoredGrant["scope"];
+    authority: GrantManagementAuthority;
+  },
+): TypedAccessSheetQrCredentialResolution {
+  const trustedAuthority = verifyGrantAuthority(
+    options.privilegedAuthorityVerifier,
+    input.authority,
+  );
+  if (trustedAuthority === null)
+    return {
+      status: "rejected",
+      reason: "unauthorized",
+      detail: "The Access Sheet credential cannot be resolved.",
+    };
+  const grantTransaction = requireGrantStorageTransaction(transaction);
+  const stored = grantTransaction.findGrantById(input.grantId);
+  if (stored === null)
+    return {
+      status: "rejected",
+      reason: "not-found",
+      detail: "The Access Sheet credential cannot be resolved.",
+    };
+  const grant = expireGrantIfDue(transaction, options, stored);
+  const resolvedAuthority = resolveManagementAuthority(transaction, options, trustedAuthority);
+  if (
+    grant.grantId !== input.grantId ||
+    grant.grantType !== input.grantType ||
+    !sameGrantScope(grant.scope, input.scope) ||
+    grant.status !== "active" ||
+    resolvedAuthority === null ||
+    !canResolveAccessSheetCredentialInTransaction(transaction, options, grant, resolvedAuthority)
+  )
+    return {
+      status: "rejected",
+      reason: "unauthorized",
+      detail: "The Access Sheet credential cannot be resolved.",
+    };
+  const token = decryptCredential(grant.credential, bindingFor(options, grant), options.keyRing);
+  if (token === null || !credentialMatches(grant, options, token))
+    return {
+      status: "rejected",
+      reason: "unavailable",
+      detail: "The Access Sheet credential cannot be resolved.",
+    };
+  grantTransaction.appendGrantAudit(
+    createAuditEntry(
+      options,
+      auditInput("credential-revealed", grant, resolvedAuthority, grant.status),
+    ),
+  );
+  refreshGrantManagementSession(transaction, options, resolvedAuthority);
+  return {
+    status: "resolved",
+    grantId: grant.grantId,
+    grantVersion: grant.grantVersion,
+    grantType: grant.grantType,
+    qrCredential: token,
+    credentialFormatVersion: GRANT_CREDENTIAL_FORMAT_VERSION,
+  };
+}
+
+function sameGrantScope(left: StoredGrant["scope"], right: StoredGrant["scope"]): boolean {
+  const leftEntries = Object.entries(left);
+  const rightEntries = Object.entries(right);
+  return (
+    leftEntries.length === rightEntries.length &&
+    leftEntries.every(([key, value]) => (right as Record<string, unknown>)[key] === value)
+  );
 }
 
 export async function rotateGrant(

--- a/src/lib/grant-management-policy.ts
+++ b/src/lib/grant-management-policy.ts
@@ -219,8 +219,9 @@ export function canManageInTransaction(
     if (resolved.status !== "eligible" || resolved.eventGameId !== session.eventGameId)
       return false;
   }
-  if (caller.grantType === "event-admin")
-    return grant.grantType !== "event-admin" && caller.scope.eventId === grant.scope.eventId;
+  if (caller.grantType === "event-admin") {
+    return caller.scope.eventId === grant.scope.eventId && grant.grantType !== "event-admin";
+  }
   if (caller.grantType === "pitch-manager" && grant.grantType === "control") {
     const callerScope = caller.scope as PitchManagerGrantScope;
     const targetScope = grant.scope as ControlGrantScope;
@@ -233,6 +234,49 @@ export function canManageInTransaction(
   return (
     operation === "reveal" && caller.grantType === "control" && caller.grantId === grant.grantId
   );
+}
+
+/**
+ * Access Sheet composition may render an Event Admin Grant for the exact
+ * Event Admin session that owns it. This exception is intentionally outside
+ * ordinary Grant reveal policy and rechecks the current session binding.
+ */
+export function canResolveAccessSheetCredentialInTransaction(
+  transaction: FoundationStorageTransaction,
+  options: GrantAuthorityOptions,
+  grant: StoredGrant,
+  authority: TrustedGrantAuthority,
+): boolean {
+  if (canManageInTransaction(transaction, options, grant, authority, "reveal")) return true;
+  if (authority.kind !== "grant-session" || grant.grantType !== "event-admin") return false;
+  const session = findSessionByBearer(transaction, options, authority.sessionBearer);
+  if (
+    session === null ||
+    session.status !== "active" ||
+    session.grantId !== grant.grantId ||
+    session.grantVersion !== grant.grantVersion
+  )
+    return false;
+  const storedCaller = transaction.findGrantById(session.grantId);
+  if (storedCaller === null) return false;
+  const caller = expireGrantIfDue(transaction, options, storedCaller);
+  if (
+    caller.status !== "active" ||
+    caller.grantId !== grant.grantId ||
+    caller.grantVersion !== session.grantVersion ||
+    caller.grantType !== "event-admin" ||
+    caller.scope.eventId !== grant.scope.eventId
+  )
+    return false;
+  const nowMs = readNow(options);
+  if (
+    nowMs >=
+    Math.min(caller.expiresAtMs ?? Number.MAX_SAFE_INTEGER, session.lastActiveAtMs + 30 * DAY_MS)
+  ) {
+    expireSession(transaction, options, caller, session);
+    return false;
+  }
+  return caller.expiresAtMs === null || nowMs < caller.expiresAtMs;
 }
 
 export function canCreateInTransaction(

--- a/src/lib/grant-management-types.ts
+++ b/src/lib/grant-management-types.ts
@@ -151,6 +151,22 @@ export type TypedGrantReveal =
     }
   | { status: "rejected"; reason: "not-found" | "unauthorized" | "unavailable"; detail: string };
 
+/**
+ * The Access Sheet composition may resolve only the current QR material for a
+ * Grant it already selected in the surrounding Foundation transaction. This
+ * deliberately has no Grant Code or session fields.
+ */
+export type TypedAccessSheetQrCredentialResolution =
+  | {
+      status: "resolved";
+      grantId: string;
+      grantVersion: string;
+      grantType: GrantType;
+      qrCredential: string;
+      credentialFormatVersion: typeof GRANT_CREDENTIAL_FORMAT_VERSION;
+    }
+  | { status: "rejected"; reason: "not-found" | "unauthorized" | "unavailable"; detail: string };
+
 export type TypedSessionSummary = {
   label: string;
   createdAtMs: number;
@@ -248,6 +264,15 @@ export type TypedGrantAuthority = {
     grantId: string,
     authority: GrantManagementAuthority,
   ): TypedGrantReveal;
+  resolveAccessSheetQrCredentialInTransaction(
+    transaction: FoundationStorageTransaction,
+    input: {
+      grantId: string;
+      grantType: GrantType;
+      scope: GrantScope;
+      authority: GrantManagementAuthority;
+    },
+  ): TypedAccessSheetQrCredentialResolution;
   disableGrant(grantId: string, authority: GrantManagementAuthority): Promise<TypedGrantMutation>;
   revokeGrant(grantId: string, authority: GrantManagementAuthority): Promise<TypedGrantMutation>;
   reactivateGrant(

--- a/src/lib/grant-management.ts
+++ b/src/lib/grant-management.ts
@@ -10,6 +10,7 @@ import {
 import {
   revealGrant,
   revealGrantInTransaction,
+  resolveAccessSheetQrCredentialInTransaction,
   rotateGrant,
   rotateGrantInTransaction,
   rotateGrantCredentialKeys,
@@ -40,6 +41,7 @@ export type {
   TypedGrantReplayAuthorization,
   TypedGrantMutation,
   TypedGrantReveal,
+  TypedAccessSheetQrCredentialResolution,
   TypedGrantRotated,
   TypedGrantAdmissionThrottled,
   TypedGrantCodeCreated,
@@ -101,6 +103,8 @@ export function createTypedGrantAuthority(
     revealGrant: (grantId, authority) => revealGrant(storage, options, grantId, authority),
     revealGrantInTransaction: (transaction, grantId, authority) =>
       revealGrantInTransaction(transaction, options, grantId, authority),
+    resolveAccessSheetQrCredentialInTransaction: (transaction, input) =>
+      resolveAccessSheetQrCredentialInTransaction(transaction, options, input),
     disableGrant: (grantId, authority) =>
       updateGrantStatus(storage, options, grantId, authority, "disabled", "grant-disabled"),
     revokeGrant: (grantId, authority) =>

--- a/src/pages/event-admin-page.tsx
+++ b/src/pages/event-admin-page.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import QRCode from "qrcode/lib/browser";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -94,6 +94,21 @@ type ControlSession = {
   deviceClass: string;
   browserClass: string;
 };
+type AccessSheetType = "event-admin" | "pitch-manager" | "control-grant";
+type AccessSheetResponse = {
+  status: "accepted";
+  value: {
+    contentType: "text/html";
+    body: string;
+    version: {
+      versionId: string;
+      environmentId: string;
+      type: AccessSheetType;
+      generatedAtMs: number;
+      testMark: boolean;
+    };
+  };
+};
 
 type CatalogRemovalPreview = {
   target: {
@@ -128,6 +143,75 @@ const publicationWarningLabels: Record<string, string> = {
   "missing-event-games": "Event Games",
   "unresolved-matchups": "unresolved matchups or confirmed sides",
 };
+
+type AccessSheetArtifactScope = {
+  eventId: string;
+  authority: HubResponse["value"]["authority"] | "none";
+  gameDayId: string | null;
+  pitchId: string;
+  type: AccessSheetType;
+};
+
+type AccessSheetGenerationAttempt = {
+  sequence: number;
+  scopeKey: string;
+};
+
+function useAccessSheetArtifactOwner(scope: AccessSheetArtifactScope) {
+  const scopeKey = JSON.stringify(scope);
+  const sequenceRef = useRef(0);
+  const [stored, setStored] = useState<{
+    scopeKey: string;
+    artifact: AccessSheetResponse["value"];
+  } | null>(null);
+
+  useEffect(() => {
+    sequenceRef.current += 1;
+    setStored(null);
+  }, [scopeKey]);
+
+  useEffect(
+    () => () => {
+      sequenceRef.current += 1;
+    },
+    [],
+  );
+
+  const invalidate = () => {
+    sequenceRef.current += 1;
+    setStored(null);
+  };
+
+  const begin = (): AccessSheetGenerationAttempt => {
+    sequenceRef.current += 1;
+    setStored(null);
+    return { sequence: sequenceRef.current, scopeKey };
+  };
+
+  const matches = (attempt: AccessSheetGenerationAttempt) =>
+    attempt.sequence === sequenceRef.current && attempt.scopeKey === scopeKey;
+
+  const install = (
+    attempt: AccessSheetGenerationAttempt,
+    artifact: AccessSheetResponse["value"],
+  ) => {
+    if (!matches(attempt)) return false;
+    setStored({ scopeKey, artifact });
+    return true;
+  };
+
+  const fail = (attempt: AccessSheetGenerationAttempt) => {
+    if (matches(attempt)) setStored(null);
+  };
+
+  return {
+    artifact: stored?.scopeKey === scopeKey ? stored.artifact : null,
+    begin,
+    fail,
+    install,
+    invalidate,
+  };
+}
 
 type ScheduleDelayPreview = {
   dimension: "gameplay-slot" | "pitch-slot";
@@ -200,8 +284,17 @@ export function EventAdminPage() {
   const [controlSessions, setControlSessions] = useState<Record<string, ControlSession[]>>({});
   const [publicationImpactConfirmed, setPublicationImpactConfirmed] = useState(false);
   const [removalPreview, setRemovalPreview] = useState<CatalogRemovalPreview | null>(null);
+  const [accessSheetType, setAccessSheetType] = useState<AccessSheetType>("event-admin");
+  const accessSheetOwner = useAccessSheetArtifactOwner({
+    eventId: eventId.trim(),
+    authority: hub?.authority ?? "none",
+    gameDayId: selectedGameDayId,
+    pitchId: selectedPitchId,
+    type: accessSheetType,
+  });
 
   const loadHub = async (nextGameDayId = selectedGameDayId) => {
+    accessSheetOwner.invalidate();
     if (eventId.trim().length === 0) throw new Error("An Event is required.");
     const params = new URLSearchParams({ eventId: eventId.trim() });
     if (nextGameDayId !== null) params.set("gameDayId", nextGameDayId);
@@ -477,6 +570,37 @@ export function EventAdminPage() {
     await loadHub(selectedGameDayId);
   };
 
+  const generateAccessSheet = async () => {
+    const attempt = accessSheetOwner.begin();
+    const gameDayId = selectedGameDayId ?? "";
+    const pitchId = selectedPitchId;
+    try {
+      if (eventId.length === 0 || (accessSheetType === "control-grant" && gameDayId.length === 0))
+        throw new Error("Select a Game Day before generating this Access Sheet.");
+      if (accessSheetType === "control-grant" && pitchId.length === 0)
+        throw new Error("Select a Pitch before generating the Control Access Sheet.");
+      const response = await fetch(
+        `/api/event-admin/events/${encodeURIComponent(eventId)}/access-sheets`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            type: accessSheetType,
+            ...(accessSheetType === "control-grant" && gameDayId.length > 0 ? { gameDayId } : {}),
+            ...(accessSheetType === "control-grant" && pitchId.length > 0 ? { pitchId } : {}),
+          }),
+        },
+      );
+      const payload = (await response.json()) as AccessSheetResponse | { status: string };
+      if (!response.ok || payload.status !== "accepted")
+        throw new Error("Access Sheet generation failed.");
+      accessSheetOwner.install(attempt, (payload as AccessSheetResponse).value);
+    } catch (error) {
+      accessSheetOwner.fail(attempt);
+      throw error;
+    }
+  };
+
   const managePitchManagerGrant = async (
     operation: "rotate" | "disable" | "revoke" | "reactivate",
   ) => {
@@ -660,7 +784,10 @@ export function EventAdminPage() {
             <Input
               id="event-id"
               value={eventId}
-              onChange={(event) => setEventId(event.target.value)}
+              onChange={(event) => {
+                accessSheetOwner.invalidate();
+                setEventId(event.target.value);
+              }}
             />
           </div>
           {hub === null ? (
@@ -859,6 +986,7 @@ export function EventAdminPage() {
                   value={selectedGameDayId ?? ""}
                   onChange={(event) => {
                     const next = event.target.value || null;
+                    accessSheetOwner.invalidate();
                     setSelectedGameDayId(next);
                     void run(async () => {
                       await loadHub(next);
@@ -1432,6 +1560,7 @@ export function EventAdminPage() {
                       key={pitch.pitchId}
                       variant={selectedPitchId === pitch.pitchId ? "default" : "outline"}
                       onClick={() => {
+                        accessSheetOwner.invalidate();
                         setSelectedPitchId(pitch.pitchId);
                         void run(() => loadPitchView(pitch.pitchId));
                       }}
@@ -1663,6 +1792,66 @@ export function EventAdminPage() {
               </div>
               <div className="space-y-3 rounded-lg border p-3">
                 <div>
+                  <p className="font-semibold">Grant Access Sheets</p>
+                  <p className="text-xs text-muted-foreground">
+                    Generate a print-ready QR handoff. Grant Codes are never included. Test sheets
+                    are marked TEST in the artifact.
+                  </p>
+                </div>
+                <div className="grid gap-2 sm:grid-cols-3">
+                  <select
+                    aria-label="Access Sheet type"
+                    className="h-10 rounded-md border bg-background px-3 text-sm"
+                    value={accessSheetType}
+                    onChange={(event) => {
+                      accessSheetOwner.invalidate();
+                      setAccessSheetType(event.target.value as AccessSheetType);
+                    }}
+                  >
+                    <option value="event-admin">Event Admin</option>
+                    <option value="pitch-manager">Pitch Manager</option>
+                    <option value="control-grant">Control Grant</option>
+                  </select>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    disabled={busy || hub === null}
+                    onClick={() => void run(generateAccessSheet)}
+                  >
+                    Generate Access Sheet
+                  </Button>
+                </div>
+                {accessSheetOwner.artifact ? (
+                  <div className="space-y-2">
+                    <p className="text-xs text-muted-foreground">
+                      Version {accessSheetOwner.artifact.version.versionId} ·{" "}
+                      {accessSheetOwner.artifact.version.environmentId}
+                      {accessSheetOwner.artifact.version.testMark ? " · TEST" : ""}
+                    </p>
+                    <iframe
+                      id="generated-access-sheet-preview"
+                      title="Generated Grant Access Sheet preview"
+                      className="min-h-[28rem] w-full rounded border bg-white"
+                      srcDoc={accessSheetOwner.artifact.body}
+                    />
+                    <Button
+                      type="button"
+                      variant="outline"
+                      onClick={() => {
+                        const frame = document.getElementById(
+                          "generated-access-sheet-preview",
+                        ) as HTMLIFrameElement | null;
+                        frame?.contentWindow?.focus();
+                        frame?.contentWindow?.print();
+                      }}
+                    >
+                      Print Access Sheet
+                    </Button>
+                  </div>
+                ) : null}
+              </div>
+              <div className="space-y-3 rounded-lg border p-3">
+                <div>
                   <p className="font-semibold">Pitch Manager handoff</p>
                   <p className="text-xs text-muted-foreground">
                     One Grant covers exactly one Pitch and Game Day. The QR is revealed only on
@@ -1675,6 +1864,7 @@ export function EventAdminPage() {
                     className="h-10 rounded-md border bg-background px-3 text-sm"
                     value={pitchManagerGameDayId}
                     onChange={(event) => {
+                      accessSheetOwner.invalidate();
                       setPitchManagerGameDayId(event.target.value);
                       setPitchManagerGrant(null);
                       setPitchManagerQrDataUrl(null);
@@ -1692,6 +1882,7 @@ export function EventAdminPage() {
                     className="h-10 rounded-md border bg-background px-3 text-sm"
                     value={pitchManagerPitchId}
                     onChange={(event) => {
+                      accessSheetOwner.invalidate();
                       setPitchManagerPitchId(event.target.value);
                       setPitchManagerGrant(null);
                       setPitchManagerQrDataUrl(null);
@@ -1815,7 +2006,13 @@ export function EventAdminPage() {
                   />
                 ) : null}
               </div>
-              <Button variant="outline" onClick={() => setHub(null)}>
+              <Button
+                variant="outline"
+                onClick={() => {
+                  accessSheetOwner.invalidate();
+                  setHub(null);
+                }}
+              >
                 Change authority
               </Button>
             </div>


### PR DESCRIPTION
## Summary

Implements GitHub issue #118 for parent Spec #105: authorized Event Admin and Technical Admin users can generate transient printable Grant Access Sheets for the current Event scope.

### Shipped

- All three sheet types: Event Admin, Pitch Manager, and Control.
- QR-only credential content: no Grant Codes, sessions, or other bearer secrets are rendered.
- Control sheets include every requested Pitch Slot, including empty or conflicted slots. Those embedded credentials remain generically inadmissible until the existing canonical live admission conditions are met.
- Environment, sheet type, scope, time, version, and prominent TEST marking are included in the printable structure. Credentials never cross environments.
- Authorization, catalog snapshot, typed Grant credential resolution, rendering, redacted audit evidence, version assignment, and commit are one Foundation transaction. Render, audit, and commit failures leave no artifact/version result and no audit row.
- Rendered HTML/SVG is transient in memory only. One artifact owner clears it before generation and on replacement failure, scope/authority/type/navigation transitions, and unmount; stale in-flight responses cannot install an artifact.
- Production-rendered QR output is independently decoded in the browser with dev-only `@zxing/browser@0.2.1`.
- Printable markup has semantic title/labels/landmarks, keyboard-operable Generate and Print interactions, 360px-safe structure, and print styling.

### Migration and stack

This PR is one commit directly stacked on `codex/120-remove-unused-event-catalog` at `75b0c58859766edd08bcf41a5834a3b4224654fb`.

- Parent migration 027 (`027-event-catalog-removal-audit`) remains unchanged with checksum `f1c986ce481312d22f44f72746cbbc9bfa7d2eab5db513b8f495e644b9758565`.
- This PR adds migration 028 (`028-access-sheet-generated-audit-action`) with checksum `52e52022edfddcf8e3cfb7a6addca8cdfddc2a84bf60649d9ce6d3f3787785c4`.
- Migration 028 rebuilds only the Event Administration audit relation, preserves rows/columns/indexes/foreign keys/order, and permits the existing actions plus `event-publication-changed`, `event-catalog-entry-removed`, and `access-sheet-generated`.

### Out of scope

No Controller workflow or actions, replay-context wiring, synthetic Event Game roots, public Timeline changes, deployment work, Qualification Tests, persisted artifacts/secrets, sheet revocation tracker, or changes to ordinary Grant reveal/admission semantics are included.

## Verification

- Focused migration/storage/erasure/Access Sheet suite: 45 passed, 0 failed, 365 expectations.
- `bun run test:focused:technical-admin-browser`: passed for Event Admin, Pitch Manager, and Control workflows, independent QR decode, TEST/redaction, print/accessibility, and artifact ownership transitions.
- `bun run test`: 625 passed, 0 failed, 17,538 expectations.
- `bun run check`: passed; only existing unrelated `await-thenable` warnings.
- `bun run build`: passed.
- `git diff --check`: passed.
