### PR TITLE
Enforce protected Ad Hoc capacity cleanup

### DIFF
--- a/scripts/ad-hoc-capacity-race-worker.ts
+++ b/scripts/ad-hoc-capacity-race-worker.ts
@@ -1,0 +1,84 @@
+import { existsSync, writeFileSync } from "node:fs";
+import { createAdHocGamesService, openSqliteAdHocStore } from "@/lib/ad-hoc-games";
+
+const databasePath = process.argv[2];
+const mode = process.argv[3];
+if (databasePath === undefined || mode === undefined) {
+  throw new Error("database path and mode required");
+}
+
+const environmentIdentity = process.argv[7] ?? "field-a";
+const options =
+  mode === "create"
+    ? {
+        beforeCapacityCommit: () => {
+          const enteredPath = process.argv[4];
+          const releasePath = process.argv[5];
+          if (enteredPath === undefined || releasePath === undefined) {
+            throw new Error("capacity barrier paths required");
+          }
+          writeFileSync(enteredPath, "entered");
+          const deadline = Date.now() + 10_000;
+          const waitCell = new Int32Array(new SharedArrayBuffer(4));
+          while (!existsSync(releasePath)) {
+            if (Date.now() >= deadline) throw new Error("capacity barrier timed out");
+            Atomics.wait(waitCell, 0, 0, 10);
+          }
+        },
+      }
+    : {};
+const startupNowMs = Number(process.argv[6] ?? "10_000_000_000");
+const store = openSqliteAdHocStore(databasePath, environmentIdentity, options);
+const service = createAdHocGamesService({
+  store,
+  environmentIdentity,
+  now: () => startupNowMs,
+});
+
+try {
+  if (mode === "create") {
+    const result = await service.create({
+      homeName: "Race Replacement",
+      awayName: "Away",
+      sourceKey: "focused-race-worker",
+      nowMs: startupNowMs,
+    });
+    console.log(
+      JSON.stringify(
+        result.status === "accepted"
+          ? { status: result.status, gameId: result.gameId }
+          : { status: result.status, reason: result.reason },
+      ),
+    );
+  } else if (mode === "connect") {
+    const gameId = process.argv[4];
+    const sessionId = process.argv[5];
+    if (gameId === undefined || sessionId === undefined) {
+      throw new Error("connection identity required");
+    }
+    const enteredPath = process.argv[8];
+    if (enteredPath !== undefined) writeFileSync(enteredPath, "entered");
+    const proceedPath = process.argv[9];
+    if (proceedPath !== undefined) waitForFile(proceedPath);
+    const connected = await service.setConnection({
+      gameId,
+      sessionId,
+      connected: true,
+      nowMs: startupNowMs,
+    });
+    console.log(JSON.stringify({ connected }));
+  } else {
+    throw new Error(`unknown mode ${mode}`);
+  }
+} finally {
+  service.close();
+}
+
+function waitForFile(path: string) {
+  const deadline = Date.now() + 10_000;
+  const waitCell = new Int32Array(new SharedArrayBuffer(4));
+  while (!existsSync(path)) {
+    if (Date.now() >= deadline) throw new Error("connection barrier timed out");
+    Atomics.wait(waitCell, 0, 0, 10);
+  }
+}

--- a/scripts/test-ad-hoc-browser.ts
+++ b/scripts/test-ad-hoc-browser.ts
@@ -1,8 +1,10 @@
 #!/usr/bin/env bun
 import { chromium, type Page } from "playwright";
+import { Database } from "bun:sqlite";
 import { mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { createAdHocGamesService, openSqliteAdHocStore } from "@/lib/ad-hoc-games";
 
 let directory = "";
 let certificatePath = "";
@@ -76,9 +78,9 @@ async function run() {
     );
     await raceWithDeadline(
       (async () => {
-        const firstContext = await browser!.newContext({ ignoreHTTPSErrors: true });
+        let firstContext = await browser!.newContext({ ignoreHTTPSErrors: true });
         let secondContext = await browser!.newContext({ ignoreHTTPSErrors: true });
-        const first = await firstContext.newPage();
+        let first = await firstContext.newPage();
         let second = await secondContext.newPage();
         first.setDefaultTimeout(15_000);
         second.setDefaultTimeout(15_000);
@@ -235,6 +237,77 @@ async function run() {
           .getByText("Server does not know this game", { exact: false })
           .first()
           .waitFor();
+        await retryContext.close();
+        await secondContext.close();
+
+        const setupContext = await browser!.newContext({ ignoreHTTPSErrors: true });
+        const setup = await setupContext.newPage();
+        setup.setDefaultTimeout(15_000);
+        await setup.goto(`${origin}/events?view=all`);
+        await setup.getByRole("button", { name: /Start an Ad Hoc Game/ }).click();
+        await setup.waitForURL(/\/game\/adhoc-/u);
+        const victimGameId = new URL(setup.url()).pathname.split("/").at(-1);
+        if (victimGameId === undefined)
+          throw new Error("Victim Game route did not contain a Game ID.");
+        await setup.getByRole("button", { name: "Start game" }).click();
+        await setup.getByText("Running", { exact: true }).waitFor();
+        const victimStorageState = await setupContext.storageState();
+        await setupContext.close();
+
+        await stopServer();
+        await seedAdditionalCapacity(victimGameId, 49);
+        await startServer();
+        const prunerContext = await browser!.newContext({ ignoreHTTPSErrors: true });
+        const pruner = await prunerContext.newPage();
+        pruner.setDefaultTimeout(15_000);
+        await pruner.goto(`${origin}/events?view=all`);
+        await pruner.getByRole("button", { name: /Start an Ad Hoc Game/ }).click();
+        await pruner.waitForURL(/\/game\/adhoc-/u);
+        await prunerContext.close();
+
+        const victimContext = await browser!.newContext({
+          ignoreHTTPSErrors: true,
+          storageState: victimStorageState,
+        });
+        const victim = await victimContext.newPage();
+        victim.setDefaultTimeout(15_000);
+        await victim.goto(`${origin}/game/${victimGameId}`);
+        await waitForGameRoute(victim, victimGameId);
+        await victim.getByText("Local", { exact: true }).waitFor();
+        await victim
+          .getByText("Server does not know this game", { exact: false })
+          .first()
+          .waitFor();
+        const removedProbe = await victim.evaluate(async (id) => {
+          const response = await fetch(`/api/games/${id}`);
+          return { status: response.status, url: location.pathname };
+        }, victimGameId);
+        if (removedProbe.status !== 404 || removedProbe.url !== `/game/${victimGameId}`) {
+          throw new Error("Pruned Ad Hoc Game was silently recreated or recovered.");
+        }
+        await victim.reload();
+        await waitForGameRoute(victim, victimGameId);
+        await victim.getByText("Local", { exact: true }).waitFor();
+        await victim
+          .getByText("Server does not know this game", { exact: false })
+          .first()
+          .waitFor();
+        await victimContext.close();
+
+        await stopServer();
+        await seedCapacity(true);
+        await startServer();
+        const capacityContext = await browser!.newContext({ ignoreHTTPSErrors: true });
+        const capacityPage = await capacityContext.newPage();
+        capacityPage.setDefaultTimeout(15_000);
+        await capacityPage.goto(`${origin}/events?view=all`);
+        await capacityPage.getByRole("button", { name: /Start an Ad Hoc Game/ }).click();
+        await capacityPage.getByRole("alert").waitFor();
+        await capacityPage
+          .getByRole("alert")
+          .getByText("Ad Hoc capacity is currently full; no game was changed.", { exact: true })
+          .waitFor();
+        await capacityContext.close();
       })(),
       lifecycleController.signal,
     );
@@ -463,4 +536,103 @@ async function waitForUnfinishedGame(page: Page, gameId: string) {
     };
     return payload.game?.state?.isFinished === false && typeof payload.game.controlQr === "string";
   }, gameId);
+}
+
+async function seedCapacity(connected: boolean) {
+  rmSync(databasePath, { force: true });
+  let seedNowMs = Date.now() - 102 * 60 * 60_000;
+  const store = openSqliteAdHocStore(databasePath, "adhoc-browser-test");
+  const games = createAdHocGamesService({
+    store,
+    environmentIdentity: "adhoc-browser-test",
+    now: () => seedNowMs,
+  });
+  try {
+    for (let index = 0; index < 50; index += 1) {
+      seedNowMs += 2 * 60 * 60_000;
+      const result = await games.create({
+        homeName: `Seed ${index}`,
+        awayName: "Away",
+        sourceKey: `browser-seed-${index}`,
+        nowMs: seedNowMs,
+      });
+      if (result.status !== "accepted") throw new Error("browser capacity seed failed");
+    }
+  } finally {
+    games.close();
+  }
+
+  if (!connected) return;
+  const database = new Database(databasePath, { create: false, strict: true });
+  try {
+    const rows = database.query("SELECT game_id, sessions_json FROM adhoc_games").all() as {
+      game_id: string;
+      sessions_json: string;
+    }[];
+    for (const row of rows) {
+      const sessions = JSON.parse(row.sessions_json) as {
+        connected: boolean;
+        lastConnectedAtMs: number;
+        lastDisconnectedAtMs: number | null;
+      }[];
+      for (const session of sessions) {
+        session.connected = true;
+        session.lastConnectedAtMs = Date.now();
+        session.lastDisconnectedAtMs = null;
+      }
+      database.run("UPDATE adhoc_games SET sessions_json = ? WHERE game_id = ?", [
+        JSON.stringify(sessions),
+        row.game_id,
+      ]);
+    }
+  } finally {
+    database.close();
+  }
+}
+
+async function seedAdditionalCapacity(victimGameId: string, count: number) {
+  const seedStartMs = Date.now() - 100 * 60 * 60_000;
+  const store = openSqliteAdHocStore(databasePath, "adhoc-browser-test");
+  const games = createAdHocGamesService({
+    store,
+    environmentIdentity: "adhoc-browser-test",
+    now: () => seedStartMs,
+  });
+  try {
+    for (let index = 0; index < count; index += 1) {
+      const nowMs = seedStartMs + index * 2 * 60 * 60_000;
+      const result = await games.create({
+        homeName: `Additional seed ${index}`,
+        awayName: "Away",
+        sourceKey: `browser-additional-seed-${index}`,
+        nowMs,
+      });
+      if (result.status !== "accepted") throw new Error("browser additional capacity seed failed");
+    }
+  } finally {
+    games.close();
+  }
+
+  const database = new Database(databasePath, { create: false, strict: true });
+  try {
+    const row = database
+      .query("SELECT sessions_json FROM adhoc_games WHERE game_id = ?")
+      .get(victimGameId) as { sessions_json: string } | null;
+    if (row === null) throw new Error("victim Game was not retained during capacity setup");
+    const sessions = JSON.parse(row.sessions_json) as {
+      connected: boolean;
+      lastDisconnectedAtMs: number | null;
+    }[];
+    for (const session of sessions) {
+      session.connected = false;
+      session.lastDisconnectedAtMs = seedStartMs - 2 * 60 * 60_000;
+    }
+    database.run("UPDATE adhoc_games SET created_at_ms = ?, sessions_json = ? WHERE game_id = ?", [
+      seedStartMs - 2 * 60 * 60_000,
+      JSON.stringify(sessions),
+      victimGameId,
+    ]);
+  } finally {
+    database.close();
+  }
 }

