### PR TITLE
Deploy one artifact independently to Production and Test

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -109,6 +109,11 @@ jobs:
   deploy-test:
     if: github.ref == 'refs/heads/main'
     needs: build
+    outputs:
+      status: ${{ steps.deployment-outcome.outputs.status }}
+      phase: ${{ steps.deployment-outcome.outputs.phase }}
+      releaseAttemptId: ${{ steps.deployment-outcome.outputs.releaseAttemptId }}
+      failureCategory: ${{ steps.deployment-outcome.outputs.failureCategory }}
     runs-on: ubuntu-latest
     environment:
       name: test
@@ -123,6 +128,7 @@ jobs:
       - name: Safely extract and verify release bundle modes
         run: |
           set -euo pipefail
+          echo "DEPLOYMENT_PHASE=artifact-verification" >> "$GITHUB_ENV"
           archive="release-bundle.tar.gz"
           install -d -m 700 release
           while IFS= read -r member; do
@@ -169,6 +175,7 @@ jobs:
           DEPLOY_BASE: ${{ vars.TEST_DEPLOY_BASE }}
         run: |
           set -euo pipefail
+          echo "DEPLOYMENT_PHASE=staging-and-activation" >> "$GITHUB_ENV"
           : "${DEPLOY_HOST:?Missing TEST_HOST secret}"
           : "${DEPLOY_USER:?Missing TEST_USER secret}"
           base_dir="${DEPLOY_BASE:-/srv/quadball-timer-test}"
@@ -184,9 +191,44 @@ jobs:
           rsync -a -e "ssh ${ssh_opts}" release/ "${DEPLOY_USER}@${DEPLOY_HOST}:${stage_dir}/"
           ssh $ssh_opts "${DEPLOY_USER}@${DEPLOY_HOST}" "'${stage_dir}/deploy/activate-test-release.sh' --base-dir '${base_dir}' --staged-dir '${stage_dir}' --release '${release_id}'"
 
+      - name: Record Test deployment outcome
+        id: deployment-outcome
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          RELEASE_ATTEMPT: ${{ env.RELEASE_ATTEMPT_ID }}
+          FAILED_PHASE: ${{ env.DEPLOYMENT_PHASE }}
+        run: |
+          set -euo pipefail
+          case "$JOB_STATUS" in
+            success)
+              phase="verified"
+              failure_category="none"
+              ;;
+            cancelled)
+              phase="${FAILED_PHASE:-deployment}"
+              failure_category="cancelled"
+              ;;
+            *)
+              phase="${FAILED_PHASE:-deployment}"
+              failure_category="${phase}-failed"
+              ;;
+          esac
+          {
+            echo "status=$JOB_STATUS"
+            echo "phase=$phase"
+            echo "releaseAttemptId=$RELEASE_ATTEMPT"
+            echo "failureCategory=$failure_category"
+          } >> "$GITHUB_OUTPUT"
+
   deploy-production:
     if: github.ref == 'refs/heads/main'
     needs: build
+    outputs:
+      status: ${{ steps.deployment-outcome.outputs.status }}
+      phase: ${{ steps.deployment-outcome.outputs.phase }}
+      releaseAttemptId: ${{ steps.deployment-outcome.outputs.releaseAttemptId }}
+      failureCategory: ${{ steps.deployment-outcome.outputs.failureCategory }}
     runs-on: ubuntu-latest
     environment:
       name: production
@@ -201,6 +243,7 @@ jobs:
       - name: Safely extract and verify release bundle modes
         run: |
           set -euo pipefail
+          echo "DEPLOYMENT_PHASE=artifact-verification" >> "$GITHUB_ENV"
           archive="release-bundle.tar.gz"
           install -d -m 700 release
           while IFS= read -r member; do
@@ -249,6 +292,7 @@ jobs:
           PROD_APP_PORT: ${{ vars.PROD_APP_PORT }}
         run: |
           set -euo pipefail
+          echo "DEPLOYMENT_PHASE=staging-and-activation" >> "$GITHUB_ENV"
           : "${DEPLOY_HOST:?Missing PROD_HOST secret}"
           : "${DEPLOY_USER:?Missing PROD_USER secret}"
           base_dir="${DEPLOY_BASE:-/srv/quadball-timer}"
