### PR TITLE
Complete IQA scoring and overtime

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -108,6 +108,38 @@ _Avoid_: Rule exception, forced command
 An accepted sporting or operational occurrence, such as a goal, card, catch, result, or stoppage, that may contribute to the current game state.
 _Avoid_: Mutable event, current value
 
+**Sporting Order**:
+The explicit adjudicated order of close sporting Game Facts, independent of Controller arrival order, device synchronization order, or their actual Game Clock times. A Head Referee close-play decision names the paired opposing fact and whether the candidate is before or after it; it never rewrites either Game Clock time.
+_Avoid_: Arrival order, device timestamp, rewritten Game time
+
+**Goal**:
+An accepted scoring Game Fact worth 10 points for its recorded Game Side.
+_Avoid_: Manual score edit, target score command
+
+**Flag Catch**:
+An accepted scoring Game Fact worth 30 points after seeker release and stopped play, subject to Head Referee adjudication where a close goal/catch pair requires an explicit Sporting Order.
+_Avoid_: Automatic winner command, catch-time rewrite
+
+**Overtime Target**:
+The fixed score required after a trailing or tied Flag Catch: the non-catching Game Side's adjudicated score at the catch plus 30. It is rebuilt when effective pre-catch facts change and cannot be changed by post-catch scoring.
+_Avoid_: Manual target, moving target
+
+**Concession**:
+An accepted overtime result fact. A Concession is admitted only while the Derived Game State is unfinished overtime and applies the trailing, tied, or leading outcome rules without changing the fixed Overtime Target.
+_Avoid_: Pre-overtime concession, generic result
+
+**Directed Forfeit**:
+An accepted result fact recorded against the named Game Side. The other Game Side wins; the existing scores are preserved and no scoring points are added by the forfeit.
+_Avoid_: Self-awarded winner, score reset
+
+**Double Forfeit**:
+An accepted result fact recorded for both Game Sides. It produces a finished result with no winner and preserves both existing scores without adding points.
+_Avoid_: Draw winner, automatic score change
+
+**Derived Result**:
+The winner, unfinished overtime, or double-forfeit outcome rebuilt from effective scoring and result facts. It is not a manually recorded target winner and remains auditable through Corrections and reinstatement.
+_Avoid_: Stored winner, manual target winner
+
 **Correction**:
 A Control Action that names one stable Game Fact and makes it ineffective or effective again without removing either the fact or earlier Corrections from the Control Audit Trail.
 _Avoid_: Delete, edit history, undo latest
@@ -129,7 +161,7 @@ An immutable Controller-submitted or Event Admin-submitted record accepted for a
 _Avoid_: Mutable command, audit entry
 
 **Derived Game State**:
-The current score, phase, overtime target, result, stoppages, and other game state rebuilt from effective Game Facts and Locked-Game Corrections whenever either changes the record.
+The current score, phase, overtime target, result, stoppages, and other game state rebuilt from effective Game Facts and Locked-Game Corrections whenever either changes the record. Its scoring bounds and lifecycle must agree with the durable Event Game Record root.
 _Avoid_: Stored result, patched state
 
 **Controller Device**:

--- a/src/lib/controller-intent-retry.test.ts
+++ b/src/lib/controller-intent-retry.test.ts
@@ -36,6 +36,50 @@ describe("Controller tap retry identity", () => {
       });
       expect(retry).toBe(first);
     }
+    const scored = intent("record-flag-catch", {
+      gameSideId: "side-a",
+      sportingOrderAdjudication: { relatedFactId: "goal", relation: "before" },
+    });
+    expect(
+      retainControllerIntent(scored, {
+        ...scored,
+        sportingOrderOverride: {
+          guardrail: "sporting-order-adjudication",
+          direction: "head-referee-adjudicated-sporting-order",
+          confirmation: "head-referee-confirmed",
+          authorityReference: "head-referee",
+          gameTimeMs: 0,
+          beforeValue: null,
+          afterValue: null,
+          reason: "head-referee-direction",
+        },
+      }),
+    ).not.toBe(scored);
+    const forfeit = intent("substantive", {
+      trigger: "forfeit",
+      gameSideId: "side-a",
+    }) as Extract<LiveEventControllerIntent, { type: "substantive" }>;
+    expect(retainControllerIntent(forfeit, { ...forfeit, gameSideId: "side-b" })).not.toBe(forfeit);
+  });
+
+  test("does not reuse identities when durable ordering or Clock authority semantics change", () => {
+    const doubleForfeit = intent("record-double-forfeit", { sportingOrder: 10 });
+    expect(retainControllerIntent(doubleForfeit, { ...doubleForfeit, sportingOrder: 11 })).not.toBe(
+      doubleForfeit,
+    );
+
+    const clock = intent("clock-adjust", {
+      adjustmentMs: 1_000,
+      clockGeneration: 2,
+      occurrence: { clientOriginAtMs: 1, source: "online" },
+    });
+    expect(retainControllerIntent(clock, { ...clock, clockGeneration: 3 })).not.toBe(clock);
+    expect(
+      retainControllerIntent(clock, {
+        ...clock,
+        occurrence: { clientOriginAtMs: 1, source: "offline" },
+      }),
+    ).not.toBe(clock);
   });
 });
 

--- a/src/lib/controller-intent-retry.ts
+++ b/src/lib/controller-intent-retry.ts
@@ -28,6 +28,27 @@ export function controllerIntentRetryKey(intent: LiveEventControllerIntent): str
         intent.gameSideId,
         intent.gameTimeMs,
         intent.sportingOrder ?? null,
+        intent.sportingOrderAdjudication ?? null,
+        intent.sportingOrderOverride ?? null,
+        intent.override ?? null,
+      ]);
+    case "record-flag-catch":
+    case "record-concession":
+    case "record-forfeit":
+      return JSON.stringify([
+        intent.type,
+        intent.gameSideId,
+        intent.gameTimeMs,
+        intent.sportingOrder ?? null,
+        intent.sportingOrderAdjudication ?? null,
+        intent.sportingOrderOverride ?? null,
+        intent.override ?? null,
+      ]);
+    case "record-double-forfeit":
+      return JSON.stringify([
+        intent.type,
+        intent.gameTimeMs,
+        intent.sportingOrder ?? null,
         intent.override ?? null,
       ]);
     case "correct-fact":
@@ -39,11 +60,29 @@ export function controllerIntentRetryKey(intent: LiveEventControllerIntent): str
       ]);
     case "clock":
     case "set-running":
-      return JSON.stringify([intent.type, intent.running, intent.gameTimeMs]);
+      return JSON.stringify([
+        intent.type,
+        intent.running,
+        intent.gameTimeMs,
+        intent.clockGeneration ?? null,
+        intent.occurrence.source ?? "online",
+      ]);
     case "clock-adjust":
-      return JSON.stringify([intent.type, intent.adjustmentMs, intent.gameTimeMs]);
+      return JSON.stringify([
+        intent.type,
+        intent.adjustmentMs,
+        intent.gameTimeMs,
+        intent.clockGeneration ?? null,
+        intent.occurrence.source ?? "online",
+      ]);
     case "clock-correction":
-      return JSON.stringify([intent.type, intent.clockTimeMs, intent.gameTimeMs]);
+      return JSON.stringify([
+        intent.type,
+        intent.clockTimeMs,
+        intent.gameTimeMs,
+        intent.clockGeneration ?? null,
+        intent.occurrence.source ?? "online",
+      ]);
     case "clock-takeover":
       return JSON.stringify([
         intent.type,
@@ -51,14 +90,17 @@ export function controllerIntentRetryKey(intent: LiveEventControllerIntent): str
         intent.running,
         intent.authorityGeneration,
         intent.gameTimeMs,
+        intent.occurrence.source ?? "online",
       ]);
     case "substantive":
       return JSON.stringify([
         intent.type,
         intent.trigger,
+        intent.gameSideId ?? null,
         intent.heatAction ?? null,
         intent.gameTimeMs,
         intent.sportingOrder ?? null,
+        intent.sportingOrderAdjudication ?? null,
         intent.override ?? null,
       ]);
     case "reset":

--- a/src/lib/controller-reconnect.test.ts
+++ b/src/lib/controller-reconnect.test.ts
@@ -37,6 +37,79 @@ describe("Controller reconnect replica", () => {
     expect(buildControllerReplayBatch(state)?.actions).toHaveLength(2);
   });
 
