### PR TITLE
Operate radio Grant Codes

### DIFF
--- a/scripts/test-technical-admin-browser.ts
+++ b/scripts/test-technical-admin-browser.ts
@@ -847,6 +847,65 @@ try {
     currentAfterRestart.status === 200,
     `Pitch Manager current projection failed after restart (${currentAfterRestart.status})`,
   );
+  const pitchManagerCodeResponse = await postJsonBodyFromPage(
+    eventAdminPage,
+    `${origin}/api/event-admin/events/${eventId}/game-days/${pitchManagerGameDayId}/pitches/${pitchManagerPitchId}/pitch-manager-grant/code`,
+    {},
+  );
+  const pitchManagerCodePayload = JSON.parse(pitchManagerCodeResponse.body) as {
+    status: string;
+    value?: { code?: string };
+  };
+  const pitchManagerCode = pitchManagerCodePayload.value?.code ?? "";
+  assert(
+    pitchManagerCodeResponse.status === 200 &&
+      pitchManagerCodePayload.status === "accepted" &&
+      pitchManagerCode.length > 0,
+    "Pitch Manager Grant Code creation failed",
+  );
+  const pitchManagerCodeContext = await browser.newContext({
+    ignoreHTTPSErrors: true,
+    timezoneId: "UTC",
+  });
+  const pitchManagerCodePage = await pitchManagerCodeContext.newPage();
+  pitchManagerCodePage.setDefaultTimeout(5_000);
+  await pitchManagerCodePage.goto(`${origin}/pitch-manager`);
+  const pitchManagerCodeAdmissionResponsePromise = pitchManagerCodePage.waitForResponse(
+    (response) =>
+      response.url() === `${origin}/api/pitch-manager/admit` &&
+      response.request().method() === "POST",
+  );
+  const pitchManagerCodeAdmission = await postJsonBodyFromPage(
+    pitchManagerCodePage,
+    `${origin}/api/pitch-manager/admit`,
+    { grantCode: pitchManagerCode, browserContext: "browser-pitch-manager-code" },
+  );
+  const pitchManagerCodeAdmissionResponse = await pitchManagerCodeAdmissionResponsePromise;
+  const pitchManagerCodeCookie = (await pitchManagerCodeAdmissionResponse.headersArray())
+    .filter((header) => header.name === "set-cookie")
+    .find((header) => header.value.includes("__Host-pitch-manager-session="))?.value;
+  const pitchManagerCodeAdmissionPayload = JSON.parse(pitchManagerCodeAdmission.body) as {
+    status: string;
+    sessionExpiresAtMs?: number | null;
+  };
+  assert(
+    pitchManagerCodeAdmission.status === 200 &&
+      pitchManagerCodeAdmissionResponse.status() === 200 &&
+      pitchManagerCodeAdmissionPayload.status === "admitted" &&
+      typeof pitchManagerCodeAdmissionPayload.sessionExpiresAtMs === "number" &&
+      pitchManagerCodeCookie?.includes("__Host-pitch-manager-session=") === true &&
+      pitchManagerCodeCookie.includes("__Host-event-admin-session=") === false,
+    "Pitch Manager code admission did not set only its audience cookie",
+  );
+  assertCappedPitchManagerCookie(pitchManagerCodeCookie);
+  const pitchManagerCodeProtected = await pitchManagerCodeContext.request.get(
+    `${origin}/api/pitch-manager/current`,
+    { headers: { cookie: cookieHeaderFor(await pitchManagerCodeContext.cookies()) } },
+  );
+  assert(
+    pitchManagerCodeProtected.status() === 200,
+    "Pitch Manager code admission did not authorize a protected current-view request",
+  );
   await pitchManagerPage.reload();
   await pitchManagerPage.getByText("Pitch Main", { exact: true }).waitFor();
   await pitchManagerPage.getByText(/2026-08-15 10:00 Europe\/Zurich/u).waitFor();
@@ -871,6 +930,8 @@ try {
     (await pitchManagerRotateResponsePromise).status() === 200,
     "Pitch Manager Grant rotation failed",
   );
+  await eventAdminPage.getByText(/Dictate now:/u).waitFor();
+  await eventAdminPage.getByAltText("Pitch Manager Grant QR code").waitFor();
   const rotatedPitchManagerInspect = await eventAdminContext.request.get(
     `${origin}/api/event-admin/events/${eventId}/game-days/${await eventAdminPage.getByLabel("Pitch Manager Game Day").inputValue()}/pitches/${await eventAdminPage.getByLabel("Pitch Manager Pitch").inputValue()}/pitch-manager-grant`,
   );
@@ -1196,6 +1257,8 @@ try {
   );
   await page.getByRole("button", { name: "Rotate Grant" }).click();
   assert((await rotateResponsePromise).status() === 200, "Grant rotation failed");
+  await page.getByText(/Dictate now:/u).waitFor();
+  await page.getByAltText("Event Admin Grant QR code").waitFor();
   const staleAfterRotation = await fetchFromPage(
     eventAdminPage,
     `${origin}/api/event-admin/hub?eventId=${eventId}`,
@@ -1216,6 +1279,66 @@ try {
   assert(
     freshRevealResponse.status() === 200 && freshCredential.length > 0,
     "fresh QR reveal failed",
+  );
+  const eventAdminCodeResponse = await context.request.post(
+    `${origin}/api/admin/events/${eventId}/event-admin-grant/code/replace`,
+    {
+      headers: { origin, "x-technical-admin-csrf": currentCsrfToken },
+    },
+  );
+  const eventAdminCodePayload = (await eventAdminCodeResponse.json()) as {
+    status: string;
+    reason?: string;
+    value?: { code?: string };
+  };
+  const eventAdminCode = eventAdminCodePayload.value?.code ?? "";
+  assert(
+    eventAdminCodeResponse.status() === 200 &&
+      eventAdminCodePayload.status === "accepted" &&
+      eventAdminCode.length > 0,
+    `Event Admin Grant Code creation failed (http=${eventAdminCodeResponse.status()} result=${eventAdminCodePayload.status} reason=${eventAdminCodePayload.reason ?? "none"})`,
+  );
+  const eventAdminCodeContext = await browser.newContext({ ignoreHTTPSErrors: true });
+  const eventAdminCodePage = await eventAdminCodeContext.newPage();
+  eventAdminCodePage.setDefaultTimeout(5_000);
+  await eventAdminCodePage.goto(`${origin}/event-admin?eventId=${eventId}`);
+  const eventAdminCodeAdmissionResponsePromise = eventAdminCodePage.waitForResponse(
+    (response) =>
+      response.url() === `${origin}/api/event-admin/admit` &&
+      response.request().method() === "POST",
+  );
+  const eventAdminCodeAdmission = await postJsonBodyFromPage(
+    eventAdminCodePage,
+    `${origin}/api/event-admin/admit`,
+    { grantCode: eventAdminCode, browserContext: "browser-event-admin-code" },
+  );
+  const eventAdminCodeAdmissionResponse = await eventAdminCodeAdmissionResponsePromise;
+  const eventAdminCodeCookie = (await eventAdminCodeAdmissionResponse.headersArray())
+    .filter((header) => header.name === "set-cookie")
+    .find((header) => header.value.includes("__Host-event-admin-session="))?.value;
+  assert(
+    eventAdminCodeAdmission.status === 200 &&
+      eventAdminCodeAdmissionResponse.status() === 200 &&
+      eventAdminCodeCookie?.includes("__Host-event-admin-session=") === true &&
+      eventAdminCodeCookie.includes("__Host-pitch-manager-session=") === false,
+    "Event Admin code admission did not set only its audience cookie",
+  );
+  const eventAdminCodeAdmissionPayload = JSON.parse(eventAdminCodeAdmission.body) as {
+    sessionExpiresAtMs?: number | null;
+  };
+  assert(
+    typeof eventAdminCodeAdmissionPayload.sessionExpiresAtMs === "number",
+    "Event Admin code admission omitted the canonical session expiry",
+  );
+  assertCappedEventAdminCookie(eventAdminCodeCookie);
+  const eventAdminCodeCookies = await eventAdminCodeContext.cookies();
+  const eventAdminCodeProtected = await eventAdminCodeContext.request.get(
+    `${origin}/api/event-admin/hub?eventId=${eventId}`,
+    { headers: { cookie: cookieHeaderFor(eventAdminCodeCookies) } },
+  );
+  assert(
+    eventAdminCodeProtected.status() === 200,
+    "Event Admin code admission did not authorize a protected Hub request",
   );
   const revokedEventAdminContext = await browser.newContext({ ignoreHTTPSErrors: true });
   const revokedEventAdminPage = await revokedEventAdminContext.newPage();
@@ -1248,6 +1371,7 @@ try {
     revokedFreshSession.status === 401,
     "explicitly revoked live Event Admin session remained live",
   );
+  await pitchManagerCodeContext.close();
   await pitchManagerContext.close();
   await eventAdminContext.close();
   await revokedEventAdminContext.close();
@@ -1327,6 +1451,8 @@ try {
       pitchManagerControlCookieIsolation: true,
       pitchManagerControlReadOnly: true,
       pitchManagerControlScopedView: true,
+      eventAdminCodeAdmission: true,
+      pitchManagerCodeAdmission: true,
       forgedAuthorityRejected: true,
       revocationRevalidated: true,
     }),
@@ -1407,6 +1533,10 @@ async function fetchFromPage(page: Page, url: string) {
   }, url);
 }
 