@@ -267,16 +311,68 @@ jobs:
           ssh $ssh_opts "${DEPLOY_USER}@${DEPLOY_HOST}" "'${stage_dir}/deploy/activate-release.sh' --base-dir '${base_dir}' --staged-dir '${stage_dir}' --release '${release_id}' --service '${service_name}' --port '${app_port}'"
           curl --fail --silent --show-error --max-time 10 https://timer.quadball.app/ | grep -qi "<!doctype html"
 
+      - name: Record Production deployment outcome
+        id: deployment-outcome
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          RELEASE_ATTEMPT: ${{ env.RELEASE_ATTEMPT_ID }}
+          FAILED_PHASE: ${{ env.DEPLOYMENT_PHASE }}
+        run: |
+          set -euo pipefail
+          case "$JOB_STATUS" in
+            success)
+              phase="verified"
+              failure_category="none"
+              ;;
+            cancelled)
+              phase="${FAILED_PHASE:-deployment}"
+              failure_category="cancelled"
+              ;;
+            *)
+              phase="${FAILED_PHASE:-deployment}"
+              failure_category="${phase}-failed"
+              ;;
+          esac
+          {
+            echo "status=$JOB_STATUS"
+            echo "phase=$phase"
+            echo "releaseAttemptId=$RELEASE_ATTEMPT"
+            echo "failureCategory=$failure_category"
+          } >> "$GITHUB_OUTPUT"
+
   report:
     if: always() && github.ref == 'refs/heads/main'
     needs: [deploy-test, deploy-production]
     runs-on: ubuntu-latest
     steps:
       - name: Report both independent environment outcomes
+        env:
+          RELEASE_ATTEMPT_ID: ${{ env.RELEASE_ATTEMPT_ID }}
+          TEST_STATUS: ${{ needs.deploy-test.outputs.status || needs.deploy-test.result }}
+          TEST_PHASE: ${{ needs.deploy-test.outputs.phase || 'deployment' }}
+          TEST_FAILURE_CATEGORY: ${{ needs.deploy-test.outputs.failureCategory || 'job-skipped' }}
+          PRODUCTION_STATUS: ${{ needs.deploy-production.outputs.status || needs.deploy-production.result }}
+          PRODUCTION_PHASE: ${{ needs.deploy-production.outputs.phase || 'deployment' }}
+          PRODUCTION_FAILURE_CATEGORY: ${{ needs.deploy-production.outputs.failureCategory || 'job-skipped' }}
         run: |
           set -euo pipefail
-          echo "Test deployment: ${{ needs.deploy-test.result }}"
-          echo "Production deployment: ${{ needs.deploy-production.result }}"
-          if [[ "${{ needs.deploy-test.result }}" != "success" || "${{ needs.deploy-production.result }}" != "success" ]]; then
+          cat > deployment-report.json <<EOF
+          {
+            "releaseAttemptId": "${RELEASE_ATTEMPT_ID}",
+            "test": {
+              "status": "${TEST_STATUS}",
+              "phase": "${TEST_PHASE}",
+              "failureCategory": "${TEST_FAILURE_CATEGORY}"
+            },
+            "production": {
+              "status": "${PRODUCTION_STATUS}",
+              "phase": "${PRODUCTION_PHASE}",
+              "failureCategory": "${PRODUCTION_FAILURE_CATEGORY}"
+            }
+          }
+          EOF
+          cat deployment-report.json
+          if [[ "$TEST_STATUS" != "success" || "$PRODUCTION_STATUS" != "success" ]]; then
             exit 1
           fi

--- a/deploy/activate-release.sh
+++ b/deploy/activate-release.sh
@@ -212,6 +212,19 @@ check_health() {
   return 1
 }
 
