### PR TITLE
Fix immutable release promotion permissions

### DIFF
--- a/deploy/activate-release.sh
+++ b/deploy/activate-release.sh
@@ -126,6 +126,7 @@ if [[ -n "$staged_dir" ]]; then
     exit 1
   fi
   verify_bundle "$staged_dir"
+  chmod u+w -- "$staged_dir"
   mv -- "$staged_dir" "$release_dir"
   cleanup_staged=0
   chmod -R a-w -- "$release_dir"

--- a/deploy/activate-test-release.sh
+++ b/deploy/activate-test-release.sh
@@ -81,6 +81,7 @@ verify_bundle() {
 if [[ -n "$staged_dir" ]]; then
   [[ ! -e "$release_dir" ]] || { echo "Test release identity already exists and cannot be overwritten." >&2; exit 1; }
   verify_bundle "$staged_dir"
+  chmod u+w -- "$staged_dir"
   mv -- "$staged_dir" "$release_dir"
   cleanup_staged=0
   chmod -R a-w -- "$release_dir"

--- a/src/production-deployment.test.ts
+++ b/src/production-deployment.test.ts
@@ -95,4 +95,17 @@ describe("Production deployment contract", () => {
     expect(activation).toContain('rm -rf -- "$staged_dir"');
     expect(activation).toContain('chmod -R a-w -- "$release_dir"');
   });
+
+  test("restores the validated staging root write bit before promotion", () => {
+    const activation = readFileSync(join(repositoryRoot, "deploy/activate-release.sh"), "utf8");
+    const verification = activation.indexOf('verify_bundle "$staged_dir"');
+    const rootWrite = activation.indexOf('chmod u+w -- "$staged_dir"', verification);
+    const promotion = activation.indexOf('mv -- "$staged_dir" "$release_dir"', rootWrite);
+    const finalization = activation.indexOf('chmod -R a-w -- "$release_dir"', promotion);
+
+    expect(verification).toBeGreaterThanOrEqual(0);
+    expect(rootWrite).toBeGreaterThan(verification);
+    expect(promotion).toBeGreaterThan(rootWrite);
+    expect(finalization).toBeGreaterThan(promotion);
+  });
 });

--- a/src/test-environment-deployment.test.ts
+++ b/src/test-environment-deployment.test.ts
@@ -94,6 +94,22 @@ describe("Test Environment deployment contract", () => {
     expect(activation).toContain('chmod -R a-w -- "$release_dir"');
   });
 
+  test("restores the validated Test staging root write bit before promotion", () => {
+    const activation = readFileSync(
+      join(repositoryRoot, "deploy/activate-test-release.sh"),
+      "utf8",
+    );
+    const verification = activation.indexOf('verify_bundle "$staged_dir"');
+    const rootWrite = activation.indexOf('chmod u+w -- "$staged_dir"', verification);
+    const promotion = activation.indexOf('mv -- "$staged_dir" "$release_dir"', rootWrite);
+    const finalization = activation.indexOf('chmod -R a-w -- "$release_dir"', promotion);
+
+    expect(verification).toBeGreaterThanOrEqual(0);
+    expect(rootWrite).toBeGreaterThan(verification);
+    expect(promotion).toBeGreaterThan(rootWrite);
+    expect(finalization).toBeGreaterThan(promotion);
+  });
+
   test("provisions and verifies the dedicated Test group before either user", () => {
     const provisioning = readFileSync(
       join(repositoryRoot, "deploy/test-environment-provisioning.md"),


### PR DESCRIPTION
## Summary

- Restore owner-write on each fully verified staging root immediately before promotion.
- Preserve the existing immutable-release ordering: verify, promote, clear staged cleanup, then recursively remove write permissions from the final release.
- Add ordered regressions for both Production and Test activation scripts.

## Why

After the ShellCheck hotfix allowed #191's workflow to reach deployment, both environments failed at the same promotion step with `Permission denied`.

The mode-preserving artifact and `rsync -a` correctly retain a read-only archive root. On the live host that combines with setgid inheritance to produce a staged root with mode `2555`. Exact reversible probes under both deployment roots showed:

- staged mode `2555`: cross-parent `mv` fails;
- staged mode `2755`: the same `mv` succeeds.

Only the verified staging root needs temporary owner-write permission. The final release is still recursively sealed read-only immediately after promotion.

Relates to #161 and parent spec #158.

## Verification

- `bun run check`
- `bun test --isolate` — 605 passed, 0 failed
- Focused review suite — 14 passed, 0 failed
- ShellCheck passed
- `git diff --check`
- Independent review found no correctness, permission, cleanup, or immutability issues.

## Operational impact

The prior failed attempts cleaned their staging directories and did not switch either active release. This PR changes no server configuration or service state itself. After merge, the next eligible `main` deployment can retry both independent environment promotions.