+function cookieHeaderFor(cookies: Array<{ name: string; value: string }>): string {
+  return cookies.map(({ name, value }) => `${name}=${value}`).join("; ");
+}
+
 async function postJsonFromPage(page: Page, url: string, body: Record<string, string>) {
   return page.evaluate(
     async ({ requestUrl, requestBody }) => {
@@ -1464,5 +1594,14 @@ function assertCappedEventAdminCookie(setCookie: string | undefined) {
   assert(
     maxAge !== null && maxAge > 0 && maxAge < 2_592_000,
     `Event Admin session cap was reset (maxAge=${maxAge ?? "missing"})`,
+  );
+}
+
+function assertCappedPitchManagerCookie(setCookie: string | undefined) {
+  const match = setCookie?.match(/__Host-pitch-manager-session=[^;]+;[^\n]*Max-Age=(\d+)/u);
+  const maxAge = match?.[1] === undefined ? null : Number(match[1]);
+  assert(
+    maxAge !== null && maxAge > 0 && maxAge < 2_592_000,
+    `Pitch Manager session cap was reset (maxAge=${maxAge ?? "missing"})`,
   );
 }

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -188,6 +188,17 @@ describe("App", () => {
     root = createRoot(container);
   });
 
+  function setControllerCredential(value: string) {
+    const input = container.querySelector("input#control-grant") as HTMLInputElement | null;
+    if (input === null) throw new Error("Expected Controller credential input.");
+    const setter = Object.getOwnPropertyDescriptor(
+      testWindow.HTMLInputElement.prototype,
+      "value",
+    )?.set;
+    setter?.call(input, value);
+    input.dispatchEvent(new testWindow.Event("input", { bubbles: true }) as unknown as Event);
+  }
+
   afterEach(async () => {
     await act(async () => {
       root.unmount();
@@ -285,6 +296,11 @@ describe("App", () => {
         await Promise.resolve();
       });
 
+      await act(async () => {
+        setControllerCredential("qr-credential");
+        await Promise.resolve();
+      });
+
       const openButton = Array.from(container.getElementsByTagName("button")).find((button) =>
         button.textContent?.includes("Open Controller Device"),
       );
@@ -347,6 +363,10 @@ describe("App", () => {
 
     await act(async () => {
       root.render(<App />);
+      await Promise.resolve();
+    });
+    await act(async () => {
+      setControllerCredential("qr-credential");
       await Promise.resolve();
     });
     const openButton = Array.from(container.getElementsByTagName("button")).find((button) =>

--- a/src/index-event-admin-headers.focused.ts
+++ b/src/index-event-admin-headers.focused.ts
@@ -69,6 +69,37 @@ describe("Pitch Manager early response headers", () => {
   });
 });
 
+describe("Event Admin admission response headers", () => {
+  test("keeps malformed and unavailable admission failures sensitive", async () => {
+    await withServer({}, async (serverUrl) => {
+      const malformed = await fetch(new URL("/api/event-admin/admit", serverUrl), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{",
+      });
+      await expectSensitiveFailure(malformed, 400, { error: "Unable to admit this Grant." });
+
+      const missingCredential = await fetch(new URL("/api/event-admin/admit", serverUrl), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({}),
+      });
+      await expectSensitiveFailure(missingCredential, 400, {
+        error: "Unable to admit this Grant.",
+      });
+    });
+
+    await withServer({ incompleteGrantKeys: true }, async (serverUrl) => {
+      const unavailable = await fetch(new URL("/api/event-admin/admit", serverUrl), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ qrCredential: "opaque" }),
+      });
+      await expectSensitiveFailure(unavailable, 503, { error: "Authentication failed." });
+    });
+  });
+});
+
 async function expectSensitiveFailure(
   response: Response,
   status: number,

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,7 @@ import {
   type EventAdministrationAuthority,
   type EventAdministrationMutationOutcome,
   type EventAdministrationOutcome,
+  type GrantCodeProjection,
 } from "@/lib/event-administration";
 import {
   createAdministrativeAuditProjection,
@@ -60,7 +61,11 @@ import {
 } from "@/lib/administrative-audit";
 import { createGrantAuthority } from "@/lib/grant-authority";
 import { readGrantAuthorityOptions } from "@/lib/grant-runtime";
-import type { TypedGrantMutation, TypedGrantReveal } from "@/lib/grant-management";
+import type {
+  TypedGrantMutation,
+  TypedGrantReveal,
+  TypedGrantRotated,
+} from "@/lib/grant-management";
 import { createInMemoryFoundationStorage } from "@/lib/foundation-storage-memory";
 import { openSqliteFoundationStorage } from "@/lib/foundation-storage-sqlite";
 import type { FoundationStorage } from "@/lib/foundation-storage";
@@ -304,12 +309,15 @@ async function startServer() {
       ) =>
       async (req: Request) => {
         const token = requireTechnicalAdminMutationToken(req, technicalAdminAuth);
-        if (token === null) return genericAuthFailure(401);
-        if (eventAdministration === null) return genericAuthFailure(503);
+        if (token === null) return sensitiveGenericAuthFailure(401);
+        if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
         const eventId = new URL(req.url).pathname.split("/").at(-3) ?? "";
         const result = await eventAdministration[operation](eventId, token);
         await liveEventRuntime?.control.reconcileActiveControllerSessions();
-        return eventAdministrationResponse(result);
+        return sensitiveEventAdministrationMutationResponse(
+          result as EventAdministrationMutationOutcome<TypedGrantRotated | TypedGrantMutation>,
+          token,
+        );
       };
     const pitchManagerGrantMutation = async (
       req: Request,
@@ -362,8 +370,12 @@ async function startServer() {
       if (operation !== "revealPitchManagerGrant") {
         await liveEventRuntime?.control.reconcileActiveControllerSessions();
       }
-      return sensitiveEventAdministrationMutationResponse<TypedGrantMutation | TypedGrantReveal>(
-        result as EventAdministrationMutationOutcome<TypedGrantMutation | TypedGrantReveal>,
+      return sensitiveEventAdministrationMutationResponse<
+        TypedGrantMutation | TypedGrantReveal | TypedGrantRotated
+      >(
+        result as EventAdministrationMutationOutcome<
+          TypedGrantMutation | TypedGrantReveal | TypedGrantRotated
+        >,
         authority,
       );
     };
@@ -391,8 +403,70 @@ async function startServer() {
       if (operation !== "reveal") {
         await liveEventRuntime?.control.reconcileActiveControllerSessions();
       }
-      return sensitiveEventAdministrationMutationResponse<TypedGrantMutation | TypedGrantReveal>(
-        result as EventAdministrationMutationOutcome<TypedGrantMutation | TypedGrantReveal>,
+      return sensitiveEventAdministrationMutationResponse<
+        TypedGrantMutation | TypedGrantReveal | TypedGrantRotated
+      >(
+        result as EventAdministrationMutationOutcome<
+          TypedGrantMutation | TypedGrantReveal | TypedGrantRotated
+        >,
+        authority,
+        200,
+        audience,
+      );
+    };
+    const pitchManagerCodeMutation = async (
+      req: Request,
+      operation: "inspect" | "create" | "replace" | "disable",
+    ) => {
+      if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
+      const authority = resolveEventAdministrationAuthority(req, technicalAdminAuth);
+      const path = new URL(req.url).pathname.split("/");
+      if (authority === null) return sensitiveGenericAuthFailure(401);
+      const common = [path[4] ?? "", path[6] ?? "", path[8] ?? ""] as const;
+      const result =
+        operation === "inspect"
+          ? await eventAdministration.inspectPitchManagerGrantCode(...common, authority)
+          : operation === "create"
+            ? await eventAdministration.createPitchManagerGrantCode(...common, authority)
+            : operation === "replace"
+              ? await eventAdministration.replacePitchManagerGrantCode(...common, authority)
+              : await eventAdministration.disablePitchManagerGrantCode(...common, authority);
+      if (operation === "inspect")
+        return sensitiveEventAdministrationResponse(
+          result as EventAdministrationOutcome<GrantCodeProjection | null>,
+        );
+      return sensitiveEventAdministrationMutationResponse(
+        result as EventAdministrationMutationOutcome<unknown>,
+        authority,
+      );
+    };
+    const controlCodeMutation = async (
+      req: Request,
+      operation: "inspect" | "create" | "replace" | "disable",
+      audience: "event-admin" | "pitch-manager" = "event-admin",
+    ) => {
+      if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
+      const authority =
+        audience === "pitch-manager"
+          ? resolvePitchManagerAuthority(req, technicalAdminAuth)
+          : resolveEventAdministrationAuthority(req, technicalAdminAuth);
+      const path = new URL(req.url).pathname.split("/");
+      if (authority === null) return sensitiveGenericAuthFailure(401);
+      const common = [path[4] ?? "", path[6] ?? "", path[8] ?? "", path[10] ?? ""] as const;
+      const result =
+        operation === "inspect"
+          ? await eventAdministration.inspectControlGrantCode(...common, authority)
+          : operation === "create"
+            ? await eventAdministration.createControlGrantCode(...common, authority)
+            : operation === "replace"
+              ? await eventAdministration.replaceControlGrantCode(...common, authority)
+              : await eventAdministration.disableControlGrantCode(...common, authority);
+      if (operation === "inspect")
+        return sensitiveEventAdministrationResponse(
+          result as EventAdministrationOutcome<GrantCodeProjection | null>,
+        );
+      return sensitiveEventAdministrationMutationResponse(
+        result as EventAdministrationMutationOutcome<unknown>,
         authority,
         200,
         audience,
@@ -894,6 +968,51 @@ async function startServer() {
             );
           },
         },
+        "/api/admin/events/:eventId/event-admin-grant/code": {
+          async GET(req: Request) {
+            const token = requireTechnicalAdminToken(req, technicalAdminAuth);
+            if (token === null) return sensitiveGenericAuthFailure(401);
+            if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
+            const eventId = new URL(req.url).pathname.split("/").at(-3) ?? "";
+            return sensitiveEventAdministrationResponse(
+              await eventAdministration.inspectEventAdminGrantCode(eventId, token),
+            );
+          },
+          async POST(req: Request) {
+            const token = requireTechnicalAdminMutationToken(req, technicalAdminAuth);
+            if (token === null) return sensitiveGenericAuthFailure(401);
+            if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
+            const eventId = new URL(req.url).pathname.split("/").at(-3) ?? "";
+            return sensitiveEventAdministrationMutationResponse(
+              await eventAdministration.createEventAdminGrantCode(eventId, token),
+              token,
+            );
+          },
+        },
+        "/api/admin/events/:eventId/event-admin-grant/code/replace": {
+          POST: async (req: Request) => {
+            const token = requireTechnicalAdminMutationToken(req, technicalAdminAuth);
+            if (token === null) return sensitiveGenericAuthFailure(401);
+            if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
+            const eventId = new URL(req.url).pathname.split("/").at(-4) ?? "";
+            return sensitiveEventAdministrationMutationResponse(
+              await eventAdministration.replaceEventAdminGrantCode(eventId, token),
+              token,
+            );
+          },
+        },
+        "/api/admin/events/:eventId/event-admin-grant/code/disable": {
+          POST: async (req: Request) => {
+            const token = requireTechnicalAdminMutationToken(req, technicalAdminAuth);
+            if (token === null) return sensitiveGenericAuthFailure(401);
+            if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
+            const eventId = new URL(req.url).pathname.split("/").at(-4) ?? "";
+            return sensitiveEventAdministrationMutationResponse(
+              await eventAdministration.disableEventAdminGrantCode(eventId, token),
+              token,
+            );
+          },
+        },
         "/api/admin/events/:eventId/event-admin-grant/rotate": {
           POST: adminGrantMutationRoute("rotateEventAdminGrant"),
         },
@@ -908,18 +1027,38 @@ async function startServer() {
         },
         "/api/event-admin/admit": {
           async POST(req: Request) {
-            if (eventAdministration === null) return genericAuthFailure(503);
+            if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
             const body = await readJsonRecord(req);
-            if (body === null || typeof body.qrCredential !== "string")
-              return json({ error: "Unable to admit this Grant." }, 400);
+            if (
+              body === null ||
+              (typeof body.qrCredential !== "string" && typeof body.grantCode !== "string") ||
+              (typeof body.qrCredential === "string" && typeof body.grantCode === "string")
+            )
+              return sensitiveJson({ error: "Unable to admit this Grant." }, 400);
             const context = readEventAdminContext(req.headers.get("cookie")) ?? crypto.randomUUID();
-            const result = await eventAdministration.admitEventAdmin({
-              qrCredential: body.qrCredential,
-              browserContext: context,
-              deviceClass: body.deviceClass,
-              browserClass: body.browserClass,
-            });
+            const result =
+              typeof body.grantCode === "string"
+                ? await eventAdministration.admitEventAdminCode({
+                    grantCode: body.grantCode,
+                    browserContext: context,
+                    deviceClass: body.deviceClass,
+                    browserClass: body.browserClass,
+                  })
+                : await eventAdministration.admitEventAdmin({
+                    qrCredential: body.qrCredential,
+                    browserContext: context,
+                    deviceClass: body.deviceClass,
+                    browserClass: body.browserClass,
+                  });
             if (result.status !== "admitted") return sensitiveJson(result, 401);
+            const sessionHeaders: Array<[string, string]> = [
+              ["set-cookie", eventAdminContextCookie(context)],
+            ];
+            if (typeof result.sessionExpiresAtMs === "number")
+              sessionHeaders.push([
+                "set-cookie",
+                eventAdminSessionCookie(result.sessionBearer, result.sessionExpiresAtMs),
+              ]);
             return sensitiveJson(
               {
                 status: "admitted",
@@ -928,15 +1067,10 @@ async function startServer() {
                 grantType: result.grantType,
                 scope: result.scope,
                 grantSessionId: result.grantSessionId,
+                sessionExpiresAtMs: result.sessionExpiresAtMs ?? null,
               },
               200,
-              [
-                ["set-cookie", eventAdminContextCookie(context)],
-                [
-                  "set-cookie",
-                  eventAdminSessionCookie(result.sessionBearer, result.sessionExpiresAtMs),
-                ],
-              ],
+              sessionHeaders,
             );
           },
         },
@@ -993,6 +1127,15 @@ async function startServer() {
           {
             POST: (req: Request) => pitchManagerGrantMutation(req, "reactivatePitchManagerGrant"),
           },
+        "/api/event-admin/events/:eventId/game-days/:gameDayId/pitches/:pitchId/pitch-manager-grant/code":
+          {
+            GET: (req: Request) => pitchManagerCodeMutation(req, "inspect"),
+            POST: (req: Request) => pitchManagerCodeMutation(req, "create"),
+          },
+        "/api/event-admin/events/:eventId/game-days/:gameDayId/pitches/:pitchId/pitch-manager-grant/code/replace":
+          { POST: (req: Request) => pitchManagerCodeMutation(req, "replace") },
+        "/api/event-admin/events/:eventId/game-days/:gameDayId/pitches/:pitchId/pitch-manager-grant/code/disable":
+          { POST: (req: Request) => pitchManagerCodeMutation(req, "disable") },
         "/api/event-admin/events/:eventId/game-days/:gameDayId/pitches/:pitchId/pitch-slots/:pitchSlotId/control-grant":
           {
             async GET(req: Request) {
@@ -1037,6 +1180,15 @@ async function startServer() {
                 "reveal",
               ),
           },
+        "/api/event-admin/events/:eventId/game-days/:gameDayId/pitches/:pitchId/pitch-slots/:pitchSlotId/control-grant/code":
+          {
+            GET: (req: Request) => controlCodeMutation(req, "inspect"),
+            POST: (req: Request) => controlCodeMutation(req, "create"),
+          },
+        "/api/event-admin/events/:eventId/game-days/:gameDayId/pitches/:pitchId/pitch-slots/:pitchSlotId/control-grant/code/replace":
+          { POST: (req: Request) => controlCodeMutation(req, "replace") },
+        "/api/event-admin/events/:eventId/game-days/:gameDayId/pitches/:pitchId/pitch-slots/:pitchSlotId/control-grant/code/disable":
+          { POST: (req: Request) => controlCodeMutation(req, "disable") },
         "/api/event-admin/events/:eventId/game-days/:gameDayId/pitches/:pitchId/pitch-slots/:pitchSlotId/control-grant/rotate":
           {
             POST: (req: Request) =>
@@ -1077,17 +1229,37 @@ async function startServer() {
           async POST(req: Request) {
             if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
             const body = await readJsonRecord(req);
-            if (body === null || typeof body.qrCredential !== "string")
+            if (
+              body === null ||
+              (typeof body.qrCredential !== "string" && typeof body.grantCode !== "string") ||
+              (typeof body.qrCredential === "string" && typeof body.grantCode === "string")
+            )
               return sensitiveJson({ error: "Unable to admit this Grant." }, 400);
             const context =
               readPitchManagerContext(req.headers.get("cookie")) ?? crypto.randomUUID();
-            const result = await eventAdministration.admitPitchManager({
-              qrCredential: body.qrCredential,
-              browserContext: context,
-              deviceClass: body.deviceClass,
-              browserClass: body.browserClass,
-            });
+            const result =
+              typeof body.grantCode === "string"
+                ? await eventAdministration.admitPitchManagerCode({
+                    grantCode: body.grantCode,
+                    browserContext: context,
+                    deviceClass: body.deviceClass,
+                    browserClass: body.browserClass,
+                  })
+                : await eventAdministration.admitPitchManager({
+                    qrCredential: body.qrCredential,
+                    browserContext: context,
+                    deviceClass: body.deviceClass,
+                    browserClass: body.browserClass,
+                  });
             if (result.status !== "admitted") return sensitiveJson(result, 401);
+            const sessionHeaders: Array<[string, string]> = [
+              ["set-cookie", pitchManagerContextCookie(context)],
+            ];
+            if (typeof result.sessionExpiresAtMs === "number")
+              sessionHeaders.push([
+                "set-cookie",
+                pitchManagerSessionCookie(result.sessionBearer, result.sessionExpiresAtMs),
+              ]);
             return sensitiveJson(
               {
                 status: "admitted",
@@ -1099,13 +1271,7 @@ async function startServer() {
                 sessionExpiresAtMs: result.sessionExpiresAtMs ?? null,
               },
               200,
-              [
-                ["set-cookie", pitchManagerContextCookie(context)],
-                [
-                  "set-cookie",
-                  pitchManagerSessionCookie(result.sessionBearer, result.sessionExpiresAtMs),
-                ],
-              ],
+              sessionHeaders,
             );
           },
         },
@@ -1232,6 +1398,19 @@ async function startServer() {
             ]);
           },
         },
+        "/api/pitch-manager/events/:eventId/game-days/:gameDayId/pitches/:pitchId/pitch-slots/:pitchSlotId/control-grant/code":
+          {
+            GET: (req: Request) => controlCodeMutation(req, "inspect", "pitch-manager"),
+            POST: (req: Request) => controlCodeMutation(req, "create", "pitch-manager"),
+          },
+        "/api/pitch-manager/events/:eventId/game-days/:gameDayId/pitches/:pitchId/pitch-slots/:pitchSlotId/control-grant/code/replace":
+          {
+            POST: (req: Request) => controlCodeMutation(req, "replace", "pitch-manager"),
+          },
+        "/api/pitch-manager/events/:eventId/game-days/:gameDayId/pitches/:pitchId/pitch-slots/:pitchSlotId/control-grant/code/disable":
+          {
+            POST: (req: Request) => controlCodeMutation(req, "disable", "pitch-manager"),
+          },
         "/api/event-admin/hub": {
           async GET(req: Request) {
             if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
@@ -2524,7 +2703,9 @@ function sensitiveEventAdministrationMutationResponse<T>(
   audience: "event-admin" | "pitch-manager" = "event-admin",
 ) {
   const refreshHeaders: Array<[string, string]> =
-    authority.kind === "grant-session" && result.status === "accepted"
+    authority.kind === "grant-session" &&
+    result.status === "accepted" &&
+    typeof result.sessionExpiresAtMs === "number"
       ? [
           [
             "set-cookie",
@@ -2599,11 +2780,11 @@ function eventAdminContextCookie(value: string): string {
   return `__Host-event-admin-context=${encodeURIComponent(value)}; Path=/; HttpOnly; Secure; SameSite=Strict`;
 }
 
-function eventAdminSessionCookie(value: string, expiresAtMs: number | null | undefined): string {
-  const maxAgeSeconds =
-    expiresAtMs === null || expiresAtMs === undefined
-      ? 2_592_000
-      : Math.max(0, Math.min(2_592_000, Math.ceil((expiresAtMs - Date.now()) / 1_000)));
+function eventAdminSessionCookie(value: string, expiresAtMs: number): string {
+  const maxAgeSeconds = Math.max(
+    0,
+    Math.min(2_592_000, Math.ceil((expiresAtMs - Date.now()) / 1_000)),
+  );
   return `__Host-event-admin-session=${encodeURIComponent(value)}; Path=/; Max-Age=${maxAgeSeconds}; HttpOnly; Secure; SameSite=Strict`;
 }
 
@@ -2611,11 +2792,8 @@ function pitchManagerContextCookie(value: string): string {
   return `__Host-pitch-manager-context=${encodeURIComponent(value)}; Path=/; HttpOnly; Secure; SameSite=Strict`;
 }
 
-function pitchManagerSessionCookie(value: string, expiresAtMs: number | null | undefined): string {
-  const maxAgeSeconds =
-    expiresAtMs === null || expiresAtMs === undefined
-      ? 0
-      : Math.max(0, Math.ceil((expiresAtMs - Date.now()) / 1_000));
+function pitchManagerSessionCookie(value: string, expiresAtMs: number): string {
+  const maxAgeSeconds = Math.max(0, Math.ceil((expiresAtMs - Date.now()) / 1_000));
   return `__Host-pitch-manager-session=${encodeURIComponent(value)}; Path=/; Max-Age=${maxAgeSeconds}; HttpOnly; Secure; SameSite=Strict`;
 }
 

--- a/src/lib/event-administration.test.ts
+++ b/src/lib/event-administration.test.ts
@@ -1221,9 +1221,256 @@ describe("Event Administration handoff", () => {
       await fixture.administration.inspectEventAdminGrant(event.value.eventId, fixture.technical),
     ).toMatchObject({ status: "accepted", value: { status: "active" } });
   });
+
+  test("keeps Grant Code management on the canonical matrix and never projects plaintext", async () => {
+    const fixture = createFixture(undefined, {
+      resolve: () => ({ status: "eligible" as const, eventGameId: "event-game-code" }),
+    });
+    const event = await fixture.catalog.createEvent(
+      { name: "Grant Code Event", timeZone: "UTC" },
+      fixture.technical,
+    );
+    if (event.status !== "accepted") throw new Error("Expected Event.");
+    const day = await fixture.catalog.addGameDay(
+      event.value.eventId,
+      { date: "2026-08-14" },
+      fixture.technical,
+    );
+    const pitch = await fixture.catalog.createPitch(
+      event.value.eventId,
+      { name: "Pitch A" },
+      fixture.technical,
+    );
+    if (day.status !== "accepted" || pitch.status !== "accepted")
+      throw new Error("Expected schedule setup.");
+    const slot = await fixture.catalog.createGameplaySlot(
+      event.value.eventId,
+      day.value.gameDayId,
+      { sequence: 1, scheduledStart: "2026-08-14T10:00" },
+      fixture.technical,
+    );
+    if (slot.status !== "accepted") throw new Error("Expected Gameplay Slot.");
+    const pitchSlot = await fixture.storage.transaction(
+      (transaction) => transaction.listPitchSlots(day.value.gameDayId, pitch.value.pitchId)[0],
+    );
+    if (pitchSlot === undefined) throw new Error("Expected Pitch Slot.");
+    const game = await fixture.catalog.createEventGame(
+      event.value.eventId,
+      day.value.gameDayId,
+      {
+        gameplaySlotId: slot.value.gameplaySlotId,
+        pitchSlotId: pitchSlot.pitchSlotId,
+        sideA: { sourceLabel: "A" },
+        sideB: { sourceLabel: "B" },
+      },
+      fixture.technical,
+    );
+    if (game.status !== "accepted") throw new Error("Expected Event Game.");
+
+    const eventAdminGrant = await fixture.administration.createEventAdminGrant(
+      event.value.eventId,
+      fixture.technical,
+    );
+    if (eventAdminGrant.status !== "accepted") throw new Error("Expected Event Admin Grant.");
+    const eventAdminQr = await fixture.grants.revealGrant(
+      eventAdminGrant.value.grantId,
+      fixture.technical,
+    );
+    if (eventAdminQr.status !== "revealed") throw new Error("Expected Event Admin QR.");
+    const eventAdminAdmission = await fixture.administration.admitEventAdmin({
+      qrCredential: eventAdminQr.qrCredential,
+      browserContext: "code-event-admin",
+    });
+    if (eventAdminAdmission.status !== "admitted")
+      throw new Error("Expected Event Admin admission.");
+    const eventAdmin = {
+      kind: "grant-session" as const,
+      sessionBearer: eventAdminAdmission.sessionBearer,
+    };
+
+    expect(
+      await fixture.administration.createEventAdminGrantCode(
+        event.value.eventId,
+        eventAdmin as never,
+      ),
+    ).toMatchObject({ status: "rejected", reason: "unauthorized" });
+    const eventAdminCode = await fixture.administration.createEventAdminGrantCode(
+      event.value.eventId,
+      fixture.technical,
+    );
+    expect(eventAdminCode).toMatchObject({ status: "accepted", value: { status: "created" } });
+    if (eventAdminCode.status !== "accepted") throw new Error("Expected Event Admin code.");
+    expect(JSON.stringify(eventAdminCode)).toMatch(/^[\s\S]*[a-z]+-[a-z]+-\d{3}[\s\S]*$/u);
+    expect(
+      await fixture.administration.inspectEventAdminGrantCode(
+        event.value.eventId,
+        fixture.technical,
+      ),
+    ).toMatchObject({ status: "accepted", value: { state: "present", formatVersion: 1 } });
+    expect(
+      JSON.stringify(
+        await fixture.administration.inspectEventAdminGrantCode(
+          event.value.eventId,
+          fixture.technical,
+        ),
+      ),
+    ).not.toContain(eventAdminCode.value.code);
+    expect(
+      await fixture.grants.admitGrantCode({
+        grantCode: eventAdminCode.value.code,
+        browserContext: "code-admission",
+      }),
+    ).toMatchObject({ status: "admitted", grantType: "event-admin" });
+
+    const pitchManagerGrant = await fixture.administration.createPitchManagerGrant(
+      event.value.eventId,
+      day.value.gameDayId,
+      pitch.value.pitchId,
+      eventAdmin,
+    );
+    if (pitchManagerGrant.status !== "accepted") throw new Error("Expected Pitch Manager Grant.");
+    const pitchManagerCode = await fixture.administration.createPitchManagerGrantCode(
+      event.value.eventId,
+      day.value.gameDayId,
+      pitch.value.pitchId,
+      eventAdmin,
+    );
+    expect(pitchManagerCode).toMatchObject({ status: "accepted", value: { status: "created" } });
+    expect(
+      await fixture.administration.createPitchManagerGrantCode(
+        event.value.eventId,
+        day.value.gameDayId,
+        pitch.value.pitchId,
+        eventAdmin,
+      ),
+    ).toMatchObject({ status: "rejected", reason: "invalid-input" });
+
+    const pitchManagerQr = await fixture.grants.revealGrant(
+      pitchManagerGrant.value.grantId,
+      eventAdmin,
+    );
+    if (pitchManagerQr.status !== "revealed") throw new Error("Expected Pitch Manager QR.");
+    const pitchManagerAdmission = await fixture.administration.admitPitchManager({
+      qrCredential: pitchManagerQr.qrCredential,
+      browserContext: "code-pitch-manager",
+    });
+    if (pitchManagerAdmission.status !== "admitted")
+      throw new Error("Expected Pitch Manager admission.");
+    const pitchManager = {
+      kind: "grant-session" as const,
+      sessionBearer: pitchManagerAdmission.sessionBearer,
+    };
+    expect(
+      await fixture.administration.inspectPitchManagerGrantCode(
+        event.value.eventId,
+        day.value.gameDayId,
+        pitch.value.pitchId,
+        pitchManager,
+      ),
+    ).toMatchObject({ status: "rejected", reason: "unauthorized" });
+
+    const controlGrant = await fixture.administration.createControlGrant(
+      event.value.eventId,
+      day.value.gameDayId,
+      pitch.value.pitchId,
+      pitchSlot.pitchSlotId,
+      eventAdmin,
+    );
+    if (controlGrant.status !== "accepted") throw new Error("Expected Control Grant.");
+    const controlCode = await fixture.administration.createControlGrantCode(
+      event.value.eventId,
+      day.value.gameDayId,
+      pitch.value.pitchId,
+      pitchSlot.pitchSlotId,
+      pitchManager,
+    );
+    expect(controlCode).toMatchObject({ status: "accepted", value: { status: "created" } });
+    if (controlCode.status !== "accepted") throw new Error("Expected Control code.");
+    expect(
+      await fixture.administration.createControlGrantCode(
+        event.value.eventId,
+        day.value.gameDayId,
+        pitch.value.pitchId,
+        pitchSlot.pitchSlotId,
+        eventAdmin,
+      ),
+    ).toMatchObject({ status: "rejected", reason: "invalid-input" });
+    const disabledControlCode = await fixture.administration.disableControlGrantCode(
+      event.value.eventId,
+      day.value.gameDayId,
+      pitch.value.pitchId,
+      pitchSlot.pitchSlotId,
+      pitchManager,
+    );
+    expect(disabledControlCode).toMatchObject({
+      status: "accepted",
+      value: { status: "updated" },
+      sessionExpiresAtMs: pitchManagerAdmission.sessionExpiresAtMs,
+    });
+    expect(
+      await fixture.administration.inspectControlGrantCode(
+        event.value.eventId,
+        day.value.gameDayId,
+        pitch.value.pitchId,
+        pitchSlot.pitchSlotId,
+        pitchManager,
+      ),
+    ).toMatchObject({ status: "accepted", value: { state: "disabled" } });
+  });
+
+  test("binds Grant Code admission to the typed Event Administration seam", async () => {
+    const fixture = createFixture();
+    const event = await fixture.catalog.createEvent(
+      { name: "Typed code admission", timeZone: "UTC" },
+      fixture.technical,
+    );
+    if (event.status !== "accepted") throw new Error("Expected Event.");
+    await fixture.catalog.addGameDay(
+      event.value.eventId,
+      { date: "2026-08-14" },
+      fixture.technical,
+    );
+    const eventAdmin = await fixture.administration.createEventAdminGrant(
+      event.value.eventId,
+      fixture.technical,
+    );
+    if (eventAdmin.status !== "accepted") throw new Error("Expected Event Admin Grant.");
+    const code = await fixture.administration.createEventAdminGrantCode(
+      event.value.eventId,
+      fixture.technical,
+    );
+    if (code.status !== "accepted") throw new Error("Expected Event Admin code.");
+
+    const wrongType = await fixture.administration.admitPitchManagerCode({
+      grantCode: code.value.code,
+      browserContext: "wrong-type",
+    });
+    expect(wrongType).toMatchObject({
+      status: "rejected",
+      code: "grant-admission-failed",
+      message: "Unable to admit this Grant.",
+    });
+    const sessions = await fixture.storage.transaction((transaction) =>
+      transaction.listGrantSessions(eventAdmin.value.grantId),
+    );
+    expect(sessions).toHaveLength(0);
+
+    const accepted = await fixture.administration.admitEventAdminCode({
+      grantCode: code.value.code,
+      browserContext: "right-type",
+    });
+    expect(accepted).toMatchObject({ status: "admitted", grantType: "event-admin" });
+  });
 });
 
-function createFixture(storage: FoundationStorage = createInMemoryFoundationStorage()) {
+function createFixture(
+  storage: FoundationStorage = createInMemoryFoundationStorage(),
+  controlScopeResolver: {
+    resolve: () => { status: "eligible"; eventGameId: string } | { status: "unavailable" };
+  } = {
+    resolve: () => ({ status: "unavailable" as const }),
+  },
+) {
   let nowMs = Date.parse("2026-08-14T12:00:00Z");
   let entropy = 7;
   const technical = createTechnicalAdminAuth(
@@ -1243,7 +1490,7 @@ function createFixture(storage: FoundationStorage = createInMemoryFoundationStor
       },
     },
     keyRing,
-    controlScopeResolver: { resolve: () => ({ status: "unavailable" as const }) },
+    controlScopeResolver,
     privilegedAuthorityVerifier: createGrantAuthorityVerifier((input) => {
       if (isTechnicalAdminAuthority(input)) return { kind: "technical-admin", id: input.sessionId };
       if (
@@ -1260,6 +1507,7 @@ function createFixture(storage: FoundationStorage = createInMemoryFoundationStor
     storage,
     grants,
     nowMs: () => nowMs,
+    controlScopeResolver,
   });
   return {
     storage,

--- a/src/lib/event-administration.ts
+++ b/src/lib/event-administration.ts
@@ -25,8 +25,10 @@ import type {
   TypedGrantAdmission,
   TypedGrantAdmissionThrottled,
   TypedGrantAuthority,
+  TypedGrantCodeCreated,
   TypedGrantMutation,
   TypedGrantReveal,
+  TypedGrantRotated,
   TypedSessionSummary,
 } from "@/lib/grant-management";
 import {
@@ -89,6 +91,13 @@ export type ControlGrantProjection = {
   expiresAtMs: number | null;
   eligibility: "eligible" | "empty" | "conflict" | "mismatch" | "unavailable" | "terminal";
   eventGameId: string | null;
+};
+
+export type GrantCodeProjection = {
+  grantId: string;
+  grantVersion: string;
+  state: "absent" | "present" | "disabled" | "erased";
+  formatVersion: 1 | null;
 };
 
 export type EventHubProjection = {
@@ -186,7 +195,7 @@ export type EventAdministration = {
     gameDayId: unknown,
     pitchId: unknown,
     authority: EventAdministrationAuthority,
-  ): Promise<EventAdministrationMutationOutcome<TypedGrantMutation>>;
+  ): Promise<EventAdministrationMutationOutcome<TypedGrantRotated | TypedGrantMutation>>;
   disablePitchManagerGrant(
     eventId: unknown,
     gameDayId: unknown,
@@ -247,7 +256,7 @@ export type EventAdministration = {
     pitchId: unknown,
     pitchSlotId: unknown,
     authority: EventAdministrationAuthority,
-  ): Promise<EventAdministrationMutationOutcome<TypedGrantMutation>>;
+  ): Promise<EventAdministrationMutationOutcome<TypedGrantRotated | TypedGrantMutation>>;
   inspectEventAdminGrant(
     eventId: unknown,
     authority: EventAdministrationAuthority,
@@ -259,7 +268,7 @@ export type EventAdministration = {
   rotateEventAdminGrant(
     eventId: unknown,
     authority: TechnicalAdminAuthority,
-  ): Promise<EventAdministrationOutcome<TypedGrantMutation>>;
+  ): Promise<EventAdministrationMutationOutcome<TypedGrantRotated | TypedGrantMutation>>;
   disableEventAdminGrant(
     eventId: unknown,
     authority: TechnicalAdminAuthority,
@@ -272,14 +281,94 @@ export type EventAdministration = {
     eventId: unknown,
     authority: TechnicalAdminAuthority,
   ): Promise<EventAdministrationOutcome<TypedGrantMutation>>;
+  inspectEventAdminGrantCode(
+    eventId: unknown,
+    authority: TechnicalAdminAuthority,
+  ): Promise<EventAdministrationOutcome<GrantCodeProjection | null>>;
+  createEventAdminGrantCode(
+    eventId: unknown,
+    authority: TechnicalAdminAuthority,
+  ): Promise<EventAdministrationMutationOutcome<TypedGrantCodeCreated>>;
+  replaceEventAdminGrantCode(
+    eventId: unknown,
+    authority: TechnicalAdminAuthority,
+  ): Promise<EventAdministrationMutationOutcome<TypedGrantCodeCreated>>;
+  disableEventAdminGrantCode(
+    eventId: unknown,
+    authority: TechnicalAdminAuthority,
+  ): Promise<EventAdministrationMutationOutcome<TypedGrantMutation>>;
+  inspectPitchManagerGrantCode(
+    eventId: unknown,
+    gameDayId: unknown,
+    pitchId: unknown,
+    authority: EventAdministrationAuthority,
+  ): Promise<EventAdministrationOutcome<GrantCodeProjection | null>>;
+  createPitchManagerGrantCode(
+    eventId: unknown,
+    gameDayId: unknown,
+    pitchId: unknown,
+    authority: EventAdministrationAuthority,
+  ): Promise<EventAdministrationMutationOutcome<TypedGrantCodeCreated>>;
+  replacePitchManagerGrantCode(
+    eventId: unknown,
+    gameDayId: unknown,
+    pitchId: unknown,
+    authority: EventAdministrationAuthority,
+  ): Promise<EventAdministrationMutationOutcome<TypedGrantCodeCreated>>;
+  disablePitchManagerGrantCode(
+    eventId: unknown,
+    gameDayId: unknown,
+    pitchId: unknown,
+    authority: EventAdministrationAuthority,
+  ): Promise<EventAdministrationMutationOutcome<TypedGrantMutation>>;
+  inspectControlGrantCode(
+    eventId: unknown,
+    gameDayId: unknown,
+    pitchId: unknown,
+    pitchSlotId: unknown,
+    authority: EventAdministrationAuthority,
+  ): Promise<EventAdministrationOutcome<GrantCodeProjection | null>>;
+  createControlGrantCode(
+    eventId: unknown,
+    gameDayId: unknown,
+    pitchId: unknown,
+    pitchSlotId: unknown,
+    authority: EventAdministrationAuthority,
+  ): Promise<EventAdministrationMutationOutcome<TypedGrantCodeCreated>>;
+  replaceControlGrantCode(
+    eventId: unknown,
+    gameDayId: unknown,
+    pitchId: unknown,
+    pitchSlotId: unknown,
+    authority: EventAdministrationAuthority,
+  ): Promise<EventAdministrationMutationOutcome<TypedGrantCodeCreated>>;
+  disableControlGrantCode(
+    eventId: unknown,
+    gameDayId: unknown,
+    pitchId: unknown,
+    pitchSlotId: unknown,
+    authority: EventAdministrationAuthority,
+  ): Promise<EventAdministrationMutationOutcome<TypedGrantMutation>>;
   admitEventAdmin(input: {
     qrCredential: unknown;
     browserContext: unknown;
     deviceClass?: unknown;
     browserClass?: unknown;
   }): Promise<TypedGrantAdmission | TypedGrantAdmissionThrottled>;
+  admitEventAdminCode(input: {
+    grantCode: unknown;
+    browserContext: unknown;
+    deviceClass?: unknown;
+    browserClass?: unknown;
+  }): Promise<TypedGrantAdmission | TypedGrantAdmissionThrottled>;
   admitPitchManager(input: {
     qrCredential: unknown;
+    browserContext: unknown;
+    deviceClass?: unknown;
+    browserClass?: unknown;
+  }): Promise<TypedGrantAdmission | TypedGrantAdmissionThrottled>;
+  admitPitchManagerCode(input: {
+    grantCode: unknown;
     browserContext: unknown;
     deviceClass?: unknown;
     browserClass?: unknown;
@@ -579,6 +668,60 @@ export function createEventAdministration(
       );
     },
 
+    async inspectPitchManagerGrantCode(eventIdInput, gameDayIdInput, pitchIdInput, authority) {
+      const ids = validateScopeIds(eventIdInput, gameDayIdInput, pitchIdInput);
+      if (!ids.ok) return invalid(ids.error);
+      try {
+        return await options.storage.transaction((transaction) => {
+          if (
+            authorizeEventScopeInTransaction(
+              options,
+              transaction,
+              ids.value.eventId,
+              authority,
+              true,
+            ) === null
+          )
+            return unauthorized();
+          const grant = findPitchManagerGrantInTransaction(transaction, ids.value);
+          return accepted(grant === null ? null : projectGrantCode(grant));
+        });
+      } catch {
+        return unavailable();
+      }
+    },
+
+    async createPitchManagerGrantCode(eventIdInput, gameDayIdInput, pitchIdInput, authority) {
+      return managePitchManagerGrantCode(
+        options,
+        eventIdInput,
+        gameDayIdInput,
+        pitchIdInput,
+        authority,
+        "createGrantCode",
+      );
+    },
+    async replacePitchManagerGrantCode(eventIdInput, gameDayIdInput, pitchIdInput, authority) {
+      return managePitchManagerGrantCode(
+        options,
+        eventIdInput,
+        gameDayIdInput,
+        pitchIdInput,
+        authority,
+        "replaceGrantCode",
+      );
+    },
+    async disablePitchManagerGrantCode(eventIdInput, gameDayIdInput, pitchIdInput, authority) {
+      return (await managePitchManagerGrantCode(
+        options,
+        eventIdInput,
+        gameDayIdInput,
+        pitchIdInput,
+        authority,
+        "disableGrantCode",
+      )) as EventAdministrationMutationOutcome<TypedGrantMutation>;
+    },
+
     async createControlGrant(
       eventIdInput,
       gameDayIdInput,
@@ -849,19 +992,101 @@ export function createEventAdministration(
             true,
           );
           return {
-            ...accepted({
-              status: "updated" as const,
-              grantId: result.grantId,
-              grantVersion: result.grantVersion,
-              affectedSessionCount:
-                "affectedSessionCount" in result ? result.affectedSessionCount : 0,
-            }),
+            ...accepted(result),
             sessionExpiresAtMs: refreshed?.sessionExpiresAtMs ?? authorization.sessionExpiresAtMs,
           };
         });
       } catch {
         return unavailable();
       }
+    },
+
+    async inspectControlGrantCode(
+      eventIdInput,
+      gameDayIdInput,
+      pitchIdInput,
+      pitchSlotIdInput,
+      authority,
+    ) {
+      const ids = validateControlScopeIds(
+        eventIdInput,
+        gameDayIdInput,
+        pitchIdInput,
+        pitchSlotIdInput,
+      );
+      if (!ids.ok) return invalid(ids.error);
+      try {
+        return await options.storage.transaction((transaction) => {
+          const scope = readControlGrantScope(transaction, ids.value);
+          if (scope === null) return notFound("Pitch Slot was not found.");
+          if (
+            authorizeControlManagementInTransaction(
+              options,
+              transaction,
+              ids.value,
+              authority,
+              true,
+            ) === null
+          )
+            return unauthorized();
+          const grant = findControlGrantInTransaction(transaction, scope);
+          return accepted(grant === null ? null : projectGrantCode(grant));
+        });
+      } catch {
+        return unavailable();
+      }
+    },
+
+    async createControlGrantCode(
+      eventIdInput,
+      gameDayIdInput,
+      pitchIdInput,
+      pitchSlotIdInput,
+      authority,
+    ) {
+      return manageControlGrantCode(
+        options,
+        eventIdInput,
+        gameDayIdInput,
+        pitchIdInput,
+        pitchSlotIdInput,
+        authority,
+        "createGrantCode",
+      );
+    },
+    async replaceControlGrantCode(
+      eventIdInput,
+      gameDayIdInput,
+      pitchIdInput,
+      pitchSlotIdInput,
+      authority,
+    ) {
+      return manageControlGrantCode(
+        options,
+        eventIdInput,
+        gameDayIdInput,
+        pitchIdInput,
+        pitchSlotIdInput,
+        authority,
+        "replaceGrantCode",
+      );
+    },
+    async disableControlGrantCode(
+      eventIdInput,
+      gameDayIdInput,
+      pitchIdInput,
+      pitchSlotIdInput,
+      authority,
+    ) {
+      return (await manageControlGrantCode(
+        options,
+        eventIdInput,
+        gameDayIdInput,
+        pitchIdInput,
+        pitchSlotIdInput,
+        authority,
+        "disableGrantCode",
+      )) as EventAdministrationOutcome<TypedGrantMutation>;
     },
 
     async inspectEventAdminGrant(eventIdInput, authority) {
@@ -920,6 +1145,28 @@ export function createEventAdministration(
       return manageEventAdminGrant(options, eventIdInput, authority, "reactivateGrant");
     },
 
+    async inspectEventAdminGrantCode(eventIdInput, authority) {
+      if (!isTechnicalAdminAuthority(authority)) return unauthorized();
+      const grant = await findEventAdminGrant(options, eventIdInput);
+      if (grant.status !== "accepted") return grant;
+      return accepted(grant.value === null ? null : projectGrantCode(grant.value));
+    },
+
+    async createEventAdminGrantCode(eventIdInput, authority) {
+      return manageEventAdminGrantCode(options, eventIdInput, authority, "createGrantCode");
+    },
+    async replaceEventAdminGrantCode(eventIdInput, authority) {
+      return manageEventAdminGrantCode(options, eventIdInput, authority, "replaceGrantCode");
+    },
+    async disableEventAdminGrantCode(eventIdInput, authority) {
+      return (await manageEventAdminGrantCode(
+        options,
+        eventIdInput,
+        authority,
+        "disableGrantCode",
+      )) as EventAdministrationOutcome<TypedGrantMutation>;
+    },
+
     async admitEventAdmin(input) {
       if (
         typeof input.qrCredential !== "string" ||
@@ -927,7 +1174,7 @@ export function createEventAdministration(
         input.qrCredential.length === 0 ||
         input.browserContext.length === 0
       )
-        return options.grants.admitGrant({ qrCredential: "", browserContext: "" });
+        return options.grants.admitEventAdminGrant({ qrCredential: "", browserContext: "" });
       return options.grants.admitEventAdminGrant({
         qrCredential: input.qrCredential,
         browserContext: input.browserContext,
@@ -943,9 +1190,41 @@ export function createEventAdministration(
         input.qrCredential.length === 0 ||
         input.browserContext.length === 0
       )
-        return options.grants.admitGrant({ qrCredential: "", browserContext: "" });
+        return options.grants.admitPitchManagerGrant({ qrCredential: "", browserContext: "" });
       return options.grants.admitPitchManagerGrant({
         qrCredential: input.qrCredential,
+        browserContext: input.browserContext,
+        deviceClass: typeof input.deviceClass === "string" ? input.deviceClass : undefined,
+        browserClass: typeof input.browserClass === "string" ? input.browserClass : undefined,
+      });
+    },
+
+    async admitEventAdminCode(input) {
+      if (
+        typeof input.grantCode !== "string" ||
+        typeof input.browserContext !== "string" ||
+        input.grantCode.length === 0 ||
+        input.browserContext.length === 0
+      )
+        return options.grants.admitEventAdminGrantCode({ grantCode: "", browserContext: "" });
+      return options.grants.admitEventAdminGrantCode({
+        grantCode: input.grantCode,
+        browserContext: input.browserContext,
+        deviceClass: typeof input.deviceClass === "string" ? input.deviceClass : undefined,
+        browserClass: typeof input.browserClass === "string" ? input.browserClass : undefined,
+      });
+    },
+
+    async admitPitchManagerCode(input) {
+      if (
+        typeof input.grantCode !== "string" ||
+        typeof input.browserContext !== "string" ||
+        input.grantCode.length === 0 ||
+        input.browserContext.length === 0
+      )
+        return options.grants.admitPitchManagerGrantCode({ grantCode: "", browserContext: "" });
+      return options.grants.admitPitchManagerGrantCode({
+        grantCode: input.grantCode,
         browserContext: input.browserContext,
         deviceClass: typeof input.deviceClass === "string" ? input.deviceClass : undefined,
         browserClass: typeof input.browserClass === "string" ? input.browserClass : undefined,
@@ -959,13 +1238,16 @@ export function createEventAdministration(
         input.qrCredential.length === 0 ||
         input.browserContext.length === 0
       )
-        return options.grants.admitGrant({ qrCredential: "", browserContext: "" });
-      return options.grants.admitGrant({
-        qrCredential: input.qrCredential,
-        browserContext: input.browserContext,
-        deviceClass: typeof input.deviceClass === "string" ? input.deviceClass : undefined,
-        browserClass: typeof input.browserClass === "string" ? input.browserClass : undefined,
-      });
+        return options.grants.admitGrant({ qrCredential: "", browserContext: "" }, GRANT_TYPE);
+      return options.grants.admitGrant(
+        {
+          qrCredential: input.qrCredential,
+          browserContext: input.browserContext,
+          deviceClass: typeof input.deviceClass === "string" ? input.deviceClass : undefined,
+          browserClass: typeof input.browserClass === "string" ? input.browserClass : undefined,
+        },
+        GRANT_TYPE,
+      );
     },
 
     async leaveEventAdminSession(sessionBearer) {
@@ -1564,7 +1846,7 @@ async function managePitchManagerGrant(
   pitchIdInput: unknown,
   authority: EventAdministrationAuthority,
   operation: "rotateGrant" | "disableGrant" | "revokeGrant" | "reactivateGrant",
-): Promise<EventAdministrationMutationOutcome<TypedGrantMutation>> {
+): Promise<EventAdministrationMutationOutcome<TypedGrantRotated | TypedGrantMutation>> {
   const grant = await findPitchManagerGrant(options, eventIdInput, gameDayIdInput, pitchIdInput);
   if (grant.status !== "accepted") return grant;
   if (grant.value === null) return notFound("Pitch Manager Grant was not found.");
@@ -1825,7 +2107,9 @@ async function findEventAdminGrant(
   }
 }
 
-function grantMutationRejection(result: TypedGrantMutation): EventAdministrationOutcome<never> {
+function grantMutationRejection<T = never>(
+  result: TypedGrantMutation,
+): EventAdministrationOutcome<T> {
   if (result.status === "updated") return invalid("Grant creation returned an invalid outcome.");
   if (result.reason === "unauthorized") return unauthorized();
   if (result.reason === "not-found") return notFound(result.detail ?? "Grant was not found.");
@@ -1845,13 +2129,167 @@ async function manageEventAdminGrant(
   eventIdInput: unknown,
   authority: TechnicalAdminAuthority,
   operation: "rotateGrant" | "disableGrant" | "revokeGrant" | "reactivateGrant",
-): Promise<EventAdministrationOutcome<TypedGrantMutation>> {
+): Promise<EventAdministrationMutationOutcome<TypedGrantRotated | TypedGrantMutation>> {
   if (!isTechnicalAdminAuthority(authority)) return unauthorized();
   const grant = await findEventAdminGrant(options, eventIdInput);
   if (grant.status !== "accepted") return grant;
   if (grant.value === null) return notFound("Event Admin Grant was not found.");
   const result = await options.grants[operation](grant.value.grantId, authority);
   return result.status === "updated" ? accepted(result) : grantMutationRejection(result);
+}
+
+async function manageEventAdminGrantCode(
+  options: EventAdministrationOptions,
+  eventIdInput: unknown,
+  authority: TechnicalAdminAuthority,
+  operation: "createGrantCode" | "replaceGrantCode" | "disableGrantCode",
+): Promise<EventAdministrationMutationOutcome<TypedGrantCodeCreated>> {
+  if (!isTechnicalAdminAuthority(authority)) return mutationFailure(unauthorized());
+  const grant = await findEventAdminGrant(options, eventIdInput);
+  if (grant.status !== "accepted") return mutationFailure(grant);
+  if (grant.value === null) return mutationFailure(notFound("Event Admin Grant was not found."));
+  if (operation === "disableGrantCode")
+    return (await disableGrantCodeMutation(
+      options.grants,
+      grant.value.grantId,
+      authority,
+      null,
+    )) as EventAdministrationMutationOutcome<TypedGrantCodeCreated>;
+  return createGrantCodeMutation(options.grants, grant.value.grantId, authority, operation);
+}
+
+async function managePitchManagerGrantCode(
+  options: EventAdministrationOptions,
+  eventIdInput: unknown,
+  gameDayIdInput: unknown,
+  pitchIdInput: unknown,
+  authority: EventAdministrationAuthority,
+  operation: "createGrantCode" | "replaceGrantCode" | "disableGrantCode",
+): Promise<EventAdministrationMutationOutcome<TypedGrantCodeCreated>> {
+  const grant = await findPitchManagerGrant(options, eventIdInput, gameDayIdInput, pitchIdInput);
+  if (grant.status !== "accepted") return mutationFailure(grant);
+  if (grant.value === null) return mutationFailure(notFound("Pitch Manager Grant was not found."));
+  const authorization = await authorizePitchManagerManagement(options, grant.value, authority);
+  if (authorization === null) return mutationFailure(unauthorized());
+  if (operation === "disableGrantCode")
+    return (await disableGrantCodeMutation(
+      options.grants,
+      grant.value.grantId,
+      authority,
+      authorization.sessionExpiresAtMs,
+    )) as EventAdministrationMutationOutcome<TypedGrantCodeCreated>;
+  return createGrantCodeMutation(
+    options.grants,
+    grant.value.grantId,
+    authority,
+    operation,
+    authorization.sessionExpiresAtMs,
+  );
+}
+
+async function manageControlGrantCode(
+  options: EventAdministrationOptions,
+  eventIdInput: unknown,
+  gameDayIdInput: unknown,
+  pitchIdInput: unknown,
+  pitchSlotIdInput: unknown,
+  authority: EventAdministrationAuthority,
+  operation: "createGrantCode" | "replaceGrantCode" | "disableGrantCode",
+): Promise<EventAdministrationMutationOutcome<TypedGrantCodeCreated>> {
+  const ids = validateControlScopeIds(eventIdInput, gameDayIdInput, pitchIdInput, pitchSlotIdInput);
+  if (!ids.ok) return mutationFailure(invalid(ids.error));
+  const grant = await findControlGrant(options, ids.value);
+  if (grant.status !== "accepted") return mutationFailure(grant);
+  if (grant.value === null) return mutationFailure(notFound("Control Grant was not found."));
+  const authorization = await authorizeControlGrantManagement(options, ids.value, authority);
+  if (authorization === null) return mutationFailure(unauthorized());
+  if (operation === "disableGrantCode")
+    return (await disableGrantCodeMutation(
+      options.grants,
+      grant.value.grantId,
+      authority,
+      authorization.sessionExpiresAtMs,
+    )) as EventAdministrationMutationOutcome<TypedGrantCodeCreated>;
+  return createGrantCodeMutation(
+    options.grants,
+    grant.value.grantId,
+    authority,
+    operation,
+    authorization.sessionExpiresAtMs,
+  );
+}
+
+async function createGrantCodeMutation(
+  grants: TypedGrantAuthority,
+  grantId: string,
+  authority: EventAdministrationAuthority,
+  operation: "createGrantCode" | "replaceGrantCode",
+  sessionExpiresAtMs: number | null = null,
+): Promise<EventAdministrationMutationOutcome<TypedGrantCodeCreated>> {
+  const result = await grants[operation](grantId, authority);
+  if (result.status === "created" || result.status === "replaced")
+    return { ...accepted(result), sessionExpiresAtMs };
+  return grantMutationRejection<TypedGrantCodeCreated>(result as TypedGrantMutation);
+}
+
+function mutationFailure<T>(
+  result: EventAdministrationOutcome<unknown>,
+): EventAdministrationMutationOutcome<T> {
+  if (result.status === "accepted")
+    return {
+      status: "retryable-failure",
+      detail: "Event Administration is temporarily unavailable.",
+    };
+  return result;
+}
+
+async function disableGrantCodeMutation(
+  grants: TypedGrantAuthority,
+  grantId: string,
+  authority: EventAdministrationAuthority,
+  sessionExpiresAtMs: number | null,
+): Promise<EventAdministrationMutationOutcome<TypedGrantMutation>> {
+  const result = await grants.disableGrantCode(grantId, authority);
+  return result.status === "updated"
+    ? { ...accepted(result), sessionExpiresAtMs }
+    : grantMutationRejection(result);
+}
+
+async function findControlGrant(
+  options: EventAdministrationOptions,
+  ids: ControlScopeIds,
+): Promise<EventAdministrationOutcome<StoredGrant | null>> {
+  try {
+    return await options.storage.transaction((transaction) => {
+      const scope = readControlGrantScope(transaction, ids);
+      return accepted(scope === null ? null : findControlGrantInTransaction(transaction, scope));
+    });
+  } catch {
+    return unavailable();
+  }
+}
+
+async function authorizeControlGrantManagement(
+  options: EventAdministrationOptions,
+  ids: ControlScopeIds,
+  authority: EventAdministrationAuthority,
+): Promise<{ sessionExpiresAtMs: number | null } | null> {
+  try {
+    return await options.storage.transaction((transaction) =>
+      authorizeControlManagementInTransaction(options, transaction, ids, authority),
+    );
+  } catch {
+    return null;
+  }
+}
+
+function projectGrantCode(grant: StoredGrant): GrantCodeProjection {
+  return {
+    grantId: grant.grantId,
+    grantVersion: grant.grantVersion,
+    state: grant.code?.state ?? "absent",
+    formatVersion: grant.code?.formatVersion ?? null,
+  };
 }
 
 function projectGrant(grant: StoredGrant): EventAdminGrantProjection {

--- a/src/lib/grant-admission-policy.ts
+++ b/src/lib/grant-admission-policy.ts
@@ -1,0 +1,78 @@
+import type { FoundationStorageTransaction } from "@/lib/foundation-storage";
+import type { GrantAuthorityOptions } from "@/lib/grant-authority";
+import { DAY_MS } from "@/lib/grant-calendar";
+import {
+  EVENT_ADMIN_GRANT_TYPE,
+  PITCH_MANAGER_GRANT_TYPE,
+  type ControlGrantScope,
+  type GrantType,
+  type PitchManagerGrantScope,
+  type StoredGrant,
+  validateControlGrantScope,
+  validateEventAdminGrantScope,
+  validatePitchManagerGrantScope,
+} from "@/lib/grant-types";
+import { validateOpaqueIdentifier } from "@/lib/validation-policy";
+
+export function grantTypeMatchesExpected(
+  grant: Pick<StoredGrant, "grantType">,
+  expectedGrantType: GrantType | undefined,
+): boolean {
+  return expectedGrantType === undefined || grant.grantType === expectedGrantType;
+}
+
+export function validateExpectedGrantScope(
+  transaction: FoundationStorageTransaction,
+  grant: Pick<StoredGrant, "grantType" | "scope">,
+  expectedGrantType: GrantType | undefined,
+): boolean {
+  if (expectedGrantType === undefined || grant.grantType !== expectedGrantType) return false;
+  if (expectedGrantType === EVENT_ADMIN_GRANT_TYPE)
+    return validateEventAdminGrantScope(grant.scope).ok;
+  if (expectedGrantType === PITCH_MANAGER_GRANT_TYPE) {
+    const scope = validatePitchManagerGrantScope(grant.scope);
+    return scope.ok && isLivePitchManagerScope(transaction, scope.value);
+  }
+  return validateControlGrantScope(grant.scope).ok;
+}
+
+export function isLivePitchManagerScope(
+  transaction: FoundationStorageTransaction,
+  scope: PitchManagerGrantScope,
+): boolean {
+  const event = transaction.findEvent(scope.eventId);
+  const day = transaction
+    .listGameDays(scope.eventId)
+    .find((candidate) => candidate.gameDayId === scope.gameDayId);
+  const pitch = transaction.findPitch(scope.pitchId);
+  return (
+    event !== null &&
+    day !== undefined &&
+    day.date === scope.gameDayDate &&
+    event.timeZone === scope.eventTimeZone &&
+    pitch !== null &&
+    pitch.eventId === scope.eventId
+  );
+}
+
+export function sessionExpiresAtMsForGrant(
+  grant: Pick<StoredGrant, "grantType" | "expiresAtMs">,
+  nowMs: number,
+): number | null {
+  if (grant.grantType === EVENT_ADMIN_GRANT_TYPE)
+    return Math.min(grant.expiresAtMs ?? Number.MAX_SAFE_INTEGER, nowMs + 30 * DAY_MS);
+  if (grant.grantType === PITCH_MANAGER_GRANT_TYPE) return grant.expiresAtMs;
+  return null;
+}
+
+export function resolveControlGrantAdmission(
+  options: GrantAuthorityOptions,
+  transaction: FoundationStorageTransaction,
+  scope: ControlGrantScope,
+): string | null {
+  const resolved = options.controlScopeResolver.resolve(scope, transaction);
+  return resolved.status === "eligible" &&
+    validateOpaqueIdentifier(resolved.eventGameId, "eventGameId").ok
+    ? resolved.eventGameId
+    : null;
+}

--- a/src/lib/grant-management-code.ts
+++ b/src/lib/grant-management-code.ts
@@ -47,8 +47,19 @@ import {
   unauthorizedGrant,
   unavailableGrant,
 } from "@/lib/grant-management-results";
-import { GRANT_CODE_KIND, GRANT_TYPE, type ControlGrantScope } from "@/lib/grant-types";
+import {
+  GRANT_CODE_KIND,
+  GRANT_TYPE,
+  type ControlGrantScope,
+  type GrantType,
+} from "@/lib/grant-types";
 import { validateOpaqueIdentifier } from "@/lib/validation-policy";
+import {
+  grantTypeMatchesExpected,
+  resolveControlGrantAdmission,
+  sessionExpiresAtMsForGrant,
+  validateExpectedGrantScope,
+} from "@/lib/grant-admission-policy";
 
 export async function createGrantCode(
   storage: FoundationStorage,
@@ -215,6 +226,7 @@ export async function admitGrantCode(
   storage: FoundationStorage,
   options: GrantAuthorityOptions,
   input: unknown,
+  expectedGrantType?: GrantType,
 ): Promise<TypedGrantAdmission | ReturnType<typeof grantAdmissionThrottled>> {
   const record = isGrantRecord(input) ? input : {};
   const browserContext = record.browserContext;
@@ -233,9 +245,20 @@ export async function admitGrantCode(
       const storedGrant = grantTransaction.findGrantByCodeLookupDigest(
         grantCodeLookupDigest(code, options.keyRing),
       );
+      if (storedGrant !== null && !grantTypeMatchesExpected(storedGrant, expectedGrantType)) {
+        recordAdmissionFailure(transaction, "code", budget.sourceDigest, nowMs);
+        return GENERIC_GRANT_ADMISSION_FAILURE;
+      }
       const grant =
         storedGrant === null ? null : expireGrantIfDue(grantTransaction, options, storedGrant);
       if (grant === null || grant.status !== "active" || grant.code?.state !== "present") {
+        recordAdmissionFailure(transaction, "code", budget.sourceDigest, nowMs);
+        return GENERIC_GRANT_ADMISSION_FAILURE;
+      }
+      if (
+        expectedGrantType !== undefined &&
+        !validateExpectedGrantScope(transaction, grant, expectedGrantType)
+      ) {
         recordAdmissionFailure(transaction, "code", budget.sourceDigest, nowMs);
         return GENERIC_GRANT_ADMISSION_FAILURE;
       }
@@ -253,15 +276,16 @@ export async function admitGrantCode(
       }
       let eventGameId: string | null = null;
       if (grant.grantType === GRANT_TYPE) {
-        const resolved = options.controlScopeResolver.resolve(grant.scope as ControlGrantScope);
-        if (
-          resolved.status !== "eligible" ||
-          !validateOpaqueIdentifier(resolved.eventGameId, "eventGameId").ok
-        ) {
+        const resolvedEventGameId = resolveControlGrantAdmission(
+          options,
+          transaction,
+          grant.scope as ControlGrantScope,
+        );
+        if (resolvedEventGameId === null) {
           recordAdmissionFailure(transaction, "code", budget.sourceDigest, nowMs);
           return GENERIC_GRANT_ADMISSION_FAILURE;
         }
-        eventGameId = resolved.eventGameId;
+        eventGameId = resolvedEventGameId;
       }
       const lookupVersion = options.keyRing.lookup.currentVersion;
       const contextDigest = computeBrowserContextDigest(
@@ -344,6 +368,7 @@ export async function admitGrantCode(
         eventGameId,
         grantSessionId: session.sessionId,
         sessionBearer: bearer,
+        sessionExpiresAtMs: sessionExpiresAtMsForGrant(grant, nowMs),
       };
     });
   } catch {

--- a/src/lib/grant-management-sessions.ts
+++ b/src/lib/grant-management-sessions.ts
@@ -11,8 +11,6 @@ import {
   GRANT_TYPE,
   PITCH_MANAGER_GRANT_TYPE,
   type GrantType,
-  validateEventAdminGrantScope,
-  validatePitchManagerGrantScope,
   type ControlGrantScope,
   type ControlGrantScopeResolution,
   type ControlGrantSessionDecision,
@@ -64,6 +62,12 @@ import {
   unavailableGrant,
 } from "@/lib/grant-management-results";
 import { grantAdmissionThrottled } from "@/lib/grant-authority-types";
+import {
+  grantTypeMatchesExpected,
+  resolveControlGrantAdmission,
+  sessionExpiresAtMsForGrant,
+  validateExpectedGrantScope,
+} from "@/lib/grant-admission-policy";
 
 export async function admitGrant(
   storage: FoundationStorage,
@@ -95,6 +99,10 @@ export async function admitGrant(
         recordAdmissionFailure(transaction, "qr", budget.sourceDigest, nowMs);
         return GENERIC_GRANT_ADMISSION_FAILURE;
       }
+      if (!grantTypeMatchesExpected(grant, expectedGrantType)) {
+        recordAdmissionFailure(transaction, "qr", budget.sourceDigest, nowMs);
+        return GENERIC_GRANT_ADMISSION_FAILURE;
+      }
       const current = expireGrantIfDue(transaction, options, grant);
       if (
         current.status !== "active" ||
@@ -103,37 +111,22 @@ export async function admitGrant(
         recordAdmissionFailure(transaction, "qr", budget.sourceDigest, nowMs);
         return GENERIC_GRANT_ADMISSION_FAILURE;
       }
-      if (expectedGrantType !== undefined && current.grantType !== expectedGrantType) {
+      if (
+        expectedGrantType !== undefined &&
+        !validateExpectedGrantScope(transaction, current, expectedGrantType)
+      ) {
         recordAdmissionFailure(transaction, "qr", budget.sourceDigest, nowMs);
         return GENERIC_GRANT_ADMISSION_FAILURE;
       }
-      if (expectedGrantType === PITCH_MANAGER_GRANT_TYPE) {
-        const scope = validatePitchManagerGrantScope(current.scope);
-        if (!scope.ok || !isLivePitchManagerScope(transaction, scope.value)) {
-          recordAdmissionFailure(transaction, "qr", budget.sourceDigest, nowMs);
-          return GENERIC_GRANT_ADMISSION_FAILURE;
-        }
-      }
-      if (expectedGrantType === EVENT_ADMIN_GRANT_TYPE) {
-        if (!validateEventAdminGrantScope(current.scope).ok) {
-          recordAdmissionFailure(transaction, "qr", budget.sourceDigest, nowMs);
-          return GENERIC_GRANT_ADMISSION_FAILURE;
-        }
-      }
       let eventGameId: string | null = null;
       if (current.grantType === GRANT_TYPE) {
-        const resolved = options.controlScopeResolver.resolve(
-          current.scope as ControlGrantScope,
-          transaction,
-        );
-        if (
-          resolved.status !== "eligible" ||
-          !validateOpaqueIdentifier(resolved.eventGameId, "eventGameId").ok
-        ) {
+        const scope = current.scope as ControlGrantScope;
+        const resolvedEventGameId = resolveControlGrantAdmission(options, transaction, scope);
+        if (resolvedEventGameId === null) {
           recordAdmissionFailure(transaction, "qr", budget.sourceDigest, nowMs);
           return GENERIC_GRANT_ADMISSION_FAILURE;
         }
-        eventGameId = resolved.eventGameId;
+        eventGameId = resolvedEventGameId;
       }
       const lookupVersion = options.keyRing.lookup.currentVersion;
       const contextDigest = computeBrowserContextDigest(
@@ -192,42 +185,12 @@ export async function admitGrant(
         eventGameId,
         grantSessionId: session.sessionId,
         sessionBearer: bearer,
-        sessionExpiresAtMs:
-          current.grantType === EVENT_ADMIN_GRANT_TYPE
-            ? Math.min(current.expiresAtMs ?? Number.MAX_SAFE_INTEGER, nowMs + 30 * DAY_MS)
-            : current.grantType === PITCH_MANAGER_GRANT_TYPE || current.grantType === GRANT_TYPE
-              ? current.expiresAtMs
-              : null,
+        sessionExpiresAtMs: sessionExpiresAtMsForGrant(current, nowMs),
       };
     });
   } catch {
     return GENERIC_GRANT_ADMISSION_FAILURE;
   }
-}
-
-function isLivePitchManagerScope(
-  transaction: FoundationStorageTransaction,
-  scope: {
-    eventId: string;
-    gameDayId: string;
-    gameDayDate: string;
-    eventTimeZone: string;
-    pitchId: string;
-  },
-): boolean {
-  const event = transaction.findEvent(scope.eventId);
-  const gameDay = transaction
-    .listGameDays(scope.eventId)
-    .find((candidate) => candidate.gameDayId === scope.gameDayId);
-  const pitch = transaction.findPitch(scope.pitchId);
-  return (
-    event !== null &&
-    gameDay !== undefined &&
-    gameDay.date === scope.gameDayDate &&
-    event.timeZone === scope.eventTimeZone &&
-    pitch !== null &&
-    pitch.eventId === scope.eventId
-  );
 }
 
 export async function authorizeGrant(

--- a/src/lib/grant-management-types.ts
+++ b/src/lib/grant-management-types.ts
@@ -199,12 +199,33 @@ export type TypedGrantAuthority = {
     deviceClass?: string;
     browserClass?: string;
   }): Promise<TypedGrantAdmission | TypedGrantAdmissionThrottled>;
-  admitGrant(input: {
-    qrCredential: string;
+  admitEventAdminGrantCode(input: {
+    grantCode: string;
     browserContext: string;
     deviceClass?: string;
     browserClass?: string;
   }): Promise<TypedGrantAdmission | TypedGrantAdmissionThrottled>;
+  admitPitchManagerGrantCode(input: {
+    grantCode: string;
+    browserContext: string;
+    deviceClass?: string;
+    browserClass?: string;
+  }): Promise<TypedGrantAdmission | TypedGrantAdmissionThrottled>;
+  admitControlGrantCode(input: {
+    grantCode: string;
+    browserContext: string;
+    deviceClass?: string;
+    browserClass?: string;
+  }): Promise<TypedGrantAdmission | TypedGrantAdmissionThrottled>;
+  admitGrant(
+    input: {
+      qrCredential: string;
+      browserContext: string;
+      deviceClass?: string;
+      browserClass?: string;
+    },
+    expectedGrantType?: GrantType,
+  ): Promise<TypedGrantAdmission | TypedGrantAdmissionThrottled>;
   admitPitchManagerGrant(input: {
     qrCredential: string;
     browserContext: string;

--- a/src/lib/grant-management.test.ts
+++ b/src/lib/grant-management.test.ts
@@ -18,6 +18,162 @@ import type { GrantKeyRing } from "@/lib/grant-types";
 import { createGrantTestAuthorityVerifier } from "@/lib/grant-authority-test-support";
 
 describe("typed Grant management", () => {
+  test("shares admission expiry, binds Control resolution to the transaction, and protects wrong-type due Grants", async () => {
+    let nowMs = 10_000;
+    let resolverSnapshotSeen = false;
+    const storage = createInMemoryFoundationStorage();
+    const options = createOptions(() => nowMs);
+    options.controlScopeResolver = {
+      resolve: (_scope, snapshot) => {
+        resolverSnapshotSeen = snapshot !== undefined;
+        return { status: "eligible", eventGameId: "game-1" };
+      },
+    };
+    const authority = createTypedGrantAuthority(storage, options);
+    const technical = { kind: "technical-admin" as const, id: "tech" };
+    const eventAdmin = await authority.createEventAdminGrant({
+      authority: technical,
+      expiresAtMs: nowMs + 40 * 24 * 60 * 60 * 1_000,
+      scope: { eventId: "admission-event", eventTimeZone: "UTC", finalGameDayDate: "2026-03-20" },
+    });
+    if (eventAdmin.status !== "created") throw new Error("Expected Event Admin Grant.");
+    const eventCode = await authority.createGrantCode(eventAdmin.grantId, technical);
+    if (eventCode.status !== "created") throw new Error("Expected Event Admin Grant Code.");
+    const qrAdmission = await authority.admitEventAdminGrant({
+      qrCredential: eventAdmin.qrCredential,
+      browserContext: "expiry-qr",
+    });
+    const codeAdmission = await authority.admitEventAdminGrantCode({
+      grantCode: eventCode.code,
+      browserContext: "expiry-code",
+    });
+    expect(qrAdmission).toMatchObject({
+      status: "admitted",
+      sessionExpiresAtMs: nowMs + 30 * 24 * 60 * 60 * 1_000,
+    });
+    expect(codeAdmission).toMatchObject({
+      status: "admitted",
+      sessionExpiresAtMs: nowMs + 30 * 24 * 60 * 60 * 1_000,
+    });
+
+    const control = await authority.createControlGrant({
+      authority: technical,
+      expiresAtMs: nowMs + 60_000,
+      scope: {
+        eventId: "admission-event",
+        gameDayId: "admission-day",
+        pitchId: "admission-pitch",
+        pitchSlotId: "admission-slot",
+      },
+    });
+    if (control.status !== "created") throw new Error("Expected Control Grant.");
+    const controlCode = await authority.createGrantCode(control.grantId, technical);
+    if (controlCode.status !== "created") throw new Error("Expected Control Grant Code.");
+    const controlAdmission = await authority.admitControlGrantCode({
+      grantCode: controlCode.code,
+      browserContext: "control-code",
+    });
+    expect(controlAdmission).toMatchObject({ status: "admitted", sessionExpiresAtMs: null });
+    expect(resolverSnapshotSeen).toBe(true);
+
+    const due = await authority.createEventAdminGrant({
+      authority: technical,
+      expiresAtMs: nowMs + 1,
+      scope: { eventId: "due-event", eventTimeZone: "UTC", finalGameDayDate: "2026-03-20" },
+    });
+    if (due.status !== "created") throw new Error("Expected due Grant.");
+    const dueCode = await authority.createGrantCode(due.grantId, technical);
+    if (dueCode.status !== "created") throw new Error("Expected due Grant Code.");
+    const before = await storage.transaction((transaction) => ({
+      grant: transaction.findGrantById(due.grantId),
+      sessions: transaction.listGrantSessions(due.grantId),
+      audit: transaction.listGrantAudit(due.grantId),
+    }));
+    nowMs = 10_002;
+    expect(
+      await authority.admitControlGrantCode({
+        grantCode: dueCode.code,
+        browserContext: "wrong-due",
+      }),
+    ).toMatchObject({ status: "rejected", code: "grant-admission-failed" });
+    const after = await storage.transaction((transaction) => ({
+      grant: transaction.findGrantById(due.grantId),
+      sessions: transaction.listGrantSessions(due.grantId),
+      audit: transaction.listGrantAudit(due.grantId),
+    }));
+    expect(after).toEqual(before);
+  });
+
+  test("full rotation returns one-time QR and Grant Code material for each managed type", async () => {
+    const storage = createInMemoryFoundationStorage();
+    const authority = createTypedGrantAuthority(
+      storage,
+      createOptions(() => 1_000),
+    );
+    const technical = { kind: "technical-admin" as const, id: "tech" };
+    const eventAdmin = await authority.createEventAdminGrant({
+      authority: technical,
+      scope: { eventId: "rotation-event", eventTimeZone: "UTC", finalGameDayDate: "2026-03-20" },
+    });
+    if (eventAdmin.status !== "created") throw new Error("Expected Event Admin Grant.");
+    const eventSession = await authority.admitEventAdminGrant({
+      qrCredential: eventAdmin.qrCredential,
+      browserContext: "rotation-browser",
+    });
+    if (eventSession.status !== "admitted") throw new Error("Expected Event Admin Session.");
+    const eventRotation = await authority.rotateGrant(eventAdmin.grantId, technical);
+    expect(eventRotation).toMatchObject({
+      status: "updated",
+      oneTime: true,
+      noStore: true,
+      affectedSessionCount: 1,
+      qrCredential: expect.any(String),
+      code: expect.any(String),
+    });
+
+    const pitch = await authority.createPitchManagerGrant({
+      authority: technical,
+      scope: {
+        eventId: "rotation-event",
+        gameDayId: "rotation-day",
+        gameDayDate: "2026-03-20",
+        eventTimeZone: "UTC",
+        pitchId: "rotation-pitch",
+      },
+    });
+    if (pitch.status !== "created") throw new Error("Expected Pitch Manager Grant.");
+    const pitchRotation = await authority.rotateGrant(pitch.grantId, technical);
+    expect(pitchRotation).toMatchObject({
+      status: "updated",
+      qrCredential: expect.any(String),
+      code: expect.any(String),
+      oneTime: true,
+      noStore: true,
+    });
+
+    const control = await authority.createControlGrant({
+      authority: technical,
+      scope: {
+        eventId: "rotation-event",
+        gameDayId: "rotation-day",
+        pitchId: "rotation-pitch",
+        pitchSlotId: "rotation-slot",
+      },
+    });
+    if (control.status !== "created") throw new Error("Expected Control Grant.");
+    const controlRotation = await authority.rotateGrant(control.grantId, technical);
+    expect(controlRotation).toMatchObject({
+      status: "updated",
+      qrCredential: expect.any(String),
+      code: expect.any(String),
+      oneTime: true,
+      noStore: true,
+    });
+    expect(JSON.stringify(eventRotation)).not.toContain("grantType");
+    expect(JSON.stringify(eventRotation)).not.toContain("scope");
+    void eventSession;
+  });
+
   test("rejects repeated status and session revocation transitions without mutation", async () => {
     const storage = createInMemoryFoundationStorage();
     const authority = createGrantAuthority(

--- a/src/lib/grant-management.ts
+++ b/src/lib/grant-management.ts
@@ -103,10 +103,18 @@ export function createTypedGrantAuthority(
     disableGrantCode: (grantId, authority) =>
       disableGrantCode(storage, options, grantId, authority),
     admitGrantCode: (input) => admitGrantCode(storage, options, input),
-    admitGrant: (input) => notifyLifecycleChange(admitGrant(storage, options, input)),
+    admitEventAdminGrantCode: (input) =>
+      notifyLifecycleChange(admitGrantCode(storage, options, input, EVENT_ADMIN_GRANT_TYPE)),
+    admitPitchManagerGrantCode: (input) =>
+      notifyLifecycleChange(admitGrantCode(storage, options, input, PITCH_MANAGER_GRANT_TYPE)),
+    admitControlGrantCode: (input) =>
+      notifyLifecycleChange(admitGrantCode(storage, options, input, GRANT_TYPE)),
+    admitGrant: (input, expectedGrantType) =>
+      notifyLifecycleChange(admitGrant(storage, options, input, expectedGrantType)),
     admitPitchManagerGrant: (input) =>
-      admitGrant(storage, options, input, PITCH_MANAGER_GRANT_TYPE),
-    admitEventAdminGrant: (input) => admitGrant(storage, options, input, EVENT_ADMIN_GRANT_TYPE),
+      notifyLifecycleChange(admitGrant(storage, options, input, PITCH_MANAGER_GRANT_TYPE)),
+    admitEventAdminGrant: (input) =>
+      notifyLifecycleChange(admitGrant(storage, options, input, EVENT_ADMIN_GRANT_TYPE)),
     authorizeGrant: (input) =>
       input.readOnly === true
         ? authorizeGrant(storage, options, input)

--- a/src/lib/grant-secret-owner.ts
+++ b/src/lib/grant-secret-owner.ts
@@ -1,0 +1,52 @@
+export type GrantSecretToken = Readonly<{
+  generation: number;
+  scopeKey: string;
+}>;
+
+export type GrantSecretOwner = {
+  capture: (scopeKey: string) => GrantSecretToken;
+  current: (token: GrantSecretToken) => boolean;
+  commit: (token: GrantSecretToken, action: () => void) => boolean;
+  invalidate: (scopeKey: string) => void;
+  unmount: () => void;
+};
+
+const ALL_SCOPES = "*";
+
+export function createGrantSecretOwner(): GrantSecretOwner {
+  let generation = 0;
+  let mounted = true;
+  const activeGenerations = new Map<string, number>();
+
+  const invalidate = (scopeKey: string) => {
+    generation += 1;
+    if (scopeKey === ALL_SCOPES) activeGenerations.clear();
+    else activeGenerations.delete(scopeKey);
+  };
+
+  const capture = (scopeKey: string): GrantSecretToken => {
+    generation += 1;
+    const token = { generation, scopeKey };
+    activeGenerations.set(scopeKey, generation);
+    return token;
+  };
+
+  const current = (token: GrantSecretToken) =>
+    mounted && activeGenerations.get(token.scopeKey) === token.generation;
+
+  return {
+    capture,
+    current,
+    commit: (token, action) => {
+      if (!current(token)) return false;
+      action();
+      return true;
+    },
+    invalidate,
+    unmount: () => {
+      mounted = false;
+      generation += 1;
+      activeGenerations.clear();
+    },
+  };
+}

--- a/src/lib/live-event-game-control.test.ts
+++ b/src/lib/live-event-game-control.test.ts
@@ -18,6 +18,7 @@ import {
 } from "@/lib/live-event-game-control";
 import { createLiveEventGameControlTransport } from "@/lib/live-event-game-transport";
 import { createAdHocGamesService } from "@/lib/ad-hoc-games";
+import { createControlScopeResolver as createRuntimeControlScopeResolver } from "@/lib/live-event-game-runtime";
 
 describe("Live Event Game control", () => {
   test("Event authority, storage, and control remain accepted after Ad Hoc pressure", async () => {
@@ -2199,6 +2200,117 @@ describe("Live Event Game control", () => {
     expect(leaveResponse.status).toBe(200);
     expect(await leaveResponse.json()).toEqual({ status: "left" });
   });
+
+  test("admits a Controller through the independent Grant Code path without exposing code material", async () => {
+    const harness = await createHarness();
+    const created = await harness.authority.createGrantCode(harness.grantId, {
+      kind: "fixture",
+      id: "fixture",
+    });
+    if (created.status !== "created") throw new Error("Expected a Control Grant Code.");
+    const allowedOrigin = "https://timer.quadball.app";
+    const transport = createLiveEventGameControlTransport(
+      () => harness.control,
+      (request) =>
+        request.headers.get("origin") === allowedOrigin &&
+        request.headers.get("host") === "timer.quadball.app",
+    );
+    const response = await transport.openController(
+      new Request("https://timer.quadball.app/api/event-control/open", {
+        method: "POST",
+        headers: { origin: allowedOrigin, host: "timer.quadball.app" },
+        body: JSON.stringify({ grantCode: created.code, browserContext: "code-controller" }),
+      }),
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get("set-cookie")).toBeNull();
+    const opened = await response.json();
+    expect(opened).toMatchObject({ status: "opened", eventGameId: harness.root.eventGameId });
+    expect(opened).toMatchObject({ sessionExpiresAtMs: null });
+    expect(JSON.stringify(opened)).not.toContain(created.code);
+
+    const refreshResponse = await transport.refreshController(
+      new Request("https://timer.quadball.app/api/event-control/refresh", {
+        method: "POST",
+        headers: { origin: allowedOrigin, host: "timer.quadball.app" },
+        body: JSON.stringify({
+          sessionBearer: opened.session.sessionBearer,
+          eventGameId: opened.eventGameId,
+        }),
+      }),
+    );
+    expect(refreshResponse.status).toBe(200);
+    expect(await refreshResponse.json()).toMatchObject({ status: "authorized" });
+  });
+
+  test("uses the production Control scope resolver transaction for typed code admission", async () => {
+    const harness = await createHarness();
+    const created = await harness.authority.createGrantCode(harness.grantId, {
+      kind: "fixture",
+      id: "fixture",
+    });
+    if (created.status !== "created") throw new Error("Expected a Control Grant Code.");
+    const wrongScope = await harness.authority.createControlGrant({
+      authority: { kind: "fixture", id: "fixture" },
+      scope: { ...harness.root.externalScope, pitchSlotId: "wrong-slot" },
+    });
+    if (wrongScope.status !== "created") throw new Error("Expected wrong-scope Control Grant.");
+    const wrongCode = await harness.authority.createGrantCode(wrongScope.grantId, {
+      kind: "fixture",
+      id: "fixture",
+    });
+    if (wrongCode.status !== "created") throw new Error("Expected wrong-scope Grant Code.");
+    harness.grantOptions.controlScopeResolver = createRuntimeControlScopeResolver(() => 10_000);
+    expect(
+      await harness.authority.admitControlGrantCode({
+        grantCode: created.code,
+        browserContext: "production-resolver-controller",
+      }),
+    ).toMatchObject({ status: "admitted", eventGameId: harness.root.eventGameId });
+    expect(
+      await harness.authority.admitControlGrantCode({
+        grantCode: wrongCode.code,
+        browserContext: "production-resolver-wrong-scope",
+      }),
+    ).toEqual({
+      status: "rejected",
+      code: "grant-admission-failed",
+      message: "Unable to admit this Grant.",
+    });
+  });
+
+  test("rejects a non-Control Grant Code before Controller session admission", async () => {
+    const harness = await createHarness();
+    const eventAdmin = await harness.authority.createEventAdminGrant({
+      authority: { kind: "fixture", id: "fixture" },
+      scope: {
+        eventId: harness.root.eventId,
+        eventTimeZone: "UTC",
+        finalGameDayDate: "2026-08-14",
+      },
+    });
+    if (eventAdmin.status !== "created") throw new Error("Expected Event Admin Grant.");
+    const code = await harness.authority.createGrantCode(eventAdmin.grantId, {
+      kind: "fixture",
+      id: "fixture",
+    });
+    if (code.status !== "created") throw new Error("Expected Event Admin Grant Code.");
+
+    const opened = await harness.control.openController({
+      grantCode: code.code,
+      browserContext: "wrong-controller-type",
+    });
+    expect(opened).toEqual({
+      status: "rejected",
+      message: "Unable to open Controller experience.",
+    });
+    expect(
+      await harness.authority.listGrantSessions(eventAdmin.grantId, {
+        kind: "fixture",
+        id: "fixture",
+      }),
+    ).toMatchObject({ status: "ok", value: [] });
+  });
 });
 
 async function createHarness(
@@ -2294,6 +2406,7 @@ async function createHarness(
     record,
     control,
     authority,
+    grantOptions,
     grantId: created.grantId,
     qrCredential: created.qrCredential,
     sessionBearer: admitted.sessionBearer,

--- a/src/lib/live-event-game-control.ts
+++ b/src/lib/live-event-game-control.ts
@@ -212,6 +212,7 @@ export type OpenControllerResult =
         grantSessionId: string;
         grantVersion: string;
       };
+      sessionExpiresAtMs: number | null;
       projection: ControllerProjection | null;
       projectionStatus: "available" | "unavailable";
       synchronization: ControllerSynchronization;
@@ -255,6 +256,8 @@ export type LiveEventGameControlOptions = {
   grantAuthority: Pick<
     TypedGrantAuthority,
     | "admitGrant"
+    | "admitGrantCode"
+    | "admitControlGrantCode"
     | "authorizeGrant"
     | "acceptControlGrantSessionSwitch"
     | "revealGrant"
@@ -647,12 +650,29 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
   }
 
   async function openController(input: {
-    qrCredential: string;
+    qrCredential?: string;
+    grantCode?: string;
     browserContext: string;
     deviceClass?: string;
     browserClass?: string;
   }): Promise<OpenControllerResult> {
-    const admitted = await options.grantAuthority.admitGrant(input);
+    const admitted =
+      input.grantCode === undefined
+        ? await options.grantAuthority.admitGrant(
+            {
+              qrCredential: input.qrCredential ?? "",
+              browserContext: input.browserContext,
+              deviceClass: input.deviceClass,
+              browserClass: input.browserClass,
+            },
+            "control",
+          )
+        : await options.grantAuthority.admitControlGrantCode({
+            grantCode: input.grantCode,
+            browserContext: input.browserContext,
+            deviceClass: input.deviceClass,
+            browserClass: input.browserClass,
+          });
     if (admitted.status !== "admitted" || admitted.eventGameId === null) {
       return rejectedOpen();
     }
@@ -698,6 +718,7 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
         grantSessionId: authorized.grantSessionId,
         grantVersion: authorized.grantVersion,
       },
+      sessionExpiresAtMs: admitted.sessionExpiresAtMs ?? null,
       projection,
       projectionStatus: projection === null ? "unavailable" : "available",
       synchronization: synchronized(),

--- a/src/lib/live-event-game-transport.ts
+++ b/src/lib/live-event-game-transport.ts
@@ -22,7 +22,8 @@ export type LiveEventGameControlTransport = {
 
 export type LiveEventGameControlTransportTarget = {
   openController(input: {
-    qrCredential: string;
+    qrCredential?: string;
+    grantCode?: string;
     browserContext: string;
   }): Promise<OpenControllerResult>;
   refreshController(input: {
@@ -74,10 +75,13 @@ export function createLiveEventGameControlTransport(
         SHARED_LIMITS.transport.httpJsonBodyBytes,
       );
       if (!body.ok || !isRecord(body.body)) return unavailable();
-      if (typeof body.body.qrCredential !== "string") return unavailable();
+      const qrCredential =
+        typeof body.body.qrCredential === "string" ? body.body.qrCredential : undefined;
+      const grantCode = typeof body.body.grantCode === "string" ? body.body.grantCode : undefined;
+      if ((qrCredential === undefined) === (grantCode === undefined)) return unavailable();
 
       const result = await control.openController({
-        qrCredential: body.body.qrCredential,
+        ...(qrCredential === undefined ? { grantCode } : { qrCredential }),
         browserContext:
           typeof body.body.browserContext === "string" ? body.body.browserContext : "phone",
       });

--- a/src/pages/event-admin-page.tsx
+++ b/src/pages/event-admin-page.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { AdministrativeAuditBrowser } from "@/pages/administrative-audit-browser";
+import { createGrantSecretOwner, type GrantSecretToken } from "@/lib/grant-secret-owner";
 
 type HubResponse = {
   status: "accepted";
@@ -90,6 +91,12 @@ type ControlGrantResponse = {
     eventGameId: string | null;
   } | null;
 };
+type GrantCodeProjection = {
+  grantId: string;
+  grantVersion: string;
+  state: "absent" | "present" | "disabled" | "erased";
+  formatVersion: 1 | null;
+};
 type ControlSession = {
   label: string;
   deviceClass: string;
@@ -97,6 +104,10 @@ type ControlSession = {
 };
 
 class EventPublicationValidationError extends Error {}
+
+export type GrantQrRenderer = (credential: string) => Promise<string>;
+
+const defaultGrantQrRenderer: GrantQrRenderer = (credential) => QRCode.toDataURL(credential);
 
 const publicationWarningLabels: Record<string, string> = {
   "missing-event-teams": "Event Teams",
@@ -125,10 +136,15 @@ type ScheduleDelayPreview = {
   }>;
 };
 
-export function EventAdminPage() {
+export function EventAdminPage({
+  qrRenderer = defaultGrantQrRenderer,
+}: {
+  qrRenderer?: GrantQrRenderer;
+} = {}) {
   const queryEventId = new URLSearchParams(window.location.search).get("eventId") ?? "";
   const [eventId, setEventId] = useState(queryEventId);
   const [credential, setCredential] = useState("");
+  const [grantCode, setGrantCode] = useState("");
   const [hub, setHub] = useState<HubResponse["value"] | null>(null);
   const [selectedGameDayId, setSelectedGameDayId] = useState<string | null>(null);
   const [pitchManagerGameDayId, setPitchManagerGameDayId] = useState("");
@@ -171,160 +187,539 @@ export function EventAdminPage() {
     PitchManagerGrantResponse["value"] | null
   >(null);
   const [pitchManagerQrDataUrl, setPitchManagerQrDataUrl] = useState<string | null>(null);
+  const [pitchManagerCode, setPitchManagerCode] = useState<GrantCodeProjection | null>(null);
+  const [pitchManagerCodePlaintext, setPitchManagerCodePlaintext] = useState<string | null>(null);
   const [controlGrants, setControlGrants] = useState<Record<string, ControlGrantResponse["value"]>>(
     {},
   );
   const [controlQrDataUrls, setControlQrDataUrls] = useState<Record<string, string>>({});
   const [controlSessions, setControlSessions] = useState<Record<string, ControlSession[]>>({});
+  const [controlCodes, setControlCodes] = useState<Record<string, GrantCodeProjection | null>>({});
+  const [controlCodePlaintexts, setControlCodePlaintexts] = useState<Record<string, string>>({});
+  const [pitchManagerQrCredential, setPitchManagerQrCredential] = useState<string | null>(null);
+  const [controlQrCredentials, setControlQrCredentials] = useState<Record<string, string>>({});
+  const [pitchManagerRotationCount, setPitchManagerRotationCount] = useState<number | null>(null);
+  const [controlRotationCounts, setControlRotationCounts] = useState<Record<string, number>>({});
+  const [secretWarning, setSecretWarning] = useState<string | null>(null);
   const [publicationImpactConfirmed, setPublicationImpactConfirmed] = useState(false);
+  const [secretOwner] = useState(createGrantSecretOwner);
 
-  const loadHub = async (nextGameDayId = selectedGameDayId) => {
+  const secretScopeKey = (
+    nextEventId = eventId,
+    nextGameDayId = selectedGameDayId,
+    nextPitchId = selectedPitchId,
+  ) => `event-admin:${nextEventId}:${nextGameDayId ?? "none"}:${nextPitchId || "none"}`;
+
+  const hubScopeKey = () => `event-admin-hub:${eventId}`;
+
+  const clearGrantSecrets = () => {
+    setCredential("");
+    setGrantCode("");
+    setPitchManagerQrDataUrl(null);
+    setPitchManagerQrCredential(null);
+    setPitchManagerCodePlaintext(null);
+    setControlQrDataUrls({});
+    setControlQrCredentials({});
+    setControlCodePlaintexts({});
+    setPitchManagerRotationCount(null);
+    setControlRotationCounts({});
+    setSecretWarning(null);
+    setMessage(null);
+  };
+
+  const invalidateGrantSecrets = () => {
+    secretOwner.invalidate(secretScopeKey());
+    secretOwner.invalidate(hubScopeKey());
+    clearGrantSecrets();
+  };
+
+  const changeEventId = (nextEventId: string) => {
+    invalidateGrantSecrets();
+    setHub(null);
+    setSelectedGameDayId(null);
+    setPitchManagerGameDayId("");
+    setTeamDrafts({});
+    setPitchDrafts({});
+    setConfirmationDrafts({});
+    setSchedule(null);
+    setDelayDrafts({});
+    setCascadeDrafts({});
+    setDelayPreviews({});
+    setReassignmentTargets({});
+    setReassignmentModes({});
+    setSelectedPitchId("");
+    setPitchView(null);
+    setPitchManagerPitchId("");
+    setPitchManagerGrant(null);
+    setPitchManagerCode(null);
+    setControlGrants({});
+    setControlSessions({});
+    setControlCodes({});
+    setTeamName("");
+    setTeamColor("#00afe8");
+    setPitchName("");
+    setRosterTeamId("");
+    setPlayerNumber("");
+    setPlayerName("");
+    setSlotSequence("1");
+    setScheduledStart("");
+    setGameplaySlotId("");
+    setPitchSlotId("");
+    setGameCode("");
+    setGameDesignation("");
+    setSideASource("");
+    setSideBSource("");
+    setPublicationImpactConfirmed(false);
+    setEventId(nextEventId);
+  };
+
+  const clearControlGrantSecrets = (pitchSlotId: string) => {
+    setControlQrDataUrls((current) => {
+      const next = { ...current };
+      delete next[pitchSlotId];
+      return next;
+    });
+    setControlQrCredentials((current) => {
+      const next = { ...current };
+      delete next[pitchSlotId];
+      return next;
+    });
+    setControlCodePlaintexts((current) => {
+      const next = { ...current };
+      delete next[pitchSlotId];
+      return next;
+    });
+    setControlRotationCounts((current) => {
+      const next = { ...current };
+      delete next[pitchSlotId];
+      return next;
+    });
+  };
+
+  useEffect(
+    () => () => {
+      secretOwner.unmount();
+      setCredential("");
+      setGrantCode("");
+      setPitchManagerQrDataUrl(null);
+      setPitchManagerQrCredential(null);
+      setPitchManagerCodePlaintext(null);
+      setControlQrDataUrls({});
+      setControlQrCredentials({});
+      setControlCodePlaintexts({});
+      setPitchManagerRotationCount(null);
+      setControlRotationCounts({});
+      setSecretWarning(null);
+    },
+    [secretOwner],
+  );
+
+  const loadHub = async (nextGameDayId = selectedGameDayId, providedToken?: GrantSecretToken) => {
     if (eventId.trim().length === 0) return;
+    const token = providedToken ?? secretOwner.capture(hubScopeKey());
+    if (!secretOwner.current(token)) return;
     const params = new URLSearchParams({ eventId: eventId.trim() });
     if (nextGameDayId !== null) params.set("gameDayId", nextGameDayId);
-    const response = await fetch(`/api/event-admin/hub?${params}`);
-    const payload = (await response.json()) as
-      | HubResponse
-      | { status: "rejected" | "retryable-failure"; message?: string };
-    if (!response.ok || payload.status !== "accepted")
-      throw new Error("Unable to open the Event Hub.");
-    setTeamDrafts(
-      Object.fromEntries(
-        payload.value.event.teams.map((team) => [
-          team.eventTeamId,
-          {
-            name: team.name,
-            defaultColor: team.defaultColor,
-          },
-        ]),
-      ),
-    );
-    setPitchDrafts(
-      Object.fromEntries(payload.value.event.pitches.map((pitch) => [pitch.pitchId, pitch.name])),
-    );
-    setHub(payload.value);
-    setSelectedGameDayId(payload.value.selectedGameDayId);
-    setSchedule({
-      gameDayId: payload.value.selectedGameDayId ?? "",
-      gameplaySlots: payload.value.event.gameplaySlots.filter(
-        (slot) => slot.gameDayId === payload.value.selectedGameDayId,
-      ),
-      pitchSlots: payload.value.event.pitchSlots.filter(
-        (slot) => slot.gameDayId === payload.value.selectedGameDayId,
-      ),
-      eventGames: payload.value.event.eventGames.filter(
-        (game) => game.gameDayId === payload.value.selectedGameDayId,
-      ),
-    });
-    setConfirmationDrafts((current) =>
-      Object.fromEntries(
-        payload.value.event.eventGames.map((game) => [
-          game.eventGameId,
-          current[game.eventGameId] ?? {
-            sideA: game.sideA.eventTeamId ?? "",
-            sideB: game.sideB.eventTeamId ?? "",
-          },
-        ]),
-      ),
-    );
+    try {
+      const response = await fetch(`/api/event-admin/hub?${params}`);
+      const payload = (await response.json()) as
+        | HubResponse
+        | { status: "rejected" | "retryable-failure"; message?: string };
+      if (!response.ok || payload.status !== "accepted")
+        throw new Error("Unable to open the Event Hub.");
+      if (!secretOwner.current(token)) return;
+      secretOwner.commit(token, () => {
+        setTeamDrafts(
+          Object.fromEntries(
+            payload.value.event.teams.map((team) => [
+              team.eventTeamId,
+              {
+                name: team.name,
+                defaultColor: team.defaultColor,
+              },
+            ]),
+          ),
+        );
+        setPitchDrafts(
+          Object.fromEntries(
+            payload.value.event.pitches.map((pitch) => [pitch.pitchId, pitch.name]),
+          ),
+        );
+        setHub(payload.value);
+        setSelectedGameDayId(payload.value.selectedGameDayId);
+        setSchedule({
+          gameDayId: payload.value.selectedGameDayId ?? "",
+          gameplaySlots: payload.value.event.gameplaySlots.filter(
+            (slot) => slot.gameDayId === payload.value.selectedGameDayId,
+          ),
+          pitchSlots: payload.value.event.pitchSlots.filter(
+            (slot) => slot.gameDayId === payload.value.selectedGameDayId,
+          ),
+          eventGames: payload.value.event.eventGames.filter(
+            (game) => game.gameDayId === payload.value.selectedGameDayId,
+          ),
+        });
+        setConfirmationDrafts((current) =>
+          Object.fromEntries(
+            payload.value.event.eventGames.map((game) => [
+              game.eventGameId,
+              current[game.eventGameId] ?? {
+                sideA: game.sideA.eventTeamId ?? "",
+                sideB: game.sideB.eventTeamId ?? "",
+              },
+            ]),
+          ),
+        );
+      });
+    } catch (error) {
+      if (secretOwner.current(token)) throw error;
+    }
   };
 
-  const loadSchedule = async (gameDayId = selectedGameDayId) => {
+  const loadSchedule = async (gameDayId = selectedGameDayId, providedToken?: GrantSecretToken) => {
     if (eventId.trim().length === 0 || gameDayId === null) return;
-    const response = await fetch(
-      `/api/event-admin/slot-setup?eventId=${encodeURIComponent(eventId)}&gameDayId=${encodeURIComponent(gameDayId)}`,
-    );
-    const payload = (await response.json()) as ScheduleResponse;
-    if (!response.ok || payload.status !== "accepted")
-      throw new Error("Unable to load Slot setup.");
-    setSchedule(payload.value);
+    const token =
+      providedToken ?? secretOwner.capture(secretScopeKey(eventId, gameDayId, selectedPitchId));
+    if (!secretOwner.current(token)) return;
+    try {
+      const response = await fetch(
+        `/api/event-admin/slot-setup?eventId=${encodeURIComponent(eventId)}&gameDayId=${encodeURIComponent(gameDayId)}`,
+      );
+      const payload = (await response.json()) as ScheduleResponse;
+      if (!response.ok || payload.status !== "accepted")
+        throw new Error("Unable to load Slot setup.");
+      if (!secretOwner.current(token)) return;
+      secretOwner.commit(token, () => setSchedule(payload.value));
+    } catch (error) {
+      if (secretOwner.current(token)) throw error;
+    }
   };
 
-  const loadPitchView = async (pitchId: string) => {
+  const loadPitchView = async (pitchId: string, providedToken?: GrantSecretToken) => {
     if (selectedGameDayId === null || pitchId.length === 0) return;
-    const response = await fetch(
-      `/api/event-admin/pitch-view?eventId=${encodeURIComponent(eventId)}&gameDayId=${encodeURIComponent(selectedGameDayId)}&pitchId=${encodeURIComponent(pitchId)}`,
-    );
-    const payload = (await response.json()) as {
-      status: "accepted";
-      value: NonNullable<typeof pitchView>;
-    };
-    if (!response.ok || payload.status !== "accepted")
-      throw new Error("Unable to load Pitch view.");
-    setPitchView(payload.value);
+    const token =
+      providedToken ?? secretOwner.capture(secretScopeKey(eventId, selectedGameDayId, pitchId));
+    if (!secretOwner.current(token)) return;
+    try {
+      const response = await fetch(
+        `/api/event-admin/pitch-view?eventId=${encodeURIComponent(eventId)}&gameDayId=${encodeURIComponent(selectedGameDayId)}&pitchId=${encodeURIComponent(pitchId)}`,
+      );
+      const payload = (await response.json()) as {
+        status: string;
+        value?: NonNullable<typeof pitchView>;
+      };
+      if (!response.ok || payload.status !== "accepted" || payload.value === undefined)
+        throw new Error("Unable to load Pitch view.");
+      if (!secretOwner.current(token)) return;
+      secretOwner.commit(token, () => setPitchView(payload.value!));
+    } catch (error) {
+      if (secretOwner.current(token)) throw error;
+    }
   };
 
   const controlGrantUrl = (pitchSlotId: string) =>
     `/api/event-admin/events/${eventId}/game-days/${selectedGameDayId}/pitches/${selectedPitchId}/pitch-slots/${pitchSlotId}/control-grant`;
 
-  const inspectControlGrant = async (pitchSlotId: string) => {
-    const response = await fetch(controlGrantUrl(pitchSlotId));
-    const payload = (await response.json()) as ControlGrantResponse;
-    if (!response.ok || payload.status !== "accepted")
-      throw new Error("Control Grant lookup failed.");
-    setControlGrants((current) => ({ ...current, [pitchSlotId]: payload.value }));
-    setControlQrDataUrls((current) => ({ ...current, [pitchSlotId]: "" }));
+  const controlCodeUrl = (pitchSlotId: string) => `${controlGrantUrl(pitchSlotId)}/code`;
+
+  const inspectControlGrant = async (
+    pitchSlotId: string,
+    preserveSecrets = false,
+    providedToken?: GrantSecretToken,
+  ) => {
+    let token = providedToken;
+    if (!preserveSecrets) {
+      invalidateGrantSecrets();
+      clearControlGrantSecrets(pitchSlotId);
+      token = secretOwner.capture(secretScopeKey());
+    }
+    token ??= secretOwner.capture(secretScopeKey());
+    if (!secretOwner.current(token)) return null;
+    try {
+      const response = await fetch(controlGrantUrl(pitchSlotId));
+      const payload = (await response.json()) as ControlGrantResponse;
+      if (!response.ok || payload.status !== "accepted")
+        throw new Error("Control Grant lookup failed.");
+      if (!secretOwner.current(token)) return null;
+      secretOwner.commit(token, () =>
+        setControlGrants((current) => ({ ...current, [pitchSlotId]: payload.value })),
+      );
+      const codeResponse = await fetch(controlCodeUrl(pitchSlotId));
+      const codePayload = (await codeResponse.json()) as {
+        status: string;
+        value?: GrantCodeProjection | null;
+      };
+      if (codeResponse.ok && codePayload.status === "accepted" && secretOwner.current(token)) {
+        const projection = codePayload.value ?? null;
+        secretOwner.commit(token, () => {
+          setControlCodes((current) => ({ ...current, [pitchSlotId]: projection }));
+          if (projection === null || projection.state !== "present")
+            clearControlGrantSecrets(pitchSlotId);
+        });
+      }
+      return payload.value;
+    } catch (error) {
+      if (secretOwner.current(token)) throw error;
+      return null;
+    }
   };
 
   const createControlGrant = async (pitchSlotId: string) => {
+    invalidateGrantSecrets();
+    const token = secretOwner.capture(secretScopeKey());
     const response = await fetch(controlGrantUrl(pitchSlotId), { method: "POST" });
-    if (!response.ok) throw new Error("Control Grant creation failed.");
-    await inspectControlGrant(pitchSlotId);
+    if (!response.ok) {
+      if (secretOwner.current(token)) throw new Error("Control Grant creation failed.");
+      return;
+    }
+    await inspectControlGrant(pitchSlotId, true, token);
   };
 
   const revealControlGrant = async (pitchSlotId: string) => {
+    invalidateGrantSecrets();
+    const token = secretOwner.capture(secretScopeKey());
     const response = await fetch(`${controlGrantUrl(pitchSlotId)}/reveal`, { method: "POST" });
     const payload = (await response.json()) as {
       status: string;
       value?: { qrCredential?: string };
     };
-    if (!response.ok || payload.status !== "accepted" || payload.value?.qrCredential === undefined)
-      throw new Error("Control Grant QR reveal failed.");
-    const dataUrl = await QRCode.toDataURL(payload.value.qrCredential);
-    setControlQrDataUrls((current) => ({ ...current, [pitchSlotId]: dataUrl }));
+    if (
+      !response.ok ||
+      payload.status !== "accepted" ||
+      payload.value?.qrCredential === undefined
+    ) {
+      if (secretOwner.current(token)) throw new Error("Control Grant QR reveal failed.");
+      return;
+    }
+    try {
+      const dataUrl = await qrRenderer(payload.value.qrCredential);
+      secretOwner.commit(token, () =>
+        setControlQrDataUrls((current) => ({ ...current, [pitchSlotId]: dataUrl })),
+      );
+    } catch (error) {
+      if (secretOwner.current(token)) throw error;
+    }
   };
 
-  const loadControlSessions = async (pitchSlotId: string) => {
-    const response = await fetch(`${controlGrantUrl(pitchSlotId)}/sessions`);
-    const payload = (await response.json()) as { status: string; value?: ControlSession[] };
-    if (!response.ok || payload.status !== "accepted") throw new Error("Session list failed.");
-    setControlSessions((current) => ({ ...current, [pitchSlotId]: payload.value ?? [] }));
+  const loadControlSessions = async (pitchSlotId: string, providedToken?: GrantSecretToken) => {
+    const token = providedToken ?? secretOwner.capture(secretScopeKey());
+    if (!secretOwner.current(token)) return;
+    try {
+      const response = await fetch(`${controlGrantUrl(pitchSlotId)}/sessions`);
+      const payload = (await response.json()) as { status: string; value?: ControlSession[] };
+      if (!response.ok || payload.status !== "accepted") throw new Error("Session list failed.");
+      secretOwner.commit(token, () =>
+        setControlSessions((current) => ({ ...current, [pitchSlotId]: payload.value ?? [] })),
+      );
+    } catch (error) {
+      if (secretOwner.current(token)) throw error;
+    }
   };
 
   const rotateControlGrant = async (pitchSlotId: string) => {
+    invalidateGrantSecrets();
+    const token = secretOwner.capture(secretScopeKey());
     const response = await fetch(`${controlGrantUrl(pitchSlotId)}/rotate`, { method: "POST" });
     const payload = (await response.json()) as {
       status: string;
-      value?: { affectedSessionCount?: number };
+      value?: { affectedSessionCount?: number; qrCredential?: string; code?: string };
     };
-    if (!response.ok || payload.status !== "accepted")
-      throw new Error("Control Grant rotation failed.");
-    setMessage(
-      `Control Grant rotated; ${payload.value?.affectedSessionCount ?? 0} session(s) revoked.`,
+    if (!response.ok || payload.status !== "accepted") {
+      if (secretOwner.current(token)) throw new Error("Control Grant rotation failed.");
+      return;
+    }
+    if (payload.value?.qrCredential === undefined || payload.value.code === undefined)
+      throw new Error("Control Grant rotation did not return replacement credentials.");
+    const { code, qrCredential, affectedSessionCount = 0 } = payload.value;
+    if (
+      !secretOwner.commit(token, () => {
+        setControlQrCredentials((current) => ({ ...current, [pitchSlotId]: qrCredential }));
+        setControlCodePlaintexts((current) => ({ ...current, [pitchSlotId]: code }));
+        setControlRotationCounts((current) => ({
+          ...current,
+          [pitchSlotId]: affectedSessionCount,
+        }));
+        setMessage(
+          `Control Grant fully rotated; ${affectedSessionCount} session(s) revoked. Dictate the new code and scan the new QR now.`,
+        );
+      })
+    )
+      return;
+    await renderControlQr(pitchSlotId, qrCredential, token);
+    if (!secretOwner.current(token)) return;
+    const refreshWarnings: string[] = [];
+    try {
+      await inspectControlGrant(pitchSlotId, true, token);
+    } catch {
+      refreshWarnings.push("Control Grant state refresh failed.");
+    }
+    try {
+      await loadControlSessions(pitchSlotId, token);
+    } catch {
+      refreshWarnings.push("Control session refresh failed.");
+    }
+    if (refreshWarnings.length > 0 && secretOwner.current(token))
+      setSecretWarning(refreshWarnings.join(" ") + " Replacement credentials remain visible.");
+  };
+
+  const renderControlQr = async (
+    pitchSlotId: string,
+    credential = controlQrCredentials[pitchSlotId],
+    providedToken?: GrantSecretToken,
+  ) => {
+    if (credential === undefined) return;
+    const token = providedToken ?? secretOwner.capture(secretScopeKey());
+    if (!secretOwner.current(token)) return;
+    try {
+      const dataUrl = await qrRenderer(credential);
+      secretOwner.commit(token, () => {
+        setControlQrDataUrls((current) => ({ ...current, [pitchSlotId]: dataUrl }));
+        setControlQrCredentials((current) => {
+          const next = { ...current };
+          delete next[pitchSlotId];
+          return next;
+        });
+        setSecretWarning((current) => (current?.includes("QR render failed") ? null : current));
+      });
+    } catch {
+      if (secretOwner.current(token))
+        setSecretWarning("Replacement QR render failed. Retry QR render locally.");
+    }
+  };
+
+  const manageControlCode = async (
+    pitchSlotId: string,
+    operation: "create" | "replace" | "disable",
+  ) => {
+    invalidateGrantSecrets();
+    const token = secretOwner.capture(secretScopeKey());
+    const response = await fetch(
+      `${controlCodeUrl(pitchSlotId)}${operation === "create" ? "" : `/${operation}`}`,
+      { method: "POST" },
     );
-    await inspectControlGrant(pitchSlotId);
-    await loadControlSessions(pitchSlotId);
+    const payload = (await response.json()) as {
+      status: string;
+      value?: GrantCodeProjection & { code?: string };
+    };
+    if (!response.ok || payload.status !== "accepted") {
+      if (secretOwner.current(token)) throw new Error("Grant Code operation failed.");
+      return;
+    }
+    if (operation !== "disable" && payload.value?.code !== undefined)
+      secretOwner.commit(token, () =>
+        setControlCodePlaintexts((current) => ({
+          ...current,
+          [pitchSlotId]: payload.value!.code!,
+        })),
+      );
+    const inspected = await fetch(controlCodeUrl(pitchSlotId));
+    const inspectedPayload = (await inspected.json()) as {
+      status: string;
+      value?: GrantCodeProjection | null;
+    };
+    if (inspected.ok && inspectedPayload.status === "accepted" && secretOwner.current(token)) {
+      const projection = inspectedPayload.value ?? null;
+      secretOwner.commit(token, () => {
+        setControlCodes((current) => ({ ...current, [pitchSlotId]: projection }));
+        if (projection === null || projection.state !== "present")
+          clearControlGrantSecrets(pitchSlotId);
+      });
+    }
   };
 
   const revokeControlSession = async (pitchSlotId: string, label: string) => {
-    const response = await fetch(`${controlGrantUrl(pitchSlotId)}/sessions/revoke`, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ sessionReference: label }),
-    });
-    if (!response.ok) throw new Error("Control session revocation failed.");
-    await loadControlSessions(pitchSlotId);
+    invalidateGrantSecrets();
+    const token = secretOwner.capture(secretScopeKey());
+    try {
+      const response = await fetch(`${controlGrantUrl(pitchSlotId)}/sessions/revoke`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ sessionReference: label }),
+      });
+      if (!response.ok) throw new Error("Control session revocation failed.");
+      await loadControlSessions(pitchSlotId, token);
+    } catch (error) {
+      if (secretOwner.current(token)) throw error;
+    }
   };
 
-  const loadPitchManagerGrant = async () => {
+  const loadPitchManagerGrant = async (
+    preserveSecrets = false,
+    providedToken?: GrantSecretToken,
+  ) => {
     if (pitchManagerGameDayId.length === 0 || pitchManagerPitchId.length === 0) return;
+    const token = providedToken ?? secretOwner.capture(secretScopeKey());
+    if (!secretOwner.current(token)) return;
     const response = await fetch(
       `/api/event-admin/events/${eventId}/game-days/${pitchManagerGameDayId}/pitches/${pitchManagerPitchId}/pitch-manager-grant`,
     );
     const payload = (await response.json()) as PitchManagerGrantResponse | { status: string };
-    if (!response.ok || payload.status !== "accepted") throw new Error("Grant lookup failed.");
-    setPitchManagerGrant((payload as PitchManagerGrantResponse).value ?? null);
-    setPitchManagerQrDataUrl(null);
+    if (!response.ok || payload.status !== "accepted") {
+      if (secretOwner.current(token)) throw new Error("Grant lookup failed.");
+      return;
+    }
+    if (!secretOwner.current(token)) return;
+    secretOwner.commit(token, () =>
+      setPitchManagerGrant((payload as PitchManagerGrantResponse).value ?? null),
+    );
+    if (!preserveSecrets) secretOwner.commit(token, () => setPitchManagerQrDataUrl(null));
+    if (
+      !preserveSecrets &&
+      ((payload as PitchManagerGrantResponse).value === null ||
+        (payload as PitchManagerGrantResponse).value?.status !== "active")
+    ) {
+      secretOwner.commit(token, () => {
+        setPitchManagerCode(null);
+        setPitchManagerCodePlaintext(null);
+        setPitchManagerQrCredential(null);
+        setPitchManagerRotationCount(null);
+      });
+      return;
+    }
+    const codeResponse = await fetch(
+      `/api/event-admin/events/${eventId}/game-days/${pitchManagerGameDayId}/pitches/${pitchManagerPitchId}/pitch-manager-grant/code`,
+    );
+    const codePayload = (await codeResponse.json()) as {
+      status: string;
+      value?: GrantCodeProjection | null;
+    };
+    if (!codeResponse.ok || codePayload.status !== "accepted") {
+      if (secretOwner.current(token)) throw new Error("Grant Code lookup failed.");
+      return;
+    }
+    if (!secretOwner.current(token)) return;
+    secretOwner.commit(token, () => setPitchManagerCode(codePayload.value ?? null));
+    if (
+      !preserveSecrets &&
+      (codePayload.value === null || codePayload.value?.state !== "present")
+    ) {
+      secretOwner.commit(token, () => {
+        setPitchManagerCodePlaintext(null);
+        setPitchManagerQrCredential(null);
+        setPitchManagerRotationCount(null);
+      });
+    }
+  };
+
+  const managePitchManagerCode = async (operation: "create" | "replace" | "disable") => {
+    invalidateGrantSecrets();
+    const token = secretOwner.capture(secretScopeKey());
+    const response = await fetch(
+      `/api/event-admin/events/${eventId}/game-days/${pitchManagerGameDayId}/pitches/${pitchManagerPitchId}/pitch-manager-grant/code${operation === "create" ? "" : `/${operation}`}`,
+      { method: "POST" },
+    );
+    const payload = (await response.json()) as {
+      status: string;
+      value?: GrantCodeProjection & { code?: string };
+    };
+    if (!response.ok || payload.status !== "accepted") {
+      if (secretOwner.current(token)) throw new Error("Grant Code operation failed.");
+      return;
+    }
+    if (operation !== "disable" && payload.value?.code !== undefined)
+      secretOwner.commit(token, () => setPitchManagerCodePlaintext(payload.value!.code!));
+    if (!secretOwner.current(token)) return;
+    await loadPitchManagerGrant(operation !== "disable", token);
   };
 
   const changePublicationStatus = async (status: "unpublished" | "published" | "cancelled") => {
@@ -369,12 +764,69 @@ export function EventAdminPage() {
     operation: "rotate" | "disable" | "revoke" | "reactivate",
   ) => {
     if (pitchManagerGameDayId.length === 0 || pitchManagerPitchId.length === 0) return;
+    invalidateGrantSecrets();
+    const token = secretOwner.capture(secretScopeKey());
     const response = await fetch(
       `/api/event-admin/events/${eventId}/game-days/${pitchManagerGameDayId}/pitches/${pitchManagerPitchId}/pitch-manager-grant/${operation}`,
       { method: "POST" },
     );
-    if (!response.ok) throw new Error("Pitch Manager Grant lifecycle change failed.");
-    await loadPitchManagerGrant();
+    const payload = (await response.json()) as {
+      status: string;
+      value?: { qrCredential?: string; code?: string; affectedSessionCount?: number };
+    };
+    if (!response.ok || payload.status !== "accepted") {
+      if (secretOwner.current(token))
+        throw new Error("Pitch Manager Grant lifecycle change failed.");
+      return;
+    }
+    if (operation === "rotate") {
+      if (payload.value?.qrCredential === undefined || payload.value.code === undefined)
+        throw new Error("Pitch Manager rotation did not return replacement credentials.");
+      const { code, qrCredential, affectedSessionCount = 0 } = payload.value;
+      if (
+        !secretOwner.commit(token, () => {
+          setPitchManagerQrCredential(qrCredential);
+          setPitchManagerCodePlaintext(code);
+          setPitchManagerRotationCount(affectedSessionCount);
+          setMessage(
+            `Pitch Manager Grant fully rotated; ${affectedSessionCount} session(s) revoked. Dictate the new code and scan the new QR now.`,
+          );
+        })
+      )
+        return;
+      await renderPitchManagerQr(qrCredential, token);
+      if (!secretOwner.current(token)) return;
+      try {
+        await loadPitchManagerGrant(true, token);
+      } catch {
+        if (secretOwner.current(token))
+          setSecretWarning(
+            "Pitch Manager Grant state refresh failed. Replacement credentials remain visible.",
+          );
+      }
+      return;
+    }
+    await loadPitchManagerGrant(false, token);
+  };
+
+  const renderPitchManagerQr = async (
+    credential = pitchManagerQrCredential,
+    providedToken?: GrantSecretToken,
+  ) => {
+    if (credential === null || credential === undefined) return;
+    const token = providedToken ?? secretOwner.capture(secretScopeKey());
+    if (!secretOwner.current(token)) return;
+    try {
+      const dataUrl = await qrRenderer(credential);
+      secretOwner.commit(token, () => {
+        setPitchManagerQrDataUrl(dataUrl);
+        setPitchManagerQrCredential(null);
+        setSecretWarning((current) => (current?.includes("QR render failed") ? null : current));
+      });
+    } catch {
+      if (secretOwner.current(token))
+        setSecretWarning("Replacement QR render failed. Retry QR render locally.");
+    }
   };
 
   const delayMsFor = (slotId: string) => {
@@ -406,6 +858,7 @@ export function EventAdminPage() {
 
   const applyGameplayDelay = async (slotId: string) => {
     if (selectedGameDayId === null) return;
+    const token = secretOwner.capture(secretScopeKey());
     const response = await fetch(
       `/api/event-admin/events/${eventId}/game-days/${selectedGameDayId}/gameplay-slots/${slotId}/expected-delay`,
       {
@@ -418,7 +871,7 @@ export function EventAdminPage() {
       },
     );
     if (!response.ok) throw new Error(await responseError(response, "Delay apply failed."));
-    await loadSchedule();
+    await loadSchedule(selectedGameDayId, token);
     setDelayPreviews((current) => {
       const next = { ...current };
       delete next[slotId];
@@ -448,6 +901,7 @@ export function EventAdminPage() {
 
   const applyPitchDelay = async (slotId: string) => {
     if (selectedGameDayId === null) return;
+    const token = secretOwner.capture(secretScopeKey());
     const response = await fetch(
       `/api/event-admin/events/${eventId}/game-days/${selectedGameDayId}/pitch-slots/${slotId}/expected-delay`,
       {
@@ -460,8 +914,8 @@ export function EventAdminPage() {
       },
     );
     if (!response.ok) throw new Error(await responseError(response, "Delay apply failed."));
-    await loadSchedule();
-    if (selectedPitchId.length > 0) await loadPitchView(selectedPitchId);
+    await loadSchedule(selectedGameDayId, token);
+    if (selectedPitchId.length > 0) await loadPitchView(selectedPitchId, token);
     setDelayPreviews((current) => {
       const next = { ...current };
       delete next[slotId];
@@ -471,6 +925,7 @@ export function EventAdminPage() {
 
   const reassignEventGame = async (eventGameId: string) => {
     if (selectedGameDayId === null) return;
+    const token = secretOwner.capture(secretScopeKey());
     const targetPitchSlotId = reassignmentTargets[eventGameId];
     if (targetPitchSlotId === undefined || targetPitchSlotId.length === 0)
       throw new Error("Choose a target Pitch Slot.");
@@ -486,8 +941,8 @@ export function EventAdminPage() {
       },
     );
     if (!response.ok) throw new Error(await responseError(response, "Pitch Reassignment failed."));
-    await loadSchedule();
-    if (selectedPitchId.length > 0) await loadPitchView(selectedPitchId);
+    await loadSchedule(selectedGameDayId, token);
+    if (selectedPitchId.length > 0) await loadPitchView(selectedPitchId, token);
   };
 
   const confirmGameplaySlot = async (
@@ -548,7 +1003,7 @@ export function EventAdminPage() {
             <Input
               id="event-id"
               value={eventId}
-              onChange={(event) => setEventId(event.target.value)}
+              onInput={(event) => changeEventId(event.currentTarget.value)}
             />
           </div>
           {hub === null ? (
@@ -560,25 +1015,53 @@ export function EventAdminPage() {
                   type="password"
                   value={credential}
                   onChange={(event) => setCredential(event.target.value)}
+                  onInput={(event) => setCredential(event.currentTarget.value)}
                   autoComplete="off"
                 />
                 <p className="text-xs text-muted-foreground">
                   Use a trusted QR scanner and submit its value here.
                 </p>
               </div>
+              <div className="space-y-2">
+                <Label htmlFor="event-admin-grant-code">Radio Grant Code</Label>
+                <Input
+                  id="event-admin-grant-code"
+                  type="password"
+                  value={grantCode}
+                  onChange={(event) => setGrantCode(event.target.value)}
+                  onInput={(event) => setGrantCode(event.currentTarget.value)}
+                  autoComplete="off"
+                  placeholder="two words and three digits"
+                />
+              </div>
               <div className="flex flex-wrap gap-2">
                 <Button
-                  disabled={busy || eventId.trim().length === 0 || credential.length === 0}
+                  disabled={
+                    busy ||
+                    eventId.trim().length === 0 ||
+                    (credential.length === 0 && grantCode.length === 0) ||
+                    (credential.length > 0 && grantCode.length > 0)
+                  }
                   onClick={() =>
                     void run(async () => {
-                      const response = await fetch("/api/event-admin/admit", {
-                        method: "POST",
-                        headers: { "content-type": "application/json" },
-                        body: JSON.stringify({ qrCredential: credential }),
-                      });
-                      if (!response.ok) throw new Error("Admission failed.");
-                      setCredential("");
-                      await loadHub(null);
+                      const body =
+                        grantCode.length > 0 ? { grantCode } : { qrCredential: credential };
+                      invalidateGrantSecrets();
+                      const token = secretOwner.capture(hubScopeKey());
+                      try {
+                        const response = await fetch("/api/event-admin/admit", {
+                          method: "POST",
+                          headers: { "content-type": "application/json" },
+                          body: JSON.stringify(body),
+                        });
+                        const payload = (await response.json()) as { status?: string };
+                        if (!response.ok || payload.status !== "admitted")
+                          throw new Error("Admission failed.");
+                        if (!secretOwner.current(token)) return;
+                        await loadHub(null, token);
+                      } catch (error) {
+                        if (secretOwner.current(token)) throw error;
+                      }
                     })
                   }
                 >
@@ -649,6 +1132,7 @@ export function EventAdminPage() {
                   value={selectedGameDayId ?? ""}
                   onChange={(event) => {
                     const next = event.target.value || null;
+                    invalidateGrantSecrets();
                     setSelectedGameDayId(next);
                     void run(() => loadHub(next));
                   }}
@@ -1220,8 +1704,12 @@ export function EventAdminPage() {
                       key={pitch.pitchId}
                       variant={selectedPitchId === pitch.pitchId ? "default" : "outline"}
                       onClick={() => {
+                        invalidateGrantSecrets();
+                        const token = secretOwner.capture(
+                          secretScopeKey(eventId, selectedGameDayId, pitch.pitchId),
+                        );
                         setSelectedPitchId(pitch.pitchId);
-                        void run(() => loadPitchView(pitch.pitchId));
+                        void run(() => loadPitchView(pitch.pitchId, token));
                       }}
                     >
                       {pitch.name}
@@ -1362,7 +1850,9 @@ export function EventAdminPage() {
                                 size="sm"
                                 variant="outline"
                                 onClick={() =>
-                                  void run(() => inspectControlGrant(slot.pitchSlotId))
+                                  void run(async () => {
+                                    await inspectControlGrant(slot.pitchSlotId);
+                                  })
                                 }
                               >
                                 Inspect Control Grant
@@ -1405,6 +1895,35 @@ export function EventAdminPage() {
                                   >
                                     Rotate Grant
                                   </Button>
+                                  <Button
+                                    size="sm"
+                                    variant="outline"
+                                    onClick={() =>
+                                      void run(() => manageControlCode(slot.pitchSlotId, "create"))
+                                    }
+                                  >
+                                    Create Radio Code
+                                  </Button>
+                                  <Button
+                                    size="sm"
+                                    variant="outline"
+                                    disabled={controlCodes[slot.pitchSlotId]?.state !== "present"}
+                                    onClick={() =>
+                                      void run(() => manageControlCode(slot.pitchSlotId, "replace"))
+                                    }
+                                  >
+                                    Replace Code
+                                  </Button>
+                                  <Button
+                                    size="sm"
+                                    variant="outline"
+                                    disabled={controlCodes[slot.pitchSlotId]?.state !== "present"}
+                                    onClick={() =>
+                                      void run(() => manageControlCode(slot.pitchSlotId, "disable"))
+                                    }
+                                  >
+                                    Disable Code
+                                  </Button>
                                 </>
                               )}
                             </div>
@@ -1414,12 +1933,52 @@ export function EventAdminPage() {
                                 {controlGrant.eventGameId ? ` · ${controlGrant.eventGameId}` : ""}
                               </p>
                             ) : null}
+                            {controlGrant ? (
+                              <p className="text-xs text-muted-foreground">
+                                Radio code: {controlCodes[slot.pitchSlotId]?.state ?? "absent"}
+                              </p>
+                            ) : null}
+                            {controlRotationCounts[slot.pitchSlotId] !== undefined ? (
+                              <p className="text-xs text-muted-foreground">
+                                Full rotation affected {controlRotationCounts[slot.pitchSlotId]}{" "}
+                                session(s).
+                              </p>
+                            ) : null}
+                            {controlCodePlaintexts[slot.pitchSlotId] ? (
+                              <div className="flex items-center gap-2 rounded bg-muted p-2">
+                                <p aria-live="polite" className="font-mono text-sm">
+                                  Dictate now: {controlCodePlaintexts[slot.pitchSlotId]}
+                                </p>
+                                <Button
+                                  size="sm"
+                                  variant="outline"
+                                  onClick={() =>
+                                    setControlCodePlaintexts((current) => {
+                                      const next = { ...current };
+                                      delete next[slot.pitchSlotId];
+                                      return next;
+                                    })
+                                  }
+                                >
+                                  Clear
+                                </Button>
+                              </div>
+                            ) : null}
                             {controlQrDataUrls[slot.pitchSlotId] ? (
                               <img
                                 alt={`Control Grant QR for Pitch Slot ${slot.sequence}`}
                                 className="h-40 w-40 rounded border bg-white p-2"
                                 src={controlQrDataUrls[slot.pitchSlotId]}
                               />
+                            ) : null}
+                            {controlQrCredentials[slot.pitchSlotId] ? (
+                              <Button
+                                size="sm"
+                                variant="outline"
+                                onClick={() => void renderControlQr(slot.pitchSlotId)}
+                              >
+                                Retry QR render
+                              </Button>
                             ) : null}
                             {(controlSessions[slot.pitchSlotId] ?? []).map((session) => (
                               <div
@@ -1463,9 +2022,12 @@ export function EventAdminPage() {
                     className="h-10 rounded-md border bg-background px-3 text-sm"
                     value={pitchManagerGameDayId}
                     onChange={(event) => {
+                      invalidateGrantSecrets();
                       setPitchManagerGameDayId(event.target.value);
                       setPitchManagerGrant(null);
                       setPitchManagerQrDataUrl(null);
+                      setPitchManagerCode(null);
+                      setPitchManagerCodePlaintext(null);
                     }}
                   >
                     <option value="">Game Day</option>
@@ -1480,9 +2042,12 @@ export function EventAdminPage() {
                     className="h-10 rounded-md border bg-background px-3 text-sm"
                     value={pitchManagerPitchId}
                     onChange={(event) => {
+                      invalidateGrantSecrets();
                       setPitchManagerPitchId(event.target.value);
                       setPitchManagerGrant(null);
                       setPitchManagerQrDataUrl(null);
+                      setPitchManagerCode(null);
+                      setPitchManagerCodePlaintext(null);
                     }}
                   >
                     <option value="">Pitch</option>
@@ -1586,6 +2151,30 @@ export function EventAdminPage() {
                   >
                     Reactivate Grant
                   </Button>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    disabled={busy || pitchManagerGrant?.status !== "active"}
+                    onClick={() => void run(() => managePitchManagerCode("create"))}
+                  >
+                    Create Radio Code
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    disabled={busy || pitchManagerCode?.state !== "present"}
+                    onClick={() => void run(() => managePitchManagerCode("replace"))}
+                  >
+                    Replace Code
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    disabled={busy || pitchManagerCode?.state !== "present"}
+                    onClick={() => void run(() => managePitchManagerCode("disable"))}
+                  >
+                    Disable Code
+                  </Button>
                 </div>
                 {pitchManagerGrant ? (
                   <p className="text-sm">
@@ -1595,6 +2184,31 @@ export function EventAdminPage() {
                       : new Date(pitchManagerGrant.expiresAtMs).toLocaleString()}
                   </p>
                 ) : null}
+                {pitchManagerGrant ? (
+                  <p className="text-xs text-muted-foreground">
+                    Radio code: {pitchManagerCode?.state ?? "absent"}
+                  </p>
+                ) : null}
+                {pitchManagerRotationCount !== null ? (
+                  <p className="text-xs text-muted-foreground">
+                    Full rotation affected {pitchManagerRotationCount} session(s).
+                  </p>
+                ) : null}
+                {pitchManagerCodePlaintext ? (
+                  <div className="flex items-center gap-2 rounded bg-muted p-2">
+                    <p aria-live="polite" className="font-mono text-sm">
+                      Dictate now: {pitchManagerCodePlaintext}
+                    </p>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      onClick={() => setPitchManagerCodePlaintext(null)}
+                    >
+                      Clear
+                    </Button>
+                  </div>
+                ) : null}
                 {pitchManagerQrDataUrl ? (
                   <img
                     alt="Pitch Manager Grant QR code"
@@ -1602,12 +2216,29 @@ export function EventAdminPage() {
                     src={pitchManagerQrDataUrl}
                   />
                 ) : null}
+                {pitchManagerQrCredential ? (
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    onClick={() => void renderPitchManagerQr()}
+                  >
+                    Retry QR render
+                  </Button>
+                ) : null}
               </div>
-              <Button variant="outline" onClick={() => setHub(null)}>
+              <Button
+                variant="outline"
+                onClick={() => {
+                  invalidateGrantSecrets();
+                  setHub(null);
+                }}
+              >
                 Change authority
               </Button>
             </div>
           )}
+          {secretWarning ? <p className="text-sm text-destructive">{secretWarning}</p> : null}
           {message ? <p className="text-sm text-destructive">{message}</p> : null}
         </CardContent>
       </Card>

--- a/src/pages/event-game-controller-page.test.tsx
+++ b/src/pages/event-game-controller-page.test.tsx
@@ -24,6 +24,7 @@ describe("Event Game Controller reconnect browser seam", () => {
   let container: HTMLDivElement;
   let root: Root;
   let replayMode: "lost" | "success" | "deferred";
+  let openBodies: Record<string, unknown>[];
   let replayCalls: number;
   let replayBodies: Record<string, any>[];
   let intentCalls: number;
@@ -39,6 +40,7 @@ describe("Event Game Controller reconnect browser seam", () => {
 
   beforeEach(() => {
     replayMode = "lost";
+    openBodies = [];
     replayCalls = 0;
     replayBodies = [];
     intentCalls = 0;
@@ -62,6 +64,7 @@ describe("Event Game Controller reconnect browser seam", () => {
         const url =
           typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
         if (url.endsWith("/api/event-control/open")) {
+          openBodies.push(JSON.parse(typeof init?.body === "string" ? init.body : "{}"));
           return new Response(
             JSON.stringify({
               status: "opened",
@@ -199,13 +202,7 @@ describe("Event Game Controller reconnect browser seam", () => {
     });
     const grantInput = container.querySelector("input#control-grant") as HTMLInputElement;
     await act(async () => {
-      grantInput.value = "qr-credential";
-      grantInput.dispatchEvent(
-        new testWindow.Event("input", { bubbles: true }) as unknown as Event,
-      );
-      grantInput.dispatchEvent(
-        new testWindow.Event("change", { bubbles: true }) as unknown as Event,
-      );
+      setInputValue(grantInput, "qr-credential");
       await Promise.resolve();
     });
     await act(async () => {
@@ -214,7 +211,25 @@ describe("Event Game Controller reconnect browser seam", () => {
         ?.click();
       await Promise.resolve();
       await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
     });
+  }
+
+  function setInputValue(input: HTMLInputElement, value: string) {
+    const setter = Object.getOwnPropertyDescriptor(
+      testWindow.HTMLInputElement.prototype,
+      "value",
+    )?.set;
+    setter?.call(input, value);
+    input.dispatchEvent(new testWindow.Event("input", { bubbles: true }) as unknown as Event);
+    input.dispatchEvent(new testWindow.Event("change", { bubbles: true }) as unknown as Event);
   }
 
   afterEach(async () => {
@@ -243,13 +258,7 @@ describe("Event Game Controller reconnect browser seam", () => {
     });
     const grantInput = container.querySelector("input#control-grant") as HTMLInputElement;
     await act(async () => {
-      grantInput.value = "qr-credential";
-      grantInput.dispatchEvent(
-        new testWindow.Event("input", { bubbles: true }) as unknown as Event,
-      );
-      grantInput.dispatchEvent(
-        new testWindow.Event("change", { bubbles: true }) as unknown as Event,
-      );
+      setInputValue(grantInput, "qr-credential");
       await Promise.resolve();
     });
     const openButton = Array.from(container.getElementsByTagName("button")).find((button) =>
@@ -275,6 +284,72 @@ describe("Event Game Controller reconnect browser seam", () => {
       testWindow.localStorage.getItem(controllerReplicaStorageKey("game-browser")) ?? "null",
     ) as { pendingActions?: unknown[] };
     expect(stored.pendingActions).toHaveLength(1);
+  });
+
+  test("requires exactly one Controller credential and keeps both/none local", async () => {
+    await act(async () => {
+      root.render(<EventGameControllerPage />);
+      await Promise.resolve();
+    });
+    const qrInput = container.querySelector("input#control-grant") as HTMLInputElement;
+    const codeInput = container.querySelector("input#control-grant-code") as HTMLInputElement;
+    const openButton = () =>
+      Array.from(container.getElementsByTagName("button")).find((button) =>
+        button.textContent?.includes("Open Controller"),
+      );
+
+    await act(async () => {
+      setInputValue(qrInput, "qr-credential");
+      setInputValue(codeInput, "alpha-bravo-123");
+      await Promise.resolve();
+      openButton()?.click();
+      await Promise.resolve();
+    });
+    expect(openBodies).toHaveLength(0);
+    expect(container.textContent).toContain(
+      "Enter exactly one Controller QR credential or Grant Code.",
+    );
+
+    await act(async () => {
+      setInputValue(qrInput, "");
+      setInputValue(codeInput, "");
+      await Promise.resolve();
+      openButton()?.click();
+      await Promise.resolve();
+    });
+    expect(openBodies).toHaveLength(0);
+    expect(container.textContent).toContain(
+      "Enter exactly one Controller QR credential or Grant Code.",
+    );
+  });
+
+  test("sends a code-only Controller admission and clears both inputs after acceptance", async () => {
+    await act(async () => {
+      root.render(<EventGameControllerPage />);
+      await Promise.resolve();
+    });
+    const qrInput = container.querySelector("input#control-grant") as HTMLInputElement;
+    const codeInput = container.querySelector("input#control-grant-code") as HTMLInputElement;
+    await act(async () => {
+      setInputValue(codeInput, "alpha-bravo-123");
+      await Promise.resolve();
+      Array.from(container.getElementsByTagName("button"))
+        .find((button) => button.textContent?.includes("Open Controller"))
+        ?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(openBodies).toEqual([
+      { grantCode: "alpha-bravo-123", browserContext: expect.any(String) },
+    ]);
+    expect(qrInput.value).toBe("");
+    expect(codeInput.value).toBe("");
   });
 
   test("renders stable fact identity and sends a contextual Correction from the browser seam", async () => {
@@ -306,13 +381,7 @@ describe("Event Game Controller reconnect browser seam", () => {
     });
     const grantInput = container.querySelector("input#control-grant") as HTMLInputElement;
     await act(async () => {
-      grantInput.value = "qr-credential";
-      grantInput.dispatchEvent(
-        new testWindow.Event("input", { bubbles: true }) as unknown as Event,
-      );
-      grantInput.dispatchEvent(
-        new testWindow.Event("change", { bubbles: true }) as unknown as Event,
-      );
+      setInputValue(grantInput, "qr-credential");
       await Promise.resolve();
     });
     await act(async () => {
@@ -648,13 +717,7 @@ describe("Event Game Controller reconnect browser seam", () => {
     });
     const grantInput = container.querySelector("input#control-grant") as HTMLInputElement;
     await act(async () => {
-      grantInput.value = "qr-credential";
-      grantInput.dispatchEvent(
-        new testWindow.Event("input", { bubbles: true }) as unknown as Event,
-      );
-      grantInput.dispatchEvent(
-        new testWindow.Event("change", { bubbles: true }) as unknown as Event,
-      );
+      setInputValue(grantInput, "qr-credential");
       await Promise.resolve();
     });
     await act(async () => {
@@ -691,13 +754,7 @@ describe("Event Game Controller reconnect browser seam", () => {
     });
     const grantInput = container.querySelector("input#control-grant") as HTMLInputElement;
     await act(async () => {
-      grantInput.value = "qr-credential";
-      grantInput.dispatchEvent(
-        new testWindow.Event("input", { bubbles: true }) as unknown as Event,
-      );
-      grantInput.dispatchEvent(
-        new testWindow.Event("change", { bubbles: true }) as unknown as Event,
-      );
+      setInputValue(grantInput, "qr-credential");
       await Promise.resolve();
     });
     await act(async () => {

--- a/src/pages/event-game-controller-page.tsx
+++ b/src/pages/event-game-controller-page.tsx
@@ -74,6 +74,9 @@ type ClockReceiptAnchor = {
 export function EventGameControllerPage() {
   const persisted = readPersistedControllerSession();
   const [qrCredential, setQrCredential] = useState("");
+  const [grantCode, setGrantCode] = useState("");
+  const qrCredentialInputRef = useRef<HTMLInputElement>(null);
+  const grantCodeInputRef = useRef<HTMLInputElement>(null);
   const [sessionBearer, setSessionBearer] = useState<string | null>(
     persisted?.sessionBearer ?? null,
   );
@@ -187,6 +190,12 @@ export function EventGameControllerPage() {
   }, [eventGameId, sessionBearer]);
 
   async function openController() {
+    const hasQrCredential = qrCredential.length > 0;
+    const hasGrantCode = grantCode.length > 0;
+    if (hasQrCredential === hasGrantCode) {
+      setMessage("Enter exactly one Controller QR credential or Grant Code.");
+      return;
+    }
     setBusy(true);
     setMessage(null);
     clearReplayAuthority();
@@ -197,10 +206,14 @@ export function EventGameControllerPage() {
     }
     try {
       const response = await postJson<ControllerOpenResponse>("/api/event-control/open", {
-        qrCredential,
+        ...(grantCode.length > 0 ? { grantCode } : { qrCredential }),
         browserContext,
       });
       if (response.status !== "opened") throw new Error("open failed");
+      setQrCredential("");
+      setGrantCode("");
+      if (qrCredentialInputRef.current !== null) qrCredentialInputRef.current.value = "";
+      if (grantCodeInputRef.current !== null) grantCodeInputRef.current.value = "";
       setSessionBearer(response.session.sessionBearer);
       setEventGameId(response.eventGameId);
       receiveProjection(response.projection);
@@ -701,6 +714,8 @@ export function EventGameControllerPage() {
       currentEventGameId,
     );
     setClockCorrectionInput("");
+    setQrCredential("");
+    setGrantCode("");
   }
 
   function emergencyClockTakeover() {
@@ -868,10 +883,26 @@ export function EventGameControllerPage() {
                 <Label htmlFor="control-grant">Active Pitch Slot Control Grant QR</Label>
                 <Input
                   id="control-grant"
+                  ref={qrCredentialInputRef}
                   value={qrCredential}
                   onChange={(event) => setQrCredential(event.target.value)}
+                  onInput={(event) => setQrCredential(event.currentTarget.value)}
                   autoComplete="off"
                   placeholder="Scan or paste the QR credential"
+                  disabled={busy}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="control-grant-code">Radio Grant Code</Label>
+                <Input
+                  id="control-grant-code"
+                  ref={grantCodeInputRef}
+                  type="password"
+                  value={grantCode}
+                  onChange={(event) => setGrantCode(event.target.value)}
+                  onInput={(event) => setGrantCode(event.currentTarget.value)}
+                  autoComplete="off"
+                  placeholder="two words and three digits"
                   disabled={busy}
                 />
               </div>

--- a/src/pages/grant-secret-lifecycle.test.tsx
+++ b/src/pages/grant-secret-lifecycle.test.tsx
@@ -1,0 +1,1746 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { act, type ReactElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { Window } from "happy-dom";
+import { EventAdminPage } from "@/pages/event-admin-page";
+import { PitchManagerPage } from "@/pages/pitch-manager-page";
+import { TechnicalAdminPage } from "@/pages/technical-admin-page";
+
+const pitchManagerView = {
+  eventId: "event",
+  gameDayId: "day",
+  gameDayDate: "2026-08-15",
+  eventTimeZone: "UTC",
+  pitch: { pitchId: "pitch", name: "Pitch Main" },
+  schedule: [
+    {
+      pitchSlotId: "slot",
+      gameplaySlotId: "gameplay",
+      sequence: 1,
+      expectedStart: "2026-08-15 10:00 UTC",
+      eventGame: null,
+      conflictEventGameIds: [],
+      controlGrantStatus: "active",
+    },
+  ],
+  grantSessionExpiresAt: "2026-08-15 12:00 UTC",
+};
+
+const eventHub = {
+  event: {
+    eventId: "event",
+    name: "Event",
+    timeZone: "UTC",
+    lifecycle: "active",
+    publicationStatus: "unpublished",
+    gameDays: [{ gameDayId: "day", date: "2026-08-15", classification: "scheduled" }],
+    teams: [],
+    pitches: [{ pitchId: "pitch", name: "Pitch Main" }],
+    gameplaySlots: [
+      {
+        gameplaySlotId: "gameplay",
+        gameDayId: "day",
+        sequence: 1,
+        scheduledStartMs: Date.UTC(2026, 7, 15, 10),
+        expectedDelayMs: 0,
+      },
+    ],
+    pitchSlots: [
+      {
+        pitchSlotId: "slot",
+        gameDayId: "day",
+        pitchId: "pitch",
+        gameplaySlotId: "gameplay",
+        sequence: 1,
+        expectedDelayMs: 0,
+      },
+    ],
+    eventGames: [],
+  },
+  selectedGameDayId: "day",
+  authority: "event-admin",
+};
+
+const twoDayEventHub = {
+  ...eventHub,
+  selectedGameDayId: "day",
+  event: {
+    ...eventHub.event,
+    gameDays: [
+      ...eventHub.event.gameDays,
+      { gameDayId: "day-two", date: "2026-08-16", classification: "scheduled" },
+    ],
+  },
+};
+
+const eventBHub = {
+  ...eventHub,
+  event: {
+    ...eventHub.event,
+    eventId: "event-b",
+    name: "Event B",
+  },
+};
+
+const eventPitchView = {
+  pitch: { pitchId: "pitch", name: "Pitch Main" },
+  gameplaySlots: eventHub.event.gameplaySlots,
+  pitchSlots: eventHub.event.pitchSlots,
+  eventGames: [],
+};
+
+describe("Grant secret UI lifecycle", () => {
+  const originalWindow = globalThis.window;
+  const originalDocument = globalThis.document;
+  const originalNavigator = globalThis.navigator;
+  const originalFetch = globalThis.fetch;
+  const originalActEnvironment = (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean })
+    .IS_REACT_ACT_ENVIRONMENT;
+  let testWindow: Window;
+  let container: HTMLDivElement;
+  let root: Root;
+  let fetchHandler: (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+
+  beforeEach(() => {
+    testWindow = new Window({ url: "http://timer.quadball.app/event-admin?eventId=event" });
+    Object.assign(globalThis, {
+      window: testWindow,
+      document: testWindow.document,
+      navigator: testWindow.navigator,
+      fetch: (input: string | URL | Request, init?: RequestInit) => fetchHandler(input, init),
+    });
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+      await Promise.resolve();
+    });
+    container.remove();
+    testWindow.close();
+    Object.assign(globalThis, {
+      window: originalWindow,
+      document: originalDocument,
+      navigator: originalNavigator,
+      fetch: originalFetch,
+    });
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+      originalActEnvironment;
+  });
+
+  test("Event Admin keeps accepted Control rotation secrets when refresh fails", async () => {
+    let hubRequests = 0;
+    let controlLookupCalls = 0;
+    fetchHandler = async (input, init) => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      const method = init?.method ?? "GET";
+      if (url.endsWith("/api/event-admin/admit"))
+        return json({ status: "admitted", sessionExpiresAtMs: 123_000 });
+      if (url.includes("/api/event-admin/hub")) {
+        hubRequests += 1;
+        return hubRequests === 1
+          ? json({ status: "rejected", message: "Authentication failed." }, 401)
+          : json({ status: "accepted", value: eventHub });
+      }
+      if (url.includes("/api/event-admin/pitch-view"))
+        return json({ status: "accepted", value: eventPitchView });
+      if (url.endsWith("/control-grant") && method === "GET") {
+        controlLookupCalls += 1;
+        return controlLookupCalls === 1
+          ? json({
+              status: "accepted",
+              value: {
+                grantId: "control-grant",
+                status: "active",
+                eligibility: "eligible",
+                eventGameId: "game",
+              },
+            })
+          : json({ status: "retryable-failure" }, 503);
+      }
+      if (url.endsWith("/control-grant/code"))
+        return json({
+          status: "accepted",
+          value: {
+            grantId: "control-grant",
+            grantVersion: "v1",
+            state: "present",
+            formatVersion: 1,
+          },
+        });
+      if (url.endsWith("/control-grant/rotate") && method === "POST")
+        return json({
+          status: "accepted",
+          value: {
+            qrCredential: "event-admin-new-qr",
+            code: "alpha-bravo-123",
+            affectedSessionCount: 2,
+          },
+        });
+      if (url.endsWith("/control-grant/sessions"))
+        return json({ status: "retryable-failure" }, 503);
+      throw new Error(`Unexpected request: ${method} ${url}`);
+    };
+
+    await render(<EventAdminPage qrRenderer={async (credential) => `data:${credential}`} />);
+    await admitEventAdmin();
+    await clickButton("Pitch Main");
+    await clickButton("Inspect Control Grant");
+    await clickButton("Rotate Grant");
+
+    expect(container.textContent).toContain("Dictate now: alpha-bravo-123");
+    expect(container.textContent).toContain("2 session(s) revoked");
+    expect(container.querySelector('img[alt="Control Grant QR for Pitch Slot 1"]')).not.toBeNull();
+    expect(container.textContent).toContain("state refresh failed");
+    expect(container.textContent).not.toContain("event-admin-new-qr");
+
+    await clickButton("Change authority");
+    expect(container.querySelector('img[alt="Control Grant QR for Pitch Slot 1"]')).toBeNull();
+    expect(container.textContent).not.toContain("Dictate now: alpha-bravo-123");
+    await admitEventAdmin();
+    expect(container.textContent).not.toContain("Dictate now: alpha-bravo-123");
+    expect(container.querySelector('img[alt="Control Grant QR for Pitch Slot 1"]')).toBeNull();
+  });
+
+  test("Pitch Manager keeps accepted Control rotation secrets when refresh fails", async () => {
+    let currentCalls = 0;
+    let controlLookupCalls = 0;
+    fetchHandler = async (input, init) => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      const method = init?.method ?? "GET";
+      if (url.endsWith("/api/pitch-manager/current")) {
+        currentCalls += 1;
+        return currentCalls === 2
+          ? json({ status: "rejected", message: "Authentication failed." }, 401)
+          : json({ status: "accepted", value: pitchManagerView });
+      }
+      if (url.endsWith("/api/pitch-manager/admit")) return json({ status: "admitted" });
+      if (url.endsWith("/api/pitch-manager/leave")) return json({ status: "left" });
+      if (url.endsWith("/control-grant") && method === "GET") {
+        controlLookupCalls += 1;
+        return controlLookupCalls === 1
+          ? json({
+              status: "accepted",
+              value: {
+                grantId: "control-grant",
+                status: "active",
+                eligibility: "eligible",
+                eventGameId: "game",
+              },
+            })
+          : json({ status: "retryable-failure" }, 503);
+      }
+      if (url.endsWith("/control-grant/code"))
+        return json({
+          status: "accepted",
+          value: {
+            grantId: "control-grant",
+            grantVersion: "v1",
+            state: "present",
+            formatVersion: 1,
+          },
+        });
+      if (url.endsWith("/control-grant/rotate") && method === "POST")
+        return json({
+          status: "accepted",
+          value: {
+            qrCredential: "pitch-manager-new-qr",
+            code: "charlie-delta-456",
+            affectedSessionCount: 3,
+          },
+        });
+      if (url.endsWith("/control-grant/sessions"))
+        return json({ status: "retryable-failure" }, 503);
+      throw new Error(`Unexpected request: ${method} ${url}`);
+    };
+
+    await render(<PitchManagerPage qrRenderer={async (credential) => `data:${credential}`} />);
+    await clickButton("Inspect Control Grant");
+    await clickButton("Rotate Grant");
+
+    expect(container.textContent).toContain("Dictate now: charlie-delta-456");
+    expect(container.textContent).toContain("3 session(s) revoked");
+    expect(container.querySelector('img[alt="Control Grant QR for Pitch Slot 1"]')).not.toBeNull();
+    expect(container.textContent).toContain("state refresh failed");
+    expect(container.textContent).not.toContain("pitch-manager-new-qr");
+
+    await clickButton("Leave");
+    expect(container.querySelector('img[alt="Control Grant QR for Pitch Slot 1"]')).toBeNull();
+    expect(container.textContent).not.toContain("Dictate now: charlie-delta-456");
+    const reAdmissionInput = container.querySelector(
+      "input#pitch-manager-grant-code",
+    ) as HTMLInputElement;
+    await act(async () => {
+      setInputValue(reAdmissionInput, "new-manager-code");
+      await flush();
+    });
+    await clickButton("Open Pitch");
+    expect(container.textContent).not.toContain("Dictate now: charlie-delta-456");
+    expect(container.querySelector('img[alt="Control Grant QR for Pitch Slot 1"]')).toBeNull();
+  });
+
+  test("Pitch Manager ignores a pending Control render after Leave", async () => {
+    const pendingRender = deferred<string>();
+    let currentCalls = 0;
+    fetchHandler = async (input, init) => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      const method = init?.method ?? "GET";
+      if (url.endsWith("/api/pitch-manager/current")) {
+        currentCalls += 1;
+        return currentCalls === 1
+          ? json({ status: "accepted", value: pitchManagerView })
+          : json({ status: "rejected" }, 401);
+      }
+      if (url.endsWith("/api/pitch-manager/leave")) return json({ status: "left" });
+      if (url.endsWith("/control-grant") && method === "GET")
+        return json({
+          status: "accepted",
+          value: {
+            grantId: "control-grant",
+            status: "active",
+            eligibility: "eligible",
+            eventGameId: "game",
+          },
+        });
+      if (url.endsWith("/control-grant/code"))
+        return json({
+          status: "accepted",
+          value: {
+            grantId: "control-grant",
+            grantVersion: "v1",
+            state: "present",
+            formatVersion: 1,
+          },
+        });
+      if (url.endsWith("/control-grant/rotate") && method === "POST")
+        return json({
+          status: "accepted",
+          value: {
+            qrCredential: "stale-pm-qr",
+            code: "stale-pm-code",
+            affectedSessionCount: 8,
+          },
+        });
+      if (url.endsWith("/control-grant/sessions")) return json({ status: "accepted", value: [] });
+      throw new Error(`Unexpected request: ${method} ${url}`);
+    };
+
+    await render(<PitchManagerPage qrRenderer={async () => pendingRender.promise} />);
+    await clickButton("Inspect Control Grant");
+    await clickButton("Rotate Grant");
+    await clickButton("Leave");
+
+    pendingRender.resolve("data:stale-pm-qr");
+    await flushAct();
+
+    expect(container.textContent).not.toContain("stale-pm-code");
+    expect(container.textContent).not.toContain("8 session(s) revoked");
+    expect(container.querySelector('img[alt="Control Grant QR for Pitch Slot 1"]')).toBeNull();
+  });
+
+  test("Event Admin ignores a pending Control render after authority change", async () => {
+    const pendingRender = deferred<string>();
+    let hubCalls = 0;
+    fetchHandler = async (input, init) => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      const method = init?.method ?? "GET";
+      if (url.endsWith("/api/event-admin/admit"))
+        return json({ status: "admitted", sessionExpiresAtMs: 123_000 });
+      if (url.includes("/api/event-admin/hub")) {
+        hubCalls += 1;
+        return hubCalls === 1
+          ? json({ status: "rejected", message: "Authentication failed." }, 401)
+          : json({ status: "accepted", value: eventHub });
+      }
+      if (url.includes("/api/event-admin/pitch-view"))
+        return json({ status: "accepted", value: eventPitchView });
+      if (url.endsWith("/control-grant") && method === "GET")
+        return json({
+          status: "accepted",
+          value: {
+            grantId: "control-grant",
+            status: "active",
+            eligibility: "eligible",
+            eventGameId: "game",
+          },
+        });
+      if (url.endsWith("/control-grant/code"))
+        return json({
+          status: "accepted",
+          value: {
+            grantId: "control-grant",
+            grantVersion: "v1",
+            state: "present",
+            formatVersion: 1,
+          },
+        });
+      if (url.endsWith("/control-grant/rotate") && method === "POST")
+        return json({
+          status: "accepted",
+          value: {
+            qrCredential: "stale-ea-qr",
+            code: "stale-ea-code",
+            affectedSessionCount: 9,
+          },
+        });
+      if (url.endsWith("/control-grant/sessions")) return json({ status: "accepted", value: [] });
+      throw new Error(`Unexpected request: ${method} ${url}`);
+    };
+
+    await render(<EventAdminPage qrRenderer={async () => pendingRender.promise} />);
+    await admitEventAdmin();
+    await clickButton("Pitch Main");
+    await clickButton("Inspect Control Grant");
+    await clickButton("Rotate Grant");
+    await clickButton("Change authority");
+
+    pendingRender.resolve("data:stale-ea-qr");
+    await flushAct();
+
+    expect(container.textContent).not.toContain("stale-ea-code");
+    expect(container.textContent).not.toContain("9 session(s) revoked");
+    expect(container.querySelector('img[alt="Control Grant QR for Pitch Slot 1"]')).toBeNull();
+  });
+
+  test("Pitch Manager ignores stale session reload after Leave and re-admission", async () => {
+    const pendingRevoke = deferred<Response>();
+    let currentCalls = 0;
+    let sessionCalls = 0;
+    fetchHandler = async (input, init) => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      const method = init?.method ?? "GET";
+      if (url.endsWith("/api/pitch-manager/current")) {
+        currentCalls += 1;
+        return currentCalls === 2
+          ? json({ status: "rejected" }, 401)
+          : json({ status: "accepted", value: pitchManagerView });
+      }
+      if (url.endsWith("/api/pitch-manager/admit")) return json({ status: "admitted" });
+      if (url.endsWith("/api/pitch-manager/leave")) return json({ status: "left" });
+      if (url.endsWith("/control-grant") && method === "GET")
+        return json({
+          status: "accepted",
+          value: {
+            grantId: "control-grant",
+            status: "active",
+            eligibility: "eligible",
+            eventGameId: "game",
+          },
+        });
+      if (url.endsWith("/control-grant/code"))
+        return json({
+          status: "accepted",
+          value: {
+            grantId: "control-grant",
+            grantVersion: "v1",
+            state: "present",
+            formatVersion: 1,
+          },
+        });
+      if (url.endsWith("/control-grant/sessions") && method === "GET")
+        return json({
+          status: "accepted",
+          value:
+            sessionCalls++ === 0
+              ? [
+                  {
+                    label: "initial-session",
+                    createdAtMs: 1,
+                    lastActiveAtMs: 2,
+                    deviceClass: "x",
+                    browserClass: "y",
+                  },
+                ]
+              : [
+                  {
+                    label: "stale-session",
+                    createdAtMs: 1,
+                    lastActiveAtMs: 2,
+                    deviceClass: "x",
+                    browserClass: "y",
+                  },
+                ],
+        });
+      if (url.endsWith("/control-grant/sessions/revoke") && method === "POST")
+        return pendingRevoke.promise;
+      throw new Error(`Unexpected request: ${method} ${url}`);
+    };
+
+    await render(<PitchManagerPage qrRenderer={async (credential) => `data:${credential}`} />);
+    await clickButton("Inspect Control Grant");
+    await clickButton("Sessions");
+    await clickButton("Revoke");
+    await clickButton("Leave");
+    const reAdmissionInput = container.querySelector(
+      "input#pitch-manager-grant-code",
+    ) as HTMLInputElement;
+    await act(async () => {
+      setInputValue(reAdmissionInput, "new-manager-code");
+      await flush();
+    });
+    await clickButton("Open Pitch");
+
+    pendingRevoke.resolve(json({ status: "accepted" }));
+    await flushAct();
+
+    expect(container.textContent).not.toContain("stale-session");
+    expect(container.textContent).not.toContain("Control session revocation failed.");
+  });
+
+  test("Event Admin ignores stale session reload after authority change and re-admission", async () => {
+    const pendingRevoke = deferred<Response>();
+    let hubCalls = 0;
+    let sessionCalls = 0;
+    fetchHandler = async (input, init) => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      const method = init?.method ?? "GET";
+      if (url.endsWith("/api/event-admin/admit"))
+        return json({ status: "admitted", sessionExpiresAtMs: 123_000 });
+      if (url.includes("/api/event-admin/hub")) {
+        hubCalls += 1;
+        return hubCalls === 1
+          ? json({ status: "rejected", message: "Authentication failed." }, 401)
+          : json({ status: "accepted", value: eventHub });
+      }
+      if (url.includes("/api/event-admin/pitch-view"))
+        return json({ status: "accepted", value: eventPitchView });
+      if (url.endsWith("/control-grant") && method === "GET")
+        return json({
+          status: "accepted",
+          value: {
+            grantId: "control-grant",
+            status: "active",
+            eligibility: "eligible",
+            eventGameId: "game",
+          },
+        });
+      if (url.endsWith("/control-grant/code"))
+        return json({
+          status: "accepted",
+          value: {
+            grantId: "control-grant",
+            grantVersion: "v1",
+            state: "present",
+            formatVersion: 1,
+          },
+        });
+      if (url.endsWith("/control-grant/sessions") && method === "GET")
+        return json({
+          status: "accepted",
+          value:
+            sessionCalls++ === 0
+              ? [{ label: "initial-event-session", deviceClass: "x", browserClass: "y" }]
+              : [{ label: "stale-event-session", deviceClass: "x", browserClass: "y" }],
+        });
+      if (url.endsWith("/control-grant/sessions/revoke") && method === "POST")
+        return pendingRevoke.promise;
+      throw new Error(`Unexpected request: ${method} ${url}`);
+    };
+
+    await render(<EventAdminPage qrRenderer={async (credential) => `data:${credential}`} />);
+    await admitEventAdmin();
+    await clickButton("Pitch Main");
+    await clickButton("Inspect Control Grant");
+    await clickButton("Sessions");
+    await clickButton("Revoke");
+    await clickButton("Change authority");
+    pendingRevoke.resolve(json({ status: "accepted" }));
+    await flushAct();
+    await admitEventAdmin();
+    await clickButton("Pitch Main");
+
+    expect(container.textContent).not.toContain("stale-event-session");
+    expect(container.textContent).not.toContain("Control session revocation failed.");
+  });
+
+  test("Event Admin ignores stale Hub success after day transition and authority change", async () => {
+    const pendingHub = deferred<Response>();
+    let hubCalls = 0;
+    fetchHandler = async (input) => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      if (url.includes("/api/event-admin/hub")) {
+        hubCalls += 1;
+        return hubCalls === 1
+          ? json({ status: "accepted", value: twoDayEventHub })
+          : pendingHub.promise;
+      }
+      throw new Error(`Unexpected Hub request: ${url}`);
+    };
+
+    await render(<EventAdminPage />);
+    const gameDaySelector = container.querySelector(
+      "select#game-day-selector",
+    ) as HTMLSelectElement;
+    await act(async () => {
+      setSelectValue(gameDaySelector, "day-two");
+      await flush();
+    });
+    await clickButton("Change authority");
+
+    pendingHub.resolve(json({ status: "accepted", value: twoDayEventHub }));
+    await flushAct();
+
+    expect(container.querySelector("input#event-admin-credential")).not.toBeNull();
+    expect(container.textContent).not.toContain("day-two");
+  });
+
+  test("Event Admin ignores stale Hub rejection after day transition and authority change", async () => {
+    const pendingHub = deferred<Response>();
+    let hubCalls = 0;
+    fetchHandler = async (input) => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      if (url.includes("/api/event-admin/hub")) {
+        hubCalls += 1;
+        return hubCalls === 1
+          ? json({ status: "accepted", value: twoDayEventHub })
+          : pendingHub.promise;
+      }
+      throw new Error(`Unexpected Hub request: ${url}`);
+    };
+
+    await render(<EventAdminPage />);
+    const gameDaySelector = container.querySelector(
+      "select#game-day-selector",
+    ) as HTMLSelectElement;
+    await act(async () => {
+      setSelectValue(gameDaySelector, "day-two");
+      await flush();
+    });
+    await clickButton("Change authority");
+
+    pendingHub.resolve(json({ status: "retryable-failure" }, 503));
+    await flushAct();
+
+    expect(container.querySelector("input#event-admin-credential")).not.toBeNull();
+    expect(container.textContent).not.toContain("Unable to open the Event Hub.");
+  });
+
+  test("Event Admin ignores stale Event A Hub success after typing Event B", async () => {
+    const pendingHub = deferred<Response>();
+    let hubCalls = 0;
+    let lastHubUrl = "";
+    fetchHandler = async (input) => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      if (!url.includes("/api/event-admin/hub")) throw new Error(`Unexpected request: ${url}`);
+      lastHubUrl = url;
+      hubCalls += 1;
+      if (hubCalls === 1) return pendingHub.promise;
+      return json({ status: "accepted", value: eventBHub });
+    };
+
+    await render(<EventAdminPage />);
+    await typeEventId("event-b");
+    pendingHub.resolve(json({ status: "accepted", value: eventHub }));
+    await flushAct();
+
+    expect(container.querySelector("input#event-admin-credential")).not.toBeNull();
+    expect((container.querySelector("input#event-id") as HTMLInputElement).value).toBe("event-b");
+    await clickButton("Open as Technical Admin");
+    expect(lastHubUrl).toContain("eventId=event-b");
+    expect(container.textContent).toContain("Event BUTC");
+  });
+
+  test("Event Admin ignores stale Event A Hub failure after typing Event B", async () => {
+    const pendingHub = deferred<Response>();
+    let hubCalls = 0;
+    let lastHubUrl = "";
+    fetchHandler = async (input) => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      if (!url.includes("/api/event-admin/hub")) throw new Error(`Unexpected request: ${url}`);
+      lastHubUrl = url;
+      hubCalls += 1;
+      if (hubCalls === 1) return pendingHub.promise;
+      return json({ status: "accepted", value: eventBHub });
+    };
+
+    await render(<EventAdminPage />);
+    await typeEventId("event-b");
+    pendingHub.resolve(json({ status: "retryable-failure" }, 503));
+    await flushAct();
+
+    expect(container.querySelector("input#event-admin-credential")).not.toBeNull();
+    expect(container.textContent).not.toContain("Unable to open the Event Hub.");
+    await clickButton("Open as Technical Admin");
+    expect(lastHubUrl).toContain("eventId=event-b");
+    expect(container.textContent).toContain("Event BUTC");
+  });
+
+  test("Event Admin keeps Event A admission completion from opening Hub after typing Event B", async () => {
+    const pendingAdmission = deferred<Response>();
+    let hubCalls = 0;
+    let lastHubUrl = "";
+    fetchHandler = async (input, init) => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      const method = init?.method ?? "GET";
+      if (url.endsWith("/api/event-admin/admit") && method === "POST")
+        return pendingAdmission.promise;
+      if (url.includes("/api/event-admin/hub")) {
+        lastHubUrl = url;
+        hubCalls += 1;
+        if (hubCalls === 1) return json({ status: "retryable-failure" }, 503);
+        return json({ status: "accepted", value: eventBHub });
+      }
+      throw new Error(`Unexpected request: ${method} ${url}`);
+    };
+
+    await render(<EventAdminPage />);
+    await admitEventAdmin();
+    await typeEventId("event-b");
+    pendingAdmission.resolve(json({ status: "admitted", sessionExpiresAtMs: 123_000 }));
+    await flushAct();
+
+    expect(container.querySelector("input#event-admin-credential")).not.toBeNull();
+    expect(container.textContent).not.toContain("Admission failed.");
+    await clickButton("Open as Technical Admin");
+    expect(lastHubUrl).toContain("eventId=event-b");
+    expect(container.textContent).toContain("Event BUTC");
+  });
+
+  test("Event Admin ignores stale non-accepted Event A admission after typing Event B", async () => {
+    const pendingAdmission = deferred<Response>();
+    let hubCalls = 0;
+    let lastHubUrl = "";
+    fetchHandler = async (input, init) => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      const method = init?.method ?? "GET";
+      if (url.endsWith("/api/event-admin/admit") && method === "POST")
+        return pendingAdmission.promise;
+      if (url.includes("/api/event-admin/hub")) {
+        lastHubUrl = url;
+        hubCalls += 1;
+        if (hubCalls === 1) return json({ status: "retryable-failure" }, 503);
+        return json({ status: "accepted", value: eventBHub });
+      }
+      throw new Error(`Unexpected request: ${method} ${url}`);
+    };
+
+    await render(<EventAdminPage />);
+    await admitEventAdmin();
+    await typeEventId("event-b");
+    pendingAdmission.resolve(json({ status: "retryable-failure" }, 401));
+    await flushAct();
+
+    expect(container.querySelector("input#event-admin-credential")).not.toBeNull();
+    expect(container.textContent).not.toContain("Admission failed.");
+    await clickButton("Open as Technical Admin");
+    expect(lastHubUrl).toContain("eventId=event-b");
+    expect(container.textContent).toContain("Event BUTC");
+  });
+
+  test("Event Admin ignores a stale Event A admission network failure after typing Event B", async () => {
+    const pendingAdmission = deferred<Response>();
+    let hubCalls = 0;
+    let lastHubUrl = "";
+    fetchHandler = async (input, init) => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      const method = init?.method ?? "GET";
+      if (url.endsWith("/api/event-admin/admit") && method === "POST")
+        return pendingAdmission.promise;
+      if (url.includes("/api/event-admin/hub")) {
+        lastHubUrl = url;
+        hubCalls += 1;
+        if (hubCalls === 1) return json({ status: "retryable-failure" }, 503);
+        return json({ status: "accepted", value: eventBHub });
+      }
+      throw new Error(`Unexpected request: ${method} ${url}`);
+    };
+
+    await render(<EventAdminPage />);
+    await admitEventAdmin();
+    await typeEventId("event-b");
+    pendingAdmission.reject(new Error("stale admission network failure"));
+    await flushAct();
+
+    expect(container.querySelector("input#event-admin-credential")).not.toBeNull();
+    expect(container.textContent).not.toContain("Admission failed.");
+    await clickButton("Open as Technical Admin");
+    expect(lastHubUrl).toContain("eventId=event-b");
+    expect(container.textContent).toContain("Event BUTC");
+  });
+
+  test("Event Admin invalidates old Event Control QR rendering after typing Event B", async () => {
+    const pendingRender = deferred<string>();
+    fetchHandler = async (input, init) => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      const method = init?.method ?? "GET";
+      if (url.includes("/api/event-admin/hub"))
+        return json({ status: "accepted", value: eventHub });
+      if (url.includes("/api/event-admin/pitch-view"))
+        return json({ status: "accepted", value: eventPitchView });
+      if (url.endsWith("/control-grant") && method === "GET")
+        return json({
+          status: "accepted",
+          value: {
+            grantId: "control-grant",
+            status: "active",
+            eligibility: "eligible",
+            eventGameId: "game",
+          },
+        });
+      if (url.endsWith("/control-grant/code") && method === "GET")
+        return json({
+          status: "accepted",
+          value: {
+            grantId: "control-grant",
+            grantVersion: "v1",
+            state: "present",
+            formatVersion: 1,
+          },
+        });
+      if (url.endsWith("/control-grant/reveal") && method === "POST")
+        return json({ status: "accepted", value: { qrCredential: "stale-event-a-qr" } });
+      throw new Error(`Unexpected request: ${method} ${url}`);
+    };
+
+    await render(<EventAdminPage qrRenderer={async () => pendingRender.promise} />);
+    await clickButton("Pitch Main");
+    await clickButton("Inspect Control Grant");
+    await clickButton("Reveal QR");
+    await typeEventId("event-b");
+    pendingRender.resolve("data:stale-event-a-qr");
+    await flushAct();
+
+    expect(container.querySelector("input#event-admin-credential")).not.toBeNull();
+    expect(container.querySelector('img[alt="Control Grant QR for Pitch Slot 1"]')).toBeNull();
+    expect(container.textContent).not.toContain("QR reveal failed");
+  });
+
+  test("Event Admin invalidates old Event Control code follow-up after typing Event B", async () => {
+    const pendingCodeProjection = deferred<Response>();
+    let codeReads = 0;
+    fetchHandler = async (input, init) => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      const method = init?.method ?? "GET";
+      if (url.includes("/api/event-admin/hub"))
+        return json({ status: "accepted", value: eventHub });
+      if (url.includes("/api/event-admin/pitch-view"))
+        return json({ status: "accepted", value: eventPitchView });
+      if (url.endsWith("/control-grant") && method === "GET")
+        return json({
+          status: "accepted",
+          value: {
+            grantId: "control-grant",
+            status: "active",
+            eligibility: "eligible",
+            eventGameId: "game",
+          },
+        });
+      if (url.endsWith("/control-grant/code") && method === "GET") {
+        codeReads += 1;
+        if (codeReads === 1)
+          return json({
+            status: "accepted",
+            value: {
+              grantId: "control-grant",
+              grantVersion: "v1",
+              state: "present",
+              formatVersion: 1,
+            },
+          });
+        return pendingCodeProjection.promise;
+      }
+      if (url.endsWith("/control-grant/code") && method === "POST")
+        return json({ status: "accepted", value: { code: "stale-event-a-code" } });
+      throw new Error(`Unexpected request: ${method} ${url}`);
+    };
+
+    await render(<EventAdminPage />);
+    await clickButton("Pitch Main");
+    await clickButton("Inspect Control Grant");
+    await clickButton("Create Radio Code");
+    await typeEventId("event-b");
+    pendingCodeProjection.resolve(
+      json({
+        status: "accepted",
+        value: { grantId: "control-grant", grantVersion: "v1", state: "present", formatVersion: 1 },
+      }),
+    );
+    await flushAct();
+
+    expect(container.querySelector("input#event-admin-credential")).not.toBeNull();
+    expect(container.textContent).not.toContain("Dictate now: stale-event-a-code");
+  });
+
+  test("Event Admin invalidates old Event Control session follow-up after typing Event B", async () => {
+    const pendingSessions = deferred<Response>();
+    let sessionReads = 0;
+    fetchHandler = async (input, init) => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      const method = init?.method ?? "GET";
+      if (url.includes("/api/event-admin/hub"))
+        return json({ status: "accepted", value: eventHub });
+      if (url.includes("/api/event-admin/pitch-view"))
+        return json({ status: "accepted", value: eventPitchView });
+      if (url.endsWith("/control-grant") && method === "GET")
+        return json({
+          status: "accepted",
+          value: {
+            grantId: "control-grant",
+            status: "active",
+            eligibility: "eligible",
+            eventGameId: "game",
+          },
+        });
+      if (url.endsWith("/control-grant/code") && method === "GET")
+        return json({
+          status: "accepted",
+          value: {
+            grantId: "control-grant",
+            grantVersion: "v1",
+            state: "present",
+            formatVersion: 1,
+          },
+        });
+      if (url.endsWith("/control-grant/sessions") && method === "GET") {
+        sessionReads += 1;
+        if (sessionReads === 1)
+          return json({
+            status: "accepted",
+            value: [{ label: "initial-event-session", deviceClass: "x", browserClass: "y" }],
+          });
+        return pendingSessions.promise;
+      }
+      if (url.endsWith("/control-grant/sessions/revoke") && method === "POST")
+        return json({ status: "accepted" });
+      throw new Error(`Unexpected request: ${method} ${url}`);
+    };
+
+    await render(<EventAdminPage />);
+    await clickButton("Pitch Main");
+    await clickButton("Inspect Control Grant");
+    await clickButton("Sessions");
+    await clickButton("Revoke");
+    await typeEventId("event-b");
+    pendingSessions.resolve(
+      json({
+        status: "accepted",
+        value: [{ label: "stale-event-a-session", deviceClass: "x", browserClass: "y" }],
+      }),
+    );
+    await flushAct();
+
+    expect(container.querySelector("input#event-admin-credential")).not.toBeNull();
+    expect(container.textContent).not.toContain("stale-event-a-session");
+  });
+
+  test("Event Admin ignores stale Event A Slot setup after typing Event B", async () => {
+    const pendingSchedule = deferred<Response>();
+    let lastHubUrl = "";
+    fetchHandler = async (input) => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      if (url.includes("/api/event-admin/hub")) {
+        lastHubUrl = url;
+        return url.includes("eventId=event-b")
+          ? json({ status: "accepted", value: eventBHub })
+          : json({ status: "accepted", value: eventHub });
+      }
+      if (url.includes("/api/event-admin/slot-setup")) return pendingSchedule.promise;
+      throw new Error(`Unexpected request: ${url}`);
+    };
+
+    await render(<EventAdminPage />);
+    await clickButton("Refresh Slot setup");
+    await typeEventId("event-b");
+    pendingSchedule.resolve(
+      json({
+        status: "accepted",
+        value: {
+          gameDayId: "day",
+          gameplaySlots: [
+            { ...eventHub.event.gameplaySlots[0], gameplaySlotId: "stale-gameplay", sequence: 77 },
+          ],
+          pitchSlots: [{ ...eventHub.event.pitchSlots[0], pitchSlotId: "stale-slot" }],
+          eventGames: [],
+        },
+      }),
+    );
+    await flushAct();
+
+    expect(container.querySelector("input#event-admin-credential")).not.toBeNull();
+    expect(container.textContent).not.toContain("Slot setup failed");
+    await clickButton("Open as Technical Admin");
+    expect(lastHubUrl).toContain("eventId=event-b");
+    expect(container.textContent).not.toContain("Slot 77");
+  });
+
+  test("Event Admin ignores stale Event A Slot setup failure after typing Event B", async () => {
+    const pendingSchedule = deferred<Response>();
+    let lastHubUrl = "";
+    fetchHandler = async (input) => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      if (url.includes("/api/event-admin/hub")) {
+        lastHubUrl = url;
+        return url.includes("eventId=event-b")
+          ? json({ status: "accepted", value: eventBHub })
+          : json({ status: "accepted", value: eventHub });
+      }
+      if (url.includes("/api/event-admin/slot-setup")) return pendingSchedule.promise;
+      throw new Error(`Unexpected request: ${url}`);
+    };
+
+    await render(<EventAdminPage />);
+    await clickButton("Refresh Slot setup");
+    await typeEventId("event-b");
+    pendingSchedule.resolve(json({ status: "retryable-failure" }, 503));
+    await flushAct();
+
+    expect(container.querySelector("input#event-admin-credential")).not.toBeNull();
+    expect(container.textContent).not.toContain("Unable to load Slot setup.");
+    await clickButton("Open as Technical Admin");
+    expect(lastHubUrl).toContain("eventId=event-b");
+    expect(container.textContent).not.toContain("Unable to load Slot setup.");
+  });
+
+  test("Event Admin ignores stale Event A Pitch view after typing Event B", async () => {
+    const pendingPitchView = deferred<Response>();
+    let lastHubUrl = "";
+    fetchHandler = async (input) => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      if (url.includes("/api/event-admin/hub")) {
+        lastHubUrl = url;
+        return url.includes("eventId=event-b")
+          ? json({ status: "accepted", value: eventBHub })
+          : json({ status: "accepted", value: eventHub });
+      }
+      if (url.includes("/api/event-admin/pitch-view")) return pendingPitchView.promise;
+      throw new Error(`Unexpected request: ${url}`);
+    };
+
+    await render(<EventAdminPage />);
+    await clickButton("Pitch Main");
+    await typeEventId("event-b");
+    pendingPitchView.resolve(
+      json({
+        status: "accepted",
+        value: {
+          pitch: { pitchId: "stale-pitch", name: "Stale Pitch" },
+          gameplaySlots: [
+            { ...eventHub.event.gameplaySlots[0], gameplaySlotId: "stale-gameplay", sequence: 77 },
+          ],
+          pitchSlots: [
+            { ...eventHub.event.pitchSlots[0], pitchSlotId: "stale-slot", sequence: 77 },
+          ],
+          eventGames: [],
+        },
+      }),
+    );
+    await flushAct();
+
+    expect(container.querySelector("input#event-admin-credential")).not.toBeNull();
+    expect(container.textContent).not.toContain("Unable to load Pitch view.");
+    await clickButton("Open as Technical Admin");
+    expect(lastHubUrl).toContain("eventId=event-b");
+    expect(container.textContent).not.toContain("Slot 77");
+  });
+
+  test("Event Admin ignores stale Event A Pitch view failure after typing Event B", async () => {
+    const pendingPitchView = deferred<Response>();
+    let lastHubUrl = "";
+    fetchHandler = async (input) => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      if (url.includes("/api/event-admin/hub")) {
+        lastHubUrl = url;
+        return url.includes("eventId=event-b")
+          ? json({ status: "accepted", value: eventBHub })
+          : json({ status: "accepted", value: eventHub });
+      }
+      if (url.includes("/api/event-admin/pitch-view")) return pendingPitchView.promise;
+      throw new Error(`Unexpected request: ${url}`);
+    };
+
+    await render(<EventAdminPage />);
+    await clickButton("Pitch Main");
+    await typeEventId("event-b");
+    pendingPitchView.resolve(json({ status: "retryable-failure" }, 503));
+    await flushAct();
+
+    expect(container.querySelector("input#event-admin-credential")).not.toBeNull();
+    expect(container.textContent).not.toContain("Unable to load Pitch view.");
+    await clickButton("Open as Technical Admin");
+    expect(lastHubUrl).toContain("eventId=event-b");
+    expect(container.textContent).not.toContain("Unable to load Pitch view.");
+  });
+
+  test("Pitch Manager keeps an accepted Control code Create value through refresh", async () => {
+    let codeState: "present" | "disabled" = "present";
+    fetchHandler = pitchManagerCodeHandler("create", "golf-hotel-123", () => codeState);
+
+    await render(<PitchManagerPage qrRenderer={async (credential) => `data:${credential}`} />);
+    await clickButton("Inspect Control Grant");
+    await clickButton("Create Radio Code");
+
+    expect(container.textContent).toContain("Dictate now: golf-hotel-123");
+    await clickButton("Disable Code");
+    codeState = "disabled";
+    expect(container.textContent).not.toContain("Dictate now: golf-hotel-123");
+  });
+
+  test("Pitch Manager keeps an accepted Control code Replace value through refresh", async () => {
+    let codeState: "present" | "disabled" = "present";
+    fetchHandler = pitchManagerCodeHandler("replace", "india-juliet-456", () => codeState);
+
+    await render(<PitchManagerPage qrRenderer={async (credential) => `data:${credential}`} />);
+    await clickButton("Inspect Control Grant");
+    await clickButton("Replace Code");
+
+    expect(container.textContent).toContain("Dictate now: india-juliet-456");
+    await clickButton("Disable Code");
+    codeState = "disabled";
+    expect(container.textContent).not.toContain("Dictate now: india-juliet-456");
+  });
+
+  test("Pitch Manager ignores stale Create success after Leave and re-admission", async () => {
+    const pending = await beginPendingPitchManagerCode("create", "disabled");
+    pending.resolve(json({ status: "accepted", value: { code: "stale-create-after-readmit" } }));
+    await flushAct();
+
+    expect(container.textContent).not.toContain("stale-create-after-readmit");
+    expect(container.textContent).not.toContain("Grant Code operation failed.");
+    expect(container.textContent).toContain("Radio code: present");
+    expect(container.textContent).not.toContain("Radio code: disabled");
+  });
+
+  test("Pitch Manager ignores stale Replace success after Leave and re-admission", async () => {
+    const pending = await beginPendingPitchManagerCode("replace", "disabled");
+    pending.resolve(json({ status: "accepted", value: { code: "stale-replace-after-readmit" } }));
+    await flushAct();
+
+    expect(container.textContent).not.toContain("stale-replace-after-readmit");
+    expect(container.textContent).not.toContain("Grant Code operation failed.");
+    expect(container.textContent).toContain("Radio code: present");
+    expect(container.textContent).not.toContain("Radio code: disabled");
+  });
+
+  test("Pitch Manager ignores stale Create rejection after Leave and re-admission", async () => {
+    const pending = await beginPendingPitchManagerCode("create", "present");
+    pending.resolve(json({ status: "retryable-failure" }, 503));
+    await flushAct();
+
+    expect(container.textContent).not.toContain("Grant Code operation failed.");
+    expect(container.textContent).toContain("Radio code: present");
+  });
+
+  test("Pitch Manager ignores stale Replace rejection after Leave and re-admission", async () => {
+    const pending = await beginPendingPitchManagerCode("replace", "present");
+    pending.resolve(json({ status: "retryable-failure" }, 503));
+    await flushAct();
+
+    expect(container.textContent).not.toContain("Grant Code operation failed.");
+    expect(container.textContent).toContain("Radio code: present");
+  });
+
+  test("Technical Admin keeps accepted full-rotation secrets through QR render retry and logout", async () => {
+    let renderAttempts = 0;
+    const technicalAdminEvent = {
+      eventId: "event",
+      name: "Event",
+      timeZone: "UTC",
+      lifecycle: "current",
+      gameDays: [],
+    };
+    fetchHandler = async (input, init) => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      const method = init?.method ?? "GET";
+      if (url.endsWith("/api/admin/session"))
+        return json({ authenticated: true, environment: "test", activeSessionCount: 1 });
+      if (url.endsWith("/api/admin/events") && method === "GET")
+        return json({ status: "accepted", value: [technicalAdminEvent] });
+      if (url.endsWith("/api/admin/events/event") && method === "GET")
+        return json({ status: "accepted", value: technicalAdminEvent });
+      if (url.endsWith("/event-admin-grant") && method === "GET")
+        return json({
+          status: "accepted",
+          value: {
+            grantId: "event-admin-grant",
+            grantVersion: "v1",
+            eventId: "event",
+            status: "active",
+            expiresAtMs: null,
+          },
+        });
+      if (url.endsWith("/event-admin-grant/code") && method === "GET")
+        return json({
+          status: "accepted",
+          value: {
+            grantId: "event-admin-grant",
+            grantVersion: "v1",
+            state: "present",
+            formatVersion: 1,
+          },
+        });
+      if (url.endsWith("/event-admin-grant/rotate") && method === "POST")
+        return json({
+          status: "accepted",
+          value: {
+            qrCredential: "technical-admin-new-qr",
+            code: "kilo-lima-789",
+            affectedSessionCount: 4,
+          },
+        });
+      if (url.endsWith("/api/admin/logout") && method === "POST")
+        return json({ status: "accepted" });
+      throw new Error(`Unexpected Technical Admin request: ${method} ${url}`);
+    };
+
+    await render(
+      <TechnicalAdminPage
+        enrollment={false}
+        qrRenderer={async (credential) => {
+          renderAttempts += 1;
+          if (renderAttempts === 1) throw new Error("local encoder failed");
+          return `data:${credential}`;
+        }}
+      />,
+    );
+    await clickButtonContaining("EventUTC · current");
+    await clickButton("Rotate Grant");
+
+    expect(container.textContent).toContain("Dictate now: kilo-lima-789");
+    expect(container.textContent).toContain("Full rotation affected 4 session(s).");
+    expect(container.textContent).toContain("QR render failed");
+    expect(container.textContent).not.toContain("technical-admin-new-qr");
+    expect(container.querySelector('img[alt="Event Admin Grant QR code"]')).toBeNull();
+
+    await clickButton("Retry QR render");
+    expect(renderAttempts).toBe(2);
+    expect(container.querySelector('img[alt="Event Admin Grant QR code"]')).not.toBeNull();
+    expect(container.textContent).toContain("Dictate now: kilo-lima-789");
+    expect(container.textContent).not.toContain("QR render failed");
+
+    await clickButton("Sign out");
+    expect(container.textContent).not.toContain("Dictate now: kilo-lima-789");
+    expect(container.textContent).not.toContain("Full rotation affected 4 session(s).");
+    expect(container.querySelector('img[alt="Event Admin Grant QR code"]')).toBeNull();
+  });
+
+  test("Technical Admin ignores a stale Event A rotation after switching to Event B", async () => {
+    const pendingRender = deferred<string>();
+    const eventA = {
+      eventId: "event-a",
+      name: "Event A",
+      timeZone: "UTC",
+      lifecycle: "current",
+      gameDays: [],
+    };
+    const eventB = {
+      eventId: "event-b",
+      name: "Event B",
+      timeZone: "UTC",
+      lifecycle: "current",
+      gameDays: [],
+    };
+    let eventACodeReads = 0;
+    fetchHandler = async (input, init) => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      const method = init?.method ?? "GET";
+      if (url.endsWith("/api/admin/session"))
+        return json({ authenticated: true, environment: "test", activeSessionCount: 1 });
+      if (url.endsWith("/api/admin/events") && method === "GET")
+        return json({ status: "accepted", value: [eventA, eventB] });
+      const event = url.includes("/events/event-a") ? eventA : eventB;
+      if (url.endsWith(`/${event.eventId}`) && method === "GET")
+        return json({ status: "accepted", value: event });
+      if (url.endsWith("/event-admin-grant") && method === "GET")
+        return json({
+          status: "accepted",
+          value: {
+            grantId: `${event.eventId}-grant`,
+            grantVersion: "v1",
+            eventId: event.eventId,
+            status: "active",
+            expiresAtMs: null,
+          },
+        });
+      if (url.endsWith("/event-admin-grant/code") && method === "GET") {
+        if (event.eventId === "event-a") eventACodeReads += 1;
+        return json({
+          status: "accepted",
+          value: {
+            grantId: `${event.eventId}-grant`,
+            grantVersion: "v1",
+            state: event.eventId === "event-a" && eventACodeReads > 1 ? "disabled" : "present",
+            formatVersion: 1,
+          },
+        });
+      }
+      if (url.endsWith("/event-admin-grant/rotate") && method === "POST")
+        return json({
+          status: "accepted",
+          value: {
+            qrCredential: "event-a-qr",
+            code: "event-a-code",
+            affectedSessionCount: 11,
+          },
+        });
+      throw new Error(`Unexpected Technical Admin request: ${method} ${url}`);
+    };
+
+    await render(
+      <TechnicalAdminPage enrollment={false} qrRenderer={async () => pendingRender.promise} />,
+    );
+    await clickButtonContaining("Event AUTC · current");
+    await clickButton("Rotate Grant");
+    await clickButtonContaining("Event BUTC · current");
+
+    pendingRender.resolve("data:event-a-qr");
+    await flushAct();
+
+    expect(container.textContent).not.toContain("event-a-code");
+    expect(container.textContent).not.toContain("11 session(s)");
+    expect(container.textContent).not.toContain("QR render failed");
+    expect(container.querySelector('img[alt="Event Admin Grant QR code"]')).toBeNull();
+    expect(container.textContent).toContain("Code state: present");
+    const replaceButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent?.trim() === "Replace Code",
+    ) as HTMLButtonElement | undefined;
+    expect(replaceButton?.disabled).toBe(false);
+    expect(eventACodeReads).toBe(1);
+  });
+
+  test("Technical Admin ignores a stale Event A render failure after switching to Event B", async () => {
+    const pendingRender = deferred<string>();
+    const eventA = {
+      eventId: "event-a",
+      name: "Event A",
+      timeZone: "UTC",
+      lifecycle: "current",
+      gameDays: [],
+    };
+    const eventB = {
+      eventId: "event-b",
+      name: "Event B",
+      timeZone: "UTC",
+      lifecycle: "current",
+      gameDays: [],
+    };
+    fetchHandler = async (input, init) => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      const method = init?.method ?? "GET";
+      if (url.endsWith("/api/admin/session"))
+        return json({ authenticated: true, environment: "test", activeSessionCount: 1 });
+      if (url.endsWith("/api/admin/events") && method === "GET")
+        return json({ status: "accepted", value: [eventA, eventB] });
+      const event = url.includes("/events/event-a") ? eventA : eventB;
+      if (url.endsWith(`/${event.eventId}`) && method === "GET")
+        return json({ status: "accepted", value: event });
+      if (url.endsWith("/event-admin-grant") && method === "GET")
+        return json({
+          status: "accepted",
+          value: {
+            grantId: `${event.eventId}-grant`,
+            grantVersion: "v1",
+            eventId: event.eventId,
+            status: "active",
+            expiresAtMs: null,
+          },
+        });
+      if (url.endsWith("/event-admin-grant/code") && method === "GET")
+        return json({
+          status: "accepted",
+          value: {
+            grantId: `${event.eventId}-grant`,
+            grantVersion: "v1",
+            state: "present",
+            formatVersion: 1,
+          },
+        });
+      if (url.endsWith("/event-admin-grant/rotate") && method === "POST")
+        return json({
+          status: "accepted",
+          value: {
+            qrCredential: "event-a-qr-failure",
+            code: "event-a-code-failure",
+            affectedSessionCount: 12,
+          },
+        });
+      throw new Error(`Unexpected Technical Admin request: ${method} ${url}`);
+    };
+
+    await render(
+      <TechnicalAdminPage enrollment={false} qrRenderer={async () => pendingRender.promise} />,
+    );
+    await clickButtonContaining("Event AUTC · current");
+    await clickButton("Rotate Grant");
+    await clickButtonContaining("Event BUTC · current");
+
+    pendingRender.reject(new Error("stale render failure"));
+    await flushAct();
+
+    expect(container.textContent).not.toContain("event-a-code-failure");
+    expect(container.textContent).not.toContain("12 session(s)");
+    expect(container.textContent).not.toContain("QR render failed");
+    expect(container.querySelector('img[alt="Event Admin Grant QR code"]')).toBeNull();
+  });
+
+  test("Technical Admin ignores stale Event A rotation rejection after switching to Event B", async () => {
+    const pendingRotation = await beginPendingTechnicalRotation();
+    pendingRotation.resolve(json({ status: "retryable-failure" }, 503));
+    await flushAct();
+
+    expect(container.textContent).toContain("Event Bevent-b · UTC");
+    expect(container.textContent).not.toContain("Event catalog operation failed.");
+    expect(container.textContent).not.toContain("Authentication failed.");
+  });
+
+  test("Technical Admin ignores stale Event A rotation network error after switching to Event B", async () => {
+    const pendingRotation = await beginPendingTechnicalRotation();
+    pendingRotation.reject(new Error("stale rotation network failure"));
+    await flushAct();
+
+    expect(container.textContent).toContain("Event Bevent-b · UTC");
+    expect(container.textContent).not.toContain("Event catalog operation failed.");
+    expect(container.textContent).not.toContain("Authentication failed.");
+  });
+
+  test("retains the accepted code and credential for a local QR render retry", async () => {
+    let renderAttempts = 0;
+    fetchHandler = async (input, init) => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      const method = init?.method ?? "GET";
+      if (url.endsWith("/api/pitch-manager/current"))
+        return json({ status: "accepted", value: pitchManagerView });
+      if (url.endsWith("/control-grant") && method === "GET")
+        return json({
+          status: "accepted",
+          value: {
+            grantId: "control-grant",
+            status: "active",
+            eligibility: "eligible",
+            eventGameId: "game",
+          },
+        });
+      if (url.endsWith("/control-grant/code"))
+        return json({
+          status: "accepted",
+          value: {
+            grantId: "control-grant",
+            grantVersion: "v1",
+            state: "present",
+            formatVersion: 1,
+          },
+        });
+      if (url.endsWith("/control-grant/rotate") && method === "POST")
+        return json({
+          status: "accepted",
+          value: {
+            qrCredential: "retryable-qr",
+            code: "echo-foxtrot-789",
+            affectedSessionCount: 1,
+          },
+        });
+      if (url.endsWith("/control-grant/sessions")) return json({ status: "accepted", value: [] });
+      throw new Error(`Unexpected request: ${method} ${url}`);
+    };
+
+    await render(
+      <PitchManagerPage
+        qrRenderer={async (credential) => {
+          renderAttempts += 1;
+          if (renderAttempts === 1) throw new Error("local encoder failed");
+          return `data:${credential}`;
+        }}
+      />,
+    );
+    await clickButton("Inspect Control Grant");
+    await clickButton("Rotate Grant");
+
+    expect(container.textContent).toContain("Dictate now: echo-foxtrot-789");
+    expect(container.textContent).toContain("QR render failed");
+    expect(container.querySelector('img[alt="Control Grant QR for Pitch Slot 1"]')).toBeNull();
+    await clickButton("Retry QR render");
+    expect(container.querySelector('img[alt="Control Grant QR for Pitch Slot 1"]')).not.toBeNull();
+    expect(renderAttempts).toBe(2);
+  });
+
+  async function render(element: ReactElement) {
+    await act(async () => {
+      root.render(element);
+      await flush();
+    });
+  }
+
+  async function admitEventAdmin() {
+    const input = container.querySelector("input#event-admin-credential") as HTMLInputElement;
+    await act(async () => {
+      setInputValue(input, "event-admin-qr");
+      await flush();
+    });
+    await clickButton("Admit Event Admin");
+  }
+
+  async function typeEventId(value: string) {
+    const input = container.querySelector("input#event-id") as HTMLInputElement;
+    await act(async () => {
+      setInputValue(input, value);
+      await flush();
+    });
+  }
+
+  async function clickButton(label: string) {
+    const button = Array.from(container.querySelectorAll("button")).find(
+      (candidate) => candidate.textContent?.trim() === label && !candidate.disabled,
+    );
+    if (button === undefined)
+      throw new Error(
+        `Missing enabled button: ${label}; text=${container.textContent}; inputs=${Array.from(
+          container.querySelectorAll("input"),
+        )
+          .map((input) => `${input.id}=${input.value}`)
+          .join(",")}`,
+      );
+    await act(async () => {
+      button.click();
+      await flush();
+    });
+  }
+
+  async function clickButtonContaining(label: string) {
+    const button = Array.from(container.querySelectorAll("button")).find(
+      (candidate) => candidate.textContent?.includes(label) && !candidate.disabled,
+    );
+    if (button === undefined) throw new Error(`Missing enabled button containing: ${label}`);
+    await act(async () => {
+      button.click();
+      await flush();
+    });
+  }
+
+  function setInputValue(input: HTMLInputElement, value: string) {
+    const setter = Object.getOwnPropertyDescriptor(
+      testWindow.HTMLInputElement.prototype,
+      "value",
+    )?.set;
+    setter?.call(input, value);
+    input.dispatchEvent(new testWindow.Event("input", { bubbles: true }) as unknown as Event);
+    input.dispatchEvent(new testWindow.Event("change", { bubbles: true }) as unknown as Event);
+  }
+
+  function setSelectValue(select: HTMLSelectElement, value: string) {
+    const setter = Object.getOwnPropertyDescriptor(
+      testWindow.HTMLSelectElement.prototype,
+      "value",
+    )?.set;
+    setter?.call(select, value);
+    select.dispatchEvent(new testWindow.Event("change", { bubbles: true }) as unknown as Event);
+  }
+
+  function pitchManagerCodeHandler(
+    operation: "create" | "replace",
+    code: string,
+    readCodeState: () => "present" | "disabled",
+  ) {
+    return async (input: string | URL | Request, init?: RequestInit) => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      const method = init?.method ?? "GET";
+      if (url.endsWith("/api/pitch-manager/current"))
+        return json({ status: "accepted", value: pitchManagerView });
+      if (url.endsWith("/control-grant") && method === "GET")
+        return json({
+          status: "accepted",
+          value: {
+            grantId: "control-grant",
+            status: "active",
+            eligibility: "eligible",
+            eventGameId: "game",
+          },
+        });
+      if (url.endsWith("/control-grant/code/disable") && method === "POST")
+        return json({ status: "accepted", value: { status: "updated" } });
+      if (url.endsWith(`/control-grant/code/${operation}`) && method === "POST")
+        return json({ status: "accepted", value: { code } });
+      if (url.endsWith("/control-grant/code") && method === "POST")
+        return json({ status: "accepted", value: { code } });
+      if (url.endsWith("/control-grant/code") && method === "GET")
+        return json({
+          status: "accepted",
+          value: {
+            grantId: "control-grant",
+            grantVersion: "v1",
+            state: readCodeState(),
+            formatVersion: 1,
+          },
+        });
+      throw new Error(`Unexpected ${operation} request: ${method} ${url}`);
+    };
+  }
+
+  async function beginPendingPitchManagerCode(
+    operation: "create" | "replace",
+    staleProjectionState: "present" | "disabled",
+  ) {
+    const pending = deferred<Response>();
+    let currentCalls = 0;
+    let codeReads = 0;
+    fetchHandler = async (input, init) => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      const method = init?.method ?? "GET";
+      if (url.endsWith("/api/pitch-manager/current")) {
+        currentCalls += 1;
+        return currentCalls === 2
+          ? json({ status: "rejected" }, 401)
+          : json({ status: "accepted", value: pitchManagerView });
+      }
+      if (url.endsWith("/api/pitch-manager/admit")) return json({ status: "admitted" });
+      if (url.endsWith("/api/pitch-manager/leave")) return json({ status: "left" });
+      if (url.endsWith("/control-grant") && method === "GET")
+        return json({
+          status: "accepted",
+          value: {
+            grantId: "control-grant",
+            status: "active",
+            eligibility: "eligible",
+            eventGameId: "game",
+          },
+        });
+      if (
+        method === "POST" &&
+        (url.endsWith("/control-grant/code") || url.endsWith(`/control-grant/code/${operation}`))
+      )
+        return pending.promise;
+      if (url.endsWith("/control-grant/code") && method === "GET") {
+        codeReads += 1;
+        return json({
+          status: "accepted",
+          value: {
+            grantId: "control-grant",
+            grantVersion: "v1",
+            state: codeReads === 1 ? "present" : staleProjectionState,
+            formatVersion: 1,
+          },
+        });
+      }
+      throw new Error(`Unexpected ${operation} request: ${method} ${url}`);
+    };
+
+    await render(<PitchManagerPage qrRenderer={async (credential) => `data:${credential}`} />);
+    await clickButton("Inspect Control Grant");
+    await clickButton(operation === "create" ? "Create Radio Code" : "Replace Code");
+    await clickButton("Leave");
+
+    const reAdmissionInput = container.querySelector(
+      "input#pitch-manager-grant-code",
+    ) as HTMLInputElement;
+    await act(async () => {
+      setInputValue(reAdmissionInput, "new-manager-code");
+      await flush();
+    });
+    await clickButton("Open Pitch");
+    return pending;
+  }
+
+  async function beginPendingTechnicalRotation() {
+    const pending = deferred<Response>();
+    const eventA = {
+      eventId: "event-a",
+      name: "Event A",
+      timeZone: "UTC",
+      lifecycle: "current",
+      gameDays: [],
+    };
+    const eventB = {
+      eventId: "event-b",
+      name: "Event B",
+      timeZone: "UTC",
+      lifecycle: "current",
+      gameDays: [],
+    };
+    fetchHandler = async (input, init) => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      const method = init?.method ?? "GET";
+      if (url.endsWith("/api/admin/session"))
+        return json({ authenticated: true, environment: "test", activeSessionCount: 1 });
+      if (url.endsWith("/api/admin/events") && method === "GET")
+        return json({ status: "accepted", value: [eventA, eventB] });
+      const event = url.includes("/events/event-a") ? eventA : eventB;
+      if (url.endsWith(`/${event.eventId}`) && method === "GET")
+        return json({ status: "accepted", value: event });
+      if (url.endsWith("/event-admin-grant") && method === "GET")
+        return json({
+          status: "accepted",
+          value: {
+            grantId: `${event.eventId}-grant`,
+            grantVersion: "v1",
+            eventId: event.eventId,
+            status: "active",
+            expiresAtMs: null,
+          },
+        });
+      if (url.endsWith("/event-admin-grant/code") && method === "GET")
+        return json({
+          status: "accepted",
+          value: {
+            grantId: `${event.eventId}-grant`,
+            grantVersion: "v1",
+            state: "present",
+            formatVersion: 1,
+          },
+        });
+      if (url.endsWith("/event-admin-grant/rotate") && method === "POST") return pending.promise;
+      throw new Error(`Unexpected Technical Admin request: ${method} ${url}`);
+    };
+
+    await render(<TechnicalAdminPage enrollment={false} />);
+    await clickButtonContaining("Event AUTC · current");
+    await clickButton("Rotate Grant");
+    await clickButtonContaining("Event BUTC · current");
+    return pending;
+  }
+});
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function json(value: unknown, status = 200): Response {
+  return new Response(JSON.stringify(value), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+async function flush() {
+  for (let index = 0; index < 8; index += 1) await Promise.resolve();
+}
+
+async function flushAct() {
+  await act(async () => {
+    await flush();
+  });
+}

--- a/src/pages/pitch-manager-page.tsx
+++ b/src/pages/pitch-manager-page.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { createGrantSecretOwner, type GrantSecretToken } from "@/lib/grant-secret-owner";
 
 type Scope = {
   eventId: string;
@@ -45,6 +46,13 @@ type ControlGrant = {
   affectedSessionCount?: number;
 };
 
+type GrantCodeProjection = {
+  grantId: string;
+  grantVersion: string;
+  state: "absent" | "present" | "disabled" | "erased";
+  formatVersion: 1 | null;
+};
+
 type ControlSession = {
   label: string;
   createdAtMs: number;
@@ -53,47 +61,135 @@ type ControlSession = {
   browserClass: string;
 };
 
-export function PitchManagerPage() {
+export type GrantQrRenderer = (credential: string) => Promise<string>;
+
+const defaultGrantQrRenderer: GrantQrRenderer = (credential) => QRCode.toDataURL(credential);
+
+export function PitchManagerPage({
+  qrRenderer = defaultGrantQrRenderer,
+}: {
+  qrRenderer?: GrantQrRenderer;
+} = {}) {
   const [credential, setCredential] = useState("");
+  const [grantCode, setGrantCode] = useState("");
   const [scope, setScope] = useState<Scope | null>(null);
   const [view, setView] = useState<View | null>(null);
   const [message, setMessage] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [controlGrants, setControlGrants] = useState<Record<string, ControlGrant | null>>({});
   const [controlQr, setControlQr] = useState<Record<string, string>>({});
+  const [controlCodes, setControlCodes] = useState<Record<string, GrantCodeProjection | null>>({});
+  const [controlCodePlaintexts, setControlCodePlaintexts] = useState<Record<string, string>>({});
   const [controlSessions, setControlSessions] = useState<Record<string, ControlSession[]>>({});
+  const [controlQrCredentials, setControlQrCredentials] = useState<Record<string, string>>({});
+  const [controlRotationCounts, setControlRotationCounts] = useState<Record<string, number>>({});
+  const [secretWarning, setSecretWarning] = useState<string | null>(null);
+  const [secretOwner] = useState(createGrantSecretOwner);
 
-  const loadCurrent = useCallback(async () => {
-    const response = await fetch("/api/pitch-manager/current");
-    const payload = (await response.json()) as { status: string; value?: View };
-    if (!response.ok || payload.status !== "accepted" || payload.value === undefined)
-      throw new Error("Unable to open the Pitch Manager view.");
-    const nextScope: Scope = {
-      eventId: payload.value.eventId,
-      gameDayId: payload.value.gameDayId,
-      gameDayDate: payload.value.gameDayDate,
-      eventTimeZone: payload.value.eventTimeZone,
-      pitchId: payload.value.pitch.pitchId,
-    };
-    setScope(nextScope);
-    setView(payload.value);
-  }, []);
+  const secretScopeKey = (nextScope = scope) =>
+    nextScope === null
+      ? "pitch-manager:admission"
+      : `pitch-manager:${nextScope.eventId}:${nextScope.gameDayId}:${nextScope.pitchId}`;
+
+  const clearGrantSecrets = () => {
+    setCredential("");
+    setGrantCode("");
+    setControlQr({});
+    setControlQrCredentials({});
+    setControlCodePlaintexts({});
+    setControlRotationCounts({});
+    setSecretWarning(null);
+    setMessage(null);
+  };
+
+  const invalidateGrantSecrets = (nextScope = scope) => {
+    secretOwner.invalidate(secretScopeKey(nextScope));
+    clearGrantSecrets();
+  };
+
+  const clearControlGrantSecrets = (pitchSlotId: string) => {
+    setControlQr((current) => {
+      const next = { ...current };
+      delete next[pitchSlotId];
+      return next;
+    });
+    setControlQrCredentials((current) => {
+      const next = { ...current };
+      delete next[pitchSlotId];
+      return next;
+    });
+    setControlCodePlaintexts((current) => {
+      const next = { ...current };
+      delete next[pitchSlotId];
+      return next;
+    });
+    setControlRotationCounts((current) => {
+      const next = { ...current };
+      delete next[pitchSlotId];
+      return next;
+    });
+  };
+
+  useEffect(
+    () => () => {
+      secretOwner.unmount();
+      setCredential("");
+      setGrantCode("");
+      setControlQr({});
+      setControlQrCredentials({});
+      setControlCodePlaintexts({});
+      setControlRotationCounts({});
+      setSecretWarning(null);
+    },
+    [secretOwner],
+  );
+
+  const loadCurrent = useCallback(
+    async (token = secretOwner.capture(secretScopeKey(null))) => {
+      const response = await fetch("/api/pitch-manager/current");
+      const payload = (await response.json()) as { status: string; value?: View };
+      if (!response.ok || payload.status !== "accepted" || payload.value === undefined) {
+        if (secretOwner.current(token)) throw new Error("Unable to open the Pitch Manager view.");
+        return;
+      }
+      if (!secretOwner.current(token)) return;
+      const nextScope: Scope = {
+        eventId: payload.value.eventId,
+        gameDayId: payload.value.gameDayId,
+        gameDayDate: payload.value.gameDayDate,
+        eventTimeZone: payload.value.eventTimeZone,
+        pitchId: payload.value.pitch.pitchId,
+      };
+      secretOwner.commit(token, () => {
+        setScope(nextScope);
+        setView(payload.value!);
+        secretOwner.capture(secretScopeKey(nextScope));
+      });
+    },
+    [secretOwner, scope],
+  );
 
   const admit = async () => {
+    const body =
+      grantCode.length > 0
+        ? { grantCode, deviceClass: "mobile" }
+        : { qrCredential: credential, deviceClass: "mobile" };
+    invalidateGrantSecrets();
+    const token = secretOwner.capture(secretScopeKey(null));
     setBusy(true);
     setMessage(null);
     try {
       const response = await fetch("/api/pitch-manager/admit", {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ qrCredential: credential, deviceClass: "mobile" }),
+        body: JSON.stringify(body),
       });
       const payload = (await response.json()) as { status: string };
       if (!response.ok || payload.status !== "admitted")
-        throw new Error("Unable to admit this Pitch Manager QR.");
-      await loadCurrent();
+        throw new Error("Unable to admit this Pitch Manager credential.");
+      await loadCurrent(token);
     } catch {
-      setMessage("Unable to admit this Pitch Manager QR.");
+      setMessage("Unable to admit this Pitch Manager credential.");
     } finally {
       setBusy(false);
     }
@@ -105,72 +201,232 @@ export function PitchManagerPage() {
   }, [loadCurrent, scope, view]);
 
   const leave = async () => {
+    invalidateGrantSecrets();
+    const token = secretOwner.capture(secretScopeKey(null));
     await fetch("/api/pitch-manager/leave", { method: "POST" });
-    setScope(null);
-    setView(null);
+    secretOwner.commit(token, () => {
+      setScope(null);
+      setView(null);
+    });
   };
 
   const controlGrantUrl = (pitchSlotId: string) =>
     `/api/pitch-manager/events/${scope?.eventId}/game-days/${scope?.gameDayId}/pitches/${scope?.pitchId}/pitch-slots/${pitchSlotId}/control-grant`;
 
-  const inspectControlGrant = async (pitchSlotId: string) => {
-    const response = await fetch(controlGrantUrl(pitchSlotId));
-    const payload = (await response.json()) as { status: string; value?: ControlGrant | null };
-    if (!response.ok || payload.status !== "accepted")
-      throw new Error("Control Grant lookup failed.");
-    setControlGrants((current) => ({ ...current, [pitchSlotId]: payload.value ?? null }));
-    setControlQr((current) => ({ ...current, [pitchSlotId]: "" }));
-    return payload.value ?? null;
+  const controlCodeUrl = (pitchSlotId: string) => `${controlGrantUrl(pitchSlotId)}/code`;
+
+  const inspectControlGrant = async (
+    pitchSlotId: string,
+    preserveSecrets = false,
+    providedToken?: GrantSecretToken,
+  ) => {
+    let token = providedToken;
+    if (!preserveSecrets) {
+      invalidateGrantSecrets();
+      clearControlGrantSecrets(pitchSlotId);
+      token = secretOwner.capture(secretScopeKey());
+    }
+    token ??= secretOwner.capture(secretScopeKey());
+    if (!secretOwner.current(token)) return null;
+    try {
+      const response = await fetch(controlGrantUrl(pitchSlotId));
+      const payload = (await response.json()) as { status: string; value?: ControlGrant | null };
+      if (!response.ok || payload.status !== "accepted")
+        throw new Error("Control Grant lookup failed.");
+      if (!secretOwner.current(token)) return null;
+      secretOwner.commit(token, () =>
+        setControlGrants((current) => ({ ...current, [pitchSlotId]: payload.value ?? null })),
+      );
+      const codeResponse = await fetch(controlCodeUrl(pitchSlotId));
+      const codePayload = (await codeResponse.json()) as {
+        status: string;
+        value?: GrantCodeProjection | null;
+      };
+      if (codeResponse.ok && codePayload.status === "accepted" && secretOwner.current(token)) {
+        const projection = codePayload.value ?? null;
+        secretOwner.commit(token, () => {
+          setControlCodes((current) => ({ ...current, [pitchSlotId]: projection }));
+          if (projection === null || projection.state !== "present")
+            clearControlGrantSecrets(pitchSlotId);
+        });
+      }
+      return payload.value ?? null;
+    } catch (error) {
+      if (secretOwner.current(token)) throw error;
+      return null;
+    }
   };
 
   const createControlGrant = async (pitchSlotId: string) => {
+    invalidateGrantSecrets();
+    const token = secretOwner.capture(secretScopeKey());
     const response = await fetch(controlGrantUrl(pitchSlotId), { method: "POST" });
-    if (!response.ok) throw new Error("Control Grant creation failed.");
-    await inspectControlGrant(pitchSlotId);
+    if (!response.ok) {
+      if (secretOwner.current(token)) throw new Error("Control Grant creation failed.");
+      return;
+    }
+    await inspectControlGrant(pitchSlotId, true, token);
   };
 
   const revealControlGrant = async (pitchSlotId: string) => {
+    invalidateGrantSecrets();
+    const token = secretOwner.capture(secretScopeKey());
     const response = await fetch(`${controlGrantUrl(pitchSlotId)}/reveal`, { method: "POST" });
     const payload = (await response.json()) as {
       status: string;
       value?: { qrCredential?: string };
     };
-    if (!response.ok || payload.status !== "accepted" || payload.value?.qrCredential === undefined)
-      throw new Error("Control Grant QR reveal failed.");
-    const dataUrl = await QRCode.toDataURL(payload.value.qrCredential);
-    setControlQr((current) => ({ ...current, [pitchSlotId]: dataUrl }));
+    if (
+      !response.ok ||
+      payload.status !== "accepted" ||
+      payload.value?.qrCredential === undefined
+    ) {
+      if (secretOwner.current(token)) throw new Error("Control Grant QR reveal failed.");
+      return;
+    }
+    try {
+      const dataUrl = await qrRenderer(payload.value.qrCredential);
+      secretOwner.commit(token, () =>
+        setControlQr((current) => ({ ...current, [pitchSlotId]: dataUrl })),
+      );
+    } catch (error) {
+      if (secretOwner.current(token)) throw error;
+    }
   };
 
-  const loadControlSessions = async (pitchSlotId: string) => {
-    const response = await fetch(`${controlGrantUrl(pitchSlotId)}/sessions`);
-    const payload = (await response.json()) as { status: string; value?: ControlSession[] };
-    if (!response.ok || payload.status !== "accepted") throw new Error("Session list failed.");
-    setControlSessions((current) => ({ ...current, [pitchSlotId]: payload.value ?? [] }));
+  const loadControlSessions = async (pitchSlotId: string, providedToken?: GrantSecretToken) => {
+    const token = providedToken ?? secretOwner.capture(secretScopeKey());
+    if (!secretOwner.current(token)) return;
+    try {
+      const response = await fetch(`${controlGrantUrl(pitchSlotId)}/sessions`);
+      const payload = (await response.json()) as { status: string; value?: ControlSession[] };
+      if (!response.ok || payload.status !== "accepted") throw new Error("Session list failed.");
+      secretOwner.commit(token, () =>
+        setControlSessions((current) => ({ ...current, [pitchSlotId]: payload.value ?? [] })),
+      );
+    } catch (error) {
+      if (secretOwner.current(token)) throw error;
+    }
   };
 
   const rotateControlGrant = async (pitchSlotId: string) => {
-    const response = await fetch(`${controlGrantUrl(pitchSlotId)}/rotate`, { method: "POST" });
-    const payload = (await response.json()) as {
-      status: string;
-      value?: { affectedSessionCount?: number };
-    };
-    if (!response.ok || payload.status !== "accepted")
-      throw new Error("Control Grant rotation failed.");
-    setMessage(
-      `Control Grant rotated; ${payload.value?.affectedSessionCount ?? 0} session(s) revoked.`,
-    );
-    await inspectControlGrant(pitchSlotId);
-    await loadControlSessions(pitchSlotId);
+    invalidateGrantSecrets();
+    const token = secretOwner.capture(secretScopeKey());
+    try {
+      const response = await fetch(`${controlGrantUrl(pitchSlotId)}/rotate`, { method: "POST" });
+      const payload = (await response.json()) as {
+        status: string;
+        value?: { affectedSessionCount?: number; qrCredential?: string; code?: string };
+      };
+      if (!response.ok || payload.status !== "accepted")
+        throw new Error("Control Grant rotation failed.");
+      if (payload.value?.qrCredential === undefined || payload.value.code === undefined)
+        throw new Error("Control Grant rotation did not return replacement credentials.");
+      const { code, qrCredential, affectedSessionCount = 0 } = payload.value;
+      if (
+        !secretOwner.commit(token, () => {
+          setControlQrCredentials((current) => ({ ...current, [pitchSlotId]: qrCredential }));
+          setControlCodePlaintexts((current) => ({ ...current, [pitchSlotId]: code }));
+          setControlRotationCounts((current) => ({
+            ...current,
+            [pitchSlotId]: affectedSessionCount,
+          }));
+          setMessage(
+            `Control Grant fully rotated; ${affectedSessionCount} session(s) revoked. Dictate the new code and scan the new QR now.`,
+          );
+        })
+      )
+        return;
+      await renderControlQr(pitchSlotId, qrCredential, token);
+      if (!secretOwner.current(token)) return;
+      const refreshWarnings: string[] = [];
+      try {
+        await inspectControlGrant(pitchSlotId, true, token);
+      } catch {
+        refreshWarnings.push("Control Grant state refresh failed.");
+      }
+      try {
+        await loadControlSessions(pitchSlotId, token);
+      } catch {
+        refreshWarnings.push("Control session refresh failed.");
+      }
+      if (refreshWarnings.length > 0 && secretOwner.current(token))
+        setSecretWarning(refreshWarnings.join(" ") + " Replacement credentials remain visible.");
+    } catch (error) {
+      if (secretOwner.current(token)) throw error;
+    }
+  };
+
+  const renderControlQr = async (
+    pitchSlotId: string,
+    credential = controlQrCredentials[pitchSlotId],
+    providedToken?: GrantSecretToken,
+  ) => {
+    if (credential === undefined) return;
+    const token = providedToken ?? secretOwner.capture(secretScopeKey());
+    if (!secretOwner.current(token)) return;
+    try {
+      const dataUrl = await qrRenderer(credential);
+      secretOwner.commit(token, () => {
+        setControlQr((current) => ({ ...current, [pitchSlotId]: dataUrl }));
+        setControlQrCredentials((current) => {
+          const next = { ...current };
+          delete next[pitchSlotId];
+          return next;
+        });
+        setSecretWarning((current) => (current?.includes("QR render failed") ? null : current));
+      });
+    } catch {
+      if (secretOwner.current(token))
+        setSecretWarning("Replacement QR render failed. Retry QR render locally.");
+    }
+  };
+
+  const manageControlCode = async (
+    pitchSlotId: string,
+    operation: "create" | "replace" | "disable",
+  ) => {
+    invalidateGrantSecrets();
+    const token = secretOwner.capture(secretScopeKey());
+    try {
+      const response = await fetch(
+        `${controlCodeUrl(pitchSlotId)}${operation === "create" ? "" : `/${operation}`}`,
+        { method: "POST" },
+      );
+      const payload = (await response.json()) as {
+        status: string;
+        value?: GrantCodeProjection & { code?: string };
+      };
+      if (!response.ok || payload.status !== "accepted")
+        throw new Error("Grant Code operation failed.");
+      if (!secretOwner.current(token)) return;
+      if (operation !== "disable" && payload.value?.code !== undefined)
+        secretOwner.commit(token, () =>
+          setControlCodePlaintexts((current) => ({
+            ...current,
+            [pitchSlotId]: payload.value!.code!,
+          })),
+        );
+      await inspectControlGrant(pitchSlotId, operation !== "disable", token);
+    } catch (error) {
+      if (secretOwner.current(token)) throw error;
+    }
   };
 
   const revokeControlSession = async (pitchSlotId: string, label: string) => {
-    const response = await fetch(`${controlGrantUrl(pitchSlotId)}/sessions/revoke`, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ sessionReference: label }),
-    });
-    if (!response.ok) throw new Error("Control session revocation failed.");
-    await loadControlSessions(pitchSlotId);
+    invalidateGrantSecrets();
+    const token = secretOwner.capture(secretScopeKey());
+    try {
+      const response = await fetch(`${controlGrantUrl(pitchSlotId)}/sessions/revoke`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ sessionReference: label }),
+      });
+      if (!response.ok) throw new Error("Control session revocation failed.");
+      await loadControlSessions(pitchSlotId, token);
+    } catch (error) {
+      if (secretOwner.current(token)) throw error;
+    }
   };
 
   if (view === null || scope === null) {
@@ -190,9 +446,29 @@ export function PitchManagerPage() {
                 autoComplete="off"
                 value={credential}
                 onChange={(event) => setCredential(event.target.value)}
+                onInput={(event) => setCredential(event.currentTarget.value)}
               />
             </div>
-            <Button disabled={busy || credential.length === 0} onClick={() => void admit()}>
+            <div className="space-y-2">
+              <Label htmlFor="pitch-manager-grant-code">Radio Grant Code</Label>
+              <Input
+                id="pitch-manager-grant-code"
+                type="password"
+                autoComplete="off"
+                placeholder="two words and three digits"
+                value={grantCode}
+                onChange={(event) => setGrantCode(event.target.value)}
+                onInput={(event) => setGrantCode(event.currentTarget.value)}
+              />
+            </div>
+            <Button
+              disabled={
+                busy ||
+                (credential.length === 0 && grantCode.length === 0) ||
+                (credential.length > 0 && grantCode.length > 0)
+              }
+              onClick={() => void admit()}
+            >
               Open Pitch
             </Button>
             {message ? <p className="text-sm text-destructive">{message}</p> : null}
@@ -305,6 +581,41 @@ export function PitchManagerPage() {
                           >
                             Rotate Grant
                           </Button>
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            onClick={() =>
+                              void manageControlCode(slot.pitchSlotId, "create").catch(() =>
+                                setMessage("Grant Code operation failed."),
+                              )
+                            }
+                          >
+                            Create Radio Code
+                          </Button>
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            disabled={controlCodes[slot.pitchSlotId]?.state !== "present"}
+                            onClick={() =>
+                              void manageControlCode(slot.pitchSlotId, "replace").catch(() =>
+                                setMessage("Grant Code operation failed."),
+                              )
+                            }
+                          >
+                            Replace Code
+                          </Button>
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            disabled={controlCodes[slot.pitchSlotId]?.state !== "present"}
+                            onClick={() =>
+                              void manageControlCode(slot.pitchSlotId, "disable").catch(() =>
+                                setMessage("Grant Code operation failed."),
+                              )
+                            }
+                          >
+                            Disable Code
+                          </Button>
                         </>
                       ) : null}
                     </div>
@@ -314,12 +625,51 @@ export function PitchManagerPage() {
                         {controlGrant.eventGameId ? ` · ${controlGrant.eventGameId}` : ""}
                       </p>
                     ) : null}
+                    {controlRotationCounts[slot.pitchSlotId] !== undefined ? (
+                      <p className="text-xs text-muted-foreground">
+                        Full rotation affected {controlRotationCounts[slot.pitchSlotId]} session(s).
+                      </p>
+                    ) : null}
                     {controlQr[slot.pitchSlotId] ? (
                       <img
                         alt={`Control Grant QR for Pitch Slot ${slot.sequence}`}
                         className="h-40 w-40 rounded border bg-white p-2"
                         src={controlQr[slot.pitchSlotId]}
                       />
+                    ) : null}
+                    {controlQrCredentials[slot.pitchSlotId] ? (
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={() => void renderControlQr(slot.pitchSlotId)}
+                      >
+                        Retry QR render
+                      </Button>
+                    ) : null}
+                    {controlGrant ? (
+                      <p className="text-xs text-muted-foreground">
+                        Radio code: {controlCodes[slot.pitchSlotId]?.state ?? "absent"}
+                      </p>
+                    ) : null}
+                    {controlCodePlaintexts[slot.pitchSlotId] ? (
+                      <div className="flex items-center gap-2 rounded bg-muted p-2">
+                        <p aria-live="polite" className="font-mono text-sm">
+                          Dictate now: {controlCodePlaintexts[slot.pitchSlotId]}
+                        </p>
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() =>
+                            setControlCodePlaintexts((current) => {
+                              const next = { ...current };
+                              delete next[slot.pitchSlotId];
+                              return next;
+                            })
+                          }
+                        >
+                          Clear
+                        </Button>
+                      </div>
                     ) : null}
                     {(controlSessions[slot.pitchSlotId] ?? []).map((session) => (
                       <div
@@ -347,6 +697,7 @@ export function PitchManagerPage() {
               );
             })}
           </div>
+          {secretWarning ? <p className="text-sm text-destructive">{secretWarning}</p> : null}
           {message ? <p className="text-sm text-destructive">{message}</p> : null}
           <Button
             variant="outline"

--- a/src/pages/technical-admin-page.tsx
+++ b/src/pages/technical-admin-page.tsx
@@ -1,10 +1,20 @@
-import { useEffect, useState, type ReactNode } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import QRCode from "qrcode/lib/browser";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { AdministrativeAuditBrowser } from "@/pages/administrative-audit-browser";
+import { createGrantSecretOwner, type GrantSecretToken } from "@/lib/grant-secret-owner";
+
+export type GrantQrRenderer = (credential: string) => Promise<string>;
+
+const defaultGrantQrRenderer: GrantQrRenderer = (credential) =>
+  QRCode.toDataURL(credential, {
+    errorCorrectionLevel: "M",
+    margin: 2,
+    width: 320,
+  });
 
 type AdminSession = {
   authenticated: true;
@@ -12,11 +22,18 @@ type AdminSession = {
   activeSessionCount: number;
 };
 
-export function TechnicalAdminPage({ enrollment }: { enrollment: boolean }) {
+export function TechnicalAdminPage({
+  enrollment,
+  qrRenderer = defaultGrantQrRenderer,
+}: {
+  enrollment: boolean;
+  qrRenderer?: GrantQrRenderer;
+}) {
   const [session, setSession] = useState<AdminSession | null>(null);
   const [enrollmentToken, setEnrollmentToken] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
+  const clearEventAdminSecretsRef = useRef<() => void>(() => undefined);
 
   useEffect(() => {
     if (enrollment) {
@@ -158,6 +175,7 @@ export function TechnicalAdminPage({ enrollment }: { enrollment: boolean }) {
         variant="outline"
         onClick={() =>
           void run(async () => {
+            clearEventAdminSecretsRef.current();
             await adminFetch("/api/admin/logout", {
               method: "POST",
               headers: { "content-type": "application/json" },
@@ -172,6 +190,7 @@ export function TechnicalAdminPage({ enrollment }: { enrollment: boolean }) {
         variant="outline"
         onClick={() =>
           void run(async () => {
+            clearEventAdminSecretsRef.current();
             await completeStepUp("replace-credential");
             const optionsResponse = await adminFetch("/api/admin/replacement/options", {
               method: "POST",
@@ -215,7 +234,7 @@ export function TechnicalAdminPage({ enrollment }: { enrollment: boolean }) {
       >
         Log out other sessions
       </Button>
-      <EventCatalogPanel />
+      <EventCatalogPanel clearSecretsRef={clearEventAdminSecretsRef} qrRenderer={qrRenderer} />
     </AdminCard>
   );
 }
@@ -244,7 +263,20 @@ type EventAdminGrantProjection = {
   expiresAtMs: number | null;
 };
 
-function EventCatalogPanel() {
+type GrantCodeProjection = {
+  grantId: string;
+  grantVersion: string;
+  state: "absent" | "present" | "disabled" | "erased";
+  formatVersion: 1 | null;
+};
+
+function EventCatalogPanel({
+  clearSecretsRef,
+  qrRenderer,
+}: {
+  clearSecretsRef: { current: () => void };
+  qrRenderer: GrantQrRenderer;
+}) {
   const [events, setEvents] = useState<EventProjection[]>([]);
   const [selected, setSelected] = useState<EventProjection | null>(null);
   const [editedName, setEditedName] = useState("");
@@ -255,27 +287,59 @@ function EventCatalogPanel() {
   const [gameDayDate, setGameDayDate] = useState("");
   const [message, setMessage] = useState<string | null>(null);
   const [eventAdminGrant, setEventAdminGrant] = useState<EventAdminGrantProjection | null>(null);
+  const [eventAdminCode, setEventAdminCode] = useState<GrantCodeProjection | null>(null);
+  const [eventAdminCodePlaintext, setEventAdminCodePlaintext] = useState<string | null>(null);
   const [revealedCredential, setRevealedCredential] = useState<string | null>(null);
   const [qrDataUrl, setQrDataUrl] = useState<string | null>(null);
+  const [eventAdminRotationCount, setEventAdminRotationCount] = useState<number | null>(null);
+  const [secretWarning, setSecretWarning] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
+  const [secretOwner] = useState(createGrantSecretOwner);
+
+  const secretScopeKey = (eventId = selected?.eventId) =>
+    `technical-admin:event:${eventId ?? "catalog"}`;
+
+  const clearEventAdminSecrets = () => {
+    setEventAdminCodePlaintext(null);
+    setRevealedCredential(null);
+    setQrDataUrl(null);
+    setEventAdminRotationCount(null);
+    setSecretWarning(null);
+    setMessage(null);
+    secretOwner.invalidate(secretScopeKey());
+  };
 
   useEffect(() => {
-    if (revealedCredential === null) {
-      setQrDataUrl(null);
-      return;
-    }
-    let cancelled = false;
-    void QRCode.toDataURL(revealedCredential, {
-      errorCorrectionLevel: "M",
-      margin: 2,
-      width: 320,
-    }).then((dataUrl) => {
-      if (!cancelled) setQrDataUrl(dataUrl);
-    });
+    clearSecretsRef.current = clearEventAdminSecrets;
     return () => {
-      cancelled = true;
+      secretOwner.unmount();
+      clearEventAdminSecrets();
+      clearSecretsRef.current = () => undefined;
     };
-  }, [revealedCredential]);
+  }, [secretOwner]);
+
+  const renderEventAdminQr = async (
+    credential = revealedCredential,
+    providedToken?: GrantSecretToken,
+  ): Promise<boolean> => {
+    if (credential === null) return false;
+    const token = providedToken ?? secretOwner.capture(secretScopeKey());
+    if (!secretOwner.current(token)) return false;
+    try {
+      const dataUrl = await qrRenderer(credential);
+      if (!secretOwner.current(token)) return false;
+      secretOwner.commit(token, () => {
+        setQrDataUrl(dataUrl);
+        setRevealedCredential(null);
+        setSecretWarning((current) => (current?.includes("QR render failed") ? null : current));
+      });
+      return true;
+    } catch {
+      if (secretOwner.current(token))
+        setSecretWarning("Replacement QR render failed. Retry QR render locally.");
+      return false;
+    }
+  };
 
   const request = async <T,>(url: string, init?: RequestInit) => {
     const response = await adminFetch(url, init);
@@ -286,11 +350,14 @@ function EventCatalogPanel() {
     return payload.value;
   };
 
-  const refresh = async () => {
+  const refresh = async (providedToken?: GrantSecretToken) => {
+    const token = providedToken ?? secretOwner.capture(secretScopeKey());
     const value = await request<readonly EventProjection[]>("/api/admin/events");
+    if (!secretOwner.current(token)) return;
     setEvents([...value]);
     if (selected !== null) {
       const current = await request<EventProjection>(`/api/admin/events/${selected.eventId}`);
+      if (!secretOwner.current(token)) return;
       setSelected(current);
       setEditedName(current.name);
       setEditedTimeZone(current.timeZone);
@@ -300,22 +367,40 @@ function EventCatalogPanel() {
       const grant = await request<EventAdminGrantProjection | null>(
         `/api/admin/events/${current.eventId}/event-admin-grant`,
       );
+      if (!secretOwner.current(token)) return;
       setEventAdminGrant(grant);
+      if (grant === null || grant.status !== "active") clearEventAdminSecrets();
+      const code =
+        grant === null
+          ? null
+          : await request<GrantCodeProjection | null>(
+              `/api/admin/events/${current.eventId}/event-admin-grant/code`,
+            );
+      if (!secretOwner.current(token)) return;
+      setEventAdminCode(code);
+      if (code === null || code.state !== "present") clearEventAdminSecrets();
     }
   };
 
   const selectEvent = async (eventId: string) => {
+    clearEventAdminSecrets();
+    const token = secretOwner.capture(secretScopeKey(eventId));
     const current = await request<EventProjection>(`/api/admin/events/${eventId}`);
+    if (!secretOwner.current(token)) return;
     setSelected(current);
     setEditedName(current.name);
     setEditedTimeZone(current.timeZone);
     setEditedGameDays(Object.fromEntries(current.gameDays.map((day) => [day.gameDayId, day.date])));
-    setEventAdminGrant(
-      await request<EventAdminGrantProjection | null>(
-        `/api/admin/events/${current.eventId}/event-admin-grant`,
-      ),
+    const grant = await request<EventAdminGrantProjection | null>(
+      `/api/admin/events/${current.eventId}/event-admin-grant`,
     );
-    setRevealedCredential(null);
+    if (!secretOwner.current(token)) return;
+    setEventAdminGrant(grant);
+    const code = await request<GrantCodeProjection | null>(
+      `/api/admin/events/${current.eventId}/event-admin-grant/code`,
+    );
+    if (!secretOwner.current(token)) return;
+    setEventAdminCode(code);
   };
 
   useEffect(() => {
@@ -458,6 +543,7 @@ function EventCatalogPanel() {
                   disabled={busy || selected.gameDays.length > 0}
                   onClick={() =>
                     void run(async () => {
+                      clearEventAdminSecrets();
                       await request(`/api/admin/events/${selected.eventId}`, {
                         method: "DELETE",
                         headers: { "x-technical-admin-csrf": "1" },
@@ -473,7 +559,10 @@ function EventCatalogPanel() {
                 </Button>
                 <Button
                   variant="outline"
-                  onClick={() => window.location.assign(`/event-admin?eventId=${selected.eventId}`)}
+                  onClick={() => {
+                    clearEventAdminSecrets();
+                    window.location.assign(`/event-admin?eventId=${selected.eventId}`);
+                  }}
                 >
                   Open Event Hub
                 </Button>
@@ -503,6 +592,7 @@ function EventCatalogPanel() {
                     disabled={busy || eventAdminGrant !== null}
                     onClick={() =>
                       void run(async () => {
+                        clearEventAdminSecrets();
                         setEventAdminGrant(
                           await request<EventAdminGrantProjection>(
                             `/api/admin/events/${selected.eventId}/event-admin-grant`,
@@ -521,6 +611,8 @@ function EventCatalogPanel() {
                     disabled={busy || eventAdminGrant === null}
                     onClick={() =>
                       void run(async () => {
+                        clearEventAdminSecrets();
+                        const token = secretOwner.capture(secretScopeKey(selected.eventId));
                         const response = await adminFetch(
                           `/api/admin/events/${selected.eventId}/event-admin-grant/reveal`,
                           { method: "POST", headers: { "content-type": "application/json" } },
@@ -530,7 +622,13 @@ function EventCatalogPanel() {
                         }>;
                         if (!response.ok || payload.status !== "accepted")
                           throw new Error("Grant reveal failed.");
-                        setRevealedCredential(payload.value.qrCredential);
+                        if (
+                          !secretOwner.commit(token, () =>
+                            setRevealedCredential(payload.value.qrCredential),
+                          )
+                        )
+                          return;
+                        await renderEventAdminQr(payload.value.qrCredential, token);
                       })
                     }
                   >
@@ -541,15 +639,55 @@ function EventCatalogPanel() {
                     disabled={busy || eventAdminGrant?.status !== "active"}
                     onClick={() =>
                       void run(async () => {
-                        await request(
-                          `/api/admin/events/${selected.eventId}/event-admin-grant/rotate`,
-                          {
+                        clearEventAdminSecrets();
+                        const token = secretOwner.capture(secretScopeKey(selected.eventId));
+                        let rotated: {
+                          qrCredential?: string;
+                          code?: string;
+                          affectedSessionCount?: number;
+                        };
+                        try {
+                          rotated = await request<{
+                            qrCredential?: string;
+                            code?: string;
+                            affectedSessionCount?: number;
+                          }>(`/api/admin/events/${selected.eventId}/event-admin-grant/rotate`, {
                             method: "POST",
                             headers: { "content-type": "application/json" },
-                          },
-                        );
-                        setRevealedCredential(null);
-                        await refresh();
+                          });
+                        } catch (error) {
+                          if (secretOwner.current(token)) throw error;
+                          return;
+                        }
+                        if (!secretOwner.current(token)) return;
+                        if (rotated.qrCredential === undefined || rotated.code === undefined)
+                          throw new Error(
+                            "Event Admin rotation did not return replacement credentials.",
+                          );
+                        const { qrCredential, code } = rotated;
+                        if (
+                          !secretOwner.commit(token, () => {
+                            setRevealedCredential(qrCredential);
+                            setEventAdminCodePlaintext(code);
+                            setEventAdminRotationCount(rotated.affectedSessionCount ?? 0);
+                            setMessage(
+                              `Event Admin Grant fully rotated; ${rotated.affectedSessionCount ?? 0} session(s) revoked. Dictate the new code and scan the new QR now.`,
+                            );
+                          })
+                        )
+                          return;
+                        await renderEventAdminQr(qrCredential, token);
+                        if (!secretOwner.current(token)) return;
+                        try {
+                          await refresh(token);
+                        } catch {
+                          if (secretOwner.current(token))
+                            setSecretWarning((current) =>
+                              current === null
+                                ? "Event Admin Grant state refresh failed. Replacement credentials remain visible."
+                                : `${current} Event Admin Grant state refresh failed. Replacement credentials remain visible.`,
+                            );
+                        }
                       })
                     }
                   >
@@ -560,6 +698,7 @@ function EventCatalogPanel() {
                     disabled={busy || eventAdminGrant?.status !== "active"}
                     onClick={() =>
                       void run(async () => {
+                        clearEventAdminSecrets();
                         await request(
                           `/api/admin/events/${selected.eventId}/event-admin-grant/disable`,
                           { method: "POST", headers: { "content-type": "application/json" } },
@@ -575,6 +714,7 @@ function EventCatalogPanel() {
                     disabled={busy || eventAdminGrant?.status !== "active"}
                     onClick={() =>
                       void run(async () => {
+                        clearEventAdminSecrets();
                         await request(
                           `/api/admin/events/${selected.eventId}/event-admin-grant/revoke`,
                           { method: "POST", headers: { "content-type": "application/json" } },
@@ -592,11 +732,11 @@ function EventCatalogPanel() {
                     }
                     onClick={() =>
                       void run(async () => {
+                        clearEventAdminSecrets();
                         await request(
                           `/api/admin/events/${selected.eventId}/event-admin-grant/reactivate`,
                           { method: "POST", headers: { "content-type": "application/json" } },
                         );
-                        setRevealedCredential(null);
                         await refresh();
                       })
                     }
@@ -604,6 +744,108 @@ function EventCatalogPanel() {
                     Reactivate Grant
                   </Button>
                 </div>
+                <div className="space-y-2 rounded-md border border-dashed p-3">
+                  <p className="text-sm font-medium">Radio Grant Code</p>
+                  <p className="text-xs text-muted-foreground">
+                    Technical Admin only. Create or replace returns the code once for immediate
+                    dictation; it is never included in the Grant projection.
+                  </p>
+                  <p className="text-xs">Code state: {eventAdminCode?.state ?? "absent"}</p>
+                  <div className="flex flex-wrap gap-2">
+                    <Button
+                      variant="outline"
+                      disabled={busy || eventAdminGrant?.status !== "active"}
+                      onClick={() =>
+                        void run(async () => {
+                          clearEventAdminSecrets();
+                          const token = secretOwner.capture(secretScopeKey(selected.eventId));
+                          const created = await request<{ code: string }>(
+                            `/api/admin/events/${selected.eventId}/event-admin-grant/code`,
+                            { method: "POST", headers: { "content-type": "application/json" } },
+                          );
+                          if (
+                            !secretOwner.commit(token, () =>
+                              setEventAdminCodePlaintext(created.code),
+                            )
+                          )
+                            return;
+                          const projection = await request<GrantCodeProjection>(
+                            `/api/admin/events/${selected.eventId}/event-admin-grant/code`,
+                          );
+                          secretOwner.commit(token, () => setEventAdminCode(projection));
+                        })
+                      }
+                    >
+                      Create Code
+                    </Button>
+                    <Button
+                      variant="outline"
+                      disabled={busy || eventAdminCode?.state !== "present"}
+                      onClick={() =>
+                        void run(async () => {
+                          clearEventAdminSecrets();
+                          const token = secretOwner.capture(secretScopeKey(selected.eventId));
+                          const created = await request<{ code: string }>(
+                            `/api/admin/events/${selected.eventId}/event-admin-grant/code/replace`,
+                            { method: "POST", headers: { "content-type": "application/json" } },
+                          );
+                          if (
+                            !secretOwner.commit(token, () =>
+                              setEventAdminCodePlaintext(created.code),
+                            )
+                          )
+                            return;
+                          const projection = await request<GrantCodeProjection>(
+                            `/api/admin/events/${selected.eventId}/event-admin-grant/code`,
+                          );
+                          secretOwner.commit(token, () => setEventAdminCode(projection));
+                        })
+                      }
+                    >
+                      Replace Code
+                    </Button>
+                    <Button
+                      variant="outline"
+                      disabled={busy || eventAdminCode?.state !== "present"}
+                      onClick={() =>
+                        void run(async () => {
+                          clearEventAdminSecrets();
+                          const token = secretOwner.capture(secretScopeKey(selected.eventId));
+                          await request(
+                            `/api/admin/events/${selected.eventId}/event-admin-grant/code/disable`,
+                            { method: "POST", headers: { "content-type": "application/json" } },
+                          );
+                          const projection = await request<GrantCodeProjection>(
+                            `/api/admin/events/${selected.eventId}/event-admin-grant/code`,
+                          );
+                          secretOwner.commit(token, () => setEventAdminCode(projection));
+                        })
+                      }
+                    >
+                      Disable Code
+                    </Button>
+                    {eventAdminCodePlaintext ? (
+                      <Button variant="outline" onClick={() => setEventAdminCodePlaintext(null)}>
+                        Clear Dictation
+                      </Button>
+                    ) : null}
+                  </div>
+                  {eventAdminCodePlaintext ? (
+                    <p aria-live="polite" className="rounded bg-muted p-2 font-mono text-lg">
+                      Dictate now: {eventAdminCodePlaintext}
+                    </p>
+                  ) : null}
+                  {eventAdminRotationCount !== null ? (
+                    <p className="text-xs text-muted-foreground">
+                      Full rotation affected {eventAdminRotationCount} session(s).
+                    </p>
+                  ) : null}
+                </div>
+                {secretWarning ? (
+                  <p className="text-sm text-destructive" role="status">
+                    {secretWarning}
+                  </p>
+                ) : null}
                 {qrDataUrl ? (
                   <div className="space-y-2 rounded-md border bg-white p-3">
                     <img
@@ -615,6 +857,11 @@ function EventCatalogPanel() {
                       Scan this protected QR code on the Event Admin device.
                     </p>
                   </div>
+                ) : null}
+                {revealedCredential ? (
+                  <Button variant="outline" onClick={() => void renderEventAdminQr()}>
+                    Retry QR render
+                  </Button>
                 ) : null}
               </div>
               <div className="space-y-2">


### PR DESCRIPTION
## Scope

Implements Spec #105 issue #117, Operate radio Grant Codes, on top of the accepted #116 integration. The change exposes radio Grant Code fallback through Event Administration and exact-scope Pitch Manager workflows while preserving the canonical Foundation, Grant, Event Catalog, and Event Administration interfaces.

## Management and admission

- Technical Admin manages the Event Admin Grant and receives its full-rotation QR plus Grant Code.
- Event Admin manages Pitch Manager and Control Grants within its Event.
- Exact-scope Pitch Manager manages only Control Grants for its Pitch and Game Day.
- Controller may enter a Control Grant QR or Grant Code for admission, exactly one at a time, but never inspects, displays, rotates, or manages credentials.
- Typed admission rejects wrong Grant types and wrong Event, Pitch, Game Day, or Pitch Slot scopes before session, audit, cookie, or foreign-lifecycle mutation.

Create/replace returns one-time Grant Code plaintext only in the accepted response and immediate in-memory dictation UI. Full rotation visibly delivers both replacement QR and Grant Code plus affected-session count exactly once; QR render and follow-up refresh failures are recoverable without another rotation.

## Security and lifecycle

Admission shares canonical expiry policy with QR admission and refreshes only the correct audience cookie with the persisted cap. QR and Grant Code throttles remain independent. Expiry, disable, revoke, replacement, and full rotation preserve session invalidation and generic failure behavior. Sensitive admission responses are no-store/no-referrer; secrets never enter URLs, storage, logs, analytics, audits, diagnostics, or projections.

A shared generation-aware transient owner guards secret, renderer, warning, message, Grant, Hub, session, schedule, and Pitch projections across authority, Event/day/pitch/slot, admission, lifecycle, leave, and unmount transitions. Stale success, parsed failure, network failure, and follow-up completions cannot resurrect old state.

## Exclusions

Controller workflows beyond admission, public Timeline, deployment, Qualification Tests, and other Spec #105 tickets remain out of scope. No migration was added, and #116 Control Grant/session behavior is preserved.

## Validation

- `bun run check` — passed; existing unrelated warnings only.
- `bun run test` — 644 passed, 0 failed, 17,541 expectations.
- `bun run test -- src/pages/grant-secret-lifecycle.test.tsx` — 32 passed, 125 expectations.
- `bun run test:focused:sqlite` — 21 passed, 189 expectations.
- `bun run test:focused:technical-admin-browser` — passed all Event Admin/Pitch Manager Grant Code and protected browser flows.
- `bun run build` — passed.
- `git diff --check` and base-range diff check — passed.

Known harness boundaries: the browser check reports its composed matrix as a JSON result rather than a Bun test count; the unrelated legacy `bun run test:focused:grant` harness has one pre-existing migration-upgrade expectation that assumes no applied migrations after schema 022 while the canonical runtime reports migrations 023–026. Qualification Tests were intentionally not run.