+check_representative_behavior() {
+  curl --fail --silent --show-error --max-time 2 "http://127.0.0.1:${port}/api/audience/events" >/dev/null || return 1
+  local websocket_headers
+  websocket_headers="$(curl --silent --show-error --max-time 2 \
+    -H "Origin: http://127.0.0.1:${port}" \
+    -H "Connection: Upgrade" \
+    -H "Upgrade: websocket" \
+    -H "Sec-WebSocket-Version: 13" \
+    -H "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==" \
+    -D - -o /dev/null "http://127.0.0.1:${port}/ws" || true)"
+  grep -Eq '^HTTP/[0-9.]+ 101 ' <<<"$websocket_headers"
+}
+
 compatible_previous_release() {
   local previous_manifest="${previous_release}/release-manifest.json" candidate_schema previous_schema
   [[ -s "$previous_manifest" ]] || return 1
@@ -232,7 +245,7 @@ prune_releases() {
   done
 }
 
-if restart_service && check_health "$release_id" "$release_dir"; then
+if restart_service && check_health "$release_id" "$release_dir" && check_representative_behavior; then
   prune_releases "$release_dir" "$previous_release"
   echo "Activated immutable release attempt ${release_id}."
   exit 0

--- a/deploy/activate-test-release.sh
+++ b/deploy/activate-test-release.sh
@@ -138,6 +138,19 @@ check_health() {
   done
   return 1
 }
+
+check_representative_behavior() {
+  curl --fail --silent --show-error --max-time 2 "http://127.0.0.1:${port}/api/audience/events" >/dev/null || return 1
+  local websocket_headers
+  websocket_headers="$(curl --silent --show-error --max-time 2 \
+    -H "Origin: http://127.0.0.1:${port}" \
+    -H "Connection: Upgrade" \
+    -H "Upgrade: websocket" \
+    -H "Sec-WebSocket-Version: 13" \
+    -H "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==" \
+    -D - -o /dev/null "http://127.0.0.1:${port}/ws" || true)"
+  grep -Eq '^HTTP/[0-9.]+ 101 ' <<<"$websocket_headers"
+}
 compatible_previous_release() {
   local previous_manifest="${previous_release}/release-manifest.json" candidate_schema previous_schema
   [[ -s "$previous_manifest" ]] || return 1
@@ -157,7 +170,7 @@ prune_releases() {
   done
 }
 
-if restart_service && check_health "$release_id" "$release_dir"; then
+if restart_service && check_health "$release_id" "$release_dir" && check_representative_behavior; then
   prune_releases "$release_dir" "$previous_release"
   echo "Activated immutable Test release attempt ${release_id}."
   exit 0

--- a/src/lib/release-orchestration.test.ts
+++ b/src/lib/release-orchestration.test.ts
@@ -22,7 +22,7 @@ const manifest = makeReleaseManifest({
 function adapter(
   environment: "production" | "test",
   events: string[],
-  failurePhase?: "verify" | "finalize",
+  failurePhase?: "stage" | "verify" | "finalize",
 ): ReleaseEnvironmentAdapter {
   return {
     environment,
@@ -37,6 +37,7 @@ function adapter(
     },
     async stage() {
       events.push(`${environment}:stage`);
+      if (failurePhase === "stage") throw new Error("stage failed");
     },
     async finalize() {
       events.push(`${environment}:finalize`);
@@ -72,6 +73,7 @@ describe("release orchestration", () => {
     expect(report.status).toBe("succeeded");
     expect(report.environments.production.status).toBe("succeeded");
     expect(report.environments.test.status).toBe("succeeded");
+    expect(report.environments.production.phase).toBe("verified");
     expect(events).toContain("production:prune");
     expect(events).toContain("test:prune");
   });
@@ -84,9 +86,73 @@ describe("release orchestration", () => {
     });
     expect(report.status).toBe("failed");
     expect(report.environments.production.status).toBe("failed");
+    expect(report.environments.production.phase).toBe("verification");
     expect(report.environments.production.rollbackReleaseAttemptId).toBe("production-prior");
     expect(report.environments.test.status).toBe("succeeded");
     expect(events).toContain("production:rollback:production-prior");
     expect(events).toContain("test:prune");
+  });
+
+  test("keeps a Test-only failure independent from Production", async () => {
+    const events: string[] = [];
+    const report = await runReleaseAttempt({
+      manifest,
+      environments: [adapter("production", events), adapter("test", events, "verify")],
+    });
+
+    expect(report.status).toBe("failed");
+    expect(report.environments.production.status).toBe("succeeded");
+    expect(report.environments.test.status).toBe("failed");
+    expect(report.environments.test.rollbackReleaseAttemptId).toBe("test-prior");
+    expect(events).toContain("production:prune");
+    expect(events).toContain("test:rollback:test-prior");
+  });
+
+  test("reports both failures and rolls each environment back independently", async () => {
+    const events: string[] = [];
+    const report = await runReleaseAttempt({
+      manifest,
+      environments: [adapter("production", events, "verify"), adapter("test", events, "verify")],
+    });
+
+    expect(report.status).toBe("failed");
+    expect(report.environments.production.status).toBe("failed");
+    expect(report.environments.test.status).toBe("failed");
+    expect(events).toContain("production:rollback:production-prior");
+    expect(events).toContain("test:rollback:test-prior");
+  });
+
+  test("does not roll back or disturb the current release after lock or staging failure", async () => {
+    const events: string[] = [];
+    const lockContended: ReleaseEnvironmentAdapter = {
+      ...adapter("production", events),
+      async acquireLock() {
+        events.push("production:lock-contention");
+        throw new Error("lock busy");
+      },
+    };
+    const report = await runReleaseAttempt({
+      manifest,
+      environments: [lockContended, adapter("test", events, "stage")],
+    });
+
+    expect(report.status).toBe("failed");
+    expect(report.environments.production.phase).toBe("lock-acquisition");
+    expect(report.environments.test.phase).toBe("staging");
+    expect(report.environments.production.rollbackReleaseAttemptId).toBeNull();
+    expect(report.environments.test.rollbackReleaseAttemptId).toBeNull();
+    expect(events).not.toContain("production:rollback:production-prior");
+    expect(events).not.toContain("test:rollback:test-prior");
+  });
+
+  test("always releases each environment lock after a failed activation", async () => {
+    const events: string[] = [];
+    await runReleaseAttempt({
+      manifest,
+      environments: [adapter("production", events, "verify"), adapter("test", events)],
+    });
+
+    expect(events).toContain("production:unlock");
+    expect(events).toContain("test:unlock");
   });
 });

--- a/src/lib/release-orchestration.ts
+++ b/src/lib/release-orchestration.ts
@@ -34,6 +34,8 @@ export type ReleaseAttemptInput = {
 export type ReleaseEnvironmentOutcome = {
   environment: ReleaseEnvironment;
   status: "succeeded" | "failed";
+  /** The last meaningful lifecycle phase reached by this environment. */
+  phase: string;
   phases: string[];
   errorCode: string | null;
   rollbackReleaseAttemptId: string | null;
@@ -83,20 +85,30 @@ async function runEnvironmentAttempt(
   const phases: string[] = [];
   let releaseLock: (() => Promise<void> | void) | undefined;
   let previousRelease: { releaseAttemptId: string; schemaCompatibility: string } | null = null;
+  let phase = "lock-acquisition";
+  let activationAttempted = false;
   try {
     releaseLock = await environment.acquireLock();
     phases.push("lock-acquired");
+    phase = "configuration-verification";
     await environment.verifyConfiguration(manifest);
     phases.push("configuration-verified");
+    phase = "current-release-read";
     previousRelease = await environment.currentRelease();
+    phase = "staging";
     await environment.stage(manifest);
     phases.push("staged");
+    phase = "finalization";
     await environment.finalize(manifest);
     phases.push("finalized");
+    phase = "activation";
+    activationAttempted = true;
     await environment.activate(manifest);
     phases.push("activated");
+    phase = "verification";
     await environment.verify(manifest);
     phases.push("verified");
+    phase = "pruning";
     await environment.prune(
       [manifest.releaseAttemptId, previousRelease?.releaseAttemptId].filter(
         (value): value is string => value !== undefined,
@@ -106,6 +118,7 @@ async function runEnvironmentAttempt(
     return {
       environment: environment.environment,
       status: "succeeded",
+      phase: "verified",
       phases,
       errorCode: null,
       rollbackReleaseAttemptId: null,
@@ -118,6 +131,7 @@ async function runEnvironmentAttempt(
     }
     let rollbackReleaseAttemptId: string | null = null;
     if (
+      activationAttempted &&
       previousRelease !== null &&
       previousRelease.schemaCompatibility === manifest.schemaCompatibility
     ) {
@@ -134,6 +148,7 @@ async function runEnvironmentAttempt(
     return {
       environment: environment.environment,
       status: "failed",
+      phase,
       phases,
       errorCode,
       rollbackReleaseAttemptId,

--- a/src/production-deployment.test.ts
+++ b/src/production-deployment.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { Buffer } from "node:buffer";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
@@ -39,6 +40,24 @@ describe("Production deployment contract", () => {
     expect(workflow).toContain("needs: [deploy-test, deploy-production]");
   });
 
+  test("reports each environment outcome with release identity and bounded phase", () => {
+    const workflow = readFileSync(
+      join(repositoryRoot, ".github/workflows/deploy-production.yml"),
+      "utf8",
+    );
+
+    expect(workflow).toContain("Record Test deployment outcome");
+    expect(workflow).toContain("Record Production deployment outcome");
+    expect(workflow).toContain('echo "releaseAttemptId=$RELEASE_ATTEMPT"');
+    expect(workflow).toContain('echo "failureCategory=$failure_category"');
+    expect(workflow).toContain('"releaseAttemptId": "${RELEASE_ATTEMPT_ID}"');
+    expect(workflow).toContain('"phase": "${TEST_PHASE}"');
+    expect(workflow).toContain('"phase": "${PRODUCTION_PHASE}"');
+    expect(workflow).toContain(
+      'if [[ "$TEST_STATUS" != "success" || "$PRODUCTION_STATUS" != "success" ]]; then',
+    );
+  });
+
   test("preserves executable modes across the GitHub artifact boundary", () => {
     const workflow = readFileSync(
       join(repositoryRoot, ".github/workflows/deploy-production.yml"),
@@ -73,6 +92,18 @@ describe("Production deployment contract", () => {
     );
     expect(activation).toContain("check_release_identity");
     expect(activation).toContain('check_health "$release_id" "$release_dir"');
+    expect(activation).toContain("check_representative_behavior");
+    expect(activation).toContain("/api/audience/events");
+    const websocketKeys = [
+      ...activation.matchAll(/Sec-WebSocket-Key:\s*([A-Za-z0-9+/]+={0,2})/gu),
+    ].map((match) => match[1]);
+    expect(websocketKeys).toHaveLength(1);
+    const [websocketKey] = websocketKeys;
+    expect(websocketKey).toBeDefined();
+    if (websocketKey === undefined) return;
+    const decodedWebSocketKey = Buffer.from(websocketKey, "base64");
+    expect(decodedWebSocketKey.byteLength).toBe(16);
+    expect(decodedWebSocketKey.toString("base64")).toBe(websocketKey);
     expect(activation).toContain('check_health "$previous_release_id" "$previous_release"');
     expect(activation).toContain(
       'check_release_identity "$selected_release_id" "$selected_release_dir"',

--- a/src/test-environment-deployment.test.ts
+++ b/src/test-environment-deployment.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { Buffer } from "node:buffer";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
@@ -77,6 +78,18 @@ describe("Test Environment deployment contract", () => {
     expect(activation).toContain("--staged-dir");
     expect(activation).toContain("release-attempt identity");
     expect(activation).toContain('check_health "$release_id" "$release_dir"');
+    expect(activation).toContain("check_representative_behavior");
+    expect(activation).toContain("/api/audience/events");
+    const websocketKeys = [
+      ...activation.matchAll(/Sec-WebSocket-Key:\s*([A-Za-z0-9+/]+={0,2})/gu),
+    ].map((match) => match[1]);
+    expect(websocketKeys).toHaveLength(1);
+    const [websocketKey] = websocketKeys;
+    expect(websocketKey).toBeDefined();
+    if (websocketKey === undefined) return;
+    const decodedWebSocketKey = Buffer.from(websocketKey, "base64");
+    expect(decodedWebSocketKey.byteLength).toBe(16);
+    expect(decodedWebSocketKey.toString("base64")).toBe(websocketKey);
     expect(activation).toContain('check_health "$previous_release_id" "$previous_release"');
     expect(activation).toContain(
       'check_release_identity "$selected_release_id" "$selected_release_dir"',


### PR DESCRIPTION
## What changed

- build one immutable release bundle and manifest per eligible `main` push
- deploy the exact same verified artifact to Production and Test in independent jobs
- preserve per-Environment locks, rollback identity, cleanup, pruning, and final outcome reporting
- verify readiness plus representative HTTP, API, and WebSocket behavior before accepting activation

## Why

Production and Test need autonomous outcomes without rebuilding, promoting between Environments, or allowing one Environment failure to undo the other. This implements the deployment contract from #163 as the next layer above the Grant key-ring custody work.

## Impact

Every eligible `main` push produces one artifact and attempts both Environment deployments. The Grant-ring bootstrap prerequisite from #195 is complete. This layer is rebased onto current `main`, independently validated, and ready to merge as the bottom of the Production Operations stack.

Refs #163 and #158.

## Validation

- Post-rebase stack validation: `bun run test` — 797 tests across 73 files; `bun run check`; application and executable builds; 29 deployment-focused Fast tests; Bash syntax, ShellCheck, and `git diff --check`.

- `bun test --isolate`: 614 passed
- `bun run check`
- release build and executable smoke verification
- ShellCheck for deployment scripts
- focused deployment regressions, including a valid WebSocket handshake nonce