+  test("rebuilds optimistic catch, overtime, winner, and correction state from effective facts", () => {
+    let state = createReplica();
+    state = dispatchControllerAction(state, goal("pre-catch", "pre-catch-fact"), {
+      nowMs: 100,
+    }).state;
+    state = dispatchControllerAction(state, flagCatch("catch", "catch-fact", "side-b"), {
+      nowMs: 101,
+    }).state;
+    expect(state.projection).toMatchObject({
+      scoreByGameSide: { "side-a": 10, "side-b": 30 },
+      winnerGameSideId: "side-b",
+      phase: "finished",
+      catch: { catchingGameSideId: "side-b" },
+    });
+
+    state = dispatchControllerAction(
+      state,
+      correction("correct-catch", "correction-catch", false, "catch-fact"),
+      { nowMs: 102 },
+    ).state;
+    expect(state.projection).toMatchObject({
+      scoreByGameSide: { "side-a": 10, "side-b": 0 },
+      winnerGameSideId: null,
+      phase: "in-progress",
+      catch: null,
+    });
+  });
+
+  test("rebuilds result correction and reinstatement without stale finished state", () => {
+    let state = dispatchControllerAction(createReplica(), substantive("result", "result"), {
+      nowMs: 100,
+    }).state;
+    expect(state.projection).toMatchObject({
+      phase: "finished",
+      result: { factId: "fact-result" },
+    });
+    state = dispatchControllerAction(
+      state,
+      correction("correct-result", "correction-result", false, "fact-result"),
+      { nowMs: 101 },
+    ).state;
+    expect(state.projection).toMatchObject({ phase: "in-progress", result: null });
+    state = dispatchControllerAction(
+      state,
+      correction("reinstate-result", "reinstate-result", true, "fact-result"),
+      { nowMs: 102 },
+    ).state;
+    expect(state.projection).toMatchObject({
+      phase: "finished",
+      result: { factId: "fact-result" },
+    });
+  });
+
+  test("retains an overflowing catch without projecting an impossible overtime target", () => {
+    let state = createReplica();
+    for (let index = 0; index < 98; index += 1) {
+      state = dispatchControllerAction(state, goal(`bound-goal-${index}`, `bound-fact-${index}`), {
+        nowMs: index,
+      }).state;
+    }
+    state = dispatchControllerAction(
+      state,
+      flagCatch("overflowing-catch", "overflowing-catch-fact", "side-b"),
+      { nowMs: 100 },
+    ).state;
+    expect(state.pendingActions).toHaveLength(99);
+    expect(state.projection).toMatchObject({
+      scoreByGameSide: { "side-a": 980, "side-b": 0 },
+      overtime: false,
+      catch: null,
+    });
+  });
+
   test("optimistically applies every ordinary Controller action family with existing lifecycle semantics", () => {
     for (const trigger of ["card", "timeout", "suspension"] as const) {
       const next = dispatchControllerAction(
@@ -53,6 +126,15 @@ describe("Controller reconnect replica", () => {
       { nowMs: 101 },
     ).state;
     expect(finished.projection.phase).toBe("finished");
+    const sideScoped = dispatchControllerAction(
+      createReplica(),
+      substantive("substantive-forfeit", "forfeit", "side-b"),
+      { nowMs: 101 },
+    ).state;
+    expect(sideScoped.projection.gameFacts?.at(-1)).toMatchObject({
+      factType: "forfeit",
+      gameSideId: "side-b",
+    });
     const resetState = dispatchControllerAction(createReplica(), reset("reset", "reset-fact"), {
       nowMs: 102,
     }).state;
@@ -292,6 +374,28 @@ describe("Controller reconnect replica", () => {
       ...state.authoritativeProjection,
       scoreByGameSide: { "side-a": 20, "side-b": 0 },
       goalCount: 2,
+      gameFacts: [
+        {
+          factId: "authoritative-goal",
+          factType: "goal",
+          gameSideId: "side-a",
+          gameTimeMs: 10,
+          sportingOrder: 10,
+          synchronizationOrder: 1,
+          effective: true,
+          data: { points: 10, sportingOrder: 10 },
+        },
+        {
+          factId: "authoritative-goal-2",
+          factType: "goal",
+          gameSideId: "side-a",
+          gameTimeMs: 20,
+          sportingOrder: 20,
+          synchronizationOrder: 2,
+          effective: true,
+          data: { points: 10, sportingOrder: 20 },
+        },
+      ],
     };
     const replaced = rebindControllerReplica(
       secondNullRebind,
@@ -489,6 +593,32 @@ function goal(operationId: string, factId: string) {
   };
 }
 
+function flagCatch(operationId: string, factId: string, gameSideId: string) {
+  return {
+    version: LIVE_EVENT_CONTROL_INTENT_VERSION,
+    type: "record-flag-catch" as const,
+    operationId,
+    factId,
+    gameSideId,
+    gameTimeMs: 1_200_000,
+    sportingOrder: 1_200_000,
+    occurrence: { clientOriginAtMs: 1_200_000, source: "offline" as const },
+  };
+}
+
+function correction(operationId: string, factId: string, effective: boolean, targetFactId: string) {
+  return {
+    version: LIVE_EVENT_CONTROL_INTENT_VERSION,
+    type: "correct-fact" as const,
+    operationId,
+    factId,
+    targetFactId,
+    effective,
+    gameTimeMs: 1_300_000,
+    occurrence: { clientOriginAtMs: 1_300_000, source: "offline" as const },
+  };
+}
+
 function reset(operationId: string, factId: string) {
   return {
     version: LIVE_EVENT_CONTROL_INTENT_VERSION,
@@ -500,7 +630,19 @@ function reset(operationId: string, factId: string) {
   };
 }
 
-function substantive(operationId: string, trigger: "card" | "timeout" | "suspension" | "result") {
+function substantive(
+  operationId: string,
+  trigger:
+    | "card"
+    | "timeout"
+    | "suspension"
+    | "result"
+    | "flag-catch"
+    | "concession"
+    | "forfeit"
+    | "double-forfeit",
+  gameSideId?: string,
+) {
   return {
     version: LIVE_EVENT_CONTROL_INTENT_VERSION,
     type: "substantive" as const,
@@ -508,6 +650,7 @@ function substantive(operationId: string, trigger: "card" | "timeout" | "suspens
     operationId,
     factId: `fact-${operationId}`,
     gameTimeMs: 0,
+    ...(gameSideId === undefined ? {} : { gameSideId }),
     occurrence: { clientOriginAtMs: 0, source: "offline" as const },
   };
 }

--- a/src/lib/controller-reconnect.ts
+++ b/src/lib/controller-reconnect.ts
@@ -4,6 +4,7 @@ import type {
   ControllerProjection,
   LiveEventControllerIntent,
   LiveHeatState,
+  LiveCatchState,
   LiveResultState,
   LiveStoppageState,
   LiveTimeoutState,
@@ -14,7 +15,10 @@ import {
   createInitialClockBaseline,
   projectClockBaseline,
 } from "@/lib/clock-authority";
-import { parseLiveEventControllerIntent } from "@/lib/live-event-game-control";
+import {
+  orderControllerGameFacts,
+  parseLiveEventControllerIntent,
+} from "@/lib/live-event-game-control";
 import {
   SHARED_LIMITS,
   validateIntegerInRange,
@@ -371,6 +375,22 @@ export function reconcileControllerReplay(
     response.projection === null
       ? state.authoritativeProjection
       : cloneProjection(response.projection);
+  if (response.projection !== null && authoritativeProjection.gameFacts !== undefined) {
+    const retainedPendingFactIds = new Set(
+      pendingActions
+        .filter(
+          (action) =>
+            action.status === "pending" ||
+            action.status === "retryable" ||
+            action.status === "causally-blocked" ||
+            action.status === "held-for-correction",
+        )
+        .map((action) => action.intent.factId),
+    );
+    authoritativeProjection.gameFacts = authoritativeProjection.gameFacts.filter(
+      (fact) => !retainedPendingFactIds.has(fact.factId),
+    );
+  }
   const reconciled = {
     ...state,
     authoritativeProjection,
@@ -635,102 +655,76 @@ function applyOptimisticAction(
   )
     return state;
   if (intent.type === "record-goal") {
-    const current = state.projection.scoreByGameSide[intent.gameSideId];
-    if (current === undefined) return state;
     const nextFacts = appendOptimisticFact(state.projection, {
       factId: intent.factId,
       factType: "goal",
       gameSideId: intent.gameSideId,
       gameTimeMs: intent.gameTimeMs,
       sportingOrder: intent.sportingOrder ?? intent.gameTimeMs,
-      data: { points: 10, sportingOrder: intent.sportingOrder ?? intent.gameTimeMs },
-    });
-    return {
-      ...state,
-      projection: {
-        ...state.projection,
-        scoreByGameSide: { ...state.projection.scoreByGameSide, [intent.gameSideId]: current + 10 },
-        goalCount: state.projection.goalCount + 1,
-        gameFacts: nextFacts,
+      data: {
+        points: 10,
+        sportingOrder: intent.sportingOrder ?? intent.gameTimeMs,
+        ...(intent.sportingOrderAdjudication === undefined
+          ? {}
+          : { sportingOrderAdjudication: intent.sportingOrderAdjudication }),
+        ...(intent.sportingOrderOverride === undefined
+          ? {}
+          : { sportingOrderOverride: intent.sportingOrderOverride }),
       },
-    };
+    });
+    return rebuildOptimisticProjection(state, nextFacts, action.dispatchedAtMs);
+  }
+  if (
+    intent.type === "record-flag-catch" ||
+    intent.type === "record-concession" ||
+    intent.type === "record-forfeit" ||
+    intent.type === "record-double-forfeit"
+  ) {
+    const factType = intent.type.replace("record-", "");
+    const gameSideId = "gameSideId" in intent ? intent.gameSideId : null;
+    const nextFacts = appendOptimisticFact(state.projection, {
+      factId: intent.factId,
+      factType,
+      gameSideId,
+      gameTimeMs: intent.gameTimeMs,
+      sportingOrder: intent.sportingOrder ?? intent.gameTimeMs,
+      data: {
+        points: factType === "flag-catch" ? 30 : 0,
+        resultKind: factType,
+        sportingOrder: intent.sportingOrder ?? intent.gameTimeMs,
+        ...(intent.sportingOrderAdjudication === undefined
+          ? {}
+          : { sportingOrderAdjudication: intent.sportingOrderAdjudication }),
+        ...(intent.sportingOrderOverride === undefined
+          ? {}
+          : { sportingOrderOverride: intent.sportingOrderOverride }),
+      },
+    });
+    return rebuildOptimisticProjection(state, nextFacts, action.dispatchedAtMs);
   }
   if (intent.type === "correct-fact") {
     const gameFacts = (state.projection.gameFacts ?? []).map((fact) =>
       fact.factId === intent.targetFactId ? { ...fact, effective: intent.effective } : fact,
     );
-    const scoreByGameSide = Object.fromEntries(
-      Object.keys(state.projection.scoreByGameSide).map((side) => [side, 0]),
-    );
-    const dependentState = deriveOptimisticDependentState(gameFacts);
-    let goalCount = 0;
-    for (const fact of gameFacts) {
-      if (!fact.effective || fact.factType !== "goal") continue;
-      if (fact.gameSideId !== null && fact.gameSideId in scoreByGameSide) {
-        scoreByGameSide[fact.gameSideId] = (scoreByGameSide[fact.gameSideId] ?? 0) + 10;
-      }
-      goalCount += 1;
-    }
-    return {
-      ...state,
-      projection: {
-        ...state.projection,
-        gameFacts,
-        scoreByGameSide,
-        goalCount,
-        phase: gameFacts.some((fact) => fact.effective && fact.factType === "result")
-          ? "finished"
-          : state.projection.phase === "finished"
-            ? "in-progress"
-            : state.projection.phase,
-        ...(state.projection.timeout === undefined ? {} : { timeout: dependentState.timeout }),
-        ...(state.projection.stoppage === undefined ? {} : { stoppage: dependentState.stoppage }),
-        ...(state.projection.heat === undefined ? {} : { heat: dependentState.heat }),
-        ...(state.projection.result === undefined ? {} : { result: dependentState.result }),
-      },
-    };
+    return rebuildOptimisticProjection(state, gameFacts, action.dispatchedAtMs);
   }
   if (intent.type === "substantive") {
     const nextFacts = appendOptimisticFact(state.projection, {
       factId: intent.factId,
       factType: intent.trigger,
-      gameSideId: null,
+      gameSideId: intent.gameSideId ?? null,
       gameTimeMs: intent.gameTimeMs,
       sportingOrder: intent.sportingOrder ?? intent.gameTimeMs,
       data: {
         trigger: intent.trigger,
         sportingOrder: intent.sportingOrder ?? intent.gameTimeMs,
+        ...(intent.sportingOrderAdjudication === undefined
+          ? {}
+          : { sportingOrderAdjudication: intent.sportingOrderAdjudication }),
         ...(intent.heatAction === undefined ? {} : { heatAction: intent.heatAction }),
       },
     });
-    const dependentState = deriveOptimisticDependentState(nextFacts);
-    const commencement =
-      state.projection.commencement.status === "commenced"
-        ? state.projection.commencement
-        : {
-            status: "commenced" as const,
-            commencedAtMs: action.dispatchedAtMs,
-            provisionalRunningSinceMs: null,
-            provisionalElapsedMs: state.projection.commencement.provisionalElapsedMs,
-          };
-    return {
-      ...state,
-      projection: {
-        ...state.projection,
-        phase:
-          intent.trigger === "result"
-            ? "finished"
-            : state.projection.commencement.status === "provisional"
-              ? "in-progress"
-              : state.projection.phase,
-        commencement,
-        gameFacts: nextFacts,
-        ...(state.projection.timeout === undefined ? {} : { timeout: dependentState.timeout }),
-        ...(state.projection.stoppage === undefined ? {} : { stoppage: dependentState.stoppage }),
-        ...(state.projection.heat === undefined ? {} : { heat: dependentState.heat }),
-        ...(state.projection.result === undefined ? {} : { result: dependentState.result }),
-      },
-    };
+    return rebuildOptimisticProjection(state, nextFacts, action.dispatchedAtMs);
   }
   if (
     intent.type === "clock" ||
@@ -863,12 +857,20 @@ function sameProjection(left: ControllerProjection, right: ControllerProjection)
     left.stoppage ?? null,
     left.heat ?? null,
     left.result ?? null,
+    left.overtime ?? false,
+    left.overtimeTarget ?? left.targetScore ?? null,
+    left.winnerGameSideId ?? null,
+    left.catch ?? null,
   ]);
   const rightDependent = JSON.stringify([
     right.timeout ?? null,
     right.stoppage ?? null,
     right.heat ?? null,
     right.result ?? null,
+    right.overtime ?? false,
+    right.overtimeTarget ?? right.targetScore ?? null,
+    right.winnerGameSideId ?? null,
+    right.catch ?? null,
   ]);
   return (
     left.eventGameId === right.eventGameId &&
@@ -975,7 +977,12 @@ function parseProjection(value: unknown): ControllerProjection {
   if (!isRecord(value)) throw new Error("Controller projection is invalid.");
   const eventGameId = requireIdentifier(value.eventGameId, "projection.eventGameId");
   const phase = value.phase;
-  if (phase !== "scheduled" && phase !== "in-progress" && phase !== "finished")
+  if (
+    phase !== "scheduled" &&
+    phase !== "in-progress" &&
+    phase !== "suspended" &&
+    phase !== "finished"
+  )
     throw new Error("Projection phase is invalid.");
   if (!isRecord(value.scoreByGameSide)) throw new Error("Projection scores are invalid.");
   const scores: Record<string, number> = {};
@@ -1017,6 +1024,11 @@ function parseProjection(value: unknown): ControllerProjection {
   const stoppage = value.stoppage === undefined ? undefined : parseStoppageState(value.stoppage);
   const heat = value.heat === undefined ? undefined : parseHeatState(value.heat);
   const result = value.result === undefined ? undefined : parseResultState(value.result);
+  const overtime =
+    value.overtime === undefined ? undefined : parseBoolean(value.overtime, "overtime");
+  const overtimeTarget = parseOptionalScore(value.overtimeTarget ?? value.targetScore);
+  const winnerGameSideId = parseOptionalIdentifier(value.winnerGameSideId, "winnerGameSideId");
+  const catchState = parseOptionalCatch(value.catch);
   return {
     eventGameId,
     phase,
@@ -1026,6 +1038,10 @@ function parseProjection(value: unknown): ControllerProjection {
     ...(value.stoppage === undefined ? {} : { stoppage }),
     ...(value.heat === undefined ? {} : { heat }),
     ...(value.result === undefined ? {} : { result }),
+    ...(overtime === undefined ? {} : { overtime }),
+    ...(overtimeTarget === undefined ? {} : { overtimeTarget, targetScore: overtimeTarget }),
+    ...(winnerGameSideId === undefined ? {} : { winnerGameSideId }),
+    ...(catchState === undefined ? {} : { catch: catchState }),
     ...(value.gameFacts === undefined ? {} : { gameFacts }),
     ...(value.guardrails === undefined ? {} : { guardrails }),
     clock,
@@ -1035,6 +1051,48 @@ function parseProjection(value: unknown): ControllerProjection {
       provisionalRunningSinceMs: runningSinceMs,
       provisionalElapsedMs: elapsed.value,
     },
+  };
+}
+
+function parseBoolean(value: unknown, field: string): boolean {
+  if (typeof value !== "boolean") throw new Error(`Projection ${field} is invalid.`);
+  return value;
+}
+
+function parseOptionalScore(value: unknown): number | null | undefined {
+  if (value === undefined) return undefined;
+  if (value === null) return null;
+  const parsed = validateIntegerInRange(value, 0, SHARED_LIMITS.score.max, "overtimeTarget");
+  if (!parsed.ok) throw new Error(parsed.error);
+  return parsed.value;
+}
+
+function parseOptionalIdentifier(value: unknown, field: string): string | null | undefined {
+  if (value === undefined) return undefined;
+  if (value === null) return null;
+  return requireIdentifier(value, field);
+}
+
+function parseOptionalCatch(value: unknown): LiveCatchState | null | undefined {
+  if (value === undefined) return undefined;
+  if (value === null) return null;
+  if (!isRecord(value)) throw new Error("Projection catch state is invalid.");
+  const gameTimeMs = validateIntegerInRange(
+    value.gameTimeMs,
+    0,
+    SHARED_LIMITS.clock.maxMs,
+    "catch.gameTimeMs",
+  );
+  if (!gameTimeMs.ok) throw new Error(gameTimeMs.error);
+  return {
+    factId: requireIdentifier(value.factId, "catch.factId"),
+    catchingGameSideId: requireIdentifier(value.catchingGameSideId, "catch.catchingGameSideId"),
+    nonCatchingGameSideId: requireIdentifier(
+      value.nonCatchingGameSideId,
+      "catch.nonCatchingGameSideId",
+    ),
+    gameTimeMs: gameTimeMs.value,
+    targetScore: parseOptionalScore(value.targetScore) ?? null,
   };
 }
 
@@ -1264,11 +1322,157 @@ function appendOptimisticFact(
     effective: true,
     data: fact.data as ControllerGameFact["data"],
   });
-  return facts.sort(
-    (left, right) =>
-      left.sportingOrder - right.sportingOrder ||
-      left.synchronizationOrder - right.synchronizationOrder,
+  return orderControllerGameFacts(facts);
+}
+
+function rebuildOptimisticProjection(
+  state: ControllerReplicaState,
+  gameFacts: readonly ControllerGameFact[],
+  dispatchedAtMs: number,
+): ControllerReplicaState {
+  const projection = state.projection;
+  const sideIds = Object.keys(projection.scoreByGameSide);
+  const scoreByGameSide: Record<string, number> = Object.fromEntries(
+    sideIds.map((side) => [side, 0]),
   );
+  let goalCount = 0;
+  let overtime = false;
+  let overtimeTarget: number | null = null;
+  let winnerGameSideId: string | null = null;
+  let winnerFactId: string | null = null;
+  let catchState: LiveCatchState | null = null;
+  let resultFact: ControllerGameFact | null = null;
+
+  const orderedGameFacts = orderControllerGameFacts(gameFacts);
+  for (const fact of orderedGameFacts.filter((candidate) => candidate.effective)) {
+    const side = fact.gameSideId;
+    const data = isRecord(fact.data) ? fact.data : null;
+    if (fact.factType === "goal") {
+      if (side !== null && side in scoreByGameSide) {
+        scoreByGameSide[side] = (scoreByGameSide[side] ?? 0) + 10;
+      }
+      goalCount += 1;
+      if (overtimeTarget !== null && winnerGameSideId === null && side !== null) {
+        if ((scoreByGameSide[side] ?? 0) >= overtimeTarget) {
+          winnerGameSideId = side;
+          winnerFactId = fact.factId;
+        }
+      }
+      continue;
+    }
+    if (fact.factType === "flag-catch" && catchState === null && side !== null) {
+      const nonCatching = sideIds.find((candidate) => candidate !== side);
+      if (nonCatching === undefined) continue;
+      const nonCatchingScore = scoreByGameSide[nonCatching] ?? 0;
+      const catchingScore = (scoreByGameSide[side] ?? 0) + 30;
+      const targetScore = nonCatchingScore + 30;
+      if (targetScore > 1_000) continue;
+      scoreByGameSide[side] = catchingScore;
+      catchState = {
+        factId: fact.factId,
+        catchingGameSideId: side,
+        nonCatchingGameSideId: nonCatching,
+        gameTimeMs: fact.gameTimeMs ?? fact.sportingOrder,
+        targetScore: catchingScore > nonCatchingScore ? null : targetScore,
+      };
+      if (catchingScore > nonCatchingScore) {
+        winnerGameSideId = side;
+        winnerFactId = fact.factId;
+      } else {
+        overtime = true;
+        overtimeTarget = targetScore;
+      }
+      continue;
+    }
+    if (fact.factType === "concession" && side !== null) {
+      const opponent = sideIds.find((candidate) => candidate !== side);
+      if (opponent === undefined) continue;
+      const concedingScore = scoreByGameSide[side] ?? 0;
+      const opponentScore = scoreByGameSide[opponent] ?? 0;
+      if (concedingScore >= opponentScore) {
+        scoreByGameSide[opponent] =
+          opponentScore + Math.max(10, Math.ceil((concedingScore + 10 - opponentScore) / 10) * 10);
+      }
+      winnerGameSideId = opponent;
+      winnerFactId = fact.factId;
+      resultFact = fact;
+      continue;
+    }
+    if (fact.factType === "forfeit" && side !== null) {
+      winnerGameSideId = sideIds.find((candidate) => candidate !== side) ?? null;
+      winnerFactId = fact.factId;
+      resultFact = fact;
+      continue;
+    }
+    if (fact.factType === "double-forfeit") {
+      winnerGameSideId = null;
+      resultFact = fact;
+      continue;
+    }
+    if (fact.factType === "result" && (!overtime || winnerGameSideId !== null)) {
+      const declaredWinner =
+        data !== null && "winnerGameSideId" in data ? data.winnerGameSideId : undefined;
+      if (typeof declaredWinner === "string" && declaredWinner in scoreByGameSide) {
+        winnerGameSideId = declaredWinner;
+        winnerFactId = fact.factId;
+      }
+      resultFact = fact;
+    }
+  }
+
+  if (Object.values(scoreByGameSide).some((score) => score > SHARED_LIMITS.score.max)) {
+    return state;
+  }
+  const dependentState = deriveOptimisticDependentState(gameFacts);
+  const commencement =
+    projection.commencement.status === "commenced"
+      ? projection.commencement
+      : {
+          status: "commenced" as const,
+          commencedAtMs: dispatchedAtMs,
+          provisionalRunningSinceMs: null,
+          provisionalElapsedMs: projection.commencement.provisionalElapsedMs,
+        };
+  const result: LiveResultState =
+    resultFact === null && winnerFactId === null
+      ? null
+      : {
+          factId: resultFact?.factId ?? winnerFactId!,
+          data: structuredClone(
+            resultFact?.data ?? { resultKind: "derived-score-completion", winnerGameSideId },
+          ),
+        };
+  const effectiveResult = result !== null || winnerGameSideId !== null;
+  const effectiveSuspension = gameFacts.some(
+    (fact) => fact.effective && fact.factType === "suspension",
+  );
+  const phase = effectiveResult
+    ? "finished"
+    : effectiveSuspension && projection.phase === "suspended"
+      ? "suspended"
+      : commencement.status === "provisional"
+        ? "scheduled"
+        : "in-progress";
+  return {
+    ...state,
+    projection: {
+      ...projection,
+      phase,
+      scoreByGameSide,
+      goalCount,
+      commencement,
+      timeout: dependentState.timeout,
+      stoppage: dependentState.stoppage,
+      heat: dependentState.heat,
+      result,
+      overtime,
+      overtimeTarget,
+      targetScore: overtimeTarget,
+      winnerGameSideId,
+      catch: catchState,
+      gameFacts: structuredClone(gameFacts),
+    },
+  };
 }
 
 function deriveOptimisticDependentState(facts: readonly ControllerGameFact[]): {

--- a/src/lib/foundation-acceptance.ts
+++ b/src/lib/foundation-acceptance.ts
@@ -87,6 +87,8 @@ export type ControlActionBatchInput = {
     replayEvidenceId: string;
   };
   lifecycleTransition?: EventGameRecordRoot["lifecycle"];
+  /** Only the composed Live Event Game seam may reconcile derived scoring lifecycle. */
+  reconcileDerivedLifecycle?: boolean;
 };
 
 export type FoundationActionResult =
@@ -859,6 +861,7 @@ export function createFoundationAcceptance(
         replayState,
         existing.action,
         batch.input.lifecycleTransition,
+        batch.input.reconcileDerivedLifecycle === true,
       );
     if (existing !== null)
       return writeOutcome(
@@ -947,6 +950,7 @@ export function createFoundationAcceptance(
       mode,
       replayState,
       batch.input.lifecycleTransition,
+      batch.input.reconcileDerivedLifecycle === true,
     );
   }
 
@@ -960,6 +964,7 @@ export function createFoundationAcceptance(
     mode: "online" | "replay",
     reservation: StoredReplayReservation | undefined,
     lifecycleTransition: EventGameRecordRoot["lifecycle"] | undefined,
+    reconcileDerivedLifecycle: boolean,
   ): OneOutcome {
     const acceptanceId = `accept-${sha256(`${root.recordId}:${action.operationId}:${action.grant.sessionId}`)}`;
     const grantAudit = linkedGrantAudit(
@@ -990,7 +995,12 @@ export function createFoundationAcceptance(
       action.interpretation.type === "team-assignment-correction"
     )
       appendConcurrentCorrectionAudits(transaction, root.recordId, action.acceptedAtMs);
-    applyLifecycleTransition(transaction, root.recordId, lifecycleTransition);
+    applyLifecycleTransition(
+      transaction,
+      root.recordId,
+      lifecycleTransition,
+      reconcileDerivedLifecycle,
+    );
     return finishReplay(
       transaction,
       reservation,
@@ -1122,6 +1132,7 @@ export function createFoundationAcceptance(
     reservation: StoredReplayReservation | undefined,
     existing: ControlAction,
     lifecycleTransition: EventGameRecordRoot["lifecycle"] | undefined,
+    reconcileDerivedLifecycle: boolean,
   ): OneOutcome {
     const nowMs = readNow(clock);
     const controlAudit = createControlAudit(
@@ -1159,7 +1170,12 @@ export function createFoundationAcceptance(
     options.failureInjector?.("after-control-audit");
     transaction.appendGrantAudit(grantAudit);
     options.failureInjector?.("after-grant-audit");
-    applyLifecycleTransition(transaction, root.recordId, lifecycleTransition);
+    applyLifecycleTransition(
+      transaction,
+      root.recordId,
+      lifecycleTransition,
+      reconcileDerivedLifecycle,
+    );
     return finishReplay(
       transaction,
       reservation,
@@ -1519,6 +1535,7 @@ export function createFoundationAcceptance(
           }
         : null,
       actions: raw.actions,
+      ...(raw.reconcileDerivedLifecycle === true ? { reconcileDerivedLifecycle: true } : {}),
       ...(isRecord(raw.lifecycleTransition)
         ? { lifecycleTransition: raw.lifecycleTransition }
         : {}),
@@ -1531,6 +1548,7 @@ export function createFoundationAcceptance(
         sessionBearer: typeof raw.sessionBearer === "string" ? raw.sessionBearer : undefined,
         mode: effectiveMode,
         replay,
+        reconcileDerivedLifecycle: raw.reconcileDerivedLifecycle === true,
         lifecycleTransition: isRecord(raw.lifecycleTransition)
           ? (structuredClone(raw.lifecycleTransition) as EventGameRecordRoot["lifecycle"])
           : undefined,
@@ -1546,6 +1564,7 @@ export function createFoundationAcceptance(
     transaction: FoundationStorageTransaction,
     recordId: string,
     lifecycle: EventGameRecordRoot["lifecycle"] | undefined,
+    reconcileDerivedLifecycle: boolean,
   ): void {
     if (lifecycle === undefined) return;
     const current = transaction.findRootByRecordId(recordId);
@@ -1564,7 +1583,11 @@ export function createFoundationAcceptance(
     });
     if (
       !validated.ok ||
-      !allowedLifecycleTransition(current.lifecycle, validated.value.lifecycle)
+      !allowedLifecycleTransition(
+        current.lifecycle,
+        validated.value.lifecycle,
+        reconcileDerivedLifecycle,
+      )
     ) {
       throw new Error("Event Game lifecycle transitions are monotonic.");
     }
@@ -1578,8 +1601,20 @@ export function createFoundationAcceptance(
   function allowedLifecycleTransition(
     current: EventGameRecordRoot["lifecycle"],
     next: EventGameRecordRoot["lifecycle"],
+    reconcileDerivedLifecycle = false,
   ): boolean {
-    if (current.lockedAtMs !== null || current.finishedAtMs !== null) return false;
+    if (current.lockedAtMs !== null) return false;
+    if (
+      reconcileDerivedLifecycle &&
+      current.phase === "finished" &&
+      current.finishedAtMs !== null &&
+      next.phase === "in-progress" &&
+      next.finishedAtMs === null &&
+      next.lockedAtMs === null &&
+      next.commencedAtMs === current.commencedAtMs
+    )
+      return true;
+    if (current.finishedAtMs !== null) return false;
     if (
       current.commencedAtMs !== null &&
       (next.commencedAtMs === null || next.commencedAtMs !== current.commencedAtMs)

--- a/src/lib/live-event-game-control.test.ts
+++ b/src/lib/live-event-game-control.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { applyGameCommand, createInitialGameState } from "@/lib/game-engine";
-import { createFoundationAcceptance } from "@/lib/foundation-acceptance";
+import { createFoundationAcceptance, type AcceptanceLimits } from "@/lib/foundation-acceptance";
 import { createInMemoryFoundationStorage } from "@/lib/foundation-storage-memory";
 import { createEventGameRecord } from "@/lib/event-game-record";
 import { createGrantTestAuthorityVerifier } from "@/lib/grant-authority-test-support";
@@ -200,6 +200,1077 @@ describe("Live Event Game control", () => {
     expect(harness.control.activeControllerSessions()).toBe(0);
   });
 
+  test("scores a released stopped flag catch, fixes overtime target, and finishes at target", async () => {
+    const harness = await createHarness();
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "iqa-overtime",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+    const submit = (intent: unknown, causalPredecessorIds?: string[]) =>
+      harness.control.submitControllerIntent({
+        sessionBearer: opened.session.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+        intent,
+        causalPredecessorIds,
+      });
+
+    await submit(
+      goalIntent({
+        operationId: "goal-b",
+        factId: "fact-goal-b",
+        gameSideId: "side-b",
+        gameTimeMs: 10_000,
+      }),
+    );
+    await submit(
+      goalIntent({
+        operationId: "goal-b-2",
+        factId: "fact-goal-b-2",
+        gameSideId: "side-b",
+        gameTimeMs: 20_000,
+      }),
+    );
+    await submit(
+      goalIntent({
+        operationId: "goal-b-3",
+        factId: "fact-goal-b-3",
+        gameSideId: "side-b",
+        gameTimeMs: 30_000,
+      }),
+    );
+    const caught = await submit(flagCatchIntent("catch-a", "catch-fact-a", "side-a"));
+    expect(caught).toMatchObject({
+      status: "accepted",
+      projection: {
+        scoreByGameSide: { "side-a": 30, "side-b": 30 },
+        overtime: true,
+        overtimeTarget: 60,
+        targetScore: 60,
+        winnerGameSideId: null,
+        catch: {
+          catchingGameSideId: "side-a",
+          nonCatchingGameSideId: "side-b",
+          targetScore: 60,
+        },
+        phase: "in-progress",
+      },
+    });
+
+    const postCatch = await submit(
+      goalIntent({
+        operationId: "post-catch-goal",
+        factId: "post-catch-fact",
+        gameSideId: "side-b",
+        gameTimeMs: 1_300_000,
+      }),
+    );
+    expect(postCatch).toMatchObject({
+      projection: { scoreByGameSide: { "side-a": 30, "side-b": 40 }, overtimeTarget: 60 },
+    });
+    const finish = await submit(
+      goalIntent({
+        operationId: "target-goal",
+        factId: "target-fact",
+        gameSideId: "side-a",
+        gameTimeMs: 1_400_000,
+      }),
+    );
+    expect(finish).toMatchObject({
+      status: "accepted",
+      projection: {
+        scoreByGameSide: { "side-a": 40, "side-b": 40 },
+        overtimeTarget: 60,
+        winnerGameSideId: null,
+        phase: "in-progress",
+      },
+    });
+    const final = await submit(
+      goalIntent({
+        operationId: "target-goal-2",
+        factId: "target-fact-2",
+        gameSideId: "side-a",
+        gameTimeMs: 1_500_000,
+      }),
+    );
+    expect(final).toMatchObject({
+      projection: {
+        scoreByGameSide: { "side-a": 50, "side-b": 40 },
+        overtimeTarget: 60,
+        winnerGameSideId: null,
+        phase: "in-progress",
+      },
+    });
+    expect(
+      await submit(
+        goalIntent({
+          operationId: "target-goal-3",
+          factId: "target-fact-3",
+          gameSideId: "side-a",
+          gameTimeMs: 1_600_000,
+        }),
+      ),
+    ).toMatchObject({
+      projection: {
+        scoreByGameSide: { "side-a": 60, "side-b": 40 },
+        winnerGameSideId: "side-a",
+        phase: "finished",
+      },
+    });
+  });
+
+  test("rebuilds catch target and winner from a corrected pre-catch goal, while retaining audit facts", async () => {
+    const harness = await createHarness();
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "iqa-late-correction",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+    const submit = (intent: unknown, causalPredecessorIds?: string[]) =>
+      harness.control.submitControllerIntent({
+        sessionBearer: opened.session.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+        intent,
+        causalPredecessorIds,
+      });
+    await submit(
+      goalIntent({
+        operationId: "pre-catch-goal",
+        factId: "pre-catch-fact",
+        gameSideId: "side-b",
+        gameTimeMs: 100_000,
+      }),
+    );
+    await submit(
+      goalIntent({
+        operationId: "pre-catch-goal-2",
+        factId: "pre-catch-fact-2",
+        gameSideId: "side-b",
+        gameTimeMs: 110_000,
+      }),
+    );
+    await submit(
+      goalIntent({
+        operationId: "pre-catch-goal-3",
+        factId: "pre-catch-fact-3",
+        gameSideId: "side-b",
+        gameTimeMs: 120_000,
+      }),
+    );
+    const caught = await submit(flagCatchIntent("late-catch", "late-catch-fact", "side-a"));
+    expect(caught).toMatchObject({ projection: { overtime: true, overtimeTarget: 60 } });
+    const corrected = await submit(
+      correctionIntent("correct-pre-catch", "correct-pre-catch-fact", false, "pre-catch-fact"),
+      ["pre-catch-goal"],
+    );
+    expect(corrected).toMatchObject({
+      status: "accepted",
+      projection: {
+        scoreByGameSide: { "side-a": 30, "side-b": 20 },
+        overtime: false,
+        overtimeTarget: null,
+        winnerGameSideId: "side-a",
+        phase: "finished",
+      },
+    });
+    expect((await harness.record.readActions()).map((stored) => stored.action.operationId)).toEqual(
+      ["pre-catch-goal", "pre-catch-goal-2", "pre-catch-goal-3", "late-catch", "correct-pre-catch"],
+    );
+  });
+
+  test("applies concession score rules and keeps forfeits as directed results", async () => {
+    const preOvertimeHarness = await createHarness();
+    const preOvertimeOpened = await preOvertimeHarness.control.openController({
+      qrCredential: preOvertimeHarness.qrCredential,
+      browserContext: "iqa-pre-overtime-concession",
+    });
+    if (preOvertimeOpened.status !== "opened") throw new Error("Expected the Controller to open.");
+    expect(
+      await preOvertimeHarness.control.submitControllerIntent({
+        sessionBearer: preOvertimeOpened.session.sessionBearer,
+        eventGameId: preOvertimeHarness.root.eventGameId,
+        intent: concessionIntent("pre-overtime-concede", "pre-overtime-concede-fact", "side-a"),
+      }),
+    ).toMatchObject({ status: "rejected" });
+    expect(await preOvertimeHarness.record.readActions()).toHaveLength(0);
+
+    const tiedHarness = await createHarness();
+    const tiedOpened = await tiedHarness.control.openController({
+      qrCredential: tiedHarness.qrCredential,
+      browserContext: "iqa-tied-concession",
+    });
+    if (tiedOpened.status !== "opened") throw new Error("Expected the Controller to open.");
+    const tiedSubmit = (intent: unknown) =>
+      tiedHarness.control.submitControllerIntent({
+        sessionBearer: tiedOpened.session.sessionBearer,
+        eventGameId: tiedHarness.root.eventGameId,
+        intent,
+      });
+    await tiedSubmit(goalIntent({ operationId: "tie-a", factId: "tie-a", gameSideId: "side-a" }));
+    for (let index = 0; index < 4; index += 1) {
+      await tiedSubmit(
+        goalIntent({
+          operationId: `tie-b-${index}`,
+          factId: `tie-b-${index}`,
+          gameSideId: "side-b",
+          gameTimeMs: 20_000 + index,
+        }),
+      );
+    }
+    await tiedSubmit(flagCatchIntent("tie-catch", "tie-catch", "side-a"));
+    expect(
+      await tiedSubmit(concessionIntent("concede-a", "concede-a-fact", "side-a")),
+    ).toMatchObject({
+      projection: {
+        scoreByGameSide: { "side-a": 40, "side-b": 50 },
+        winnerGameSideId: "side-b",
+        phase: "finished",
+      },
+    });
+
+    const forfeitHarness = await createHarness();
+    const forfeitOpened = await forfeitHarness.control.openController({
+      qrCredential: forfeitHarness.qrCredential,
+      browserContext: "iqa-forfeit",
+    });
+    if (forfeitOpened.status !== "opened") throw new Error("Expected the Controller to open.");
+    expect(
+      await forfeitHarness.control.submitControllerIntent({
+        sessionBearer: forfeitOpened.session.sessionBearer,
+        eventGameId: forfeitHarness.root.eventGameId,
+        intent: forfeitIntent("forfeit-a", "forfeit-a-fact", "side-a"),
+      }),
+    ).toMatchObject({
+      projection: {
+        scoreByGameSide: { "side-a": 0, "side-b": 0 },
+        winnerGameSideId: "side-b",
+        phase: "finished",
+      },
+    });
+  });
+
+  test("covers trailing, leading, and double-forfeit outcomes", async () => {
+    const trailingHarness = await createHarness();
+    const trailingOpened = await trailingHarness.control.openController({
+      qrCredential: trailingHarness.qrCredential,
+      browserContext: "iqa-trailing-concession",
+    });
+    if (trailingOpened.status !== "opened") throw new Error("Expected the Controller to open.");
+    const trailingSubmit = (intent: unknown) =>
+      trailingHarness.control.submitControllerIntent({
+        sessionBearer: trailingOpened.session.sessionBearer,
+        eventGameId: trailingHarness.root.eventGameId,
+        intent,
+      });
+    for (let index = 0; index < 5; index += 1) {
+      await trailingSubmit(
+        goalIntent({
+          operationId: `trailing-lead-${index}`,
+          factId: `trailing-lead-${index}`,
+          gameSideId: "side-b",
+          gameTimeMs: 20_000 + index,
+        }),
+      );
+    }
+    await trailingSubmit(
+      goalIntent({ operationId: "trailing-a", factId: "trailing-a", gameSideId: "side-a" }),
+    );
+    await trailingSubmit(flagCatchIntent("trailing-catch", "trailing-catch", "side-a"));
+    expect(
+      await trailingSubmit(concessionIntent("trailing-concede", "trailing-concede-fact", "side-a")),
+    ).toMatchObject({
+      projection: { scoreByGameSide: { "side-a": 40, "side-b": 50 }, winnerGameSideId: "side-b" },
+    });
+
+    const leadingHarness = await createHarness();
+    const leadingOpened = await leadingHarness.control.openController({
+      qrCredential: leadingHarness.qrCredential,
+      browserContext: "iqa-leading-concession",
+    });
+    if (leadingOpened.status !== "opened") throw new Error("Expected the Controller to open.");
+    const leadingSubmit = (intent: unknown) =>
+      leadingHarness.control.submitControllerIntent({
+        sessionBearer: leadingOpened.session.sessionBearer,
+        eventGameId: leadingHarness.root.eventGameId,
+        intent,
+      });
+    await leadingSubmit(
+      goalIntent({ operationId: "leading-a", factId: "leading-a", gameSideId: "side-a" }),
+    );
+    for (let index = 0; index < 4; index += 1) {
+      await leadingSubmit(
+        goalIntent({
+          operationId: `leading-b-${index}`,
+          factId: `leading-b-${index}`,
+          gameSideId: "side-b",
+          gameTimeMs: 20_000 + index,
+        }),
+      );
+    }
+    await leadingSubmit(flagCatchIntent("leading-catch", "leading-catch", "side-a"));
+    await leadingSubmit(
+      goalIntent({
+        operationId: "leading-overtime-goal",
+        factId: "leading-overtime-goal",
+        gameSideId: "side-a",
+        gameTimeMs: 1_300_000,
+      }),
+    );
+    expect(
+      await leadingSubmit(concessionIntent("leading-concede", "leading-concede-fact", "side-a")),
+    ).toMatchObject({
+      projection: { scoreByGameSide: { "side-a": 50, "side-b": 60 }, winnerGameSideId: "side-b" },
+    });
+
+    const doubleForfeitHarness = await createHarness();
+    const doubleForfeitOpened = await doubleForfeitHarness.control.openController({
+      qrCredential: doubleForfeitHarness.qrCredential,
+      browserContext: "iqa-double-forfeit",
+    });
+    if (doubleForfeitOpened.status !== "opened")
+      throw new Error("Expected the Controller to open.");
+    expect(
+      await doubleForfeitHarness.control.submitControllerIntent({
+        sessionBearer: doubleForfeitOpened.session.sessionBearer,
+        eventGameId: doubleForfeitHarness.root.eventGameId,
+        intent: {
+          version: LIVE_EVENT_CONTROL_INTENT_VERSION,
+          type: "record-double-forfeit",
+          operationId: "double-forfeit",
+          factId: "double-forfeit-fact",
+          gameTimeMs: 30_000,
+          sportingOrder: 30_000,
+          occurrence: { clientOriginAtMs: 30_000 },
+        },
+      }),
+    ).toMatchObject({
+      projection: {
+        winnerGameSideId: null,
+        result: { data: { resultKind: "double-forfeit" } },
+        phase: "finished",
+      },
+    });
+  });
+
+  test("rejects concession reinstatement after its overtime catch becomes ineffective", async () => {
+    const harness = await createHarness();
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "iqa-concession-reinstatement-precondition",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+    const submit = (intent: unknown) =>
+      harness.control.submitControllerIntent({
+        sessionBearer: opened.session.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+        intent,
+      });
+    for (let index = 0; index < 3; index += 1) {
+      await submit(
+        goalIntent({
+          operationId: `concession-precondition-goal-${index}`,
+          factId: `concession-precondition-goal-${index}`,
+          gameSideId: "side-b",
+          gameTimeMs: 10_000 + index,
+        }),
+      );
+    }
+    await submit(
+      flagCatchIntent("concession-precondition-catch", "concession-precondition-catch", "side-a"),
+    );
+    expect(
+      await submit(
+        concessionIntent(
+          "concession-precondition-result",
+          "concession-precondition-result",
+          "side-a",
+        ),
+      ),
+    ).toMatchObject({ status: "accepted", projection: { phase: "finished" } });
+    expect(
+      await submit(
+        correctionIntent(
+          "concession-precondition-disable-result",
+          "concession-precondition-disable-result",
+          false,
+          "concession-precondition-result",
+        ),
+      ),
+    ).toMatchObject({ status: "accepted", projection: { overtime: true, phase: "in-progress" } });
+    expect(
+      await submit(
+        correctionIntent(
+          "concession-precondition-disable-catch",
+          "concession-precondition-disable-catch",
+          false,
+          "concession-precondition-catch",
+        ),
+      ),
+    ).toMatchObject({ status: "accepted", projection: { overtime: false, catch: null } });
+
+    const beforeReinstatement = await harness.record.readActions();
+    expect(
+      await submit(
+        correctionIntent(
+          "concession-precondition-reinstate-result",
+          "concession-precondition-reinstate-result",
+          true,
+          "concession-precondition-result",
+        ),
+      ),
+    ).toMatchObject({ status: "rejected" });
+    expect(await harness.record.readActions()).toHaveLength(beforeReinstatement.length);
+    expect(
+      await harness.control.refreshController({
+        sessionBearer: opened.session.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+      }),
+    ).toMatchObject({
+      projection: {
+        scoreByGameSide: { "side-a": 0, "side-b": 30 },
+        overtime: false,
+        catch: null,
+        result: null,
+        phase: "in-progress",
+        gameFacts: [
+          expect.anything(),
+          expect.anything(),
+          expect.anything(),
+          expect.objectContaining({ factId: "concession-precondition-catch", effective: false }),
+          expect.objectContaining({ factId: "concession-precondition-result", effective: false }),
+        ],
+      },
+    });
+  });
+
+  test("rejects generic result reinstatement during unfinished overtime", async () => {
+    const harness = await createHarness();
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "iqa-generic-result-reinstatement",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+    const submit = (intent: unknown) =>
+      harness.control.submitControllerIntent({
+        sessionBearer: opened.session.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+        intent,
+      });
+    expect(await submit(substantiveIntent("early-generic-result", "result"))).toMatchObject({
+      status: "accepted",
+    });
+    expect(
+      await submit(
+        correctionIntent(
+          "disable-early-generic-result",
+          "disable-early-generic-result-fact",
+          false,
+          "fact-early-generic-result",
+        ),
+      ),
+    ).toMatchObject({ status: "accepted" });
+    for (let index = 0; index < 3; index += 1) {
+      await submit(
+        goalIntent({
+          operationId: `generic-result-goal-${index}`,
+          factId: `generic-result-goal-${index}`,
+          gameSideId: "side-b",
+          gameTimeMs: 10_000 + index,
+        }),
+      );
+    }
+    expect(
+      await submit(flagCatchIntent("generic-result-catch", "generic-result-catch", "side-a")),
+    ).toMatchObject({ projection: { overtime: true, phase: "in-progress" } });
+    const beforeReinstatement = await harness.record.readActions();
+    expect(
+      await submit(
+        correctionIntent(
+          "reinstate-early-generic-result",
+          "reinstate-early-generic-result-fact",
+          true,
+          "fact-early-generic-result",
+        ),
+      ),
+    ).toMatchObject({ status: "rejected" });
+    expect(await harness.record.readActions()).toHaveLength(beforeReinstatement.length);
+  });
+
+  test("rejects score overflow before durable acceptance", async () => {
+    const harness = await createHarness();
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "iqa-score-bound",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+    const submit = (intent: unknown) =>
+      harness.control.submitControllerIntent({
+        sessionBearer: opened.session.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+        intent,
+      });
+    for (let index = 0; index < 100; index += 1) {
+      harness.setNow(11_000 + index * 1_000);
+      expect(
+        await submit(
+          goalIntent({
+            operationId: `bound-${index}`,
+            factId: `bound-fact-${index}`,
+            gameTimeMs: index + 1,
+          }),
+        ),
+      ).toMatchObject({ status: "accepted" });
+    }
+    expect(
+      await submit(
+        goalIntent({ operationId: "bound-over", factId: "bound-over-fact", gameTimeMs: 101 }),
+      ),
+    ).toMatchObject({ status: "rejected" });
+    expect(await submit(flagCatchIntent("catch-over", "catch-over-fact", "side-a"))).toMatchObject({
+      status: "rejected",
+    });
+    expect(
+      await submit(concessionIntent("concession-over", "concession-over-fact", "side-a")),
+    ).toMatchObject({ status: "rejected" });
+    expect((await harness.record.readActions()).length).toBe(100);
+  });
+
+  test("rejects a correction reinstatement that would overflow without losing projection state", async () => {
+    const harness = await createHarness();
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "iqa-correction-score-bound",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+    const submit = (intent: unknown) =>
+      harness.control.submitControllerIntent({
+        sessionBearer: opened.session.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+        intent,
+      });
+
+    await submit(
+      goalIntent({
+        operationId: "correction-boundary-goal",
+        factId: "correction-boundary-goal",
+        gameTimeMs: 1_000,
+      }),
+    );
+    expect(
+      await submit(
+        correctionIntent(
+          "correction-boundary-disable",
+          "correction-boundary-disable-fact",
+          false,
+          "correction-boundary-goal",
+        ),
+      ),
+    ).toMatchObject({ status: "accepted" });
+    for (let index = 0; index < 96; index += 1) {
+      harness.setNow(20_000 + index * 1_000);
+      expect(
+        await submit(
+          goalIntent({
+            operationId: `correction-bound-${index}`,
+            factId: `correction-bound-fact-${index}`,
+            gameTimeMs: 20_000 + index,
+          }),
+        ),
+      ).toMatchObject({ status: "accepted" });
+    }
+    expect(
+      await submit(
+        flagCatchIntent("correction-boundary-catch", "correction-boundary-catch", "side-a"),
+      ),
+    ).toMatchObject({ status: "accepted" });
+    expect(
+      await submit(
+        goalIntent({
+          operationId: "correction-boundary-late-goal",
+          factId: "correction-boundary-late-goal",
+          gameTimeMs: 1_100_000,
+        }),
+      ),
+    ).toMatchObject({ status: "accepted" });
+
+    const actionsBeforeReinstatement = await harness.record.readActions();
+    const reinstated = await submit(
+      correctionIntent(
+        "correction-boundary-reinstate",
+        "correction-boundary-reinstate-fact",
+        true,
+        "correction-boundary-goal",
+      ),
+    );
+    expect(reinstated).toMatchObject({ status: "rejected" });
+    expect(await harness.record.readActions()).toHaveLength(actionsBeforeReinstatement.length);
+    const refreshed = await harness.control.refreshController({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+    });
+    expect(refreshed).toMatchObject({ status: "authorized" });
+    if (refreshed.status !== "authorized" || refreshed.projection === null) {
+      throw new Error("Expected the retained Controller projection.");
+    }
+    expect(refreshed.projection.scoreByGameSide).toEqual({ "side-a": 1000, "side-b": 0 });
+    expect(refreshed.projection.gameFacts).toContainEqual(
+      expect.objectContaining({ factId: "correction-boundary-goal", effective: false }),
+    );
+  });
+
+  test("rejects a catch whose overtime target would exceed the derived score bound", async () => {
+    const harness = await createHarness();
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "iqa-catch-target-bound",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+    const submit = (intent: unknown) =>
+      harness.control.submitControllerIntent({
+        sessionBearer: opened.session.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+        intent,
+      });
+    for (let index = 0; index < 98; index += 1) {
+      harness.setNow(30_000 + index * 1_000);
+      expect(
+        await submit(
+          goalIntent({
+            operationId: `catch-target-bound-${index}`,
+            factId: `catch-target-bound-fact-${index}`,
+            gameSideId: "side-b",
+            gameTimeMs: 30_000 + index,
+          }),
+        ),
+      ).toMatchObject({ status: "accepted" });
+    }
+
+    const rejectedCatch = await submit(
+      flagCatchIntent("catch-target-bound", "catch-target-bound-fact", "side-a"),
+    );
+    expect(rejectedCatch).toMatchObject({ status: "rejected" });
+    expect(await harness.record.readActions()).toHaveLength(98);
+    const refreshed = await harness.control.refreshController({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+    });
+    expect(refreshed).toMatchObject({
+      projection: {
+        scoreByGameSide: { "side-a": 0, "side-b": 980 },
+        catch: null,
+        phase: "in-progress",
+      },
+    });
+  });
+
+  test("accepts and replays a late pre-catch goal after a temporary finished catch", async () => {
+    const harness = await createHarness();
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "iqa-late-pre-catch",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+    const submit = (intent: unknown) =>
+      harness.control.submitControllerIntent({
+        sessionBearer: opened.session.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+        intent,
+      });
+    await submit(
+      goalIntent({
+        operationId: "before-catch-a",
+        factId: "before-catch-a",
+        gameSideId: "side-b",
+        gameTimeMs: 100,
+      }),
+    );
+    await submit(
+      goalIntent({
+        operationId: "before-catch-b",
+        factId: "before-catch-b",
+        gameSideId: "side-b",
+        gameTimeMs: 200,
+      }),
+    );
+    expect(
+      await submit(flagCatchIntent("temporary-catch", "temporary-catch-fact", "side-a")),
+    ).toMatchObject({ projection: { phase: "finished", winnerGameSideId: "side-a" } });
+    expect(
+      await submit(
+        goalIntent({
+          operationId: "dangerous-post-catch",
+          factId: "dangerous-post-catch-fact",
+          gameSideId: "side-b",
+          gameTimeMs: 1_300_000,
+        }),
+      ),
+    ).toMatchObject({ status: "rejected" });
+    expect(
+      await submit({
+        ...goalIntent({
+          operationId: "late-pre-catch",
+          factId: "late-pre-catch-fact",
+          gameSideId: "side-b",
+          gameTimeMs: 150,
+        }),
+        occurrence: { clientOriginAtMs: 1_301_000, source: "offline" as const },
+      }),
+    ).toMatchObject({
+      status: "accepted",
+      projection: {
+        scoreByGameSide: { "side-a": 30, "side-b": 30 },
+        overtime: true,
+        overtimeTarget: 60,
+        winnerGameSideId: null,
+        phase: "in-progress",
+      },
+    });
+    const replay = await harness.control.replayControllerActions({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      batchId: "late-pre-catch-replay",
+      replicaGeneration: "late-pre-catch-generation",
+      expectedGrantSessionId: opened.session.grantSessionId,
+      expectedGrantVersion: opened.session.grantVersion,
+      actions: [
+        {
+          eventGameId: harness.root.eventGameId,
+          intent: {
+            ...goalIntent({
+              operationId: "late-pre-catch-replay-goal",
+              factId: "late-pre-catch-replay-fact",
+              gameSideId: "side-b",
+              gameTimeMs: 175,
+            }),
+            occurrence: { clientOriginAtMs: 1_302_000, source: "offline" as const },
+          },
+          causalPredecessorIds: [],
+        },
+      ],
+    });
+    expect(replay.outcomes).toEqual([
+      { operationId: "late-pre-catch-replay-goal", status: "accepted" },
+    ]);
+    expect(replay.projection).toMatchObject({
+      scoreByGameSide: { "side-a": 30, "side-b": 40 },
+      overtimeTarget: 70,
+      phase: "in-progress",
+    });
+  });
+
+  test("refreshes replay state for a same-batch paired late goal after a catch", async () => {
+    const harness = await createHarness();
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "iqa-same-batch-close-play-replay",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+    const replay = await harness.control.replayControllerActions({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      batchId: "same-batch-close-play-replay",
+      replicaGeneration: "same-batch-close-play-generation",
+      expectedGrantSessionId: opened.session.grantSessionId,
+      expectedGrantVersion: opened.session.grantVersion,
+      actions: [
+        {
+          eventGameId: harness.root.eventGameId,
+          intent: goalIntent({
+            operationId: "same-batch-before-catch-a",
+            factId: "same-batch-before-catch-a",
+            gameSideId: "side-b",
+            gameTimeMs: 10_000,
+          }),
+          causalPredecessorIds: [],
+        },
+        {
+          eventGameId: harness.root.eventGameId,
+          intent: goalIntent({
+            operationId: "same-batch-before-catch-b",
+            factId: "same-batch-before-catch-b",
+            gameSideId: "side-b",
+            gameTimeMs: 20_000,
+          }),
+          causalPredecessorIds: [],
+        },
+        {
+          eventGameId: harness.root.eventGameId,
+          intent: flagCatchIntent("same-batch-catch", "same-batch-catch-fact", "side-a"),
+          causalPredecessorIds: [],
+        },
+        {
+          eventGameId: harness.root.eventGameId,
+          intent: {
+            ...goalIntent({
+              operationId: "same-batch-late-goal",
+              factId: "same-batch-late-goal-fact",
+              gameSideId: "side-b",
+              gameTimeMs: 1_200_000,
+            }),
+            sportingOrderAdjudication: {
+              relatedFactId: "same-batch-catch-fact",
+              relation: "before",
+            },
+            override: closePlayAdjudicationOverride(
+              1_200_000,
+              "same-batch-catch-fact",
+              1_200_000,
+              "before",
+            ),
+            occurrence: { clientOriginAtMs: 1_201_000, source: "offline" as const },
+          },
+          causalPredecessorIds: [],
+        },
+      ],
+    });
+    expect(replay.outcomes).toEqual([
+      { operationId: "same-batch-before-catch-a", status: "accepted" },
+      { operationId: "same-batch-before-catch-b", status: "accepted" },
+      { operationId: "same-batch-catch", status: "accepted" },
+      { operationId: "same-batch-late-goal", status: "accepted" },
+    ]);
+    expect(replay.projection).toMatchObject({
+      scoreByGameSide: { "side-a": 30, "side-b": 30 },
+      overtime: true,
+      overtimeTarget: 60,
+      targetScore: 60,
+      winnerGameSideId: null,
+      phase: "in-progress",
+      gameFacts: [
+        expect.objectContaining({ factId: "same-batch-before-catch-a" }),
+        expect.objectContaining({ factId: "same-batch-before-catch-b" }),
+        expect.objectContaining({ factId: "same-batch-late-goal-fact" }),
+        expect.objectContaining({ factId: "same-batch-catch-fact" }),
+      ],
+    });
+  });
+
+  test("atomically reconciles durable finish lifecycle through late scoring and catch Correction", async () => {
+    const harness = await createHarness();
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "iqa-lifecycle-reconciliation",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+    const submit = (intent: unknown) =>
+      harness.control.submitControllerIntent({
+        sessionBearer: opened.session.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+        intent,
+      });
+    await submit(
+      goalIntent({ operationId: "lifecycle-a", factId: "lifecycle-a", gameSideId: "side-a" }),
+    );
+    for (let index = 0; index < 3; index += 1) {
+      await submit(
+        goalIntent({
+          operationId: `lifecycle-b-${index}`,
+          factId: `lifecycle-b-${index}`,
+          gameSideId: "side-b",
+          gameTimeMs: 20_000 + index,
+        }),
+      );
+    }
+    await submit(flagCatchIntent("lifecycle-catch", "lifecycle-catch-fact", "side-a"));
+    expect((await harness.record.readRoot(harness.root.recordId))?.lifecycle).toMatchObject({
+      phase: "finished",
+      finishedAtMs: expect.any(Number),
+    });
+
+    harness.failureBoundary = "after-lifecycle";
+    expect(
+      await submit(
+        goalIntent({
+          operationId: "lifecycle-late-failed",
+          factId: "lifecycle-late-failed-fact",
+          gameSideId: "side-b",
+          gameTimeMs: 1_100_000,
+        }),
+      ),
+    ).toMatchObject({ status: "retryable" });
+    expect((await harness.record.readRoot(harness.root.recordId))?.lifecycle.phase).toBe(
+      "finished",
+    );
+    expect(await harness.record.readActions()).toHaveLength(5);
+
+    harness.failureBoundary = undefined;
+    const late = await submit(
+      goalIntent({
+        operationId: "lifecycle-late",
+        factId: "lifecycle-late-fact",
+        gameSideId: "side-b",
+        gameTimeMs: 1_100_000,
+      }),
+    );
+    expect(late).toMatchObject({
+      projection: {
+        phase: "in-progress",
+        overtime: true,
+        overtimeTarget: 70,
+        winnerGameSideId: null,
+      },
+    });
+    expect((await harness.record.readRoot(harness.root.recordId))?.lifecycle).toMatchObject({
+      phase: "in-progress",
+      finishedAtMs: null,
+    });
+    expect(
+      await harness.control.revealControllerQr({
+        sessionBearer: opened.session.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+      }),
+    ).toMatchObject({ status: "revealed" });
+
+    const correction = await submit(
+      correctionIntent(
+        "lifecycle-correct-catch",
+        "lifecycle-correct-catch-fact",
+        false,
+        "lifecycle-catch-fact",
+      ),
+    );
+    expect(correction).toMatchObject({ projection: { phase: "in-progress", catch: null } });
+    expect((await harness.record.readRoot(harness.root.recordId))?.lifecycle).toMatchObject({
+      phase: "in-progress",
+      finishedAtMs: null,
+    });
+
+    expect(
+      await submit(
+        correctionIntent(
+          "lifecycle-correct-late-goal",
+          "lifecycle-correct-late-goal-fact",
+          false,
+          "lifecycle-late-fact",
+        ),
+      ),
+    ).toMatchObject({ status: "accepted" });
+    const reinstated = await submit(
+      correctionIntent(
+        "lifecycle-reinstate-catch",
+        "lifecycle-reinstate-catch-fact",
+        true,
+        "lifecycle-catch-fact",
+      ),
+    );
+    expect(reinstated).toMatchObject({
+      projection: { phase: "finished", winnerGameSideId: "side-a" },
+    });
+    expect((await harness.record.readRoot(harness.root.recordId))?.lifecycle).toMatchObject({
+      phase: "finished",
+      finishedAtMs: expect.any(Number),
+    });
+  });
+
+  test("does not re-finish a repaired Game when a corrected scoring operation is retried", async () => {
+    const harness = await createHarness();
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "duplicate-corrected-finish",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+    const submit = (intent: unknown) =>
+      harness.control.submitControllerIntent({
+        sessionBearer: opened.session.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+        intent,
+      });
+    await submit(
+      goalIntent({
+        operationId: "duplicate-finish-goal",
+        factId: "duplicate-finish-goal",
+        gameSideId: "side-a",
+      }),
+    );
+    const winningCatch = flagCatchIntent(
+      "duplicate-finish-catch",
+      "duplicate-finish-catch",
+      "side-a",
+    );
+    expect(await submit(winningCatch)).toMatchObject({
+      status: "accepted",
+      projection: { phase: "finished", winnerGameSideId: "side-a" },
+    });
+    expect(
+      await submit(
+        correctionIntent(
+          "duplicate-finish-correction",
+          "duplicate-finish-correction",
+          false,
+          "duplicate-finish-catch",
+        ),
+      ),
+    ).toMatchObject({ status: "accepted", projection: { phase: "in-progress", catch: null } });
+    expect(await submit(winningCatch)).toMatchObject({
+      status: "duplicate-accepted",
+      projection: { phase: "in-progress", catch: null, winnerGameSideId: null },
+    });
+    expect((await harness.record.readRoot(harness.root.recordId))?.lifecycle).toMatchObject({
+      phase: "in-progress",
+      finishedAtMs: null,
+    });
+  });
+
+  test("rejects a late pre-catch goal whose rebuilt overtime target exceeds 1,000", async () => {
+    const harness = await createHarness({
+      acceptanceLimits: { onlineSessionCapacity: 120, onlineEventCapacity: 120 },
+    });
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "iqa-late-target-bound",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+    const submit = (intent: unknown) =>
+      harness.control.submitControllerIntent({
+        sessionBearer: opened.session.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+        intent,
+      });
+    for (let index = 0; index < 97; index += 1) {
+      expect(
+        await submit(
+          goalIntent({
+            operationId: `late-bound-${index}`,
+            factId: `late-bound-fact-${index}`,
+            gameSideId: "side-b",
+            gameTimeMs: 30_000 + index,
+          }),
+        ),
+      ).toMatchObject({ status: "accepted" });
+    }
+    expect(
+      await submit(flagCatchIntent("late-bound-catch", "late-bound-catch-fact", "side-a")),
+    ).toMatchObject({ projection: { overtime: true, overtimeTarget: 1_000 } });
+    const before = await harness.record.readActions();
+    const lateGoal = {
+      ...goalIntent({
+        operationId: "late-bound-overflow",
+        factId: "late-bound-overflow-fact",
+        gameSideId: "side-b",
+        gameTimeMs: 1_100_000,
+      }),
+      occurrence: { clientOriginAtMs: 1_301_000, source: "offline" as const },
+    };
+    expect(await submit(lateGoal)).toMatchObject({ status: "rejected" });
+    expect(await harness.record.readActions()).toHaveLength(before.length);
+    expect(
+      await harness.control.replayControllerActions({
+        sessionBearer: opened.session.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+        batchId: "late-bound-replay",
+        replicaGeneration: "late-bound-generation",
+        expectedGrantSessionId: opened.session.grantSessionId,
+        expectedGrantVersion: opened.session.grantVersion,
+        actions: [
+          { eventGameId: harness.root.eventGameId, intent: lateGoal, causalPredecessorIds: [] },
+        ],
+      }),
+    ).toMatchObject({
+      outcomes: [{ operationId: "late-bound-overflow", status: "terminally-rejected" }],
+    });
+    expect(await harness.record.readActions()).toHaveLength(before.length);
+  });
+
   test("exposes stable Game Facts and rebuilds score through contextual correction and reinstatement", async () => {
     const harness = await createHarness();
     const opened = await harness.control.openController({
@@ -332,6 +1403,902 @@ describe("Live Event Game control", () => {
     expect(adjudicated).toMatchObject({ status: "accepted" });
     expect((await harness.record.readActions()).at(-1)?.action.override).toMatchObject({
       guardrail: "sporting-order-adjudication",
+    });
+  });
+
+  test("keeps close-play order authority separate from the flag-catch boundary override", async () => {
+    const harness = await createHarness();
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "close-play-separate-catch-boundary",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+    const submit = (intent: unknown) =>
+      harness.control.submitControllerIntent({
+        sessionBearer: opened.session.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+        intent,
+      });
+    await submit(
+      goalIntent({
+        operationId: "boundary-close-goal",
+        factId: "boundary-close-goal",
+        gameSideId: "side-b",
+        gameTimeMs: 11_500,
+      }),
+    );
+    const closeOrderOverride = closePlayAdjudicationOverride(
+      12_000,
+      "boundary-close-goal",
+      11_500,
+      "after",
+    );
+    const catchIntent = {
+      ...flagCatchIntent("boundary-close-catch", "boundary-close-catch", "side-a"),
+      gameTimeMs: 12_000,
+      sportingOrderAdjudication: {
+        relatedFactId: "boundary-close-goal",
+        relation: "after" as const,
+      },
+    };
+    expect(
+      await submit({
+        ...catchIntent,
+        operationId: "boundary-close-catch-order-only",
+        factId: "boundary-close-catch-order-only",
+        override: closeOrderOverride,
+      }),
+    ).toMatchObject({ status: "rejected" });
+    expect(await harness.record.readActions()).toHaveLength(1);
+
+    expect(
+      await submit({
+        ...catchIntent,
+        sportingOrderOverride: closeOrderOverride,
+        override: flagCatchBoundaryOverride(12_000),
+      }),
+    ).toMatchObject({
+      status: "accepted",
+      projection: { scoreByGameSide: { "side-a": 30, "side-b": 10 } },
+    });
+    const storedCatch = (await harness.record.readActions()).at(-1)?.action;
+    expect(storedCatch?.override).toMatchObject({
+      guardrail: "flag-catch-requires-seeker-release-and-stopped-play",
+    });
+    expect(storedCatch?.interpretation).toMatchObject({
+      type: "fact",
+      payload: {
+        data: {
+          sportingOrderAdjudication: {
+            relatedFactId: "boundary-close-goal",
+            relation: "after",
+          },
+          sportingOrderOverride: { guardrail: "sporting-order-adjudication" },
+        },
+      },
+    });
+
+    const runningHarness = await createHarness();
+    const runningOpened = await runningHarness.control.openController({
+      qrCredential: runningHarness.qrCredential,
+      browserContext: "close-play-running-catch-boundary",
+    });
+    if (runningOpened.status !== "opened") throw new Error("Expected the Controller to open.");
+    const runningSubmit = (intent: unknown) =>
+      runningHarness.control.submitControllerIntent({
+        sessionBearer: runningOpened.session.sessionBearer,
+        eventGameId: runningHarness.root.eventGameId,
+        intent,
+      });
+    await runningSubmit(clockIntent("running-boundary-clock", true));
+    await runningSubmit(
+      goalIntent({
+        operationId: "running-boundary-goal",
+        factId: "running-boundary-goal",
+        gameSideId: "side-b",
+        gameTimeMs: 1_199_500,
+      }),
+    );
+    expect(
+      await runningSubmit({
+        ...flagCatchIntent("running-boundary-catch", "running-boundary-catch", "side-a"),
+        sportingOrderAdjudication: {
+          relatedFactId: "running-boundary-goal",
+          relation: "after",
+        },
+        override: closePlayAdjudicationOverride(
+          1_200_000,
+          "running-boundary-goal",
+          1_199_500,
+          "after",
+        ),
+      }),
+    ).toMatchObject({ status: "rejected" });
+    expect(await runningHarness.record.readActions()).toHaveLength(2);
+  });
+
+  test("rejects a second effective catch before considering a boundary override", async () => {
+    const harness = await createHarness();
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "second-catch-boundary-override",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+    const submit = (intent: unknown) =>
+      harness.control.submitControllerIntent({
+        sessionBearer: opened.session.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+        intent,
+      });
+    for (let index = 0; index < 3; index += 1) {
+      await submit(
+        goalIntent({
+          operationId: `second-catch-goal-${index}`,
+          factId: `second-catch-goal-${index}`,
+          gameSideId: "side-b",
+          gameTimeMs: 100_000 + index * 100_000,
+        }),
+      );
+    }
+    expect(
+      await submit(flagCatchIntent("first-effective-catch", "first-effective-catch", "side-a")),
+    ).toMatchObject({ status: "accepted", projection: { overtime: true, phase: "in-progress" } });
+    const beforeSecondCatch = await harness.record.readActions();
+    expect(
+      await submit({
+        ...flagCatchIntent("second-effective-catch", "second-effective-catch", "side-a"),
+        gameTimeMs: 12_000,
+        override: flagCatchBoundaryOverride(12_000),
+      }),
+    ).toMatchObject({ status: "rejected" });
+    expect(await harness.record.readActions()).toHaveLength(beforeSecondCatch.length);
+
+    expect(
+      await submit(
+        correctionIntent(
+          "correct-first-effective-catch",
+          "correct-first-effective-catch-fact",
+          false,
+          "first-effective-catch",
+        ),
+      ),
+    ).toMatchObject({ status: "accepted" });
+    expect(
+      await submit(
+        flagCatchIntent("replacement-effective-catch", "replacement-effective-catch", "side-a"),
+      ),
+    ).toMatchObject({ status: "accepted" });
+    const beforeReinstatement = await harness.record.readActions();
+    expect(
+      await submit(
+        correctionIntent(
+          "reinstate-first-effective-catch",
+          "reinstate-first-effective-catch-fact",
+          true,
+          "first-effective-catch",
+        ),
+      ),
+    ).toMatchObject({ status: "rejected" });
+    expect(await harness.record.readActions()).toHaveLength(beforeReinstatement.length);
+  });
+
+  test("requires Head Referee order for close-play goal and catch and follows the chosen order", async () => {
+    const createClosePlayHarness = async (browserContext: string) => {
+      const harness = await createHarness();
+      const opened = await harness.control.openController({
+        qrCredential: harness.qrCredential,
+        browserContext,
+      });
+      if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+      return { harness, sessionBearer: opened.session.sessionBearer };
+    };
+    const closePlayGameTime = 1_200_000;
+    const relatedGameTime = closePlayGameTime - 500;
+
+    const afterOrder = await createClosePlayHarness("close-play-after");
+    const submitAfter = (intent: unknown) =>
+      afterOrder.harness.control.submitControllerIntent({
+        sessionBearer: afterOrder.sessionBearer,
+        eventGameId: afterOrder.harness.root.eventGameId,
+        intent,
+      });
+    await submitAfter(
+      goalIntent({
+        operationId: "close-play-before-1",
+        factId: "close-play-before-1",
+        gameSideId: "side-b",
+        gameTimeMs: 10_000,
+      }),
+    );
+    await submitAfter(
+      goalIntent({
+        operationId: "close-play-before-2",
+        factId: "close-play-before-2",
+        gameSideId: "side-b",
+        gameTimeMs: 20_000,
+      }),
+    );
+    await submitAfter(
+      goalIntent({
+        operationId: "close-play-goal",
+        factId: "close-play-goal",
+        gameSideId: "side-b",
+        gameTimeMs: relatedGameTime,
+      }),
+    );
+    expect(
+      await submitAfter(
+        flagCatchIntent(
+          "close-play-catch-unadjudicated",
+          "close-play-catch-unadjudicated",
+          "side-a",
+        ),
+      ),
+    ).toMatchObject({ status: "rejected" });
+    expect(await afterOrder.harness.record.readActions()).toHaveLength(3);
+    expect(
+      await submitAfter({
+        ...flagCatchIntent("close-play-catch-after", "close-play-catch-after", "side-a"),
+        sportingOrderAdjudication: {
+          relatedFactId: "close-play-goal",
+          relation: "after",
+        },
+        override: closePlayAdjudicationOverride(
+          closePlayGameTime,
+          "close-play-goal",
+          relatedGameTime,
+          "after",
+        ),
+      }),
+    ).toMatchObject({
+      status: "accepted",
+      projection: {
+        scoreByGameSide: { "side-a": 30, "side-b": 30 },
+        overtime: true,
+        overtimeTarget: 60,
+        winnerGameSideId: null,
+        phase: "in-progress",
+      },
+    });
+
+    const beforeOrder = await createClosePlayHarness("close-play-before");
+    const submitBefore = (intent: unknown) =>
+      beforeOrder.harness.control.submitControllerIntent({
+        sessionBearer: beforeOrder.sessionBearer,
+        eventGameId: beforeOrder.harness.root.eventGameId,
+        intent,
+      });
+    await submitBefore(
+      goalIntent({
+        operationId: "close-play-before-order-1",
+        factId: "close-play-before-order-1",
+        gameSideId: "side-b",
+        gameTimeMs: 10_000,
+      }),
+    );
+    await submitBefore(
+      goalIntent({
+        operationId: "close-play-before-order-2",
+        factId: "close-play-before-order-2",
+        gameSideId: "side-b",
+        gameTimeMs: 20_000,
+      }),
+    );
+    await submitBefore(
+      goalIntent({
+        operationId: "close-play-before-order-goal",
+        factId: "close-play-before-order-goal",
+        gameSideId: "side-b",
+        gameTimeMs: relatedGameTime,
+      }),
+    );
+    expect(
+      await submitBefore({
+        ...flagCatchIntent("close-play-catch-before", "close-play-catch-before", "side-a"),
+        sportingOrderAdjudication: {
+          relatedFactId: "close-play-before-order-goal",
+          relation: "before",
+        },
+        override: closePlayAdjudicationOverride(
+          closePlayGameTime,
+          "close-play-before-order-goal",
+          relatedGameTime,
+          "before",
+        ),
+      }),
+    ).toMatchObject({
+      status: "accepted",
+      projection: {
+        scoreByGameSide: { "side-a": 30, "side-b": 30 },
+        overtime: false,
+        overtimeTarget: null,
+        winnerGameSideId: "side-a",
+        phase: "finished",
+      },
+    });
+  });
+
+  test("selects one close goal across goals-first and catch-first replay permutations", async () => {
+    const catchGameTimeMs = 1_200_000;
+    const pairedGoalTimeMs = 1_199_500;
+    const unrelatedGoalTimeMs = 1_199_750;
+    const expectedOrder = [
+      "multi-close-catch",
+      "multi-close-unrelated-goal",
+      "multi-close-paired-goal",
+    ];
+
+    const goalsFirst = await createHarness();
+    const goalsFirstOpened = await goalsFirst.control.openController({
+      qrCredential: goalsFirst.qrCredential,
+      browserContext: "multi-close-goals-first",
+    });
+    if (goalsFirstOpened.status !== "opened") throw new Error("Expected the Controller to open.");
+    const submitGoalsFirst = (intent: unknown) =>
+      goalsFirst.control.submitControllerIntent({
+        sessionBearer: goalsFirstOpened.session.sessionBearer,
+        eventGameId: goalsFirst.root.eventGameId,
+        intent,
+      });
+    await submitGoalsFirst(
+      goalIntent({
+        operationId: "multi-close-paired-goal",
+        factId: "multi-close-paired-goal",
+        gameSideId: "side-b",
+        gameTimeMs: pairedGoalTimeMs,
+      }),
+    );
+    await submitGoalsFirst(
+      goalIntent({
+        operationId: "multi-close-unrelated-goal",
+        factId: "multi-close-unrelated-goal",
+        gameSideId: "side-b",
+        gameTimeMs: unrelatedGoalTimeMs,
+      }),
+    );
+    expect(
+      await submitGoalsFirst({
+        ...flagCatchIntent("multi-close-ambiguous", "multi-close-ambiguous", "side-a"),
+        gameTimeMs: catchGameTimeMs,
+      }),
+    ).toMatchObject({ status: "rejected" });
+    const goalsFirstResult = await submitGoalsFirst({
+      ...flagCatchIntent("multi-close-catch", "multi-close-catch", "side-a"),
+      sportingOrderAdjudication: {
+        relatedFactId: "multi-close-paired-goal",
+        relation: "before",
+      },
+      override: closePlayAdjudicationOverride(
+        catchGameTimeMs,
+        "multi-close-paired-goal",
+        pairedGoalTimeMs,
+        "before",
+      ),
+    });
+    expect(goalsFirstResult).toMatchObject({
+      status: "accepted",
+      projection: {
+        scoreByGameSide: { "side-a": 30, "side-b": 20 },
+        overtime: false,
+        overtimeTarget: null,
+        winnerGameSideId: "side-a",
+        phase: "finished",
+      },
+    });
+    if (
+      goalsFirstResult.status !== "accepted" ||
+      goalsFirstResult.projection?.gameFacts === undefined
+    ) {
+      throw new Error("Expected the goals-first projection.");
+    }
+    expect(
+      goalsFirstResult.projection.gameFacts
+        .filter((fact) => fact.effective)
+        .map((fact) => fact.factId),
+    ).toEqual(expectedOrder);
+
+    const catchFirst = await createHarness();
+    const catchFirstOpened = await catchFirst.control.openController({
+      qrCredential: catchFirst.qrCredential,
+      browserContext: "multi-close-catch-first-replay",
+    });
+    if (catchFirstOpened.status !== "opened") throw new Error("Expected the Controller to open.");
+    const catchFirstReplay = await catchFirst.control.replayControllerActions({
+      sessionBearer: catchFirstOpened.session.sessionBearer,
+      eventGameId: catchFirst.root.eventGameId,
+      batchId: "multi-close-catch-first-batch",
+      replicaGeneration: "multi-close-catch-first-generation",
+      expectedGrantSessionId: catchFirstOpened.session.grantSessionId,
+      expectedGrantVersion: catchFirstOpened.session.grantVersion,
+      actions: [
+        {
+          eventGameId: catchFirst.root.eventGameId,
+          intent: flagCatchIntent("multi-close-catch", "multi-close-catch", "side-a"),
+          causalPredecessorIds: [],
+        },
+        {
+          eventGameId: catchFirst.root.eventGameId,
+          intent: {
+            ...goalIntent({
+              operationId: "multi-close-paired-goal",
+              factId: "multi-close-paired-goal",
+              gameSideId: "side-b",
+              gameTimeMs: pairedGoalTimeMs,
+            }),
+            sportingOrderAdjudication: {
+              relatedFactId: "multi-close-catch",
+              relation: "after",
+            },
+            override: closePlayAdjudicationOverride(
+              pairedGoalTimeMs,
+              "multi-close-catch",
+              catchGameTimeMs,
+              "after",
+            ),
+            occurrence: { clientOriginAtMs: catchGameTimeMs + 1, source: "offline" as const },
+          },
+          causalPredecessorIds: [],
+        },
+        {
+          eventGameId: catchFirst.root.eventGameId,
+          intent: {
+            ...goalIntent({
+              operationId: "multi-close-unrelated-goal",
+              factId: "multi-close-unrelated-goal",
+              gameSideId: "side-b",
+              gameTimeMs: unrelatedGoalTimeMs,
+            }),
+            occurrence: { clientOriginAtMs: catchGameTimeMs + 2, source: "offline" as const },
+          },
+          causalPredecessorIds: [],
+        },
+      ],
+    });
+    expect(catchFirstReplay).toMatchObject({
+      outcomes: [
+        { operationId: "multi-close-catch", status: "accepted" },
+        { operationId: "multi-close-paired-goal", status: "accepted" },
+        { operationId: "multi-close-unrelated-goal", status: "accepted" },
+      ],
+      projection: {
+        scoreByGameSide: { "side-a": 30, "side-b": 20 },
+        overtime: false,
+        overtimeTarget: null,
+        winnerGameSideId: "side-a",
+        phase: "finished",
+      },
+    });
+    expect(
+      catchFirstReplay.projection?.gameFacts
+        ?.filter((fact) => fact.effective)
+        .map((fact) => fact.factId),
+    ).toEqual(expectedOrder);
+  });
+
+  test("rejects unknown, non-close, and conflicting explicit close-play pair evidence", async () => {
+    const harness = await createHarness();
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "multi-close-invalid-pair-evidence",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+    const submit = (intent: unknown) =>
+      harness.control.submitControllerIntent({
+        sessionBearer: opened.session.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+        intent,
+      });
+    await submit(
+      goalIntent({
+        operationId: "invalid-pair-close-goal",
+        factId: "invalid-pair-close-goal",
+        gameSideId: "side-b",
+        gameTimeMs: 1_199_500,
+      }),
+    );
+    await submit(
+      goalIntent({
+        operationId: "invalid-pair-far-goal",
+        factId: "invalid-pair-far-goal",
+        gameSideId: "side-b",
+        gameTimeMs: 1_100_000,
+      }),
+    );
+    const invalidCatch = (
+      operationId: string,
+      relatedFactId: string,
+      relatedGameTimeMs: number,
+    ) => ({
+      ...flagCatchIntent(operationId, operationId, "side-a"),
+      sportingOrderAdjudication: { relatedFactId, relation: "before" as const },
+      override: closePlayAdjudicationOverride(
+        1_200_000,
+        relatedFactId,
+        relatedGameTimeMs,
+        "before",
+      ),
+    });
+    expect(
+      await submit(invalidCatch("invalid-pair-unknown", "unknown-goal", 1_199_500)),
+    ).toMatchObject({
+      status: "rejected",
+    });
+    expect(
+      await submit(invalidCatch("invalid-pair-non-close", "invalid-pair-far-goal", 1_100_000)),
+    ).toMatchObject({ status: "rejected" });
+    expect(
+      await submit(
+        invalidCatch("invalid-pair-accepted-catch", "invalid-pair-close-goal", 1_199_500),
+      ),
+    ).toMatchObject({ status: "accepted" });
+    expect(
+      await submit({
+        ...goalIntent({
+          operationId: "invalid-pair-conflicting-goal",
+          factId: "invalid-pair-conflicting-goal",
+          gameSideId: "side-b",
+          gameTimeMs: 1_199_750,
+        }),
+        sportingOrderAdjudication: {
+          relatedFactId: "invalid-pair-accepted-catch",
+          relation: "before",
+        },
+        override: closePlayAdjudicationOverride(
+          1_199_750,
+          "invalid-pair-accepted-catch",
+          1_200_000,
+          "before",
+        ),
+      }),
+    ).toMatchObject({ status: "rejected" });
+    expect(await harness.record.readActions()).toHaveLength(3);
+  });
+
+  test("swaps only an adjudicated pair around unrelated endpoint facts across replay", async () => {
+    const closePlayGameTime = 1_200_000;
+    const relatedGameTime = closePlayGameTime - 500;
+    const submitScenario = async (unrelatedGameTime: number, browserContext: string) => {
+      const harness = await createHarness();
+      const opened = await harness.control.openController({
+        qrCredential: harness.qrCredential,
+        browserContext,
+      });
+      if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+      const submit = (intent: unknown) =>
+        harness.control.submitControllerIntent({
+          sessionBearer: opened.session.sessionBearer,
+          eventGameId: harness.root.eventGameId,
+          intent,
+        });
+      await submit(
+        goalIntent({
+          operationId: `${browserContext}-goal`,
+          factId: `${browserContext}-goal`,
+          gameSideId: "side-b",
+          gameTimeMs: relatedGameTime,
+        }),
+      );
+      await submit(substantiveIntent(`${browserContext}-card`, "card", unrelatedGameTime));
+      const caught = await submit({
+        ...flagCatchIntent(`${browserContext}-catch`, `${browserContext}-catch`, "side-a"),
+        sportingOrderAdjudication: {
+          relatedFactId: `${browserContext}-goal`,
+          relation: "before",
+        },
+        override: closePlayAdjudicationOverride(
+          closePlayGameTime,
+          `${browserContext}-goal`,
+          relatedGameTime,
+          "before",
+        ),
+      });
+      expect(caught).toMatchObject({
+        projection: { phase: "finished", winnerGameSideId: "side-a" },
+      });
+      return caught;
+    };
+
+    for (const [unrelatedGameTime, browserContext] of [
+      [relatedGameTime, "close-play-lower-endpoint"],
+      [closePlayGameTime, "close-play-upper-endpoint"],
+    ] as const) {
+      const caught = await submitScenario(unrelatedGameTime, browserContext);
+      const expectedFactTypes =
+        unrelatedGameTime === relatedGameTime
+          ? (["card", "flag-catch", "goal"] as const)
+          : (["flag-catch", "card", "goal"] as const);
+      expect(caught).toMatchObject({
+        projection: {
+          gameFacts: expectedFactTypes.map((factType) =>
+            expect.objectContaining({
+              factType,
+              gameTimeMs:
+                factType === "card"
+                  ? unrelatedGameTime
+                  : factType === "goal"
+                    ? relatedGameTime
+                    : closePlayGameTime,
+            }),
+          ),
+        },
+      });
+    }
+
+    const replayHarness = await createHarness();
+    const replayOpened = await replayHarness.control.openController({
+      qrCredential: replayHarness.qrCredential,
+      browserContext: "close-play-reordered-replay",
+    });
+    if (replayOpened.status !== "opened") throw new Error("Expected the Controller to open.");
+    const submitReplaySetup = (intent: unknown) =>
+      replayHarness.control.submitControllerIntent({
+        sessionBearer: replayOpened.session.sessionBearer,
+        eventGameId: replayHarness.root.eventGameId,
+        intent,
+      });
+    await submitReplaySetup(substantiveIntent("close-play-replay-card", "card", closePlayGameTime));
+    await submitReplaySetup(
+      goalIntent({
+        operationId: "close-play-replay-goal",
+        factId: "close-play-replay-goal",
+        gameSideId: "side-b",
+        gameTimeMs: relatedGameTime,
+      }),
+    );
+    const replay = await replayHarness.control.replayControllerActions({
+      sessionBearer: replayOpened.session.sessionBearer,
+      eventGameId: replayHarness.root.eventGameId,
+      batchId: "close-play-reordered-batch",
+      replicaGeneration: "close-play-reordered-generation",
+      expectedGrantSessionId: replayOpened.session.grantSessionId,
+      expectedGrantVersion: replayOpened.session.grantVersion,
+      actions: [
+        {
+          eventGameId: replayHarness.root.eventGameId,
+          intent: {
+            ...flagCatchIntent("close-play-replay-catch", "close-play-replay-catch", "side-a"),
+            sportingOrderAdjudication: {
+              relatedFactId: "close-play-replay-goal",
+              relation: "before",
+            },
+            override: closePlayAdjudicationOverride(
+              closePlayGameTime,
+              "close-play-replay-goal",
+              relatedGameTime,
+              "before",
+            ),
+            occurrence: { clientOriginAtMs: closePlayGameTime, source: "offline" as const },
+          },
+          causalPredecessorIds: [],
+        },
+      ],
+    });
+    expect(replay).toMatchObject({
+      outcomes: [{ operationId: "close-play-replay-catch", status: "accepted" }],
+      projection: {
+        phase: "finished",
+        winnerGameSideId: "side-a",
+        gameFacts: [
+          expect.objectContaining({ factType: "flag-catch", gameTimeMs: closePlayGameTime }),
+          expect.objectContaining({ factType: "card", gameTimeMs: closePlayGameTime }),
+          expect.objectContaining({ factType: "goal", gameTimeMs: relatedGameTime }),
+        ],
+      },
+    });
+    const refreshed = await replayHarness.control.refreshController({
+      sessionBearer: replayOpened.session.sessionBearer,
+      eventGameId: replayHarness.root.eventGameId,
+    });
+    expect(refreshed).toMatchObject({
+      projection: {
+        gameFacts: [
+          expect.objectContaining({ factType: "flag-catch", gameTimeMs: closePlayGameTime }),
+          expect.objectContaining({ factType: "card", gameTimeMs: closePlayGameTime }),
+          expect.objectContaining({ factType: "goal", gameTimeMs: relatedGameTime }),
+        ],
+      },
+    });
+  });
+
+  test("does not move a surviving endpoint across unrelated facts after correction and reinstatement", async () => {
+    const harness = await createHarness();
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "close-play-corrected-endpoint-order",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+    const submit = (intent: unknown) =>
+      harness.control.submitControllerIntent({
+        sessionBearer: opened.session.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+        intent,
+      });
+    await submit(
+      goalIntent({
+        operationId: "corrected-endpoint-goal",
+        factId: "corrected-endpoint-goal",
+        gameSideId: "side-b",
+        gameTimeMs: 1_199_500,
+      }),
+    );
+    await submit(substantiveIntent("corrected-endpoint-card", "card", 1_200_000));
+    expect(
+      await submit({
+        ...flagCatchIntent("corrected-endpoint-catch", "corrected-endpoint-catch", "side-a"),
+        gameTimeMs: 1_200_000,
+        sportingOrderAdjudication: {
+          relatedFactId: "corrected-endpoint-goal",
+          relation: "before",
+        },
+        override: closePlayAdjudicationOverride(
+          1_200_000,
+          "corrected-endpoint-goal",
+          1_199_500,
+          "before",
+        ),
+      }),
+    ).toMatchObject({ projection: { phase: "finished", winnerGameSideId: "side-a" } });
+
+    const corrected = await submit(
+      correctionIntent(
+        "corrected-endpoint-disable-catch",
+        "corrected-endpoint-disable-catch",
+        false,
+        "corrected-endpoint-catch",
+      ),
+    );
+    expect(corrected).toMatchObject({
+      projection: {
+        scoreByGameSide: { "side-a": 0, "side-b": 10 },
+        phase: "in-progress",
+        winnerGameSideId: null,
+      },
+    });
+    if (corrected.status !== "accepted" || corrected.projection === null) {
+      throw new Error("Expected the corrected projection.");
+    }
+    if (corrected.projection.gameFacts === undefined) {
+      throw new Error("Expected corrected Game Facts.");
+    }
+    expect(
+      corrected.projection.gameFacts.filter((fact) => fact.effective).map((fact) => fact.factId),
+    ).toEqual(["corrected-endpoint-goal", "fact-corrected-endpoint-card"]);
+
+    const reinstated = await submit(
+      correctionIntent(
+        "corrected-endpoint-reinstate-catch",
+        "corrected-endpoint-reinstate-catch",
+        true,
+        "corrected-endpoint-catch",
+      ),
+    );
+    expect(reinstated).toMatchObject({
+      projection: {
+        scoreByGameSide: { "side-a": 30, "side-b": 10 },
+        phase: "finished",
+        winnerGameSideId: "side-a",
+      },
+    });
+    if (reinstated.status !== "accepted" || reinstated.projection === null) {
+      throw new Error("Expected the reinstated projection.");
+    }
+    if (reinstated.projection.gameFacts === undefined) {
+      throw new Error("Expected reinstated Game Facts.");
+    }
+    expect(
+      reinstated.projection.gameFacts.filter((fact) => fact.effective).map((fact) => fact.factId),
+    ).toEqual([
+      "corrected-endpoint-catch",
+      "fact-corrected-endpoint-card",
+      "corrected-endpoint-goal",
+    ]);
+  });
+
+  test("rejects a catch reinstatement that creates an unresolved close pair", async () => {
+    const harness = await createHarness();
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "close-play-correction-reinstatement",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+    const submit = (intent: unknown) =>
+      harness.control.submitControllerIntent({
+        sessionBearer: opened.session.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+        intent,
+      });
+    await submit(flagCatchIntent("unpaired-catch", "unpaired-catch-fact", "side-a"));
+    expect(
+      await submit(
+        correctionIntent("disable-catch", "disable-catch-fact", false, "unpaired-catch-fact"),
+      ),
+    ).toMatchObject({ status: "accepted", projection: { catch: null, phase: "in-progress" } });
+    expect(
+      await submit(
+        goalIntent({
+          operationId: "close-goal-after-correction",
+          factId: "close-goal-after-correction-fact",
+          gameSideId: "side-b",
+          gameTimeMs: 1_199_500,
+        }),
+      ),
+    ).toMatchObject({ status: "accepted", projection: { catch: null } });
+    const beforeReinstatement = await harness.record.readActions();
+    expect(
+      await submit(
+        correctionIntent(
+          "reinstate-unpaired-catch",
+          "reinstate-unpaired-catch-fact",
+          true,
+          "unpaired-catch-fact",
+        ),
+      ),
+    ).toMatchObject({ status: "rejected" });
+    expect(await harness.record.readActions()).toHaveLength(beforeReinstatement.length);
+    expect(
+      await harness.control.refreshController({
+        sessionBearer: opened.session.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+      }),
+    ).toMatchObject({ projection: { catch: null, phase: "in-progress" } });
+  });
+
+  test("accepts an equal-time late goal only with explicit paired sporting order", async () => {
+    const harness = await createHarness();
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "close-play-equal-time-late-goal",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+    const submit = (intent: unknown) =>
+      harness.control.submitControllerIntent({
+        sessionBearer: opened.session.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+        intent,
+      });
+    await submit(flagCatchIntent("equal-time-catch", "equal-time-catch-fact", "side-a"));
+    expect(
+      await submit(
+        goalIntent({
+          operationId: "equal-time-unrelated-late-goal",
+          factId: "equal-time-unrelated-late-goal-fact",
+          gameSideId: "side-b",
+          gameTimeMs: 1_200_000,
+        }),
+      ),
+    ).toMatchObject({ status: "rejected" });
+    const accepted = await submit({
+      ...goalIntent({
+        operationId: "equal-time-adjudicated-late-goal",
+        factId: "equal-time-adjudicated-late-goal-fact",
+        gameSideId: "side-b",
+        gameTimeMs: 1_200_000,
+      }),
+      sportingOrderAdjudication: {
+        relatedFactId: "equal-time-catch-fact",
+        relation: "before",
+      },
+      override: closePlayAdjudicationOverride(
+        1_200_000,
+        "equal-time-catch-fact",
+        1_200_000,
+        "before",
+      ),
+      occurrence: { clientOriginAtMs: 1_201_000, source: "offline" as const },
+    });
+    expect(accepted).toMatchObject({
+      status: "accepted",
+      projection: {
+        phase: "finished",
+        winnerGameSideId: "side-a",
+        gameFacts: [
+          expect.objectContaining({
+            factId: "equal-time-adjudicated-late-goal-fact",
+            gameTimeMs: 1_200_000,
+          }),
+          expect.objectContaining({ factId: "equal-time-catch-fact", gameTimeMs: 1_200_000 }),
+        ],
+      },
     });
   });
 
@@ -2323,6 +4290,7 @@ async function createHarness(
     scopeStatus?: "empty" | "conflict";
     controlClock?: () => number;
     sessionResolution?: ControlGrantSessionResolution;
+    acceptanceLimits?: AcceptanceLimits;
   } = {},
 ) {
   const root = createRoot(overrides.eventGameId ?? "game-live-control");
@@ -2384,6 +4352,7 @@ async function createHarness(
         root,
         action,
       ),
+    limits: overrides.acceptanceLimits,
   });
   const control = createLiveEventGameControl({
     resolveEventGameRecord: async (eventGameId) =>
@@ -2453,6 +4422,73 @@ function goalIntent(
   };
 }
 
+function flagCatchIntent(operationId: string, factId: string, gameSideId: string) {
+  return {
+    version: LIVE_EVENT_CONTROL_INTENT_VERSION,
+    type: "record-flag-catch" as const,
+    operationId,
+    factId,
+    gameSideId,
+    gameTimeMs: 1_200_000,
+    occurrence: { clientOriginAtMs: 1_200_000 },
+  };
+}
+
+function closePlayAdjudicationOverride(
+  gameTimeMs: number,
+  relatedFactId: string,
+  relatedGameTimeMs: number,
+  relation: "before" | "after",
+) {
+  return {
+    guardrail: "sporting-order-adjudication" as const,
+    direction: "head-referee-adjudicated-sporting-order" as const,
+    confirmation: "head-referee-confirmed" as const,
+    authorityReference: "head-referee",
+    gameTimeMs,
+    beforeValue: { candidateGameTimeMs: gameTimeMs, relatedFactId, relatedGameTimeMs },
+    afterValue: { relation, sportingOrder: "explicit-pair-order" },
+    reason: "head-referee-direction" as const,
+  };
+}
+
+function flagCatchBoundaryOverride(gameTimeMs: number, running = false) {
+  return {
+    guardrail: "flag-catch-requires-seeker-release-and-stopped-play" as const,
+    direction: "head-referee-directed-flag-catch-boundary" as const,
+    confirmation: "head-referee-confirmed" as const,
+    authorityReference: "head-referee",
+    gameTimeMs,
+    beforeValue: { seekerReleased: gameTimeMs >= 1_200_000, running },
+    afterValue: { flagCatch: "accepted" },
+    reason: "head-referee-direction" as const,
+  };
+}
+
+function concessionIntent(operationId: string, factId: string, gameSideId: string) {
+  return {
+    version: LIVE_EVENT_CONTROL_INTENT_VERSION,
+    type: "record-concession" as const,
+    operationId,
+    factId,
+    gameSideId,
+    gameTimeMs: 1_400_000,
+    occurrence: { clientOriginAtMs: 1_400_000 },
+  };
+}
+
+function forfeitIntent(operationId: string, factId: string, gameSideId: string) {
+  return {
+    version: LIVE_EVENT_CONTROL_INTENT_VERSION,
+    type: "record-forfeit" as const,
+    operationId,
+    factId,
+    gameSideId,
+    gameTimeMs: 30_000,
+    occurrence: { clientOriginAtMs: 30_000 },
+  };
+}
+
 function correctionIntent(
   operationId: string,
   factId: string,
@@ -2514,6 +4550,7 @@ function clockAdjustmentIntent(operationId: string, adjustmentMs: number) {
 function substantiveIntent(
   operationId: string,
   trigger: "card" | "timeout" | "suspension" | "result" | "heat-stoppage",
+  gameTimeMs = 0,
 ) {
   return {
     version: LIVE_EVENT_CONTROL_INTENT_VERSION,
@@ -2521,7 +4558,7 @@ function substantiveIntent(
     trigger,
     operationId,
     factId: `fact-${operationId}`,
-    gameTimeMs: 0,
+    gameTimeMs,
     occurrence: { clientOriginAtMs: null },
   };
 }

--- a/src/lib/live-event-game-control.ts
+++ b/src/lib/live-event-game-control.ts
@@ -8,6 +8,8 @@ import {
   canonicalizeJson,
   createControlActionCodecRegistry,
   createDefaultControlActionCodecs,
+  materializeControlAction,
+  prepareControlAction,
   rebuildControlActionHistory,
 } from "@/lib/event-game-actions";
 import { parseJsonValue, validateOverride } from "@/lib/event-game-action-codecs";
@@ -16,6 +18,7 @@ import {
   CLOCK_AUTHORITY_VERSION,
   deriveClockAuthority,
   projectClockBaseline,
+  SEEKER_RELEASE_MS,
   validateClockAuthorityAction,
   type ClockAuthorityAction,
   type ClockProjection,
@@ -35,6 +38,12 @@ import {
 
 export const LIVE_EVENT_CONTROL_INTENT_VERSION = "live-event-control-intent-v1" as const;
 export const LIVE_EVENT_IQA_INTERPRETER_VERSION = "live-event-iqa-v1" as const;
+export const CLOSE_PLAY_ADJUDICATION_WINDOW_MS = 1_000;
+
+export type SportingOrderAdjudication = {
+  relatedFactId: string;
+  relation: "before" | "after";
+};
 
 type ControllerIntentBase = {
   version: typeof LIVE_EVENT_CONTROL_INTENT_VERSION;
@@ -42,6 +51,8 @@ type ControllerIntentBase = {
   factId: string;
   gameTimeMs: number;
   sportingOrder?: number;
+  sportingOrderAdjudication?: SportingOrderAdjudication;
+  sportingOrderOverride?: OfficialOverrideMetadata;
   occurrence: {
     clientOriginAtMs: number | null;
     source?: "online" | "offline";
@@ -54,6 +65,13 @@ export type LiveEventControllerIntent =
   | (ControllerIntentBase & {
       type: "record-goal";
       gameSideId: string;
+    })
+  | (ControllerIntentBase & {
+      type: "record-flag-catch" | "record-concession" | "record-forfeit";
+      gameSideId: string;
+    })
+  | (ControllerIntentBase & {
+      type: "record-double-forfeit";
     })
   | (ControllerIntentBase & {
       type: "correct-fact";
@@ -81,7 +99,17 @@ export type LiveEventControllerIntent =
     })
   | (ControllerIntentBase & {
       type: "substantive";
-      trigger: "card" | "timeout" | "suspension" | "result" | "heat-stoppage";
+      trigger:
+        | "card"
+        | "timeout"
+        | "suspension"
+        | "result"
+        | "heat-stoppage"
+        | "flag-catch"
+        | "concession"
+        | "forfeit"
+        | "double-forfeit";
+      gameSideId?: string;
       heatAction?: "start" | "end" | "skip-required" | "extend-permitted";
     })
   | (ControllerIntentBase & {
@@ -140,6 +168,10 @@ export type LiveEventGameDerivedState = {
   stoppage: LiveStoppageState;
   heat: LiveHeatState;
   result: LiveResultState;
+  overtime: boolean;
+  overtimeTarget: number | null;
+  winnerGameSideId: string | null;
+  catch: LiveCatchState | null;
   gameFacts: readonly ControllerGameFact[];
 };
 
@@ -164,6 +196,14 @@ export type LiveResultState = {
   factId: string;
   data: ActionJsonValue;
 } | null;
+
+export type LiveCatchState = {
+  factId: string;
+  catchingGameSideId: string;
+  nonCatchingGameSideId: string;
+  gameTimeMs: number;
+  targetScore: number | null;
+};
 
 export type ControllerGameFact = {
   factId: string;
@@ -192,6 +232,12 @@ export type ControllerProjection = {
   stoppage?: LiveStoppageState;
   heat?: LiveHeatState;
   result?: LiveResultState;
+  overtime?: boolean;
+  overtimeTarget?: number | null;
+  /** Alias retained for Controller clients that call the IQA target a target score. */
+  targetScore?: number | null;
+  winnerGameSideId?: string | null;
+  catch?: LiveCatchState | null;
   gameFacts?: readonly ControllerGameFact[];
   guardrails?: readonly LiveEventGuardrailExplanation[];
   commencement: ControllerCommencement;
@@ -316,6 +362,10 @@ export function parseLiveEventControllerIntent(
   }
   if (
     value.type !== "record-goal" &&
+    value.type !== "record-flag-catch" &&
+    value.type !== "record-concession" &&
+    value.type !== "record-forfeit" &&
+    value.type !== "record-double-forfeit" &&
     value.type !== "correct-fact" &&
     value.type !== "correction" &&
     value.type !== "clock" &&
@@ -364,9 +414,39 @@ export function parseLiveEventControllerIntent(
     if (!parsedSportingOrder.ok) return invalid(parsedSportingOrder.error);
     sportingOrder = parsedSportingOrder.value;
   }
+  let sportingOrderAdjudication: SportingOrderAdjudication | undefined;
+  if (value.sportingOrderAdjudication !== undefined) {
+    if (!isRecord(value.sportingOrderAdjudication)) {
+      return invalid("sportingOrderAdjudication must be an object.");
+    }
+    const relatedFactId = validateOpaqueIdentifier(
+      value.sportingOrderAdjudication.relatedFactId,
+      "sportingOrderAdjudication.relatedFactId",
+    );
+    if (!relatedFactId.ok) return invalid(relatedFactId.error);
+    if (
+      value.sportingOrderAdjudication.relation !== "before" &&
+      value.sportingOrderAdjudication.relation !== "after"
+    ) {
+      return invalid("sportingOrderAdjudication.relation is unsupported.");
+    }
+    sportingOrderAdjudication = {
+      relatedFactId: relatedFactId.value,
+      relation: value.sportingOrderAdjudication.relation,
+    };
+  }
 
   let gameSideId: string | undefined;
-  if (value.type === "record-goal") {
+  const requiresGameSide =
+    value.type === "record-goal" ||
+    value.type === "record-flag-catch" ||
+    value.type === "record-concession" ||
+    value.type === "record-forfeit" ||
+    (value.type === "substantive" &&
+      (value.trigger === "flag-catch" ||
+        value.trigger === "concession" ||
+        value.trigger === "forfeit"));
+  if (requiresGameSide) {
     const parsedSide = validateOpaqueIdentifier(value.gameSideId, "gameSideId");
     if (!parsedSide.ok) return invalid(parsedSide.error);
     gameSideId = parsedSide.value;
@@ -433,7 +513,17 @@ export function parseLiveEventControllerIntent(
       clockGeneration = generation.value;
     }
   }
-  let trigger: "card" | "timeout" | "suspension" | "result" | "heat-stoppage" | undefined;
+  let trigger:
+    | "card"
+    | "timeout"
+    | "suspension"
+    | "result"
+    | "heat-stoppage"
+    | "flag-catch"
+    | "concession"
+    | "forfeit"
+    | "double-forfeit"
+    | undefined;
   let heatAction: "start" | "end" | "skip-required" | "extend-permitted" | undefined;
   if (value.type === "substantive") {
     if (
@@ -441,7 +531,11 @@ export function parseLiveEventControllerIntent(
       value.trigger !== "timeout" &&
       value.trigger !== "suspension" &&
       value.trigger !== "result" &&
-      value.trigger !== "heat-stoppage"
+      value.trigger !== "heat-stoppage" &&
+      value.trigger !== "flag-catch" &&
+      value.trigger !== "concession" &&
+      value.trigger !== "forfeit" &&
+      value.trigger !== "double-forfeit"
     )
       return invalid("substantive trigger is unsupported.");
     trigger = value.trigger;
@@ -483,6 +577,18 @@ export function parseLiveEventControllerIntent(
   }
   const overrideResult = validateOverride(value.override);
   if (!overrideResult.ok) return invalid(overrideResult.error);
+  const sportingOrderOverrideResult = validateOverride(value.sportingOrderOverride);
+  if (!sportingOrderOverrideResult.ok) return invalid(sportingOrderOverrideResult.error);
+  if (
+    sportingOrderAdjudication !== undefined &&
+    normalizedType !== "record-goal" &&
+    normalizedType !== "record-flag-catch"
+  ) {
+    return invalid("Sporting-order adjudication is only valid for a goal or flag catch.");
+  }
+  if (sportingOrderOverrideResult.value !== undefined && sportingOrderAdjudication === undefined) {
+    return invalid("sportingOrderOverride requires sportingOrderAdjudication.");
+  }
   return {
     ok: true,
     value: {
@@ -493,6 +599,10 @@ export function parseLiveEventControllerIntent(
       gameTimeMs: gameTimeMs.value,
       occurrence: { clientOriginAtMs, ...(source === undefined ? {} : { source }) },
       ...(sportingOrder === undefined ? {} : { sportingOrder }),
+      ...(sportingOrderAdjudication === undefined ? {} : { sportingOrderAdjudication }),
+      ...(sportingOrderOverrideResult.value === undefined
+        ? {}
+        : { sportingOrderOverride: sportingOrderOverrideResult.value }),
       ...(targetFactId === undefined ? {} : { targetFactId }),
       ...(effective === undefined ? {} : { effective }),
       ...(gameSideId === undefined ? {} : { gameSideId }),
@@ -511,7 +621,7 @@ export function parseLiveEventControllerIntent(
 
 export function explainLiveEventGuardrail(intent: {
   type: LiveEventControllerIntent["type"];
-  trigger?: "card" | "timeout" | "suspension" | "result" | "heat-stoppage";
+  trigger?: Extract<LiveEventControllerIntent, { type: "substantive" }>["trigger"];
   gameTimeMs?: number;
   sportingOrder?: number;
 }): LiveEventGuardrailExplanation {
@@ -541,6 +651,17 @@ export function explainLiveEventGuardrail(intent: {
       normalBehavior: "A suspension is recorded as a normal Controller action.",
       overrideAllowed: false,
       fixedReason: null,
+    };
+  }
+  if (
+    intent.type === "record-flag-catch" ||
+    (intent.type === "substantive" && intent.trigger === "flag-catch")
+  ) {
+    return {
+      guardrail: "flag-catch-requires-seeker-release-and-stopped-play",
+      normalBehavior: "A flag catch is recorded after seeker release and while play is stopped.",
+      overrideAllowed: true,
+      fixedReason: "head-referee-direction",
     };
   }
   if (intent.type === "substantive" && intent.trigger === "heat-stoppage") {
@@ -969,7 +1090,16 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
     if (commenced.status === "rejected") return retryableAction(parsed.value.operationId);
     const activeRoot = commenced.root;
 
-    if (parsed.value.type === "record-goal") {
+    if (
+      parsed.value.type === "record-goal" ||
+      parsed.value.type === "record-flag-catch" ||
+      parsed.value.type === "record-concession" ||
+      parsed.value.type === "record-forfeit" ||
+      (parsed.value.type === "substantive" &&
+        (parsed.value.trigger === "flag-catch" ||
+          parsed.value.trigger === "concession" ||
+          parsed.value.trigger === "forfeit"))
+    ) {
       const gameSideId = parsed.value.gameSideId;
       if (!activeRoot.gameSides.some((side) => side.id === gameSideId)) {
         return rejectedAction(parsed.value.operationId);
@@ -987,7 +1117,16 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
     if (
       effectiveStateBefore.phase === "finished" &&
       existingAction === undefined &&
-      parsed.value.type !== "correct-fact"
+      parsed.value.type !== "correct-fact" &&
+      !allowsLatePreCatchGoal(parsed.value, effectiveStateBefore)
+    ) {
+      return rejectedAction(parsed.value.operationId);
+    }
+    if (
+      effectiveStateBefore.overtime &&
+      parsed.value.type === "substantive" &&
+      parsed.value.trigger === "result" &&
+      effectiveStateBefore.winnerGameSideId === null
     ) {
       return rejectedAction(parsed.value.operationId);
     }
@@ -1026,7 +1165,7 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
           : previousClockStartMs
         : null;
     const factType = controllerFactType(parsed.value);
-    const gameSideId = parsed.value.type === "record-goal" ? parsed.value.gameSideId : null;
+    const gameSideId = controllerGameSideId(parsed.value);
     const isCorrection = parsed.value.type === "correct-fact";
     let override: OfficialOverrideMetadata | undefined;
     try {
@@ -1060,21 +1199,67 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
                   ? {
                       points: 10,
                       sportingOrder: parsed.value.sportingOrder ?? parsed.value.gameTimeMs,
+                      ...(parsed.value.sportingOrderAdjudication === undefined
+                        ? {}
+                        : { sportingOrderAdjudication: parsed.value.sportingOrderAdjudication }),
+                      ...(parsed.value.sportingOrderOverride === undefined
+                        ? {}
+                        : { sportingOrderOverride: parsed.value.sportingOrderOverride }),
                     }
-                  : clockData.value !== null
+                  : isScoringIntent(parsed.value)
                     ? {
-                        ...clockData.value,
+                        points:
+                          parsed.value.type === "record-flag-catch" ||
+                          (parsed.value.type === "substantive" &&
+                            parsed.value.trigger === "flag-catch")
+                            ? 30
+                            : 0,
                         sportingOrder: parsed.value.sportingOrder ?? parsed.value.gameTimeMs,
+                        ...(parsed.value.sportingOrderAdjudication === undefined
+                          ? {}
+                          : { sportingOrderAdjudication: parsed.value.sportingOrderAdjudication }),
+                        ...(parsed.value.sportingOrderOverride === undefined
+                          ? {}
+                          : { sportingOrderOverride: parsed.value.sportingOrderOverride }),
+                        ...(parsed.value.type === "substantive"
+                          ? { trigger: parsed.value.trigger }
+                          : {}),
                       }
-                    : parsed.value.type === "substantive"
+                    : isResultIntent(parsed.value)
                       ? {
-                          trigger: parsed.value.trigger,
+                          resultKind: controllerFactType(parsed.value),
                           sportingOrder: parsed.value.sportingOrder ?? parsed.value.gameTimeMs,
-                          ...(parsed.value.heatAction === undefined
+                          ...(parsed.value.sportingOrderAdjudication === undefined
                             ? {}
-                            : { heatAction: parsed.value.heatAction }),
+                            : {
+                                sportingOrderAdjudication: parsed.value.sportingOrderAdjudication,
+                              }),
                         }
-                      : null,
+                      : clockData.value !== null
+                        ? {
+                            ...clockData.value,
+                            sportingOrder: parsed.value.sportingOrder ?? parsed.value.gameTimeMs,
+                            ...(parsed.value.sportingOrderAdjudication === undefined
+                              ? {}
+                              : {
+                                  sportingOrderAdjudication: parsed.value.sportingOrderAdjudication,
+                                }),
+                          }
+                        : parsed.value.type === "substantive"
+                          ? {
+                              trigger: parsed.value.trigger,
+                              sportingOrder: parsed.value.sportingOrder ?? parsed.value.gameTimeMs,
+                              ...(parsed.value.sportingOrderAdjudication === undefined
+                                ? {}
+                                : {
+                                    sportingOrderAdjudication:
+                                      parsed.value.sportingOrderAdjudication,
+                                  }),
+                              ...(parsed.value.heatAction === undefined
+                                ? {}
+                                : { heatAction: parsed.value.heatAction }),
+                            }
+                          : null,
             },
       causalPredecessorIds: [...(input.causalPredecessorIds ?? [])],
       occurrence: {
@@ -1090,28 +1275,34 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
       ...(override === undefined ? {} : { override }),
     };
 
-    const shouldCommence = isCorrection
-      ? null
-      : shouldRecordCommencement(parsed.value, activeRoot, nowMs, clockStartMs);
+    const derivedLifecycle =
+      existingAction === undefined
+        ? deriveControllerLifecycleAfterAction(
+            activeRoot,
+            actionsBefore,
+            action,
+            parsed.value,
+            nowMs,
+          )
+        : undefined;
+    const shouldCommence =
+      existingAction !== undefined || isCorrection
+        ? null
+        : shouldRecordCommencement(parsed.value, activeRoot, nowMs, clockStartMs);
     const shouldFinish =
-      parsed.value.type === "substantive" &&
-      parsed.value.trigger === "result" &&
-      activeRoot.lifecycle.finishedAtMs === null;
+      existingAction === undefined &&
+      activeRoot.lifecycle.finishedAtMs === null &&
+      intentFinishesGame(parsed.value, effectiveStateBefore);
     const lifecycleTransition: EventGameRecordRoot["lifecycle"] | undefined =
-      shouldCommence !== null || shouldFinish
+      derivedLifecycle ??
+      (shouldCommence !== null || shouldFinish
         ? {
             ...activeRoot.lifecycle,
-            phase:
-              parsed.value.type === "substantive" && parsed.value.trigger === "result"
-                ? "finished"
-                : "in-progress",
+            phase: shouldFinish ? "finished" : "in-progress",
             commencedAtMs: activeRoot.lifecycle.commencedAtMs ?? shouldCommence?.atMs ?? nowMs,
-            finishedAtMs:
-              parsed.value.type === "substantive" && parsed.value.trigger === "result"
-                ? nowMs
-                : activeRoot.lifecycle.finishedAtMs,
+            finishedAtMs: shouldFinish ? nowMs : activeRoot.lifecycle.finishedAtMs,
           }
-        : undefined;
+        : undefined);
 
     let accepted;
     try {
@@ -1121,6 +1312,7 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
         sessionBearer: input.sessionBearer,
         lifecycleTransition,
         actions: [action],
+        reconcileDerivedLifecycle: derivedLifecycle !== undefined,
       });
     } catch {
       return retryableAction(parsed.value.operationId);
@@ -1221,7 +1413,7 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
       );
       const replayRoot = await replayOwner.record.readRoot(replayOwner.recordId);
       if (replayRoot === null) return replayRetryable(input.actions, replayContext);
-      const replayState = rebuildLiveDerivedState(replayRoot, persistedActions);
+      let replayState = rebuildLiveDerivedState(replayRoot, persistedActions);
       if (replayState === null) return replayRetryable(input.actions, replayContext);
       let finishedUnlocked =
         replayState.phase === "finished" && replayRoot.lifecycle.lockedAtMs === null;
@@ -1230,6 +1422,7 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
         if (currentRoot === null) return true;
         const currentActions = await replayOwner.record.readActions();
         const currentState = rebuildLiveDerivedState(currentRoot, currentActions);
+        if (currentState !== null) replayState = currentState;
         return currentState?.phase === "finished" && currentRoot.lifecycle.lockedAtMs === null;
       };
       const outcomes: ControllerReplayOutcome[] = [];
@@ -1311,6 +1504,7 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
           if (
             finishedUnlocked &&
             parsedIntent.value.type !== "correct-fact" &&
+            !allowsLatePreCatchGoal(parsedIntent.value, replayState) &&
             !persistedOperationIds.has(operationId)
           ) {
             outcomes.push({ operationId, status: "held-for-correction" });
@@ -1403,6 +1597,11 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
         stoppage: structuredClone(derived.stoppage),
         heat: structuredClone(derived.heat),
         result: structuredClone(derived.result),
+        overtime: derived.overtime,
+        overtimeTarget: derived.overtimeTarget,
+        targetScore: derived.overtimeTarget,
+        winnerGameSideId: derived.winnerGameSideId,
+        catch: structuredClone(derived.catch),
         gameFacts: derived.gameFacts.map((fact) => ({
           ...fact,
           data: structuredClone(fact.data),
@@ -1465,15 +1664,6 @@ function deriveLiveEventGameState(
   const scoreByGameSide: Record<string, number> = Object.fromEntries(
     root.gameSides.map((side) => [side.id, 0]),
   );
-  let goalCount = 0;
-  for (const fact of effectiveFacts) {
-    if (fact.interpretation.factType !== "goal") continue;
-    const gameSideId = fact.interpretation.gameSideId;
-    if (gameSideId !== null && gameSideId in scoreByGameSide) {
-      scoreByGameSide[gameSideId] = (scoreByGameSide[gameSideId] ?? 0) + 10;
-    }
-    goalCount += 1;
-  }
   const effectiveFactIds = new Set(effectiveFacts.map((fact) => fact.factId));
   const synchronizationOrderByOperationId = new Map(
     [...canonicalActions]
@@ -1484,42 +1674,130 @@ function deriveLiveEventGameState(
       )
       .map(({ action }, index) => [action.operationId, index + 1]),
   );
-  const gameFacts = canonicalActions
-    .flatMap(({ action }) => {
-      if (action.interpretation.type !== "fact") return [];
-      const payload = action.interpretation.payload;
-      const gameTimeMs =
-        isRecord(payload) && typeof payload.gameTimeMs === "number" ? payload.gameTimeMs : null;
-      const data = isRecord(payload) && "data" in payload ? payload.data : null;
-      const sportingOrder =
-        isRecord(data) && typeof data.sportingOrder === "number"
-          ? data.sportingOrder
-          : (gameTimeMs ?? 0);
-      return [
-        {
-          factId: action.interpretation.factId,
-          factType: action.interpretation.factType,
-          gameSideId: action.interpretation.gameSideId,
-          gameTimeMs,
-          sportingOrder,
-          synchronizationOrder: synchronizationOrderByOperationId.get(action.operationId) ?? 0,
-          effective: effectiveFactIds.has(action.interpretation.factId),
-          data: isActionJsonValue(data) ? structuredClone(data) : null,
-        } satisfies ControllerGameFact,
-      ];
-    })
-    .sort(
-      (left, right) =>
-        left.sportingOrder - right.sportingOrder ||
-        left.synchronizationOrder - right.synchronizationOrder ||
-        left.factId.localeCompare(right.factId),
-    );
+  const gameFacts = orderControllerGameFacts(
+    canonicalActions
+      .flatMap(({ action }) => {
+        if (action.interpretation.type !== "fact") return [];
+        const payload = action.interpretation.payload;
+        const gameTimeMs =
+          isRecord(payload) && typeof payload.gameTimeMs === "number" ? payload.gameTimeMs : null;
+        const data = isRecord(payload) && "data" in payload ? payload.data : null;
+        const sportingOrder =
+          isRecord(data) && typeof data.sportingOrder === "number"
+            ? data.sportingOrder
+            : (gameTimeMs ?? 0);
+        return [
+          {
+            factId: action.interpretation.factId,
+            factType: action.interpretation.factType,
+            gameSideId: action.interpretation.gameSideId,
+            gameTimeMs,
+            sportingOrder,
+            synchronizationOrder: synchronizationOrderByOperationId.get(action.operationId) ?? 0,
+            effective: effectiveFactIds.has(action.interpretation.factId),
+            data: isActionJsonValue(data) ? structuredClone(data) : null,
+          } satisfies ControllerGameFact,
+        ];
+      })
+      .sort(
+        (left, right) =>
+          left.sportingOrder - right.sportingOrder ||
+          left.synchronizationOrder - right.synchronizationOrder ||
+          left.factId.localeCompare(right.factId),
+      ),
+  );
+  const orderedEffectiveFacts = gameFacts.filter((fact) => fact.effective);
+  const sideIds = root.gameSides.map((side) => side.id);
+  let goalCount = 0;
+  let overtime = false;
+  let overtimeTarget: number | null = null;
+  let winnerGameSideId: string | null = null;
+  let winnerFactId: string | null = null;
+  let catchState: LiveCatchState | null = null;
+  let resultFact: ControllerGameFact | null = null;
+
+  for (const fact of orderedEffectiveFacts) {
+    const data = isRecord(fact.data) ? fact.data : null;
+    const side = fact.gameSideId;
+    if (fact.factType === "goal") {
+      if (side !== null && side in scoreByGameSide) {
+        scoreByGameSide[side] = (scoreByGameSide[side] ?? 0) + 10;
+      }
+      goalCount += 1;
+      if (overtimeTarget !== null && winnerGameSideId === null) {
+        const reached = side !== null && (scoreByGameSide[side] ?? 0) >= overtimeTarget;
+        if (reached) {
+          winnerGameSideId = side;
+          winnerFactId = fact.factId;
+        }
+      }
+      continue;
+    }
+    if (fact.factType === "flag-catch" && catchState === null && side !== null) {
+      const nonCatching = sideIds.find((candidate) => candidate !== side);
+      if (nonCatching === undefined) continue;
+      scoreByGameSide[side] = (scoreByGameSide[side] ?? 0) + 30;
+      const nonCatchingScore = scoreByGameSide[nonCatching] ?? 0;
+      const catchingScore = scoreByGameSide[side] ?? 0;
+      const targetScore = nonCatchingScore + 30;
+      catchState = {
+        factId: fact.factId,
+        catchingGameSideId: side,
+        nonCatchingGameSideId: nonCatching,
+        gameTimeMs: fact.gameTimeMs ?? fact.sportingOrder,
+        targetScore: catchingScore > nonCatchingScore ? null : targetScore,
+      };
+      if (catchingScore > nonCatchingScore) {
+        winnerGameSideId = side;
+        winnerFactId = fact.factId;
+      } else {
+        overtime = true;
+        overtimeTarget = targetScore;
+      }
+      continue;
+    }
+    if (fact.factType === "concession" && side !== null) {
+      const opponent = sideIds.find((candidate) => candidate !== side);
+      if (opponent === undefined) continue;
+      const concedingScore = scoreByGameSide[side] ?? 0;
+      const opponentScore = scoreByGameSide[opponent] ?? 0;
+      if (concedingScore >= opponentScore) {
+        const requiredLead = concedingScore + 10;
+        const points = Math.max(10, Math.ceil((requiredLead - opponentScore) / 10) * 10);
+        scoreByGameSide[opponent] = opponentScore + points;
+      }
+      winnerGameSideId = opponent;
+      resultFact = fact;
+      winnerFactId = fact.factId;
+      continue;
+    }
+    if (fact.factType === "forfeit" && side !== null) {
+      winnerGameSideId = sideIds.find((candidate) => candidate !== side) ?? null;
+      resultFact = fact;
+      winnerFactId = fact.factId;
+      continue;
+    }
+    if (fact.factType === "double-forfeit") {
+      winnerGameSideId = null;
+      resultFact = fact;
+      continue;
+    }
+    if (fact.factType === "result") {
+      const declaredWinner = data?.winnerGameSideId;
+      winnerGameSideId =
+        typeof declaredWinner === "string" && declaredWinner in scoreByGameSide
+          ? declaredWinner
+          : winnerGameSideId;
+      resultFact = fact;
+      if (winnerGameSideId !== null) winnerFactId = fact.factId;
+    }
+  }
   const latestEffectiveFact = (factType: string): ControllerGameFact | null =>
     gameFacts.filter((fact) => fact.effective && fact.factType === factType).at(-1) ?? null;
   const timeoutFact = latestEffectiveFact("timeout");
   const suspensionFact = latestEffectiveFact("suspension");
   const heatFact = latestEffectiveFact("heat-stoppage");
-  const resultFact = latestEffectiveFact("result");
+  const latestResultFact = latestEffectiveFact("result");
   const heatAction =
     isRecord(heatFact?.data) &&
     (heatFact.data.heatAction === "start" ||
@@ -1576,19 +1854,28 @@ function deriveLiveEventGameState(
         ? { status: "heat-stoppage", factId: heat.factId }
         : { status: "none", factId: null };
   const result: LiveResultState =
-    resultFact === null
+    resultFact === null && latestResultFact === null && winnerFactId === null
       ? null
-      : { factId: resultFact.factId, data: structuredClone(resultFact.data) };
-  const effectiveResult = gameFacts.some((fact) => fact.effective && fact.factType === "result");
+      : {
+          factId: (resultFact ?? latestResultFact)?.factId ?? winnerFactId!,
+          data: structuredClone(
+            (resultFact ?? latestResultFact)?.data ?? {
+              resultKind: "derived-score-completion",
+              winnerGameSideId,
+            },
+          ),
+        };
+  const effectiveResult = result !== null || winnerGameSideId !== null;
   const effectiveSuspension = gameFacts.some(
     (fact) => fact.effective && fact.factType === "suspension",
   );
-  const phase =
-    root.lifecycle.phase === "finished" && !effectiveResult
-      ? "in-progress"
-      : effectiveSuspension && root.lifecycle.phase !== "finished"
-        ? "suspended"
-        : root.lifecycle.phase;
+  const phase = effectiveResult
+    ? "finished"
+    : effectiveSuspension && root.lifecycle.phase !== "finished"
+      ? "suspended"
+      : root.lifecycle.phase === "scheduled"
+        ? "scheduled"
+        : "in-progress";
   return {
     interpreterVersion: version,
     phase,
@@ -1598,6 +1885,10 @@ function deriveLiveEventGameState(
     stoppage,
     heat,
     result,
+    overtime,
+    overtimeTarget,
+    winnerGameSideId,
+    catch: catchState,
     gameFacts,
     clock: projectClockBaseline(
       deriveClockAuthority(
@@ -1610,6 +1901,10 @@ function deriveLiveEventGameState(
 
 function controllerFactType(intent: LiveEventControllerIntent): string {
   if (intent.type === "record-goal") return "goal";
+  if (intent.type === "record-flag-catch") return "flag-catch";
+  if (intent.type === "record-concession") return "concession";
+  if (intent.type === "record-forfeit") return "forfeit";
+  if (intent.type === "record-double-forfeit") return "double-forfeit";
   if (
     intent.type === "clock" ||
     intent.type === "set-running" ||
@@ -1671,7 +1966,14 @@ function shouldRecordCommencement(
   clockStartMs: number | null,
 ): { atMs: number } | null {
   if (root.lifecycle.commencedAtMs !== null) return null;
-  if (intent.type === "record-goal" || intent.type === "substantive") {
+  if (
+    intent.type === "record-goal" ||
+    intent.type === "record-flag-catch" ||
+    intent.type === "record-concession" ||
+    intent.type === "record-forfeit" ||
+    intent.type === "record-double-forfeit" ||
+    intent.type === "substantive"
+  ) {
     return { atMs: nowMs };
   }
   if (
@@ -1682,6 +1984,172 @@ function shouldRecordCommencement(
     return { atMs: clockStartMs + 10_000 };
   }
   return null;
+}
+
+function controllerGameSideId(intent: LiveEventControllerIntent): string | null {
+  return "gameSideId" in intent && typeof intent.gameSideId === "string" ? intent.gameSideId : null;
+}
+
+function isScoringIntent(intent: LiveEventControllerIntent): boolean {
+  return (
+    intent.type === "record-flag-catch" ||
+    intent.type === "record-concession" ||
+    (intent.type === "substantive" &&
+      (intent.trigger === "flag-catch" || intent.trigger === "concession"))
+  );
+}
+
+function isResultIntent(intent: LiveEventControllerIntent): boolean {
+  return (
+    intent.type === "record-forfeit" ||
+    intent.type === "record-double-forfeit" ||
+    (intent.type === "substantive" &&
+      (intent.trigger === "forfeit" || intent.trigger === "double-forfeit"))
+  );
+}
+
+function intentFinishesGame(
+  intent: LiveEventControllerIntent,
+  current: LiveEventGameDerivedState,
+): boolean {
+  if (
+    intent.type === "record-concession" ||
+    intent.type === "record-forfeit" ||
+    intent.type === "record-double-forfeit" ||
+    (intent.type === "substantive" &&
+      (intent.trigger === "concession" ||
+        intent.trigger === "forfeit" ||
+        intent.trigger === "double-forfeit"))
+  )
+    return true;
+  if (intent.type === "substantive" && intent.trigger === "result") {
+    return !current.overtime || current.winnerGameSideId !== null;
+  }
+  if (
+    intent.type === "record-flag-catch" ||
+    (intent.type === "substantive" && intent.trigger === "flag-catch")
+  ) {
+    const catching = intent.gameSideId;
+    if (catching === undefined) return false;
+    const other = currentSideIds(current).find((side) => side !== catching);
+    return (
+      other !== undefined &&
+      (current.scoreByGameSide[catching] ?? 0) + 30 > (current.scoreByGameSide[other] ?? 0)
+    );
+  }
+  if (intent.type === "record-goal" && current.overtimeTarget !== null) {
+    return (current.scoreByGameSide[intent.gameSideId] ?? 0) + 10 >= current.overtimeTarget;
+  }
+  return false;
+}
+
+function deriveControllerLifecycleAfterAction(
+  root: EventGameRecordRoot,
+  actionsBefore: readonly {
+    action: ControlAction;
+    canonicalContent: string;
+    contentFingerprint: string;
+  }[],
+  actionInput: unknown,
+  intent: LiveEventControllerIntent,
+  acceptedAtMs: number,
+): EventGameRecordRoot["lifecycle"] | undefined {
+  const scoringFactNeedsRebuild =
+    root.lifecycle.phase === "finished" ||
+    intent.type !== "record-goal" ||
+    actionsBefore.some(({ action }) => {
+      if (action.interpretation.type !== "fact") return false;
+      return action.interpretation.factType === "flag-catch";
+    });
+  const relevantFact =
+    intent.type === "correct-fact"
+      ? rootDerivedScoringFactForCorrection(root, actionsBefore, intent.targetFactId)
+      : scoringFactNeedsRebuild &&
+          (intent.type === "record-goal" ||
+            intent.type === "record-flag-catch" ||
+            intent.type === "record-concession" ||
+            intent.type === "record-forfeit" ||
+            intent.type === "record-double-forfeit" ||
+            (intent.type === "substantive" && intent.trigger === "result"))
+        ? true
+        : false;
+  if (!relevantFact) return undefined;
+  const prepared = prepareControlAction(
+    actionInput,
+    root,
+    createControlActionCodecRegistry(createDefaultControlActionCodecs()),
+    acceptedAtMs,
+  );
+  if (!prepared.ok) return undefined;
+  const candidate = materializeControlAction(prepared.value, acceptedAtMs);
+  const rebuilt = rebuildLiveDerivedState(root, [
+    ...actionsBefore,
+    {
+      action: candidate,
+      canonicalContent: prepared.value.canonicalContent,
+      contentFingerprint: prepared.value.contentFingerprint,
+    },
+  ]);
+  if (rebuilt === null || (rebuilt.phase !== "in-progress" && rebuilt.phase !== "finished")) {
+    return undefined;
+  }
+  const desiredPhase = rebuilt.phase;
+  const desired: EventGameRecordRoot["lifecycle"] = {
+    ...root.lifecycle,
+    phase: desiredPhase,
+    commencedAtMs: root.lifecycle.commencedAtMs ?? acceptedAtMs,
+    finishedAtMs:
+      desiredPhase === "finished" ? (root.lifecycle.finishedAtMs ?? acceptedAtMs) : null,
+  };
+  return JSON.stringify(desired) === JSON.stringify(root.lifecycle) ? undefined : desired;
+}
+
+function rootDerivedScoringFactForCorrection(
+  root: EventGameRecordRoot,
+  actionsBefore: readonly {
+    action: ControlAction;
+    canonicalContent: string;
+    contentFingerprint: string;
+  }[],
+  targetFactId: string,
+): boolean {
+  const current = rebuildLiveDerivedState(root, actionsBefore);
+  if (current === null) return false;
+  const fact = current.gameFacts.find((candidate) => candidate.factId === targetFactId);
+  return (
+    fact !== undefined &&
+    (fact.factType === "goal" ||
+      fact.factType === "flag-catch" ||
+      fact.factType === "concession" ||
+      fact.factType === "forfeit" ||
+      fact.factType === "double-forfeit" ||
+      fact.factType === "result")
+  );
+}
+
+function allowsLatePreCatchGoal(
+  intent: LiveEventControllerIntent,
+  current: LiveEventGameDerivedState,
+): boolean {
+  if (intent.type !== "record-goal" || current.catch === null) return false;
+  const catchFact = current.gameFacts.find(
+    (fact) => fact.factId === current.catch?.factId && fact.effective,
+  );
+  if (catchFact === undefined) return false;
+  if (
+    intent.sportingOrderAdjudication?.relatedFactId === catchFact.factId &&
+    intent.sportingOrderAdjudication.relation === "before" &&
+    catchFact.gameTimeMs !== null &&
+    Math.abs(intent.gameTimeMs - catchFact.gameTimeMs) <= CLOSE_PLAY_ADJUDICATION_WINDOW_MS
+  ) {
+    return true;
+  }
+  const candidateOrder = intent.sportingOrder ?? intent.gameTimeMs;
+  return candidateOrder < catchFact.sportingOrder;
+}
+
+function currentSideIds(state: LiveEventGameDerivedState): string[] {
+  return Object.keys(state.scoreByGameSide);
 }
 
 function readDerivedState(value: unknown): LiveEventGameDerivedState | null {
@@ -1700,7 +2168,8 @@ function readDerivedState(value: unknown): LiveEventGameDerivedState | null {
       !validateOpaqueIdentifier(gameSideId, "scoreByGameSide.gameSideId").ok ||
       typeof score !== "number" ||
       !Number.isSafeInteger(score) ||
-      score < 0
+      score < 0 ||
+      score > SHARED_LIMITS.score.max
     )
       return null;
     scoreByGameSide[gameSideId] = score;
@@ -1717,6 +2186,14 @@ function readDerivedState(value: unknown): LiveEventGameDerivedState | null {
   const stoppage = readLiveStoppageState(value.stoppage);
   const heat = readLiveHeatState(value.heat);
   const result = readLiveResultState(value.result);
+  const overtime = value.overtime === undefined ? false : value.overtime;
+  if (typeof overtime !== "boolean") return null;
+  const overtimeTarget = readNullableScore(value.overtimeTarget ?? value.targetScore);
+  if (overtimeTarget === "invalid") return null;
+  const winnerGameSideId = readNullableIdentifier(value.winnerGameSideId);
+  if (winnerGameSideId.status === "invalid") return null;
+  const catchState = readLiveCatchState(value.catch);
+  if (catchState === "invalid") return null;
   const gameFacts = readControllerGameFacts(value.gameFacts);
   if (gameFacts === null) return null;
   return {
@@ -1728,6 +2205,10 @@ function readDerivedState(value: unknown): LiveEventGameDerivedState | null {
     stoppage,
     heat,
     result,
+    overtime,
+    overtimeTarget: overtimeTarget === "missing" ? null : overtimeTarget,
+    winnerGameSideId: winnerGameSideId.status === "value" ? winnerGameSideId.value : null,
+    catch: catchState === "missing" ? null : catchState,
     gameFacts,
     clock,
   };
@@ -1875,6 +2356,60 @@ function readLiveResultState(value: unknown): LiveResultState {
   return { factId: factId.value, data: data.value };
 }
 
+function readNullableScore(value: unknown): number | null | "missing" | "invalid" {
+  if (value === undefined) return "missing";
+  if (value === null) return null;
+  const parsed = validateIntegerInRange(value, 0, 1_000, "overtimeTarget");
+  return parsed.ok ? parsed.value : "invalid";
+}
+
+function readNullableIdentifier(
+  value: unknown,
+): { status: "missing" | "null" | "invalid" } | { status: "value"; value: string } {
+  if (value === undefined) return { status: "missing" };
+  if (value === null) return { status: "null" };
+  const parsed = validateOpaqueIdentifier(value, "winnerGameSideId");
+  return parsed.ok ? { status: "value", value: parsed.value } : { status: "invalid" };
+}
+
+function readLiveCatchState(value: unknown): LiveCatchState | null | "missing" | "invalid" {
+  if (value === undefined) return "missing";
+  if (value === null) return null;
+  if (!isRecord(value)) return "invalid";
+  const factId = validateOpaqueIdentifier(value.factId, "catch.factId");
+  const catchingGameSideId = validateOpaqueIdentifier(
+    value.catchingGameSideId,
+    "catch.catchingGameSideId",
+  );
+  const nonCatchingGameSideId = validateOpaqueIdentifier(
+    value.nonCatchingGameSideId,
+    "catch.nonCatchingGameSideId",
+  );
+  const gameTimeMs = validateIntegerInRange(
+    value.gameTimeMs,
+    0,
+    SHARED_LIMITS.clock.maxMs,
+    "catch.gameTimeMs",
+  );
+  const targetScore = readNullableScore(value.targetScore);
+  if (
+    !factId.ok ||
+    !catchingGameSideId.ok ||
+    !nonCatchingGameSideId.ok ||
+    !gameTimeMs.ok ||
+    targetScore === "missing" ||
+    targetScore === "invalid"
+  )
+    return "invalid";
+  return {
+    factId: factId.value,
+    catchingGameSideId: catchingGameSideId.value,
+    nonCatchingGameSideId: nonCatchingGameSideId.value,
+    gameTimeMs: gameTimeMs.value,
+    targetScore,
+  };
+}
+
 export function validateLiveEventClockActionInTransaction(
   actions: readonly { action: ControlAction }[],
   candidate: ControlAction,
@@ -1941,6 +2476,127 @@ function rebuildLiveDerivedState(
   );
 }
 
+function rebuildLiveDerivedStateWithCandidate(
+  actions: readonly {
+    action: ControlAction;
+    canonicalContent: string;
+    contentFingerprint: string;
+  }[],
+  root: EventGameRecordRoot,
+  candidate: ControlAction,
+): LiveEventGameDerivedState | null {
+  const prepared = prepareControlAction(
+    candidate,
+    root,
+    createControlActionCodecRegistry(createDefaultControlActionCodecs()),
+    candidate.acceptedAtMs,
+  );
+  if (!prepared.ok) return null;
+  return rebuildLiveDerivedState(root, [
+    ...actions,
+    {
+      action: candidate,
+      canonicalContent: prepared.value.canonicalContent,
+      contentFingerprint: prepared.value.contentFingerprint,
+    },
+  ]);
+}
+
+function validateEffectiveClosePlayOrdering(
+  state: LiveEventGameDerivedState,
+): { status: "accepted" } | { status: "rejected"; reason: "invalid-action"; detail: string } {
+  const scoringFacts = state.gameFacts.filter(
+    (fact) =>
+      fact.effective &&
+      fact.gameTimeMs !== null &&
+      (fact.factType === "goal" || fact.factType === "flag-catch"),
+  );
+  const selectedPairs: { catchFactId: string; goalFactId: string }[] = [];
+  for (const fact of scoringFacts) {
+    const adjudication = readSportingOrderAdjudication(isRecord(fact.data) ? fact.data : null);
+    if (adjudication === null) continue;
+    const related = scoringFacts.filter(
+      (candidate) => candidate.factId === adjudication.relatedFactId,
+    );
+    if (related.length !== 1 || !isCloseOpposingScoringPair(fact, related[0]!)) {
+      return rejectedLiveAction(
+        "Sporting-order adjudication must name one effective close opposing Game Fact.",
+      );
+    }
+    const pair =
+      fact.factType === "flag-catch"
+        ? { catchFactId: fact.factId, goalFactId: related[0]!.factId }
+        : { catchFactId: related[0]!.factId, goalFactId: fact.factId };
+    if (
+      !selectedPairs.some(
+        (candidate) =>
+          candidate.catchFactId === pair.catchFactId && candidate.goalFactId === pair.goalFactId,
+      )
+    ) {
+      selectedPairs.push(pair);
+    }
+  }
+  for (const catchFact of scoringFacts.filter((fact) => fact.factType === "flag-catch")) {
+    const nearbyGoals = scoringFacts.filter(
+      (fact) => fact.factType === "goal" && isCloseOpposingScoringPair(catchFact, fact),
+    );
+    if (nearbyGoals.length === 0) continue;
+    const catchPairs = selectedPairs.filter((pair) => pair.catchFactId === catchFact.factId);
+    if (catchPairs.length !== 1) {
+      return rejectedLiveAction(
+        catchPairs.length === 0
+          ? "A close goal and flag catch require explicit Head Referee sporting-order adjudication."
+          : "Close-play sporting-order evidence must identify exactly one paired goal.",
+      );
+    }
+  }
+  return { status: "accepted" };
+}
+
+function validateEffectiveConcessionPreconditions(
+  state: LiveEventGameDerivedState,
+): { status: "accepted" } | { status: "rejected"; reason: "invalid-action"; detail: string } {
+  const effectiveFacts = orderControllerGameFacts(state.gameFacts).filter((fact) => fact.effective);
+  for (const [index, fact] of effectiveFacts.entries()) {
+    if (fact.factType !== "concession") continue;
+    const precedingFacts = effectiveFacts.slice(0, index);
+    const precedingOutcome = deriveScoringOutcomeByGameFacts(state.scoreByGameSide, precedingFacts);
+    const precedingResult = precedingFacts.some(
+      (candidate) =>
+        candidate.factType === "concession" ||
+        candidate.factType === "forfeit" ||
+        candidate.factType === "double-forfeit" ||
+        candidate.factType === "result",
+    );
+    if (
+      precedingOutcome.overtimeTarget === null ||
+      precedingResult ||
+      Object.values(precedingOutcome.scoreByGameSide).some(
+        (score) => score >= precedingOutcome.overtimeTarget!,
+      )
+    ) {
+      return rejectedLiveAction("A concession is only effective during unfinished overtime.");
+    }
+  }
+  return { status: "accepted" };
+}
+
+function validateEffectiveResultPreconditions(
+  state: LiveEventGameDerivedState,
+): { status: "accepted" } | { status: "rejected"; reason: "invalid-action"; detail: string } {
+  const hasEffectiveGenericResult = state.gameFacts.some(
+    (fact) => fact.effective && fact.factType === "result",
+  );
+  if (
+    hasEffectiveGenericResult &&
+    state.overtimeTarget !== null &&
+    state.winnerGameSideId === null
+  ) {
+    return rejectedLiveAction("A generic Result cannot finish unfinished overtime.");
+  }
+  return { status: "accepted" };
+}
+
 export function validateLiveEventGameActionInTransaction(
   actions: readonly {
     action: ControlAction;
@@ -1961,7 +2617,27 @@ export function validateLiveEventGameActionInTransaction(
       detail: "The current Event Game state cannot be rebuilt authoritatively.",
     };
   }
+  const scoreValidation = validateDerivedScoreUpperBound(current, candidate);
+  if (scoreValidation.status === "rejected") return scoreValidation;
   if (candidate.interpretation.type === "correction") {
+    const rebuilt = rebuildLiveDerivedStateWithCandidate(actions, root, candidate);
+    if (rebuilt === null) {
+      return rejectedLiveAction("The corrected live Game state cannot be rebuilt authoritatively.");
+    }
+    if (candidate.interpretation.effective) {
+      const effectiveCatchCount = rebuilt.gameFacts.filter(
+        (fact) => fact.effective && fact.factType === "flag-catch",
+      ).length;
+      if (effectiveCatchCount > 1) {
+        return rejectedLiveAction("Only one Flag Catch can remain effective.");
+      }
+      const closePlayValidation = validateEffectiveClosePlayOrdering(rebuilt);
+      if (closePlayValidation.status === "rejected") return closePlayValidation;
+    }
+    const concessionValidation = validateEffectiveConcessionPreconditions(rebuilt);
+    if (concessionValidation.status === "rejected") return concessionValidation;
+    const resultValidation = validateEffectiveResultPreconditions(rebuilt);
+    if (resultValidation.status === "rejected") return resultValidation;
     return candidate.override === undefined
       ? { status: "accepted" }
       : rejectedLiveAction("Official Overrides cannot be attached to a Correction.");
@@ -1979,12 +2655,93 @@ export function validateLiveEventGameActionInTransaction(
     data !== null && typeof data.sportingOrder === "number" ? data.sportingOrder : gameTimeMs;
   const sportingOrderDiffers =
     gameTimeMs !== null && sportingOrder !== null && sportingOrder !== gameTimeMs;
+  const sportingOrderAdjudication = readSportingOrderAdjudication(data);
+  const sportingOrderOverride = readSportingOrderOverride(data);
+  const closePair = findCloseGoalCatchPair(
+    candidate,
+    current,
+    gameTimeMs,
+    sportingOrderAdjudication,
+  );
+  if (closePair.status === "rejected") return closePair;
+  if (closePair.fact !== null) {
+    if (sportingOrderAdjudication === null) {
+      return rejectedLiveAction(
+        "A close goal and flag catch require explicit Head Referee sporting-order adjudication.",
+      );
+    }
+    if (sportingOrderAdjudication.relatedFactId !== closePair.fact.factId) {
+      return rejectedLiveAction(
+        "Sporting-order adjudication must name the close opposing Game Fact.",
+      );
+    }
+  } else if (sportingOrderAdjudication !== null) {
+    return rejectedLiveAction("Sporting-order adjudication requires one close opposing Game Fact.");
+  }
+  if (candidate.interpretation.factType === "target-score") {
+    return rejectedLiveAction("Overtime winners are derived from accepted scoring facts.");
+  }
+  if (
+    candidate.interpretation.factType === "concession" &&
+    (!current.overtime || current.winnerGameSideId !== null || current.phase === "finished")
+  ) {
+    return rejectedLiveAction("A concession is only accepted during unfinished overtime.");
+  }
+  if (candidate.interpretation.factType === "flag-catch") {
+    if (current.catch !== null) {
+      return rejectedLiveAction("Only one effective flag catch may determine the Game result.");
+    }
+    const validCatchBoundary =
+      gameTimeMs !== null && gameTimeMs >= SEEKER_RELEASE_MS && !current.clock.running;
+    if (!validCatchBoundary) {
+      const expectedBoundaryOverride = expectedLiveOverride(
+        candidate,
+        current,
+        false,
+        gameTimeMs,
+        data,
+      );
+      if (candidate.override === undefined || expectedBoundaryOverride === null) {
+        return rejectedLiveAction("A flag catch requires released seekers and stopped play.");
+      }
+      const boundaryValidation = validateOfficialOverrideEvidence(
+        candidate.override,
+        expectedBoundaryOverride,
+      );
+      if (boundaryValidation.status === "rejected") return boundaryValidation;
+      if (closePair.fact !== null && sportingOrderAdjudication !== null) {
+        const expectedSportingOrderOverride = expectedClosePlayOverride(
+          closePair.fact,
+          gameTimeMs,
+          sportingOrderAdjudication,
+        );
+        if (sportingOrderOverride === undefined || expectedSportingOrderOverride === null) {
+          return rejectedLiveAction(
+            "A separate Sporting Order override is required for this close flag catch.",
+          );
+        }
+        return validateOfficialOverrideEvidence(
+          sportingOrderOverride,
+          expectedSportingOrderOverride,
+        );
+      }
+      return { status: "accepted" };
+    }
+  }
   if (candidate.interpretation.factType === "timeout" && current.clock.running) {
     if (candidate.override?.guardrail !== "timeout-requires-paused-play") {
       return rejectedLiveAction("A normal timeout requires paused play.");
     }
   }
-  const expected = expectedLiveOverride(candidate, current, sportingOrderDiffers, gameTimeMs, data);
+  const expected =
+    closePair.fact !== null && sportingOrderAdjudication !== null
+      ? expectedClosePlayOverride(closePair.fact, gameTimeMs, sportingOrderAdjudication)
+      : expectedLiveOverride(candidate, current, sportingOrderDiffers, gameTimeMs, data);
+  if (sportingOrderOverride !== undefined) {
+    return rejectedLiveAction(
+      "A separate Sporting Order override is only valid with a flag-catch boundary override.",
+    );
+  }
   if (expected === null) {
     return candidate.override === undefined
       ? { status: "accepted" }
@@ -2040,6 +2797,22 @@ function expectedLiveOverride(
       gameTimeMs,
     };
   }
+  if (factType === "flag-catch") {
+    if (gameTimeMs >= SEEKER_RELEASE_MS && !current.clock.running && current.catch === null) {
+      return null;
+    }
+    return {
+      required: true,
+      guardrail: "flag-catch-requires-seeker-release-and-stopped-play",
+      direction: "head-referee-directed-flag-catch-boundary",
+      beforeValue: {
+        seekerReleased: gameTimeMs >= SEEKER_RELEASE_MS,
+        running: current.clock.running,
+      },
+      afterValue: { flagCatch: "accepted" },
+      gameTimeMs,
+    };
+  }
   if (factType === "heat-stoppage") {
     const heatAction = data?.heatAction;
     if (
@@ -2071,12 +2844,42 @@ function expectedLiveOverride(
   return null;
 }
 
+function expectedClosePlayOverride(
+  relatedFact: ControllerGameFact,
+  gameTimeMs: number | null,
+  adjudication: SportingOrderAdjudication,
+): LiveOverrideExpectation | null {
+  if (gameTimeMs === null) return null;
+  return {
+    required: true,
+    guardrail: "sporting-order-adjudication",
+    direction: "head-referee-adjudicated-sporting-order",
+    beforeValue: {
+      candidateGameTimeMs: gameTimeMs,
+      relatedFactId: relatedFact.factId,
+      relatedGameTimeMs: relatedFact.gameTimeMs,
+    },
+    afterValue: {
+      relation: adjudication.relation,
+      sportingOrder: "explicit-pair-order",
+    },
+    gameTimeMs,
+  };
+}
+
 function validateLiveOfficialOverrideEvidence(
   candidate: ControlAction,
   expected: LiveOverrideExpectation,
 ): { status: "accepted" } | { status: "rejected"; reason: "invalid-action"; detail: string } {
   const override = candidate.override;
   if (override === undefined) return rejectedLiveAction("Official Override evidence is missing.");
+  return validateOfficialOverrideEvidence(override, expected);
+}
+
+function validateOfficialOverrideEvidence(
+  override: OfficialOverrideMetadata,
+  expected: LiveOverrideExpectation,
+): { status: "accepted" } | { status: "rejected"; reason: "invalid-action"; detail: string } {
   if (
     override.guardrail !== expected.guardrail ||
     override.direction !== expected.direction ||
@@ -2099,6 +2902,296 @@ function rejectedLiveAction(detail: string): {
   detail: string;
 } {
   return { status: "rejected", reason: "invalid-action", detail };
+}
+
+function validateDerivedScoreUpperBound(
+  current: LiveEventGameDerivedState,
+  candidate: ControlAction,
+): { status: "accepted" } | { status: "rejected"; reason: "invalid-action"; detail: string } {
+  const currentScores = Object.values(current.scoreByGameSide);
+  if (currentScores.some((score) => score > SHARED_LIMITS.score.max)) {
+    return rejectedLiveAction("The derived score already exceeds the permitted upper bound.");
+  }
+  const interpretation = candidate.interpretation;
+  if (interpretation.type === "correction") {
+    const target = current.gameFacts.find((fact) => fact.factId === interpretation.targetFactId);
+    if (target === undefined || target.effective === interpretation.effective) {
+      return { status: "accepted" };
+    }
+    const facts = current.gameFacts.map((fact) =>
+      fact.factId === target.factId ? { ...fact, effective: interpretation.effective } : fact,
+    );
+    return validateScoringOutcomeBounds(
+      deriveScoringOutcomeByGameFacts(current.scoreByGameSide, facts),
+    );
+  }
+  if (candidate.interpretation.type !== "fact") return { status: "accepted" };
+  const factType = candidate.interpretation.factType;
+  const gameSideId = candidate.interpretation.gameSideId;
+  if (gameSideId === null || !(gameSideId in current.scoreByGameSide)) {
+    return { status: "accepted" };
+  }
+  const nextScores = { ...current.scoreByGameSide };
+  if (factType === "goal") {
+    nextScores[gameSideId] = (nextScores[gameSideId] ?? 0) + 10;
+  } else if (factType === "flag-catch" && current.catch === null) {
+    nextScores[gameSideId] = (nextScores[gameSideId] ?? 0) + 30;
+  } else if (factType === "concession") {
+    const opponent = Object.keys(nextScores).find((side) => side !== gameSideId);
+    if (opponent !== undefined) {
+      const concedingScore = nextScores[gameSideId] ?? 0;
+      const opponentScore = nextScores[opponent] ?? 0;
+      if (concedingScore >= opponentScore) {
+        const points = Math.max(10, Math.ceil((concedingScore + 10 - opponentScore) / 10) * 10);
+        nextScores[opponent] = opponentScore + points;
+      }
+    }
+  }
+  const scoreValidation = scoreUpperBoundResult(nextScores);
+  if (scoreValidation.status === "rejected") return scoreValidation;
+  if (
+    (factType === "goal" || factType === "flag-catch") &&
+    (factType !== "flag-catch" || current.catch === null)
+  ) {
+    return validateScoringOutcomeBounds(
+      deriveScoringOutcomeByGameFacts(current.scoreByGameSide, [
+        ...current.gameFacts,
+        controllerGameFactFromCandidate(candidate, current.gameFacts),
+      ]),
+    );
+  }
+  return { status: "accepted" };
+}
+
+function scoreUpperBoundResult(
+  scores: Readonly<Record<string, number>>,
+): { status: "accepted" } | { status: "rejected"; reason: "invalid-action"; detail: string } {
+  return Object.values(scores).some((score) => score > SHARED_LIMITS.score.max)
+    ? rejectedLiveAction(`The derived score must not exceed ${SHARED_LIMITS.score.max}.`)
+    : { status: "accepted" };
+}
+
+function validateScoringOutcomeBounds(outcome: {
+  scoreByGameSide: Readonly<Record<string, number>>;
+  overtimeTarget: number | null;
+}): { status: "accepted" } | { status: "rejected"; reason: "invalid-action"; detail: string } {
+  const scoreValidation = scoreUpperBoundResult(outcome.scoreByGameSide);
+  if (scoreValidation.status === "rejected") return scoreValidation;
+  return outcome.overtimeTarget !== null && outcome.overtimeTarget > SHARED_LIMITS.score.max
+    ? rejectedLiveAction(`The derived overtime target must not exceed ${SHARED_LIMITS.score.max}.`)
+    : { status: "accepted" };
+}
+
+function controllerGameFactFromCandidate(
+  candidate: ControlAction,
+  currentFacts: readonly ControllerGameFact[],
+): ControllerGameFact {
+  if (candidate.interpretation.type !== "fact") {
+    throw new Error("Only a Game Fact can be projected as a candidate fact.");
+  }
+  const payload = isRecord(candidate.interpretation.payload)
+    ? candidate.interpretation.payload
+    : {};
+  const gameTimeMs = typeof payload.gameTimeMs === "number" ? payload.gameTimeMs : null;
+  const data = isActionJsonValue(payload.data) ? payload.data : null;
+  const sportingOrder =
+    isRecord(data) && typeof data.sportingOrder === "number"
+      ? data.sportingOrder
+      : (gameTimeMs ?? 0);
+  return {
+    factId: candidate.interpretation.factId,
+    factType: candidate.interpretation.factType,
+    gameSideId: candidate.interpretation.gameSideId,
+    gameTimeMs,
+    sportingOrder,
+    synchronizationOrder:
+      currentFacts.reduce((highest, fact) => Math.max(highest, fact.synchronizationOrder), 0) + 1,
+    effective: true,
+    data,
+  };
+}
+
+function readSportingOrderAdjudication(
+  data: Record<string, unknown> | null,
+): SportingOrderAdjudication | null {
+  const value = data?.sportingOrderAdjudication;
+  if (!isRecord(value)) return null;
+  if (
+    typeof value.relatedFactId !== "string" ||
+    (value.relation !== "before" && value.relation !== "after")
+  ) {
+    return null;
+  }
+  return { relatedFactId: value.relatedFactId, relation: value.relation };
+}
+
+function readSportingOrderOverride(
+  data: Record<string, unknown> | null,
+): OfficialOverrideMetadata | undefined {
+  const parsed = validateOverride(data?.sportingOrderOverride);
+  return parsed.ok ? parsed.value : undefined;
+}
+
+function findCloseGoalCatchPair(
+  candidate: ControlAction,
+  current: LiveEventGameDerivedState,
+  gameTimeMs: number | null,
+  adjudication: SportingOrderAdjudication | null,
+):
+  | { status: "accepted"; fact: ControllerGameFact | null }
+  | { status: "rejected"; reason: "invalid-action"; detail: string } {
+  if (candidate.interpretation.type !== "fact" || gameTimeMs === null)
+    return { status: "accepted", fact: null };
+  const candidateIsGoal = candidate.interpretation.factType === "goal";
+  const candidateIsCatch = candidate.interpretation.factType === "flag-catch";
+  if (!candidateIsGoal && !candidateIsCatch) return { status: "accepted", fact: null };
+  const candidates = current.gameFacts.filter(
+    (fact) =>
+      fact.effective &&
+      fact.gameTimeMs !== null &&
+      Math.abs(fact.gameTimeMs - gameTimeMs) <= CLOSE_PLAY_ADJUDICATION_WINDOW_MS &&
+      ((candidateIsGoal && fact.factType === "flag-catch") ||
+        (candidateIsCatch && fact.factType === "goal")),
+  );
+  if (adjudication !== null) {
+    const namedFacts = current.gameFacts.filter(
+      (fact) => fact.factId === adjudication.relatedFactId,
+    );
+    if (namedFacts.length !== 1) {
+      return rejectedLiveAction(
+        "Sporting-order adjudication must name one known opposing Game Fact.",
+      );
+    }
+    const namedFact = namedFacts[0];
+    if (namedFact === undefined || !candidates.some((fact) => fact.factId === namedFact.factId)) {
+      return rejectedLiveAction(
+        "Sporting-order adjudication must name one effective close opposing Game Fact.",
+      );
+    }
+    if (hasEffectiveClosePlayPair(namedFact, current)) {
+      return rejectedLiveAction(
+        "Close-play sporting-order evidence must identify exactly one paired goal and catch.",
+      );
+    }
+    return { status: "accepted", fact: namedFact };
+  }
+  const unpairedCandidates = candidates.filter((fact) => !hasEffectiveClosePlayPair(fact, current));
+  if (unpairedCandidates.length === 0) return { status: "accepted", fact: null };
+  if (unpairedCandidates.length > 1) {
+    return rejectedLiveAction(
+      "Head Referee sporting-order adjudication must identify the exact paired Game Fact.",
+    );
+  }
+  return { status: "accepted", fact: unpairedCandidates[0] ?? null };
+}
+
+function hasEffectiveClosePlayPair(
+  fact: ControllerGameFact,
+  current: LiveEventGameDerivedState,
+): boolean {
+  const effectiveScoringFacts = current.gameFacts.filter(
+    (candidate) =>
+      candidate.effective && (candidate.factType === "goal" || candidate.factType === "flag-catch"),
+  );
+  const ownAdjudication = readSportingOrderAdjudication(isRecord(fact.data) ? fact.data : null);
+  if (
+    ownAdjudication !== null &&
+    effectiveScoringFacts.some(
+      (candidate) =>
+        candidate.factId === ownAdjudication.relatedFactId &&
+        isCloseOpposingScoringPair(fact, candidate),
+    )
+  ) {
+    return true;
+  }
+  return effectiveScoringFacts.some((candidate) => {
+    const adjudication = readSportingOrderAdjudication(
+      isRecord(candidate.data) ? candidate.data : null,
+    );
+    return (
+      adjudication?.relatedFactId === fact.factId && isCloseOpposingScoringPair(fact, candidate)
+    );
+  });
+}
+
+function isCloseOpposingScoringPair(left: ControllerGameFact, right: ControllerGameFact): boolean {
+  return (
+    left.gameTimeMs !== null &&
+    right.gameTimeMs !== null &&
+    ((left.factType === "goal" && right.factType === "flag-catch") ||
+      (left.factType === "flag-catch" && right.factType === "goal")) &&
+    Math.abs(left.gameTimeMs - right.gameTimeMs) <= CLOSE_PLAY_ADJUDICATION_WINDOW_MS
+  );
+}
+
+export function orderControllerGameFacts(
+  facts: readonly ControllerGameFact[],
+): ControllerGameFact[] {
+  const ordered = [...facts].sort(
+    (left, right) =>
+      left.sportingOrder - right.sportingOrder ||
+      left.synchronizationOrder - right.synchronizationOrder ||
+      left.factId.localeCompare(right.factId),
+  );
+  for (const candidate of facts) {
+    if (!candidate.effective) continue;
+    const adjudication = readSportingOrderAdjudication(
+      isRecord(candidate.data) ? candidate.data : null,
+    );
+    if (adjudication === null) continue;
+    const relatedIndex = ordered.findIndex((fact) => fact.factId === adjudication.relatedFactId);
+    const candidateIndex = ordered.findIndex((fact) => fact.factId === candidate.factId);
+    if (relatedIndex < 0 || candidateIndex < 0 || relatedIndex === candidateIndex) continue;
+    if (ordered[relatedIndex]?.effective !== true) continue;
+    const candidateShouldPrecedeRelated = adjudication.relation === "before";
+    const candidateCurrentlyPrecedesRelated = candidateIndex < relatedIndex;
+    if (candidateShouldPrecedeRelated === candidateCurrentlyPrecedesRelated) continue;
+    const related = ordered[relatedIndex];
+    const currentCandidate = ordered[candidateIndex];
+    if (related === undefined || currentCandidate === undefined) continue;
+    // Swap only the adjudicated pair. Every unrelated fact keeps its established
+    // slot, including facts sharing either endpoint's Game Clock time.
+    ordered[relatedIndex] = currentCandidate;
+    ordered[candidateIndex] = related;
+  }
+  return ordered;
+}
+
+function deriveScoringOutcomeByGameFacts(
+  initialScores: Readonly<Record<string, number>>,
+  facts: readonly ControllerGameFact[],
+): {
+  scoreByGameSide: Readonly<Record<string, number>>;
+  overtimeTarget: number | null;
+} {
+  const scores = Object.fromEntries(Object.keys(initialScores).map((side) => [side, 0]));
+  let catchProcessed = false;
+  let overtimeTarget: number | null = null;
+  const orderedFacts = orderControllerGameFacts(facts).filter((candidate) => candidate.effective);
+  for (const fact of orderedFacts) {
+    const side = fact.gameSideId;
+    if (fact.factType === "goal" && side !== null && side in scores) {
+      scores[side] = (scores[side] ?? 0) + 10;
+    } else if (fact.factType === "flag-catch" && side !== null && side in scores) {
+      if (catchProcessed) continue;
+      scores[side] = (scores[side] ?? 0) + 30;
+      const opponent = Object.keys(scores).find((candidate) => candidate !== side);
+      if (opponent !== undefined && (scores[side] ?? 0) <= (scores[opponent] ?? 0)) {
+        overtimeTarget = (scores[opponent] ?? 0) + 30;
+      }
+      catchProcessed = true;
+    } else if (fact.factType === "concession" && side !== null && side in scores) {
+      const opponent = Object.keys(scores).find((candidate) => candidate !== side);
+      if (opponent === undefined) continue;
+      const concedingScore = scores[side] ?? 0;
+      const opponentScore = scores[opponent] ?? 0;
+      if (concedingScore >= opponentScore) {
+        scores[opponent] =
+          opponentScore + Math.max(10, Math.ceil((concedingScore + 10 - opponentScore) / 10) * 10);
+      }
+    }
+  }
+  return { scoreByGameSide: scores, overtimeTarget };
 }
 
 function readClockAuthorityActions(
@@ -2358,6 +3451,16 @@ function buildLiveOfficialOverride(
     intent.type === "correct-fact"
   ) {
     throw new Error("Official Overrides are not valid for this Controller action.");
+  }
+  if (intent.sportingOrderAdjudication !== undefined) {
+    if (intent.type !== "record-goal" && intent.type !== "record-flag-catch") {
+      throw new Error("Sporting-order adjudication is only valid for a goal or flag catch.");
+    }
+    return {
+      ...structuredClone(intent.override),
+      gameTimeMs: intent.gameTimeMs,
+      authorityReference: intent.override.authorityReference || sessionId,
+    };
   }
   const expected = explainLiveEventGuardrail({
     type: intent.type,

--- a/src/pages/event-game-controller-page.test.tsx
+++ b/src/pages/event-game-controller-page.test.tsx
@@ -23,7 +23,7 @@ describe("Event Game Controller reconnect browser seam", () => {
   let testWindow: Window;
   let container: HTMLDivElement;
   let root: Root;
-  let replayMode: "lost" | "success" | "deferred";
+  let replayMode: "lost" | "success" | "deferred" | "retryable";
   let openBodies: Record<string, unknown>[];
   let replayCalls: number;
   let replayBodies: Record<string, any>[];
@@ -32,6 +32,7 @@ describe("Event Game Controller reconnect browser seam", () => {
   let openGrantSessionId: string;
   let openGrantVersion: string;
   let openBearer: string;
+  let openProjection: ControllerProjection;
   let refreshProjection: ControllerProjection | null;
   let refreshRejected: boolean;
   let switchRequested: boolean;
@@ -48,6 +49,7 @@ describe("Event Game Controller reconnect browser seam", () => {
     openGrantSessionId = "session";
     openGrantVersion = "version";
     openBearer = "bearer";
+    openProjection = projection();
     refreshProjection = projection();
     refreshRejected = false;
     switchRequested = false;
@@ -74,7 +76,7 @@ describe("Event Game Controller reconnect browser seam", () => {
                 grantSessionId: openGrantSessionId,
                 grantVersion: openGrantVersion,
               },
-              projection: projection(),
+              projection: openProjection,
               projectionStatus: "available",
             }),
             { status: 200, headers: { "content-type": "application/json" } },
@@ -103,12 +105,12 @@ describe("Event Game Controller reconnect browser seam", () => {
                 grantSessionId: body.grantSessionId,
                 grantVersion: body.grantVersion,
               },
-              status: "synchronized",
+              status: replayMode === "retryable" ? "retryable" : "synchronized",
               outcomes: body.actions.map((action) => ({
                 operationId: action.intent.operationId,
-                status: "accepted",
+                status: replayMode === "retryable" ? "retryable" : "accepted",
               })),
-              projection: projection(),
+              projection: replayMode === "retryable" ? openProjection : projection(),
             }),
             { status: 200, headers: { "content-type": "application/json" } },
           );
@@ -282,8 +284,12 @@ describe("Event Game Controller reconnect browser seam", () => {
     expect(container.textContent).toContain("retained for reconnect replay");
     const stored = JSON.parse(
       testWindow.localStorage.getItem(controllerReplicaStorageKey("game-browser")) ?? "null",
-    ) as { pendingActions?: unknown[] };
+    ) as { pendingActions?: { intent?: { gameTimeMs?: number; sportingOrder?: number } }[] };
     expect(stored.pendingActions).toHaveLength(1);
+    expect(stored.pendingActions?.[0]?.intent).toMatchObject({
+      gameTimeMs: 12_000,
+      sportingOrder: 12_000,
+    });
   });
 
   test("requires exactly one Controller credential and keeps both/none local", async () => {
@@ -371,6 +377,361 @@ describe("Event Game Controller reconnect browser seam", () => {
       targetFactId: "fact-goal",
       effective: false,
     });
+  });
+
+  test("uses a contextual Head Referee choice for close-play catch ordering", async () => {
+    await enterAndOpen();
+    const catchButtons = Array.from(container.getElementsByTagName("button")).filter((button) =>
+      button.textContent?.includes("Record flag catch"),
+    );
+    expect(catchButtons.length).toBeGreaterThan(1);
+    await act(async () => {
+      catchButtons.at(-1)?.click();
+      await Promise.resolve();
+    });
+    expect(container.querySelector('[data-close-play-adjudication="true"]')).not.toBeNull();
+    expect(container.textContent).toContain("Head Referee close goal/catch ordering");
+
+    await act(async () => {
+      Array.from(container.getElementsByTagName("button"))
+        .find((button) => button.textContent?.includes("Catch before goal"))
+        ?.click();
+      await Promise.resolve();
+    });
+    expect(
+      replayBodies
+        .flatMap((body) => body.actions ?? [])
+        .find((action) => action.intent.type === "record-flag-catch"),
+    ).toBeUndefined();
+    expect(container.querySelector('[data-flag-catch-boundary-override="true"]')).not.toBeNull();
+    expect(container.textContent).toContain("Sporting Order recorded");
+    await act(async () => {
+      Array.from(container.getElementsByTagName("button"))
+        .find((button) => button.textContent?.includes("Confirm boundary override"))
+        ?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const selected = replayBodies
+      .flatMap((body) => body.actions ?? [])
+      .find((action) => action.intent.type === "record-flag-catch");
+    expect(selected?.intent).toMatchObject({
+      type: "record-flag-catch",
+      gameTimeMs: 12_000,
+      sportingOrderAdjudication: {
+        relatedFactId: "fact-goal",
+        relation: "before",
+      },
+      override: {
+        guardrail: "flag-catch-requires-seeker-release-and-stopped-play",
+        direction: "head-referee-directed-flag-catch-boundary",
+        confirmation: "head-referee-confirmed",
+      },
+      sportingOrderOverride: {
+        guardrail: "sporting-order-adjudication",
+        direction: "head-referee-adjudicated-sporting-order",
+        confirmation: "head-referee-confirmed",
+        beforeValue: {
+          candidateGameTimeMs: 12_000,
+          relatedFactId: "fact-goal",
+          relatedGameTimeMs: 12_000,
+        },
+        afterValue: { relation: "before", sportingOrder: "explicit-pair-order" },
+      },
+    });
+  });
+
+  test("causally retains a close-play fact behind its optimistic paired predecessor", async () => {
+    replayMode = "retryable";
+    const initial = projection();
+    openProjection = {
+      ...initial,
+      scoreByGameSide: { "side-a": 0, "side-b": 0 },
+      goalCount: 0,
+      gameFacts: [],
+    };
+    await enterAndOpen();
+
+    await act(async () => {
+      Array.from(container.getElementsByTagName("button"))
+        .find((button) => button.textContent?.includes("Record 10-point goal"))
+        ?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const goal = replayBodies
+      .flatMap((body) => body.actions ?? [])
+      .find((action) => action.intent.type === "record-goal");
+    expect(goal).toBeDefined();
+
+    await act(async () => {
+      Array.from(container.getElementsByTagName("button"))
+        .find((button) => button.textContent?.includes("Record flag catch"))
+        ?.click();
+      await Promise.resolve();
+    });
+    await act(async () => {
+      Array.from(container.getElementsByTagName("button"))
+        .find((button) => button.textContent?.includes("Catch before goal"))
+        ?.click();
+      await Promise.resolve();
+    });
+    await act(async () => {
+      Array.from(container.getElementsByTagName("button"))
+        .find((button) => button.textContent?.includes("Confirm boundary override"))
+        ?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const catchAction = replayBodies
+      .flatMap((body) => body.actions ?? [])
+      .find((action) => action.intent.type === "record-flag-catch");
+    expect(catchAction?.causalPredecessorIds).toEqual([goal?.intent.operationId]);
+  });
+
+  test("confirms a flag-catch boundary override without conflating Sporting Order", async () => {
+    const initial = projection();
+    openProjection = { ...initial, gameFacts: [] };
+    refreshProjection = openProjection;
+    await enterAndOpen();
+    await act(async () => {
+      Array.from(container.getElementsByTagName("button"))
+        .find((button) => button.textContent?.includes("Record flag catch"))
+        ?.click();
+      await Promise.resolve();
+    });
+    expect(container.querySelector('[data-flag-catch-boundary-override="true"]')).not.toBeNull();
+    await act(async () => {
+      Array.from(container.getElementsByTagName("button"))
+        .find((button) => button.textContent?.includes("Confirm boundary override"))
+        ?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const selected = replayBodies
+      .flatMap((body) => body.actions ?? [])
+      .find((action) => action.intent.type === "record-flag-catch");
+    expect(selected?.intent).toMatchObject({
+      type: "record-flag-catch",
+      gameTimeMs: 12_000,
+      override: {
+        guardrail: "flag-catch-requires-seeker-release-and-stopped-play",
+        direction: "head-referee-directed-flag-catch-boundary",
+        confirmation: "head-referee-confirmed",
+      },
+    });
+    expect(selected?.intent.sportingOrderOverride).toBeUndefined();
+  });
+
+  test("lets the Head Referee select the exact goal from multiple close candidates", async () => {
+    const initial = projection();
+    const firstGoal = initial.gameFacts?.[0];
+    if (firstGoal === undefined) throw new Error("Expected a goal fixture.");
+    openProjection = {
+      ...initial,
+      gameFacts: [
+        firstGoal,
+        {
+          ...firstGoal,
+          factId: "fact-goal-second-close",
+          gameTimeMs: 11_500,
+          sportingOrder: 11_500,
+          synchronizationOrder: firstGoal.synchronizationOrder + 1,
+          data: { points: 10, sportingOrder: 11_500 },
+        },
+      ],
+    };
+    await enterAndOpen();
+    await act(async () => {
+      Array.from(container.getElementsByTagName("button"))
+        .find((button) => button.textContent?.includes("Record flag catch"))
+        ?.click();
+      await Promise.resolve();
+    });
+    const candidates = Array.from(
+      container.querySelectorAll<HTMLElement>("[data-close-play-related-fact-id]"),
+    );
+    expect(candidates).toHaveLength(2);
+    expect(container.textContent).toContain("2 opposing close-play candidates");
+    await act(async () => {
+      Array.from(candidates[1]?.getElementsByTagName("button") ?? [])
+        .find((button) => button.textContent?.includes("Catch before goal"))
+        ?.click();
+      await Promise.resolve();
+    });
+    await act(async () => {
+      Array.from(container.getElementsByTagName("button"))
+        .find((button) => button.textContent?.includes("Confirm boundary override"))
+        ?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const selected = replayBodies
+      .flatMap((body) => body.actions ?? [])
+      .find((action) => action.intent.type === "record-flag-catch");
+    expect(selected?.intent).toMatchObject({
+      sportingOrderAdjudication: {
+        relatedFactId: "fact-goal-second-close",
+        relation: "before",
+      },
+      override: {
+        guardrail: "flag-catch-requires-seeker-release-and-stopped-play",
+      },
+      sportingOrderOverride: {
+        beforeValue: {
+          relatedFactId: "fact-goal-second-close",
+          relatedGameTimeMs: 11_500,
+        },
+      },
+    });
+  });
+
+  test("adjudicates a non-identical close pair without rewriting Game Clock times", async () => {
+    const initial = projection();
+    openProjection = {
+      ...initial,
+      gameFacts: (initial.gameFacts ?? []).map((fact) => ({
+        ...fact,
+        gameTimeMs: 11_500,
+        sportingOrder: 11_500,
+        data: { points: 10, sportingOrder: 11_500 },
+      })),
+    };
+    await enterAndOpen();
+    await act(async () => {
+      Array.from(container.getElementsByTagName("button"))
+        .find((button) => button.textContent?.includes("Record flag catch"))
+        ?.click();
+      await Promise.resolve();
+    });
+    expect(container.textContent).toContain("11500");
+    await act(async () => {
+      Array.from(container.getElementsByTagName("button"))
+        .find((button) => button.textContent?.includes("Catch before goal"))
+        ?.click();
+      await Promise.resolve();
+    });
+    await act(async () => {
+      Array.from(container.getElementsByTagName("button"))
+        .find((button) => button.textContent?.includes("Confirm boundary override"))
+        ?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const selected = replayBodies
+      .flatMap((body) => body.actions ?? [])
+      .find((action) => action.intent.type === "record-flag-catch");
+    expect(selected?.intent).toMatchObject({
+      gameTimeMs: 12_000,
+      sportingOrderAdjudication: { relatedFactId: "fact-goal", relation: "before" },
+      override: {
+        guardrail: "flag-catch-requires-seeker-release-and-stopped-play",
+      },
+      sportingOrderOverride: {
+        beforeValue: {
+          candidateGameTimeMs: 12_000,
+          relatedFactId: "fact-goal",
+          relatedGameTimeMs: 11_500,
+        },
+      },
+    });
+    expect(selected?.intent.sportingOrder).toBeUndefined();
+  });
+
+  test("keeps close-play adjudication safe at Game Clock zero and hides concession outside overtime", async () => {
+    const initial = projection();
+    openProjection = {
+      ...initial,
+      clock: { ...initial.clock, gameTimeMs: 0 },
+      gameFacts: (initial.gameFacts ?? []).map((fact) => ({
+        ...fact,
+        gameTimeMs: 0,
+        sportingOrder: 0,
+        data: { points: 10, sportingOrder: 0 },
+      })),
+    };
+    await enterAndOpen();
+    expect(container.textContent).not.toContain("Concede");
+    await act(async () => {
+      Array.from(container.getElementsByTagName("button"))
+        .find((button) => button.textContent?.includes("Record flag catch"))
+        ?.click();
+      await Promise.resolve();
+    });
+    await act(async () => {
+      Array.from(container.getElementsByTagName("button"))
+        .find((button) => button.textContent?.includes("Catch before goal"))
+        ?.click();
+      await Promise.resolve();
+    });
+    await act(async () => {
+      Array.from(container.getElementsByTagName("button"))
+        .find((button) => button.textContent?.includes("Confirm boundary override"))
+        ?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const selected = replayBodies
+      .flatMap((body) => body.actions ?? [])
+      .find((action) => action.intent.type === "record-flag-catch");
+    expect(selected?.intent).toMatchObject({
+      gameTimeMs: 0,
+      sportingOrderAdjudication: { relatedFactId: "fact-goal", relation: "before" },
+    });
+    expect(selected?.intent.sportingOrder).toBeUndefined();
+    expect(selected?.intent.override.beforeValue).not.toHaveProperty("sportingOrder", -1);
+  });
+
+  test("shows overtime concession and communicates winner or double-forfeit results", async () => {
+    await enterAndOpen();
+    const current = projection();
+    refreshProjection = {
+      ...current,
+      overtime: true,
+      overtimeTarget: 40,
+      targetScore: 40,
+      winnerGameSideId: null,
+      catch: {
+        factId: "catch",
+        catchingGameSideId: "side-a",
+        nonCatchingGameSideId: "side-b",
+        gameTimeMs: 1_200_000,
+        targetScore: 40,
+      },
+    };
+    await act(async () => {
+      document.dispatchEvent(new testWindow.Event("visibilitychange") as unknown as Event);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(container.textContent).toContain("Concede");
+
+    refreshProjection = {
+      ...current,
+      phase: "finished",
+      overtime: true,
+      winnerGameSideId: "side-b",
+      result: { factId: "result", data: { resultKind: "forfeit" } },
+    };
+    await act(async () => {
+      document.dispatchEvent(new testWindow.Event("visibilitychange") as unknown as Event);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(container.textContent).toContain("Winner: Game Side side-b");
+
+    refreshProjection = {
+      ...current,
+      winnerGameSideId: null,
+      result: { factId: "double-result", data: { resultKind: "double-forfeit" } },
+    };
+    await act(async () => {
+      document.dispatchEvent(new testWindow.Event("visibilitychange") as unknown as Event);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(container.textContent).toContain("Double-forfeit: no winner");
   });
 
   test("revalidates a fresh same-Game authority before foreground replay", async () => {
@@ -512,8 +873,8 @@ describe("Event Game Controller reconnect browser seam", () => {
       authoritativeProjection: ControllerProjection;
       projection: ControllerProjection;
     };
-    expect(before.authoritativeProjection.goalCount).toBe(0);
-    expect(before.projection.goalCount).toBe(1);
+    expect(before.authoritativeProjection.goalCount).toBe(1);
+    expect(before.projection.goalCount).toBe(2);
 
     await act(async () => {
       root.unmount();
@@ -527,14 +888,14 @@ describe("Event Game Controller reconnect browser seam", () => {
       await Promise.resolve();
       await Promise.resolve();
     });
-    expect(container.textContent).toContain("Goals: 1");
-    expect(container.textContent).not.toContain("Goals: 2");
+    expect(container.textContent).toContain("Goals: 2");
+    expect(container.textContent).not.toContain("Goals: 1");
     const after = JSON.parse(testWindow.localStorage.getItem(storageKey) ?? "null") as {
       authoritativeProjection: ControllerProjection;
       projection: ControllerProjection;
     };
-    expect(after.authoritativeProjection.goalCount).toBe(0);
-    expect(after.projection.goalCount).toBe(1);
+    expect(after.authoritativeProjection.goalCount).toBe(1);
+    expect(after.projection.goalCount).toBe(2);
   });
 
   test("reconnect drains successive bounded batches without another wake event", async () => {
@@ -806,11 +1167,12 @@ function projection(eventGameId = "game-browser"): ControllerProjection {
   baseline.holderGrantSessionId = "session";
   baseline.holderGeneration = 1;
   baseline.authorityGeneration = 1;
+  baseline.gameTimeMs = 12_000;
   return {
     eventGameId,
-    phase: "scheduled",
-    scoreByGameSide: { "side-a": 0, "side-b": 0 },
-    goalCount: 0,
+    phase: "in-progress",
+    scoreByGameSide: { "side-a": 10, "side-b": 0 },
+    goalCount: 1,
     gameFacts: [
       {
         factId: "fact-goal",
@@ -825,8 +1187,8 @@ function projection(eventGameId = "game-browser"): ControllerProjection {
     ],
     clock: projectClockBaseline(baseline, 0),
     commencement: {
-      status: "provisional",
-      commencedAtMs: null,
+      status: "commenced",
+      commencedAtMs: 10_000,
       provisionalRunningSinceMs: null,
       provisionalElapsedMs: 0,
     },

--- a/src/pages/event-game-controller-page.tsx
+++ b/src/pages/event-game-controller-page.tsx
@@ -7,13 +7,18 @@ import {
   createInitialClockBaseline,
   projectClockBaseline,
   projectClockSample,
+  SEEKER_RELEASE_MS,
 } from "@/lib/clock-authority";
 import type {
   ControllerProjection,
   LiveEventGameControlResult,
   LiveEventControllerIntent,
 } from "@/lib/live-event-game-control";
-import { LIVE_EVENT_CONTROL_INTENT_VERSION } from "@/lib/live-event-game-control";
+import type { OfficialOverrideMetadata } from "@/lib/event-game-actions";
+import {
+  CLOSE_PLAY_ADJUDICATION_WINDOW_MS,
+  LIVE_EVENT_CONTROL_INTENT_VERSION,
+} from "@/lib/live-event-game-control";
 import { validateGameClockMs } from "@/lib/validation-policy";
 import { readControllerDeviceContext } from "@/lib/controller-device-context";
 import {
@@ -66,6 +71,29 @@ type ReplayRequest = { state: ControllerReplicaState; authority: ReplayAuthority
 
 type ActiveReplay = ReplayRequest & { requestToken: symbol };
 
+type PendingClosePlayAdjudication = {
+  intentType: "record-goal" | "record-flag-catch";
+  gameSideId: string;
+  gameTimeMs: number;
+  flagCatchBoundaryRunning: boolean | null;
+  relatedFacts: readonly {
+    factType: "goal" | "flag-catch";
+    factId: string;
+    gameTimeMs: number;
+  }[];
+};
+
+type PendingFlagCatchBoundaryOverride = {
+  gameSideId: string;
+  gameTimeMs: number;
+  running: boolean;
+  sportingOrderAdjudication?: {
+    relatedFactId: string;
+    relation: "before" | "after";
+  };
+  sportingOrderOverride?: OfficialOverrideMetadata;
+};
+
 type ClockReceiptAnchor = {
   projection: ControllerProjection["clock"];
   localMonotonicMs: number;
@@ -95,6 +123,10 @@ export function EventGameControllerPage() {
   const [takeoverAdjustmentInput, setTakeoverAdjustmentInput] = useState("");
   const [message, setMessage] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
+  const [pendingClosePlayAdjudication, setPendingClosePlayAdjudication] =
+    useState<PendingClosePlayAdjudication | null>(null);
+  const [pendingFlagCatchBoundaryOverride, setPendingFlagCatchBoundaryOverride] =
+    useState<PendingFlagCatchBoundaryOverride | null>(null);
   const [persistedReplicaLoad] = useState<ControllerReplicaLoad>(() =>
     readPersistedControllerReplica(persisted?.eventGameId),
   );
@@ -426,18 +458,188 @@ export function EventGameControllerPage() {
   }
 
   function recordGoal(gameSideId: string) {
+    recordScoringFact("record-goal", gameSideId);
+  }
+
+  function recordFlagCatch(gameSideId: string) {
+    recordScoringFact("record-flag-catch", gameSideId);
+  }
+
+  function recordScoringFact(intentType: "record-goal" | "record-flag-catch", gameSideId: string) {
+    const gameTimeMs = currentSportingTimeMs();
+    if (gameTimeMs === null) return;
+    const running = clockProjection?.running ?? projection?.clock.running ?? false;
+    const flagCatchBoundaryRunning =
+      intentType === "record-flag-catch" && (gameTimeMs < SEEKER_RELEASE_MS || running)
+        ? running
+        : null;
+    const relatedFacts = (projection?.gameFacts ?? []).filter(
+      (fact) =>
+        fact.effective &&
+        fact.gameTimeMs !== null &&
+        Math.abs(fact.gameTimeMs - gameTimeMs) <= CLOSE_PLAY_ADJUDICATION_WINDOW_MS &&
+        ((intentType === "record-goal" && fact.factType === "flag-catch") ||
+          (intentType === "record-flag-catch" && fact.factType === "goal")),
+    );
+    if (relatedFacts.length > 0) {
+      setPendingClosePlayAdjudication({
+        intentType,
+        gameSideId,
+        gameTimeMs,
+        flagCatchBoundaryRunning,
+        relatedFacts: relatedFacts.map((fact) => ({
+          factType: fact.factType as "goal" | "flag-catch",
+          factId: fact.factId,
+          gameTimeMs: fact.gameTimeMs ?? gameTimeMs,
+        })),
+      });
+      setMessage("Head Referee adjudication is required to order this close goal and flag catch.");
+      return;
+    }
+    if (flagCatchBoundaryRunning !== null) {
+      setPendingFlagCatchBoundaryOverride({ gameSideId, gameTimeMs, running });
+      setMessage(
+        "Head Referee confirmation is required for a flag catch before seeker release or while play is running.",
+      );
+      return;
+    }
     queueIntent({
       version: LIVE_EVENT_CONTROL_INTENT_VERSION,
-      type: "record-goal",
+      type: intentType,
       operationId: crypto.randomUUID(),
       factId: crypto.randomUUID(),
       gameSideId,
-      gameTimeMs: 0,
+      gameTimeMs,
+      sportingOrder: gameTimeMs,
+      occurrence: { clientOriginAtMs: Date.now() },
+    });
+  }
+
+  function submitClosePlayAdjudication(order: "before" | "after", relatedFactId: string) {
+    const pending = pendingClosePlayAdjudication;
+    if (pending === null) return;
+    const relatedFact = pending.relatedFacts.find((fact) => fact.factId === relatedFactId);
+    if (relatedFact === undefined) return;
+    const override: OfficialOverrideMetadata = {
+      guardrail: "sporting-order-adjudication",
+      direction: "head-referee-adjudicated-sporting-order",
+      confirmation: "head-referee-confirmed",
+      authorityReference: "head-referee",
+      gameTimeMs: pending.gameTimeMs,
+      beforeValue: {
+        candidateGameTimeMs: pending.gameTimeMs,
+        relatedFactId: relatedFact.factId,
+        relatedGameTimeMs: relatedFact.gameTimeMs,
+      },
+      afterValue: {
+        relation: order,
+        sportingOrder: "explicit-pair-order",
+      },
+      reason: "head-referee-direction",
+    };
+    if (pending.flagCatchBoundaryRunning !== null) {
+      setPendingFlagCatchBoundaryOverride({
+        gameSideId: pending.gameSideId,
+        gameTimeMs: pending.gameTimeMs,
+        running: pending.flagCatchBoundaryRunning,
+        sportingOrderAdjudication: {
+          relatedFactId: relatedFact.factId,
+          relation: order,
+        },
+        sportingOrderOverride: override,
+      });
+      setPendingClosePlayAdjudication(null);
+      setMessage(
+        "Sporting Order recorded. Separately confirm the flag-catch boundary override before submission.",
+      );
+      return;
+    }
+    queueIntent({
+      version: LIVE_EVENT_CONTROL_INTENT_VERSION,
+      type: pending.intentType,
+      operationId: crypto.randomUUID(),
+      factId: crypto.randomUUID(),
+      gameSideId: pending.gameSideId,
+      gameTimeMs: pending.gameTimeMs,
+      sportingOrderAdjudication: {
+        relatedFactId: relatedFact.factId,
+        relation: order,
+      },
+      override,
+      occurrence: { clientOriginAtMs: Date.now() },
+    });
+    setPendingClosePlayAdjudication(null);
+  }
+
+  function submitFlagCatchBoundaryOverride() {
+    const pending = pendingFlagCatchBoundaryOverride;
+    if (pending === null) return;
+    queueIntent({
+      version: LIVE_EVENT_CONTROL_INTENT_VERSION,
+      type: "record-flag-catch",
+      operationId: crypto.randomUUID(),
+      factId: crypto.randomUUID(),
+      gameSideId: pending.gameSideId,
+      gameTimeMs: pending.gameTimeMs,
+      override: flagCatchBoundaryOverride(pending.gameTimeMs, pending.running),
+      ...(pending.sportingOrderAdjudication === undefined
+        ? {}
+        : {
+            sportingOrderAdjudication: pending.sportingOrderAdjudication,
+            sportingOrderOverride: pending.sportingOrderOverride,
+          }),
+      occurrence: { clientOriginAtMs: Date.now() },
+    });
+    setPendingFlagCatchBoundaryOverride(null);
+  }
+
+  function recordConcession(gameSideId: string) {
+    const gameTimeMs = currentSportingTimeMs();
+    if (gameTimeMs === null) return;
+    queueIntent({
+      version: LIVE_EVENT_CONTROL_INTENT_VERSION,
+      type: "record-concession",
+      operationId: crypto.randomUUID(),
+      factId: crypto.randomUUID(),
+      gameSideId,
+      gameTimeMs,
+      sportingOrder: gameTimeMs,
+      occurrence: { clientOriginAtMs: Date.now() },
+    });
+  }
+
+  function recordForfeit(gameSideId: string) {
+    const gameTimeMs = currentSportingTimeMs();
+    if (gameTimeMs === null) return;
+    queueIntent({
+      version: LIVE_EVENT_CONTROL_INTENT_VERSION,
+      type: "record-forfeit",
+      operationId: crypto.randomUUID(),
+      factId: crypto.randomUUID(),
+      gameSideId,
+      gameTimeMs,
+      sportingOrder: gameTimeMs,
+      occurrence: { clientOriginAtMs: Date.now() },
+    });
+  }
+
+  function recordDoubleForfeit() {
+    const gameTimeMs = currentSportingTimeMs();
+    if (gameTimeMs === null) return;
+    queueIntent({
+      version: LIVE_EVENT_CONTROL_INTENT_VERSION,
+      type: "record-double-forfeit",
+      operationId: crypto.randomUUID(),
+      factId: crypto.randomUUID(),
+      gameTimeMs,
+      sportingOrder: gameTimeMs,
       occurrence: { clientOriginAtMs: Date.now() },
     });
   }
 
   function correctFact(factId: string, effective: boolean) {
+    const gameTimeMs = currentSportingTimeMs();
+    if (gameTimeMs === null) return;
     queueIntent({
       version: LIVE_EVENT_CONTROL_INTENT_VERSION,
       type: "correct-fact",
@@ -445,19 +647,23 @@ export function EventGameControllerPage() {
       factId: crypto.randomUUID(),
       targetFactId: factId,
       effective,
-      gameTimeMs: projection?.clock.gameTimeMs ?? 0,
+      gameTimeMs,
+      sportingOrder: gameTimeMs,
       occurrence: { clientOriginAtMs: Date.now() },
     });
   }
 
   function trigger(type: "card" | "timeout" | "suspension" | "result") {
+    const gameTimeMs = currentSportingTimeMs();
+    if (gameTimeMs === null) return;
     queueIntent({
       version: LIVE_EVENT_CONTROL_INTENT_VERSION,
       type: "substantive",
       trigger: type,
       operationId: crypto.randomUUID(),
       factId: crypto.randomUUID(),
-      gameTimeMs: 0,
+      gameTimeMs,
+      sportingOrder: gameTimeMs,
       occurrence: { clientOriginAtMs: Date.now() },
     });
   }
@@ -466,13 +672,26 @@ export function EventGameControllerPage() {
     const current = replicaRef.current;
     if (current === null) return;
     try {
-      const dispatched = dispatchControllerAction(current, {
-        ...candidate,
-        occurrence: {
-          ...candidate.occurrence,
-          source: navigator.onLine === false ? "offline" : "online",
+      const relatedFactId = candidate.sportingOrderAdjudication?.relatedFactId;
+      const relatedPendingOperationId =
+        relatedFactId === undefined
+          ? undefined
+          : current.pendingActions.find((action) => action.intent.factId === relatedFactId)?.intent
+              .operationId;
+      const dispatched = dispatchControllerAction(
+        current,
+        {
+          ...candidate,
+          occurrence: {
+            ...candidate.occurrence,
+            source: navigator.onLine === false ? "offline" : "online",
+          },
         },
-      });
+        {
+          causalPredecessorIds:
+            relatedPendingOperationId === undefined ? [] : [relatedPendingOperationId],
+        },
+      );
       replicaRef.current = dispatched.state;
       setReplica(dispatched.state);
       setProjection(dispatched.state.projection);
@@ -481,6 +700,15 @@ export function EventGameControllerPage() {
     } catch {
       setMessage("The Controller action could not be retained safely.");
     }
+  }
+
+  function currentSportingTimeMs(): number | null {
+    const value = clockProjection?.gameTimeMs ?? projection?.clock.gameTimeMs;
+    if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) {
+      setMessage("The current Game time is unavailable; resynchronize before recording a fact.");
+      return null;
+    }
+    return value;
   }
 
   async function flushReplica(state: ControllerReplicaState, bearer = sessionBearer) {
@@ -1076,14 +1304,112 @@ export function EventGameControllerPage() {
                 <div className="space-y-3">
                   <p className="text-sm text-muted-foreground">
                     Phase: {projection.phase} · Goals: {projection.goalCount}
+                    {projection.overtime ? " · Overtime" : ""}
                   </p>
+                  {projection.overtime ? (
+                    <p data-overtime-target="true" className="text-sm font-semibold">
+                      Overtime target: {projection.overtimeTarget ?? projection.targetScore ?? "—"}
+                    </p>
+                  ) : null}
+                  {pendingClosePlayAdjudication === null ? null : (
+                    <div
+                      data-close-play-adjudication="true"
+                      className="space-y-2 rounded-lg border border-amber-500/60 bg-amber-50 p-3 text-sm text-amber-950"
+                    >
+                      <p className="font-medium">Head Referee close goal/catch ordering</p>
+                      <p>
+                        The{" "}
+                        {pendingClosePlayAdjudication.intentType === "record-goal"
+                          ? "goal"
+                          : "flag catch"}{" "}
+                        has {pendingClosePlayAdjudication.relatedFacts.length} opposing close-play
+                        candidate
+                        {pendingClosePlayAdjudication.relatedFacts.length === 1 ? "" : "s"}. Choose
+                        the exact paired fact and adjudicated sporting order without changing either
+                        Game Clock time.
+                      </p>
+                      {pendingClosePlayAdjudication.relatedFacts.map((relatedFact) => (
+                        <div
+                          key={relatedFact.factId}
+                          data-close-play-related-fact-id={relatedFact.factId}
+                          className="space-y-1"
+                        >
+                          <p>
+                            Existing {relatedFact.factType} at {relatedFact.gameTimeMs}
+                          </p>
+                          <div className="flex flex-wrap gap-2">
+                            <Button
+                              variant="outline"
+                              onClick={() =>
+                                submitClosePlayAdjudication("before", relatedFact.factId)
+                              }
+                              disabled={busy}
+                            >
+                              {pendingClosePlayAdjudication.intentType === "record-goal"
+                                ? "Goal before catch"
+                                : "Catch before goal"}
+                            </Button>
+                            <Button
+                              variant="outline"
+                              onClick={() =>
+                                submitClosePlayAdjudication("after", relatedFact.factId)
+                              }
+                              disabled={busy}
+                            >
+                              {pendingClosePlayAdjudication.intentType === "record-goal"
+                                ? "Goal after catch"
+                                : "Catch after goal"}
+                            </Button>
+                          </div>
+                        </div>
+                      ))}
+                      <div>
+                        <Button
+                          variant="ghost"
+                          onClick={() => setPendingClosePlayAdjudication(null)}
+                          disabled={busy}
+                        >
+                          Cancel
+                        </Button>
+                      </div>
+                    </div>
+                  )}
+                  {pendingFlagCatchBoundaryOverride === null ? null : (
+                    <div
+                      data-flag-catch-boundary-override="true"
+                      className="space-y-2 rounded-lg border border-amber-500/60 bg-amber-50 p-3 text-sm text-amber-950"
+                    >
+                      <p className="font-medium">Head Referee flag-catch boundary override</p>
+                      <p>
+                        Confirm the catch despite unreleased seekers or running play. This records
+                        the affected guardrail separately from any Sporting Order decision.
+                      </p>
+                      <div className="flex flex-wrap gap-2">
+                        <Button onClick={submitFlagCatchBoundaryOverride} disabled={busy}>
+                          Confirm boundary override
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          onClick={() => setPendingFlagCatchBoundaryOverride(null)}
+                          disabled={busy}
+                        >
+                          Cancel
+                        </Button>
+                      </div>
+                    </div>
+                  )}
                   <p className="text-xs text-muted-foreground">
                     Timeout: {projection.timeout?.status ?? "inactive"} · Stoppage:{" "}
                     {projection.stoppage?.status ?? "none"} · Heat:{" "}
                     {projection.heat?.status ?? "inactive"}
                     {projection.result === null || projection.result === undefined
                       ? ""
-                      : " · Result recorded"}
+                      : projection.winnerGameSideId !== null &&
+                          projection.winnerGameSideId !== undefined
+                        ? ` · Winner: Game Side ${projection.winnerGameSideId}`
+                        : isDoubleForfeitResult(projection.result)
+                          ? " · Double-forfeit: no winner"
+                          : " · Result recorded"}
                   </p>
                   {Object.entries(projection.scoreByGameSide).map(([gameSideId, score]) => (
                     <div key={gameSideId} className="flex items-center justify-between gap-3">
@@ -1093,9 +1419,37 @@ export function EventGameControllerPage() {
                         <Button onClick={() => recordGoal(gameSideId)} disabled={busy}>
                           Record 10-point goal
                         </Button>
+                        <Button
+                          variant="outline"
+                          onClick={() => recordFlagCatch(gameSideId)}
+                          disabled={busy}
+                        >
+                          Record flag catch
+                        </Button>
+                        {projection.overtime &&
+                        projection.phase !== "finished" &&
+                        projection.winnerGameSideId === null ? (
+                          <Button
+                            variant="outline"
+                            onClick={() => recordConcession(gameSideId)}
+                            disabled={busy}
+                          >
+                            Concede
+                          </Button>
+                        ) : null}
+                        <Button
+                          variant="outline"
+                          onClick={() => recordForfeit(gameSideId)}
+                          disabled={busy}
+                        >
+                          Directed forfeit
+                        </Button>
                       </div>
                     </div>
                   ))}
+                  <Button variant="outline" onClick={recordDoubleForfeit} disabled={busy}>
+                    Record double-forfeit
+                  </Button>
                   <div className="space-y-2 rounded-lg border p-3">
                     <p className="text-sm font-medium">Game Facts</p>
                     {(projection.gameFacts ?? []).length === 0 ? (
@@ -1150,6 +1504,22 @@ export function EventGameControllerPage() {
   );
 }
 
+function flagCatchBoundaryOverride(gameTimeMs: number, running: boolean): OfficialOverrideMetadata {
+  return {
+    guardrail: "flag-catch-requires-seeker-release-and-stopped-play",
+    direction: "head-referee-directed-flag-catch-boundary",
+    confirmation: "head-referee-confirmed",
+    authorityReference: "head-referee",
+    gameTimeMs,
+    beforeValue: {
+      seekerReleased: gameTimeMs >= SEEKER_RELEASE_MS,
+      running,
+    },
+    afterValue: { flagCatch: "accepted" },
+    reason: "head-referee-direction",
+  };
+}
+
 function formatClock(milliseconds: number): string {
   const totalSeconds = Math.floor(milliseconds / 1000);
   const minutes = Math.floor(totalSeconds / 60);
@@ -1159,6 +1529,17 @@ function formatClock(milliseconds: number): string {
 
 function formatSynchronizationTime(milliseconds: number | null | undefined): string {
   return typeof milliseconds !== "number" ? "not available" : new Date(milliseconds).toISOString();
+}
+
+function isDoubleForfeitResult(result: ControllerProjection["result"]): boolean {
+  return (
+    result !== null &&
+    result !== undefined &&
+    typeof result.data === "object" &&
+    result.data !== null &&
+    !Array.isArray(result.data) &&
+    result.data.resultKind === "double-forfeit"
+  );
 }
 
 function readMonotonicNow(): number {


### PR DESCRIPTION
## What changed

- Implemented durable IQA goal and flag-catch scoring through rebuilt Derived Game State.
- Added fixed overtime-target, completion, concession, directed-forfeit, and double-forfeit behavior.
- Added Head Referee adjudication for closely timed goal/catch facts, including Correction, reinstatement, replay, and reconnect behavior.
- Exposed the resulting score, phase, target, winner, and official outcomes in the Controller projection and phone workflow.

## Why

The Live Event Game Controller previously lacked the complete IQA scoring and result path required by Spec #83. In particular, overtime and late/corrected scoring could not reliably rebuild every dependent result from durable facts.

## Impact

Controllers can now record and repair goals, catches, overtime, concessions, and forfeits while preserving idempotency, audit evidence, offline replay, and deterministic state reconstruction. Ad Hoc Game behavior remains unchanged.

## Validation

- Focused ordinary scoring and Controller suites: 117 passed
- Full ordinary suite: 693 passed
- `bun run check`
- `bun run build`
- `git diff --check`

Closes #90.