--- a/src/index-ad-hoc.test.ts
+++ b/src/index-ad-hoc.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+  createAdHocLiveSessionTracker,
   createAdHocGamesService,
   createInMemoryAdHocStore,
   type AdHocGamesService,
@@ -69,6 +70,140 @@ describe("Ad Hoc HTTP and WebSocket authority boundaries", () => {
         adHocSocketCeiling: 10,
       }),
     ).toBe(0);
+  });
+
+  test("deduplicates concurrent socket subscriptions and retries a failed final disconnect", async () => {
+    const disconnected: string[] = [];
+    let durable = false;
+    const scheduled: Array<{ delayMs: number; task: () => void }> = [];
+    const tracker = createAdHocLiveSessionTracker(
+      async (identity) => {
+        disconnected.push(`${identity.gameId}:${identity.sessionId}`);
+        return durable;
+      },
+      {
+        scheduleRetry: (delayMs, task) => scheduled.push({ delayMs, task }),
+      },
+    );
+    const identity = { gameId: "adhoc-game", sessionId: "session-token" };
+
+    const subscriptions = await Promise.all([
+      tracker.subscribe("socket-1", identity),
+      tracker.subscribe("socket-1", identity),
+    ]);
+    expect(subscriptions.map((result) => result.attached)).toEqual([true, true]);
+    expect(tracker.count(identity)).toBe(1);
+    expect(await tracker.disconnect("socket-1")).toBe(false);
+    expect(tracker.count(identity)).toBe(0);
+    expect(disconnected).toEqual(["adhoc-game:session-token"]);
+    expect(tracker.pendingCount()).toBe(1);
+    expect(scheduled.map((item) => item.delayMs)).toEqual([100]);
+
+    durable = true;
+    scheduled.shift()!.task();
+    expect(await tracker.retryPending()).toBe(true);
+    expect(tracker.pendingCount()).toBe(0);
+    expect(disconnected).toEqual(["adhoc-game:session-token", "adhoc-game:session-token"]);
+  });
+
+  test("bounds pending disconnect work per injected retry tick and releases socket tombstones", async () => {
+    const scheduled: Array<{ delayMs: number; task: () => void }> = [];
+    let durable = false;
+    let disconnectAttempts = 0;
+    const tracker = createAdHocLiveSessionTracker(
+      async () => {
+        disconnectAttempts += 1;
+        return durable;
+      },
+      {
+        retryBatchSize: 2,
+        retryBaseDelayMs: 40,
+        retryMaxDelayMs: 160,
+        scheduleRetry: (delayMs, task) => scheduled.push({ delayMs, task }),
+      },
+    );
+
+    for (let index = 0; index < 5; index += 1) {
+      const identity = { gameId: `game-${index}`, sessionId: `session-${index}` };
+      await tracker.subscribe(`socket-${index}`, identity);
+      expect(await tracker.disconnect(`socket-${index}`)).toBe(false);
+    }
+    expect(tracker.pendingCount()).toBe(5);
+    expect(scheduled.map((item) => item.delayMs)).toEqual([40]);
+    expect(disconnectAttempts).toBe(5);
+
+    scheduled.shift()!.task();
+    expect(await tracker.retryPending()).toBe(false);
+    expect(disconnectAttempts).toBe(7);
+    expect(tracker.pendingCount()).toBe(5);
+    expect(scheduled.map((item) => item.delayMs)).toEqual([80]);
+
+    durable = true;
+    while (tracker.pendingCount() > 0) {
+      scheduled.shift()!.task();
+      await tracker.retryPending();
+    }
+    expect(tracker.pendingCount()).toBe(0);
+    expect(tracker.tombstoneCount()).toBe(0);
+  });
+
+  test("rotates failed retry entries so a later transient disconnect is not starved", async () => {
+    const scheduled: Array<{ delayMs: number; task: () => void }> = [];
+    let transientAttempts = 0;
+    const tracker = createAdHocLiveSessionTracker(
+      async (identity) => {
+        if (identity.gameId === "transient") {
+          transientAttempts += 1;
+          return transientAttempts > 1;
+        }
+        return false;
+      },
+      {
+        retryBatchSize: 2,
+        scheduleRetry: (delayMs, task) => scheduled.push({ delayMs, task }),
+      },
+    );
+
+    for (const gameId of ["permanent-1", "permanent-2", "permanent-3", "transient"]) {
+      const identity = { gameId, sessionId: `${gameId}-session` };
+      await tracker.subscribe(gameId, identity);
+      expect(await tracker.disconnect(gameId)).toBe(false);
+    }
+    expect(transientAttempts).toBe(1);
+    expect(tracker.pendingCount()).toBe(4);
+
+    scheduled.shift()!.task();
+    await tracker.retryPending();
+    expect(transientAttempts).toBe(1);
+
+    scheduled.shift()!.task();
+    await tracker.retryPending();
+    expect(transientAttempts).toBe(2);
+    expect(tracker.pendingCount()).toBe(3);
+  });
+
+  test("retains a closed socket tombstone until queued disconnect durability drains", async () => {
+    let releaseDisconnect!: (durable: boolean) => void;
+    let markCallbackStarted!: () => void;
+    const callbackStarted = new Promise<void>((resolve) => {
+      markCallbackStarted = resolve;
+    });
+    const tracker = createAdHocLiveSessionTracker(
+      async () =>
+        await new Promise<boolean>((resolve) => {
+          markCallbackStarted();
+          releaseDisconnect = resolve;
+        }),
+      { scheduleRetry: () => undefined },
+    );
+    const identity = { gameId: "game", sessionId: "session" };
+    await tracker.subscribe("socket", identity);
+    const disconnect = tracker.disconnect("socket");
+    await callbackStarted;
+    expect(tracker.tombstoneCount()).toBe(1);
+    releaseDisconnect(true);
+    expect(await disconnect).toBe(true);
+    expect(tracker.tombstoneCount()).toBe(0);
   });
 
   test("retains two Games in one browser authority set and leaving one preserves the other", async () => {
@@ -393,6 +528,33 @@ describe("Ad Hoc HTTP and WebSocket authority boundaries", () => {
     expect(firstResult.sessionId).not.toBe(secondResult.sessionId);
   });
 
+  test("authorizes and protects a WebSocket subscription in one durable mutation", async () => {
+    const baseStore = createInMemoryAdHocStore();
+    const creator = createAdHocGamesService({ store: baseStore, now: () => 1_000 });
+    const created = await creator.create({ homeName: "Home", awayName: "Away" });
+    if (created.status !== "accepted") throw new Error("creation failed");
+
+    const failingStore = {
+      ...baseStore,
+      mutateGame: () => null,
+    };
+    const unavailable = await resolveAdHocWebSocketSubscription({
+      service: createAdHocGamesService({ store: failingStore, now: () => 1_001 }),
+      cookieHeader: `adhoc_session_${created.gameId}=${created.sessionId}`,
+      gameId: created.gameId,
+    });
+    expect(unavailable).toEqual({ status: "unavailable" });
+    expect(baseStore.readGame(created.gameId)?.sessions[0]?.connected).toBe(false);
+
+    const accepted = await resolveAdHocWebSocketSubscription({
+      service: creator,
+      cookieHeader: `adhoc_session_${created.gameId}=${created.sessionId}`,
+      gameId: created.gameId,
+    });
+    expect(accepted.status).toBe("accepted");
+    expect(baseStore.readGame(created.gameId)?.sessions[0]?.connected).toBe(true);
+  });
+
   test("fails creation unavailable without committing a Game when storage is contended", async () => {
     const store = {
       ...createInMemoryAdHocStore(),
@@ -502,6 +664,48 @@ describe("Ad Hoc HTTP and WebSocket authority boundaries", () => {
       games,
     );
     expect(differentSource.status).toBe(201);
+  });
+
+  test("returns a generic HTTP capacity outcome without exposing or removing a Game", async () => {
+    let nowMs = 1_000;
+    const store = createInMemoryAdHocStore();
+    const games = createAdHocGamesService({ store, now: () => nowMs });
+    const created: Array<{ gameId: string; sessionId: string }> = [];
+
+    for (let index = 0; index < 50; index += 1) {
+      nowMs += 60 * 60_000;
+      const result = await games.create({
+        homeName: `Home ${index}`,
+        awayName: "Away",
+        sourceKey: `capacity-source-${index}`,
+      });
+      if (result.status !== "accepted") throw new Error("capacity setup failed");
+      created.push(result);
+      expect(
+        await games.setConnection({
+          gameId: result.gameId,
+          sessionId: result.sessionId,
+          connected: true,
+          nowMs,
+        }),
+      ).toBe(true);
+    }
+
+    const response = await createGame(
+      new Request("http://localhost/api/games", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ homeName: "New", awayName: "Game" }),
+      }),
+      games,
+    );
+
+    expect(response.status).toBe(429);
+    expect(await response.text()).toBe(
+      '{"error":"Ad Hoc capacity is currently full; no game was changed."}',
+    );
+    expect(store.listGames()).toHaveLength(50);
+    expect(store.readGame(created[0]!.gameId)).not.toBeNull();
   });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,6 +62,7 @@ import type { FoundationStorage } from "@/lib/foundation-storage";
 import { assertProductionStateBoundary } from "@/lib/runtime-storage-config";
 import { createStartupCleanup } from "@/lib/startup-resources";
 import {
+  createAdHocLiveSessionTracker,
   createAdHocGamesService,
   openSqliteAdHocStore,
   type AdHocGameView,
@@ -93,6 +94,8 @@ type SessionData = {
   cookieHeader: string | null;
   sessionId: string | null;
   subscription: SessionSubscription;
+  subscriptionWork: Promise<void>;
+  closed: boolean;
 };
 
 const sockets = new Set<ServerWebSocket<SessionData>>();
@@ -172,8 +175,17 @@ async function startServer() {
       store:
         environment === "test" && !process.env.AD_HOC_DATABASE?.trim()
           ? undefined
-          : openSqliteAdHocStore(adHocDatabasePath, adHocEnvironmentIdentity),
+          : openSqliteAdHocStore(adHocDatabasePath, adHocEnvironmentIdentity, {
+              reconcileConnectionsAtStartup: true,
+            }),
     });
+    const liveAdHocSessions = createAdHocLiveSessionTracker((identity) =>
+      adHocService.setConnection({
+        gameId: identity.gameId,
+        sessionId: identity.sessionId,
+        connected: false,
+      }),
+    );
     startupCleanup.add(() => adHocService.close());
     let runtimeGrantOptions: ReturnType<typeof readGrantAuthorityOptions> | null = null;
     try {
@@ -439,6 +451,8 @@ async function startServer() {
               cookieHeader: req.headers.get("cookie"),
               sessionId: null,
               subscription: { type: "none" },
+              subscriptionWork: Promise.resolve(),
+              closed: false,
             },
           });
 
