### PR TITLE
Isolate Ad Hoc resource budgets

### DIFF
--- a/scripts/test-ad-hoc-browser.ts
+++ b/scripts/test-ad-hoc-browser.ts
@@ -90,6 +90,67 @@ async function run() {
 
         const gameId = new URL(first.url()).pathname.split("/").at(-1);
         if (gameId === undefined) throw new Error("Game route did not contain a Game ID.");
+        for (let index = 0; index < 4; index += 1) {
+          await first.goto(origin);
+          await first.getByRole("button", { name: /Start an Ad Hoc Game/ }).click();
+          await first.waitForURL(/\/game\/adhoc-/u);
+        }
+        await first.goto(origin);
+        await first.getByRole("button", { name: /Start an Ad Hoc Game/ }).click();
+        await first
+          .getByRole("status")
+          .filter({ hasText: /Retrying in/u })
+          .waitFor();
+        await first.waitForURL(/\/game\/adhoc-/u);
+        const creationRetryGameId = new URL(first.url()).pathname.split("/").at(-1);
+        if (creationRetryGameId === undefined)
+          throw new Error("Rendered creation retry did not navigate to a Game.");
+        await first.goto(`${origin}/game/${gameId}`);
+        await waitForGameRoute(first, gameId);
+        const replayRetryEvidence = await first.evaluate(async (id) => {
+          const wsUrl = `${location.protocol === "https:" ? "wss" : "ws"}://${location.host}/ws`;
+          const ws = new WebSocket(wsUrl);
+          const messages: unknown[] = [];
+          let notify: (() => void) | null = null;
+          ws.onmessage = (event) => {
+            messages.push(JSON.parse(String(event.data)) as unknown);
+            notify?.();
+          };
+          const nextMessage = async () => {
+            while (messages.length === 0) await new Promise<void>((resolve) => (notify = resolve));
+            notify = null;
+            return messages.shift() as {
+              type?: string;
+              retryAfterMs?: number;
+              ackedCommandIds?: string[];
+            };
+          };
+          await new Promise<void>((resolve, reject) => {
+            ws.onopen = () => resolve();
+            ws.onerror = () => reject(new Error("Replay evidence WebSocket failed to open."));
+          });
+          ws.send(JSON.stringify({ type: "subscribe-game", gameId: id }));
+          while ((await nextMessage()).type !== "game-snapshot") {}
+          const batch = Array.from({ length: 100 }, (_, index) => ({
+            id: `browser-replay-${index}`,
+            clientSentAtMs: Date.now(),
+            command: { type: "set-running", running: index % 2 === 0 },
+          }));
+          ws.send(JSON.stringify({ type: "apply-commands", gameId: id, commands: batch }));
+          let acknowledged = false;
+          for (;;) {
+            const message = await nextMessage();
+            if (message.type === "game-snapshot") {
+              acknowledged = message.ackedCommandIds?.includes("browser-replay-99") ?? false;
+              if (acknowledged) break;
+            }
+          }
+          ws.close();
+          if (!acknowledged) throw new Error("Scheduled replay was not eventually acknowledged.");
+          return { batchSize: batch.length };
+        }, creationRetryGameId);
+        if (replayRetryEvidence.batchSize !== 100)
+          throw new Error("Browser replay evidence did not use the full batch envelope.");
         const snapshot = (await first.evaluate(async (id) => {
           const response = await fetch(`/api/games/${id}`);
           return (await response.json()) as { game?: { controlQr?: string | null } };
@@ -145,17 +206,35 @@ async function run() {
         if (new URL(second.url()).pathname !== "/") await second.waitForURL(`${origin}/`);
         await first.getByText("Paused", { exact: true }).waitFor();
 
-        await second.goto(handoffUrl);
-        await waitForGameRoute(second, gameId);
-        await assertAccessibleQr(second, "readmitted second browser");
+        environment.AD_HOC_MAX_CONNECTED_SOCKETS = "1";
+        await stopServer();
+        await startServer();
+        await first.reload();
+        await waitForGameRoute(first, gameId);
+        await first.getByText("Live", { exact: true }).waitFor();
+        await first.waitForTimeout(250);
+        const retryContext = await browser!.newContext({
+          ignoreHTTPSErrors: true,
+          storageState: secondStorageState,
+        });
+        const retryPage = await retryContext.newPage();
+        retryPage.setDefaultTimeout(15_000);
+        await retryPage.goto(handoffUrl);
+        await waitForGameRoute(retryPage, gameId);
+        await retryPage.getByText(/Ad Hoc connection busy/u).waitFor();
+        await first.close();
+        await retryPage.getByText("Live", { exact: true }).waitFor();
 
         await stopServer();
         rmSync(databasePath, { force: true });
         await startServer();
-        await second.reload();
-        await waitForGameRoute(second, gameId);
-        await second.getByText("Local", { exact: true }).waitFor();
-        await second.getByText("Server does not know this game", { exact: false }).waitFor();
+        await retryPage.reload();
+        await waitForGameRoute(retryPage, gameId);
+        await retryPage.getByText("Local", { exact: true }).waitFor();
+        await retryPage
+          .getByText("Server does not know this game", { exact: false })
+          .first()
+          .waitFor();
       })(),
       lifecycleController.signal,
     );
@@ -368,7 +447,10 @@ async function assertAccessibleQr(page: Page, stage: string) {
       throw new Error("Close did not restore focus to the QR trigger");
     }
   } catch (error) {
-    throw new Error(`${stage} QR display failed at ${page.url()}.`, { cause: error });
+    throw new Error(
+      `${stage} QR display failed at ${page.url()}: ${error instanceof Error ? error.message : String(error)}`,
+      { cause: error },
+    );
   }
 }
 

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -906,6 +906,68 @@ describe("App", () => {
     expect(payload.awayColor).toBe(DEFAULT_AWAY_TEAM_COLOR);
   });
 
+  test("owns one rendered creation retry chain and prevents duplicate submission", async () => {
+    testWindow.history.replaceState(null, "", "/");
+    const requests: string[] = [];
+    const retryCallbacks: (() => void)[] = [];
+    testWindow.setTimeout = ((callback: () => void) => {
+      retryCallbacks.push(callback);
+      return 1;
+    }) as unknown as typeof testWindow.setTimeout;
+    testWindow.clearTimeout = (() => {}) as typeof testWindow.clearTimeout;
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      if (url.endsWith("/api/games") && init?.method === "POST") {
+        requests.push(url);
+        if (requests.length === 1)
+          return new Response(JSON.stringify({ retryAfterMs: 1_000 }), {
+            status: 429,
+            headers: { "content-type": "application/json", "retry-after": "1" },
+          });
+        return new Response(JSON.stringify({ gameId: "retry-created" }), { status: 201 });
+      }
+      if (url.endsWith("/api/games/retry-created")) {
+        const state = createInitialGameState({
+          id: "retry-created",
+          nowMs: Date.now(),
+          homeName: "Home",
+          awayName: "Away",
+        });
+        return new Response(JSON.stringify({ game: { state } }), { status: 200 });
+      }
+      return new Response("Not found", { status: 404 });
+    }) as typeof fetch;
+
+    await act(async () => {
+      root.render(<App />);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const createButton = Array.from(container.getElementsByTagName("button")).find((button) =>
+      (button.textContent ?? "").includes("Create new game"),
+    );
+    expect(createButton).not.toBeNull();
+    await act(async () => {
+      createButton?.click();
+      createButton?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(requests).toHaveLength(1);
+    expect(container.textContent).toContain("Retrying in 1s.");
+    expect(retryCallbacks).toHaveLength(1);
+
+    await act(async () => {
+      retryCallbacks.shift()?.();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(requests).toHaveLength(2);
+    expect(testWindow.location.pathname).toBe("/game/retry-created");
+  });
+
   test("color test route renders 100 color samples", async () => {
     testWindow.history.replaceState(null, "", "/color-test");
 

--- a/src/index-ad-hoc.test.ts
+++ b/src/index-ad-hoc.test.ts
@@ -7,6 +7,7 @@ import {
 import {
   adHocFallbackRoute,
   admitGame,
+  calculateAdHocUpgradeCapacity,
   createGame,
   leaveGame,
   readAdHocSession,
@@ -43,6 +44,33 @@ async function createViaHttp(games: AdHocGamesService, homeName: string, browser
 }
 
 describe("Ad Hoc HTTP and WebSocket authority boundaries", () => {
+  test("caps pre-upgrade Ad Hoc capacity below the configured Event reserve", () => {
+    expect(
+      calculateAdHocUpgradeCapacity({
+        eventTotalConnections: 5,
+        eventReservedConnections: 2,
+        activeEventConnections: 0,
+        adHocSocketCeiling: 10,
+      }),
+    ).toBe(3);
+    expect(
+      calculateAdHocUpgradeCapacity({
+        eventTotalConnections: 5,
+        eventReservedConnections: 2,
+        activeEventConnections: 4,
+        adHocSocketCeiling: 10,
+      }),
+    ).toBe(1);
+    expect(
+      calculateAdHocUpgradeCapacity({
+        eventTotalConnections: 5,
+        eventReservedConnections: 8,
+        activeEventConnections: 0,
+        adHocSocketCeiling: 10,
+      }),
+    ).toBe(0);
+  });
+
   test("retains two Games in one browser authority set and leaving one preserves the other", async () => {
     const games = service();
     const first = await createViaHttp(games, "First");
@@ -376,6 +404,104 @@ describe("Ad Hoc HTTP and WebSocket authority boundaries", () => {
     const result = await games.create({ homeName: "Home", awayName: "Away" });
     expect(result).toMatchObject({ status: "rejected", reason: "unavailable" });
     expect(store.listGames()).toHaveLength(0);
+  });
+
+  test("presents delayed anonymous creation with bounded generic retry guidance", async () => {
+    const games = service();
+    for (let index = 0; index < 5; index += 1) {
+      const response = await createGame(
+        new Request("http://localhost/api/games", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ homeName: `Home ${index}`, awayName: "Away" }),
+        }),
+        games,
+        "stable-anonymous-source",
+      );
+      expect(response.status).toBe(201);
+    }
+    const delayed = await createGame(
+      new Request("http://localhost/api/games", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ homeName: "Delayed", awayName: "Away" }),
+      }),
+      games,
+      "stable-anonymous-source",
+    );
+    expect(delayed.status).toBe(429);
+    expect(Number(delayed.headers.get("retry-after"))).toBeGreaterThan(0);
+    expect(Number(delayed.headers.get("retry-after"))).toBeLessThanOrEqual(30);
+    expect(await delayed.json()).toEqual({
+      error: "Try again later.",
+      retryAfterMs: 1_000,
+    });
+    expect(games.store.listGames()).toHaveLength(5);
+  });
+
+  test("uses a private browser source cookie instead of venue request material", async () => {
+    const games = service();
+    const first = await createGame(
+      new Request("http://localhost/api/games", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "user-agent": "same-browser-material",
+          "x-forwarded-for": "198.51.100.10",
+        },
+        body: JSON.stringify({ homeName: "First", awayName: "Away" }),
+      }),
+      games,
+    );
+    expect(first.status).toBe(201);
+    const setCookie = first.headers.get("set-cookie") ?? "";
+    const sourceCookie = setCookie.match(/adhoc_source=[^;, ]+/u)?.[0];
+    expect(sourceCookie).toBeDefined();
+    if (sourceCookie === undefined) return;
+    for (let index = 1; index < 5; index += 1) {
+      const response = await createGame(
+        new Request("http://localhost/api/games", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            cookie: sourceCookie,
+            "user-agent": "same-browser-material",
+            "x-forwarded-for": "198.51.100.10",
+          },
+          body: JSON.stringify({ homeName: `Same source ${index}`, awayName: "Away" }),
+        }),
+        games,
+      );
+      expect(response.status).toBe(201);
+    }
+    const delayed = await createGame(
+      new Request("http://localhost/api/games", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          cookie: sourceCookie,
+          "user-agent": "same-browser-material",
+          "x-forwarded-for": "198.51.100.10",
+        },
+        body: JSON.stringify({ homeName: "Delayed", awayName: "Away" }),
+      }),
+      games,
+    );
+    expect(delayed.status).toBe(429);
+    const differentSource = await createGame(
+      new Request("http://localhost/api/games", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          cookie: "adhoc_source=different-private-browser-source-1234567890123456",
+          "user-agent": "same-browser-material",
+          "x-forwarded-for": "198.51.100.10",
+        },
+        body: JSON.stringify({ homeName: "Different source", awayName: "Away" }),
+      }),
+      games,
+    );
+    expect(differentSource.status).toBe(201);
   });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { serve, type ServerWebSocket } from "bun";
+import { randomBytes } from "node:crypto";
 import { dirname, resolve } from "node:path";
 import index from "./index.html";
 import { readJsonBodyWithinLimit } from "@/lib/http-body";
@@ -67,6 +68,12 @@ import {
   type AdHocGamesService,
 } from "@/lib/ad-hoc-games";
 import { readBuiltRuntimeIdentity, readRunningReleaseIdentity } from "@/lib/release-identity";