@@ -1623,14 +1637,16 @@ async function startServer() {
         close(ws) {
           releasePendingSocketReservation(ws.data.id);
           sockets.delete(ws);
-          if (ws.data.subscription.type === "game" && ws.data.sessionId !== null) {
-            void adHocService.setConnection({
-              gameId: ws.data.subscription.gameId,
-              sessionId: ws.data.sessionId,
-              connected: false,
-              connectionId: ws.data.id,
-            });
-          }
+          ws.data.closed = true;
+          void ws.data.subscriptionWork
+            .then(
+              () => liveAdHocSessions.disconnect(ws.data.id),
+              () => liveAdHocSessions.disconnect(ws.data.id),
+            )
+            .then((durable) => {
+              if (!durable) void liveAdHocSessions.retryPending();
+            })
+            .catch(() => undefined);
         },
         async message(ws, message) {
           if (typeof message !== "string") {
@@ -1660,52 +1676,74 @@ async function startServer() {
             }
 
             case "subscribe-game": {
-              const result = await resolveAdHocWebSocketSubscription({
-                service: adHocService,
-                cookieHeader: ws.data.cookieHeader,
-                gameId: parsed.message.gameId,
-              });
-              if (result.status !== "accepted") {
-                sendMessage(ws, { type: "error", message: adHocService.genericUnavailableMessage });
-                ws.close(1008, "Ad Hoc subscription unavailable.");
-                return;
-              }
-              if (ws.data.subscription.type === "game") {
-                await adHocService.setConnection({
-                  gameId: ws.data.subscription.gameId,
-                  sessionId: ws.data.subscription.sessionId,
-                  connected: false,
-                  connectionId: ws.data.id,
+              const subscribeGameId = parsed.message.gameId;
+              const handleSubscription = async () => {
+                const result = await resolveAdHocWebSocketSubscription({
+                  service: adHocService,
+                  cookieHeader: ws.data.cookieHeader,
+                  gameId: subscribeGameId,
                 });
-              }
-              const connected = await adHocService.setConnection({
-                gameId: parsed.message.gameId,
-                sessionId: result.sessionId,
-                connected: true,
-                connectionId: ws.data.id,
-              });
-              if (!connected) {
-                adHocService.recordResourcePressure("connection-shed");
-                sendMessage(ws, {
-                  type: "error",
-                  message: "Ad Hoc connection busy. Try again later.",
-                  retryAfterMs: 1_000,
+                if (result.status === "capacity") {
+                  if (!ws.data.closed) {
+                    adHocService.recordResourcePressure("connection-shed");
+                    sendMessage(ws, {
+                      type: "error",
+                      message: "Ad Hoc connection busy. Try again later.",
+                      retryAfterMs: result.retryAfterMs,
+                    });
+                    setTimeout(() => ws.close(1013, "Ad Hoc connection busy."), 25);
+                  }
+                  return;
+                }
+                if (result.status !== "accepted") {
+                  if (!ws.data.closed) {
+                    sendMessage(ws, {
+                      type: "error",
+                      message: adHocService.genericUnavailableMessage,
+                    });
+                    ws.close(1008, "Ad Hoc subscription unavailable.");
+                  }
+                  return;
+                }
+                const identity = {
+                  gameId: subscribeGameId,
+                  sessionId: result.sessionId,
+                };
+                const tracking = await liveAdHocSessions.subscribe(ws.data.id, {
+                  ...identity,
                 });
-                setTimeout(() => ws.close(1013, "Ad Hoc connection busy."), 25);
-                return;
-              }
-              ws.data.sessionId = result.sessionId;
-              ws.data.subscription = {
-                type: "game",
-                gameId: parsed.message.gameId,
-                sessionId: result.sessionId,
+                if (!tracking.attached) {
+                  if (liveAdHocSessions.count(identity) === 0) {
+                    await adHocService.setConnection({ ...identity, connected: false });
+                  }
+                  if (!ws.data.closed) {
+                    sendMessage(ws, {
+                      type: "error",
+                      message: adHocService.genericUnavailableMessage,
+                    });
+                    ws.close(1008, "Ad Hoc subscription unavailable.");
+                  }
+                  return;
+                }
+                ws.data.sessionId = result.sessionId;
+                ws.data.subscription = {
+                  type: "game",
+                  gameId: subscribeGameId,
+                  sessionId: result.sessionId,
+                };
+                if (!ws.data.closed) {
+                  sendMessage(ws, {
+                    type: "game-snapshot",
+                    game: stripSession(result.game),
+                    serverNowMs: Date.now(),
+                    ackedCommandIds: [],
+                  });
+                }
+                if (!tracking.previousDisconnectDurable) void liveAdHocSessions.retryPending();
               };
-              sendMessage(ws, {
-                type: "game-snapshot",
-                game: stripSession(result.game),
-                serverNowMs: Date.now(),
-                ackedCommandIds: [],
-              });
+              const queued = ws.data.subscriptionWork.then(handleSubscription, handleSubscription);
+              ws.data.subscriptionWork = queued.catch(() => undefined);
+              await queued;
               return;
             }
 
@@ -2019,10 +2057,13 @@ export async function resolveAdHocWebSocketSubscription({
   cookieHeader: string | null;
   gameId: unknown;
 }): Promise<
-  { status: "accepted"; sessionId: string; game: AdHocGameView } | { status: "unavailable" }
+  | { status: "accepted"; sessionId: string; game: AdHocGameView }
+  | { status: "capacity"; retryAfterMs: number }
+  | { status: "unavailable" }
 > {
   const sessionId = readAdHocSession(cookieHeader, gameId);
-  const result = await service.read({ gameId, sessionId });
+  const result = await service.subscribe({ gameId, sessionId });
+  if (result.status === "capacity") return result;
   if (result.status !== "accepted") return { status: "unavailable" };
   return { status: "accepted", sessionId: result.game.sessionId, game: result.game };
 }

--- a/src/lib/ad-hoc-games.focused.ts
+++ b/src/lib/ad-hoc-games.focused.ts
@@ -1,11 +1,22 @@
 import { describe, expect, test } from "bun:test";
 import { Database } from "bun:sqlite";
+import { existsSync, writeFileSync } from "node:fs";
 import { createHash } from "node:crypto";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { applyGameCommand, createInitialGameState } from "@/lib/game-engine";
-import { createAdHocGamesService, openSqliteAdHocStore } from "@/lib/ad-hoc-games";
+import { createEventCatalog, createInMemoryEventCatalogStorage } from "@/lib/event-catalog";
+import {
+  MemoryTechnicalAdminAuthRepository,
+  createTechnicalAdminAuth,
+} from "@/lib/technical-admin-auth";
+import {
+  AD_HOC_DISCONNECTED_GRACE_MS,
+  createAdHocGamesService,
+  createInMemoryAdHocStore,
+  openSqliteAdHocStore,
+} from "@/lib/ad-hoc-games";
 
 describe("Ad Hoc SQLite focused integration", () => {
   test("migrates accepted history as a replay baseline and preserves duplicate/conflict outcomes after restart", async () => {
@@ -300,38 +311,326 @@ describe("Ad Hoc SQLite focused integration", () => {
       await rm(root, { recursive: true, force: true });
     }
   });
+
+  test("leaves the complete SQLite snapshot unchanged when capacity is fully protected", async () => {
+    const root = await mkdtemp(join(tmpdir(), "quadball-timer-adhoc-capacity-snapshot-"));
+    const databasePath = join(root, "ad-hoc.sqlite");
+    const nowMs = 10_000_000_000;
+    const store = openSqliteAdHocStore(databasePath, "field-a");
+    const games = createAdHocGamesService({
+      store,
+      environmentIdentity: "field-a",
+      now: () => nowMs,
+    });
+    try {
+      for (let index = 0; index < 50; index += 1) {
+        const created = await games.create({
+          homeName: `Home ${index}`,
+          awayName: "Away",
+          sourceKey: `protected-source-${index}`,
+          nowMs: nowMs - (50 - index) * 2 * 60 * 60_000,
+        });
+        if (created.status !== "accepted") throw new Error("protected capacity setup failed");
+        expect(
+          await games.setConnection({
+            gameId: created.gameId,
+            sessionId: created.sessionId,
+            connected: true,
+            nowMs,
+          }),
+        ).toBe(true);
+      }
+
+      const seed = new Database(databasePath, { strict: true });
+      seed.run(
+        "INSERT INTO adhoc_creation_events (source_hash, successful, occurred_at_ms, retry_until_ms) VALUES (?, 1, ?, NULL)",
+        ["expired-evidence", nowMs - 2 * 60 * 60_000],
+      );
+      seed.close();
+      const snapshot = () => {
+        const database = new Database(databasePath, { strict: true });
+        const value = JSON.stringify({
+          games: database.query("SELECT * FROM adhoc_games ORDER BY game_id").all(),
+          creationEvents: database
+            .query(
+              "SELECT * FROM adhoc_creation_events ORDER BY occurred_at_ms, source_hash, successful, retry_until_ms",
+            )
+            .all(),
+        });
+        database.close();
+        return value;
+      };
+      const before = snapshot();
+
+      expect(
+        await games.create({
+          homeName: "Rejected",
+          awayName: "Capacity",
+          sourceKey: "new-protected-source",
+          nowMs,
+        }),
+      ).toMatchObject({ status: "rejected", reason: "capacity" });
+      expect(snapshot()).toBe(before);
+    } finally {
+      games.close();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("holds a real SQLite cleanup transaction across a competing connection and survives restart", async () => {
+    const root = await mkdtemp(join(tmpdir(), "quadball-timer-adhoc-capacity-focused-"));
+    const databasePath = join(root, "ad-hoc.sqlite");
+    const worker = join(process.cwd(), "scripts/ad-hoc-capacity-race-worker.ts");
+    const seedStore = openSqliteAdHocStore(databasePath, "field-a");
+    const first = createAdHocGamesService({
+      store: seedStore,
+      environmentIdentity: "field-a",
+      now: () => 10_000_000_000,
+    });
+    const created: Array<{ gameId: string; sessionId: string }> = [];
+    const nowMs = 10_000_000_000;
+    let firstClosed = false;
+    let connectWorker: ReturnType<typeof startWorker> | null = null;
+    let createWorker: ReturnType<typeof startWorker> | null = null;
+    let primaryError: unknown = null;
+
+    try {
+      for (let index = 0; index < 50; index += 1) {
+        const result = await first.create({
+          homeName: `Home ${index}`,
+          awayName: "Away",
+          sourceKey: `focused-source-${index}`,
+          nowMs: nowMs - (50 - index) * 2 * 60 * 60_000,
+        });
+        if (result.status !== "accepted") throw new Error("focused capacity setup failed");
+        created.push(result);
+      }
+
+      const oldest = created[0]!;
+      const connectedBeforeRestart = await first.subscribe({
+        gameId: created[1]!.gameId,
+        sessionId: created[1]!.sessionId,
+        nowMs,
+      });
+      expect(connectedBeforeRestart.status).toBe("accepted");
+      first.close();
+      firstClosed = true;
+
+      const enteredPath = join(root, "create-entered");
+      const releasePath = join(root, "create-release");
+      const connectEnteredPath = join(root, "connect-entered");
+      const connectProceedPath = join(root, "connect-proceed");
+      connectWorker = startWorker(
+        worker,
+        databasePath,
+        "connect",
+        oldest.gameId,
+        oldest.sessionId,
+        String(nowMs),
+        "field-a",
+        connectEnteredPath,
+        connectProceedPath,
+      );
+      await waitForFile(connectEnteredPath);
+      createWorker = startWorker(
+        worker,
+        databasePath,
+        "create",
+        enteredPath,
+        releasePath,
+        String(nowMs),
+        "field-a",
+      );
+      await waitForFile(enteredPath);
+      writeFileSync(connectProceedPath, "proceed");
+      const connectOutput = await connectWorker.result;
+      expect(JSON.parse(connectOutput)).toEqual({ connected: false });
+      writeFileSync(releasePath, "release");
+      const createOutput = await createWorker.result;
+      expect(JSON.parse(createOutput)).toMatchObject({ status: "accepted" });
+
+      const verifyStore = openSqliteAdHocStore(databasePath, "field-a");
+      const retained = verifyStore.listGames();
+      expect(retained).toHaveLength(50);
+      expect(
+        retained.filter((game) => !created.some((item) => item.gameId === game.gameId)),
+      ).toHaveLength(1);
+      expect(verifyStore.readGame(oldest.gameId)).toBeNull();
+
+      const collisionTarget = retained.at(-1)!;
+      const collisionId = collisionTarget.gameId.replace(/^adhoc-/u, "");
+      const collision = createAdHocGamesService({
+        store: verifyStore,
+        environmentIdentity: "field-a",
+        now: () => nowMs,
+        random: () => collisionId,
+      });
+      const failedReplacement = await collision.create({
+        homeName: "Collision",
+        awayName: "Away",
+        sourceKey: "focused-collision",
+        nowMs,
+      });
+      expect(failedReplacement).toMatchObject({ status: "rejected", reason: "unavailable" });
+      expect(verifyStore.listGames()).toHaveLength(50);
+      expect(verifyStore.readGame(collisionTarget.gameId)).not.toBeNull();
+
+      collision.close();
+
+      const replacementStore = openSqliteAdHocStore(databasePath, "field-a", {
+        reconcileConnectionsAtStartup: true,
+        startupNowMs: nowMs + 1,
+      });
+      const restarted = createAdHocGamesService({
+        store: replacementStore,
+        environmentIdentity: "field-a",
+        now: () => nowMs + AD_HOC_DISCONNECTED_GRACE_MS + 1,
+      });
+      const restartedGame = replacementStore
+        .listGames()
+        .find((game) => game.gameId === created[1]!.gameId);
+      expect(restartedGame).toBeDefined();
+      expect(restartedGame?.sessions[0]?.connected).toBe(false);
+      expect(restartedGame?.sessions[0]?.lastDisconnectedAtMs).toBe(nowMs + 1);
+      restarted.close();
+    } catch (error) {
+      primaryError = error;
+    }
+    const cleanupResults = await Promise.allSettled(
+      [createWorker, connectWorker]
+        .filter((worker): worker is ReturnType<typeof startWorker> => worker !== null)
+        .map((worker) => cleanupWorker(worker)),
+    );
+    if (!firstClosed) first.close();
+    const cleanupErrors = cleanupResults
+      .filter((result): result is PromiseRejectedResult => result.status === "rejected")
+      .map((result) => result.reason);
+    if (cleanupErrors.length > 0) {
+      if (primaryError !== null) {
+        throw new AggregateError(
+          [primaryError, ...cleanupErrors],
+          "Focused SQLite race failed and worker cleanup also failed.",
+        );
+      }
+      throw cleanupErrors.length === 1
+        ? cleanupErrors[0]
+        : new AggregateError(cleanupErrors, "Focused SQLite worker cleanup failed.");
+    }
+    await rm(root, { recursive: true, force: true });
+    if (primaryError !== null) throw primaryError;
+  });
+
+  test("keeps Event storage and authority work accepted while Ad Hoc capacity is protected", async () => {
+    const eventAuth = createTechnicalAdminAuth(
+      { environment: "test", origin: "https://timer.example", rpId: "timer.example" },
+      new MemoryTechnicalAdminAuthRepository(),
+    );
+    const authority = eventAuth.resolveHostLocalAuthority();
+    const eventStorage = createInMemoryEventCatalogStorage();
+    let nextEventId = 0;
+    const eventCatalog = createEventCatalog(eventStorage, {
+      clock: { nowMs: () => 1_000 },
+      ids: { next: (kind) => `${kind}-isolation-${++nextEventId}` },
+    });
+    const event = await eventCatalog.createEvent(
+      { name: "SQM isolation", timeZone: "Europe/Zurich" },
+      authority,
+    );
+    expect(event.status).toBe("accepted");
+    if (event.status !== "accepted") return;
+
+    let nowMs = 1_000;
+    const adHocStore = createInMemoryAdHocStore();
+    const adHoc = createAdHocGamesService({ store: adHocStore, now: () => nowMs });
+    for (let index = 0; index < 50; index += 1) {
+      nowMs += 60 * 60_000;
+      const created = await adHoc.create({
+        homeName: `Protected ${index}`,
+        awayName: "Away",
+        sourceKey: `protected-${index}`,
+      });
+      if (created.status !== "accepted") throw new Error("Event isolation setup failed");
+      await adHoc.setConnection({
+        gameId: created.gameId,
+        sessionId: created.sessionId,
+        connected: true,
+        nowMs,
+      });
+    }
+
+    const blocked = await adHoc.create({
+      homeName: "Blocked",
+      awayName: "Ad Hoc",
+      sourceKey: "blocked-isolation",
+      nowMs,
+    });
+    expect(blocked).toMatchObject({ status: "rejected", reason: "capacity" });
+    expect(adHocStore.listGames()).toHaveLength(50);
+
+    const updated = await eventCatalog.updateEvent(
+      event.value.eventId,
+      { name: "SQM isolation updated" },
+      authority,
+    );
+    expect(updated).toMatchObject({ status: "accepted", value: { name: "SQM isolation updated" } });
+    const inspected = await eventCatalog.inspectEvent(event.value.eventId, authority);
+    expect(inspected).toMatchObject({
+      status: "accepted",
+      value: { eventId: event.value.eventId, name: "SQM isolation updated" },
+    });
+    eventAuth.close();
+  });
 });
 
 async function runWorker(worker: string, databasePath: string, mode: string, ...args: string[]) {
+  return await startWorker(worker, databasePath, mode, ...args).result;
+}
+
+async function cleanupWorker(worker: ReturnType<typeof startWorker>) {
+  if (!(await waitForExit(worker.child, 0))) await terminateChild(worker.child);
+}
+
+function startWorker(worker: string, databasePath: string, mode: string, ...args: string[]) {
   const child = Bun.spawn([process.execPath, "run", worker, databasePath, mode, ...args], {
     cwd: process.cwd(),
     stdout: "pipe",
     stderr: "pipe",
   });
-  let timeout: ReturnType<typeof setTimeout> | undefined;
-  try {
-    const output = Promise.all([
-      readBounded(child.stdout, 16 * 1024),
-      readBounded(child.stderr, 16 * 1024),
-      child.exited,
-    ]);
-    const result = await Promise.race([
-      output,
-      new Promise<never>((_, reject) => {
-        timeout = setTimeout(
-          () => reject(new Error("focused worker exceeded 10 second deadline")),
-          10_000,
-        );
-      }),
-    ]);
-    const [stdout, stderr, exitCode] = result;
-    if (exitCode !== 0) throw new Error(`worker failed: ${stderr || stdout}`);
-    return stdout.trim();
-  } catch (error) {
-    await terminateChild(child);
-    throw error;
-  } finally {
-    if (timeout !== undefined) clearTimeout(timeout);
+  const result = (async () => {
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    try {
+      const output = Promise.all([
+        readBounded(child.stdout, 16 * 1024),
+        readBounded(child.stderr, 16 * 1024),
+        child.exited,
+      ]);
+      const result = await Promise.race([
+        output,
+        new Promise<never>((_, reject) => {
+          timeout = setTimeout(
+            () => reject(new Error("focused worker exceeded 10 second deadline")),
+            10_000,
+          );
+        }),
+      ]);
+      const [stdout, stderr, exitCode] = result;
+      if (exitCode !== 0) throw new Error(`worker failed: ${stderr || stdout}`);
+      return stdout.trim();
+    } catch (error) {
+      await terminateChild(child);
+      throw error;
+    } finally {
+      if (timeout !== undefined) clearTimeout(timeout);
+    }
+  })();
+  return { child, result };
+}
+
+async function waitForFile(path: string) {
+  const deadline = Date.now() + 10_000;
+  while (!existsSync(path)) {
+    if (Date.now() >= deadline) throw new Error(`focused barrier did not appear: ${path}`);
+    await Bun.sleep(10);
   }
 }
 

--- a/src/lib/ad-hoc-games.test.ts
+++ b/src/lib/ad-hoc-games.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+  AD_HOC_DISCONNECTED_GRACE_MS,
   createAdHocGamesService,
   createInMemoryAdHocStore,
   type AdHocStore,
@@ -487,7 +488,11 @@ describe("Ad Hoc Games service", () => {
       awayName: "Game",
       sourceKey: "new-source",
     });
-    expect(rejected).toMatchObject({ status: "rejected", reason: "capacity" });
+    expect(rejected).toMatchObject({
+      status: "rejected",
+      reason: "capacity",
+      detail: "Ad Hoc capacity is currently full; no game was changed.",
+    });
 
     await games.setConnection({
       gameId: created[0]!.gameId,
@@ -503,5 +508,117 @@ describe("Ad Hoc Games service", () => {
     expect(replacement.status).toBe("accepted");
     expect(store.listGames()).toHaveLength(50);
     expect(store.readGame(created[0]!.gameId)).toBeNull();
+  });
+
+  test("protects newly admitted sessions and enforces the exact five-minute boundary", async () => {
+    let nowMs = 1_000;
+    const store = createInMemoryAdHocStore();
+    const games = createAdHocGamesService({ store, now: () => nowMs });
+
+    for (let index = 0; index < 49; index += 1) {
+      nowMs += 60 * 60_000;
+      const result = await games.create({
+        homeName: `Home ${index}`,
+        awayName: "Away",
+        sourceKey: `source-${index}`,
+      });
+      if (result.status !== "accepted") throw new Error("capacity setup failed");
+      await games.setConnection({
+        gameId: result.gameId,
+        sessionId: result.sessionId,
+        connected: true,
+      });
+    }
+
+    const newlyAdmitted = await games.create({
+      homeName: "Newly",
+      awayName: "Admitted",
+      sourceKey: "newly-admitted",
+      nowMs,
+    });
+    expect(newlyAdmitted.status).toBe("accepted");
+    if (newlyAdmitted.status !== "accepted") return;
+
+    const immediatelyRejected = await games.create({
+      homeName: "Immediate",
+      awayName: "Attempt",
+      sourceKey: "immediate-attempt",
+      nowMs,
+    });
+    expect(immediatelyRejected).toMatchObject({ status: "rejected", reason: "capacity" });
+
+    nowMs += AD_HOC_DISCONNECTED_GRACE_MS - 1;
+    const beforeBoundary = await games.create({
+      homeName: "Before",
+      awayName: "Boundary",
+      sourceKey: "before-boundary",
+      nowMs,
+    });
+    expect(beforeBoundary).toMatchObject({ status: "rejected", reason: "capacity" });
+    expect(store.readGame(newlyAdmitted.gameId)).not.toBeNull();
+
+    nowMs += 1;
+    const atBoundary = await games.create({
+      homeName: "At",
+      awayName: "Boundary",
+      sourceKey: "at-boundary",
+      nowMs,
+    });
+    expect(atBoundary.status).toBe("accepted");
+    expect(store.readGame(newlyAdmitted.gameId)).toBeNull();
+  });
+
+  test("enforces one global cap without pruning another environment", async () => {
+    let nowMs = 1_000;
+    const store = createInMemoryAdHocStore();
+    const fieldA = createAdHocGamesService({
+      store,
+      environmentIdentity: "field-a",
+      now: () => nowMs,
+    });
+    const fieldB = createAdHocGamesService({
+      store,
+      environmentIdentity: "field-b",
+      now: () => nowMs,
+    });
+
+    for (let index = 0; index < 49; index += 1) {
+      nowMs += 60 * 60_000;
+      const result = await fieldA.create({
+        homeName: `Field A ${index}`,
+        awayName: "Away",
+        sourceKey: `field-a-${index}`,
+      });
+      if (result.status !== "accepted") throw new Error("mixed capacity setup failed");
+      await fieldA.setConnection({
+        gameId: result.gameId,
+        sessionId: result.sessionId,
+        connected: true,
+      });
+    }
+
+    const otherEnvironment = await fieldB.create({
+      homeName: "Field B",
+      awayName: "Away",
+      sourceKey: "field-b",
+      nowMs,
+    });
+    if (otherEnvironment.status !== "accepted") throw new Error("mixed environment setup failed");
+    await fieldB.setConnection({
+      gameId: otherEnvironment.gameId,
+      sessionId: otherEnvironment.sessionId,
+      connected: true,
+      nowMs,
+    });
+
+    const rejected = await fieldA.create({
+      homeName: "Blocked",
+      awayName: "Capacity",
+      sourceKey: "field-a-new",
+      nowMs,
+    });
+    expect(rejected).toMatchObject({ status: "rejected", reason: "capacity" });
+    expect(store.listGames()).toHaveLength(50);
+    expect(store.readGame(otherEnvironment.gameId)).not.toBeNull();
   });
 });

--- a/src/lib/ad-hoc-games.ts
+++ b/src/lib/ad-hoc-games.ts
@@ -50,6 +50,7 @@ export const AD_HOC_MAX_OPERATIONS_PER_SECOND_PER_GAME = AD_HOC_GAME_BURST;
 
 const SCHEMA_VERSION = 4;
 const GENERIC_UNAVAILABLE = "Ad Hoc Game unavailable.";
+const GENERIC_CAPACITY = "Ad Hoc capacity is currently full; no game was changed.";
 
 export type AdHocGameView = GameView & {
   gameId: string;
@@ -110,6 +111,10 @@ export type AdHocAccessResult =
   | { status: "accepted"; game: AdHocGameView }
   | { status: "unavailable"; detail: string };
 
+export type AdHocSubscriptionResult =
+  | AdHocAccessResult
+  | { status: "capacity"; retryAfterMs: number };
+
 type StoredSession = {
   sessionHash: string;
   browserId: string | null;
@@ -167,12 +172,219 @@ export type AdHocStore = {
     sourceHash: string;
     nowMs: number;
   }):
-    | "accepted"
     | "rate-limited"
     | "capacity"
     | "unavailable"
-    | { status: "rate-limited"; retryAfterMs: number };
+    | { status: "rate-limited"; retryAfterMs: number }
+    | { status: "accepted"; removedGameId: string | null };
   mutateGame<T>(gameId: string, mutation: (game: StoredAdHocGame) => T): T | null;
+};
+
+export type AdHocLiveSessionIdentity = {
+  gameId: string;
+  sessionId: string;
+};
+
+export type AdHocLiveSessionSubscribeResult = {
+  attached: boolean;
+  previousDisconnectDurable: boolean;
+};
+
+export type AdHocLiveSessionTrackerOptions = {
+  retryBatchSize?: number;
+  retryBaseDelayMs?: number;
+  retryMaxDelayMs?: number;
+  scheduleRetry?: (delayMs: number, task: () => void) => void;
+};
+
+export function createAdHocLiveSessionTracker(
+  onLastSocketClosed: (identity: AdHocLiveSessionIdentity) => Promise<boolean>,
+  options: AdHocLiveSessionTrackerOptions = {},
+) {
+  const socketOwners = new Map<string, AdHocLiveSessionIdentity>();
+  const sessionSockets = new Map<string, Set<string>>();
+  const pendingDisconnects = new Map<string, AdHocLiveSessionIdentity>();
+  const closedSockets = new Set<string>();
+  const socketTasks = new Map<string, Promise<unknown>>();
+  const sessionTasks = new Map<string, Promise<unknown>>();
+  const retryBatchSize = Math.max(1, Math.floor(options.retryBatchSize ?? 8));
+  const retryBaseDelayMs = Math.max(1, Math.floor(options.retryBaseDelayMs ?? 100));
+  const retryMaxDelayMs = Math.max(retryBaseDelayMs, Math.floor(options.retryMaxDelayMs ?? 10_000));
+  const schedule =
+    options.scheduleRetry ??
+    ((delayMs: number, task: () => void) => {
+      const timer = setTimeout(task, delayMs);
+      (timer as ReturnType<typeof setTimeout> & { unref?: () => void }).unref?.();
+    });
+  let retryScheduled = false;
+  let retryDelayMs = retryBaseDelayMs;
+  let retryInFlight: Promise<boolean> | null = null;
+  let retryPending: () => Promise<boolean> = async () => true;
+  const keyFor = (identity: AdHocLiveSessionIdentity) =>
+    JSON.stringify([identity.gameId, identity.sessionId]);
+  const enqueue = <T>(
+    tasks: Map<string, Promise<unknown>>,
+    key: string,
+    work: () => Promise<T>,
+  ) => {
+    const previous = tasks.get(key) ?? Promise.resolve();
+    const next = previous.then(work, work);
+    tasks.set(key, next);
+    void next.then(
+      () => {
+        if (tasks.get(key) === next) tasks.delete(key);
+        if (tasks === socketTasks && closedSockets.has(key) && !socketTasks.has(key)) {
+          closedSockets.delete(key);
+        }
+      },
+      () => {
+        if (tasks.get(key) === next) tasks.delete(key);
+        if (tasks === socketTasks && closedSockets.has(key) && !socketTasks.has(key)) {
+          closedSockets.delete(key);
+        }
+      },
+    );
+    return next;
+  };
+  const scheduleRetry = () => {
+    if (retryScheduled || pendingDisconnects.size === 0) return;
+    retryScheduled = true;
+    schedule(retryDelayMs, () => {
+      retryScheduled = false;
+      void retryPending();
+    });
+  };
+  const disconnectIfLast = (identity: AdHocLiveSessionIdentity) => {
+    const key = keyFor(identity);
+    return enqueue(sessionTasks, key, async () => {
+      if (sessionSockets.has(key)) {
+        pendingDisconnects.delete(key);
+        return true;
+      }
+      let durable = false;
+      try {
+        durable = await onLastSocketClosed(identity);
+      } catch {
+        durable = false;
+      }
+      if (sessionSockets.has(key)) {
+        pendingDisconnects.delete(key);
+        return true;
+      }
+      if (durable) pendingDisconnects.delete(key);
+      else pendingDisconnects.set(key, identity);
+      return durable;
+    });
+  };
+  const performRetry = async (): Promise<boolean> => {
+    const batch = [...pendingDisconnects.values()].slice(0, retryBatchSize);
+    if (batch.length === 0) {
+      retryDelayMs = retryBaseDelayMs;
+      return true;
+    }
+    const results = await Promise.all(batch.map((identity) => disconnectIfLast(identity)));
+    for (let index = 0; index < batch.length; index += 1) {
+      if (results[index] === true) continue;
+      const identity = batch[index]!;
+      const key = keyFor(identity);
+      const pending = pendingDisconnects.get(key);
+      if (pending !== undefined) {
+        pendingDisconnects.delete(key);
+        pendingDisconnects.set(key, pending);
+      }
+    }
+    if (pendingDisconnects.size === 0) retryDelayMs = retryBaseDelayMs;
+    else {
+      retryDelayMs = Math.min(retryMaxDelayMs, retryDelayMs * 2);
+      scheduleRetry();
+    }
+    return pendingDisconnects.size === 0 && results.every(Boolean);
+  };
+  const tracker = {
+    async subscribe(
+      socketId: string,
+      identity: AdHocLiveSessionIdentity,
+    ): Promise<AdHocLiveSessionSubscribeResult> {
+      return await enqueue(socketTasks, socketId, async () => {
+        if (closedSockets.has(socketId)) {
+          const durable = await disconnectIfLast(identity);
+          if (!durable) scheduleRetry();
+          return { attached: false, previousDisconnectDurable: durable };
+        }
+        const previous = socketOwners.get(socketId);
+        if (previous !== undefined && keyFor(previous) === keyFor(identity)) {
+          pendingDisconnects.delete(keyFor(identity));
+          return { attached: true, previousDisconnectDurable: true };
+        }
+        let previousDisconnectDurable = true;
+        if (previous !== undefined) {
+          socketOwners.delete(socketId);
+          const previousKey = keyFor(previous);
+          const previousSockets = sessionSockets.get(previousKey);
+          previousSockets?.delete(socketId);
+          if (previousSockets?.size === 0) {
+            sessionSockets.delete(previousKey);
+            previousDisconnectDurable = await disconnectIfLast(previous);
+          }
+        }
+        const key = keyFor(identity);
+        socketOwners.set(socketId, identity);
+        const socketsForSession = sessionSockets.get(key) ?? new Set<string>();
+        socketsForSession.add(socketId);
+        sessionSockets.set(key, socketsForSession);
+        pendingDisconnects.delete(key);
+        if (!previousDisconnectDurable) scheduleRetry();
+        return { attached: true, previousDisconnectDurable };
+      });
+    },
+    async disconnect(socketId: string): Promise<boolean> {
+      closedSockets.add(socketId);
+      const durable = await enqueue(socketTasks, socketId, async () => {
+        const identity = socketOwners.get(socketId);
+        if (identity === undefined) return true;
+        socketOwners.delete(socketId);
+        const key = keyFor(identity);
+        const socketsForSession = sessionSockets.get(key);
+        socketsForSession?.delete(socketId);
+        if (socketsForSession?.size !== 0) return true;
+        sessionSockets.delete(key);
+        return await disconnectIfLast(identity);
+      });
+      if (!durable) scheduleRetry();
+      return durable;
+    },
+    count(identity: AdHocLiveSessionIdentity) {
+      return sessionSockets.get(keyFor(identity))?.size ?? 0;
+    },
+    pendingCount() {
+      return pendingDisconnects.size;
+    },
+    tombstoneCount() {
+      return closedSockets.size;
+    },
+    async retryPending(): Promise<boolean> {
+      if (retryInFlight !== null) return await retryInFlight;
+      const current = performRetry();
+      retryInFlight = current;
+      void current.then(
+        () => {
+          if (retryInFlight === current) retryInFlight = null;
+        },
+        () => {
+          if (retryInFlight === current) retryInFlight = null;
+        },
+      );
+      return await current;
+    },
+  };
+  retryPending = () => tracker.retryPending();
+  return tracker;
+}
+
+export type AdHocSqliteStoreOptions = {
+  reconcileConnectionsAtStartup?: boolean;
+  startupNowMs?: number;
+  beforeCapacityCommit?: () => void;
 };
 
 export type AdHocGamesServiceOptions = {
@@ -246,6 +458,58 @@ export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) 
     return cancel;
   };
 
+  const updateConnection = (input: {
+    gameId: string;
+    sessionId: string;
+    connected: boolean;
+    connectionId: string;
+    nowMs: number;
+  }): { status: "accepted"; game: StoredAdHocGame } | { status: "capacity" } | null => {
+    const sessionKey = digest(input.sessionId);
+    let connectionChange: "add" | "remove" | null = null;
+    let outcome: StoredAdHocGame | false | { capacity: true; rollback: true } | null;
+    try {
+      outcome = store.mutateGame(input.gameId, (game) => {
+        if (game.environmentIdentity !== environmentIdentity) return false;
+        const session = game.sessions.find((candidate) => candidate.sessionHash === sessionKey);
+        if (session === undefined) return false;
+        if (input.connected && !connections.has(input.connectionId)) {
+          const activeEventConnections = Math.max(0, eventCapacity.activeConnections());
+          const availableForAdHoc = Math.max(
+            0,
+            Math.min(
+              maxConnectedSockets,
+              eventCapacity.totalConnections -
+                Math.max(eventCapacity.reservedConnections, activeEventConnections),
+            ),
+          );
+          if (connections.size >= availableForAdHoc) {
+            return { capacity: true, rollback: true } as const;
+          }
+          connectionChange = "add";
+        }
+        if (!input.connected && connections.has(input.connectionId)) {
+          connectionChange = "remove";
+        }
+        const hasOtherConnection = [...connections].some(
+          ([candidateId, candidateSessionKey]) =>
+            candidateId !== input.connectionId && candidateSessionKey === sessionKey,
+        );
+        session.connected = input.connected || hasOtherConnection;
+        if (input.connected) session.lastConnectedAtMs = input.nowMs;
+        else if (!hasOtherConnection) session.lastDisconnectedAtMs = input.nowMs;
+        return game;
+      });
+    } catch {
+      return null;
+    }
+    if (outcome === null || outcome === false) return null;
+    if ("capacity" in outcome) return { status: "capacity" };
+    if (connectionChange === "add") connections.set(input.connectionId, sessionKey);
+    if (connectionChange === "remove") connections.delete(input.connectionId);
+    return { status: "accepted", game: outcome };
+  };
+
   return {
     async create(input: AdHocCreationInput): Promise<AdHocCreateResult> {
       const home = normalizeTeamInput(input.homeName, "homeName");
@@ -311,7 +575,10 @@ export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) 
       } catch {
         return { status: "rejected", reason: "unavailable" };
       }
-      if (outcome === "rate-limited" || typeof outcome === "object") {
+      if (
+        outcome === "rate-limited" ||
+        (typeof outcome === "object" && outcome.status === "rate-limited")
+      ) {
         const retryAfterMs = typeof outcome === "object" ? outcome.retryAfterMs : 60 * 60_000;
         metrics.creationDelay += retryAfterMs <= 30_000 ? 1 : 0;
         metrics.creationRateExhausted += retryAfterMs > 30_000 ? 1 : 0;
@@ -323,9 +590,20 @@ export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) 
         };
       }
       if (outcome === "capacity") {
-        return { status: "rejected", reason: "capacity" };
+        return { status: "rejected", reason: "capacity", detail: GENERIC_CAPACITY };
       }
       if (outcome === "unavailable") return { status: "rejected", reason: "unavailable" };
+
+      if (outcome.removedGameId !== null) {
+        gameActionBuckets.delete(outcome.removedGameId);
+        const prefix = `${outcome.removedGameId}:`;
+        for (const key of controllerActionBuckets.keys()) {
+          if (key.startsWith(prefix)) controllerActionBuckets.delete(key);
+        }
+        for (const key of replayBuckets.keys()) {
+          if (key.startsWith(prefix)) replayBuckets.delete(key);
+        }
+      }
 
       return {
         status: "accepted",
@@ -359,6 +637,31 @@ export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) 
       return {
         status: "accepted",
         game: projectAuthorizedGame(game, sessionId, null, input.nowMs ?? now(), iqaRules),
+      };
+    },
+
+    async subscribe(input: {
+      gameId: unknown;
+      sessionId: unknown;
+      nowMs?: number;
+    }): Promise<AdHocSubscriptionResult> {
+      const gameId = validateGameId(input.gameId);
+      const sessionId = validateBearer(input.sessionId);
+      if (gameId === null || sessionId === null) return unavailable();
+      const nowMs = input.nowMs ?? now();
+      if (!isSafeTimestamp(nowMs)) return unavailable();
+      const outcome = updateConnection({
+        gameId,
+        sessionId,
+        connected: true,
+        connectionId: digest(sessionId),
+        nowMs,
+      });
+      if (outcome === null) return unavailable();
+      if (outcome.status === "capacity") return { status: "capacity", retryAfterMs: 1_000 };
+      return {
+        status: "accepted",
+        game: projectAuthorizedGame(outcome.game, sessionId, null, nowMs, iqaRules),
       };
     },
 
@@ -441,8 +744,8 @@ export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) 
           input.operations.length > 0 &&
           input.operations.length <= AD_HOC_REPLAY_MAX_OPERATIONS_PER_BATCH
         ) {
-          const sessionKey = digest(sessionId);
-          if (pendingReplays.has(sessionKey)) {
+          const replaySessionKey = digest(sessionId);
+          if (pendingReplays.has(replaySessionKey)) {
             metrics.replayPressure += 1;
             return {
               status: "rejected",
@@ -515,7 +818,7 @@ export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) 
             },
           );
           const replayId = random();
-          pendingReplays.set(sessionKey, replayId);
+          pendingReplays.set(replaySessionKey, replayId);
           const chunks = Array.from({ length: Math.ceil(plannedEntries.length / 20) }, (_, index) =>
             plannedEntries.slice(index * 20, (index + 1) * 20),
           );
@@ -526,10 +829,11 @@ export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) 
             let duplicate = true;
             let retryCount = 0;
             const deadlineMs = nowMs + 30_000;
-            const isCurrentJob = () => !closed && replayJobs.get(sessionKey)?.resolve === resolve;
+            const isCurrentJob = () =>
+              !closed && replayJobs.get(replaySessionKey)?.resolve === resolve;
             const rejectJob = (result: AdHocActionResult) => {
-              pendingReplays.delete(sessionKey);
-              replayJobs.delete(sessionKey);
+              pendingReplays.delete(replaySessionKey);
+              replayJobs.delete(replaySessionKey);
               resolve(result);
             };
             const runChunk = (index: number, scheduledAtMs: number) => {
@@ -562,7 +866,7 @@ export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) 
                       const cancel = scheduleReplayTask(delayMs, () =>
                         runChunk(index, scheduledAtMs + delayMs),
                       );
-                      const job = replayJobs.get(sessionKey);
+                      const job = replayJobs.get(replaySessionKey);
                       if (job !== undefined) job.cancel = cancel;
                       return;
                     }
@@ -578,11 +882,11 @@ export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) 
                     const cancel = scheduleReplayTask(1_000, () =>
                       runChunk(index + 1, scheduledAtMs + 1_000),
                     );
-                    const job = replayJobs.get(sessionKey);
+                    const job = replayJobs.get(replaySessionKey);
                     if (job !== undefined) job.cancel = cancel;
                     return;
                   }
-                  replayJobs.delete(sessionKey);
+                  replayJobs.delete(replaySessionKey);
                   resolve({
                     status: duplicate ? "duplicate" : "accepted",
                     game: projectedGame,
@@ -594,7 +898,7 @@ export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) 
               );
             };
             const job = { cancel: () => {}, resolve };
-            replayJobs.set(sessionKey, job);
+            replayJobs.set(replaySessionKey, job);
             job.cancel = scheduleReplayTask(0, () => runChunk(0, nowMs));
           });
         }
@@ -613,10 +917,11 @@ export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) 
       const nowMs = input.nowMs ?? now();
       if (!isSafeTimestamp(nowMs)) return { status: "rejected", reason: "invalid-operation" };
       let outcome: AdHocApplyMutationResult | null;