+import {
+  AD_HOC_EVENT_RESERVED_CONNECTION_CAPACITY,
+  AD_HOC_EVENT_TOTAL_CONNECTION_CAPACITY,
+  AD_HOC_MAX_CONNECTED_CONTROLLERS,
+  AD_HOC_MAX_QUEUED_OUTPUT_BYTES,
+} from "@/lib/ad-hoc-resource-budgets";
 
 type SessionSubscription =
   | {
@@ -90,6 +97,7 @@ type SessionData = {
 
 const sockets = new Set<ServerWebSocket<SessionData>>();
 const defaultAdHocService = createAdHocGamesService();
+const pendingSocketReservations = new Map<string, ReturnType<typeof setTimeout>>();
 
 const probeInvocation = parseSqliteProbeInvocation(process.argv.slice(1));
 
@@ -142,8 +150,25 @@ async function startServer() {
     }
     const adHocEnvironmentIdentity =
       process.env.AD_HOC_ENVIRONMENT_ID?.trim() || `${environment}:${technicalAdminConfig.origin}`;
+    let eventCapacitySource = () => 0;
     const adHocService = createAdHocGamesService({
       environmentIdentity: adHocEnvironmentIdentity,
+      deferReplayAcknowledgement: true,
+      maxConnectedSockets: readRuntimeCapacity(
+        process.env.AD_HOC_MAX_CONNECTED_SOCKETS,
+        AD_HOC_MAX_CONNECTED_CONTROLLERS,
+      ),
+      eventCapacity: {
+        totalConnections: readRuntimeCapacity(
+          process.env.EVENT_TOTAL_CONNECTION_CAPACITY,
+          AD_HOC_EVENT_TOTAL_CONNECTION_CAPACITY,
+        ),
+        reservedConnections: readRuntimeCapacity(
+          process.env.EVENT_RESERVED_CONNECTION_CAPACITY,
+          AD_HOC_EVENT_RESERVED_CONNECTION_CAPACITY,
+        ),
+        activeConnections: () => eventCapacitySource(),
+      },
       store:
         environment === "test" && !process.env.AD_HOC_DATABASE?.trim()
           ? undefined
@@ -242,6 +267,7 @@ async function startServer() {
         console.warn("Durable Event Game Controller is unavailable.", error);
       }
     }
+    eventCapacitySource = () => liveEventRuntime?.control.activeControllerSessions() ?? 0;
     const liveEventControlTransport = createLiveEventGameControlTransport(
       () => liveEventRuntime?.control ?? null,
       (request) => technicalAdminAuth.isExpectedBinding(requestBinding(request)),
@@ -259,7 +285,9 @@ async function startServer() {
         if (token === null) return genericAuthFailure(401);
         if (eventAdministration === null) return genericAuthFailure(503);
         const eventId = new URL(req.url).pathname.split("/").at(-3) ?? "";
-        return eventAdministrationResponse(await eventAdministration[operation](eventId, token));
+        const result = await eventAdministration[operation](eventId, token);
+        await liveEventRuntime?.control.reconcileActiveControllerSessions();
+        return eventAdministrationResponse(result);
       };
     const pitchManagerGrantMutation = async (
       req: Request,
@@ -309,6 +337,9 @@ async function startServer() {
                     path[8] ?? "",
                     authority,
                   );
+      if (operation !== "revealPitchManagerGrant") {
+        await liveEventRuntime?.control.reconcileActiveControllerSessions();
+      }
       return sensitiveEventAdministrationMutationResponse<TypedGrantMutation | TypedGrantReveal>(
         result as EventAdministrationMutationOutcome<TypedGrantMutation | TypedGrantReveal>,
         authority,
@@ -335,6 +366,9 @@ async function startServer() {
                 (await readJsonRecord(req))?.sessionReference,
                 authority,
               );
+      if (operation !== "reveal") {
+        await liveEventRuntime?.control.reconcileActiveControllerSessions();
+      }
       return sensitiveEventAdministrationMutationResponse<TypedGrantMutation | TypedGrantReveal>(
         result as EventAdministrationMutationOutcome<TypedGrantMutation | TypedGrantReveal>,
         authority,
@@ -363,7 +397,7 @@ async function startServer() {
       port,
       ...(tls ? { tls } : {}),
       routes: {
-        "/ws": (req: Bun.BunRequest<"/ws">, routeServer: Bun.Server<SessionData>) => {
+        "/ws": async (req: Bun.BunRequest<"/ws">, routeServer: Bun.Server<SessionData>) => {
           if (!isAllowedWebSocketOrigin(req.headers.get("origin"), req.headers.get("host"))) {
             return json(
               {
@@ -373,9 +407,35 @@ async function startServer() {
             );
           }
 
+          const socketId = crypto.randomUUID();
+          const totalSocketCapacity = calculateAdHocUpgradeCapacity({
+            eventTotalConnections: readRuntimeCapacity(
+              process.env.EVENT_TOTAL_CONNECTION_CAPACITY,
+              AD_HOC_EVENT_TOTAL_CONNECTION_CAPACITY,
+            ),
+            eventReservedConnections: readRuntimeCapacity(
+              process.env.EVENT_RESERVED_CONNECTION_CAPACITY,
+              AD_HOC_EVENT_RESERVED_CONNECTION_CAPACITY,
+            ),
+            activeEventConnections: eventCapacitySource(),
+            adHocSocketCeiling: readRuntimeCapacity(
+              process.env.AD_HOC_MAX_CONNECTED_SOCKETS,
+              AD_HOC_MAX_CONNECTED_CONTROLLERS,
+            ),
+          });
+          if (sockets.size + pendingSocketReservations.size >= totalSocketCapacity) {
+            adHocService.recordResourcePressure("connection-shed");
+            return json({ error: "Ad Hoc connection busy.", retryAfterMs: 1_000 }, 503, [
+              ["retry-after", "1"],
+            ]);
+          }
+          pendingSocketReservations.set(
+            socketId,
+            setTimeout(() => releasePendingSocketReservation(socketId), 5_000),
+          );
           const upgraded = routeServer.upgrade(req, {
             data: {
-              id: crypto.randomUUID(),
+              id: socketId,
               cookieHeader: req.headers.get("cookie"),
               sessionId: null,
               subscription: { type: "none" },
@@ -385,6 +445,7 @@ async function startServer() {
           if (upgraded) {
             return;
           }
+          releasePendingSocketReservation(socketId);
 
           console.warn("WebSocket upgrade failed", {
             url: req.url,
@@ -404,11 +465,7 @@ async function startServer() {
             return adHocUnavailableResponse();
           },
           POST(req: Request) {
-            return createGame(
-              req,
-              adHocService,
-              requestSource(req, technicalAdminConfig.trustProxyHeaders),
-            );
+            return createGame(req, adHocService);
           },
         },
         "/api/audience/events/:eventId": {
@@ -1557,16 +1614,21 @@ async function startServer() {
           console: true,
         },
       websocket: {
+        backpressureLimit: AD_HOC_MAX_QUEUED_OUTPUT_BYTES,
+        closeOnBackpressureLimit: true,
         open(ws) {
+          releasePendingSocketReservation(ws.data.id);
           sockets.add(ws);
         },
         close(ws) {
+          releasePendingSocketReservation(ws.data.id);
           sockets.delete(ws);
           if (ws.data.subscription.type === "game" && ws.data.sessionId !== null) {
             void adHocService.setConnection({
               gameId: ws.data.subscription.gameId,
               sessionId: ws.data.sessionId,
               connected: false,
+              connectionId: ws.data.id,
             });
           }
         },
@@ -1593,6 +1655,7 @@ async function startServer() {
           switch (parsed.message.type) {
             case "subscribe-lobby": {
               sendMessage(ws, { type: "error", message: adHocService.genericUnavailableMessage });
+              ws.close(1008, "Ad Hoc subscription unavailable.");
               return;
             }
 
@@ -1604,6 +1667,7 @@ async function startServer() {
               });
               if (result.status !== "accepted") {
                 sendMessage(ws, { type: "error", message: adHocService.genericUnavailableMessage });
+                ws.close(1008, "Ad Hoc subscription unavailable.");
                 return;
               }
               if (ws.data.subscription.type === "game") {
@@ -1611,13 +1675,25 @@ async function startServer() {
                   gameId: ws.data.subscription.gameId,
                   sessionId: ws.data.subscription.sessionId,
                   connected: false,
+                  connectionId: ws.data.id,
                 });
               }
-              await adHocService.setConnection({
+              const connected = await adHocService.setConnection({
                 gameId: parsed.message.gameId,
                 sessionId: result.sessionId,
                 connected: true,
+                connectionId: ws.data.id,
               });
+              if (!connected) {
+                adHocService.recordResourcePressure("connection-shed");
+                sendMessage(ws, {
+                  type: "error",
+                  message: "Ad Hoc connection busy. Try again later.",
+                  retryAfterMs: 1_000,
+                });
+                setTimeout(() => ws.close(1013, "Ad Hoc connection busy."), 25);
+                return;
+              }
               ws.data.sessionId = result.sessionId;
               ws.data.subscription = {
                 type: "game",
@@ -1670,17 +1746,29 @@ async function startServer() {
                   message:
                     result.reason === "unavailable"
                       ? adHocService.genericUnavailableMessage
-                      : "Ad Hoc operation rejected.",
+                      : result.reason === "rate-limited"
+                        ? "Ad Hoc operation busy. Try again later."
+                        : "Ad Hoc operation rejected.",
+                  ...(result.retryAfterMs === undefined
+                    ? {}
+                    : { retryAfterMs: Math.min(30_000, Math.max(1, result.retryAfterMs)) }),
                 });
                 return;
               }
-              await broadcastGameSnapshot({
+              const delivered = await broadcastGameSnapshot({
                 gameId: parsed.message.gameId,
                 service: adHocService,
                 sender: ws,
                 senderAckedCommandIds: result.ackedOperationIds,
                 operationOutcomes: result.outcomes,
               });
+              if (result.replayId !== undefined) {
+                await adHocService.acknowledgeReplay({
+                  sessionId: ws.data.subscription.sessionId,
+                  replayId: result.replayId,
+                  delivered,
+                });
+              }
               return;
             }
 
@@ -1792,7 +1880,7 @@ async function runProbeMode(
 export async function createGame(
   req: Request,
   service: AdHocGamesService = defaultAdHocService,
-  sourceKey = "anonymous-browser",
+  sourceKey?: string,
 ) {
   const body = await readJsonBodyWithinLimit(req, SHARED_LIMITS.transport.httpJsonBodyBytes);
   if (!body.ok) {
@@ -1804,29 +1892,41 @@ export async function createGame(
   }
 
   const payload = body.body;
+  const existingSource = readAdHocSource(req.headers.get("cookie"));
+  const effectiveSource = sourceKey ?? existingSource ?? randomBytes(32).toString("base64url");
+  const sourceCookie =
+    sourceKey === undefined && existingSource === null ? adHocSourceCookie(effectiveSource) : null;
   const result = await service.create({
     homeName: payload.homeName === undefined ? "Home" : payload.homeName,
     awayName: payload.awayName === undefined ? "Away" : payload.awayName,
     homeColor: payload.homeColor,
     awayColor: payload.awayColor,
     browserId: payload.browserId,
-    sourceKey,
+    sourceKey: effectiveSource,
   });
   if (result.status !== "accepted") {
     const status =
       result.reason === "invalid-input" ? 400 : result.reason === "unavailable" ? 503 : 429;
+    const headers: Array<[string, string]> = [];
+    if (result.retryAfterMs !== undefined)
+      headers.push(["retry-after", String(Math.max(1, Math.ceil(result.retryAfterMs / 1_000)))]);
+    if (sourceCookie !== null) headers.push(["set-cookie", sourceCookie]);
     return sensitiveJson(
       {
         error: result.detail ?? "Unable to create an Ad Hoc Game.",
         retryAfterMs: result.retryAfterMs,
       },
       status,
+      headers,
     );
   }
   return sensitiveJson(
     { gameId: result.gameId, controlQr: result.controlQr, game: stripSession(result.game) },
     201,
-    [["set-cookie", adHocSessionCookie(result.gameId, result.sessionId)]],
+    [
+      ["set-cookie", adHocSessionCookie(result.gameId, result.sessionId)],
+      ...(sourceCookie === null ? [] : [["set-cookie", sourceCookie] as [string, string]]),
+    ],
   );
 }
 
@@ -1954,11 +2054,11 @@ async function broadcastGameSnapshot({
     status: "accepted" | "duplicate" | "rejected" | "causally-blocked";
     detail?: string;
   }[];
-}) {
-  await Promise.all(
+}): Promise<boolean> {
+  const delivery = await Promise.all(
     [...sockets].map(async (ws) => {
       if (ws.data.subscription.type !== "game" || ws.data.subscription.gameId !== gameId) {
-        return;
+        return ws === sender ? false : null;
       }
       const serverNowMs = Date.now();
       const game = await readAuthorizedAdHocGame(
@@ -1967,20 +2067,39 @@ async function broadcastGameSnapshot({
         ws.data.subscription.sessionId,
         serverNowMs,
       );
-      if (game === null) return;
-      sendMessage(ws, {
+      if (game === null) return ws === sender ? false : null;
+      const sent = sendMessage(ws, {
         type: "game-snapshot",
         game: stripSession(game),
         serverNowMs,
         ackedCommandIds: ws === sender ? senderAckedCommandIds : [],
         operationOutcomes,
       });
+      if (!sent) service.recordResourcePressure("queue-pressure");
+      return ws === sender ? sent : null;
     }),
   );
+  return delivery.some((sent) => sent === true);
 }
 
 function sendMessage(ws: ServerWebSocket<SessionData>, payload: ServerWsMessage) {
-  ws.send(JSON.stringify(payload));
+  const serialized = JSON.stringify(payload);
+  const bytes = new TextEncoder().encode(serialized).byteLength;
+  if (bytes > AD_HOC_MAX_QUEUED_OUTPUT_BYTES) {
+    ws.close(1013, "Ad Hoc output limit reached.");
+    return false;
+  }
+  try {
+    const sentBytes = ws.send(serialized);
+    if (sentBytes !== bytes) {
+      ws.close(1013, "Ad Hoc output backpressure.");
+      return false;
+    }
+  } catch {
+    ws.close(1011, "Ad Hoc output unavailable.");
+    return false;
+  }
+  return true;
 }
 
 function stripSession<T extends { sessionId: string }>(game: T) {
@@ -2007,6 +2126,27 @@ export function readAdHocSession(cookieHeader: string | null, gameId: unknown): 
     }
   }
   return null;
+}
+
+const AD_HOC_SOURCE_COOKIE_NAME = "adhoc_source";
+
+function readAdHocSource(cookieHeader: string | null): string | null {
+  if (cookieHeader === null) return null;
+  for (const cookie of cookieHeader.split(";")) {
+    const [name, ...value] = cookie.trim().split("=");
+    if (name !== AD_HOC_SOURCE_COOKIE_NAME || value.length === 0) continue;
+    try {
+      const decoded = decodeURIComponent(value.join("="));
+      return /^[A-Za-z0-9_-]{32,128}$/.test(decoded) ? decoded : null;
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+function adHocSourceCookie(source: string): string {
+  return `${AD_HOC_SOURCE_COOKIE_NAME}=${encodeURIComponent(source)}; Path=/; Max-Age=31536000; HttpOnly; SameSite=Lax`;
 }
 
 function adHocSessionCookieName(gameId: unknown): string | null {
@@ -2376,6 +2516,31 @@ function clearEventAdminSessionCookie(): string {
 
 function clearPitchManagerSessionCookie(): string {
   return "__Host-pitch-manager-session=; Path=/; Max-Age=0; HttpOnly; Secure; SameSite=Strict";
+}
+
+function readRuntimeCapacity(value: string | undefined, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+export function calculateAdHocUpgradeCapacity(input: {
+  eventTotalConnections: number;
+  eventReservedConnections: number;
+  activeEventConnections: number;
+  adHocSocketCeiling: number;
+}): number {
+  const eventTotal = Math.max(0, input.eventTotalConnections);
+  const eventReserve = Math.max(0, input.eventReservedConnections);
+  const activeEvent = Math.max(0, input.activeEventConnections);
+  const adHocCeiling = Math.max(0, input.adHocSocketCeiling);
+  return Math.max(0, Math.min(adHocCeiling, eventTotal - Math.max(eventReserve, activeEvent)));
+}
+
+function releasePendingSocketReservation(socketId: string) {
+  const timer = pendingSocketReservations.get(socketId);
+  if (timer === undefined) return;
+  clearTimeout(timer);
+  pendingSocketReservations.delete(socketId);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/lib/ad-hoc-games.test.ts
+++ b/src/lib/ad-hoc-games.test.ts
@@ -386,6 +386,32 @@ describe("Ad Hoc Games service", () => {
     ).toBe("accepted");
   });
 
+  test("does not remove connected resource accounting when leave durability fails", async () => {
+    const base = createInMemoryAdHocStore();
+    let failMutations = false;
+    const store: AdHocStore = {
+      close: () => base.close(),
+      listGames: () => base.listGames(),
+      readGame: (gameId) => base.readGame(gameId),
+      createGame: (input) => base.createGame(input),
+      mutateGame: (gameId, mutation) => (failMutations ? null : base.mutateGame(gameId, mutation)),
+    };
+    const games = createAdHocGamesService({ store, now: () => 1_000 });
+    const created = await games.create({ homeName: "Home", awayName: "Away" });
+    if (created.status !== "accepted") throw new Error("creation failed");
+    expect(
+      await games.setConnection({
+        gameId: created.gameId,
+        sessionId: created.sessionId,
+        connected: true,
+        connectionId: "socket-leave",
+      }),
+    ).toBe(true);
+    failMutations = true;
+    expect(await games.leave({ gameId: created.gameId, sessionId: created.sessionId })).toBe(false);
+    expect(games.getResourceMetrics().connectedControllers).toBe(1);
+  });
+
   test("rejects malformed commands without changing current state", async () => {
     const games = service();
     const created = await games.create({ homeName: "Home", awayName: "Away" });

--- a/src/lib/ad-hoc-games.ts
+++ b/src/lib/ad-hoc-games.ts
@@ -20,6 +20,24 @@ import {
   SHARED_LIMITS,
   validateOpaqueIdentifier,
 } from "@/lib/validation-policy";
+import {
+  AD_HOC_CONTROLLER_BURST,
+  AD_HOC_CONTROLLER_SUSTAINED_PER_SECOND,
+  AD_HOC_GAME_BURST,
+  AD_HOC_GAME_SUSTAINED_PER_SECOND,
+  AD_HOC_EVENT_RESERVED_CONNECTION_CAPACITY,
+  AD_HOC_EVENT_TOTAL_CONNECTION_CAPACITY,
+  AD_HOC_MAX_CONNECTED_CONTROLLERS,
+  AD_HOC_REPLAY_BURST,
+  AD_HOC_REPLAY_MAX_OPERATIONS_PER_BATCH,
+  AD_HOC_REPLAY_SUSTAINED_PER_SECOND,
+  adHocCreationDelayMs,
+  consumeAdHocTokens,
+  emptyAdHocResourceMetrics,
+  type AdHocResourceMetric,
+  type AdHocResourceMetrics,
+  type AdHocTokenBucket,
+} from "@/lib/ad-hoc-resource-budgets";
 
 export const AD_HOC_MAX_RETAINED_GAMES = 50;
 export const AD_HOC_DISCONNECTED_GRACE_MS = 5 * 60_000;
@@ -27,10 +45,10 @@ export const AD_HOC_CREATION_SOURCE_WINDOW_MS = 10 * 60_000;
 export const AD_HOC_CREATION_GLOBAL_WINDOW_MS = 60 * 60_000;
 export const AD_HOC_MAX_CREATIONS_PER_SOURCE = 5;
 export const AD_HOC_MAX_CREATIONS_PER_HOUR = 30;
-export const AD_HOC_MAX_OPERATIONS_PER_SECOND_PER_CONTROLLER = 40;
-export const AD_HOC_MAX_OPERATIONS_PER_SECOND_PER_GAME = 100;
+export const AD_HOC_MAX_OPERATIONS_PER_SECOND_PER_CONTROLLER = AD_HOC_CONTROLLER_BURST;
+export const AD_HOC_MAX_OPERATIONS_PER_SECOND_PER_GAME = AD_HOC_GAME_BURST;
 
-const SCHEMA_VERSION = 3;
+const SCHEMA_VERSION = 4;
 const GENERIC_UNAVAILABLE = "Ad Hoc Game unavailable.";
 
 export type AdHocGameView = GameView & {
@@ -78,11 +96,13 @@ export type AdHocActionResult =
       game: AdHocGameView;
       ackedOperationIds: string[];
       outcomes: readonly ControllerOperationOutcome[];
+      replayId?: string;
     }
   | {
       status: "rejected";
       reason: "unavailable" | "invalid-operation" | "conflict" | "rate-limited";
       detail?: string;
+      retryAfterMs?: number;
       outcomes?: readonly ControllerOperationOutcome[];
     };
 
@@ -125,12 +145,18 @@ type AdHocApplyMutationResult =
   | false
   | { invalid: true; rollback: true }
   | { conflict: true; operationId: string }
-  | { rateLimited: true }
+  | { rateLimited: true; retryAfterMs: number }
   | {
       acknowledged: string[];
       duplicate: boolean;
       outcomes: readonly ControllerOperationOutcome[];
     };
+
+type PreparedReplayEntry = {
+  operation: ControllerSynchronizationOperation<GameCommand>;
+  status: "accepted" | "rejected" | "causally-blocked" | "duplicate";
+  detail?: string;
+};
 
 export type AdHocStore = {
   close(): void;
@@ -140,7 +166,12 @@ export type AdHocStore = {
     game: StoredAdHocGame;
     sourceHash: string;
     nowMs: number;
-  }): "accepted" | "rate-limited" | "capacity" | "unavailable";
+  }):
+    | "accepted"
+    | "rate-limited"
+    | "capacity"
+    | "unavailable"
+    | { status: "rate-limited"; retryAfterMs: number };
   mutateGame<T>(gameId: string, mutation: (game: StoredAdHocGame) => T): T | null;
 };
 
@@ -150,6 +181,14 @@ export type AdHocGamesServiceOptions = {
   random?: () => string;
   environmentIdentity?: string;
   iqaRules?: AdHocIqaGameRules;
+  deferReplayAcknowledgement?: boolean;
+  maxConnectedSockets?: number;
+  eventCapacity?: {
+    totalConnections?: number;
+    reservedConnections?: number;
+    activeConnections?: () => number;
+  };
+  schedule?: (delayMs: number, task: () => void) => unknown;
 };
 
 /** Shared sporting interpretation consumed by both Controller workflows. */
@@ -165,8 +204,47 @@ export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) 
   const random = options.random ?? (() => randomBytes(32).toString("base64url"));
   const environmentIdentity = options.environmentIdentity?.trim() || "test";
   const iqaRules = options.iqaRules ?? DEFAULT_AD_HOC_IQA_RULES;
-  const controllerActionTimes = new Map<string, number[]>();
-  const gameActionTimes = new Map<string, number[]>();
+  const deferReplayAcknowledgement = options.deferReplayAcknowledgement ?? false;
+  const maxConnectedSockets = options.maxConnectedSockets ?? AD_HOC_MAX_CONNECTED_CONTROLLERS;
+  const eventCapacity = {
+    totalConnections:
+      options.eventCapacity?.totalConnections ?? AD_HOC_EVENT_TOTAL_CONNECTION_CAPACITY,
+    reservedConnections:
+      options.eventCapacity?.reservedConnections ?? AD_HOC_EVENT_RESERVED_CONNECTION_CAPACITY,
+    activeConnections: options.eventCapacity?.activeConnections ?? (() => 0),
+  };
+  const schedule =
+    options.schedule ??
+    ((delayMs: number, task: () => void) => {
+      const timer = setTimeout(task, delayMs);
+      return () => clearTimeout(timer);
+    });
+  const controllerActionBuckets = new Map<string, AdHocTokenBucket>();
+  const gameActionBuckets = new Map<string, AdHocTokenBucket>();
+  const replayBuckets = new Map<string, AdHocTokenBucket>();
+  const replayInFlight = new Set<string>();
+  const pendingReplays = new Map<string, string>();
+  const replayJobs = new Map<
+    string,
+    { cancel: () => void; resolve: (result: AdHocActionResult) => void }
+  >();
+  const connections = new Map<string, string>();
+  const metrics = emptyAdHocResourceMetrics();
+  let closed = false;
+  const preparedReplayChunk = Symbol("preparedReplayChunk");
+  const scheduleReplayTask = (delayMs: number, task: () => void) => {
+    let active = true;
+    let cancelUnderlying: (() => void) | undefined;
+    const cancel = () => {
+      active = false;
+      cancelUnderlying?.();
+    };
+    const scheduled = schedule(delayMs, () => {
+      if (active) task();
+    });
+    if (typeof scheduled === "function") cancelUnderlying = scheduled as () => void;
+    return cancel;
+  };
 
   return {
     async create(input: AdHocCreationInput): Promise<AdHocCreateResult> {
@@ -233,11 +311,15 @@ export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) 
       } catch {
         return { status: "rejected", reason: "unavailable" };
       }
-      if (outcome === "rate-limited") {
+      if (outcome === "rate-limited" || typeof outcome === "object") {
+        const retryAfterMs = typeof outcome === "object" ? outcome.retryAfterMs : 60 * 60_000;
+        metrics.creationDelay += retryAfterMs <= 30_000 ? 1 : 0;
+        metrics.creationRateExhausted += retryAfterMs > 30_000 ? 1 : 0;
         return {
           status: "rejected",
           reason: "rate-limited",
-          retryAfterMs: 60 * 60_000,
+          detail: "Try again later.",
+          retryAfterMs,
         };
       }
       if (outcome === "capacity") {
@@ -341,6 +423,182 @@ export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) 
       operations: AdHocOperation[];
       nowMs?: number;
     }): Promise<AdHocActionResult> {
+      if (closed) return { status: "rejected", reason: "unavailable" };
+      const preparedChunk = (
+        input as typeof input & {
+          [preparedReplayChunk]?: readonly PreparedReplayEntry[];
+        }
+      )[preparedReplayChunk];
+      if (deferReplayAcknowledgement && preparedChunk === undefined) {
+        const sessionId = validateBearer(input.sessionId);
+        const gameId = validateGameId(input.gameId);
+        const nowMs = input.nowMs ?? now();
+        if (
+          sessionId !== null &&
+          gameId !== null &&
+          isSafeTimestamp(nowMs) &&
+          Array.isArray(input.operations) &&
+          input.operations.length > 0 &&
+          input.operations.length <= AD_HOC_REPLAY_MAX_OPERATIONS_PER_BATCH
+        ) {
+          const sessionKey = digest(sessionId);
+          if (pendingReplays.has(sessionKey)) {
+            metrics.replayPressure += 1;
+            return {
+              status: "rejected",
+              reason: "rate-limited",
+              detail: "Try again later.",
+              retryAfterMs: 1_000,
+            };
+          }
+          let game: StoredAdHocGame | null;
+          try {
+            game = store.readGame(gameId);
+          } catch {
+            return { status: "rejected", reason: "unavailable" };
+          }
+          if (game === null || game.environmentIdentity !== environmentIdentity) {
+            return { status: "rejected", reason: "unavailable" };
+          }
+          if (!hasSession(game, sessionId)) return { status: "rejected", reason: "unavailable" };
+          const parsed = parseAdHocOperations(input.operations);
+          if (!parsed.ok) return { status: "rejected", reason: "invalid-operation" };
+          for (const operation of parsed.operations) {
+            const existing = game.operations[operation.operationId];
+            if (
+              existing !== undefined &&
+              existing.fingerprint !== operationFingerprint(operation)
+            ) {
+              return {
+                status: "rejected",
+                reason: "conflict",
+                outcomes: [
+                  {
+                    operationId: operation.operationId,
+                    workflow: "ad-hoc",
+                    status: "rejected",
+                    detail: "The operation identity is already bound to different content.",
+                  },
+                ],
+              };
+            }
+          }
+          const retainedStatuses = new Map(
+            Object.entries(game.operations).map(
+              ([operationId, operation]) => [operationId, operation.status] as const,
+            ),
+          );
+          const incoming = parsed.operations;
+          const resolution = resolveControllerBatch({
+            operations: incoming.filter(
+              (operation) => game.operations[operation.operationId] === undefined,
+            ),
+            retainedStatuses,
+          });
+          const plannedEntries: PreparedReplayEntry[] = orderReplayPlan(incoming).map(
+            (operation) => {
+              const existing = game.operations[operation.operationId];
+              if (existing !== undefined) {
+                return {
+                  operation,
+                  status: existing.status === "accepted" ? "duplicate" : existing.status,
+                  ...(existing.detail === undefined ? {} : { detail: existing.detail }),
+                };
+              }
+              return {
+                operation,
+                status: resolution.statuses.get(operation.operationId) ?? "rejected",
+                ...(resolution.details.has(operation.operationId)
+                  ? { detail: resolution.details.get(operation.operationId) }
+                  : {}),
+              };
+            },
+          );
+          const replayId = random();
+          pendingReplays.set(sessionKey, replayId);
+          const chunks = Array.from({ length: Math.ceil(plannedEntries.length / 20) }, (_, index) =>
+            plannedEntries.slice(index * 20, (index + 1) * 20),
+          );
+          return new Promise<AdHocActionResult>((resolve) => {
+            const acknowledgedOperationIds: string[] = [];
+            const outcomes: ControllerOperationOutcome[] = [];
+            let projectedGame: AdHocGameView | null = null;
+            let duplicate = true;
+            let retryCount = 0;
+            const deadlineMs = nowMs + 30_000;
+            const isCurrentJob = () => !closed && replayJobs.get(sessionKey)?.resolve === resolve;
+            const rejectJob = (result: AdHocActionResult) => {
+              pendingReplays.delete(sessionKey);
+              replayJobs.delete(sessionKey);
+              resolve(result);
+            };
+            const runChunk = (index: number, scheduledAtMs: number) => {
+              if (!isCurrentJob()) {
+                rejectJob({ status: "rejected", reason: "unavailable" });
+                return;
+              }
+              void this.apply({
+                gameId,
+                sessionId,
+                operations: chunks[index]!.map((entry) => fromControllerOperation(entry.operation)),
+                nowMs: scheduledAtMs,
+                [preparedReplayChunk]: chunks[index]!,
+              } as typeof input & { [preparedReplayChunk]: readonly PreparedReplayEntry[] }).then(
+                (result) => {
+                  if (!isCurrentJob()) return;
+                  if (result.status === "rejected") {
+                    if (result.reason === "rate-limited") {
+                      const delayMs = Math.max(1, result.retryAfterMs ?? 1_000);
+                      retryCount += 1;
+                      if (retryCount > 5 || scheduledAtMs + delayMs > deadlineMs) {
+                        rejectJob({
+                          status: "rejected",
+                          reason: "rate-limited",
+                          retryAfterMs: delayMs,
+                        });
+                        return;
+                      }
+                      if (!isCurrentJob()) return;
+                      const cancel = scheduleReplayTask(delayMs, () =>
+                        runChunk(index, scheduledAtMs + delayMs),
+                      );
+                      const job = replayJobs.get(sessionKey);
+                      if (job !== undefined) job.cancel = cancel;
+                      return;
+                    }
+                    rejectJob(result);
+                    return;
+                  }
+                  acknowledgedOperationIds.push(...result.ackedOperationIds);
+                  outcomes.push(...result.outcomes);
+                  projectedGame = result.game;
+                  duplicate &&= result.status === "duplicate";
+                  if (index + 1 < chunks.length) {
+                    if (!isCurrentJob()) return;
+                    const cancel = scheduleReplayTask(1_000, () =>
+                      runChunk(index + 1, scheduledAtMs + 1_000),
+                    );
+                    const job = replayJobs.get(sessionKey);
+                    if (job !== undefined) job.cancel = cancel;
+                    return;
+                  }
+                  replayJobs.delete(sessionKey);
+                  resolve({
+                    status: duplicate ? "duplicate" : "accepted",
+                    game: projectedGame,
+                    ackedOperationIds: acknowledgedOperationIds,
+                    outcomes,
+                    replayId,
+                  });
+                },
+              );
+            };
+            const job = { cancel: () => {}, resolve };
+            replayJobs.set(sessionKey, job);
+            job.cancel = scheduleReplayTask(0, () => runChunk(0, nowMs));
+          });
+        }
+      }
       const gameId = validateGameId(input.gameId);
       const sessionId = validateBearer(input.sessionId);
       if (
@@ -348,13 +606,30 @@ export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) 
         sessionId === null ||
         !Array.isArray(input.operations) ||
         input.operations.length === 0 ||
-        input.operations.length > SHARED_LIMITS.replay.maxControlActions
+        input.operations.length > AD_HOC_REPLAY_MAX_OPERATIONS_PER_BATCH
       ) {
         return { status: "rejected", reason: "invalid-operation" };
       }
       const nowMs = input.nowMs ?? now();
       if (!isSafeTimestamp(nowMs)) return { status: "rejected", reason: "invalid-operation" };
       let outcome: AdHocApplyMutationResult | null;
+      const sessionKey = digest(sessionId);
+      if (
+        preparedChunk === undefined &&
+        (replayInFlight.has(sessionKey) || pendingReplays.has(sessionKey))
+      ) {
+        metrics.replayPressure += 1;
+        return {
+          status: "rejected",
+          reason: "rate-limited",
+          detail: "Try again later.",
+          retryAfterMs: 1_000,
+        };
+      }
+      replayInFlight.add(sessionKey);
+      let nextControllerBucket: AdHocTokenBucket | undefined;
+      let nextGameBucket: AdHocTokenBucket | undefined;
+      let nextReplayBucket: AdHocTokenBucket | undefined;
       try {
         outcome = store.mutateGame<AdHocApplyMutationResult>(gameId, (game) => {
           if (game.environmentIdentity !== environmentIdentity || !hasSession(game, sessionId))
@@ -362,26 +637,13 @@ export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) 
           const next = structuredClone(game) as StoredAdHocGame;
           const acknowledged: string[] = [];
           let duplicate = false;
-          const parsed = parseAdHocOperations(input.operations);
-          if (!parsed.ok) return { invalid: true, rollback: true } as const;
-          const incoming = parsed.operations;
-          const newOperationCount = incoming.filter(
-            (operation) => next.operations[operation.operationId] === undefined,
-          ).length;
-          const sessionKey = digest(sessionId);
-          const sessionTimes = (controllerActionTimes.get(sessionKey) ?? []).filter(
-            (timestamp) => timestamp > nowMs - 1_000,
-          );
-          const gameTimes = (gameActionTimes.get(gameId) ?? []).filter(
-            (timestamp) => timestamp > nowMs - 1_000,
-          );
-          if (
-            sessionTimes.length + newOperationCount >
-              AD_HOC_MAX_OPERATIONS_PER_SECOND_PER_CONTROLLER ||
-            gameTimes.length + newOperationCount > AD_HOC_MAX_OPERATIONS_PER_SECOND_PER_GAME
-          ) {
-            return { rateLimited: true } as const;
-          }
+          const parsed =
+            preparedChunk === undefined ? parseAdHocOperations(input.operations) : null;
+          if (preparedChunk === undefined && (parsed === null || !parsed.ok))
+            return { invalid: true, rollback: true } as const;
+          const incoming =
+            preparedChunk?.map((entry) => entry.operation) ??
+            (parsed as Extract<typeof parsed, { ok: true }>).operations;
           const outcomes: ControllerOperationOutcome[] = [];
           for (const operation of incoming) {
             const existing = next.operations[operation.operationId];
@@ -400,72 +662,157 @@ export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) 
               continue;
             }
           }
-          const retainedStatuses = new Map(
-            Object.entries(next.operations).map(
-              ([operationId, operation]) => [operationId, operation.status] as const,
-            ),
-          );
-          const resolution = resolveControllerBatch({
-            operations: incoming.filter(
-              (operation) => next.operations[operation.operationId] === undefined,
-            ),
-            retainedStatuses,
-          });
-          for (const operation of resolution.ordered) {
-            const status = resolution.statuses.get(operation.operationId) ?? "rejected";
-            const detail = resolution.details.get(operation.operationId);
-            next.operations[operation.operationId] =
-              status === "accepted"
-                ? {
-                    fingerprint: operationFingerprint(operation),
-                    command: structuredClone(operation.payload),
-                    acceptedAtMs: nowMs,
-                    clientSentAtMs: operation.clientOriginAtMs,
-                    causalPredecessorIds: [...operation.causalPredecessorIds],
-                    status: "accepted",
-                  }
-                : rejectedOperation(operation, nowMs, detail ?? "Causal cycle.", status);
-            outcomes.push({
-              operationId: operation.operationId,
-              workflow: "ad-hoc",
-              status,
-              ...(detail === undefined ? {} : { detail }),
-            });
-            acknowledged.push(operation.operationId);
-          }
-          for (const operation of incoming) {
-            if (
-              next.operations[operation.operationId] !== undefined &&
-              acknowledged.includes(operation.operationId)
-            )
-              continue;
-            if (next.operations[operation.operationId] === undefined) {
-              const status = resolution.statuses.get(operation.operationId) ?? "rejected";
-              const detail = resolution.details.get(operation.operationId) ?? "Causal cycle.";
-              next.operations[operation.operationId] = rejectedOperation(
-                operation,
-                nowMs,
-                detail,
-                status === "accepted" ? "rejected" : status,
+          const reconciledPreparedChunk =
+            preparedChunk === undefined
+              ? undefined
+              : reconcilePreparedReplayChunk(preparedChunk, next.operations);
+          const acceptedNewOperationCount =
+            preparedChunk === undefined
+              ? (() => {
+                  const retainedStatuses = new Map(
+                    Object.entries(next.operations).map(
+                      ([operationId, operation]) => [operationId, operation.status] as const,
+                    ),
+                  );
+                  const resolution = resolveControllerBatch({
+                    operations: incoming.filter(
+                      (operation) => next.operations[operation.operationId] === undefined,
+                    ),
+                    retainedStatuses,
+                  });
+                  return resolution.ordered.filter(
+                    (operation) => resolution.statuses.get(operation.operationId) === "accepted",
+                  ).length;
+                })()
+              : reconciledPreparedChunk!.filter(
+                  (entry) =>
+                    entry.status === "accepted" &&
+                    next.operations[entry.operation.operationId] === undefined,
+                ).length;
+          if (acceptedNewOperationCount > 0) {
+            const controller = consumeAdHocTokens(
+              controllerActionBuckets.get(sessionKey),
+              nowMs,
+              AD_HOC_CONTROLLER_BURST,
+              AD_HOC_CONTROLLER_SUSTAINED_PER_SECOND,
+              acceptedNewOperationCount,
+            );
+            const gameBucket = consumeAdHocTokens(
+              gameActionBuckets.get(gameId),
+              nowMs,
+              AD_HOC_GAME_BURST,
+              AD_HOC_GAME_SUSTAINED_PER_SECOND,
+              acceptedNewOperationCount,
+            );
+            const replay = consumeAdHocTokens(
+              replayBuckets.get(sessionKey),
+              nowMs,
+              deferReplayAcknowledgement
+                ? AD_HOC_REPLAY_BURST
+                : AD_HOC_REPLAY_MAX_OPERATIONS_PER_BATCH,
+              AD_HOC_REPLAY_SUSTAINED_PER_SECOND,
+              acceptedNewOperationCount,
+            );
+            if (!controller.accepted || !gameBucket.accepted || !replay.accepted) {
+              const retryAfterMs = Math.max(
+                controller.accepted ? 0 : controller.retryAfterMs,
+                gameBucket.accepted ? 0 : gameBucket.retryAfterMs,
+                replay.accepted ? 0 : replay.retryAfterMs,
               );
+              return { rateLimited: true, retryAfterMs } as const;
+            }
+            nextControllerBucket = controller.bucket;
+            nextGameBucket = gameBucket.bucket;
+            nextReplayBucket = replay.bucket;
+          }
+          if (preparedChunk !== undefined) {
+            for (const entry of reconciledPreparedChunk!) {
+              const operation = entry.operation;
+              if (next.operations[operation.operationId] !== undefined) continue;
+              const status = entry.status === "duplicate" ? "rejected" : entry.status;
+              const detail = entry.detail;
+              next.operations[operation.operationId] =
+                status === "accepted"
+                  ? {
+                      fingerprint: operationFingerprint(operation),
+                      command: structuredClone(operation.payload),
+                      acceptedAtMs: nowMs,
+                      clientSentAtMs: operation.clientOriginAtMs,
+                      causalPredecessorIds: [...operation.causalPredecessorIds],
+                      status: "accepted",
+                    }
+                  : rejectedOperation(operation, nowMs, detail ?? "Causal cycle.", status);
               outcomes.push({
                 operationId: operation.operationId,
                 workflow: "ad-hoc",
                 status,
-                detail,
+                ...(detail === undefined ? {} : { detail }),
               });
               acknowledged.push(operation.operationId);
+            }
+          } else {
+            const retainedStatuses = new Map(
+              Object.entries(next.operations).map(
+                ([operationId, operation]) => [operationId, operation.status] as const,
+              ),
+            );
+            const resolution = resolveControllerBatch({
+              operations: incoming.filter(
+                (operation) => next.operations[operation.operationId] === undefined,
+              ),
+              retainedStatuses,
+            });
+            for (const operation of resolution.ordered) {
+              const status = resolution.statuses.get(operation.operationId) ?? "rejected";
+              const detail = resolution.details.get(operation.operationId);
+              next.operations[operation.operationId] =
+                status === "accepted"
+                  ? {
+                      fingerprint: operationFingerprint(operation),
+                      command: structuredClone(operation.payload),
+                      acceptedAtMs: nowMs,
+                      clientSentAtMs: operation.clientOriginAtMs,
+                      causalPredecessorIds: [...operation.causalPredecessorIds],
+                      status: "accepted",
+                    }
+                  : rejectedOperation(operation, nowMs, detail ?? "Causal cycle.", status);
+              outcomes.push({
+                operationId: operation.operationId,
+                workflow: "ad-hoc",
+                status,
+                ...(detail === undefined ? {} : { detail }),
+              });
+              acknowledged.push(operation.operationId);
+            }
+            for (const operation of incoming) {
+              if (
+                next.operations[operation.operationId] !== undefined &&
+                acknowledged.includes(operation.operationId)
+              )
+                continue;
+              if (next.operations[operation.operationId] === undefined) {
+                const status = resolution.statuses.get(operation.operationId) ?? "rejected";
+                const detail = resolution.details.get(operation.operationId) ?? "Causal cycle.";
+                next.operations[operation.operationId] = rejectedOperation(
+                  operation,
+                  nowMs,
+                  detail,
+                  status === "accepted" ? "rejected" : status,
+                );
+                outcomes.push({
+                  operationId: operation.operationId,
+                  workflow: "ad-hoc",
+                  status,
+                  detail,
+                });
+                acknowledged.push(operation.operationId);
+              }
             }
           }
           const rebuilt = rebuildAdHocState(next, iqaRules);
           if (rebuilt === null) return { invalid: true, rollback: true } as const;
           next.state = rebuilt;
           next.state.updatedAtMs = nowMs;
-          if (newOperationCount > 0) {
-            const acceptedTimes = Array.from({ length: newOperationCount }, () => nowMs);
-            controllerActionTimes.set(sessionKey, [...sessionTimes, ...acceptedTimes]);
-            gameActionTimes.set(gameId, [...gameTimes, ...acceptedTimes]);
-          }
           Object.assign(game, next);
           const acknowledgement = createControllerReplayAcknowledgement({
             workflow: "ad-hoc",
@@ -480,10 +827,21 @@ export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) 
         });
       } catch {
         return { status: "rejected", reason: "unavailable" };
+      } finally {
+        replayInFlight.delete(sessionKey);
       }
       if (outcome === null || outcome === false)
         return { status: "rejected", reason: "unavailable" };
-      if ("rateLimited" in outcome) return { status: "rejected", reason: "rate-limited" };
+      if ("rateLimited" in outcome) {
+        metrics.actionRateExhausted += 1;
+        metrics.replayPressure += outcome.retryAfterMs > 0 ? 1 : 0;
+        return {
+          status: "rejected",
+          reason: "rate-limited",
+          detail: "Try again later.",
+          retryAfterMs: outcome.retryAfterMs,
+        };
+      }
       if ("conflict" in outcome) {
         return {
           status: "rejected",
@@ -506,6 +864,10 @@ export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) 
         return { status: "rejected", reason: "unavailable" };
       }
       if (game === null) return { status: "rejected", reason: "unavailable" };
+      if (nextControllerBucket !== undefined)
+        controllerActionBuckets.set(sessionKey, nextControllerBucket);
+      if (nextGameBucket !== undefined) gameActionBuckets.set(gameId, nextGameBucket);
+      if (nextReplayBucket !== undefined) replayBuckets.set(sessionKey, nextReplayBucket);
       return {
         status: outcome.duplicate ? "duplicate" : "accepted",
         ackedOperationIds: outcome.acknowledged,
@@ -514,10 +876,27 @@ export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) 
       };
     },
 
+    async acknowledgeReplay(input: {
+      sessionId: unknown;
+      replayId: unknown;
+      delivered: boolean;
+    }): Promise<boolean> {
+      const sessionId = validateBearer(input.sessionId);
+      const replayId = validateBearer(input.replayId);
+      if (sessionId === null || replayId === null) return false;
+      const sessionKey = digest(sessionId);
+      if (pendingReplays.get(sessionKey) !== replayId) return false;
+      // A failed transport delivery releases the reservation without
+      // acknowledging operations; the browser can safely resend them.
+      pendingReplays.delete(sessionKey);
+      return true;
+    },
+
     async setConnection(input: {
       gameId: unknown;
       sessionId: unknown;
       connected: boolean;
+      connectionId?: string;
       nowMs?: number;
     }): Promise<boolean> {
       const gameId = validateGameId(input.gameId);
@@ -525,20 +904,47 @@ export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) 
       if (gameId === null || sessionId === null) return false;
       const nowMs = input.nowMs ?? now();
       if (!isSafeTimestamp(nowMs)) return false;
+      const sessionKey = digest(sessionId);
+      const connectionId = input.connectionId?.trim() || sessionKey;
+      let connectionChange: "add" | "remove" | null = null;
       try {
-        return (
-          store.mutateGame(gameId, (game) => {
-            if (game.environmentIdentity !== environmentIdentity) return false;
-            const session = game.sessions.find(
-              (candidate) => candidate.sessionHash === digest(sessionId),
+        const changed = store.mutateGame(gameId, (game) => {
+          if (game.environmentIdentity !== environmentIdentity) return false;
+          const session = game.sessions.find(
+            (candidate) => candidate.sessionHash === digest(sessionId),
+          );
+          if (session === undefined) return false;
+          if (input.connected && !connections.has(connectionId)) {
+            const activeEventConnections = Math.max(0, eventCapacity.activeConnections());
+            const availableForAdHoc = Math.max(
+              0,
+              Math.min(
+                maxConnectedSockets,
+                eventCapacity.totalConnections -
+                  Math.max(eventCapacity.reservedConnections, activeEventConnections),
+              ),
             );
-            if (session === undefined) return false;
-            session.connected = input.connected;
-            if (input.connected) session.lastConnectedAtMs = nowMs;
-            else session.lastDisconnectedAtMs = nowMs;
-            return true;
-          }) === true
-        );
+            if (connections.size >= availableForAdHoc) {
+              metrics.connectionShed += 1;
+              return false;
+            }
+            connectionChange = "add";
+          }
+          if (!input.connected && connections.has(connectionId)) connectionChange = "remove";
+          const hasOtherConnection = [...connections].some(
+            ([candidateId, candidateSessionKey]) =>
+              candidateId !== connectionId && candidateSessionKey === sessionKey,
+          );
+          session.connected = input.connected;
+          if (input.connected) session.lastConnectedAtMs = nowMs;
+          else if (!hasOtherConnection) session.lastDisconnectedAtMs = nowMs;
+          if (!input.connected && hasOtherConnection) session.connected = true;
+          return true;
+        });
+        if (changed === true && connectionChange === "add")
+          connections.set(connectionId, sessionKey);
+        if (changed === true && connectionChange === "remove") connections.delete(connectionId);
+        return changed === true;
       } catch {
         return false;
       }
@@ -549,7 +955,7 @@ export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) 
       const sessionId = validateBearer(input.sessionId);
       if (gameId === null || sessionId === null) return false;
       try {
-        return (
+        const changed =
           store.mutateGame(gameId, (game) => {
             if (game.environmentIdentity !== environmentIdentity) return false;
             const before = game.sessions.length;
@@ -557,16 +963,56 @@ export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) 
               (session) => session.sessionHash !== digest(sessionId),
             );
             return game.sessions.length !== before;
-          }) === true
-        );
+          }) === true;
+        if (changed) {
+          for (const [connectionId, connectionSessionKey] of connections) {
+            if (connectionSessionKey === digest(sessionId)) connections.delete(connectionId);
+          }
+        }
+        return changed;
       } catch {
         return false;
       }
     },
 
     genericUnavailableMessage: GENERIC_UNAVAILABLE,
+    getResourceMetrics(): AdHocResourceMetrics {
+      metrics.connectedControllers = connections.size;
+      const activeEventConnections = Math.max(0, eventCapacity.activeConnections());
+      metrics.eventReservedCapacity = {
+        configured: eventCapacity.reservedConnections,
+        active: activeEventConnections,
+        availableForAdHoc: Math.max(
+          0,
+          Math.min(
+            maxConnectedSockets,
+            eventCapacity.totalConnections -
+              Math.max(eventCapacity.reservedConnections, activeEventConnections),
+          ),
+        ),
+      };
+      return { ...metrics };
+    },
+    recordResourcePressure(metric: AdHocResourceMetric) {
+      if (metric === "creation-delay") metrics.creationDelay += 1;
+      if (metric === "creation-rate-exhausted") metrics.creationRateExhausted += 1;
+      if (metric === "action-rate-exhausted") metrics.actionRateExhausted += 1;
+      if (metric === "replay-pressure") metrics.replayPressure += 1;
+      if (metric === "connection-shed") metrics.connectionShed += 1;
+      if (metric === "queue-pressure") metrics.queuePressure += 1;
+    },
     store,
     close() {
+      if (closed) return;
+      closed = true;
+      for (const job of replayJobs.values()) {
+        job.cancel();
+        job.resolve({ status: "rejected", reason: "unavailable" });
+      }
+      replayJobs.clear();
+      pendingReplays.clear();
+      replayInFlight.clear();
+      connections.clear();
       store.close();
     },
   };
@@ -574,7 +1020,10 @@ export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) 
 
 export function createInMemoryAdHocStore(): AdHocStore {
   const games = new Map<string, StoredAdHocGame>();
-  const attempts = new Map<string, number[]>();
+  const attempts = new Map<
+    string,
+    { occurredAtMs: number; successful: boolean; retryUntilMs?: number }[]
+  >();
   const successes: number[] = [];
   return {
     close() {},
@@ -585,13 +1034,45 @@ export function createInMemoryAdHocStore(): AdHocStore {
     },
     createGame({ game, sourceHash, nowMs }) {
       const sourceAttempts = (attempts.get(sourceHash) ?? []).filter(
-        (value) => value > nowMs - AD_HOC_CREATION_SOURCE_WINDOW_MS,
+        (attempt) => attempt.occurredAtMs > nowMs - AD_HOC_CREATION_SOURCE_WINDOW_MS,
       );
-      if (sourceAttempts.length >= AD_HOC_MAX_CREATIONS_PER_SOURCE) return "rate-limited";
+      const latest = sourceAttempts.at(-1);
+      if (latest?.successful === false && (latest.retryUntilMs ?? 0) > nowMs) {
+        return {
+          status: "rate-limited",
+          retryAfterMs: (latest.retryUntilMs ?? nowMs) - nowMs,
+        };
+      }
+      const sourceSuccesses = sourceAttempts.filter((attempt) => attempt.successful);
+      const expiredDelay = latest?.successful === false && (latest.retryUntilMs ?? 0) <= nowMs;
+      if (sourceSuccesses.length >= AD_HOC_MAX_CREATIONS_PER_SOURCE && !expiredDelay) {
+        const retryAfterMs = adHocCreationDelayMs(sourceSuccesses.length);
+        attempts.set(sourceHash, [
+          ...sourceAttempts,
+          { occurredAtMs: nowMs, successful: false, retryUntilMs: nowMs + retryAfterMs },
+        ]);
+        return {
+          status: "rate-limited",
+          retryAfterMs,
+        };
+      }
       const recentSuccesses = successes.filter(
         (value) => value > nowMs - AD_HOC_CREATION_GLOBAL_WINDOW_MS,
       );
-      if (recentSuccesses.length >= AD_HOC_MAX_CREATIONS_PER_HOUR) return "rate-limited";
+      if (recentSuccesses.length >= AD_HOC_MAX_CREATIONS_PER_HOUR) {
+        const retryAfterMs = Math.max(
+          1_000,
+          (recentSuccesses[0] ?? nowMs) + AD_HOC_CREATION_GLOBAL_WINDOW_MS - nowMs,
+        );
+        attempts.set(sourceHash, [
+          ...sourceAttempts,
+          { occurredAtMs: nowMs, successful: false, retryUntilMs: nowMs + retryAfterMs },
+        ]);
+        return {
+          status: "rate-limited",
+          retryAfterMs,
+        };
+      }
       if (games.size >= AD_HOC_MAX_RETAINED_GAMES) {
         const victim = [...games.values()]
           .filter((candidate) =>
@@ -607,8 +1088,8 @@ export function createInMemoryAdHocStore(): AdHocStore {
         games.delete(victim.gameId);
       }
       games.set(game.gameId, cloneStoredGame(game));
-      attempts.set(sourceHash, [...sourceAttempts, nowMs]);
       successes.push(nowMs);
+      attempts.set(sourceHash, [...sourceAttempts, { occurredAtMs: nowMs, successful: true }]);
       return "accepted";
     },
     mutateGame(gameId, mutation) {
@@ -694,8 +1175,14 @@ export function openSqliteAdHocStore(
     migrate();
   }
   db.run(
-    "CREATE TABLE IF NOT EXISTS adhoc_creation_events (source_hash TEXT NOT NULL, successful INTEGER NOT NULL, occurred_at_ms INTEGER NOT NULL)",
+    "CREATE TABLE IF NOT EXISTS adhoc_creation_events (source_hash TEXT NOT NULL, successful INTEGER NOT NULL, occurred_at_ms INTEGER NOT NULL, retry_until_ms INTEGER)",
   );
+  const creationEventColumns = db.query("PRAGMA table_info(adhoc_creation_events)").all() as {
+    name?: string;
+  }[];
+  if (!creationEventColumns.some((column) => column.name === "retry_until_ms")) {
+    db.run("ALTER TABLE adhoc_creation_events ADD COLUMN retry_until_ms INTEGER");
+  }
 
   const read = (gameId: string): StoredAdHocGame | null => {
     const row = db.query("SELECT * FROM adhoc_games WHERE game_id = ?").get(gameId) as Record<
@@ -723,20 +1210,60 @@ export function openSqliteAdHocStore(
         db.run("DELETE FROM adhoc_creation_events WHERE occurred_at_ms <= ?", [
           nowMs - AD_HOC_CREATION_GLOBAL_WINDOW_MS,
         ]);
+        const pendingRow = db
+          .query(
+            "SELECT retry_until_ms FROM adhoc_creation_events WHERE source_hash = ? AND successful = 0 AND retry_until_ms IS NOT NULL ORDER BY occurred_at_ms DESC LIMIT 1",
+          )
+          .get(sourceHash) as { retry_until_ms?: number | string } | null;
+        const pendingUntilMs = Number(pendingRow?.retry_until_ms ?? 0);
+        if (pendingUntilMs > nowMs) {
+          return { status: "rate-limited", retryAfterMs: pendingUntilMs - nowMs } as const;
+        }
         const sourceCountRow = db
           .query(
-            "SELECT COUNT(*) AS count FROM adhoc_creation_events WHERE source_hash = ? AND occurred_at_ms > ?",
+            "SELECT COUNT(*) AS count FROM adhoc_creation_events WHERE source_hash = ? AND successful = 1 AND occurred_at_ms > ?",
           )
           .get(sourceHash, nowMs - AD_HOC_CREATION_SOURCE_WINDOW_MS) as {
           count?: number | string;
         } | null;
         const sourceCount = Number(sourceCountRow?.count ?? 0);
-        if (sourceCount >= AD_HOC_MAX_CREATIONS_PER_SOURCE) return "rate-limited" as const;
+        const expiredPendingDelay = pendingUntilMs > 0 && pendingUntilMs <= nowMs;
+        if (sourceCount >= AD_HOC_MAX_CREATIONS_PER_SOURCE && !expiredPendingDelay) {
+          const retryAfterMs = adHocCreationDelayMs(sourceCount);
+          db.run(
+            "INSERT INTO adhoc_creation_events (source_hash, successful, occurred_at_ms, retry_until_ms) VALUES (?, 0, ?, ?)",
+            [sourceHash, nowMs, nowMs + retryAfterMs],
+          );
+          return {
+            status: "rate-limited",
+            retryAfterMs,
+          } as const;
+        }
         const globalCountRow = db
           .query("SELECT COUNT(*) AS count FROM adhoc_creation_events WHERE successful = 1")
           .get() as { count?: number | string } | null;
         const globalCount = Number(globalCountRow?.count ?? 0);
-        if (globalCount >= AD_HOC_MAX_CREATIONS_PER_HOUR) return "rate-limited" as const;
+        if (globalCount >= AD_HOC_MAX_CREATIONS_PER_HOUR) {
+          const firstSuccessRow = db
+            .query(
+              "SELECT MIN(occurred_at_ms) AS occurred_at_ms FROM adhoc_creation_events WHERE successful = 1",
+            )
+            .get() as { occurred_at_ms?: number | string } | null;
+          const retryAfterMs = Math.max(
+            1_000,
+            Number(firstSuccessRow?.occurred_at_ms ?? nowMs) +
+              AD_HOC_CREATION_GLOBAL_WINDOW_MS -
+              nowMs,
+          );
+          db.run(
+            "INSERT INTO adhoc_creation_events (source_hash, successful, occurred_at_ms, retry_until_ms) VALUES (?, 0, ?, ?)",
+            [sourceHash, nowMs, nowMs + retryAfterMs],
+          );
+          return {
+            status: "rate-limited",
+            retryAfterMs,
+          } as const;
+        }
         const countRow = db.query("SELECT COUNT(*) AS count FROM adhoc_games").get() as {
           count?: number | string;
         } | null;
@@ -769,11 +1296,16 @@ export function openSqliteAdHocStore(
           ],
         );
         db.run(
-          "INSERT INTO adhoc_creation_events (source_hash, successful, occurred_at_ms) VALUES (?, 1, ?)",
+          "INSERT INTO adhoc_creation_events (source_hash, successful, occurred_at_ms, retry_until_ms) VALUES (?, 1, ?, NULL)",
           [sourceHash, nowMs],
         );
         return "accepted" as const;
-      }) as "accepted" | "rate-limited" | "capacity" | "unavailable";
+      }) as
+        | "accepted"
+        | "rate-limited"
+        | "capacity"
+        | "unavailable"
+        | { status: "rate-limited"; retryAfterMs: number };
     },
     mutateGame<T>(gameId: string, mutation: (game: StoredAdHocGame) => T): T | null {
       return transaction(() => {
@@ -1236,6 +1768,92 @@ function operationFingerprint(operation: ControllerSynchronizationOperation<Game
     command: operation.payload,
     workflow: "ad-hoc",
     causalPredecessorIds: operation.causalPredecessorIds,
+  });
+}
+
+function fromControllerOperation(
+  operation: ControllerSynchronizationOperation<GameCommand>,
+): AdHocOperation {
+  return {
+    id: operation.operationId,
+    workflow: "ad-hoc",
+    clientSentAtMs: operation.clientOriginAtMs,
+    causalPredecessorIds: [...operation.causalPredecessorIds],
+    command: operation.payload,
+  };
+}
+
+function orderReplayPlan(
+  operations: readonly ControllerSynchronizationOperation<GameCommand>[],
+): readonly ControllerSynchronizationOperation<GameCommand>[] {
+  const byId = new Map(operations.map((operation) => [operation.operationId, operation]));
+  const indegree = new Map<string, number>();
+  const dependents = new Map<string, string[]>();
+  for (const operation of operations) {
+    const retainedPredecessors = operation.causalPredecessorIds.filter((id) => byId.has(id));
+    indegree.set(operation.operationId, retainedPredecessors.length);
+    for (const predecessor of retainedPredecessors) {
+      dependents.set(predecessor, [...(dependents.get(predecessor) ?? []), operation.operationId]);
+    }
+  }
+  const compare = (
+    left: ControllerSynchronizationOperation<GameCommand>,
+    right: ControllerSynchronizationOperation<GameCommand>,
+  ) =>
+    left.clientOriginAtMs - right.clientOriginAtMs ||
+    left.operationId.localeCompare(right.operationId);
+  const ready = operations
+    .filter((operation) => indegree.get(operation.operationId) === 0)
+    .sort(compare);
+  const ordered: ControllerSynchronizationOperation<GameCommand>[] = [];
+  while (ready.length > 0) {
+    const operation = ready.shift();
+    if (operation === undefined) break;
+    ordered.push(operation);
+    for (const dependentId of dependents.get(operation.operationId) ?? []) {
+      const nextIndegree = (indegree.get(dependentId) ?? 0) - 1;
+      indegree.set(dependentId, nextIndegree);
+      if (nextIndegree === 0) {
+        const dependent = byId.get(dependentId);
+        if (dependent !== undefined) ready.push(dependent);
+        ready.sort(compare);
+      }
+    }
+  }
+  const orderedIds = new Set(ordered.map((operation) => operation.operationId));
+  return [...ordered, ...operations.filter((operation) => !orderedIds.has(operation.operationId))];
+}
+
+function reconcilePreparedReplayChunk(
+  entries: readonly PreparedReplayEntry[],
+  retainedOperations: Readonly<Record<string, StoredOperation>>,
+): PreparedReplayEntry[] {
+  const statuses = new Map(
+    Object.entries(retainedOperations).map(([operationId, operation]) => [
+      operationId,
+      operation.status,
+    ]),
+  );
+  return entries.map((entry) => {
+    const existing = retainedOperations[entry.operation.operationId];
+    if (existing !== undefined) {
+      statuses.set(entry.operation.operationId, existing.status);
+      return entry;
+    }
+    let status = entry.status;
+    let detail = entry.detail;
+    if (
+      status === "accepted" &&
+      entry.operation.causalPredecessorIds.some(
+        (predecessorId) =>
+          statuses.get(predecessorId) !== undefined && statuses.get(predecessorId) !== "accepted",
+      )
+    ) {
+      status = "causally-blocked";
+      detail = "Causal predecessor was rejected.";
+    }
+    statuses.set(entry.operation.operationId, status === "duplicate" ? "rejected" : status);
+    return { ...entry, status, ...(detail === undefined ? {} : { detail }) };
   });
 }
 

--- a/src/lib/ad-hoc-resource-budgets.test.ts
+++ b/src/lib/ad-hoc-resource-budgets.test.ts
@@ -1,0 +1,667 @@
+import { describe, expect, test } from "bun:test";
+import {
+  AD_HOC_CREATION_IMMEDIATE_ATTEMPTS,
+  AD_HOC_CREATION_MAX_DELAY_MS,
+  AD_HOC_CONTROLLER_BURST,
+  AD_HOC_CONTROLLER_SUSTAINED_PER_SECOND,
+  AD_HOC_GAME_BURST,
+  AD_HOC_GAME_SUSTAINED_PER_SECOND,
+  AD_HOC_REPLAY_BURST,
+  AD_HOC_REPLAY_SUSTAINED_PER_SECOND,
+  adHocCreationDelayMs,
+  consumeAdHocTokens,
+} from "@/lib/ad-hoc-resource-budgets";
+import { createAdHocGamesService, type AdHocGamesService } from "@/lib/ad-hoc-games";
+
+async function drainScheduled<T>(promise: Promise<T>, queue: (() => void)[]): Promise<T> {
+  let settled = false;
+  void promise.finally(() => {
+    settled = true;
+  });
+  while (!settled) {
+    const task = queue.shift();
+    if (task === undefined) {
+      await Promise.resolve();
+      continue;
+    }
+    task();
+    await Promise.resolve();
+    await Promise.resolve();
+  }
+  return promise;
+}
+
+describe("Ad Hoc resource budgets", () => {
+  test("delays only later source attempts and caps the retry guidance", () => {
+    expect(adHocCreationDelayMs(AD_HOC_CREATION_IMMEDIATE_ATTEMPTS - 1)).toBe(0);
+    expect(adHocCreationDelayMs(AD_HOC_CREATION_IMMEDIATE_ATTEMPTS)).toBe(1_000);
+    expect(adHocCreationDelayMs(AD_HOC_CREATION_IMMEDIATE_ATTEMPTS + 1)).toBe(2_000);
+    expect(adHocCreationDelayMs(100)).toBe(AD_HOC_CREATION_MAX_DELAY_MS);
+  });
+
+  test("keeps Controller, Game, and replay buckets distinct with burst and refill semantics", () => {
+    const controller = consumeAdHocTokens(
+      undefined,
+      1_000,
+      AD_HOC_CONTROLLER_BURST,
+      AD_HOC_CONTROLLER_SUSTAINED_PER_SECOND,
+      AD_HOC_CONTROLLER_BURST,
+    );
+    const game = consumeAdHocTokens(
+      undefined,
+      1_000,
+      AD_HOC_GAME_BURST,
+      AD_HOC_GAME_SUSTAINED_PER_SECOND,
+      AD_HOC_GAME_BURST,
+    );
+    const replay = consumeAdHocTokens(
+      undefined,
+      1_000,
+      AD_HOC_REPLAY_BURST,
+      AD_HOC_REPLAY_SUSTAINED_PER_SECOND,
+      AD_HOC_REPLAY_BURST,
+    );
+
+    expect(controller.accepted).toBe(true);
+    expect(game.accepted).toBe(true);
+    expect(replay.accepted).toBe(true);
+    expect(
+      consumeAdHocTokens(
+        controller.accepted ? controller.bucket : undefined,
+        1_000,
+        AD_HOC_CONTROLLER_BURST,
+        AD_HOC_CONTROLLER_SUSTAINED_PER_SECOND,
+        1,
+      ),
+    ).toMatchObject({ accepted: false });
+    expect(
+      consumeAdHocTokens(
+        controller.accepted ? controller.bucket : undefined,
+        2_000,
+        AD_HOC_CONTROLLER_BURST,
+        AD_HOC_CONTROLLER_SUSTAINED_PER_SECOND,
+        AD_HOC_CONTROLLER_SUSTAINED_PER_SECOND,
+      ),
+    ).toMatchObject({ accepted: true });
+  });
+
+  test("does not retain delayed or globally exhausted creation attempts", async () => {
+    let nowMs = 1_000;
+    const service = createAdHocGamesService({ now: () => nowMs });
+    for (let index = 0; index < AD_HOC_CREATION_IMMEDIATE_ATTEMPTS; index += 1) {
+      expect(
+        (await service.create({ homeName: `Home ${index}`, awayName: "Away", sourceKey: "same" }))
+          .status,
+      ).toBe("accepted");
+    }
+    const beforeDelayed = service.store.listGames().length;
+    const delayed = await service.create({
+      homeName: "Delayed",
+      awayName: "Away",
+      sourceKey: "same",
+    });
+    expect(delayed).toMatchObject({ status: "rejected", reason: "rate-limited" });
+    if (delayed.status === "rejected") {
+      expect(delayed.detail).toBe("Try again later.");
+      expect(delayed.retryAfterMs).toBeGreaterThan(0);
+      expect(delayed.retryAfterMs).toBeLessThanOrEqual(AD_HOC_CREATION_MAX_DELAY_MS);
+    }
+    expect(service.store.listGames()).toHaveLength(beforeDelayed);
+
+    nowMs += 10 * 60_000;
+    expect(
+      (await service.create({ homeName: "New window", awayName: "Away", sourceKey: "same" }))
+        .status,
+    ).toBe("accepted");
+
+    for (let index = 0; index < 24; index += 1) {
+      expect(
+        (
+          await service.create({
+            homeName: `Global ${index}`,
+            awayName: "Away",
+            sourceKey: `source-${index}`,
+          })
+        ).status,
+      ).toBe("accepted");
+    }
+    const beforeGlobal = service.store.listGames().length;
+    const global = await service.create({
+      homeName: "Global limit",
+      awayName: "Away",
+      sourceKey: "source-global-limit",
+    });
+    expect(global).toMatchObject({ status: "rejected", reason: "rate-limited" });
+    expect(service.store.listGames()).toHaveLength(beforeGlobal);
+  });
+
+  test("requires a retry window and then admits the same anonymous source", async () => {
+    let nowMs = 1_000;
+    const service = createAdHocGamesService({ now: () => nowMs });
+    for (let index = 0; index < AD_HOC_CREATION_IMMEDIATE_ATTEMPTS; index += 1)
+      await service.create({ homeName: `Home ${index}`, awayName: "Away", sourceKey: "cookie-a" });
+    const limited = await service.create({
+      homeName: "Busy",
+      awayName: "Away",
+      sourceKey: "cookie-a",
+    });
+    expect(limited).toMatchObject({ status: "rejected", retryAfterMs: 1_000 });
+    nowMs += 1_000;
+    expect(
+      (await service.create({ homeName: "Retry", awayName: "Away", sourceKey: "cookie-a" })).status,
+    ).toBe("accepted");
+  });
+
+  test("rejects Ad Hoc action saturation without sharing Event capacity", async () => {
+    const service = createAdHocGamesService({ now: () => 1_000 });
+    const created = await service.create({ homeName: "Home", awayName: "Away" });
+    if (created.status !== "accepted") throw new Error("creation failed");
+    const operations = Array.from({ length: AD_HOC_CONTROLLER_BURST }, (_, index) => ({
+      id: `burst-${index}`,
+      clientSentAtMs: 1_000,
+      command: { type: "set-running", running: index % 2 === 0 },
+    })) as never[];
+    expect(
+      (await service.apply({ gameId: created.gameId, sessionId: created.sessionId, operations }))
+        .status,
+    ).toBe("accepted");
+    const rejected = await service.apply({
+      gameId: created.gameId,
+      sessionId: created.sessionId,
+      operations: [
+        {
+          id: "over-burst",
+          clientSentAtMs: 1_000,
+          command: { type: "set-running", running: true },
+        },
+      ],
+    });
+    expect(rejected).toMatchObject({
+      status: "rejected",
+      reason: "rate-limited",
+      detail: "Try again later.",
+    });
+    expect(service.getResourceMetrics().actionRateExhausted).toBeGreaterThan(0);
+
+    const second = await service.create({ homeName: "Second", awayName: "Away" });
+    if (second.status !== "accepted") throw new Error("second creation failed");
+    expect(
+      (
+        await service.apply({
+          gameId: second.gameId,
+          sessionId: second.sessionId,
+          operations: [
+            {
+              id: "independent-game-operation",
+              clientSentAtMs: 1_000,
+              command: { type: "set-running", running: true },
+            },
+          ],
+        })
+      ).status,
+    ).toBe("accepted");
+  });
+
+  test("charges accepted operations only and keeps replay acknowledgement explicit", async () => {
+    let nowMs = 1_000;
+    const scheduled: (() => void)[] = [];
+    const service = createAdHocGamesService({
+      now: () => nowMs,
+      deferReplayAcknowledgement: true,
+      schedule: (_delayMs, task) => scheduled.push(task),
+    });
+    const created = await service.create({ homeName: "Home", awayName: "Away" });
+    if (created.status !== "accepted") throw new Error("creation failed");
+    const admitted = await service.admit({ gameId: created.gameId, controlQr: created.controlQr });
+    if (admitted.status !== "accepted") throw new Error("admission failed");
+    const firstControllerOperations = Array.from({ length: 20 }, (_, index) => ({
+      id: `accepted-${index}`,
+      clientSentAtMs: 1_000,
+      command: { type: "set-running", running: index % 2 === 0 },
+    })) as never[];
+    const first = await drainScheduled(
+      service.apply({
+        gameId: created.gameId,
+        sessionId: created.sessionId,
+        operations: firstControllerOperations,
+      }),
+      scheduled,
+    );
+    expect(first.status).toBe("accepted");
+    if (first.status !== "accepted" || first.replayId === undefined)
+      throw new Error("replay missing");
+    await service.acknowledgeReplay({
+      sessionId: created.sessionId,
+      replayId: first.replayId,
+      delivered: true,
+    });
+    nowMs += 1_000;
+    const secondFirstController = await drainScheduled(
+      service.apply({
+        gameId: created.gameId,
+        sessionId: created.sessionId,
+        operations: Array.from({ length: 20 }, (_, index) => ({
+          id: `accepted-again-${index}`,
+          clientSentAtMs: 1_000,
+          command: { type: "set-running", running: index % 2 === 0 },
+        })) as never[],
+      }),
+      scheduled,
+    );
+    expect(secondFirstController.status).toBe("accepted");
+    if (secondFirstController.status !== "accepted" || secondFirstController.replayId === undefined)
+      throw new Error("second replay missing");
+    await service.acknowledgeReplay({
+      sessionId: created.sessionId,
+      replayId: secondFirstController.replayId,
+      delivered: true,
+    });
+    const blocked = await drainScheduled(
+      service.apply({
+        gameId: created.gameId,
+        sessionId: created.sessionId,
+        operations: [
+          {
+            id: "blocked",
+            clientSentAtMs: 1_000,
+            causalPredecessorIds: ["missing"],
+            command: { type: "set-running", running: true },
+          },
+        ],
+      }),
+      scheduled,
+    );
+    expect(blocked.status).toBe("accepted");
+    if (blocked.status === "accepted") {
+      expect(blocked.outcomes.find((outcome) => outcome.operationId === "blocked")?.status).toBe(
+        "rejected",
+      );
+      if (blocked.replayId !== undefined)
+        await service.acknowledgeReplay({
+          sessionId: created.sessionId,
+          replayId: blocked.replayId,
+          delivered: true,
+        });
+    }
+    await service.acknowledgeReplay({
+      sessionId: created.sessionId,
+      replayId: secondFirstController.replayId,
+      delivered: true,
+    });
+    const second = await drainScheduled(
+      service.apply({
+        gameId: created.gameId,
+        sessionId: admitted.game.sessionId,
+        operations: Array.from({ length: 10 }, (_, index) => ({
+          id: `second-${index}`,
+          clientSentAtMs: 1_000,
+          command: { type: "set-running", running: index % 2 === 0 },
+        })) as never[],
+      }),
+      scheduled,
+    );
+    expect(second.status).toBe("accepted");
+  });
+
+  test("accepts a 100-operation replay and schedules durable chunks at 20 per second", async () => {
+    const scheduled: (() => void)[] = [];
+    const delays: number[] = [];
+    const service = createAdHocGamesService({
+      now: () => 1_000,
+      deferReplayAcknowledgement: true,
+      schedule: (delayMs, task) => {
+        delays.push(delayMs);
+        scheduled.push(task);
+      },
+    });
+    const created = await service.create({ homeName: "Home", awayName: "Away" });
+    if (created.status !== "accepted") throw new Error("creation failed");
+    const operations = Array.from({ length: 100 }, (_, index) => ({
+      id: `scheduled-${index}`,
+      clientSentAtMs: 1_000,
+      command: { type: "set-running", running: index % 2 === 0 },
+    })) as never[];
+    const pending = service.apply({
+      gameId: created.gameId,
+      sessionId: created.sessionId,
+      operations,
+    });
+    expect(scheduled).toHaveLength(1);
+    const result = await drainScheduled(pending, scheduled);
+    expect(result.status).toBe("accepted");
+    if (result.status === "accepted") {
+      expect(result.ackedOperationIds).toHaveLength(100);
+      expect(result.outcomes).toHaveLength(100);
+    }
+    expect(delays).toEqual([0, 1_000, 1_000, 1_000, 1_000]);
+  });
+
+  test("prevalidates a malformed later operation without scheduling or mutating", async () => {
+    const scheduled: (() => void)[] = [];
+    const service = createAdHocGamesService({
+      now: () => 1_000,
+      deferReplayAcknowledgement: true,
+      schedule: (_delayMs, task) => scheduled.push(task),
+    });
+    const created = await service.create({ homeName: "Home", awayName: "Away" });
+    if (created.status !== "accepted") throw new Error("creation failed");
+    const before = service.store.readGame(created.gameId);
+    const rejected = await service.apply({
+      gameId: created.gameId,
+      sessionId: created.sessionId,
+      operations: [
+        {
+          id: "valid-before-malformed",
+          clientSentAtMs: 1_000,
+          command: { type: "set-running", running: true },
+        },
+        {
+          id: "malformed-later",
+          clientSentAtMs: 1_001,
+          command: { type: "not-a-game-command" },
+        },
+      ] as never[],
+    });
+    expect(rejected).toMatchObject({ status: "rejected", reason: "invalid-operation" });
+    expect(scheduled).toHaveLength(0);
+    expect(service.store.readGame(created.gameId)).toEqual(before);
+  });
+
+  test("causally orders a later-position predecessor across scheduled chunks", async () => {
+    const scheduled: (() => void)[] = [];
+    const service = createAdHocGamesService({
+      now: () => 1_000,
+      deferReplayAcknowledgement: true,
+      schedule: (_delayMs, task) => scheduled.push(task),
+    });
+    const created = await service.create({ homeName: "Home", awayName: "Away" });
+    if (created.status !== "accepted") throw new Error("creation failed");
+    const operations = [
+      {
+        id: "dependent-first",
+        clientSentAtMs: 2_001,
+        causalPredecessorIds: ["predecessor-later"],
+        command: { type: "change-score", team: "home", delta: 10, reason: "goal" },
+      },
+      ...Array.from({ length: 19 }, (_, index) => ({
+        id: `before-${index}`,
+        clientSentAtMs: 1_000 + index,
+        command: { type: "change-score", team: "home", delta: 10, reason: "goal" },
+      })),
+      {
+        id: "predecessor-later",
+        clientSentAtMs: 2_000,
+        command: { type: "change-score", team: "home", delta: 10, reason: "goal" },
+      },
+      ...Array.from({ length: 19 }, (_, index) => ({
+        id: `after-${index}`,
+        clientSentAtMs: 3_000 + index,
+        command: { type: "change-score", team: "home", delta: 10, reason: "goal" },
+      })),
+    ] as never[];
+    const pending = service.apply({
+      gameId: created.gameId,
+      sessionId: created.sessionId,
+      operations,
+    });
+    const result = await drainScheduled(pending, scheduled);
+    expect(result.status).toBe("accepted");
+    if (result.status === "accepted") {
+      expect(result.ackedOperationIds).toHaveLength(40);
+      expect(
+        result.outcomes.find((outcome) => outcome.operationId === "dependent-first")?.status,
+      ).toBe("accepted");
+      expect(result.game.state.score.home).toBe(400);
+    }
+  });
+
+  test("preserves whole-batch causal blocking across scheduled chunks", async () => {
+    const scheduled: (() => void)[] = [];
+    const service = createAdHocGamesService({
+      now: () => 1_000,
+      deferReplayAcknowledgement: true,
+      schedule: (_delayMs, task) => scheduled.push(task),
+    });
+    const created = await service.create({ homeName: "Home", awayName: "Away" });
+    if (created.status !== "accepted") throw new Error("creation failed");
+    const operations = [
+      ...Array.from({ length: 20 }, (_, index) => ({
+        id: `causal-before-${index}`,
+        clientSentAtMs: 1_000 + index,
+        command: { type: "change-score", team: "home", delta: 10, reason: "goal" },
+      })),
+      {
+        id: "missing-predecessor",
+        clientSentAtMs: 2_000,
+        causalPredecessorIds: ["not-retained"],
+        command: { type: "change-score", team: "home", delta: 10, reason: "goal" },
+      },
+      {
+        id: "blocked-dependent",
+        clientSentAtMs: 2_001,
+        causalPredecessorIds: ["missing-predecessor"],
+        command: { type: "change-score", team: "home", delta: 10, reason: "goal" },
+      },
+      ...Array.from({ length: 20 }, (_, index) => ({
+        id: `causal-after-${index}`,
+        clientSentAtMs: 3_000 + index,
+        command: { type: "change-score", team: "home", delta: 10, reason: "goal" },
+      })),
+    ] as never[];
+    const result = await drainScheduled(
+      service.apply({
+        gameId: created.gameId,
+        sessionId: created.sessionId,
+        operations,
+      }),
+      scheduled,
+    );
+    expect(result.status).toBe("accepted");
+    if (result.status === "accepted") {
+      expect(
+        result.outcomes.find((outcome) => outcome.operationId === "missing-predecessor")?.status,
+      ).toBe("rejected");
+      expect(
+        result.outcomes.find((outcome) => outcome.operationId === "blocked-dependent")?.status,
+      ).toBe("causally-blocked");
+      expect(result.game.state.score.home).toBe(400);
+    }
+  });
+
+  test("reconciles a concurrent rejected predecessor before applying a dependent chunk", async () => {
+    const scheduled: { delayMs: number; task: () => void }[] = [];
+    const service = createAdHocGamesService({
+      now: () => 1_000,
+      deferReplayAcknowledgement: true,
+      schedule: (delayMs, task) => scheduled.push({ delayMs, task }),
+    });
+    const created = await service.create({ homeName: "Home", awayName: "Away" });
+    if (created.status !== "accepted") throw new Error("creation failed");
+    const second = await service.admit({ gameId: created.gameId, controlQr: created.controlQr });
+    if (second.status !== "accepted") throw new Error("second admission failed");
+    const predecessor = {
+      id: "same-fingerprint-predecessor",
+      clientSentAtMs: 2_000,
+      causalPredecessorIds: ["batch-root"],
+      command: { type: "set-running", running: true },
+    };
+    const dependent = {
+      id: "dependent-after-concurrent-rejection",
+      clientSentAtMs: 2_001,
+      causalPredecessorIds: [predecessor.id],
+      command: { type: "set-running", running: false },
+    };
+    const pending = service.apply({
+      gameId: created.gameId,
+      sessionId: created.sessionId,
+      operations: [
+        ...Array.from({ length: 20 }, (_, index) => ({
+          id: `batch-unrelated-${index}`,
+          clientSentAtMs: 1_000 + index,
+          command: { type: "set-running", running: index % 2 === 0 },
+        })),
+        {
+          id: "batch-root",
+          clientSentAtMs: 2_000,
+          command: { type: "set-running", running: true },
+        },
+        predecessor,
+        dependent,
+      ] as never[],
+    });
+    const initial = scheduled.shift();
+    expect(initial?.delayMs).toBe(0);
+    initial?.task();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(scheduled[0]?.delayMs).toBe(1_000);
+
+    const competing = service.apply({
+      gameId: created.gameId,
+      sessionId: second.game.sessionId,
+      operations: [predecessor] as never[],
+    });
+    const competingTask = scheduled.pop();
+    expect(competingTask?.delayMs).toBe(0);
+    competingTask?.task();
+    await Promise.resolve();
+    await Promise.resolve();
+    const competingResult = await competing;
+    expect(competingResult.status).toBe("accepted");
+    if (competingResult.status === "accepted" && competingResult.replayId !== undefined) {
+      await service.acknowledgeReplay({
+        sessionId: second.game.sessionId,
+        replayId: competingResult.replayId,
+        delivered: true,
+      });
+    }
+
+    scheduled.shift()?.task();
+    await Promise.resolve();
+    await Promise.resolve();
+    const result = await pending;
+    expect(result.status).toBe("accepted");
+    if (result.status === "accepted") {
+      expect(
+        result.outcomes.find((outcome) => outcome.operationId === predecessor.id)?.status,
+      ).toBe("rejected");
+      expect(result.outcomes.find((outcome) => outcome.operationId === dependent.id)?.status).toBe(
+        "causally-blocked",
+      );
+    }
+    const retained = service.store.readGame(created.gameId);
+    expect(retained?.operations[predecessor.id]?.status).toBe("rejected");
+    expect(retained?.operations[dependent.id]?.status).toBe("causally-blocked");
+  });
+
+  test("cancels pending replay work on service close without acknowledging it", async () => {
+    const scheduled: (() => void)[] = [];
+    const service = createAdHocGamesService({
+      deferReplayAcknowledgement: true,
+      schedule: (_delayMs, task) => scheduled.push(task),
+    });
+    const created = await service.create({ homeName: "Home", awayName: "Away" });
+    if (created.status !== "accepted") throw new Error("creation failed");
+    const pending = service.apply({
+      gameId: created.gameId,
+      sessionId: created.sessionId,
+      operations: [
+        {
+          id: "close-before-apply",
+          clientSentAtMs: 1_000,
+          command: { type: "set-running", running: true },
+        },
+      ],
+    });
+    service.close();
+    expect(await pending).toMatchObject({ status: "rejected", reason: "unavailable" });
+    scheduled.shift()?.();
+    expect(scheduled).toHaveLength(0);
+    expect(service.store.listGames()).toHaveLength(1);
+  });
+
+  test("does not schedule a later replay chunk after an in-flight close", async () => {
+    const scheduled: { delayMs: number; task: () => void }[] = [];
+    let service!: AdHocGamesService;
+    service = createAdHocGamesService({
+      deferReplayAcknowledgement: true,
+      schedule: (delayMs, task) => scheduled.push({ delayMs, task }),
+    });
+    const created = await service.create({ homeName: "Home", awayName: "Away" });
+    if (created.status !== "accepted") throw new Error("creation failed");
+    const pending = service.apply({
+      gameId: created.gameId,
+      sessionId: created.sessionId,
+      operations: Array.from({ length: 40 }, (_, index) => ({
+        id: `close-in-flight-${index}`,
+        clientSentAtMs: 1_000,
+        command: { type: "set-running", running: index % 2 === 0 },
+      })) as never[],
+    });
+    expect(scheduled).toHaveLength(1);
+    scheduled.shift()!.task();
+    service.close();
+    expect(await pending).toMatchObject({ status: "rejected", reason: "unavailable" });
+    await Promise.resolve();
+    expect(scheduled).toHaveLength(0);
+  });
+
+  test("counts socket instances before ownership and exposes Event reserve pressure", async () => {
+    let activeEventConnections = 0;
+    const service = createAdHocGamesService({
+      now: () => 1_000,
+      maxConnectedSockets: 2,
+      eventCapacity: {
+        totalConnections: 3,
+        reservedConnections: 1,
+        activeConnections: () => activeEventConnections,
+      },
+    });
+    const first = await service.create({ homeName: "One", awayName: "Away" });
+    const second = await service.create({ homeName: "Two", awayName: "Away" });
+    if (first.status !== "accepted" || second.status !== "accepted")
+      throw new Error("creation failed");
+    expect(
+      await service.setConnection({
+        gameId: first.gameId,
+        sessionId: first.sessionId,
+        connected: true,
+        connectionId: "socket-1",
+      }),
+    ).toBe(true);
+    expect(
+      await service.setConnection({
+        gameId: first.gameId,
+        sessionId: first.sessionId,
+        connected: true,
+        connectionId: "socket-2",
+      }),
+    ).toBe(true);
+    expect(
+      await service.setConnection({
+        gameId: second.gameId,
+        sessionId: second.sessionId,
+        connected: true,
+        connectionId: "socket-3",
+      }),
+    ).toBe(false);
+    expect(service.getResourceMetrics()).toMatchObject({
+      connectedControllers: 2,
+      eventReservedCapacity: { configured: 1, active: 0, availableForAdHoc: 2 },
+    });
+    expect(
+      await service.setConnection({
+        gameId: first.gameId,
+        sessionId: first.sessionId,
+        connected: false,
+        connectionId: "socket-1",
+      }),
+    ).toBe(true);
+    expect(service.getResourceMetrics().connectedControllers).toBe(1);
+    activeEventConnections = 1;
+    expect(service.getResourceMetrics().eventReservedCapacity).toMatchObject({
+      active: 1,
+      availableForAdHoc: 2,
+    });
+  });
+});

--- a/src/lib/ad-hoc-resource-budgets.ts
+++ b/src/lib/ad-hoc-resource-budgets.ts
@@ -1,0 +1,103 @@
+/**
+ * Ad Hoc resource policy is deliberately kept in its own module.  None of
+ * these buckets are reused by Event Games, Grants, or the Event transport.
+ */
+
+export const AD_HOC_CREATION_IMMEDIATE_ATTEMPTS = 5;
+export const AD_HOC_CREATION_MAX_DELAY_MS = 30_000;
+
+export const AD_HOC_CONTROLLER_SUSTAINED_PER_SECOND = 20;
+export const AD_HOC_CONTROLLER_BURST = 40;
+export const AD_HOC_GAME_SUSTAINED_PER_SECOND = 50;
+export const AD_HOC_GAME_BURST = 100;
+
+export const AD_HOC_REPLAY_MAX_OPERATIONS_PER_BATCH = 100;
+export const AD_HOC_REPLAY_SUSTAINED_PER_SECOND = 20;
+// Replay batches are admitted in a 20-operation scheduling slice. The wire
+// envelope remains 100 so malformed or oversized replay requests fail closed.
+export const AD_HOC_REPLAY_BURST = AD_HOC_REPLAY_SUSTAINED_PER_SECOND;
+export const AD_HOC_REPLAY_MAX_UNACKNOWLEDGED_BATCHES = 1;
+
+// This is an Ad Hoc-only ceiling.  Event connection capacity is not read or
+// mutated here, so a full Ad Hoc pool cannot consume Event capacity.
+export const AD_HOC_MAX_CONNECTED_CONTROLLERS = 256;
+export const AD_HOC_MAX_QUEUED_OUTPUT_BYTES = 256 * 1024;
+export const AD_HOC_EVENT_TOTAL_CONNECTION_CAPACITY = AD_HOC_MAX_CONNECTED_CONTROLLERS + 1;
+export const AD_HOC_EVENT_RESERVED_CONNECTION_CAPACITY = 1;
+
+export type AdHocResourceMetric =
+  | "creation-delay"
+  | "creation-rate-exhausted"
+  | "action-rate-exhausted"
+  | "replay-pressure"
+  | "connection-shed"
+  | "queue-pressure";
+
+export type AdHocResourceMetrics = Readonly<{
+  creationDelay: number;
+  creationRateExhausted: number;
+  actionRateExhausted: number;
+  replayPressure: number;
+  connectionShed: number;
+  queuePressure: number;
+  connectedControllers: number;
+  eventReservedCapacity: {
+    configured: number;
+    active: number;
+    availableForAdHoc: number;
+  };
+}>;
+
+export type AdHocTokenBucket = {
+  tokens: number;
+  updatedAtMs: number;
+};
+
+export type AdHocTokenDecision =
+  | { accepted: true; bucket: AdHocTokenBucket }
+  | { accepted: false; retryAfterMs: number; bucket: AdHocTokenBucket };
+
+/** Returns a bounded, progressive delay after the five immediate attempts. */
+export function adHocCreationDelayMs(sourceAttemptCount: number): number {
+  if (sourceAttemptCount < AD_HOC_CREATION_IMMEDIATE_ATTEMPTS) return 0;
+  const exponent = Math.min(5, sourceAttemptCount - AD_HOC_CREATION_IMMEDIATE_ATTEMPTS);
+  return Math.min(AD_HOC_CREATION_MAX_DELAY_MS, 1_000 * 2 ** exponent);
+}
+
+export function consumeAdHocTokens(
+  previous: AdHocTokenBucket | undefined,
+  nowMs: number,
+  capacity: number,
+  refillPerSecond: number,
+  cost: number,
+): AdHocTokenDecision {
+  const current = previous ?? { tokens: capacity, updatedAtMs: nowMs };
+  const elapsedMs = Math.max(0, nowMs - current.updatedAtMs);
+  const refilled = Math.min(capacity, current.tokens + (elapsedMs * refillPerSecond) / 1_000);
+  const bucket = { tokens: refilled, updatedAtMs: nowMs };
+  if (cost <= refilled) return { accepted: true, bucket: { ...bucket, tokens: refilled - cost } };
+  return {
+    accepted: false,
+    retryAfterMs: Math.max(1, Math.ceil(((cost - refilled) * 1_000) / refillPerSecond)),
+    bucket,
+  };
+}
+
+export function emptyAdHocResourceMetrics(): {
+  -readonly [K in keyof AdHocResourceMetrics]: AdHocResourceMetrics[K];
+} {
+  return {
+    creationDelay: 0,
+    creationRateExhausted: 0,
+    actionRateExhausted: 0,
+    replayPressure: 0,
+    connectionShed: 0,
+    queuePressure: 0,
+    connectedControllers: 0,
+    eventReservedCapacity: {
+      configured: AD_HOC_EVENT_RESERVED_CONNECTION_CAPACITY,
+      active: 0,
+      availableForAdHoc: AD_HOC_MAX_CONNECTED_CONTROLLERS,
+    },
+  };
+}

--- a/src/lib/game-page-support.ts
+++ b/src/lib/game-page-support.ts
@@ -50,6 +50,8 @@ export function useGameConnection({ gameId, role }: { gameId: string; role: Cont
   const pendingRef = useRef<AdHocPendingOperation[]>([]);
   const outcomesRef = useRef<AdHocControllerOutcomes>({});
   const reconnectTimeoutRef = useRef<number | null>(null);
+  const replayRetryTimeoutRef = useRef<number | null>(null);
+  const replayInFlightRef = useRef(false);
   const wsRef = useRef<WebSocket | null>(null);
   const commandCounterRef = useRef(0);
   const clientInstanceId = useRef(crypto.randomUUID());
@@ -94,14 +96,16 @@ export function useGameConnection({ gameId, role }: { gameId: string; role: Cont
       localOnlyModeRef.current ||
       !subscribedToServerGameRef.current ||
       wsRef.current?.readyState !== WebSocket.OPEN ||
+      replayInFlightRef.current ||
       pendingRef.current.length === 0
     )
       return;
+    replayInFlightRef.current = true;
     wsRef.current.send(
       JSON.stringify({
         type: "apply-commands",
         gameId,
-        commands: pendingRef.current,
+        commands: pendingRef.current.slice(0, 100),
       }),
     );
   }, [gameId, role]);
@@ -205,16 +209,39 @@ export function useGameConnection({ gameId, role }: { gameId: string; role: Cont
         const parsed = parseServerMessage(event.data);
         if (parsed === null) return;
         if (parsed.type === "error") {
+          replayInFlightRef.current = false;
           if (role === "controller" && isServerGameUnavailableError(parsed.message)) {
             subscribedToServerGameRef.current = false;
             setLocalOnlyState(true);
             setConnectionState("local-only");
             setError(LOCAL_ONLY_MESSAGE);
             ws.close();
+          } else if (parsed.retryAfterMs !== undefined) {
+            const delayMs = Math.min(30_000, Math.max(1, parsed.retryAfterMs));
+            replayInFlightRef.current = false;
+            if (!subscribedToServerGameRef.current) {
+              if (reconnectTimeoutRef.current !== null)
+                window.clearTimeout(reconnectTimeoutRef.current);
+              reconnectTimeoutRef.current = window.setTimeout(() => {
+                reconnectTimeoutRef.current = null;
+                connect();
+              }, delayMs);
+              setError(`Ad Hoc connection busy. Retrying in ${Math.ceil(delayMs / 1_000)}s.`);
+              ws.close(1013, "Ad Hoc subscription retry.");
+              return;
+            }
+            if (replayRetryTimeoutRef.current !== null)
+              window.clearTimeout(replayRetryTimeoutRef.current);
+            setError(`Ad Hoc busy. Retrying in ${Math.ceil(delayMs / 1_000)}s.`);
+            replayRetryTimeoutRef.current = window.setTimeout(() => {
+              replayRetryTimeoutRef.current = null;
+              flushPendingCommands();
+            }, delayMs);
           } else setError(parsed.message);
           return;
         }
         if (parsed.type === "game-snapshot") {
+          replayInFlightRef.current = false;
           subscribedToServerGameRef.current = true;
           setLocalOnlyState(false);
           setConnectionState("online");
@@ -229,18 +256,24 @@ export function useGameConnection({ gameId, role }: { gameId: string; role: Cont
           flushPendingCommands();
         }
       };
-      ws.onclose = () => {
+      ws.onclose = (event) => {
+        replayInFlightRef.current = false;
         setConnectionState(localOnlyModeRef.current ? "local-only" : "offline");
         wsRef.current = null;
         subscribedToServerGameRef.current = false;
-        if (!cancelled) {
+        if (event.code === 1013 && !cancelled) setError("Ad Hoc connection busy. Retrying in 1s.");
+        if (!cancelled && reconnectTimeoutRef.current === null) {
           reconnectTimeoutRef.current = window.setTimeout(
             connect,
             localOnlyModeRef.current ? LOCAL_ONLY_RETRY_DELAY_MS : NORMAL_RECONNECT_DELAY_MS,
           );
         }
       };
-      ws.onerror = () => ws.close();
+      ws.onerror = () => {
+        if (!cancelled && !localOnlyModeRef.current)
+          setError("Ad Hoc connection busy. Retrying in 1s.");
+        ws.close();
+      };
     };
     void fetchInitialSnapshot();
     connect();
@@ -249,6 +282,8 @@ export function useGameConnection({ gameId, role }: { gameId: string; role: Cont
       subscribedToServerGameRef.current = false;
       wsRef.current?.close();
       if (reconnectTimeoutRef.current !== null) window.clearTimeout(reconnectTimeoutRef.current);
+      if (replayRetryTimeoutRef.current !== null)
+        window.clearTimeout(replayRetryTimeoutRef.current);
     };
   }, [
     flushPendingCommands,

--- a/src/lib/grant-authority.ts
+++ b/src/lib/grant-authority.ts
@@ -50,6 +50,8 @@ export type GrantAuthorityOptions = {
     ) => { eventGameId: string; apply(transaction: FoundationStorageTransaction): void } | null;
   };
   privilegedAuthorityVerifier: GrantAuthorityVerifier;
+  /** Refresh cheap Event capacity snapshots after lifecycle mutations. */
+  onLifecycleChange?: () => void;
 };
 
 /** The single public Grant facade. All Grant types use the trusted typed lifecycle. */

--- a/src/lib/grant-management-sessions.ts
+++ b/src/lib/grant-management-sessions.ts
@@ -195,7 +195,7 @@ export async function admitGrant(
         sessionExpiresAtMs:
           current.grantType === EVENT_ADMIN_GRANT_TYPE
             ? Math.min(current.expiresAtMs ?? Number.MAX_SAFE_INTEGER, nowMs + 30 * DAY_MS)
-            : current.grantType === "pitch-manager"
+            : current.grantType === PITCH_MANAGER_GRANT_TYPE || current.grantType === GRANT_TYPE
               ? current.expiresAtMs
               : null,
       };
@@ -376,7 +376,7 @@ export function authorizeGrantInTransaction(
             grant.expiresAtMs ?? Number.MAX_SAFE_INTEGER,
             effectiveActivityAtMs + 30 * DAY_MS,
           )
-        : grant.grantType === "pitch-manager"
+        : grant.grantType === PITCH_MANAGER_GRANT_TYPE || grant.grantType === GRANT_TYPE
           ? grant.expiresAtMs
           : null,
   };
@@ -443,6 +443,7 @@ export async function acceptControlGrantSessionSwitch(
         grantSessionId: session.sessionId,
         previousEventGameId: relationship.previousEventGameId,
         eventGameId: relationship.currentEventGameId,
+        ...(grant.expiresAtMs === null ? {} : { sessionExpiresAtMs: grant.expiresAtMs }),
       } satisfies TypedControlGrantSwitch;
     });
   } catch {

--- a/src/lib/grant-management-types.ts
+++ b/src/lib/grant-management-types.ts
@@ -111,6 +111,7 @@ export type TypedControlGrantSwitch =
       grantSessionId: string;
       previousEventGameId: string;
       eventGameId: string;
+      sessionExpiresAtMs?: number | null;
     }
   | typeof GENERIC_GRANT_AUTHORIZATION_FAILURE;
 

--- a/src/lib/grant-management.ts
+++ b/src/lib/grant-management.ts
@@ -53,6 +53,21 @@ export function createTypedGrantAuthority(
   options: GrantAuthorityOptions,
 ): TypedGrantAuthority {
   requireGrantStorageCapabilities(storage);
+  const notifyLifecycleChange = <T>(
+    operation: Promise<T>,
+    changedStatuses: readonly string[] = ["admitted", "switched", "updated"],
+  ): Promise<T> =>
+    operation.then((result) => {
+      if (
+        typeof result === "object" &&
+        result !== null &&
+        "status" in result &&
+        changedStatuses.includes(String(result.status))
+      ) {
+        options.onLifecycleChange?.();
+      }
+      return result;
+    });
   storage.setGrantValidationContext({
     environmentId: options.environmentId,
     keyRing: options.keyRing,
@@ -88,36 +103,48 @@ export function createTypedGrantAuthority(
     disableGrantCode: (grantId, authority) =>
       disableGrantCode(storage, options, grantId, authority),
     admitGrantCode: (input) => admitGrantCode(storage, options, input),
-    admitGrant: (input) => admitGrant(storage, options, input),
+    admitGrant: (input) => notifyLifecycleChange(admitGrant(storage, options, input)),
     admitPitchManagerGrant: (input) =>
       admitGrant(storage, options, input, PITCH_MANAGER_GRANT_TYPE),
     admitEventAdminGrant: (input) => admitGrant(storage, options, input, EVENT_ADMIN_GRANT_TYPE),
-    authorizeGrant: (input) => authorizeGrant(storage, options, input),
+    authorizeGrant: (input) =>
+      input.readOnly === true
+        ? authorizeGrant(storage, options, input)
+        : notifyLifecycleChange(authorizeGrant(storage, options, input), ["authorized"]),
     authorizeGrantInTransaction: (transaction, input) =>
       authorizeGrantInTransaction(transaction, options, input),
     acceptControlGrantSessionSwitch: (input) =>
-      acceptControlGrantSessionSwitch(storage, options, input.sessionBearer),
+      notifyLifecycleChange(acceptControlGrantSessionSwitch(storage, options, input.sessionBearer)),
     authorizeControlGrantReplay: (input) => authorizeControlGrantReplay(storage, options, input),
     revealGrant: (grantId, authority) => revealGrant(storage, options, grantId, authority),
     revealGrantInTransaction: (transaction, grantId, authority) =>
       revealGrantInTransaction(transaction, options, grantId, authority),
     disableGrant: (grantId, authority) =>
-      updateGrantStatus(storage, options, grantId, authority, "disabled", "grant-disabled"),
+      notifyLifecycleChange(
+        updateGrantStatus(storage, options, grantId, authority, "disabled", "grant-disabled"),
+      ),
     revokeGrant: (grantId, authority) =>
-      updateGrantStatus(storage, options, grantId, authority, "revoked", "grant-revoked"),
-    reactivateGrant: (grantId, authority) => reactivateGrant(storage, options, grantId, authority),
-    rotateGrant: (grantId, authority) => rotateGrant(storage, options, grantId, authority),
+      notifyLifecycleChange(
+        updateGrantStatus(storage, options, grantId, authority, "revoked", "grant-revoked"),
+      ),
+    reactivateGrant: (grantId, authority) =>
+      notifyLifecycleChange(reactivateGrant(storage, options, grantId, authority)),
+    rotateGrant: (grantId, authority) =>
+      notifyLifecycleChange(rotateGrant(storage, options, grantId, authority)),
     rotateGrantInTransaction: (transaction, grantId, authority) =>
       rotateGrantInTransaction(transaction, options, grantId, authority),
     rotateGrantCredentialKeys: (grantId, authority) =>
-      rotateGrantCredentialKeys(storage, options, grantId, authority),
+      notifyLifecycleChange(rotateGrantCredentialKeys(storage, options, grantId, authority)),
     recalculateGrantExpiry: (grantId, correction, authority) =>
-      recalculateExpiry(storage, options, grantId, correction, authority),
+      notifyLifecycleChange(recalculateExpiry(storage, options, grantId, correction, authority)),
     revokeGrantSession: (grantId, sessionReference, authority) =>
-      revokeGrantSession(storage, options, grantId, sessionReference, authority),
+      notifyLifecycleChange(
+        revokeGrantSession(storage, options, grantId, sessionReference, authority),
+      ),
     revokeGrantSessionInTransaction: (transaction, grantId, sessionReference, authority) =>
       revokeGrantSessionInTransaction(transaction, options, grantId, sessionReference, authority),
-    leaveGrantSession: (sessionBearer) => leaveGrantSession(storage, options, sessionBearer),
+    leaveGrantSession: (sessionBearer) =>
+      notifyLifecycleChange(leaveGrantSession(storage, options, sessionBearer)),
     listGrantSessions: (grantId, authority) => listSessions(storage, options, grantId, authority),
     listGrantSessionsInTransaction: (transaction, grantId, authority) =>
       listSessionsInTransaction(transaction, options, grantId, authority),

--- a/src/lib/live-event-game-control.test.ts
+++ b/src/lib/live-event-game-control.test.ts
@@ -17,8 +17,188 @@ import {
   validateLiveEventGameActionInTransaction,
 } from "@/lib/live-event-game-control";
 import { createLiveEventGameControlTransport } from "@/lib/live-event-game-transport";
+import { createAdHocGamesService } from "@/lib/ad-hoc-games";
 
 describe("Live Event Game control", () => {
+  test("Event authority, storage, and control remain accepted after Ad Hoc pressure", async () => {
+    const adHoc = createAdHocGamesService({
+      now: () => 1_000,
+      maxConnectedSockets: 1,
+      eventCapacity: { totalConnections: 2, reservedConnections: 1, activeConnections: () => 0 },
+    });
+    const created = await adHoc.create({
+      homeName: "Ad Hoc",
+      awayName: "Pressure",
+      sourceKey: "pressure-source",
+    });
+    if (created.status !== "accepted") throw new Error("Expected Ad Hoc Game.");
+    expect(
+      await adHoc.setConnection({
+        gameId: created.gameId,
+        sessionId: created.sessionId,
+        connected: true,
+        connectionId: "pressure-socket",
+      }),
+    ).toBe(true);
+    const operations = Array.from({ length: 40 }, (_, index) => ({
+      id: `pressure-${index}`,
+      clientSentAtMs: 1_000,
+      command: { type: "set-running", running: index % 2 === 0 },
+    })) as never[];
+    expect(
+      (await adHoc.apply({ gameId: created.gameId, sessionId: created.sessionId, operations }))
+        .status,
+    ).toBe("accepted");
+    for (let index = 0; index < 4; index += 1)
+      expect(
+        (
+          await adHoc.create({
+            homeName: `Pressure ${index}`,
+            awayName: "Away",
+            sourceKey: "pressure-source",
+          })
+        ).status,
+      ).toBe("accepted");
+    expect(
+      (await adHoc.create({ homeName: "Delayed", awayName: "Away", sourceKey: "pressure-source" }))
+        .status,
+    ).toBe("rejected");
+
+    const harness = await createHarness();
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "event-after-ad-hoc-pressure",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Event Controller to open.");
+    const eventResult = await harness.control.submitControllerIntent({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      intent: goalIntent({
+        operationId: "event-after-ad-hoc-pressure",
+        factId: "event-after-ad-hoc-pressure",
+      }),
+    });
+    expect(eventResult).toMatchObject({ status: "accepted" });
+    expect(await harness.record.readActions()).toHaveLength(1);
+  });
+
+  test("reconciles invalidated Event Grant Sessions before reporting connection capacity", async () => {
+    const harness = await createHarness();
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "capacity-expiry",
+    });
+    expect(opened.status).toBe("opened");
+    expect(harness.control.activeControllerSessions()).toBe(1);
+    await harness.authority.revokeGrant(harness.grantId, { kind: "fixture", id: "fixture" });
+    expect(await harness.control.reconcileActiveControllerSessions()).toBe(0);
+    harness.control.close();
+    expect(harness.control.activeControllerSessions()).toBe(0);
+  });
+
+  test("does not scan Event storage for authorization reads or known expiry", async () => {
+    const harness = await createHarness({ grantExpiresAtMs: 10_500 });
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "capacity-read-boundary",
+    });
+    expect(opened.status).toBe("opened");
+    const notifications = harness.lifecycleNotifications;
+    harness.setNow(11_000);
+    expect(harness.control.activeControllerSessions()).toBe(0);
+    expect(harness.lifecycleNotifications).toBe(notifications);
+    expect(
+      await harness.control.refreshController({
+        sessionBearer: harness.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+      }),
+    ).toMatchObject({ status: "authorized" });
+    expect(harness.lifecycleNotifications).toBe(notifications);
+  });
+
+  test("reruns one dirty Event capacity scan after a lifecycle change arrives", async () => {
+    const harness = await createHarness();
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "capacity-dirty-scan",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+    const originalAuthorize = harness.authority.authorizeGrant.bind(harness.authority);
+    let release!: () => void;
+    let markStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      markStarted = resolve;
+    });
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let authorizeCalls = 0;
+    harness.authority.authorizeGrant = async (input) => {
+      authorizeCalls += 1;
+      if (authorizeCalls === 1) {
+        markStarted();
+        await gate;
+      }
+      return originalAuthorize(input);
+    };
+    const scan = harness.control.reconcileActiveControllerSessions();
+    await started;
+    harness.triggerLifecycleChange();
+    release();
+    expect(await scan).toBe(1);
+    expect(authorizeCalls).toBe(2);
+  });
+
+  test("does not repopulate Event capacity after close during reconciliation", async () => {
+    const harness = await createHarness();
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "capacity-close-scan",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+    const originalAuthorize = harness.authority.authorizeGrant.bind(harness.authority);
+    let release!: () => void;
+    let markStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      markStarted = resolve;
+    });
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    harness.authority.authorizeGrant = async (input) => {
+      markStarted();
+      await gate;
+      return originalAuthorize(input);
+    };
+    const scan = harness.control.reconcileActiveControllerSessions();
+    await started;
+    harness.control.close();
+    release();
+    expect(await scan).toBe(0);
+    expect(harness.control.activeControllerSessions()).toBe(0);
+  });
+
+  test("expires a switched post-restart Event session from synchronous capacity", async () => {
+    const harness = await createHarness({ grantExpiresAtMs: 10_500 });
+    harness.setSessionResolution({
+      status: "switchable",
+      previousEventGameId: harness.root.eventGameId,
+      currentEventGameId: "game-reassigned",
+    });
+    expect(
+      await harness.control.refreshController({
+        sessionBearer: harness.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+      }),
+    ).toMatchObject({ status: "switch-required" });
+    expect(
+      await harness.control.switchController({ sessionBearer: harness.sessionBearer }),
+    ).toMatchObject({ status: "authorized", session: { eventGameId: "game-reassigned" } });
+    expect(harness.control.activeControllerSessions()).toBe(1);
+    harness.setNow(11_000);
+    expect(harness.control.activeControllerSessions()).toBe(0);
+  });
+
   test("exposes stable Game Facts and rebuilds score through contextual correction and reinstatement", async () => {
     const harness = await createHarness();
     const opened = await harness.control.openController({
@@ -2052,6 +2232,12 @@ async function createHarness(
   if (overrides.scopeStatus !== undefined) grantOptions.setScopeStatus(overrides.scopeStatus);
   if (overrides.sessionResolution !== undefined)
     grantOptions.setSessionResolution(overrides.sessionResolution);
+  let lifecycleNotifications = 0;
+  let triggerLifecycleChange = () => {};
+  grantOptions.onLifecycleChange = () => {
+    lifecycleNotifications += 1;
+    triggerLifecycleChange();
+  };
 
   let failureBoundary = overrides.failureBoundary;
   const record = createEventGameRecord(storage, {
@@ -2099,6 +2285,9 @@ async function createHarness(
     clock: overrides.controlClock ?? (() => grantOptions.clock.nowMs()),
     projectionFailure: overrides.projectionFailure,
   });
+  triggerLifecycleChange = () => {
+    void control.reconcileActiveControllerSessions();
+  };
   return {
     root,
     storage,
@@ -2108,11 +2297,20 @@ async function createHarness(
     grantId: created.grantId,
     qrCredential: created.qrCredential,
     sessionBearer: admitted.sessionBearer,
+    get lifecycleNotifications() {
+      return lifecycleNotifications;
+    },
+    triggerLifecycleChange() {
+      grantOptions.onLifecycleChange?.();
+    },
     set failureBoundary(value: typeof failureBoundary) {
       failureBoundary = value;
     },
     setNow(value: number) {
       grantOptions.setNow(value);
+    },
+    setScopeStatus(value: "empty" | "conflict" | undefined) {
+      grantOptions.setScopeStatus(value);
     },
     setScopeEventGameId(value: string) {
       grantOptions.setScopeEventGameId(value);

--- a/src/lib/live-event-game-control.ts
+++ b/src/lib/live-event-game-control.ts
@@ -566,6 +566,85 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
   }
   const goalCodec = gameFactCodec;
   const replayingSessions = new Set<string>();
+  const activeControllerSessions = new Map<
+    string,
+    { eventGameId: string; expiresAtMs: number | null }
+  >();
+  let reconcilingActiveControllerSessions = false;
+  let reconciliationDirty = false;
+  let reconciliationGeneration = 0;
+  let reconciliationCompletion: Promise<number> | null = null;
+  let closed = false;
+
+  const trackActiveControllerSession = (
+    sessionBearer: string,
+    eventGameId: string,
+    expiresAtMs?: number | null,
+  ) => {
+    activeControllerSessions.set(sessionBearer, {
+      eventGameId,
+      expiresAtMs: expiresAtMs ?? activeControllerSessions.get(sessionBearer)?.expiresAtMs ?? null,
+    });
+  };
+
+  async function reconcileActiveControllerSessions(): Promise<number> {
+    if (closed) return 0;
+    if (reconcilingActiveControllerSessions) {
+      reconciliationDirty = true;
+      return reconciliationCompletion ?? activeControllerSessions.size;
+    }
+    reconcilingActiveControllerSessions = true;
+    const generation = reconciliationGeneration;
+    const completion = (async () => {
+      try {
+        do {
+          reconciliationDirty = false;
+          for (const [sessionBearer, session] of activeControllerSessions) {
+            if (closed || generation !== reconciliationGeneration) return 0;
+            let authorized: Awaited<ReturnType<typeof options.grantAuthority.authorizeGrant>>;
+            try {
+              authorized = await options.grantAuthority.authorizeGrant({
+                sessionBearer,
+                eventGameId: session.eventGameId,
+                readOnly: true,
+              });
+            } catch {
+              continue;
+            }
+            if (closed || generation !== reconciliationGeneration) return 0;
+            if (authorized.status === "authorized" && authorized.grantType === "control") {
+              if (authorized.eventGameId !== null) {
+                trackActiveControllerSession(
+                  sessionBearer,
+                  authorized.eventGameId,
+                  authorized.sessionExpiresAtMs,
+                );
+              }
+            } else if (authorized.status === "switch-required") {
+              trackActiveControllerSession(
+                sessionBearer,
+                authorized.currentEventGameId,
+                session.expiresAtMs,
+              );
+            } else {
+              activeControllerSessions.delete(sessionBearer);
+            }
+          }
+        } while (reconciliationDirty && !closed && generation === reconciliationGeneration);
+        if (closed || generation !== reconciliationGeneration) return 0;
+        return activeControllerSessions.size;
+      } finally {
+        reconcilingActiveControllerSessions = false;
+        reconciliationDirty = false;
+      }
+    })();
+    reconciliationCompletion = completion;
+    try {
+      return await completion;
+    } finally {
+      if (reconciliationCompletion === completion) reconciliationCompletion = null;
+    }
+  }
 
   async function openController(input: {
     qrCredential: string;
@@ -606,6 +685,11 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
     }
 
     const projection = await readProjection(owner.record, commenced.root);
+    trackActiveControllerSession(
+      admitted.sessionBearer,
+      commenced.root.eventGameId,
+      authorized.sessionExpiresAtMs,
+    );
     return {
       status: "opened",
       eventGameId: commenced.root.eventGameId,
@@ -653,6 +737,11 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
             const root = owner === null ? null : await owner.record.readRoot(owner.recordId);
             if (owner !== null && root !== null) {
               const projection = await readProjection(owner.record, root);
+              trackActiveControllerSession(
+                input.sessionBearer,
+                root.eventGameId,
+                pinned.sessionExpiresAtMs,
+              );
               return {
                 status: "authorized",
                 session: {
@@ -694,6 +783,11 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
       return { status: "rejected", message: "Unable to refresh Controller session." };
     }
     const projection = await readProjection(owner.record, commenced.root);
+    trackActiveControllerSession(
+      input.sessionBearer,
+      commenced.root.eventGameId,
+      authorized.sessionExpiresAtMs,
+    );
     return {
       status: "authorized",
       session: {
@@ -725,6 +819,11 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
       return { status: "rejected", message: "Unable to refresh Controller session." };
     }
     const projection = await readProjection(owner.record, commenced.root);
+    trackActiveControllerSession(
+      input.sessionBearer,
+      commenced.root.eventGameId,
+      switched.sessionExpiresAtMs,
+    );
     return {
       status: "authorized",
       session: {
@@ -763,6 +862,11 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
       return { status: "rejected", message: "Unable to refresh Controller session." };
     }
     const projection = await readProjection(owner.record, commenced.root);
+    trackActiveControllerSession(
+      input.sessionBearer,
+      commenced.root.eventGameId,
+      authorized.sessionExpiresAtMs,
+    );
     return {
       status: "authorized",
       session: {
@@ -806,6 +910,7 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
 
   async function leaveController(input: { sessionBearer: string }): Promise<ControllerLeaveResult> {
     const left = await options.grantAuthority.leaveGrantSession(input.sessionBearer);
+    if (left.status === "updated") activeControllerSessions.delete(input.sessionBearer);
     return left.status === "updated"
       ? { status: "left" }
       : { status: "rejected", message: "Unable to leave Controller session." };
@@ -1308,6 +1413,23 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
     stayController,
     revealControllerQr,
     leaveController,
+    activeControllerSessions: () => {
+      if (closed) return 0;
+      const nowMs = clock();
+      for (const [sessionBearer, session] of activeControllerSessions) {
+        if (session.expiresAtMs !== null && nowMs >= session.expiresAtMs) {
+          activeControllerSessions.delete(sessionBearer);
+        }
+      }
+      return activeControllerSessions.size;
+    },
+    reconcileActiveControllerSessions,
+    close() {
+      closed = true;
+      reconciliationGeneration += 1;
+      reconciliationDirty = false;
+      activeControllerSessions.clear();
+    },
     submitControllerIntent,
     replayControllerActions,
   };

--- a/src/lib/live-event-game-runtime.ts
+++ b/src/lib/live-event-game-runtime.ts
@@ -45,7 +45,10 @@ export async function openLiveEventGameRuntime(input: {
   const storage = openSqliteFoundationStorage(input.databasePath, { grantKeyRing: input.keyRing });
   try {
     const clock = input.clock ?? (() => Date.now());
-    const grantOptions = createGrantOptions(input.environmentId, input.keyRing, clock);
+    let refreshEventCapacitySnapshot = () => {};
+    const grantOptions = createGrantOptions(input.environmentId, input.keyRing, clock, () =>
+      refreshEventCapacitySnapshot(),
+    );
     const authority = createTypedGrantAuthority(storage, grantOptions);
     const scopeResolver = createExternalScopeResolver();
     const acceptance = createFoundationAcceptance(storage, {
@@ -80,14 +83,19 @@ export async function openLiveEventGameRuntime(input: {
       }
       return { recordId: root.recordId, record };
     };
+    const control = createLiveEventGameControl({
+      resolveEventGameRecord,
+      acceptance,
+      grantAuthority: authority,
+      clock,
+    });
+    refreshEventCapacitySnapshot = () => {
+      void control.reconcileActiveControllerSessions();
+    };
     return {
-      control: createLiveEventGameControl({
-        resolveEventGameRecord,
-        acceptance,
-        grantAuthority: authority,
-        clock,
-      }),
+      control,
       close() {
+        control.close();
         storage.close();
       },
     };
@@ -115,6 +123,7 @@ function createGrantOptions(
   environmentId: string,
   keyRing: GrantKeyRing,
   clock: () => number,
+  onLifecycleChange?: () => void,
 ): GrantAuthorityOptions {
   return {
     environmentId,
@@ -123,6 +132,7 @@ function createGrantOptions(
     keyRing,
     controlScopeResolver: createControlScopeResolver(clock),
     privilegedAuthorityVerifier: { verify: () => null },
+    onLifecycleChange,
   };
 }
 

--- a/src/lib/ws-protocol.ts
+++ b/src/lib/ws-protocol.ts
@@ -44,6 +44,7 @@ export type ServerWsMessage =
   | {
       type: "error";
       message: string;
+      retryAfterMs?: number;
     }
   | {
       type: "lobby-snapshot";

--- a/src/pages/game-page.tsx
+++ b/src/pages/game-page.tsx
@@ -851,6 +851,15 @@ export function GamePage({ gameId, role }: { gameId: string; role: ControllerRol
           {leaveMessage ? (
             <p className="mt-1 text-[10px] font-medium text-rose-700">{leaveMessage}</p>
           ) : null}
+          {error !== null ? (
+            <p
+              className="mt-1 text-[10px] font-medium text-amber-700"
+              role="status"
+              aria-live="polite"
+            >
+              {error}
+            </p>
+          ) : null}
           {controller ? (
             localOnlyMode ? (
               <p className="mt-1 text-[10px] font-medium text-amber-700">{LOCAL_ONLY_MESSAGE}</p>

--- a/src/pages/public-event-page.tsx
+++ b/src/pages/public-event-page.tsx
@@ -1,8 +1,9 @@
-import { useCallback, useEffect, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { getAdHocBrowserId } from "@/lib/ad-hoc-handoff";
 import type { PublicAudienceEventProjection } from "@/lib/audience-projection";
 import { DEFAULT_AWAY_TEAM_COLOR, DEFAULT_HOME_TEAM_COLOR } from "@/lib/team-colors";
 
@@ -235,32 +236,104 @@ function StartAdHocGame() {
   const [awayName, setAwayName] = useState("Away");
   const [homeColor, setHomeColor] = useState(DEFAULT_HOME_TEAM_COLOR);
   const [awayColor, setAwayColor] = useState(DEFAULT_AWAY_TEAM_COLOR);
+  const [creationStatus, setCreationStatus] = useState<string | null>(null);
+  const [creationPending, setCreationPending] = useState(false);
+  const creationPendingRef = useRef(false);
+  const creationRetryTimerRef = useRef<number | null>(null);
+  const mountedRef = useRef(true);
 
-  const handleCreateGame = useCallback(async () => {
-    const response = await fetch("/api/games", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({
-        homeName,
-        awayName,
-        homeColor,
-        awayColor,
-      }),
-    });
+  useEffect(
+    () => () => {
+      mountedRef.current = false;
+      if (creationRetryTimerRef.current !== null)
+        window.clearTimeout(creationRetryTimerRef.current);
+      creationRetryTimerRef.current = null;
+      creationPendingRef.current = false;
+    },
+    [],
+  );
 
-    if (!response.ok) return;
+  const handleCreateGame = useCallback(
+    async (attempt = 0) => {
+      if (!mountedRef.current) return;
+      if (attempt === 0) {
+        if (creationPendingRef.current) return;
+        creationPendingRef.current = true;
+        setCreationPending(true);
+      }
+      setCreationStatus(attempt === 0 ? "Creating Ad Hoc Game…" : "Retrying Ad Hoc Game…");
 
-    const payload = (await response.json()) as { gameId?: string };
-    if (typeof payload.gameId === "string") navigateTo(`/game/${payload.gameId}`);
-  }, [awayColor, awayName, homeColor, homeName]);
+      let response: Response;
+      try {
+        response = await fetch("/api/games", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            homeName,
+            awayName,
+            homeColor,
+            awayColor,
+            browserId: getAdHocBrowserId(),
+          }),
+        });
+      } catch {
+        if (mountedRef.current) setCreationStatus("Ad Hoc Game unavailable. Try again later.");
+        creationPendingRef.current = false;
+        setCreationPending(false);
+        return;
+      }
+      if (!mountedRef.current) return;
+
+      if (!response.ok) {
+        if (response.status === 429 && attempt < 3) {
+          const payload = (await response.json().catch(() => null)) as {
+            retryAfterMs?: unknown;
+          } | null;
+          const headerDelayMs = Number(response.headers.get("retry-after")) * 1_000;
+          const retryAfterMs = Math.min(
+            30_000,
+            Math.max(
+              1_000,
+              typeof payload?.retryAfterMs === "number" ? payload.retryAfterMs : headerDelayMs,
+            ),
+          );
+          setCreationStatus(
+            `Ad Hoc creation busy. Retrying in ${Math.ceil(retryAfterMs / 1_000)}s.`,
+          );
+          if (creationRetryTimerRef.current !== null)
+            window.clearTimeout(creationRetryTimerRef.current);
+          creationRetryTimerRef.current = window.setTimeout(() => {
+            creationRetryTimerRef.current = null;
+            void handleCreateGame(attempt + 1);
+          }, retryAfterMs);
+          return;
+        }
+        setCreationStatus("Ad Hoc Game unavailable. Try again later.");
+        creationPendingRef.current = false;
+        setCreationPending(false);
+        return;
+      }
+
+      const payload = (await response.json()) as { gameId?: string };
+      if (typeof payload.gameId === "string") {
+        creationPendingRef.current = false;
+        setCreationPending(false);
+        navigateTo(`/game/${payload.gameId}`);
+        return;
+      }
+      setCreationStatus("Ad Hoc Game unavailable. Try again later.");
+      creationPendingRef.current = false;
+      setCreationPending(false);
+    },
+    [awayColor, awayName, homeColor, homeName],
+  );
 
   return (
     <Card>
       <CardHeader>
         <CardTitle>Start Ad Hoc Game</CardTitle>
         <CardDescription>
-          Need an unscheduled Game? Start one here. You are admitted as the initially admitted Ad
-          Hoc Controller.
+          Need an unscheduled Game? Start one here as an equal Ad Hoc Controller.
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-3">
@@ -302,9 +375,18 @@ function StartAdHocGame() {
             />
           </div>
         </div>
-        <Button className="w-full" onClick={handleCreateGame}>
+        <Button
+          className="w-full"
+          disabled={creationPending}
+          onClick={() => void handleCreateGame()}
+        >
           Start an Ad Hoc Game <span className="sr-only">Create new game</span>
         </Button>
+        {creationStatus !== null ? (
+          <p className="text-sm text-muted-foreground" role="status" aria-live="polite">
+            {creationStatus}
+          </p>
+        ) : null}
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
## What changed

- adds independent Ad Hoc creation, action, replay, connection, and queued-output budgets
- reserves Event connection capacity and reconciles live Event Controller Sessions without sharing Ad Hoc authority or rate state
- presents bounded generic retry guidance and owns browser retry lifecycle
- adds deterministic Fast Tests plus separately named SQLite and browser integration coverage

## Why

Anonymous Ad Hoc traffic must remain bounded without exhausting or slowing ongoing Event Game operations. The Ad Hoc workflow needs its own admission and resource accounting instead of borrowing Event Grant limits or authority.

## Impact

Ad Hoc overload is shed or delayed within Ad Hoc only. Event Game authorization, storage, action acceptance, and reserved connection capacity remain available under representative Ad Hoc pressure.

## Validation

- `bun run check`
- `bun run test` — 630 passed, 0 failed on the restacked branch
- `bun run test:focused:ad-hoc`
- `bun run test:focused:adhoc-browser`
- `bun run build`
- `git diff --check`

Closes #155