-      const sessionKey = digest(sessionId);
+      const replaySessionKey = digest(sessionId);
+      const sessionBucketKey = `${gameId}:${replaySessionKey}`;
       if (
         preparedChunk === undefined &&
-        (replayInFlight.has(sessionKey) || pendingReplays.has(sessionKey))
+        (replayInFlight.has(replaySessionKey) || pendingReplays.has(replaySessionKey))
       ) {
         metrics.replayPressure += 1;
         return {
@@ -626,7 +931,7 @@ export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) 
           retryAfterMs: 1_000,
         };
       }
-      replayInFlight.add(sessionKey);
+      replayInFlight.add(replaySessionKey);
       let nextControllerBucket: AdHocTokenBucket | undefined;
       let nextGameBucket: AdHocTokenBucket | undefined;
       let nextReplayBucket: AdHocTokenBucket | undefined;
@@ -691,7 +996,7 @@ export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) 
                 ).length;
           if (acceptedNewOperationCount > 0) {
             const controller = consumeAdHocTokens(
-              controllerActionBuckets.get(sessionKey),
+              controllerActionBuckets.get(sessionBucketKey),
               nowMs,
               AD_HOC_CONTROLLER_BURST,
               AD_HOC_CONTROLLER_SUSTAINED_PER_SECOND,
@@ -705,7 +1010,7 @@ export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) 
               acceptedNewOperationCount,
             );
             const replay = consumeAdHocTokens(
-              replayBuckets.get(sessionKey),
+              replayBuckets.get(sessionBucketKey),
               nowMs,
               deferReplayAcknowledgement
                 ? AD_HOC_REPLAY_BURST
@@ -828,7 +1133,7 @@ export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) 
       } catch {
         return { status: "rejected", reason: "unavailable" };
       } finally {
-        replayInFlight.delete(sessionKey);
+        replayInFlight.delete(replaySessionKey);
       }
       if (outcome === null || outcome === false)
         return { status: "rejected", reason: "unavailable" };
@@ -865,9 +1170,9 @@ export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) 
       }
       if (game === null) return { status: "rejected", reason: "unavailable" };
       if (nextControllerBucket !== undefined)
-        controllerActionBuckets.set(sessionKey, nextControllerBucket);
+        controllerActionBuckets.set(sessionBucketKey, nextControllerBucket);
       if (nextGameBucket !== undefined) gameActionBuckets.set(gameId, nextGameBucket);
-      if (nextReplayBucket !== undefined) replayBuckets.set(sessionKey, nextReplayBucket);
+      if (nextReplayBucket !== undefined) replayBuckets.set(sessionBucketKey, nextReplayBucket);
       return {
         status: outcome.duplicate ? "duplicate" : "accepted",
         ackedOperationIds: outcome.acknowledged,
@@ -904,50 +1209,16 @@ export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) 
       if (gameId === null || sessionId === null) return false;
       const nowMs = input.nowMs ?? now();
       if (!isSafeTimestamp(nowMs)) return false;
-      const sessionKey = digest(sessionId);
-      const connectionId = input.connectionId?.trim() || sessionKey;
-      let connectionChange: "add" | "remove" | null = null;
-      try {
-        const changed = store.mutateGame(gameId, (game) => {
-          if (game.environmentIdentity !== environmentIdentity) return false;
-          const session = game.sessions.find(
-            (candidate) => candidate.sessionHash === digest(sessionId),
-          );
-          if (session === undefined) return false;
-          if (input.connected && !connections.has(connectionId)) {
-            const activeEventConnections = Math.max(0, eventCapacity.activeConnections());
-            const availableForAdHoc = Math.max(
-              0,
-              Math.min(
-                maxConnectedSockets,
-                eventCapacity.totalConnections -
-                  Math.max(eventCapacity.reservedConnections, activeEventConnections),
-              ),
-            );
-            if (connections.size >= availableForAdHoc) {
-              metrics.connectionShed += 1;
-              return false;
-            }
-            connectionChange = "add";
-          }
-          if (!input.connected && connections.has(connectionId)) connectionChange = "remove";
-          const hasOtherConnection = [...connections].some(
-            ([candidateId, candidateSessionKey]) =>
-              candidateId !== connectionId && candidateSessionKey === sessionKey,
-          );
-          session.connected = input.connected;
-          if (input.connected) session.lastConnectedAtMs = nowMs;
-          else if (!hasOtherConnection) session.lastDisconnectedAtMs = nowMs;
-          if (!input.connected && hasOtherConnection) session.connected = true;
-          return true;
-        });
-        if (changed === true && connectionChange === "add")
-          connections.set(connectionId, sessionKey);
-        if (changed === true && connectionChange === "remove") connections.delete(connectionId);
-        return changed === true;
-      } catch {
-        return false;
-      }
+      const connectionId = input.connectionId?.trim() || digest(sessionId);
+      const outcome = updateConnection({
+        gameId,
+        sessionId,
+        connected: input.connected,
+        connectionId,
+        nowMs,
+      });
+      if (outcome?.status === "capacity") metrics.connectionShed += 1;
+      return outcome?.status === "accepted";
     },
 
     async leave(input: { gameId: unknown; sessionId: unknown; nowMs?: number }): Promise<boolean> {
@@ -1073,24 +1344,24 @@ export function createInMemoryAdHocStore(): AdHocStore {
           retryAfterMs,
         };
       }
-      if (games.size >= AD_HOC_MAX_RETAINED_GAMES) {
+      let removedGameId: string | null = null;
+      const retainedCount = games.size;
+      if (retainedCount >= AD_HOC_MAX_RETAINED_GAMES) {
         const victim = [...games.values()]
-          .filter((candidate) =>
-            candidate.sessions.every(
-              (session) =>
-                !session.connected &&
-                session.lastDisconnectedAtMs !== null &&
-                session.lastDisconnectedAtMs <= nowMs - AD_HOC_DISCONNECTED_GRACE_MS,
-            ),
+          .filter(
+            (candidate) =>
+              candidate.environmentIdentity === game.environmentIdentity &&
+              candidate.sessions.every((session) => isCleanupEligible(session, nowMs)),
           )
-          .sort((a, b) => a.createdAtMs - b.createdAtMs)[0];
+          .sort((a, b) => a.createdAtMs - b.createdAtMs || a.gameId.localeCompare(b.gameId))[0];
         if (victim === undefined) return "capacity";
         games.delete(victim.gameId);
+        removedGameId = victim.gameId;
       }
       games.set(game.gameId, cloneStoredGame(game));
       successes.push(nowMs);
       attempts.set(sourceHash, [...sourceAttempts, { occurredAtMs: nowMs, successful: true }]);
-      return "accepted";
+      return { status: "accepted", removedGameId };
     },
     mutateGame(gameId, mutation) {
       const game = games.get(gameId);
@@ -1116,6 +1387,7 @@ export function createInMemoryAdHocStore(): AdHocStore {
 export function openSqliteAdHocStore(
   databasePath: string,
   environmentIdentity = "test",
+  options: AdHocSqliteStoreOptions = {},
 ): AdHocStore {
   mkdirSync(dirname(databasePath), { recursive: true });
   const db = new Database(databasePath, { create: true, strict: true });
@@ -1184,6 +1456,33 @@ export function openSqliteAdHocStore(
     db.run("ALTER TABLE adhoc_creation_events ADD COLUMN retry_until_ms INTEGER");
   }
 
+  if (options.reconcileConnectionsAtStartup === true) {
+    const startupNowMs = options.startupNowMs ?? Date.now();
+    if (!isSafeTimestamp(startupNowMs)) throw new Error("Startup timestamp is invalid.");
+    const reconcile = db.transaction(() => {
+      const rows = db
+        .query("SELECT game_id, sessions_json FROM adhoc_games WHERE environment_identity = ?")
+        .all(environmentIdentity) as { game_id: string; sessions_json: string }[];
+      for (const row of rows) {
+        const sessions = JSON.parse(row.sessions_json) as StoredSession[];
+        let changed = false;
+        for (const session of sessions) {
+          if (!session.connected) continue;
+          session.connected = false;
+          session.lastDisconnectedAtMs = startupNowMs;
+          changed = true;
+        }
+        if (changed) {
+          db.run("UPDATE adhoc_games SET sessions_json = ? WHERE game_id = ?", [
+            JSON.stringify(sessions),
+            row.game_id,
+          ]);
+        }
+      }
+    });
+    reconcile.immediate();
+  }
+
   const read = (gameId: string): StoredAdHocGame | null => {
     const row = db.query("SELECT * FROM adhoc_games WHERE game_id = ?").get(gameId) as Record<
       string,
@@ -1206,15 +1505,14 @@ export function openSqliteAdHocStore(
     },
     readGame: read,
     createGame({ game, sourceHash, nowMs }) {
-      return transaction(() => {
-        db.run("DELETE FROM adhoc_creation_events WHERE occurred_at_ms <= ?", [
-          nowMs - AD_HOC_CREATION_GLOBAL_WINDOW_MS,
-        ]);
+      return transaction.immediate(() => {
         const pendingRow = db
           .query(
-            "SELECT retry_until_ms FROM adhoc_creation_events WHERE source_hash = ? AND successful = 0 AND retry_until_ms IS NOT NULL ORDER BY occurred_at_ms DESC LIMIT 1",
+            "SELECT retry_until_ms FROM adhoc_creation_events WHERE source_hash = ? AND successful = 0 AND retry_until_ms IS NOT NULL AND occurred_at_ms > ? ORDER BY occurred_at_ms DESC LIMIT 1",
           )
-          .get(sourceHash) as { retry_until_ms?: number | string } | null;
+          .get(sourceHash, nowMs - AD_HOC_CREATION_GLOBAL_WINDOW_MS) as {
+          retry_until_ms?: number | string;
+        } | null;
         const pendingUntilMs = Number(pendingRow?.retry_until_ms ?? 0);
         if (pendingUntilMs > nowMs) {
           return { status: "rate-limited", retryAfterMs: pendingUntilMs - nowMs } as const;
@@ -1240,15 +1538,21 @@ export function openSqliteAdHocStore(
           } as const;
         }
         const globalCountRow = db
-          .query("SELECT COUNT(*) AS count FROM adhoc_creation_events WHERE successful = 1")
-          .get() as { count?: number | string } | null;
+          .query(
+            "SELECT COUNT(*) AS count FROM adhoc_creation_events WHERE successful = 1 AND occurred_at_ms > ?",
+          )
+          .get(nowMs - AD_HOC_CREATION_GLOBAL_WINDOW_MS) as {
+          count?: number | string;
+        } | null;
         const globalCount = Number(globalCountRow?.count ?? 0);
         if (globalCount >= AD_HOC_MAX_CREATIONS_PER_HOUR) {
           const firstSuccessRow = db
             .query(
-              "SELECT MIN(occurred_at_ms) AS occurred_at_ms FROM adhoc_creation_events WHERE successful = 1",
+              "SELECT MIN(occurred_at_ms) AS occurred_at_ms FROM adhoc_creation_events WHERE successful = 1 AND occurred_at_ms > ?",
             )
-            .get() as { occurred_at_ms?: number | string } | null;
+            .get(nowMs - AD_HOC_CREATION_GLOBAL_WINDOW_MS) as {
+            occurred_at_ms?: number | string;
+          } | null;
           const retryAfterMs = Math.max(
             1_000,
             Number(firstSuccessRow?.occurred_at_ms ?? nowMs) +
@@ -1268,18 +1572,31 @@ export function openSqliteAdHocStore(
           count?: number | string;
         } | null;
         const count = Number(countRow?.count ?? 0);
+        let removedGameId: string | null = null;
         if (count >= AD_HOC_MAX_RETAINED_GAMES) {
           const victim = db
-            .query(`SELECT game_id FROM adhoc_games WHERE NOT EXISTS (
+            .query(`SELECT game_id FROM adhoc_games WHERE environment_identity = ? AND NOT EXISTS (
             SELECT 1 FROM json_each(sessions_json) AS session
             WHERE json_extract(session.value, '$.connected') = 1
-               OR json_extract(session.value, '$.lastDisconnectedAtMs') IS NULL
-               OR json_extract(session.value, '$.lastDisconnectedAtMs') > ?
-          ) ORDER BY created_at_ms ASC LIMIT 1`)
-            .get(nowMs - AD_HOC_DISCONNECTED_GRACE_MS) as { game_id?: string } | null;
+               OR COALESCE(
+                    json_extract(session.value, '$.lastDisconnectedAtMs'),
+                    json_extract(session.value, '$.lastConnectedAtMs')
+                  ) > ?
+          ) ORDER BY created_at_ms ASC, game_id ASC LIMIT 1`)
+            .get(game.environmentIdentity, nowMs - AD_HOC_DISCONNECTED_GRACE_MS) as {
+            game_id?: string;
+          } | null;
           if (victim?.game_id === undefined) return "capacity" as const;
-          db.run("DELETE FROM adhoc_games WHERE game_id = ?", [victim.game_id]);
+          options.beforeCapacityCommit?.();
+          db.run("DELETE FROM adhoc_games WHERE game_id = ? AND environment_identity = ?", [
+            victim.game_id,
+            game.environmentIdentity,
+          ]);
+          removedGameId = victim.game_id;
         }
+        db.run("DELETE FROM adhoc_creation_events WHERE occurred_at_ms <= ?", [
+          nowMs - AD_HOC_CREATION_GLOBAL_WINDOW_MS,
+        ]);
         db.run(
           "INSERT INTO adhoc_games (game_id, environment_identity, created_at_ms, state_json, initial_state_json, replay_baseline_operation_ids_json, control_qr, control_qr_hash, sessions_json, operations_json) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
           [
@@ -1299,13 +1616,8 @@ export function openSqliteAdHocStore(
           "INSERT INTO adhoc_creation_events (source_hash, successful, occurred_at_ms, retry_until_ms) VALUES (?, 1, ?, NULL)",
           [sourceHash, nowMs],
         );
-        return "accepted" as const;
-      }) as
-        | "accepted"
-        | "rate-limited"
-        | "capacity"
-        | "unavailable"
-        | { status: "rate-limited"; retryAfterMs: number };
+        return { status: "accepted", removedGameId } as const;
+      }) as ReturnType<AdHocStore["createGame"]>;
     },
     mutateGame<T>(gameId: string, mutation: (game: StoredAdHocGame) => T): T | null {
       return transaction(() => {
@@ -1739,6 +2051,12 @@ function validateBrowserId(value: unknown): string | null {
 
 function isSafeTimestamp(value: number): boolean {
   return Number.isSafeInteger(value) && value >= 0;
+}
+
+function isCleanupEligible(session: StoredSession, nowMs: number): boolean {
+  if (session.connected) return false;
+  const lastEvidenceMs = session.lastDisconnectedAtMs ?? session.lastConnectedAtMs;
+  return lastEvidenceMs <= nowMs - AD_HOC_DISCONNECTED_GRACE_MS;
 }
 
 function normalizeTeamInput(value: unknown, field: string) {

--- a/src/pages/public-event-page.tsx
+++ b/src/pages/public-event-page.tsx
@@ -237,6 +237,7 @@ function StartAdHocGame() {
   const [homeColor, setHomeColor] = useState(DEFAULT_HOME_TEAM_COLOR);
   const [awayColor, setAwayColor] = useState(DEFAULT_AWAY_TEAM_COLOR);
   const [creationStatus, setCreationStatus] = useState<string | null>(null);
+  const [creationAlert, setCreationAlert] = useState(false);
   const [creationPending, setCreationPending] = useState(false);
   const creationPendingRef = useRef(false);
   const creationRetryTimerRef = useRef<number | null>(null);
@@ -261,6 +262,7 @@ function StartAdHocGame() {
         creationPendingRef.current = true;
         setCreationPending(true);
       }
+      setCreationAlert(false);
       setCreationStatus(attempt === 0 ? "Creating Ad Hoc Game…" : "Retrying Ad Hoc Game…");
 
       let response: Response;
@@ -277,7 +279,10 @@ function StartAdHocGame() {
           }),
         });
       } catch {
-        if (mountedRef.current) setCreationStatus("Ad Hoc Game unavailable. Try again later.");
+        if (mountedRef.current) {
+          setCreationAlert(true);
+          setCreationStatus("Ad Hoc Game unavailable. Try again later.");
+        }
         creationPendingRef.current = false;
         setCreationPending(false);
         return;
@@ -285,10 +290,15 @@ function StartAdHocGame() {
       if (!mountedRef.current) return;
 
       if (!response.ok) {
-        if (response.status === 429 && attempt < 3) {
-          const payload = (await response.json().catch(() => null)) as {
-            retryAfterMs?: unknown;
-          } | null;
+        const payload = (await response.json().catch(() => null)) as {
+          error?: unknown;
+          retryAfterMs?: unknown;
+        } | null;
+        const capacityMessage =
+          typeof payload?.error === "string" && payload.error.startsWith("Ad Hoc capacity")
+            ? payload.error
+            : null;
+        if (response.status === 429 && attempt < 3 && capacityMessage === null) {
           const headerDelayMs = Number(response.headers.get("retry-after")) * 1_000;
           const retryAfterMs = Math.min(
             30_000,
@@ -308,7 +318,8 @@ function StartAdHocGame() {
           }, retryAfterMs);
           return;
         }
-        setCreationStatus("Ad Hoc Game unavailable. Try again later.");
+        setCreationAlert(true);
+        setCreationStatus(capacityMessage ?? "Ad Hoc Game unavailable. Try again later.");
         creationPendingRef.current = false;
         setCreationPending(false);
         return;
@@ -321,6 +332,7 @@ function StartAdHocGame() {
         navigateTo(`/game/${payload.gameId}`);
         return;
       }
+      setCreationAlert(true);
       setCreationStatus("Ad Hoc Game unavailable. Try again later.");
       creationPendingRef.current = false;
       setCreationPending(false);
@@ -383,7 +395,11 @@ function StartAdHocGame() {
           Start an Ad Hoc Game <span className="sr-only">Create new game</span>
         </Button>
         {creationStatus !== null ? (
-          <p className="text-sm text-muted-foreground" role="status" aria-live="polite">
+          <p
+            className={creationAlert ? "text-sm text-destructive" : "text-sm text-muted-foreground"}
+            role={creationAlert ? "alert" : "status"}
+            aria-live="polite"
+          >
             {creationStatus}
           </p>
         ) : null}


### PR DESCRIPTION
## What changed

- enforces the 50-Game retained-capacity rule with atomic oldest-eligible cleanup
- protects connected and recently disconnected Ad Hoc Games, including concurrent SQLite subscribe/create races
- serializes socket ownership and retries failed durable final disconnects with bounded lifecycle state
- removes evicted Game resource buckets and keeps pruned browsers locally operable without recreating server state
- returns one generic, no-mutation capacity outcome when every retained Game is protected

## Why

Capacity cleanup must be deterministic and atomic: a 51st creation may remove only the oldest eligible disconnected Game, while protected saturation must change nothing and disclose nothing.

## Impact

Retained Ad Hoc capacity is bounded without deleting active or grace-period Games. The cleanup path remains isolated from Event authority and resources, and pruned clients cannot silently restore the removed server Game.

## Validation

- `bun run check`
- `bun run test` — 638 passed, 0 failed
- `bun run test:focused:ad-hoc` — 8 passed, 0 failed
- `bun run test:focused:adhoc-browser`
- `bun run build`
- `git diff --check`

Stacked on #205.

Closes #156