### PR TITLE
Complete live Event Game penalty timing

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -180,6 +180,10 @@ _Avoid_: Scorekeeper app role, score-only Controller
 An optional broad classification of why a penalty card was issued in the app, supplementary to the exact foul recorded on the Official Score Sheet.
 _Avoid_: Foul text, official penalty record
 
+**Penalty Release Cause**:
+The sporting occurrence that ends penalty service early, such as an opposing score or a foul-before-score ruling; it is distinct from the optional Penalty Reason that classifies why the card was issued.
+_Avoid_: Penalty Reason, foul classification
+
 **Control Grant**:
 A Pitch Slot-scoped shared capability that admits Controllers to the one Event Game currently assigned to that slot. Its QR credential remains with the Pitch Slot when the schedule or Game assignment changes.
 _Avoid_: User account, controller account, controller role

--- a/src/lib/controller-intent-retry.test.ts
+++ b/src/lib/controller-intent-retry.test.ts
@@ -20,6 +20,13 @@ describe("Controller tap retry identity", () => {
   test("uses one immutable pending seam for every controller intent", () => {
     const cases: LiveEventControllerIntent[] = [
       intent("record-goal", { gameSideId: "side-a" }),
+      intent("record-card", { gameSideId: "side-b", playerNumber: 7, cardType: "blue" }),
+      intent("record-penalty-reason", { targetCardFactId: "fact-card", reason: "conduct" }),
+      intent("resolve-penalty-expiration", {
+        pendingId: "pending",
+        scoreFactId: "score",
+        playerKey: "side-b:7",
+      }),
       intent("clock", { running: true }),
       intent("substantive", { trigger: "card" }),
       intent("substantive", { trigger: "timeout" }),
@@ -36,6 +43,7 @@ describe("Controller tap retry identity", () => {
       });
       expect(retry).toBe(first);
     }
+
     const scored = intent("record-flag-catch", {
       gameSideId: "side-a",
       sportingOrderAdjudication: { relatedFactId: "goal", relation: "before" },
@@ -55,6 +63,30 @@ describe("Controller tap retry identity", () => {
         },
       }),
     ).not.toBe(scored);
+
+    const card = intent("record-card", {
+      gameSideId: "side-b",
+      playerNumber: 7,
+      cardType: "blue",
+      sportingOrder: 100,
+    });
+    expect(retainControllerIntent(card, { ...card, sportingOrder: 101 })).not.toBe(card);
+    expect(
+      retainControllerIntent(card, {
+        ...card,
+        override: {
+          guardrail: "test-guardrail",
+          direction: "head-referee-direction",
+          confirmation: "head-referee-confirmed",
+          authorityReference: "head-referee",
+          gameTimeMs: 0,
+          beforeValue: null,
+          afterValue: null,
+          reason: "head-referee-direction",
+        },
+      }),
+    ).not.toBe(card);
+
     const forfeit = intent("substantive", {
       trigger: "forfeit",
       gameSideId: "side-a",

--- a/src/lib/controller-intent-retry.ts
+++ b/src/lib/controller-intent-retry.ts
@@ -51,6 +51,33 @@ export function controllerIntentRetryKey(intent: LiveEventControllerIntent): str
         intent.sportingOrder ?? null,
         intent.override ?? null,
       ]);
+    case "record-card":
+      return JSON.stringify([
+        intent.type,
+        intent.gameSideId,
+        intent.playerNumber,
+        intent.cardType,
+        intent.foulBeforeScore ?? false,
+        intent.seekerPenalty ?? null,
+        intent.gameTimeMs,
+        intent.sportingOrder ?? null,
+        intent.override ?? null,
+      ]);
+    case "record-penalty-reason":
+      return JSON.stringify([
+        intent.type,
+        intent.targetCardFactId,
+        intent.reason,
+        intent.gameTimeMs,
+      ]);
+    case "resolve-penalty-expiration":
+      return JSON.stringify([
+        intent.type,
+        intent.pendingId,
+        intent.scoreFactId,
+        intent.playerKey,
+        intent.gameTimeMs,
+      ]);
     case "correct-fact":
       return JSON.stringify([
         intent.type,

--- a/src/lib/controller-reconnect.test.ts
+++ b/src/lib/controller-reconnect.test.ts
@@ -147,6 +147,50 @@ describe("Controller reconnect replica", () => {
     expect(undoState.projection.phase).toBe("scheduled");
   });
 
+  test("materializes passive commencement before classifying an offline card", () => {
+    let state = dispatchControllerClockAction(createReplica(), clock("start-clock", true), {
+      nowMs: 100,
+    }).state;
+    state = dispatchControllerAction(state, card("card-after-passive-boundary"), {
+      nowMs: 10_200,
+    }).state;
+    expect(state.projection.commencement).toMatchObject({
+      status: "commenced",
+      commencedAtMs: 10_100,
+    });
+    expect(state.projection.gameFacts?.at(-1)?.data).toMatchObject({
+      penaltyStart: "immediate",
+    });
+  });
+
+  test("anchors an optimistic delayed tie choice to its score fact", () => {
+    let state = dispatchControllerAction(createReplica(), goal("tie-score", "tie-score-fact"), {
+      nowMs: 100,
+    }).state;
+    state = dispatchControllerAction(
+      state,
+      {
+        version: LIVE_EVENT_CONTROL_INTENT_VERSION,
+        type: "resolve-penalty-expiration",
+        operationId: "delayed-choice",
+        factId: "delayed-choice-fact",
+        pendingId: "penalty-expiration:tie-score-fact",
+        scoreFactId: "tie-score-fact",
+        playerKey: "side-b:7",
+        gameTimeMs: 90_000,
+        sportingOrder: 90_000,
+        occurrence: { clientOriginAtMs: 90_000, source: "offline" as const },
+      },
+      { nowMs: 90_000 },
+    ).state;
+    expect(state.projection.gameFacts?.at(-1)).toMatchObject({
+      factType: "penalty-release",
+      gameTimeMs: 42,
+      sportingOrder: 42,
+      data: { scoreFactId: "tie-score-fact", sportingOrder: 42 },
+    });
+  });
+
   test("keeps mixed causal optimistic effects while unrelated actions progress", () => {
     let state = createReplica();
     const card = dispatchControllerAction(state, substantive("card", "card"), { nowMs: 100 });
@@ -616,6 +660,20 @@ function correction(operationId: string, factId: string, effective: boolean, tar
     effective,
     gameTimeMs: 1_300_000,
     occurrence: { clientOriginAtMs: 1_300_000, source: "offline" as const },
+  };
+}
+
+function card(operationId: string) {
+  return {
+    version: LIVE_EVENT_CONTROL_INTENT_VERSION,
+    type: "record-card" as const,
+    operationId,
+    factId: `fact-${operationId}`,
+    gameSideId: "side-b",
+    playerNumber: 7,
+    cardType: "blue" as const,
+    gameTimeMs: 10_000,
+    occurrence: { clientOriginAtMs: 10_000, source: "offline" as const },
   };
 }
 

--- a/src/lib/controller-reconnect.ts
+++ b/src/lib/controller-reconnect.ts
@@ -9,6 +9,7 @@ import type {
   LiveStoppageState,
   LiveTimeoutState,
 } from "@/lib/live-event-game-control";
+import { deriveLivePenaltyProjection } from "@/lib/live-event-penalties";
 import { parseJsonValue } from "@/lib/event-game-action-codecs";
 import {
   applyClockProjectionAction,
@@ -655,6 +656,8 @@ function applyOptimisticAction(
   )
     return state;
   if (intent.type === "record-goal") {
+    const current = state.projection.scoreByGameSide[intent.gameSideId];
+    if (current === undefined) return state;
     const nextFacts = appendOptimisticFact(state.projection, {
       factId: intent.factId,
       factType: "goal",
@@ -673,6 +676,136 @@ function applyOptimisticAction(
       },
     });
     return rebuildOptimisticProjection(state, nextFacts, action.dispatchedAtMs);
+  }
+  if (intent.type === "record-card") {
+    const commencementAtDispatch = projectOptimisticCommencement(
+      state.projection.commencement,
+      state.projection.clock.running,
+      action.dispatchedAtMs,
+    );
+    const penaltyStart =
+      commencementAtDispatch.status === "provisional"
+        ? "sticks-up"
+        : intent.seekerPenalty === "head-referee-confirmed" &&
+            intent.gameTimeMs >= 19 * 60_000 &&
+            intent.gameTimeMs < 20 * 60_000
+          ? "seeker-release"
+          : "immediate";
+    const playerKey =
+      intent.playerNumber === null
+        ? `${intent.gameSideId}:unknown:${intent.factId}`
+        : `${intent.gameSideId}:${intent.playerNumber}`;
+    let nextFacts = appendOptimisticFact(state.projection, {
+      factId: intent.factId,
+      factType: "card",
+      gameSideId: intent.gameSideId,
+      gameTimeMs: intent.gameTimeMs,
+      sportingOrder: intent.sportingOrder ?? intent.gameTimeMs,
+      data: {
+        cardType: intent.cardType,
+        playerNumber: intent.playerNumber,
+        penaltyStart,
+        ...(intent.foulBeforeScore === undefined
+          ? {}
+          : { foulBeforeScore: intent.foulBeforeScore }),
+        ...(intent.seekerPenalty === undefined ? {} : { seekerPenalty: intent.seekerPenalty }),
+        sportingOrder: intent.sportingOrder ?? intent.gameTimeMs,
+      },
+    });
+    if (
+      intent.foulBeforeScore === true &&
+      (intent.cardType === "blue" || intent.cardType === "yellow")
+    ) {
+      nextFacts = appendOptimisticFact(
+        { ...state.projection, gameFacts: nextFacts },
+        {
+          factId: `${intent.factId}-penalty-release`,
+          factType: "penalty-release-consequence",
+          gameSideId: intent.gameSideId,
+          gameTimeMs: intent.gameTimeMs,
+          sportingOrder: intent.sportingOrder ?? intent.gameTimeMs,
+          data: {
+            sourceFactId: intent.factId,
+            playerKey,
+            releaseCause: "foul-before-score",
+            releasedMs: intent.gameTimeMs,
+            serviceDurationMs: 60_000,
+            sportingOrder: intent.sportingOrder ?? intent.gameTimeMs,
+          },
+        },
+      );
+    }
+    return {
+      ...state,
+      projection: {
+        ...state.projection,
+        phase:
+          state.projection.commencement.status === "provisional"
+            ? "in-progress"
+            : state.projection.phase,
+        commencement:
+          commencementAtDispatch.status === "provisional"
+            ? {
+                ...commencementAtDispatch,
+                status: "commenced",
+                commencedAtMs: action.dispatchedAtMs,
+                provisionalRunningSinceMs: null,
+              }
+            : commencementAtDispatch,
+        gameFacts: nextFacts,
+        penalties: deriveLivePenaltyProjection(nextFacts, state.projection.clock.gameTimeMs),
+      },
+    };
+  }
+  if (intent.type === "record-penalty-reason") {
+    const nextFacts = appendOptimisticFact(state.projection, {
+      factId: intent.factId,
+      factType: "penalty-reason",
+      gameSideId: null,
+      gameTimeMs: intent.gameTimeMs,
+      sportingOrder: intent.sportingOrder ?? intent.gameTimeMs,
+      data: {
+        targetCardFactId: intent.targetCardFactId,
+        reason: intent.reason,
+        sportingOrder: intent.sportingOrder ?? intent.gameTimeMs,
+      },
+    });
+    return {
+      ...state,
+      projection: {
+        ...state.projection,
+        gameFacts: nextFacts,
+        penalties: deriveLivePenaltyProjection(nextFacts, state.projection.clock.gameTimeMs),
+      },
+    };
+  }
+  if (intent.type === "resolve-penalty-expiration") {
+    const scoreFact = (state.projection.gameFacts ?? []).find(
+      (fact) => fact.factId === intent.scoreFactId && fact.factType === "goal",
+    );
+    const scoreGameTimeMs = scoreFact?.gameTimeMs ?? intent.gameTimeMs;
+    const scoreSportingOrder = scoreFact?.sportingOrder ?? scoreGameTimeMs;
+    const nextFacts = appendOptimisticFact(state.projection, {
+      factId: intent.factId,
+      factType: "penalty-release",
+      gameSideId: null,
+      gameTimeMs: scoreGameTimeMs,
+      sportingOrder: scoreSportingOrder,
+      data: {
+        pendingId: intent.pendingId,
+        scoreFactId: intent.scoreFactId,
+        playerKey: intent.playerKey,
+        sportingOrder: scoreSportingOrder,
+      },
+    });
+    return {
+      ...state,
+      projection: {
+        ...state.projection,
+        gameFacts: nextFacts,
+        penalties: deriveLivePenaltyProjection(nextFacts, state.projection.clock.gameTimeMs),
+      },
+    };
   }
   if (
     intent.type === "record-flag-catch" ||
@@ -733,32 +866,75 @@ function applyOptimisticAction(
     intent.type === "clock-correction" ||
     intent.type === "clock-takeover"
   ) {
+    const commencementAtDispatch = projectOptimisticCommencement(
+      state.projection.commencement,
+      state.projection.clock.running,
+      action.dispatchedAtMs,
+    );
+    const clock = applyClockProjectionAction(state.projection.clock, {
+      command:
+        intent.type === "clock" || intent.type === "set-running"
+          ? "set-running"
+          : intent.type === "clock-adjust"
+            ? "adjust"
+            : intent.type === "clock-correction"
+              ? "correct"
+              : "takeover",
+      running: "running" in intent ? intent.running : undefined,
+      gameTimeMs: "clockTimeMs" in intent ? intent.clockTimeMs : undefined,
+      adjustmentMs: "adjustmentMs" in intent ? intent.adjustmentMs : undefined,
+      authorityGeneration:
+        "authorityGeneration" in intent ? intent.authorityGeneration : intent.clockGeneration,
+      sessionId: state.session.grantSessionId,
+      operationId: intent.operationId,
+    });
     return {
       ...state,
       projection: {
         ...state.projection,
-        clock: applyClockProjectionAction(state.projection.clock, {
-          command:
-            intent.type === "clock" || intent.type === "set-running"
-              ? "set-running"
-              : intent.type === "clock-adjust"
-                ? "adjust"
-                : intent.type === "clock-correction"
-                  ? "correct"
-                  : "takeover",
-          running: "running" in intent ? intent.running : undefined,
-          gameTimeMs: "clockTimeMs" in intent ? intent.clockTimeMs : undefined,
-          adjustmentMs: "adjustmentMs" in intent ? intent.adjustmentMs : undefined,
-          authorityGeneration:
-            "authorityGeneration" in intent ? intent.authorityGeneration : intent.clockGeneration,
-          sessionId: state.session.grantSessionId,
-          operationId: intent.operationId,
-        }),
+        clock,
+        commencement:
+          commencementAtDispatch.status === "commenced"
+            ? commencementAtDispatch
+            : {
+                ...commencementAtDispatch,
+                provisionalRunningSinceMs: clock.running ? action.dispatchedAtMs : null,
+              },
       },
     };
   }
   return {
     ...state,
+  };
+}
+
+function projectOptimisticCommencement(
+  commencement: ControllerProjection["commencement"],
+  clockRunning: boolean,
+  nowMs: number,
+): ControllerProjection["commencement"] {
+  if (commencement.status === "commenced") return commencement;
+  const liveElapsedMs =
+    clockRunning && commencement.provisionalRunningSinceMs !== null
+      ? Math.max(0, nowMs - commencement.provisionalRunningSinceMs)
+      : 0;
+  const provisionalElapsedMs = commencement.provisionalElapsedMs + liveElapsedMs;
+  if (provisionalElapsedMs >= 10_000) {
+    return {
+      status: "commenced",
+      commencedAtMs:
+        commencement.provisionalRunningSinceMs === null
+          ? nowMs
+          : commencement.provisionalRunningSinceMs +
+            Math.max(0, 10_000 - commencement.provisionalElapsedMs),
+      provisionalRunningSinceMs: null,
+      provisionalElapsedMs,
+    };
+  }
+  return {
+    ...commencement,
+    provisionalElapsedMs,
+    provisionalRunningSinceMs: clockRunning ? nowMs : null,
   };
 }
 
@@ -1029,6 +1205,13 @@ function parseProjection(value: unknown): ControllerProjection {
   const overtimeTarget = parseOptionalScore(value.overtimeTarget ?? value.targetScore);
   const winnerGameSideId = parseOptionalIdentifier(value.winnerGameSideId, "winnerGameSideId");
   const catchState = parseOptionalCatch(value.catch);
+  const penalties =
+    value.penalties === undefined
+      ? undefined
+      : deriveLivePenaltyProjection(
+          gameFacts ?? [],
+          isRecord(clock) && typeof clock.gameTimeMs === "number" ? clock.gameTimeMs : 0,
+        );
   return {
     eventGameId,
     phase,
@@ -1043,6 +1226,7 @@ function parseProjection(value: unknown): ControllerProjection {
     ...(winnerGameSideId === undefined ? {} : { winnerGameSideId }),
     ...(catchState === undefined ? {} : { catch: catchState }),
     ...(value.gameFacts === undefined ? {} : { gameFacts }),
+    ...(penalties === undefined ? {} : { penalties }),
     ...(value.guardrails === undefined ? {} : { guardrails }),
     clock,
     commencement: {

--- a/src/lib/live-event-game-control.test.ts
+++ b/src/lib/live-event-game-control.test.ts
@@ -17,10 +17,687 @@ import {
   validateLiveEventGameActionInTransaction,
 } from "@/lib/live-event-game-control";
 import { createLiveEventGameControlTransport } from "@/lib/live-event-game-transport";
+import { LIVE_SEEKER_RELEASE_MS } from "@/lib/live-event-penalties";
 import { createAdHocGamesService } from "@/lib/ad-hoc-games";
 import { createControlScopeResolver as createRuntimeControlScopeResolver } from "@/lib/live-event-game-runtime";
 
 describe("Live Event Game control", () => {
+  test("keeps Penalty Reason values fixed while skip remains a Controller-only absence", () => {
+    expect(
+      parseLiveEventControllerIntent({
+        ...reasonIntent(),
+        reason: "skip",
+      }),
+    ).toMatchObject({ ok: false });
+    expect(
+      parseLiveEventControllerIntent({
+        ...reasonIntent(),
+        reason: "free text",
+      }),
+    ).toMatchObject({ ok: false });
+    expect(
+      parseLiveEventControllerIntent({
+        ...cardIntent(),
+        seekerPenalty: "controller-guessed",
+      }),
+    ).toMatchObject({ ok: false });
+  });
+
+  test("derives sticks-up and seeker-floor timing from the real Controller seam", async () => {
+    const pregame = await createHarness();
+    const pregameOpened = await pregame.control.openController({
+      qrCredential: pregame.qrCredential,
+      browserContext: "pregame-card-controller",
+    });
+    if (pregameOpened.status !== "opened") throw new Error("Expected the Controller to open.");
+    await pregame.control.submitControllerIntent({
+      sessionBearer: pregameOpened.session.sessionBearer,
+      eventGameId: pregame.root.eventGameId,
+      intent: clockCorrectionIntent("pregame-clock", 90_000),
+    });
+    const pregameCard = await pregame.control.submitControllerIntent({
+      sessionBearer: pregameOpened.session.sessionBearer,
+      eventGameId: pregame.root.eventGameId,
+      intent: cardIntent(),
+    });
+    expect(pregameCard).toMatchObject({
+      status: "accepted",
+      projection: { phase: "in-progress" },
+    });
+    expect((await pregame.record.readActions()).at(-1)?.action.interpretation).toMatchObject({
+      type: "fact",
+      factType: "card",
+      payload: { gameTimeMs: 90_000, data: { penaltyStart: "sticks-up" } },
+    });
+
+    const inGame = await createHarness();
+    const opened = await inGame.control.openController({
+      qrCredential: inGame.qrCredential,
+      browserContext: "seeker-floor-controller",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+    await inGame.control.submitControllerIntent({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: inGame.root.eventGameId,
+      intent: goalIntent({ operationId: "commence-game", factId: "commence-game" }),
+    });
+    const seekerGameTime = 19 * 60_000 + 30_000;
+    await inGame.control.submitControllerIntent({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: inGame.root.eventGameId,
+      intent: clockCorrectionIntent("seeker-clock", seekerGameTime),
+    });
+    const ordinaryCard = await inGame.control.submitControllerIntent({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: inGame.root.eventGameId,
+      intent: cardIntent({
+        operationId: "ordinary-floor-card",
+        factId: "ordinary-floor-card",
+        playerNumber: 8,
+      }),
+    });
+    expect(ordinaryCard).toMatchObject({ status: "accepted" });
+    const seekerCard = await inGame.control.submitControllerIntent({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: inGame.root.eventGameId,
+      intent: cardIntent({
+        operationId: "seeker-card",
+        factId: "seeker-card",
+        seekerPenalty: "head-referee-confirmed",
+      }),
+    });
+    expect(seekerCard).toMatchObject({ status: "accepted" });
+    expect((await inGame.record.readActions()).at(-1)?.action.interpretation).toMatchObject({
+      type: "fact",
+      factType: "card",
+      payload: {
+        gameTimeMs: seekerGameTime,
+        data: {
+          penaltyStart: "seeker-release",
+          seekerPenalty: "head-referee-confirmed",
+        },
+      },
+    });
+    expect(
+      (await inGame.record.readActions()).find(
+        ({ action }) => action.operationId === "ordinary-floor-card",
+      )?.action.interpretation,
+    ).toMatchObject({
+      type: "fact",
+      payload: { data: { penaltyStart: "immediate" } },
+    });
+
+    const earlierGoal = await inGame.control.submitControllerIntent({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: inGame.root.eventGameId,
+      intent: {
+        ...goalIntent({
+          operationId: "before-seeker-floor",
+          factId: "before-seeker-floor",
+          gameTimeMs: seekerGameTime + 1,
+        }),
+        occurrence: { clientOriginAtMs: 10_000, source: "offline" as const },
+      },
+    });
+    expect(earlierGoal).toMatchObject({
+      status: "accepted",
+      projection: {
+        penalties: {
+          pendingExpirations: [],
+          releases: [{ playerKey: "side-b:8", releasedMs: seekerGameTime + 1 }],
+        },
+      },
+    });
+    if (earlierGoal.status !== "accepted" || earlierGoal.projection?.penalties === undefined) {
+      throw new Error("Expected the pre-floor score projection.");
+    }
+    expect(
+      earlierGoal.projection.penalties.players.some((player) => player.playerNumber === 7),
+    ).toBe(true);
+    expect(
+      earlierGoal.projection.penalties.releases.some((release) => release.playerKey === "side-b:7"),
+    ).toBe(false);
+    await inGame.control.submitControllerIntent({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: inGame.root.eventGameId,
+      intent: clockCorrectionIntent("seeker-release-clock", 20 * 60_000),
+    });
+    const releasedAtFloor = await inGame.control.submitControllerIntent({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: inGame.root.eventGameId,
+      intent: goalIntent({
+        operationId: "at-seeker-floor",
+        factId: "at-seeker-floor",
+        gameTimeMs: 0,
+      }),
+    });
+    expect(releasedAtFloor).toMatchObject({ status: "accepted" });
+    if (
+      releasedAtFloor.status !== "accepted" ||
+      releasedAtFloor.projection?.penalties === undefined
+    ) {
+      throw new Error("Expected the seeker-floor score projection.");
+    }
+    expect(
+      releasedAtFloor.projection.penalties.releases.some(
+        (release) =>
+          release.scoreFactId === "at-seeker-floor" &&
+          release.playerKey === "side-b:7" &&
+          release.releasedMs === LIVE_SEEKER_RELEASE_MS,
+      ),
+    ).toBe(true);
+  });
+
+  test("uses every queued penalty minute including red for Controller score priority", async () => {
+    const harness = await createHarness();
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "queued-priority-controller",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+    const submit = (intent: unknown) =>
+      harness.control.submitControllerIntent({
+        sessionBearer: opened.session.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+        intent,
+      });
+
+    await submit(substantiveIntent("commence-priority", "card"));
+    await submit(
+      cardIntent({
+        operationId: "two-first-controller",
+        factId: "two-first-controller",
+        playerNumber: 7,
+      }),
+    );
+    await submit(
+      cardIntent({
+        operationId: "queued-red-controller",
+        factId: "queued-red-controller",
+        playerNumber: 7,
+        cardType: "red",
+      }),
+    );
+    await submit(
+      cardIntent({ operationId: "one-controller", factId: "one-controller", playerNumber: 8 }),
+    );
+    const scored = await submit(
+      goalIntent({ operationId: "queued-priority-goal", factId: "queued-priority-goal" }),
+    );
+
+    expect(scored).toMatchObject({
+      status: "accepted",
+      projection: {
+        penalties: {
+          releases: [{ playerKey: "side-b:8", releaseCause: "score" }],
+          pendingExpirations: [],
+        },
+      },
+    });
+  });
+
+  test("keeps tie choice, red-to-blue gating, foul expiry, and reason follow-up on the Controller seam", async () => {
+    const tieHarness = await createHarness();
+    const tieOpened = await tieHarness.control.openController({
+      qrCredential: tieHarness.qrCredential,
+      browserContext: "tie-controller",
+    });
+    if (tieOpened.status !== "opened") throw new Error("Expected the Controller to open.");
+    const tieSubmit = (intent: unknown) =>
+      tieHarness.control.submitControllerIntent({
+        sessionBearer: tieOpened.session.sessionBearer,
+        eventGameId: tieHarness.root.eventGameId,
+        intent,
+      });
+    await tieSubmit(substantiveIntent("tie-commence", "card"));
+    await tieSubmit(
+      cardIntent({ operationId: "tie-card-a", factId: "tie-card-a", playerNumber: 7 }),
+    );
+    await tieSubmit(
+      cardIntent({ operationId: "tie-card-b", factId: "tie-card-b", playerNumber: 8 }),
+    );
+    const tie = await tieSubmit(
+      goalIntent({ operationId: "tie-goal", factId: "tie-goal", gameTimeMs: 0 }),
+    );
+    expect(tie).toMatchObject({
+      status: "accepted",
+      projection: {
+        penalties: {
+          pendingExpirations: [
+            {
+              candidatePlayerKeys: ["side-b:7", "side-b:8"],
+              requiresOfficialChoice: true,
+            },
+          ],
+        },
+      },
+    });
+    const selected = await tieSubmit({
+      ...releaseIntent("penalty-expiration:tie-goal", "tie-goal", "side-b:8"),
+    });
+    expect(selected).toMatchObject({
+      status: "accepted",
+      projection: { penalties: { pendingExpirations: [], players: [{ playerNumber: 7 }] } },
+    });
+
+    const redBlueHarness = await createHarness();
+    const redBlueOpened = await redBlueHarness.control.openController({
+      qrCredential: redBlueHarness.qrCredential,
+      browserContext: "red-blue-controller",
+    });
+    if (redBlueOpened.status !== "opened") throw new Error("Expected the Controller to open.");
+    const redBlueSubmit = (intent: unknown) =>
+      redBlueHarness.control.submitControllerIntent({
+        sessionBearer: redBlueOpened.session.sessionBearer,
+        eventGameId: redBlueHarness.root.eventGameId,
+        intent,
+      });
+    await redBlueSubmit(substantiveIntent("red-blue-commence", "card"));
+    await redBlueSubmit(
+      cardIntent({
+        operationId: "a-red-controller",
+        factId: "a-red-controller",
+        playerNumber: 7,
+        cardType: "red",
+      }),
+    );
+    await redBlueSubmit(
+      cardIntent({
+        operationId: "b-blue-controller",
+        factId: "b-blue-controller",
+        playerNumber: 7,
+      }),
+    );
+    await redBlueSubmit(
+      cardIntent({
+        operationId: "c-blue-controller",
+        factId: "c-blue-controller",
+        playerNumber: 7,
+      }),
+    );
+    await redBlueSubmit(clockCorrectionIntent("a-red-blue-clock-30", 30_000));
+    const beforeBlue = await redBlueSubmit(
+      goalIntent({
+        operationId: "red-blue-early-goal",
+        factId: "red-blue-early-goal",
+        gameTimeMs: 0,
+      }),
+    );
+    expect(beforeBlue).toMatchObject({
+      status: "accepted",
+      projection: { penalties: { releases: [], pendingExpirations: [] } },
+    });
+    await redBlueSubmit(clockCorrectionIntent("b-red-blue-clock-120", 120_000));
+    const afterBlue = await redBlueSubmit(
+      goalIntent({
+        operationId: "red-blue-late-goal",
+        factId: "red-blue-late-goal",
+        gameTimeMs: 0,
+      }),
+    );
+    expect(afterBlue).toMatchObject({
+      status: "accepted",
+      projection: { penalties: { releases: [{ playerKey: "side-b:7", releaseCause: "score" }] } },
+    });
+    const afterFirstRelease = await redBlueSubmit(
+      goalIntent({
+        operationId: "red-blue-repeated-goal",
+        factId: "red-blue-repeated-goal",
+        gameTimeMs: 0,
+      }),
+    );
+    if (
+      afterFirstRelease.status !== "accepted" &&
+      afterFirstRelease.status !== "duplicate-accepted"
+    ) {
+      throw new Error("Expected the repeated score to be accepted.");
+    }
+    if (
+      afterFirstRelease.projection === null ||
+      afterFirstRelease.projection.penalties === undefined
+    ) {
+      throw new Error("Expected the repeated score projection.");
+    }
+    expect(
+      afterFirstRelease.projection.penalties.releases.some(
+        (release) =>
+          release.scoreFactId === "red-blue-repeated-goal" &&
+          release.playerKey === "side-b:7" &&
+          release.releaseCause === "score",
+      ),
+    ).toBe(true);
+
+    const foulHarness = await createHarness();
+    const foulOpened = await foulHarness.control.openController({
+      qrCredential: foulHarness.qrCredential,
+      browserContext: "foul-controller",
+    });
+    if (foulOpened.status !== "opened") throw new Error("Expected the Controller to open.");
+    const foulSubmit = (intent: unknown) =>
+      foulHarness.control.submitControllerIntent({
+        sessionBearer: foulOpened.session.sessionBearer,
+        eventGameId: foulHarness.root.eventGameId,
+        intent,
+      });
+    await foulSubmit(goalIntent({ operationId: "foul-commence", factId: "foul-commence" }));
+    const foul = await foulSubmit(
+      cardIntent({
+        operationId: "foul-card-controller",
+        factId: "foul-card-controller",
+        playerNumber: 9,
+        foulBeforeScore: true,
+      }),
+    );
+    expect(foul).toMatchObject({
+      status: "accepted",
+      projection: {
+        penalties: {
+          players: [],
+          releases: [{ playerKey: "side-b:9", releaseCause: "foul-before-score" }],
+        },
+      },
+    });
+    const foulRelease = (await foulHarness.record.readActions()).find(
+      ({ action }) =>
+        action.interpretation.type === "fact" &&
+        action.interpretation.factType === "penalty-release-consequence",
+    );
+    expect(foulRelease?.action.interpretation).toMatchObject({
+      type: "fact",
+      factType: "penalty-release-consequence",
+      payload: {
+        data: { releaseCause: "foul-before-score", sourceFactId: "foul-card-controller" },
+      },
+    });
+    const foulCorrection = await foulSubmit(
+      correctionIntent(
+        "correct-foul-release",
+        "correct-foul-release-fact",
+        false,
+        "foul-card-controller-penalty-release",
+      ),
+    );
+    expect(foulCorrection).toMatchObject({
+      status: "accepted",
+      projection: {
+        penalties: {
+          releases: [{ scoreFactId: "foul-commence", releaseCause: "score" }],
+          players: [{ playerNumber: 9 }],
+        },
+      },
+    });
+
+    const reasonHarness = await createHarness();
+    const reasonOpened = await reasonHarness.control.openController({
+      qrCredential: reasonHarness.qrCredential,
+      browserContext: "reason-controller",
+    });
+    if (reasonOpened.status !== "opened") throw new Error("Expected the Controller to open.");
+    const reasonSubmit = (intent: unknown) =>
+      reasonHarness.control.submitControllerIntent({
+        sessionBearer: reasonOpened.session.sessionBearer,
+        eventGameId: reasonHarness.root.eventGameId,
+        intent,
+      });
+    await reasonSubmit(cardIntent());
+    const laterReason = await reasonSubmit(
+      reasonIntent({
+        operationId: "zz-later-reason",
+        factId: "zz-later-reason",
+        reason: "conduct",
+      }),
+    );
+    expect(laterReason).toMatchObject({
+      status: "accepted",
+      projection: { penalties: { cards: [{ factId: "fact-card", reason: "conduct" }] } },
+    });
+  });
+
+  test("strips foul-before-score from ejection cards at the Controller boundary", async () => {
+    const harness = await createHarness();
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "ejection-foul-boundary",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+    const result = await harness.control.submitControllerIntent({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      intent: cardIntent({
+        operationId: "ejection-foul-card",
+        factId: "ejection-foul-card",
+        cardType: "ejection",
+        foulBeforeScore: true,
+      }),
+    });
+    expect(result).toMatchObject({
+      status: "accepted",
+      projection: { penalties: { releases: [] } },
+    });
+    const actions = await harness.record.readActions();
+    expect(actions).toHaveLength(1);
+    const interpretation = actions[0]?.action.interpretation;
+    expect(interpretation).toMatchObject({ factType: "card" });
+    if (
+      interpretation?.type !== "fact" ||
+      typeof interpretation.payload !== "object" ||
+      interpretation.payload === null
+    ) {
+      throw new Error("Expected a durable ejection card fact.");
+    }
+    if (Array.isArray(interpretation.payload) || !("data" in interpretation.payload)) {
+      throw new Error("Expected card payload data.");
+    }
+    expect(interpretation.payload.data).not.toHaveProperty("foulBeforeScore");
+  });
+
+  test("accepts a delayed tie choice after natural expiry and anchors it to the score fact", async () => {
+    const harness = await createHarness();
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "delayed-tie-controller",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+    const submit = (intent: unknown) =>
+      harness.control.submitControllerIntent({
+        sessionBearer: opened.session.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+        intent,
+      });
+
+    await submit(substantiveIntent("delayed-tie-commence", "card"));
+    await submit(cardIntent({ operationId: "delayed-tie-card-7", factId: "delayed-tie-card-7" }));
+    await submit(
+      cardIntent({
+        operationId: "delayed-tie-card-8",
+        factId: "delayed-tie-card-8",
+        playerNumber: 8,
+      }),
+    );
+    await submit(clockCorrectionIntent("delayed-tie-score-clock", 10_000));
+    const score = await submit(
+      goalIntent({
+        operationId: "delayed-tie-score",
+        factId: "delayed-tie-score",
+        gameTimeMs: 10_000,
+      }),
+    );
+    expect(score).toMatchObject({
+      status: "accepted",
+      projection: {
+        penalties: {
+          pendingExpirations: [{ scoreFactId: "delayed-tie-score", requiresOfficialChoice: true }],
+        },
+      },
+    });
+
+    await submit(clockCorrectionIntent("delayed-tie-clock-after-expiry", 90_000));
+    const selected = await submit(
+      releaseIntent(
+        "penalty-expiration:delayed-tie-score",
+        "delayed-tie-score",
+        "side-b:8",
+        90_000,
+      ),
+    );
+    expect(selected).toMatchObject({
+      status: "accepted",
+      projection: {
+        penalties: {
+          releases: [
+            {
+              scoreFactId: "delayed-tie-score",
+              playerKey: "side-b:8",
+              releasedMs: 10_000,
+            },
+          ],
+        },
+      },
+    });
+    const release = (await harness.record.readActions()).find(
+      ({ action }) => action.operationId === "zz-release-side-b:8",
+    );
+    expect(release?.action.interpretation).toMatchObject({
+      type: "fact",
+      factType: "penalty-release",
+      payload: {
+        gameTimeMs: 10_000,
+        data: {
+          pendingId: "penalty-expiration:delayed-tie-score",
+          scoreFactId: "delayed-tie-score",
+        },
+      },
+    });
+    expect(
+      await submit(
+        releaseIntent(
+          "penalty-expiration:delayed-tie-score",
+          "delayed-tie-score",
+          "side-b:8",
+          90_000,
+        ),
+      ),
+    ).toMatchObject({ status: "duplicate-accepted" });
+    expect(
+      await submit({
+        ...releaseIntent(
+          "penalty-expiration:delayed-tie-score",
+          "delayed-tie-score",
+          "side-b:7",
+          90_000,
+        ),
+        operationId: "competing-delayed-release",
+        factId: "competing-delayed-release",
+      }),
+    ).toMatchObject({ status: "rejected" });
+  });
+
+  test("accepts cards before optional fixed reasons, applies score release choice, and rebuilds corrections", async () => {
+    const harness = await createHarness();
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "penalty-control",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+    const submit = (intent: unknown) =>
+      harness.control.submitControllerIntent({
+        sessionBearer: opened.session.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+        intent,
+      });
+
+    expect(
+      await submit({
+        ...reasonIntent(),
+        operationId: "orphan-reason",
+        factId: "orphan-reason-fact",
+      }),
+    ).toMatchObject({ status: "rejected" });
+    const acceptedCard = await submit(cardIntent());
+    expect(acceptedCard).toMatchObject({
+      status: "accepted",
+      projection: {
+        penalties: {
+          cards: [{ factId: "fact-card", reason: null }],
+          pendingExpirations: [],
+        },
+      },
+    });
+    const reason = await submit(reasonIntent());
+    expect(reason).toMatchObject({
+      status: "accepted",
+      projection: { penalties: { cards: [{ reason: "contact-safety" }] } },
+    });
+
+    const goal = await submit(goalIntent({ gameSideId: "side-a", gameTimeMs: 0 }));
+    expect(goal).toMatchObject({
+      status: "accepted",
+      projection: {
+        penalties: {
+          pendingExpirations: [],
+          players: [],
+          releases: [
+            {
+              id: "fact-goal-penalty-release",
+              scoreFactId: "fact-goal",
+              playerKey: "side-b:7",
+            },
+          ],
+        },
+      },
+    });
+    expect(await submit(goalIntent({ gameSideId: "side-a", gameTimeMs: 0 }))).toMatchObject({
+      status: "duplicate-accepted",
+      projection: { penalties: { releases: [{ id: "fact-goal-penalty-release" }] } },
+    });
+    expect(
+      (await harness.record.readActions()).some(
+        ({ action }) =>
+          action.interpretation.type === "fact" &&
+          action.interpretation.factType === "penalty-release-consequence" &&
+          action.interpretation.factId === "fact-goal-penalty-release",
+      ),
+    ).toBe(true);
+    const correctedRelease = await submit(
+      correctionIntent(
+        "correct-release-consequence",
+        "correction-release-consequence",
+        false,
+        "fact-goal-penalty-release",
+      ),
+    );
+    expect(correctedRelease).toMatchObject({
+      status: "accepted",
+      projection: {
+        scoreByGameSide: { "side-a": 10 },
+        penalties: { players: [{ playerNumber: 7 }], releases: [] },
+      },
+    });
+    const reinstatedRelease = await submit(
+      correctionIntent(
+        "reinstate-release-consequence",
+        "reinstate-release-consequence",
+        true,
+        "fact-goal-penalty-release",
+      ),
+    );
+    expect(reinstatedRelease).toMatchObject({
+      status: "accepted",
+      projection: {
+        scoreByGameSide: { "side-a": 10 },
+        penalties: { releases: [{ id: "fact-goal-penalty-release" }] },
+      },
+    });
+
+    const corrected = await submit(
+      correctionIntent("correct-card", "correction-card", false, "fact-card"),
+    );
+    expect(corrected).toMatchObject({
+      status: "accepted",
+      projection: { penalties: { cards: [], players: [], pendingExpirations: [] } },
+    });
+  });
+
   test("Event authority, storage, and control remain accepted after Ad Hoc pressure", async () => {
     const adHoc = createAdHocGamesService({
       now: () => 1_000,
@@ -4278,6 +4955,431 @@ describe("Live Event Game control", () => {
       }),
     ).toMatchObject({ status: "ok", value: [] });
   });
+  test("keeps a retryable card ahead of its reason while unrelated replay work progresses", async () => {
+    const harness = await createHarness({ failureAfterActionNumber: 1 });
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "card-reason-causal-replay",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+    const card = cardIntent({
+      operationId: "retryable-card",
+      factId: "retryable-card-fact",
+      cardType: "ejection",
+    });
+    const reason = reasonIntent({
+      operationId: "card-dependent-reason",
+      factId: "card-dependent-reason-fact",
+      targetCardFactId: "retryable-card-fact",
+    });
+    const replayInput = {
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      batchId: "card-reason-causal-batch",
+      replicaGeneration: "card-reason-causal-generation",
+      expectedGrantSessionId: opened.session.grantSessionId,
+      expectedGrantVersion: opened.session.grantVersion,
+      actions: [
+        { eventGameId: harness.root.eventGameId, intent: card, causalPredecessorIds: [] },
+        {
+          eventGameId: harness.root.eventGameId,
+          intent: reason,
+          causalPredecessorIds: ["retryable-card"],
+        },
+        {
+          eventGameId: harness.root.eventGameId,
+          intent: goalIntent({
+            operationId: "unrelated-replay-goal",
+            factId: "unrelated-replay-goal-fact",
+          }),
+          causalPredecessorIds: [],
+        },
+      ],
+    };
+    const first = await harness.control.replayControllerActions(replayInput);
+    expect(
+      Object.fromEntries(first.outcomes.map((outcome) => [outcome.operationId, outcome.status])),
+    ).toEqual({
+      "retryable-card": "retryable",
+      "unrelated-replay-goal": "accepted",
+      "card-dependent-reason": "causally-blocked",
+    });
+
+    harness.failureAfterActionNumber = undefined;
+    const converged = await harness.control.replayControllerActions({
+      ...replayInput,
+      batchId: "card-reason-causal-retry",
+      actions: replayInput.actions.slice(0, 2),
+    });
+    expect(converged.outcomes).toEqual([
+      { operationId: "retryable-card", status: "accepted" },
+      { operationId: "card-dependent-reason", status: "accepted" },
+    ]);
+    expect(converged.projection).toMatchObject({
+      penalties: { cards: [{ factId: "retryable-card-fact", reason: "contact-safety" }] },
+    });
+  });
+
+  test("retains a complete-tie choice behind a retryable score during replay", async () => {
+    const harness = await createHarness();
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "score-choice-causal-replay",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+    const submit = (intent: unknown) =>
+      harness.control.submitControllerIntent({
+        sessionBearer: opened.session.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+        intent,
+      });
+    await submit(
+      cardIntent({ operationId: "choice-card-7", factId: "choice-card-7", playerNumber: 7 }),
+    );
+    await submit(
+      cardIntent({ operationId: "choice-card-8", factId: "choice-card-8", playerNumber: 8 }),
+    );
+    harness.failureAfterActionNumber = 3;
+    const score = goalIntent({
+      operationId: "choice-score",
+      factId: "choice-score",
+      gameTimeMs: 12_000,
+    });
+    const choice = releaseIntent(
+      "penalty-expiration:choice-score",
+      "choice-score",
+      "side-b:8",
+      12_000,
+    );
+    const replayInput = {
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      batchId: "score-choice-causal-batch",
+      replicaGeneration: "score-choice-causal-generation",
+      expectedGrantSessionId: opened.session.grantSessionId,
+      expectedGrantVersion: opened.session.grantVersion,
+      actions: [
+        { eventGameId: harness.root.eventGameId, intent: score, causalPredecessorIds: [] },
+        {
+          eventGameId: harness.root.eventGameId,
+          intent: choice,
+          causalPredecessorIds: ["choice-score"],
+        },
+      ],
+    };
+    const first = await harness.control.replayControllerActions(replayInput);
+    expect(first.outcomes).toEqual([
+      { operationId: "choice-score", status: "retryable", detail: "retryable server outcome" },
+      { operationId: choice.operationId, status: "causally-blocked" },
+    ]);
+    expect(await harness.record.readActions()).toHaveLength(2);
+
+    harness.failureAfterActionNumber = undefined;
+    const second = await harness.control.replayControllerActions({
+      ...replayInput,
+      batchId: "score-choice-causal-retry",
+    });
+    expect(second.outcomes).toEqual([
+      { operationId: "choice-score", status: "accepted" },
+      { operationId: choice.operationId, status: "accepted" },
+    ]);
+    expect(second.projection).toMatchObject({
+      penalties: { releases: [{ scoreFactId: "choice-score", playerKey: "side-b:8" }] },
+    });
+  });
+
+  test("repairs a missing automatic release consequence after a source-only batch commit", async () => {
+    const harness = await createHarness({ failureAfterActionNumber: 3 });
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "automatic-release-repair",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+    const submit = (intent: unknown) =>
+      harness.control.submitControllerIntent({
+        sessionBearer: opened.session.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+        intent,
+      });
+    await submit(cardIntent({ operationId: "repair-card", factId: "repair-card" }));
+    const firstGoal = await submit(
+      goalIntent({
+        operationId: "repair-goal",
+        factId: "repair-goal",
+        sportingOrder: 7_000,
+        override: {
+          guardrail: "sporting-order-adjudication",
+          direction: "head-referee-adjudicated-sporting-order",
+          confirmation: "head-referee-confirmed",
+          authorityReference: "head-referee",
+          gameTimeMs: 12_000,
+          beforeValue: { sportingOrder: 12_000 },
+          afterValue: { sportingOrder: 7_000 },
+          reason: "head-referee-direction",
+        },
+      }),
+    );
+    expect(firstGoal).toMatchObject({ status: "retryable", operationId: "repair-goal" });
+    expect(await harness.record.readActions()).toHaveLength(2);
+
+    harness.failureAfterActionNumber = undefined;
+    const repaired = await submit(
+      goalIntent({
+        operationId: "repair-goal",
+        factId: "repair-goal",
+        sportingOrder: 7_000,
+        override: {
+          guardrail: "sporting-order-adjudication",
+          direction: "head-referee-adjudicated-sporting-order",
+          confirmation: "head-referee-confirmed",
+          authorityReference: "head-referee",
+          gameTimeMs: 12_000,
+          beforeValue: { sportingOrder: 12_000 },
+          afterValue: { sportingOrder: 7_000 },
+          reason: "head-referee-direction",
+        },
+      }),
+    );
+    expect(repaired).toMatchObject({
+      status: "duplicate-accepted",
+      projection: { penalties: { releases: [{ releaseCause: "score" }] } },
+    });
+    expect(await harness.record.readActions()).toHaveLength(3);
+    const releaseConsequences = (await harness.record.readActions()).filter(
+      ({ action }) =>
+        action.interpretation.type === "fact" &&
+        action.interpretation.factType === "penalty-release-consequence",
+    );
+    expect(releaseConsequences).toHaveLength(1);
+    expect(releaseConsequences[0]?.action.causalPredecessorIds).toContain("repair-goal");
+    expect(releaseConsequences[0]?.action.interpretation).toMatchObject({
+      payload: { data: { sportingOrder: 7_000 } },
+    });
+    expect(
+      (await harness.record.readActions()).find(
+        ({ action }) => action.operationId === "repair-goal",
+      )?.action.interpretation,
+    ).toMatchObject({ payload: { data: { sportingOrder: 7_000 } } });
+
+    const duplicate = await submit(
+      goalIntent({
+        operationId: "repair-goal",
+        factId: "repair-goal",
+        sportingOrder: 7_000,
+        override: {
+          guardrail: "sporting-order-adjudication",
+          direction: "head-referee-adjudicated-sporting-order",
+          confirmation: "head-referee-confirmed",
+          authorityReference: "head-referee",
+          gameTimeMs: 12_000,
+          beforeValue: { sportingOrder: 12_000 },
+          afterValue: { sportingOrder: 7_000 },
+          reason: "head-referee-direction",
+        },
+      }),
+    );
+    expect(duplicate).toMatchObject({ status: "duplicate-accepted" });
+    expect(await harness.record.readActions()).toHaveLength(3);
+  });
+
+  test("keeps direct and repaired release consequences on the source sporting order", async () => {
+    const harness = await createHarness();
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "direct-sporting-order-release",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+    const submit = (intent: unknown) =>
+      harness.control.submitControllerIntent({
+        sessionBearer: opened.session.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+        intent,
+      });
+    await submit(cardIntent({ operationId: "direct-order-card", factId: "direct-order-card" }));
+    await submit(
+      goalIntent({
+        operationId: "direct-order-goal",
+        factId: "direct-order-goal",
+        sportingOrder: 7_000,
+        override: {
+          guardrail: "sporting-order-adjudication",
+          direction: "head-referee-adjudicated-sporting-order",
+          confirmation: "head-referee-confirmed",
+          authorityReference: "head-referee",
+          gameTimeMs: 12_000,
+          beforeValue: { sportingOrder: 12_000 },
+          afterValue: { sportingOrder: 7_000 },
+          reason: "head-referee-direction",
+        },
+      }),
+    );
+    const consequence = (await harness.record.readActions()).find(
+      ({ action }) =>
+        action.interpretation.type === "fact" &&
+        action.interpretation.factType === "penalty-release-consequence",
+    );
+    expect(consequence?.action.interpretation).toMatchObject({
+      payload: { data: { sourceFactId: "direct-order-goal", sportingOrder: 7_000 } },
+    });
+  });
+
+  test("materializes an automatic consequence when a late card precedes an accepted score", async () => {
+    const harness = await createHarness();
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "late-card-consequence",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+    const submit = (intent: unknown) =>
+      harness.control.submitControllerIntent({
+        sessionBearer: opened.session.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+        intent,
+      });
+    expect(
+      await submit(
+        goalIntent({
+          operationId: "late-card-score",
+          factId: "late-card-score",
+          gameTimeMs: 10_000,
+          sportingOrder: 7_000,
+          override: {
+            guardrail: "sporting-order-adjudication",
+            direction: "head-referee-adjudicated-sporting-order",
+            confirmation: "head-referee-confirmed",
+            authorityReference: "head-referee",
+            gameTimeMs: 10_000,
+            beforeValue: { sportingOrder: 10_000 },
+            afterValue: { sportingOrder: 7_000 },
+            reason: "head-referee-direction",
+          },
+        }),
+      ),
+    ).toMatchObject({ status: "accepted" });
+    expect(
+      await submit({
+        ...cardIntent({
+          operationId: "late-card",
+          factId: "late-card",
+          gameTimeMs: 0,
+        }),
+        occurrence: { clientOriginAtMs: 0, source: "offline" as const },
+      }),
+    ).toMatchObject({
+      status: "accepted",
+      projection: {
+        penalties: {
+          players: [{ playerNumber: 7 }],
+          releases: [{ sourceFactId: "late-card-score" }],
+        },
+      },
+    });
+    const consequence = (await harness.record.readActions()).find(
+      ({ action }) =>
+        action.interpretation.type === "fact" &&
+        action.interpretation.factType === "penalty-release-consequence",
+    );
+    expect(consequence?.action.interpretation).toMatchObject({
+      payload: { data: { sourceFactId: "late-card-score", sportingOrder: 7_000 } },
+    });
+    expect(consequence?.action.causalPredecessorIds).toEqual(
+      expect.arrayContaining(["late-card-score", "late-card"]),
+    );
+  });
+
+  test("preserves offline sporting time while delayed replay records current acceptance evidence", async () => {
+    const harness = await createHarness();
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "delayed-offline-device",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+    const serverClock = await harness.control.submitControllerIntent({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      intent: {
+        ...clockCorrectionIntent("delayed-server-clock", 60_000),
+        occurrence: { clientOriginAtMs: 60_000, source: "online" as const },
+      },
+    });
+    expect(serverClock).toMatchObject({ status: "accepted" });
+    const offlineCard = {
+      ...cardIntent({
+        operationId: "delayed-offline-card",
+        factId: "delayed-offline-card",
+        gameTimeMs: 0,
+      }),
+      occurrence: { clientOriginAtMs: 1_000, source: "offline" as const },
+    };
+    const offlineGoal = {
+      ...goalIntent({
+        operationId: "delayed-offline-goal",
+        factId: "delayed-offline-goal",
+        gameTimeMs: 15_000,
+      }),
+      occurrence: { clientOriginAtMs: 2_000, source: "offline" as const },
+    };
+    const replay = await harness.control.replayControllerActions({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      batchId: "delayed-offline-batch",
+      replicaGeneration: "delayed-offline-generation",
+      expectedGrantSessionId: opened.session.grantSessionId,
+      expectedGrantVersion: opened.session.grantVersion,
+      actions: [
+        { eventGameId: harness.root.eventGameId, intent: offlineCard, causalPredecessorIds: [] },
+        {
+          eventGameId: harness.root.eventGameId,
+          intent: offlineGoal,
+          causalPredecessorIds: ["delayed-offline-card"],
+        },
+      ],
+    });
+    expect(replay.outcomes).toEqual([
+      { operationId: "delayed-offline-card", status: "accepted" },
+      { operationId: "delayed-offline-goal", status: "accepted" },
+    ]);
+    const stored = await harness.record.readActions();
+    expect(
+      stored
+        .filter(({ action }) =>
+          ["delayed-offline-card", "delayed-offline-goal"].includes(action.operationId),
+        )
+        .map(({ action }) => {
+          const payload =
+            action.interpretation.type === "fact" ? action.interpretation.payload : null;
+          const gameTimeMs =
+            payload !== null &&
+            typeof payload === "object" &&
+            !Array.isArray(payload) &&
+            "gameTimeMs" in payload
+              ? payload.gameTimeMs
+              : null;
+          return {
+            operationId: action.operationId,
+            gameTimeMs,
+            source: action.occurrence.source,
+            trustedAtMs: action.occurrence.trustedAtMs,
+          };
+        }),
+    ).toEqual([
+      {
+        operationId: "delayed-offline-card",
+        gameTimeMs: 0,
+        source: "offline",
+        trustedAtMs: 10_000,
+      },
+      {
+        operationId: "delayed-offline-goal",
+        gameTimeMs: 15_000,
+        source: "offline",
+        trustedAtMs: 10_000,
+      },
+    ]);
+    expect(
+      stored.some(({ action }) => action.operationId === "delayed-offline-goal-penalty-release"),
+    ).toBe(true);
+  });
 });
 
 async function createHarness(
@@ -4286,6 +5388,7 @@ async function createHarness(
     grantEventGameId?: string;
     grantExpiresAtMs?: number | null;
     failureBoundary?: "after-action" | "after-lifecycle";
+    failureAfterActionNumber?: number;
     projectionFailure?: () => boolean;
     scopeStatus?: "empty" | "conflict";
     controlClock?: () => number;
@@ -4320,6 +5423,8 @@ async function createHarness(
   };
 
   let failureBoundary = overrides.failureBoundary;
+  let failureAfterActionNumber = overrides.failureAfterActionNumber;
+  let afterActionCount = 0;
   const record = createEventGameRecord(storage, {
     externalScopeResolver: createScopeResolver(root),
     interpreter: createLiveEventGameIqaInterpreter(),
@@ -4344,7 +5449,12 @@ async function createHarness(
     clock: () => grantOptions.clock.nowMs(),
     interpreter: createLiveEventGameIqaInterpreter(),
     failureInjector: (boundary) => {
-      if (boundary === failureBoundary) throw new Error("simulated durable failure");
+      if (boundary === "after-action") afterActionCount += 1;
+      if (
+        boundary === failureBoundary ||
+        (boundary === "after-action" && afterActionCount === failureAfterActionNumber)
+      )
+        throw new Error("simulated durable failure");
     },
     validateActionInTransaction: ({ transaction, root, action }) =>
       validateLiveEventGameActionInTransaction(
@@ -4388,6 +5498,9 @@ async function createHarness(
     set failureBoundary(value: typeof failureBoundary) {
       failureBoundary = value;
     },
+    set failureAfterActionNumber(value: number | undefined) {
+      failureAfterActionNumber = value;
+    },
     setNow(value: number) {
       grantOptions.setNow(value);
     },
@@ -4409,6 +5522,8 @@ function goalIntent(
     operationId?: string;
     factId?: string;
     gameTimeMs?: number;
+    sportingOrder?: number;
+    override?: Record<string, unknown>;
   } = {},
 ) {
   return {
@@ -4418,6 +5533,76 @@ function goalIntent(
     factId: overrides.factId ?? "fact-goal",
     gameSideId: overrides.gameSideId ?? "side-a",
     gameTimeMs: overrides.gameTimeMs ?? 12_000,
+    ...(overrides.sportingOrder === undefined ? {} : { sportingOrder: overrides.sportingOrder }),
+    ...(overrides.override === undefined ? {} : { override: overrides.override }),
+    occurrence: { clientOriginAtMs: 10_000 },
+  };
+}
+
+function cardIntent(
+  overrides: {
+    operationId?: string;
+    factId?: string;
+    gameSideId?: string;
+    playerNumber?: number | null;
+    cardType?: "blue" | "yellow" | "red" | "ejection";
+    foulBeforeScore?: boolean;
+    seekerPenalty?: "head-referee-confirmed";
+    gameTimeMs?: number;
+  } = {},
+) {
+  return {
+    version: LIVE_EVENT_CONTROL_INTENT_VERSION,
+    type: "record-card" as const,
+    operationId: overrides.operationId ?? "operation-card",
+    factId: overrides.factId ?? "fact-card",
+    gameSideId: overrides.gameSideId ?? "side-b",
+    playerNumber: overrides.playerNumber ?? 7,
+    cardType: overrides.cardType ?? ("blue" as const),
+    ...(overrides.foulBeforeScore === undefined
+      ? {}
+      : { foulBeforeScore: overrides.foulBeforeScore }),
+    ...(overrides.seekerPenalty === undefined ? {} : { seekerPenalty: overrides.seekerPenalty }),
+    gameTimeMs: overrides.gameTimeMs ?? 0,
+    occurrence: { clientOriginAtMs: 10_000 },
+  };
+}
+
+function reasonIntent(
+  overrides: {
+    operationId?: string;
+    factId?: string;
+    targetCardFactId?: string;
+    reason?:
+      | "contact-safety"
+      | "ball-interaction"
+      | "position-boundary"
+      | "procedure-substitution"
+      | "conduct";
+  } = {},
+) {
+  return {
+    version: LIVE_EVENT_CONTROL_INTENT_VERSION,
+    type: "record-penalty-reason" as const,
+    operationId: overrides.operationId ?? "operation-reason",
+    factId: overrides.factId ?? "fact-reason",
+    targetCardFactId: overrides.targetCardFactId ?? "fact-card",
+    reason: overrides.reason ?? ("contact-safety" as const),
+    gameTimeMs: 0,
+    occurrence: { clientOriginAtMs: 10_000 },
+  };
+}
+
+function releaseIntent(pendingId: string, scoreFactId: string, playerKey: string, gameTimeMs = 0) {
+  return {
+    version: LIVE_EVENT_CONTROL_INTENT_VERSION,
+    type: "resolve-penalty-expiration" as const,
+    operationId: `zz-release-${playerKey}`,
+    factId: `zz-release-${playerKey}`,
+    pendingId,
+    scoreFactId,
+    playerKey,
+    gameTimeMs,
     occurrence: { clientOriginAtMs: 10_000 },
   };
 }
@@ -4507,13 +5692,13 @@ function correctionIntent(
   };
 }
 
-function clockCorrectionIntent(operationId: string) {
+function clockCorrectionIntent(operationId: string, clockTimeMs = 1_000) {
   return {
     version: LIVE_EVENT_CONTROL_INTENT_VERSION,
     type: "clock-correction" as const,
     operationId,
     factId: `fact-${operationId}`,
-    clockTimeMs: 1_000,
+    clockTimeMs,
     gameTimeMs: 0,
     occurrence: { clientOriginAtMs: null },
   };

--- a/src/lib/live-event-game-control.ts
+++ b/src/lib/live-event-game-control.ts
@@ -29,6 +29,17 @@ import type { FoundationAcceptance } from "@/lib/foundation-acceptance";
 import type { ControlAction } from "@/lib/event-game-actions";
 import type { TypedGrantAuthority } from "@/lib/grant-management-types";
 import {
+  compareLivePenaltyFactOrder,
+  deriveLivePenaltyProjection,
+  LIVE_PENALTY_MINUTE_MS,
+  LIVE_PENALTY_REASONS,
+  LIVE_SEEKER_RELEASE_MS,
+  type LiveCardType,
+  type LivePenaltyProjection,
+  type LivePenaltyReason,
+  type LivePenaltyStart,
+} from "@/lib/live-event-penalties";
+import {
   SHARED_LIMITS,
   validateClockAdjustmentMs,
   validateGameClockMs,
@@ -72,6 +83,25 @@ export type LiveEventControllerIntent =
     })
   | (ControllerIntentBase & {
       type: "record-double-forfeit";
+    })
+  | (ControllerIntentBase & {
+      type: "record-card";
+      gameSideId: string;
+      playerNumber: number | null;
+      cardType: LiveCardType;
+      foulBeforeScore?: boolean;
+      seekerPenalty?: "head-referee-confirmed";
+    })
+  | (ControllerIntentBase & {
+      type: "record-penalty-reason";
+      targetCardFactId: string;
+      reason: LivePenaltyReason;
+    })
+  | (ControllerIntentBase & {
+      type: "resolve-penalty-expiration";
+      pendingId: string;
+      scoreFactId: string;
+      playerKey: string;
     })
   | (ControllerIntentBase & {
       type: "correct-fact";
@@ -173,6 +203,7 @@ export type LiveEventGameDerivedState = {
   winnerGameSideId: string | null;
   catch: LiveCatchState | null;
   gameFacts: readonly ControllerGameFact[];
+  penalties: LivePenaltyProjection;
 };
 
 export type LiveTimeoutState = {
@@ -239,6 +270,7 @@ export type ControllerProjection = {
   winnerGameSideId?: string | null;
   catch?: LiveCatchState | null;
   gameFacts?: readonly ControllerGameFact[];
+  penalties?: LivePenaltyProjection;
   guardrails?: readonly LiveEventGuardrailExplanation[];
   commencement: ControllerCommencement;
   clock: ClockProjection;
@@ -366,6 +398,9 @@ export function parseLiveEventControllerIntent(
     value.type !== "record-concession" &&
     value.type !== "record-forfeit" &&
     value.type !== "record-double-forfeit" &&
+    value.type !== "record-card" &&
+    value.type !== "record-penalty-reason" &&
+    value.type !== "resolve-penalty-expiration" &&
     value.type !== "correct-fact" &&
     value.type !== "correction" &&
     value.type !== "clock" &&
@@ -446,10 +481,47 @@ export function parseLiveEventControllerIntent(
       (value.trigger === "flag-catch" ||
         value.trigger === "concession" ||
         value.trigger === "forfeit"));
-  if (requiresGameSide) {
+  if (requiresGameSide || value.type === "record-card") {
     const parsedSide = validateOpaqueIdentifier(value.gameSideId, "gameSideId");
     if (!parsedSide.ok) return invalid(parsedSide.error);
     gameSideId = parsedSide.value;
+  }
+  let playerNumber: number | null | undefined;
+  let cardType: LiveCardType | undefined;
+  let foulBeforeScore: boolean | undefined;
+  let seekerPenalty: "head-referee-confirmed" | undefined;
+  if (value.type === "record-card") {
+    if (
+      value.cardType !== "blue" &&
+      value.cardType !== "yellow" &&
+      value.cardType !== "red" &&
+      value.cardType !== "ejection"
+    ) {
+      return invalid("cardType is unsupported.");
+    }
+    if (value.playerNumber !== null && value.playerNumber !== undefined) {
+      if (
+        typeof value.playerNumber !== "number" ||
+        !Number.isSafeInteger(value.playerNumber) ||
+        value.playerNumber < 0 ||
+        value.playerNumber > 99
+      ) {
+        return invalid("playerNumber is invalid.");
+      }
+      playerNumber = value.playerNumber;
+    } else {
+      playerNumber = null;
+    }
+    if (value.foulBeforeScore !== undefined && typeof value.foulBeforeScore !== "boolean") {
+      return invalid("foulBeforeScore must be a boolean.");
+    }
+    if (value.seekerPenalty !== undefined && value.seekerPenalty !== "head-referee-confirmed") {
+      return invalid("seekerPenalty requires Head Referee confirmation.");
+    }
+    cardType = value.cardType;
+    foulBeforeScore =
+      value.cardType === "blue" || value.cardType === "yellow" ? value.foulBeforeScore : undefined;
+    seekerPenalty = value.seekerPenalty;
   }
   let targetFactId: string | undefined;
   let effective: boolean | undefined;
@@ -459,6 +531,31 @@ export function parseLiveEventControllerIntent(
     if (typeof value.effective !== "boolean") return invalid("effective must be a boolean.");
     targetFactId = parsedTarget.value;
     effective = value.effective;
+  }
+  let targetCardFactId: string | undefined;
+  let reason: LivePenaltyReason | undefined;
+  if (value.type === "record-penalty-reason") {
+    const target = validateOpaqueIdentifier(value.targetCardFactId, "targetCardFactId");
+    if (!target.ok) return invalid(target.error);
+    if (!(LIVE_PENALTY_REASONS as readonly string[]).includes(value.reason as string)) {
+      return invalid("reason is unsupported.");
+    }
+    targetCardFactId = target.value;
+    reason = value.reason as LivePenaltyReason;
+  }
+  let pendingId: string | undefined;
+  let scoreFactId: string | undefined;
+  let playerKey: string | undefined;
+  if (value.type === "resolve-penalty-expiration") {
+    const pending = validateOpaqueIdentifier(value.pendingId, "pendingId");
+    const scoreFact = validateOpaqueIdentifier(value.scoreFactId, "scoreFactId");
+    const player = validateOpaqueIdentifier(value.playerKey, "playerKey");
+    if (!pending.ok) return invalid(pending.error);
+    if (!scoreFact.ok) return invalid(scoreFact.error);
+    if (!player.ok) return invalid(player.error);
+    pendingId = pending.value;
+    scoreFactId = scoreFact.value;
+    playerKey = player.value;
   }
   let running: boolean | undefined;
   if (value.type === "clock" || value.type === "set-running" || value.type === "clock-takeover") {
@@ -606,6 +703,15 @@ export function parseLiveEventControllerIntent(
       ...(targetFactId === undefined ? {} : { targetFactId }),
       ...(effective === undefined ? {} : { effective }),
       ...(gameSideId === undefined ? {} : { gameSideId }),
+      ...(playerNumber === undefined ? {} : { playerNumber }),
+      ...(cardType === undefined ? {} : { cardType }),
+      ...(foulBeforeScore === undefined ? {} : { foulBeforeScore }),
+      ...(seekerPenalty === undefined ? {} : { seekerPenalty }),
+      ...(targetCardFactId === undefined ? {} : { targetCardFactId }),
+      ...(reason === undefined ? {} : { reason }),
+      ...(pendingId === undefined ? {} : { pendingId }),
+      ...(scoreFactId === undefined ? {} : { scoreFactId }),
+      ...(playerKey === undefined ? {} : { playerKey }),
       ...(running === undefined ? {} : { running }),
       ...(adjustmentMs === undefined ? {} : { adjustmentMs }),
       ...(clockTimeMs === undefined ? {} : { clockTimeMs }),
@@ -1092,6 +1198,7 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
 
     if (
       parsed.value.type === "record-goal" ||
+      parsed.value.type === "record-card" ||
       parsed.value.type === "record-flag-catch" ||
       parsed.value.type === "record-concession" ||
       parsed.value.type === "record-forfeit" ||
@@ -1131,11 +1238,32 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
       return rejectedAction(parsed.value.operationId);
     }
     const nowMs = clock();
-    const previousClockStartMs = latestRunningClockStart(actionsBefore);
+    const previousClockStartMs = latestRunningClockStart(effectiveStateBefore.gameFacts);
+    const clockAuthorityActionsBefore = readClockAuthorityActions(actionsBefore);
     const clockBefore = projectClockBaseline(
-      deriveClockAuthority(readClockAuthorityActions(actionsBefore)),
+      deriveClockAuthority(clockAuthorityActionsBefore),
       nowMs,
     );
+    const releaseScoreFactId =
+      parsed.value.type === "resolve-penalty-expiration" ? parsed.value.scoreFactId : null;
+    const releaseSourceFact =
+      releaseScoreFactId === null
+        ? undefined
+        : effectiveStateBefore.gameFacts.find(
+            (fact) =>
+              fact.factId === releaseScoreFactId && fact.factType === "goal" && fact.effective,
+          );
+    const releaseSourceGameTimeMs =
+      releaseSourceFact?.gameTimeMs ?? releaseSourceFact?.sportingOrder;
+    const factGameTimeMs =
+      parsed.value.type === "resolve-penalty-expiration" && releaseSourceGameTimeMs !== undefined
+        ? releaseSourceGameTimeMs
+        : (parsed.value.type === "record-goal" || parsed.value.type === "record-card") &&
+            parsed.value.occurrence.source !== "offline" &&
+            parsed.value.gameTimeMs === 0 &&
+            clockAuthorityActionsBefore.length > 0
+          ? clockBefore.gameTimeMs
+          : parsed.value.gameTimeMs;
     const clockData = readClockIntentData(parsed.value, clockBefore, nowMs);
     if (clockData.status === "rejected") {
       return rejectedAction(parsed.value.operationId);
@@ -1165,7 +1293,14 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
           : previousClockStartMs
         : null;
     const factType = controllerFactType(parsed.value);
-    const gameSideId = controllerGameSideId(parsed.value);
+    const derivedPenaltyStart =
+      parsed.value.type === "record-card"
+        ? deriveControllerPenaltyStart(activeRoot, factGameTimeMs, parsed.value.seekerPenalty)
+        : undefined;
+    const gameSideId =
+      parsed.value.type === "record-card"
+        ? parsed.value.gameSideId
+        : controllerGameSideId(parsed.value);
     const isCorrection = parsed.value.type === "correct-fact";
     let override: OfficialOverrideMetadata | undefined;
     try {
@@ -1193,12 +1328,12 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
               factId: parsed.value.factId,
               factType,
               gameSideId,
-              gameTimeMs: parsed.value.gameTimeMs,
+              gameTimeMs: factGameTimeMs,
               data:
                 parsed.value.type === "record-goal"
                   ? {
                       points: 10,
-                      sportingOrder: parsed.value.sportingOrder ?? parsed.value.gameTimeMs,
+                      sportingOrder: parsed.value.sportingOrder ?? factGameTimeMs,
                       ...(parsed.value.sportingOrderAdjudication === undefined
                         ? {}
                         : { sportingOrderAdjudication: parsed.value.sportingOrderAdjudication }),
@@ -1206,48 +1341,41 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
                         ? {}
                         : { sportingOrderOverride: parsed.value.sportingOrderOverride }),
                     }
-                  : isScoringIntent(parsed.value)
+                  : parsed.value.type === "record-card"
                     ? {
-                        points:
-                          parsed.value.type === "record-flag-catch" ||
-                          (parsed.value.type === "substantive" &&
-                            parsed.value.trigger === "flag-catch")
-                            ? 30
-                            : 0,
-                        sportingOrder: parsed.value.sportingOrder ?? parsed.value.gameTimeMs,
-                        ...(parsed.value.sportingOrderAdjudication === undefined
+                        cardType: parsed.value.cardType,
+                        playerNumber: parsed.value.playerNumber,
+                        penaltyStart: derivedPenaltyStart,
+                        ...(parsed.value.foulBeforeScore === undefined
                           ? {}
-                          : { sportingOrderAdjudication: parsed.value.sportingOrderAdjudication }),
-                        ...(parsed.value.sportingOrderOverride === undefined
+                          : { foulBeforeScore: parsed.value.foulBeforeScore }),
+                        ...(parsed.value.seekerPenalty === undefined
                           ? {}
-                          : { sportingOrderOverride: parsed.value.sportingOrderOverride }),
-                        ...(parsed.value.type === "substantive"
-                          ? { trigger: parsed.value.trigger }
-                          : {}),
+                          : { seekerPenalty: parsed.value.seekerPenalty }),
+                        sportingOrder: parsed.value.sportingOrder ?? factGameTimeMs,
                       }
-                    : isResultIntent(parsed.value)
+                    : parsed.value.type === "record-penalty-reason"
                       ? {
-                          resultKind: controllerFactType(parsed.value),
+                          targetCardFactId: parsed.value.targetCardFactId,
+                          reason: parsed.value.reason,
                           sportingOrder: parsed.value.sportingOrder ?? parsed.value.gameTimeMs,
-                          ...(parsed.value.sportingOrderAdjudication === undefined
-                            ? {}
-                            : {
-                                sportingOrderAdjudication: parsed.value.sportingOrderAdjudication,
-                              }),
                         }
-                      : clockData.value !== null
+                      : parsed.value.type === "resolve-penalty-expiration"
                         ? {
-                            ...clockData.value,
-                            sportingOrder: parsed.value.sportingOrder ?? parsed.value.gameTimeMs,
-                            ...(parsed.value.sportingOrderAdjudication === undefined
-                              ? {}
-                              : {
-                                  sportingOrderAdjudication: parsed.value.sportingOrderAdjudication,
-                                }),
+                            pendingId: parsed.value.pendingId,
+                            scoreFactId: parsed.value.scoreFactId,
+                            playerKey: parsed.value.playerKey,
+                            sportingOrder:
+                              releaseSourceFact?.sportingOrder ?? parsed.value.gameTimeMs,
                           }
-                        : parsed.value.type === "substantive"
+                        : isScoringIntent(parsed.value)
                           ? {
-                              trigger: parsed.value.trigger,
+                              points:
+                                parsed.value.type === "record-flag-catch" ||
+                                (parsed.value.type === "substantive" &&
+                                  parsed.value.trigger === "flag-catch")
+                                  ? 30
+                                  : 0,
                               sportingOrder: parsed.value.sportingOrder ?? parsed.value.gameTimeMs,
                               ...(parsed.value.sportingOrderAdjudication === undefined
                                 ? {}
@@ -1255,11 +1383,53 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
                                     sportingOrderAdjudication:
                                       parsed.value.sportingOrderAdjudication,
                                   }),
-                              ...(parsed.value.heatAction === undefined
+                              ...(parsed.value.sportingOrderOverride === undefined
                                 ? {}
-                                : { heatAction: parsed.value.heatAction }),
+                                : { sportingOrderOverride: parsed.value.sportingOrderOverride }),
+                              ...(parsed.value.type === "substantive"
+                                ? { trigger: parsed.value.trigger }
+                                : {}),
                             }
-                          : null,
+                          : isResultIntent(parsed.value)
+                            ? {
+                                resultKind: controllerFactType(parsed.value),
+                                sportingOrder:
+                                  parsed.value.sportingOrder ?? parsed.value.gameTimeMs,
+                                ...(parsed.value.sportingOrderAdjudication === undefined
+                                  ? {}
+                                  : {
+                                      sportingOrderAdjudication:
+                                        parsed.value.sportingOrderAdjudication,
+                                    }),
+                              }
+                            : clockData.value !== null
+                              ? {
+                                  ...clockData.value,
+                                  sportingOrder:
+                                    parsed.value.sportingOrder ?? parsed.value.gameTimeMs,
+                                  ...(parsed.value.sportingOrderAdjudication === undefined
+                                    ? {}
+                                    : {
+                                        sportingOrderAdjudication:
+                                          parsed.value.sportingOrderAdjudication,
+                                      }),
+                                }
+                              : parsed.value.type === "substantive"
+                                ? {
+                                    trigger: parsed.value.trigger,
+                                    sportingOrder:
+                                      parsed.value.sportingOrder ?? parsed.value.gameTimeMs,
+                                    ...(parsed.value.sportingOrderAdjudication === undefined
+                                      ? {}
+                                      : {
+                                          sportingOrderAdjudication:
+                                            parsed.value.sportingOrderAdjudication,
+                                        }),
+                                    ...(parsed.value.heatAction === undefined
+                                      ? {}
+                                      : { heatAction: parsed.value.heatAction }),
+                                  }
+                                : null,
             },
       causalPredecessorIds: [...(input.causalPredecessorIds ?? [])],
       occurrence: {
@@ -1274,6 +1444,49 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
       lifecycle: structuredClone(existingAction?.action.lifecycle ?? activeRoot.lifecycle),
       ...(override === undefined ? {} : { override }),
     };
+    const hasDirectAutomaticPenaltyConsequence = actionsBefore.some(
+      ({ action: storedAction }) =>
+        storedAction.interpretation.type === "fact" &&
+        storedAction.interpretation.factType === "penalty-release-consequence" &&
+        isRecord(storedAction.interpretation.payload) &&
+        isRecord(storedAction.interpretation.payload.data) &&
+        storedAction.interpretation.payload.data.sourceFactId === parsed.value.factId,
+    );
+    const automaticPenaltyConsequence =
+      (hasDirectAutomaticPenaltyConsequence
+        ? null
+        : buildAutomaticPenaltyConsequence({
+            intent: parsed.value,
+            factGameTimeMs,
+            beforeFacts: effectiveStateBefore.gameFacts,
+          })) ?? buildMissingAutomaticPenaltyConsequence(activeRoot, actionsBefore, action);
+    const { override: sourceOverride, ...automaticConsequenceBase } = action;
+    void sourceOverride;
+    const actions =
+      automaticPenaltyConsequence === null
+        ? [action]
+        : [
+            action,
+            {
+              ...automaticConsequenceBase,
+              kind: { id: goalCodec.kind, version: goalCodec.version },
+              operationId: automaticPenaltyConsequence.operationId,
+              causalPredecessorIds: [
+                ...new Set([
+                  ...(input.causalPredecessorIds ?? []),
+                  action.operationId,
+                  automaticPenaltyConsequence.sourceOperationId,
+                ]),
+              ],
+              payload: {
+                factId: automaticPenaltyConsequence.factId,
+                factType: "penalty-release-consequence",
+                gameSideId: automaticPenaltyConsequence.gameSideId,
+                gameTimeMs: automaticPenaltyConsequence.gameTimeMs,
+                data: automaticPenaltyConsequence.data,
+              },
+            },
+          ];
 
     const derivedLifecycle =
       existingAction === undefined
@@ -1311,7 +1524,7 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
         eventGameId: activeRoot.eventGameId,
         sessionBearer: input.sessionBearer,
         lifecycleTransition,
-        actions: [action],
+        actions,
         reconcileDerivedLifecycle: derivedLifecycle !== undefined,
       });
     } catch {
@@ -1319,7 +1532,15 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
     }
 
     const result = accepted.results[0];
+    const consequenceResult = accepted.results[1];
     if (accepted.status === "partial" || result?.status === "retry-later") {
+      return retryableAction(parsed.value.operationId);
+    }
+    if (
+      consequenceResult !== undefined &&
+      consequenceResult.status !== "accepted" &&
+      consequenceResult.status !== "duplicate-accepted"
+    ) {
       return retryableAction(parsed.value.operationId);
     }
     if (result === undefined) return rejectedAction(parsed.value.operationId);
@@ -1585,9 +1806,13 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
       if (rebuild.status !== "ready") return null;
       const derived = readDerivedState(rebuild.derivedGameState);
       if (derived === null) return null;
-      const actions = await record.readActions();
+      const projectedClock = projectClockBaseline(derived.clock.baseline, clock());
+      const projectedFacts = derived.gameFacts.map((fact) => ({
+        ...fact,
+        data: structuredClone(fact.data),
+      }));
       const runningSinceMs =
-        root.lifecycle.commencedAtMs === null ? latestRunningClockStart(actions) : null;
+        root.lifecycle.commencedAtMs === null ? latestRunningClockStart(derived.gameFacts) : null;
       const controllerProjection: ControllerProjection = {
         eventGameId: root.eventGameId,
         phase: derived.phase,
@@ -1602,17 +1827,15 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
         targetScore: derived.overtimeTarget,
         winnerGameSideId: derived.winnerGameSideId,
         catch: structuredClone(derived.catch),
-        gameFacts: derived.gameFacts.map((fact) => ({
-          ...fact,
-          data: structuredClone(fact.data),
-        })),
+        gameFacts: projectedFacts,
+        penalties: deriveLivePenaltyProjection(projectedFacts, projectedClock.gameTimeMs),
         guardrails: [
           explainLiveEventGuardrail({ type: "substantive", trigger: "timeout" }),
           explainLiveEventGuardrail({ type: "substantive", trigger: "suspension" }),
           explainLiveEventGuardrail({ type: "substantive", trigger: "heat-stoppage" }),
           explainLiveEventGuardrail({ type: "record-goal", gameTimeMs: 1, sportingOrder: 0 }),
         ],
-        clock: projectClockBaseline(derived.clock.baseline, clock()),
+        clock: projectedClock,
         commencement: {
           status: root.lifecycle.commencedAtMs === null ? "provisional" : "commenced",
           commencedAtMs: root.lifecycle.commencedAtMs,
@@ -1876,6 +2099,12 @@ function deriveLiveEventGameState(
       : root.lifecycle.phase === "scheduled"
         ? "scheduled"
         : "in-progress";
+  const clock = projectClockBaseline(
+    deriveClockAuthority(
+      readClockAuthorityActions(effectiveFacts.map((fact) => ({ action: fact.action }))),
+    ),
+    0,
+  );
   return {
     interpreterVersion: version,
     phase,
@@ -1890,12 +2119,8 @@ function deriveLiveEventGameState(
     winnerGameSideId,
     catch: catchState,
     gameFacts,
-    clock: projectClockBaseline(
-      deriveClockAuthority(
-        readClockAuthorityActions(effectiveFacts.map((fact) => ({ action: fact.action }))),
-      ),
-      0,
-    ),
+    penalties: deriveLivePenaltyProjection(gameFacts, clock.gameTimeMs),
+    clock,
   };
 }
 
@@ -1905,6 +2130,9 @@ function controllerFactType(intent: LiveEventControllerIntent): string {
   if (intent.type === "record-concession") return "concession";
   if (intent.type === "record-forfeit") return "forfeit";
   if (intent.type === "record-double-forfeit") return "double-forfeit";
+  if (intent.type === "record-card") return "card";
+  if (intent.type === "record-penalty-reason") return "penalty-reason";
+  if (intent.type === "resolve-penalty-expiration") return "penalty-release";
   if (
     intent.type === "clock" ||
     intent.type === "set-running" ||
@@ -1918,6 +2146,182 @@ function controllerFactType(intent: LiveEventControllerIntent): string {
   return intent.type;
 }
 
+function buildAutomaticPenaltyConsequence(input: {
+  intent: LiveEventControllerIntent;
+  factGameTimeMs: number;
+  beforeFacts: readonly ControllerGameFact[];
+}): {
+  operationId: string;
+  sourceOperationId: string;
+  factId: string;
+  gameTimeMs: number;
+  gameSideId: string | null;
+  data: ActionJsonValue;
+} | null {
+  const { intent, factGameTimeMs, beforeFacts } = input;
+  if (
+    intent.type === "record-card" &&
+    intent.foulBeforeScore === true &&
+    (intent.cardType === "blue" || intent.cardType === "yellow")
+  ) {
+    const sourceFact = beforeFacts.find((fact) => fact.factId === intent.factId);
+    const sourceSportingOrder = sourceFact?.sportingOrder ?? intent.sportingOrder ?? factGameTimeMs;
+    const playerKey =
+      intent.playerNumber === null
+        ? `${intent.gameSideId}:unknown:${intent.factId}`
+        : `${intent.gameSideId}:${intent.playerNumber}`;
+    return {
+      operationId: `${intent.operationId}-penalty-release`,
+      sourceOperationId: intent.operationId,
+      factId: `${intent.factId}-penalty-release`,
+      gameTimeMs: factGameTimeMs,
+      gameSideId: intent.gameSideId,
+      data: {
+        sourceFactId: intent.factId,
+        playerKey,
+        releaseCause: "foul-before-score",
+        releasedMs: factGameTimeMs,
+        serviceDurationMs: LIVE_PENALTY_MINUTE_MS,
+        sportingOrder: sourceSportingOrder,
+      },
+    };
+  }
+  if (intent.type !== "record-goal") return null;
+  const sourceFact = beforeFacts.find((fact) => fact.factId === intent.factId);
+  const sourceSportingOrder = sourceFact?.sportingOrder ?? intent.sportingOrder ?? factGameTimeMs;
+  const prospectiveFact = {
+    factId: intent.factId,
+    factType: "goal",
+    gameSideId: intent.gameSideId,
+    gameTimeMs: factGameTimeMs,
+    sportingOrder: sourceSportingOrder,
+    synchronizationOrder:
+      beforeFacts.reduce((highest, fact) => Math.max(highest, fact.synchronizationOrder), 0) + 1,
+    effective: true,
+    data: {
+      points: 10,
+      sportingOrder: sourceSportingOrder,
+    },
+  } satisfies import("@/lib/live-event-penalties").LivePenaltyFact;
+  const projected = deriveLivePenaltyProjection(
+    beforeFacts.some((fact) => fact.factId === intent.factId)
+      ? beforeFacts
+      : [...beforeFacts, prospectiveFact],
+    factGameTimeMs,
+  );
+  const release = projected.releases.find(
+    (candidate) => candidate.scoreFactId === intent.factId && candidate.releaseCause === "score",
+  );
+  if (release === undefined) return null;
+  const beforeProjection = deriveLivePenaltyProjection(beforeFacts, factGameTimeMs);
+  const serviceDurationMs = Math.min(
+    ...(beforeProjection.players
+      .find((player) => player.playerKey === release.playerKey)
+      ?.segments.filter(
+        (segment) =>
+          segment.expirableByScore &&
+          segment.eligibleForScoreAtGameTimeMs <= factGameTimeMs &&
+          segment.startsAtGameTimeMs <= factGameTimeMs &&
+          segment.endsAtGameTimeMs > factGameTimeMs,
+      )
+      .map((segment) =>
+        Math.max(
+          0,
+          Math.min(segment.endsAtGameTimeMs, factGameTimeMs + LIVE_PENALTY_MINUTE_MS) -
+            factGameTimeMs,
+        ),
+      ) ?? [LIVE_PENALTY_MINUTE_MS]),
+  );
+  return {
+    operationId: `${intent.operationId}-penalty-release`,
+    sourceOperationId: intent.operationId,
+    factId: `${intent.factId}-penalty-release`,
+    gameTimeMs: factGameTimeMs,
+    gameSideId: release.gameSideId,
+    data: {
+      sourceFactId: intent.factId,
+      playerKey: release.playerKey,
+      releaseCause: "score",
+      releasedMs: factGameTimeMs,
+      serviceDurationMs,
+      sportingOrder: sourceSportingOrder,
+    },
+  };
+}
+
+function buildMissingAutomaticPenaltyConsequence(
+  root: EventGameRecordRoot,
+  actionsBefore: readonly {
+    action: ControlAction;
+    canonicalContent: string;
+    contentFingerprint: string;
+  }[],
+  candidate: unknown,
+): {
+  operationId: string;
+  sourceOperationId: string;
+  factId: string;
+  gameTimeMs: number;
+  gameSideId: string | null;
+  data: ActionJsonValue;
+} | null {
+  if (
+    !isRecord(candidate) ||
+    !isRecord(candidate.occurrence) ||
+    typeof candidate.occurrence.trustedAtMs !== "number"
+  ) {
+    return null;
+  }
+  const acceptedAtMs = candidate.occurrence.trustedAtMs;
+  const registry = createControlActionCodecRegistry(createDefaultControlActionCodecs());
+  const prepared = prepareControlAction(candidate, root, registry, acceptedAtMs);
+  if (!prepared.ok) return null;
+  const candidateStored = {
+    action: materializeControlAction(prepared.value, acceptedAtMs),
+    canonicalContent: prepared.value.canonicalContent,
+    contentFingerprint: prepared.value.contentFingerprint,
+  };
+  const prospectiveActions = [...actionsBefore, candidateStored];
+  const prospective = rebuildLiveDerivedState(root, prospectiveActions);
+  if (prospective?.penalties === undefined) return null;
+  const knownSources = new Set(
+    prospective.gameFacts.flatMap((fact) => {
+      if (fact.factType !== "penalty-release-consequence" || !isRecord(fact.data)) return [];
+      return typeof fact.data.sourceFactId === "string" ? [fact.data.sourceFactId] : [];
+    }),
+  );
+  const release = prospective.penalties.releases.find(
+    (candidateRelease) =>
+      candidateRelease.sourceFactId.length > 0 && !knownSources.has(candidateRelease.sourceFactId),
+  );
+  if (release === undefined) return null;
+  const sourceFact = prospective.gameFacts.find(
+    (fact) => fact.factId === release.sourceFactId && fact.effective,
+  );
+  const sourceAction = prospectiveActions.find(({ action }) => {
+    if (action.interpretation.type !== "fact" || !isRecord(action.interpretation.payload)) {
+      return false;
+    }
+    return action.interpretation.payload.factId === release.sourceFactId;
+  })?.action;
+  if (sourceAction === undefined) return null;
+  return {
+    operationId: `${sourceAction.operationId}-penalty-release`,
+    sourceOperationId: sourceAction.operationId,
+    factId: `${release.sourceFactId}-penalty-release`,
+    gameTimeMs: release.releasedMs,
+    gameSideId: release.gameSideId,
+    data: {
+      sourceFactId: release.sourceFactId,
+      playerKey: release.playerKey,
+      releaseCause: release.releaseCause,
+      releasedMs: release.releasedMs,
+      serviceDurationMs: release.serviceDurationMs,
+      sportingOrder: sourceFact?.sportingOrder ?? release.releasedMs,
+    },
+  };
+}
+
 async function ensureClockCommencement(
   owner: { recordId: string; record: EventGameRecord },
   root: EventGameRecordRoot,
@@ -1927,7 +2331,9 @@ async function ensureClockCommencement(
     return { status: "ready", root };
   }
   const actions = await owner.record.readActions();
-  const runningSinceMs = latestRunningClockStart(actions);
+  const rebuilt = rebuildLiveDerivedState(root, actions);
+  if (rebuilt === null) return { status: "rejected" };
+  const runningSinceMs = latestRunningClockStart(rebuilt.gameFacts);
   if (runningSinceMs === null || nowMs - runningSinceMs < 10_000) {
     return { status: "ready", root };
   }
@@ -1940,21 +2346,11 @@ async function ensureClockCommencement(
   return { status: "ready", root: transition.root };
 }
 
-function latestRunningClockStart(
-  actions: readonly { action: { interpretation: unknown } }[],
-): number | null {
-  for (const stored of [...actions].reverse()) {
-    const interpretation = stored.action.interpretation;
-    if (
-      !isRecord(interpretation) ||
-      interpretation.type !== "fact" ||
-      interpretation.factType !== "clock"
-    )
-      continue;
-    const payload = interpretation.payload;
-    if (!isRecord(payload) || !isRecord(payload.data)) return null;
-    if (payload.data.running !== true) return null;
-    return typeof payload.data.startedAtMs === "number" ? payload.data.startedAtMs : null;
+function latestRunningClockStart(facts: readonly ControllerGameFact[]): number | null {
+  for (const fact of [...facts].reverse()) {
+    if (!fact.effective || fact.factType !== "clock" || !isRecord(fact.data)) continue;
+    if (fact.data.running !== true) return null;
+    return typeof fact.data.startedAtMs === "number" ? fact.data.startedAtMs : null;
   }
   return null;
 }
@@ -1972,6 +2368,7 @@ function shouldRecordCommencement(
     intent.type === "record-concession" ||
     intent.type === "record-forfeit" ||
     intent.type === "record-double-forfeit" ||
+    intent.type === "record-card" ||
     intent.type === "substantive"
   ) {
     return { atMs: nowMs };
@@ -2152,6 +2549,19 @@ function currentSideIds(state: LiveEventGameDerivedState): string[] {
   return Object.keys(state.scoreByGameSide);
 }
 
+function deriveControllerPenaltyStart(
+  root: EventGameRecordRoot,
+  gameTimeMs: number,
+  seekerPenalty: "head-referee-confirmed" | undefined,
+): LivePenaltyStart {
+  if (root.lifecycle.commencedAtMs === null) return "sticks-up";
+  return seekerPenalty === "head-referee-confirmed" &&
+    gameTimeMs >= 19 * LIVE_PENALTY_MINUTE_MS &&
+    gameTimeMs < LIVE_SEEKER_RELEASE_MS
+    ? "seeker-release"
+    : "immediate";
+}
+
 function readDerivedState(value: unknown): LiveEventGameDerivedState | null {
   if (!isRecord(value) || typeof value.interpreterVersion !== "string") return null;
   if (
@@ -2210,6 +2620,7 @@ function readDerivedState(value: unknown): LiveEventGameDerivedState | null {
     winnerGameSideId: winnerGameSideId.status === "value" ? winnerGameSideId.value : null,
     catch: catchState === "missing" ? null : catchState,
     gameFacts,
+    penalties: deriveLivePenaltyProjection(gameFacts, clock.gameTimeMs),
     clock,
   };
 }
@@ -2651,6 +3062,95 @@ export function validateLiveEventGameActionInTransaction(
   if (!isRecord(payload)) return rejectedLiveAction("The live Game Fact payload is invalid.");
   const gameTimeMs = typeof payload.gameTimeMs === "number" ? payload.gameTimeMs : null;
   const data = isRecord(payload.data) ? payload.data : null;
+  if (candidate.interpretation.factType === "penalty-reason") {
+    const targetCardFactId = data?.targetCardFactId;
+    if (
+      typeof targetCardFactId !== "string" ||
+      !actions.some(
+        ({ action }) =>
+          action.interpretation.type === "fact" &&
+          action.interpretation.factId === targetCardFactId &&
+          action.interpretation.factType === "card",
+      )
+    ) {
+      return rejectedLiveAction("A Penalty Reason must refer to an accepted card fact.");
+    }
+  }
+  if (candidate.interpretation.factType === "penalty-release-consequence") {
+    const sourceFactId = data?.sourceFactId;
+    const playerKey = data?.playerKey;
+    const releaseCause = data?.releaseCause;
+    const source =
+      typeof sourceFactId === "string"
+        ? actions.find(
+            ({ action }) =>
+              action.interpretation.type === "fact" &&
+              action.interpretation.factId === sourceFactId,
+          )
+        : undefined;
+    if (
+      source === undefined ||
+      typeof playerKey !== "string" ||
+      (releaseCause !== "score" && releaseCause !== "foul-before-score") ||
+      (releaseCause === "score" &&
+        source.action.interpretation.type === "fact" &&
+        source.action.interpretation.factType !== "goal") ||
+      (releaseCause === "foul-before-score" &&
+        (source.action.interpretation.type !== "fact" ||
+          source.action.interpretation.factType !== "card"))
+    ) {
+      return rejectedLiveAction("The automatic Penalty Release consequence is invalid.");
+    }
+  }
+  if (candidate.interpretation.factType === "penalty-release") {
+    const pendingId = data?.pendingId;
+    const scoreFactId = data?.scoreFactId;
+    const playerKey = data?.playerKey;
+    const scoreFact =
+      typeof scoreFactId === "string"
+        ? current.gameFacts.find(
+            (fact) => fact.factId === scoreFactId && fact.factType === "goal" && fact.effective,
+          )
+        : undefined;
+    const scoreGameTimeMs = scoreFact?.gameTimeMs ?? scoreFact?.sportingOrder;
+    const releaseSportingOrder =
+      data !== null && typeof data.sportingOrder === "number" ? data.sportingOrder : null;
+    const factsThroughScore =
+      scoreFact === undefined
+        ? []
+        : current.gameFacts.filter((fact) => compareLivePenaltyFactOrder(fact, scoreFact) <= 0);
+    const scoreProjection =
+      scoreGameTimeMs === undefined
+        ? null
+        : deriveLivePenaltyProjection(factsThroughScore, scoreGameTimeMs);
+    const existingEffectiveChoice =
+      typeof scoreFactId === "string"
+        ? current.gameFacts.find(
+            (fact) =>
+              fact.factType === "penalty-release" &&
+              fact.effective &&
+              isRecord(fact.data) &&
+              fact.data.scoreFactId === scoreFactId,
+          )
+        : undefined;
+    const pending =
+      typeof pendingId === "string" && typeof scoreFactId === "string"
+        ? scoreProjection?.pendingExpirations.find(
+            (expiration) => expiration.id === pendingId && expiration.scoreFactId === scoreFactId,
+          )
+        : undefined;
+    if (
+      pending === undefined ||
+      typeof playerKey !== "string" ||
+      !pending.candidatePlayerKeys.includes(playerKey) ||
+      gameTimeMs !== scoreGameTimeMs ||
+      releaseSportingOrder !== scoreFact?.sportingOrder ||
+      (existingEffectiveChoice !== undefined &&
+        existingEffectiveChoice.factId !== candidate.interpretation.factId)
+    ) {
+      return rejectedLiveAction("The Penalty Release choice is no longer valid.");
+    }
+  }
   const sportingOrder =
     data !== null && typeof data.sportingOrder === "number" ? data.sportingOrder : gameTimeMs;
   const sportingOrderDiffers =
@@ -2734,9 +3234,11 @@ export function validateLiveEventGameActionInTransaction(
     }
   }
   const expected =
-    closePair.fact !== null && sportingOrderAdjudication !== null
-      ? expectedClosePlayOverride(closePair.fact, gameTimeMs, sportingOrderAdjudication)
-      : expectedLiveOverride(candidate, current, sportingOrderDiffers, gameTimeMs, data);
+    candidate.interpretation.factType === "penalty-release-consequence"
+      ? null
+      : closePair.fact !== null && sportingOrderAdjudication !== null
+        ? expectedClosePlayOverride(closePair.fact, gameTimeMs, sportingOrderAdjudication)
+        : expectedLiveOverride(candidate, current, sportingOrderDiffers, gameTimeMs, data);
   if (sportingOrderOverride !== undefined) {
     return rejectedLiveAction(
       "A separate Sporting Order override is only valid with a flag-catch boundary override.",
@@ -3228,6 +3730,12 @@ function readClockAuthorityActions(
     const data = interpretation.payload.data;
     if (!isRecord(data)) continue;
     if (interpretation.factType === "card") {
+      if (isRecord(data) && typeof data.cardType === "string") {
+        // Live penalty timing is rebuilt from the sporting Game Clock. The
+        // legacy trigger-only card fact retains the clock-authority signal
+        // used by the earlier live-control slice.
+        continue;
+      }
       clockActions.push({
         operationId: storedAction.operationId,
         trustedAtMs: storedAction.occurrence.trustedAtMs,

--- a/src/lib/live-event-penalties.test.ts
+++ b/src/lib/live-event-penalties.test.ts
@@ -1,0 +1,425 @@
+import { describe, expect, test } from "bun:test";
+import {
+  deriveLivePenaltyProjection,
+  LIVE_PENALTY_MINUTE_MS,
+  LIVE_SEEKER_RELEASE_MS,
+  type LivePenaltyFact,
+} from "@/lib/live-event-penalties";
+
+let nextSync = 0;
+
+function fact(
+  factType: string,
+  factId: string,
+  gameSideId: string | null,
+  gameTimeMs: number,
+  data: Record<string, unknown> = {},
+): LivePenaltyFact {
+  nextSync += 1;
+  return {
+    factType,
+    factId,
+    gameSideId,
+    gameTimeMs,
+    sportingOrder: gameTimeMs,
+    synchronizationOrder: nextSync,
+    effective: true,
+    data,
+  } as LivePenaltyFact;
+}
+
+function card(
+  factId: string,
+  playerNumber: number,
+  gameTimeMs: number,
+  cardType: "blue" | "yellow" | "red",
+  extra: Record<string, unknown> = {},
+) {
+  return fact("card", factId, "away", gameTimeMs, {
+    cardType,
+    playerNumber,
+    penaltyStart: "immediate",
+    ...extra,
+  });
+}
+
+describe("live Event Game penalty timing", () => {
+  test("blue and yellow have one expirable minute while red has two consecutive non-expirable minutes", () => {
+    const projection = deriveLivePenaltyProjection(
+      [
+        card("blue-card", 1, 0, "blue"),
+        card("yellow-card", 2, 0, "yellow"),
+        card("red-card", 3, 0, "red"),
+      ],
+      30_000,
+    );
+
+    expect(projection.players).toMatchObject([
+      { playerNumber: 1, segments: [{ expirableByScore: true, remainingMs: 30_000 }] },
+      { playerNumber: 2, segments: [{ expirableByScore: true, remainingMs: 30_000 }] },
+      {
+        playerNumber: 3,
+        segments: [
+          { expirableByScore: false, remainingMs: 30_000 },
+          { expirableByScore: false, remainingMs: 60_000 },
+        ],
+      },
+    ]);
+  });
+
+  test("multiple penalties serve in assessment order and follow the Game Clock, not wall time", () => {
+    const projection = deriveLivePenaltyProjection(
+      [card("first", 7, 10_000, "blue"), card("second", 7, 20_000, "yellow")],
+      80_000,
+    );
+
+    expect(projection.players[0]?.segments).toMatchObject([
+      { cardFactId: "second", remainingMs: 50_000 },
+    ]);
+  });
+
+  test("does not release a blue minute queued behind a red card before that minute starts", () => {
+    const beforeBlueStarts = deriveLivePenaltyProjection(
+      [
+        card("red-card", 1, 0, "red"),
+        card("blue-card", 1, 0, "blue"),
+        fact("goal", "early-goal", "home", 30_000, { points: 10, sportingOrder: 30_000 }),
+      ],
+      30_000,
+    );
+
+    expect(beforeBlueStarts.pendingExpirations).toHaveLength(0);
+    expect(beforeBlueStarts.releases).toHaveLength(0);
+    expect(beforeBlueStarts.players).toMatchObject([
+      {
+        playerNumber: 1,
+        segments: [
+          { cardType: "red", expirableByScore: false, remainingMs: 30_000 },
+          { cardType: "red", expirableByScore: false, remainingMs: 60_000 },
+          { cardType: "blue", expirableByScore: true, startsAtGameTimeMs: 120_000 },
+        ],
+      },
+    ]);
+
+    const afterBlueStarts = deriveLivePenaltyProjection(
+      [
+        card("red-card", 1, 0, "red"),
+        card("blue-card", 1, 0, "blue"),
+        fact("goal", "late-goal", "home", 120_000, { points: 10, sportingOrder: 120_000 }),
+      ],
+      120_000,
+    );
+
+    expect(afterBlueStarts.releases).toMatchObject([
+      { id: "penalty-expiration:late-goal", playerKey: "away:1", releaseCause: "score" },
+    ]);
+  });
+
+  test("starts the next assessed blue segment at the early score sporting time", () => {
+    const projection = deriveLivePenaltyProjection(
+      [
+        card("red", 20, 0, "red"),
+        card("blue-one", 20, 0, "blue"),
+        card("blue-two", 20, 0, "blue"),
+        fact("goal", "release-blue-one", "home", 150_000, { points: 10 }),
+      ],
+      150_000,
+    );
+
+    expect(projection.releases).toMatchObject([
+      { scoreFactId: "release-blue-one", playerKey: "away:20" },
+    ]);
+    expect(projection.players).toMatchObject([
+      {
+        playerNumber: 20,
+        segments: [{ cardFactId: "blue-two", startsAtGameTimeMs: 150_000 }],
+      },
+    ]);
+  });
+
+  test("compaction respects a deferred seeker floor through mixed red and repeated blue service", () => {
+    const projection = deriveLivePenaltyProjection(
+      [
+        card("red-floor", 22, 0, "red"),
+        card("blue-active", 22, 0, "blue"),
+        card("blue-deferred", 22, 19 * LIVE_PENALTY_MINUTE_MS + 30_000, "blue", {
+          penaltyStart: "seeker-release",
+        }),
+        card("blue-after-floor", 22, LIVE_SEEKER_RELEASE_MS, "blue"),
+        fact("goal", "release-active", "home", 150_000, { points: 10 }),
+      ],
+      150_000,
+    );
+
+    expect(projection.releases).toMatchObject([
+      { scoreFactId: "release-active", playerKey: "away:22", releaseCause: "score" },
+    ]);
+    const deferred = projection.players
+      .find((player) => player.playerKey === "away:22")
+      ?.segments.find((segment) => segment.cardFactId === "blue-deferred");
+    expect(deferred).toMatchObject({
+      startsAtGameTimeMs: LIVE_SEEKER_RELEASE_MS,
+      notBeforeGameTimeMs: LIVE_SEEKER_RELEASE_MS,
+    });
+  });
+
+  test("opposing score chooses the least remaining eligible minute and records complete ties", () => {
+    const projection = deriveLivePenaltyProjection(
+      [
+        card("one", 2, 0, "blue"),
+        card("tie", 3, 20_000, "blue"),
+        fact("goal", "goal-1", "home", 30_000, { points: 10, sportingOrder: 30_000 }),
+      ],
+      30_000,
+    );
+
+    expect(projection.releases).toMatchObject([
+      { scoreFactId: "goal-1", playerKey: "away:2", releaseCause: "score" },
+    ]);
+
+    const tieProjection = deriveLivePenaltyProjection(
+      [
+        card("tie-a", 4, 0, "blue"),
+        card("tie-b", 5, 0, "blue"),
+        fact("goal", "goal-tie", "home", 0, { points: 10, sportingOrder: 0 }),
+      ],
+      0,
+    );
+    expect(tieProjection.pendingExpirations[0]).toMatchObject({
+      candidatePlayerKeys: ["away:4", "away:5"],
+      requiresOfficialChoice: true,
+    });
+  });
+
+  test("counts queued expirable minutes for priority but releases only an active minute", () => {
+    const projection = deriveLivePenaltyProjection(
+      [
+        card("two-first", 14, 0, "blue"),
+        card("two-second", 14, 0, "yellow"),
+        card("one", 15, 0, "blue"),
+        fact("goal", "two-versus-one", "home", 30_000, {
+          points: 10,
+          sportingOrder: 30_000,
+        }),
+      ],
+      30_000,
+    );
+
+    expect(projection.releases).toMatchObject([
+      { scoreFactId: "two-versus-one", playerKey: "away:15", releaseCause: "score" },
+    ]);
+    expect(
+      projection.players.find((player) => player.playerKey === "away:14")?.segments,
+    ).toMatchObject([{ cardFactId: "two-first" }, { cardFactId: "two-second" }]);
+  });
+
+  test("counts queued red minutes for priority while requiring an active expirable segment", () => {
+    const projection = deriveLivePenaltyProjection(
+      [
+        card("blue-before-red", 16, 0, "blue"),
+        card("queued-red", 16, 0, "red"),
+        card("single-blue", 17, 0, "blue"),
+        fact("goal", "red-blue-priority", "home", 30_000, { points: 10 }),
+      ],
+      30_000,
+    );
+
+    expect(projection.releases).toMatchObject([
+      { scoreFactId: "red-blue-priority", playerKey: "away:17" },
+    ]);
+    expect(
+      projection.players.find((player) => player.playerKey === "away:16")?.segments,
+    ).toHaveLength(3);
+  });
+
+  test("a foul-before-score one-minute penalty expires immediately", () => {
+    const projection = deriveLivePenaltyProjection(
+      [card("foul-card", 8, 40_000, "blue", { foulBeforeScore: true })],
+      40_000,
+    );
+
+    expect(projection.players).toHaveLength(0);
+    expect(projection.releases).toMatchObject([
+      { playerKey: "away:8", releaseCause: "foul-before-score", releasedMs: 40_000 },
+    ]);
+  });
+
+  test("a skipped reason can be replaced later by one fixed category", () => {
+    const projection = deriveLivePenaltyProjection(
+      [
+        card("reason-card", 13, 0, "blue"),
+        fact("penalty-reason", "later-reason", null, 1, {
+          targetCardFactId: "reason-card",
+          reason: "conduct",
+        }),
+      ],
+      0,
+    );
+
+    expect(projection.cards).toMatchObject([{ factId: "reason-card", reason: "conduct" }]);
+  });
+
+  test("durable automatic releases can be corrected without removing the source fact", () => {
+    const facts = [
+      card("durable-card", 21, 0, "blue"),
+      fact("goal", "durable-goal", "home", 10_000, { points: 10 }),
+      fact("penalty-release-consequence", "durable-release", "away", 10_000, {
+        sourceFactId: "durable-goal",
+        playerKey: "away:21",
+        releaseCause: "score",
+        serviceDurationMs: 50_000,
+        releasedMs: 10_000,
+      }),
+    ];
+    expect(deriveLivePenaltyProjection(facts, 10_000).releases).toMatchObject([
+      { id: "durable-release", sourceFactId: "durable-goal" },
+    ]);
+    expect(
+      deriveLivePenaltyProjection(
+        facts.map((candidate) =>
+          candidate.factId === "durable-release" ? { ...candidate, effective: false } : candidate,
+        ),
+        10_000,
+      ).releases,
+    ).toHaveLength(0);
+  });
+
+  test("pregame penalties start at sticks up and seeker-floor penalties start at 20:00", () => {
+    const projection = deriveLivePenaltyProjection(
+      [
+        card("pregame", 9, 0, "blue", { penaltyStart: "sticks-up" }),
+        fact("goal", "early-goal", "home", 19 * LIVE_PENALTY_MINUTE_MS + 30_000, {
+          points: 10,
+          sportingOrder: 19 * LIVE_PENALTY_MINUTE_MS + 30_000,
+        }),
+        card("seeker-floor", 10, 19 * LIVE_PENALTY_MINUTE_MS + 30_000, "blue", {
+          penaltyStart: "seeker-release",
+        }),
+      ],
+      LIVE_SEEKER_RELEASE_MS + 30_000,
+    );
+
+    expect(projection.players).toMatchObject([
+      { playerNumber: 10, segments: [{ remainingMs: 30_000 }] },
+    ]);
+    expect(projection.pendingExpirations).toHaveLength(0);
+
+    const delayedRecordCard = deriveLivePenaltyProjection(
+      [
+        card("pregame-recorded-late", 11, 90_000, "blue", { penaltyStart: "sticks-up" }),
+        fact("goal", "post-sticks-up-goal", "home", 30_000, {
+          points: 10,
+          sportingOrder: 30_000,
+        }),
+      ],
+      90_000,
+    );
+    expect(delayedRecordCard.releases).toMatchObject([
+      {
+        scoreFactId: "post-sticks-up-goal",
+        playerKey: "away:11",
+        releasedMs: 30_000,
+      },
+    ]);
+
+    const adjudicatedLater = deriveLivePenaltyProjection(
+      [
+        {
+          ...card("adjudicated-pregame", 12, 90_000, "blue", {
+            penaltyStart: "sticks-up",
+          }),
+          sportingOrder: 60_000,
+        },
+        fact("goal", "before-adjudicated-card", "home", 30_000, {
+          points: 10,
+          sportingOrder: 30_000,
+        }),
+      ],
+      90_000,
+    );
+    expect(adjudicatedLater.releases).toHaveLength(0);
+  });
+
+  test("defers only a confirmed seeker while an ordinary player serves during 19:00-20:00", () => {
+    const cardTime = 19 * LIVE_PENALTY_MINUTE_MS + 30_000;
+    const projection = deriveLivePenaltyProjection(
+      [
+        card("ordinary-floor-card", 30, cardTime, "blue", { penaltyStart: "immediate" }),
+        card("seeker-floor-card", 31, cardTime, "blue", { penaltyStart: "seeker-release" }),
+      ],
+      cardTime + 15_000,
+    );
+
+    expect(projection.players).toMatchObject([
+      { playerNumber: 30, segments: [{ startsAtGameTimeMs: cardTime, remainingMs: 45_000 }] },
+      {
+        playerNumber: 31,
+        segments: [{ startsAtGameTimeMs: LIVE_SEEKER_RELEASE_MS, remainingMs: 60_000 }],
+      },
+    ]);
+  });
+
+  test("a selected score release is an auditable fact and removes only the chosen player penalty", () => {
+    const projection = deriveLivePenaltyProjection(
+      [
+        card("release-a", 11, 0, "blue"),
+        card("release-b", 12, 0, "blue"),
+        fact("goal", "goal-release", "home", 10_000, { points: 10, sportingOrder: 10_000 }),
+        fact("penalty-release", "release-choice", null, 10_000, {
+          pendingId: "penalty-expiration:goal-release",
+          scoreFactId: "goal-release",
+          playerKey: "away:12",
+        }),
+      ],
+      10_000,
+    );
+
+    expect(projection.pendingExpirations).toHaveLength(0);
+    expect(projection.releases).toMatchObject([
+      { id: "release-choice", scoreFactId: "goal-release", playerKey: "away:12" },
+    ]);
+    expect(projection.players.map((player) => player.playerKey)).toEqual(["away:11"]);
+  });
+
+  test("a delayed complete-tie choice releases at the exact score sporting time", () => {
+    const unresolved = deriveLivePenaltyProjection(
+      [
+        card("delayed-release-a", 40, 0, "blue"),
+        card("delayed-release-b", 41, 0, "blue"),
+        fact("goal", "delayed-release-goal", "home", 10_000, { points: 10 }),
+      ],
+      90_000,
+    );
+    expect(unresolved.pendingExpirations).toMatchObject([
+      {
+        id: "penalty-expiration:delayed-release-goal",
+        scoreFactId: "delayed-release-goal",
+        candidatePlayerKeys: ["away:40", "away:41"],
+      },
+    ]);
+
+    const projection = deriveLivePenaltyProjection(
+      [
+        card("delayed-release-a", 40, 0, "blue"),
+        card("delayed-release-b", 41, 0, "blue"),
+        fact("goal", "delayed-release-goal", "home", 10_000, { points: 10 }),
+        fact("penalty-release", "delayed-release-choice", null, 90_000, {
+          pendingId: "penalty-expiration:delayed-release-goal",
+          scoreFactId: "delayed-release-goal",
+          playerKey: "away:41",
+        }),
+      ],
+      90_000,
+    );
+
+    expect(projection.pendingExpirations).toHaveLength(0);
+    expect(projection.releases).toMatchObject([
+      {
+        id: "delayed-release-choice",
+        scoreFactId: "delayed-release-goal",
+        playerKey: "away:41",
+        releasedMs: 10_000,
+      },
+    ]);
+  });
+});

--- a/src/lib/live-event-penalties.ts
+++ b/src/lib/live-event-penalties.ts
@@ -1,0 +1,522 @@
+import type { ActionJsonValue } from "@/lib/event-game-actions";
+
+export const LIVE_PENALTY_MINUTE_MS = 60_000;
+export const LIVE_SEEKER_RELEASE_MS = 20 * LIVE_PENALTY_MINUTE_MS;
+
+export const LIVE_PENALTY_REASONS = [
+  "contact-safety",
+  "ball-interaction",
+  "position-boundary",
+  "procedure-substitution",
+  "conduct",
+] as const;
+
+export type LivePenaltyReason = (typeof LIVE_PENALTY_REASONS)[number];
+export type LiveCardType = "blue" | "yellow" | "red" | "ejection";
+export type LivePenaltyStart = "immediate" | "sticks-up" | "seeker-release";
+
+export type LivePenaltyFact = {
+  factId: string;
+  factType: string;
+  gameSideId: string | null;
+  gameTimeMs: number | null;
+  sportingOrder: number;
+  synchronizationOrder: number;
+  effective: boolean;
+  data: ActionJsonValue;
+};
+
+export type LivePenaltySegment = {
+  id: string;
+  cardFactId: string;
+  cardType: Exclude<LiveCardType, "ejection">;
+  expirableByScore: boolean;
+  eligibleForScoreAtGameTimeMs: number;
+  notBeforeGameTimeMs: number;
+  startsAtGameTimeMs: number;
+  endsAtGameTimeMs: number;
+  remainingMs: number;
+};
+
+export type LivePenaltyPlayer = {
+  playerKey: string;
+  gameSideId: string;
+  playerNumber: number | null;
+  segments: readonly LivePenaltySegment[];
+};
+
+export type LivePenaltyPendingExpiration = {
+  id: string;
+  scoreFactId: string;
+  scoreGameTimeMs: number;
+  benefitingGameSideId: string;
+  penalizedGameSideId: string;
+  candidatePlayerKeys: readonly string[];
+  serviceDurationMs: number;
+  requiresOfficialChoice: boolean;
+  resolvedPlayerKey: string | null;
+};
+
+/** The sporting cause that released service; distinct from a card's fixed Penalty Reason. */
+export type LivePenaltyRelease = {
+  id: string;
+  scoreFactId: string;
+  playerKey: string;
+  gameSideId: string;
+  releasedMs: number;
+  releaseCause: "score" | "foul-before-score";
+  sourceFactId: string;
+  serviceDurationMs: number;
+};
+
+export type LivePenaltyCard = {
+  factId: string;
+  gameSideId: string;
+  playerKey: string | null;
+  playerNumber: number | null;
+  cardType: LiveCardType;
+  penaltyStart: LivePenaltyStart;
+  reason: LivePenaltyReason | null;
+};
+
+export type LivePenaltyProjection = {
+  cards: readonly LivePenaltyCard[];
+  players: readonly LivePenaltyPlayer[];
+  pendingExpirations: readonly LivePenaltyPendingExpiration[];
+  releases: readonly LivePenaltyRelease[];
+};
+
+type MutablePlayer = {
+  playerKey: string;
+  gameSideId: string;
+  playerNumber: number | null;
+  segments: LivePenaltySegment[];
+};
+
+type MutablePending = LivePenaltyPendingExpiration & { resolvedPlayerKey: string | null };
+
+export function deriveLivePenaltyProjection(
+  facts: readonly LivePenaltyFact[],
+  currentGameTimeMs: number,
+): LivePenaltyProjection {
+  const ordered = facts
+    .filter((fact) => fact.effective)
+    .slice()
+    .sort(compareLivePenaltyFactOrder);
+  const players = new Map<string, MutablePlayer>();
+  const cards: LivePenaltyCard[] = [];
+  const pending = new Map<string, MutablePending>();
+  const releases: LivePenaltyRelease[] = [];
+  const reasonByCard = new Map<string, LivePenaltyReason>();
+  const durableConsequences = new Map<string, LivePenaltyFact[]>();
+  const knownConsequenceSources = new Set<string>();
+
+  for (const fact of facts) {
+    if (fact.factType !== "penalty-release-consequence") continue;
+    const sourceFactId = stringValue(recordData(fact.data)?.sourceFactId);
+    if (sourceFactId === null) continue;
+    knownConsequenceSources.add(sourceFactId);
+    if (!fact.effective) continue;
+    const consequences = durableConsequences.get(sourceFactId) ?? [];
+    consequences.push(fact);
+    durableConsequences.set(sourceFactId, consequences);
+  }
+
+  for (const fact of ordered) {
+    const gameTimeMs = fact.gameTimeMs ?? fact.sportingOrder;
+    if (!Number.isSafeInteger(gameTimeMs) || gameTimeMs < 0) continue;
+
+    if (fact.factType === "penalty-reason") {
+      const data = recordData(fact.data);
+      const target = stringValue(data?.targetCardFactId);
+      const reason = data?.reason;
+      if (target !== null && isPenaltyReason(reason)) {
+        reasonByCard.set(target, reason);
+      }
+      continue;
+    }
+
+    if (fact.factType === "penalty-release-consequence") continue;
+
+    if (fact.factType === "penalty-release") {
+      const data = recordData(fact.data);
+      const pendingId = stringValue(data?.pendingId);
+      const scoreFactId = stringValue(data?.scoreFactId);
+      const playerKey = stringValue(data?.playerKey);
+      if (pendingId === null || scoreFactId === null || playerKey === null) continue;
+      const release = pending.get(scoreFactId);
+      if (release?.id !== pendingId) continue;
+      if (release === undefined || release.resolvedPlayerKey !== null) continue;
+      if (!release.candidatePlayerKeys.includes(playerKey)) continue;
+      const player = players.get(playerKey);
+      if (player === undefined) continue;
+      const removed = consumeExpirable(
+        player.segments,
+        release.serviceDurationMs,
+        release.scoreGameTimeMs,
+      );
+      if (removed <= 0) continue;
+      release.resolvedPlayerKey = playerKey;
+      releases.push({
+        id: fact.factId,
+        scoreFactId: release.scoreFactId,
+        playerKey,
+        gameSideId: player.gameSideId,
+        releasedMs: release.scoreGameTimeMs,
+        releaseCause: "score",
+        sourceFactId: release.scoreFactId,
+        serviceDurationMs: release.serviceDurationMs,
+      });
+      continue;
+    }
+
+    if (fact.factType === "card") {
+      const data = recordData(fact.data);
+      const cardType = data?.cardType;
+      if (!isCardType(cardType) || fact.gameSideId === null) continue;
+      const playerNumber = numberOrNull(data?.playerNumber);
+      const playerKey =
+        playerNumber === null
+          ? `${fact.gameSideId}:unknown:${fact.factId}`
+          : `${fact.gameSideId}:${playerNumber}`;
+      const penaltyStart = isPenaltyStart(data?.penaltyStart)
+        ? data.penaltyStart
+        : inferPenaltyStart(gameTimeMs);
+      const card: LivePenaltyCard = {
+        factId: fact.factId,
+        gameSideId: fact.gameSideId,
+        playerKey: cardType === "ejection" ? null : playerKey,
+        playerNumber,
+        cardType,
+        penaltyStart,
+        reason: reasonByCard.get(fact.factId) ?? null,
+      };
+      cards.push(card);
+      if (cardType === "ejection") continue;
+
+      const player = players.get(playerKey) ?? {
+        playerKey,
+        gameSideId: fact.gameSideId,
+        playerNumber,
+        segments: [],
+      };
+      players.set(playerKey, player);
+      const startsAt = penaltyStartAt(penaltyStart, gameTimeMs);
+      const previousEnd = player.segments.at(-1)?.endsAtGameTimeMs ?? startsAt;
+      const serviceStart = Math.max(startsAt, previousEnd);
+      const segmentCount = cardType === "red" ? 2 : 1;
+      for (let index = 0; index < segmentCount; index += 1) {
+        const segmentStart = serviceStart + index * LIVE_PENALTY_MINUTE_MS;
+        const hasDurableConsequence = knownConsequenceSources.has(fact.factId);
+        const immediateExpiry =
+          data?.foulBeforeScore === true && cardType !== "red" && !hasDurableConsequence;
+        const segment: LivePenaltySegment = {
+          id: `${fact.factId}:${index + 1}`,
+          cardFactId: fact.factId,
+          cardType,
+          expirableByScore: cardType !== "red",
+          eligibleForScoreAtGameTimeMs: startsAt,
+          notBeforeGameTimeMs: penaltyStartAt(penaltyStart, gameTimeMs),
+          startsAtGameTimeMs: segmentStart,
+          endsAtGameTimeMs: immediateExpiry ? segmentStart : segmentStart + LIVE_PENALTY_MINUTE_MS,
+          remainingMs: immediateExpiry
+            ? 0
+            : remainingAt(segmentStart, segmentStart + LIVE_PENALTY_MINUTE_MS, currentGameTimeMs),
+        };
+        player.segments.push(segment);
+        if (immediateExpiry) {
+          releases.push({
+            id: `${fact.factId}:foul-before-score`,
+            scoreFactId: "",
+            playerKey,
+            gameSideId: fact.gameSideId,
+            releasedMs: gameTimeMs,
+            releaseCause: "foul-before-score",
+            sourceFactId: fact.factId,
+            serviceDurationMs: LIVE_PENALTY_MINUTE_MS,
+          });
+        }
+      }
+      applyDurableConsequences(fact.factId, durableConsequences, players, releases);
+      continue;
+    }
+
+    if (fact.factType !== "goal") continue;
+    const scoringSide = fact.gameSideId;
+    if (scoringSide === null) continue;
+    const penalizedSide = opposingSide(scoringSide, players);
+    if (penalizedSide === null) continue;
+    const candidates = [...players.values()]
+      .filter((player) => player.gameSideId === penalizedSide)
+      .map((player) => {
+        const activeExpirable = player.segments.find(
+          (segment) =>
+            segment.expirableByScore &&
+            segment.eligibleForScoreAtGameTimeMs <= gameTimeMs &&
+            segment.startsAtGameTimeMs <= gameTimeMs &&
+            segment.endsAtGameTimeMs > gameTimeMs,
+        );
+        return {
+          playerKey: player.playerKey,
+          count: player.segments.filter((segment) => segment.endsAtGameTimeMs > gameTimeMs).length,
+          remainingMs:
+            activeExpirable === undefined
+              ? Number.POSITIVE_INFINITY
+              : remainingAt(
+                  activeExpirable.startsAtGameTimeMs,
+                  activeExpirable.endsAtGameTimeMs,
+                  gameTimeMs,
+                ),
+        };
+      })
+      .filter((candidate) => Number.isFinite(candidate.remainingMs));
+    if (candidates.length === 0) continue;
+    const minimumCount = Math.min(...candidates.map((candidate) => candidate.count));
+    const byCount = candidates.filter((candidate) => candidate.count === minimumCount);
+    const minimumRemaining = Math.min(...byCount.map((candidate) => candidate.remainingMs));
+    const candidatePlayerKeys = byCount
+      .filter((candidate) => candidate.remainingMs === minimumRemaining)
+      .map((candidate) => candidate.playerKey)
+      .sort();
+    const expiration: MutablePending = {
+      id: `penalty-expiration:${fact.factId}`,
+      scoreFactId: fact.factId,
+      scoreGameTimeMs: gameTimeMs,
+      benefitingGameSideId: scoringSide,
+      penalizedGameSideId: penalizedSide,
+      candidatePlayerKeys,
+      serviceDurationMs: minimumRemaining,
+      requiresOfficialChoice: candidatePlayerKeys.length > 1,
+      resolvedPlayerKey: null,
+    };
+    if (knownConsequenceSources.has(fact.factId)) {
+      applyDurableConsequences(fact.factId, durableConsequences, players, releases);
+      continue;
+    }
+    if (candidatePlayerKeys.length === 1) {
+      const playerKey = candidatePlayerKeys[0];
+      const player = playerKey === undefined ? undefined : players.get(playerKey);
+      if (player !== undefined && playerKey !== undefined) {
+        const removed = consumeExpirable(player.segments, minimumRemaining, gameTimeMs);
+        if (removed > 0) {
+          releases.push({
+            id: expiration.id,
+            scoreFactId: fact.factId,
+            playerKey,
+            gameSideId: player.gameSideId,
+            releasedMs: gameTimeMs,
+            releaseCause: "score",
+            sourceFactId: fact.factId,
+            serviceDurationMs: minimumRemaining,
+          });
+          continue;
+        }
+      }
+    }
+    pending.set(fact.factId, expiration);
+  }
+
+  const resultPlayers = [...players.values()]
+    .map((player) => ({
+      ...player,
+      segments: player.segments
+        .map((segment) => ({
+          ...segment,
+          remainingMs: remainingAt(
+            segment.startsAtGameTimeMs,
+            segment.endsAtGameTimeMs,
+            currentGameTimeMs,
+          ),
+        }))
+        .filter((segment) => segment.remainingMs > 0),
+    }))
+    .filter((player) => player.segments.length > 0)
+    .sort((left, right) => left.playerKey.localeCompare(right.playerKey));
+  const resultPending = [...pending.values()].filter(
+    (expiration) => expiration.resolvedPlayerKey === null,
+  );
+  return {
+    cards: cards.map((card) => ({
+      ...card,
+      reason: reasonByCard.get(card.factId) ?? null,
+    })),
+    players: resultPlayers,
+    pendingExpirations: resultPending,
+    releases,
+  };
+}
+
+function consumeExpirable(
+  segments: LivePenaltySegment[],
+  amountMs: number,
+  atGameTimeMs: number,
+): number {
+  let remaining = amountMs;
+  let removed = 0;
+  for (const [index, segment] of segments.entries()) {
+    if (remaining <= 0) break;
+    if (
+      !segment.expirableByScore ||
+      segment.eligibleForScoreAtGameTimeMs > atGameTimeMs ||
+      segment.startsAtGameTimeMs > atGameTimeMs ||
+      segment.endsAtGameTimeMs <= atGameTimeMs
+    )
+      continue;
+    const available = remainingAt(
+      segment.startsAtGameTimeMs,
+      segment.endsAtGameTimeMs,
+      atGameTimeMs,
+    );
+    const consumed = Math.min(available, remaining);
+    const oldEnd = segment.endsAtGameTimeMs;
+    segment.endsAtGameTimeMs = Math.min(segment.endsAtGameTimeMs, atGameTimeMs);
+    segment.remainingMs = Math.max(0, available - consumed);
+    shiftQueuedSegments(segments, index + 1, oldEnd - segment.endsAtGameTimeMs);
+    remaining -= consumed;
+    removed += consumed;
+  }
+  return removed;
+}
+
+function shiftQueuedSegments(segments: LivePenaltySegment[], fromIndex: number, deltaMs: number) {
+  if (deltaMs <= 0) return;
+  for (let index = fromIndex; index < segments.length; index += 1) {
+    const segment = segments[index];
+    if (segment === undefined) continue;
+    const durationMs = Math.max(0, segment.endsAtGameTimeMs - segment.startsAtGameTimeMs);
+    const previousEnd = segments[index - 1]?.endsAtGameTimeMs ?? segment.startsAtGameTimeMs;
+    segment.startsAtGameTimeMs = Math.max(
+      segment.notBeforeGameTimeMs,
+      previousEnd,
+      segment.startsAtGameTimeMs - deltaMs,
+    );
+    segment.endsAtGameTimeMs = segment.startsAtGameTimeMs + durationMs;
+  }
+}
+
+function applyDurableConsequences(
+  sourceFactId: string,
+  consequences: Map<string, LivePenaltyFact[]>,
+  players: Map<string, MutablePlayer>,
+  releases: LivePenaltyRelease[],
+) {
+  for (const fact of consequences.get(sourceFactId) ?? []) {
+    const data = recordData(fact.data);
+    const playerKey = stringValue(data?.playerKey);
+    const releaseCause = data?.releaseCause;
+    if (
+      playerKey === null ||
+      (releaseCause !== "score" && releaseCause !== "foul-before-score") ||
+      releases.some((release) => release.id === fact.factId)
+    )
+      continue;
+    const player = players.get(playerKey);
+    if (player === undefined) continue;
+    const releaseTime =
+      typeof data?.releasedMs === "number" ? data.releasedMs : (fact.gameTimeMs ?? 0);
+    const removed =
+      releaseCause === "foul-before-score"
+        ? expireCardImmediately(player.segments, sourceFactId)
+        : consumeExpirable(
+            player.segments,
+            typeof data?.serviceDurationMs === "number" ? data.serviceDurationMs : 0,
+            releaseTime,
+          );
+    if (removed <= 0) continue;
+    releases.push({
+      id: fact.factId,
+      scoreFactId: releaseCause === "score" ? sourceFactId : "",
+      playerKey,
+      gameSideId: player.gameSideId,
+      releasedMs: releaseTime,
+      releaseCause,
+      sourceFactId,
+      serviceDurationMs:
+        typeof data?.serviceDurationMs === "number" ? data.serviceDurationMs : removed,
+    });
+  }
+}
+
+function expireCardImmediately(segments: LivePenaltySegment[], cardFactId: string): number {
+  let removed = 0;
+  for (const [index, segment] of segments.entries()) {
+    if (!segment.expirableByScore || segment.cardFactId !== cardFactId) continue;
+    const duration = Math.max(0, segment.endsAtGameTimeMs - segment.startsAtGameTimeMs);
+    segment.endsAtGameTimeMs = segment.startsAtGameTimeMs;
+    segment.remainingMs = 0;
+    shiftQueuedSegments(segments, index + 1, duration);
+    removed += duration;
+  }
+  return removed;
+}
+
+function remainingAt(start: number, end: number, current: number): number {
+  if (current <= start) return Math.max(0, end - start);
+  return Math.max(0, end - Math.max(start, current));
+}
+
+function penaltyStartAt(start: LivePenaltyStart, gameTimeMs: number): number {
+  if (start === "sticks-up") return 0;
+  if (start === "seeker-release") return LIVE_SEEKER_RELEASE_MS;
+  return gameTimeMs;
+}
+
+function penaltyFactSportingOrder(fact: LivePenaltyFact): number {
+  if (fact.factType !== "card" || fact.gameTimeMs === null) return fact.sportingOrder;
+  if (fact.sportingOrder !== fact.gameTimeMs) return fact.sportingOrder;
+  const penaltyStart = recordData(fact.data)?.penaltyStart;
+  return isPenaltyStart(penaltyStart)
+    ? penaltyStartAt(penaltyStart, fact.gameTimeMs)
+    : fact.sportingOrder;
+}
+
+function penaltyFactOrderRank(fact: LivePenaltyFact): number {
+  if (fact.factType === "card") return 0;
+  if (fact.factType === "goal") return 1;
+  if (fact.factType === "penalty-release" || fact.factType === "penalty-release-consequence") {
+    return 2;
+  }
+  return 1;
+}
+
+export function compareLivePenaltyFactOrder(left: LivePenaltyFact, right: LivePenaltyFact): number {
+  return (
+    penaltyFactSportingOrder(left) - penaltyFactSportingOrder(right) ||
+    penaltyFactOrderRank(left) - penaltyFactOrderRank(right) ||
+    left.synchronizationOrder - right.synchronizationOrder ||
+    left.factId.localeCompare(right.factId)
+  );
+}
+
+function inferPenaltyStart(_gameTimeMs: number): LivePenaltyStart {
+  return "immediate";
+}
+
+function opposingSide(scoringSide: string, players: Map<string, MutablePlayer>): string | null {
+  const sides = [...new Set([...players.values()].map((player) => player.gameSideId))];
+  return sides.find((side) => side !== scoringSide) ?? null;
+}
+
+function recordData(value: ActionJsonValue): Record<string, ActionJsonValue> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value) ? value : null;
+}
+
+function stringValue(value: ActionJsonValue | undefined): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+function numberOrNull(value: ActionJsonValue | undefined): number | null {
+  return typeof value === "number" && Number.isSafeInteger(value) ? value : null;
+}
+
+function isCardType(value: ActionJsonValue | undefined): value is LiveCardType {
+  return value === "blue" || value === "yellow" || value === "red" || value === "ejection";
+}
+
+function isPenaltyStart(value: ActionJsonValue | undefined): value is LivePenaltyStart {
+  return value === "immediate" || value === "sticks-up" || value === "seeker-release";
+}
+
+function isPenaltyReason(value: ActionJsonValue | undefined): value is LivePenaltyReason {
+  return typeof value === "string" && (LIVE_PENALTY_REASONS as readonly string[]).includes(value);
+}

--- a/src/pages/event-game-controller-page.test.tsx
+++ b/src/pages/event-game-controller-page.test.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/lib/controller-reconnect";
 import type { ControllerProjection } from "@/lib/live-event-game-control";
 import { createInitialClockBaseline, projectClockBaseline } from "@/lib/clock-authority";
+import { deriveLivePenaltyProjection } from "@/lib/live-event-penalties";
 
 describe("Event Game Controller reconnect browser seam", () => {
   const originalWindow = globalThis.window;
@@ -18,6 +19,7 @@ describe("Event Game Controller reconnect browser seam", () => {
   const originalSessionStorage = globalThis.sessionStorage;
   const originalLocalStorage = globalThis.localStorage;
   const originalFetch = globalThis.fetch;
+  const originalPerformance = globalThis.performance;
   const originalActEnvironment = (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean })
     .IS_REACT_ACT_ENVIRONMENT;
   let testWindow: Window;
@@ -32,12 +34,14 @@ describe("Event Game Controller reconnect browser seam", () => {
   let openGrantSessionId: string;
   let openGrantVersion: string;
   let openBearer: string;
-  let openProjection: ControllerProjection;
+  let openProjection: ControllerProjection | null;
   let refreshProjection: ControllerProjection | null;
   let refreshRejected: boolean;
   let switchRequested: boolean;
   let deferredReplay: ((response: Response) => void) | null;
   let deferredReplayResponse: Response | null;
+  let replayProjection: ControllerProjection | null;
+  let monotonicNow: number;
 
   beforeEach(() => {
     replayMode = "lost";
@@ -55,6 +59,8 @@ describe("Event Game Controller reconnect browser seam", () => {
     switchRequested = false;
     deferredReplay = null;
     deferredReplayResponse = null;
+    replayProjection = null;
+    monotonicNow = 0;
     testWindow = new Window({ url: "http://timer.quadball.app/event-control" });
     Object.assign(globalThis, {
       window: testWindow,
@@ -76,7 +82,7 @@ describe("Event Game Controller reconnect browser seam", () => {
                 grantSessionId: openGrantSessionId,
                 grantVersion: openGrantVersion,
               },
-              projection: openProjection,
+              projection: openProjection ?? projection(),
               projectionStatus: "available",
             }),
             { status: 200, headers: { "content-type": "application/json" } },
@@ -110,7 +116,10 @@ describe("Event Game Controller reconnect browser seam", () => {
                 operationId: action.intent.operationId,
                 status: replayMode === "retryable" ? "retryable" : "accepted",
               })),
-              projection: replayMode === "retryable" ? openProjection : projection(),
+              projection:
+                replayMode === "retryable"
+                  ? (openProjection ?? projection())
+                  : (replayProjection ?? projection()),
             }),
             { status: 200, headers: { "content-type": "application/json" } },
           );
@@ -191,6 +200,16 @@ describe("Event Game Controller reconnect browser seam", () => {
         return new Response("Not found", { status: 404 });
       },
     });
+    Object.defineProperty(globalThis, "performance", {
+      configurable: true,
+      value: new Proxy(originalPerformance, {
+        get(target, property) {
+          if (property === "now") return () => monotonicNow;
+          const value = Reflect.get(target, property, target);
+          return typeof value === "function" ? value.bind(target) : value;
+        },
+      }),
+    });
     (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     container = document.createElement("div");
     document.body.appendChild(container);
@@ -248,6 +267,10 @@ describe("Event Game Controller reconnect browser seam", () => {
       sessionStorage: originalSessionStorage,
       localStorage: originalLocalStorage,
       fetch: originalFetch,
+    });
+    Object.defineProperty(globalThis, "performance", {
+      configurable: true,
+      value: originalPerformance,
     });
     (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
       originalActEnvironment;
@@ -356,6 +379,372 @@ describe("Event Game Controller reconnect browser seam", () => {
     ]);
     expect(qrInput.value).toBe("");
     expect(codeInput.value).toBe("");
+  });
+
+  test("uses the injected live Clock for a goal tap and penalty countdown through seeker release", async () => {
+    const gameTimeBeforeRelease = 20 * 60 * 1000 - 1_000;
+    const gameFacts: ControllerProjection["gameFacts"] = [
+      {
+        factId: "seeker-card-ui",
+        factType: "card",
+        gameSideId: "side-b",
+        gameTimeMs: gameTimeBeforeRelease,
+        sportingOrder: gameTimeBeforeRelease,
+        synchronizationOrder: 1,
+        effective: true,
+        data: {
+          cardType: "blue",
+          playerNumber: 7,
+          penaltyStart: "seeker-release",
+          foulBeforeScore: false,
+        },
+      },
+    ];
+    openProjection = projection("game-browser", {
+      gameTimeMs: gameTimeBeforeRelease,
+      running: true,
+      gameFacts,
+    });
+    Object.defineProperty(testWindow.navigator, "onLine", { configurable: true, value: true });
+    await enterAndOpen();
+    expect(container.textContent).toContain("19:59");
+
+    monotonicNow = 1_000;
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 300));
+    });
+    expect(container.textContent).toContain("SEEKER RELEASED at 20:00");
+
+    const goalButton = Array.from(container.getElementsByTagName("button")).find((button) =>
+      button.textContent?.includes("Record 10-point goal"),
+    );
+    await act(async () => {
+      goalButton?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const sentIntent =
+      intentBodies.at(-1)?.intent ??
+      replayBodies.flatMap((body) => body.actions ?? []).at(-1)?.intent;
+    expect(sentIntent).toMatchObject({
+      type: "record-goal",
+      gameTimeMs: 20 * 60 * 1000,
+    });
+  });
+
+  test("marks only a Head Referee-confirmed seeker card for the 20:00 floor", async () => {
+    const seekerFloorTime = 19 * 60 * 1000 + 30_000;
+    openProjection = projection("game-browser", {
+      gameTimeMs: seekerFloorTime,
+      gameFacts: [],
+      commenced: true,
+    });
+    replayMode = "lost";
+    await enterAndOpen();
+    Object.defineProperty(testWindow.navigator, "onLine", { configurable: true, value: false });
+    const sideSelect = container.querySelector("select#penalty-game-side") as HTMLSelectElement;
+    await act(async () => {
+      sideSelect.value = "side-b";
+      sideSelect.dispatchEvent(
+        new testWindow.Event("change", { bubbles: true }) as unknown as Event,
+      );
+      await Promise.resolve();
+    });
+    const acceptCard = () =>
+      Array.from(container.getElementsByTagName("button")).find((button) =>
+        button.textContent?.includes("Accept card"),
+      );
+    await act(async () => {
+      acceptCard()?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const seekerLabel = Array.from(container.getElementsByTagName("label")).find((label) =>
+      label.textContent?.includes("Penalized player is the seeker"),
+    );
+    const seekerCheckbox = seekerLabel?.querySelector("input") as HTMLInputElement;
+    await act(async () => {
+      seekerCheckbox.click();
+      await Promise.resolve();
+    });
+    await act(async () => {
+      acceptCard()?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const retained = JSON.parse(
+      testWindow.localStorage.getItem(controllerReplicaStorageKey("game-browser")) ?? "null",
+    ) as {
+      pendingActions: { intent: any }[];
+      projection: ControllerProjection;
+    };
+    const cards = retained.pendingActions.filter((action) => action.intent.type === "record-card");
+    expect(cards).toHaveLength(2);
+    expect(cards[0]?.intent.seekerPenalty).toBeUndefined();
+    expect(cards[1]?.intent.seekerPenalty).toBe("head-referee-confirmed");
+    expect(retained.projection.penalties?.cards).toMatchObject([
+      { penaltyStart: "immediate" },
+      { penaltyStart: "seeker-release" },
+    ]);
+  });
+
+  test("disables foul-before-score for ejection cards and omits it from offline intent", async () => {
+    replayMode = "lost";
+    await enterAndOpen();
+    Object.defineProperty(testWindow.navigator, "onLine", { configurable: true, value: false });
+    const sideSelect = container.querySelector("select#penalty-game-side") as HTMLSelectElement;
+    const cardTypeSelect = container.querySelector("select#penalty-card-type") as HTMLSelectElement;
+    await act(async () => {
+      sideSelect.value = "side-b";
+      sideSelect.dispatchEvent(
+        new testWindow.Event("change", { bubbles: true }) as unknown as Event,
+      );
+      cardTypeSelect.value = "ejection";
+      cardTypeSelect.dispatchEvent(
+        new testWindow.Event("change", { bubbles: true }) as unknown as Event,
+      );
+      await Promise.resolve();
+    });
+    const foulCheckbox = container.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    expect(foulCheckbox.disabled).toBe(true);
+    const acceptCard = Array.from(container.getElementsByTagName("button")).find((button) =>
+      button.textContent?.includes("Accept card"),
+    );
+    await act(async () => {
+      acceptCard?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const retained = JSON.parse(
+      testWindow.localStorage.getItem(controllerReplicaStorageKey("game-browser")) ?? "null",
+    ) as { pendingActions: { intent: any }[] };
+    const card = retained.pendingActions.find((action) => action.intent.type === "record-card");
+    expect(card?.intent.cardType).toBe("ejection");
+    expect(card?.intent).not.toHaveProperty("foulBeforeScore");
+  });
+
+  test("projects offline card and reason taps, then converges after reconnect", async () => {
+    replayMode = "lost";
+    await enterAndOpen();
+    Object.defineProperty(testWindow.navigator, "onLine", { configurable: true, value: false });
+
+    const sideSelect = container.querySelector("select#penalty-game-side") as HTMLSelectElement;
+    const playerInput = container.querySelector("input#penalty-player-number") as HTMLInputElement;
+    await act(async () => {
+      sideSelect.value = "side-b";
+      sideSelect.dispatchEvent(
+        new testWindow.Event("change", { bubbles: true }) as unknown as Event,
+      );
+      playerInput.value = "7";
+      playerInput.dispatchEvent(
+        new testWindow.Event("input", { bubbles: true }) as unknown as Event,
+      );
+      playerInput.dispatchEvent(
+        new testWindow.Event("change", { bubbles: true }) as unknown as Event,
+      );
+      await Promise.resolve();
+    });
+    await act(async () => {
+      Array.from(container.getElementsByTagName("button"))
+        .find((button) => button.textContent?.includes("Accept card"))
+        ?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(container.textContent).toContain("Game Side side-b · Player unknown");
+
+    await act(async () => {
+      Array.from(container.getElementsByTagName("button"))
+        .find((button) => button.textContent?.includes("Skip"))
+        ?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(container.textContent).toContain("reason skipped; add later");
+    const afterSkip = JSON.parse(
+      testWindow.localStorage.getItem(controllerReplicaStorageKey("game-browser")) ?? "null",
+    ) as { pendingActions: { intent: any }[]; projection: ControllerProjection };
+    expect(afterSkip.pendingActions).toHaveLength(1);
+    expect(afterSkip.projection.gameFacts?.some((fact) => fact.factType.includes("absence"))).toBe(
+      false,
+    );
+
+    await act(async () => {
+      Array.from(container.getElementsByTagName("button"))
+        .find((button) => button.textContent?.includes("Contact/Safety"))
+        ?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(container.textContent).toContain("reason: contact-safety");
+    const retained = JSON.parse(
+      testWindow.localStorage.getItem(controllerReplicaStorageKey("game-browser")) ?? "null",
+    ) as { pendingActions: { intent: any; causalPredecessorIds: string[] }[] };
+    expect(retained.pendingActions).toHaveLength(2);
+    const cardIntent = retained.pendingActions.find(
+      (action) => action.intent.type === "record-card",
+    )?.intent;
+    const reasonIntent = retained.pendingActions.find(
+      (action) => action.intent.type === "record-penalty-reason",
+    );
+    if (cardIntent === undefined || reasonIntent === undefined) {
+      throw new Error("Expected retained card and Penalty Reason actions.");
+    }
+    expect(reasonIntent?.causalPredecessorIds).toEqual([cardIntent.operationId]);
+    replayProjection = projection("game-browser", {
+      gameFacts: [
+        {
+          factId: cardIntent.factId,
+          factType: "card",
+          gameSideId: "side-b",
+          gameTimeMs: 0,
+          sportingOrder: 0,
+          synchronizationOrder: 1,
+          effective: true,
+          data: {
+            cardType: "blue",
+            playerNumber: 7,
+            penaltyStart: "sticks-up",
+            foulBeforeScore: false,
+          },
+        },
+        {
+          factId: reasonIntent.intent.factId,
+          factType: "penalty-reason",
+          gameSideId: null,
+          gameTimeMs: 0,
+          sportingOrder: 0,
+          synchronizationOrder: 2,
+          effective: true,
+          data: { targetCardFactId: cardIntent.factId, reason: "contact-safety" },
+        },
+      ],
+    });
+    replayMode = "success";
+    Object.defineProperty(testWindow.navigator, "onLine", { configurable: true, value: true });
+    await act(async () => {
+      document.dispatchEvent(new testWindow.Event("visibilitychange") as unknown as Event);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const after = JSON.parse(
+      testWindow.localStorage.getItem(controllerReplicaStorageKey("game-browser")) ?? "null",
+    ) as { pendingActions: unknown[] };
+    expect(after.pendingActions).toHaveLength(0);
+    const replayedTypes = replayBodies
+      .flatMap((body) => body.actions ?? [])
+      .map((action) => action.intent.type);
+    expect(replayedTypes).toContain("record-card");
+    expect(replayedTypes).toContain("record-penalty-reason");
+    expect(container.textContent).toContain("reason: contact-safety");
+  });
+
+  test("projects an offline complete-tie choice and converges its release fact", async () => {
+    const gameFacts: ControllerProjection["gameFacts"] = [
+      {
+        factId: "tie-card-7",
+        factType: "card",
+        gameSideId: "side-b",
+        gameTimeMs: 0,
+        sportingOrder: 0,
+        synchronizationOrder: 1,
+        effective: true,
+        data: { cardType: "blue", playerNumber: 7, penaltyStart: "immediate" },
+      },
+      {
+        factId: "tie-card-8",
+        factType: "card",
+        gameSideId: "side-b",
+        gameTimeMs: 0,
+        sportingOrder: 0,
+        synchronizationOrder: 2,
+        effective: true,
+        data: { cardType: "blue", playerNumber: 8, penaltyStart: "immediate" },
+      },
+    ];
+    openProjection = projection("game-browser", { gameFacts, gameTimeMs: 0 });
+    replayMode = "lost";
+    await enterAndOpen();
+    Object.defineProperty(testWindow.navigator, "onLine", { configurable: true, value: false });
+    const goalButton = Array.from(container.getElementsByTagName("button")).find((button) =>
+      button.textContent?.includes("Record 10-point goal"),
+    );
+    await act(async () => {
+      goalButton?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(container.textContent).toContain("Complete tie requires official choice.");
+    await act(async () => {
+      Array.from(container.getElementsByTagName("button"))
+        .find((button) => button.textContent?.includes("Player #8"))
+        ?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(container.textContent).not.toContain("Complete tie requires official choice.");
+    const retained = JSON.parse(
+      testWindow.localStorage.getItem(controllerReplicaStorageKey("game-browser")) ?? "null",
+    ) as { pendingActions: { intent: any; causalPredecessorIds: string[] }[] };
+    expect(retained.pendingActions).toHaveLength(2);
+    const scoreAction = retained.pendingActions.find(
+      (action) => action.intent.type === "record-goal",
+    );
+    const choiceAction = retained.pendingActions.find(
+      (action) => action.intent.type === "resolve-penalty-expiration",
+    );
+    if (scoreAction === undefined || choiceAction === undefined) {
+      throw new Error("Expected retained score and complete-tie choice actions.");
+    }
+    expect(choiceAction.causalPredecessorIds).toEqual([scoreAction.intent.operationId]);
+    expect(choiceAction.intent.scoreFactId).toBe(scoreAction.intent.factId);
+    replayProjection = projection("game-browser", {
+      gameFacts: [
+        ...gameFacts,
+        {
+          factId: scoreAction.intent.factId,
+          factType: "goal",
+          gameSideId: "side-a",
+          gameTimeMs: scoreAction.intent.gameTimeMs,
+          sportingOrder: scoreAction.intent.gameTimeMs,
+          synchronizationOrder: 3,
+          effective: true,
+          data: { points: 10 },
+        },
+        {
+          factId: choiceAction.intent.factId,
+          factType: "penalty-release",
+          gameSideId: null,
+          gameTimeMs: 0,
+          sportingOrder: 0,
+          synchronizationOrder: 4,
+          effective: true,
+          data: {
+            pendingId: choiceAction.intent.pendingId,
+            scoreFactId: scoreAction.intent.factId,
+            playerKey: "side-b:8",
+          },
+        },
+      ],
+    });
+    replayMode = "success";
+    Object.defineProperty(testWindow.navigator, "onLine", { configurable: true, value: true });
+    await act(async () => {
+      document.dispatchEvent(new testWindow.Event("visibilitychange") as unknown as Event);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const after = JSON.parse(
+      testWindow.localStorage.getItem(controllerReplicaStorageKey("game-browser")) ?? "null",
+    ) as { pendingActions: unknown[] };
+    expect(after.pendingActions).toHaveLength(0);
+    expect(replayBodies.at(-1)?.actions[0]?.intent).toMatchObject({
+      type: "resolve-penalty-expiration",
+      scoreFactId: scoreAction.intent.factId,
+    });
   });
 
   test("renders stable fact identity and sends a contextual Correction from the browser seam", async () => {
@@ -1162,18 +1551,32 @@ describe("Event Game Controller reconnect browser seam", () => {
   });
 });
 
-function projection(eventGameId = "game-browser"): ControllerProjection {
+function projection(
+  eventGameId = "game-browser",
+  options: {
+    gameTimeMs?: number;
+    running?: boolean;
+    gameFacts?: ControllerProjection["gameFacts"];
+    commenced?: boolean;
+  } = {},
+): ControllerProjection {
   const baseline = createInitialClockBaseline();
   baseline.holderGrantSessionId = "session";
   baseline.holderGeneration = 1;
   baseline.authorityGeneration = 1;
-  baseline.gameTimeMs = 12_000;
+  baseline.gameTimeMs = options.gameTimeMs ?? 0;
+  baseline.running = options.running ?? false;
+  baseline.runningSinceMs = baseline.running ? 0 : null;
+  const defaultProjection = Object.keys(options).length === 0;
+  if (defaultProjection) baseline.gameTimeMs = 12_000;
   return {
     eventGameId,
-    phase: "in-progress",
-    scoreByGameSide: { "side-a": 10, "side-b": 0 },
-    goalCount: 1,
-    gameFacts: [
+    phase: defaultProjection || options.commenced !== false ? "in-progress" : "scheduled",
+    scoreByGameSide: defaultProjection
+      ? { "side-a": 10, "side-b": 0 }
+      : { "side-a": 0, "side-b": 0 },
+    goalCount: defaultProjection ? 1 : 0,
+    gameFacts: options.gameFacts ?? [
       {
         factId: "fact-goal",
         factType: "goal",
@@ -1185,10 +1588,11 @@ function projection(eventGameId = "game-browser"): ControllerProjection {
         data: { points: 10 },
       },
     ],
+    penalties: deriveLivePenaltyProjection(options.gameFacts ?? [], baseline.gameTimeMs),
     clock: projectClockBaseline(baseline, 0),
     commencement: {
-      status: "commenced",
-      commencedAtMs: 10_000,
+      status: defaultProjection || options.commenced === true ? "commenced" : "provisional",
+      commencedAtMs: defaultProjection ? 10_000 : options.commenced === true ? 0 : null,
       provisionalRunningSinceMs: null,
       provisionalElapsedMs: 0,
     },

--- a/src/pages/event-game-controller-page.tsx
+++ b/src/pages/event-game-controller-page.tsx
@@ -19,6 +19,12 @@ import {
   CLOSE_PLAY_ADJUDICATION_WINDOW_MS,
   LIVE_EVENT_CONTROL_INTENT_VERSION,
 } from "@/lib/live-event-game-control";
+import {
+  deriveLivePenaltyProjection,
+  type LiveCardType,
+  type LivePenaltyProjection,
+  type LivePenaltyReason,
+} from "@/lib/live-event-penalties";
 import { validateGameClockMs } from "@/lib/validation-policy";
 import { readControllerDeviceContext } from "@/lib/controller-device-context";
 import {
@@ -121,6 +127,14 @@ export function EventGameControllerPage() {
   const [localMonotonicMs, setLocalMonotonicMs] = useState(readMonotonicNow);
   const [clockCorrectionInput, setClockCorrectionInput] = useState("");
   const [takeoverAdjustmentInput, setTakeoverAdjustmentInput] = useState("");
+  const [cardGameSideId, setCardGameSideId] = useState("");
+  const [cardPlayerNumber, setCardPlayerNumber] = useState("");
+  const [cardType, setCardType] = useState<LiveCardType>("blue");
+  const [cardFoulBeforeScore, setCardFoulBeforeScore] = useState(false);
+  const [cardSeekerPenaltyConfirmed, setCardSeekerPenaltyConfirmed] = useState(false);
+  const [skippedPenaltyReasonCardIds, setSkippedPenaltyReasonCardIds] = useState<
+    ReadonlySet<string>
+  >(() => new Set());
   const [message, setMessage] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [pendingClosePlayAdjudication, setPendingClosePlayAdjudication] =
@@ -220,6 +234,17 @@ export function EventGameControllerPage() {
       document.removeEventListener("visibilitychange", reconcileWhenForegrounded);
     };
   }, [eventGameId, sessionBearer]);
+
+  const livePenalties =
+    projection === null
+      ? null
+      : clockProjection === null
+        ? projection.penalties
+        : deriveLivePenaltyProjection(projection.gameFacts ?? [], clockProjection.gameTimeMs);
+
+  function controllerGameTimeMs(): number {
+    return clockProjection?.gameTimeMs ?? projection?.clock.gameTimeMs ?? 0;
+  }
 
   async function openController() {
     const hasQrCredential = qrCredential.length > 0;
@@ -637,6 +662,80 @@ export function EventGameControllerPage() {
     });
   }
 
+  function recordCard() {
+    if (cardGameSideId === "") return;
+    const parsedPlayerNumber = cardPlayerNumber === "" ? null : Number(cardPlayerNumber);
+    if (parsedPlayerNumber !== null && !Number.isSafeInteger(parsedPlayerNumber)) return;
+    queueIntent({
+      version: LIVE_EVENT_CONTROL_INTENT_VERSION,
+      type: "record-card",
+      operationId: crypto.randomUUID(),
+      factId: crypto.randomUUID(),
+      gameSideId: cardGameSideId,
+      playerNumber: parsedPlayerNumber,
+      cardType,
+      ...(cardType === "blue" || cardType === "yellow"
+        ? { foulBeforeScore: cardFoulBeforeScore }
+        : {}),
+      ...(cardSeekerPenaltyConfirmed ? { seekerPenalty: "head-referee-confirmed" as const } : {}),
+      gameTimeMs: controllerGameTimeMs(),
+      occurrence: { clientOriginAtMs: Date.now() },
+    });
+  }
+
+  function recordPenaltyReason(targetCardFactId: string, reason: LivePenaltyReason) {
+    setSkippedPenaltyReasonCardIds((current) => {
+      if (!current.has(targetCardFactId)) return current;
+      const next = new Set(current);
+      next.delete(targetCardFactId);
+      return next;
+    });
+    const cardOperationId = replicaRef.current?.pendingActions.find(
+      (action) => action.intent.type === "record-card" && action.intent.factId === targetCardFactId,
+    )?.intent.operationId;
+    queueIntent(
+      {
+        version: LIVE_EVENT_CONTROL_INTENT_VERSION,
+        type: "record-penalty-reason",
+        operationId: crypto.randomUUID(),
+        factId: crypto.randomUUID(),
+        targetCardFactId,
+        reason,
+        gameTimeMs: controllerGameTimeMs(),
+        occurrence: { clientOriginAtMs: Date.now() },
+      },
+      cardOperationId === undefined ? {} : { causalPredecessorIds: [cardOperationId] },
+    );
+  }
+
+  function skipPenaltyReason(targetCardFactId: string) {
+    setSkippedPenaltyReasonCardIds((current) => {
+      const next = new Set(current);
+      next.add(targetCardFactId);
+      return next;
+    });
+  }
+
+  function resolvePenaltyExpiration(pendingId: string, scoreFactId: string, playerKey: string) {
+    const scoreOperationId = replicaRef.current?.pendingActions.find(
+      (action) => action.intent.type === "record-goal" && action.intent.factId === scoreFactId,
+    )?.intent.operationId;
+    queueIntent(
+      {
+        version: LIVE_EVENT_CONTROL_INTENT_VERSION,
+        type: "resolve-penalty-expiration",
+        operationId: crypto.randomUUID(),
+        factId: crypto.randomUUID(),
+        pendingId,
+        scoreFactId,
+        playerKey,
+        gameTimeMs: controllerGameTimeMs(),
+        occurrence: { clientOriginAtMs: Date.now() },
+      },
+      scoreOperationId === undefined ? {} : { causalPredecessorIds: [scoreOperationId] },
+    );
+  }
+
   function correctFact(factId: string, effective: boolean) {
     const gameTimeMs = currentSportingTimeMs();
     if (gameTimeMs === null) return;
@@ -668,7 +767,10 @@ export function EventGameControllerPage() {
     });
   }
 
-  function queueIntent(candidate: LiveEventControllerIntent) {
+  function queueIntent(
+    candidate: LiveEventControllerIntent,
+    options: { causalPredecessorIds?: readonly string[] } = {},
+  ) {
     const current = replicaRef.current;
     if (current === null) return;
     try {
@@ -688,8 +790,12 @@ export function EventGameControllerPage() {
           },
         },
         {
-          causalPredecessorIds:
-            relatedPendingOperationId === undefined ? [] : [relatedPendingOperationId],
+          ...options,
+          causalPredecessorIds: [
+            ...(options.causalPredecessorIds ?? []),
+            ...(relatedPendingOperationId === undefined ? [] : [relatedPendingOperationId]),
+          ],
+          nowMs: Math.floor(readMonotonicNow()),
         },
       );
       replicaRef.current = dispatched.state;
@@ -1287,9 +1393,86 @@ export function EventGameControllerPage() {
                     Emergency clock takeover
                   </Button>
                 </div>
-                <Button variant="outline" onClick={() => trigger("card")} disabled={busy}>
-                  Record card
-                </Button>
+                <div className="flex w-full flex-wrap items-end gap-2 rounded border p-2 text-left">
+                  <div className="min-w-32 flex-1 space-y-1">
+                    <Label htmlFor="penalty-game-side">Penalized Game Side</Label>
+                    <select
+                      id="penalty-game-side"
+                      className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+                      value={cardGameSideId}
+                      onChange={(event) => setCardGameSideId(event.target.value)}
+                      disabled={busy}
+                    >
+                      <option value="">Choose side</option>
+                      {Object.keys(projection?.scoreByGameSide ?? {}).map((sideId) => (
+                        <option key={sideId} value={sideId}>
+                          {sideId}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                  <div className="w-24 space-y-1">
+                    <Label htmlFor="penalty-player-number">Player #</Label>
+                    <Input
+                      id="penalty-player-number"
+                      inputMode="numeric"
+                      value={cardPlayerNumber}
+                      onChange={(event) => setCardPlayerNumber(event.target.value)}
+                      placeholder="optional"
+                      disabled={busy}
+                    />
+                  </div>
+                  <div className="min-w-24 space-y-1">
+                    <Label htmlFor="penalty-card-type">Card</Label>
+                    <select
+                      id="penalty-card-type"
+                      className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+                      value={cardType}
+                      onChange={(event) => {
+                        const nextCardType = event.target.value as LiveCardType;
+                        setCardType(nextCardType);
+                        if (nextCardType === "red" || nextCardType === "ejection") {
+                          setCardFoulBeforeScore(false);
+                        }
+                      }}
+                      disabled={busy}
+                    >
+                      <option value="blue">Blue</option>
+                      <option value="yellow">Yellow</option>
+                      <option value="red">Red</option>
+                      <option value="ejection">Ejection</option>
+                    </select>
+                  </div>
+                  <p className="max-w-52 self-center text-xs text-muted-foreground">
+                    Timing follows the live Game Clock: pregame cards begin at sticks up and
+                    confirmed seeker penalties during the seeker floor begin at 20:00.
+                  </p>
+                  <Button
+                    variant="outline"
+                    onClick={recordCard}
+                    disabled={busy || cardGameSideId === ""}
+                  >
+                    Accept card
+                  </Button>
+                  <label className="flex items-center gap-2 text-xs">
+                    <input
+                      type="checkbox"
+                      checked={cardFoulBeforeScore}
+                      onChange={(event) => setCardFoulBeforeScore(event.target.checked)}
+                      disabled={busy || cardType === "red" || cardType === "ejection"}
+                    />
+                    Foul before score
+                  </label>
+                  <label className="flex items-center gap-2 text-xs">
+                    <input
+                      type="checkbox"
+                      checked={cardSeekerPenaltyConfirmed}
+                      onChange={(event) => setCardSeekerPenaltyConfirmed(event.target.checked)}
+                      disabled={busy}
+                    />
+                    Penalized player is the seeker (Head Referee confirmed)
+                  </label>
+                </div>
                 <Button variant="outline" onClick={() => trigger("timeout")} disabled={busy}>
                   Start timeout
                 </Button>
@@ -1450,6 +1633,112 @@ export function EventGameControllerPage() {
                   <Button variant="outline" onClick={recordDoubleForfeit} disabled={busy}>
                     Record double-forfeit
                   </Button>
+                  <div className="space-y-3 rounded-lg border p-3">
+                    <p className="text-sm font-medium">Penalties</p>
+                    {(livePenalties?.players ?? []).length === 0 ? (
+                      <p className="text-sm text-muted-foreground">No active penalties.</p>
+                    ) : (
+                      (livePenalties?.players ?? []).map((player) => (
+                        <div
+                          key={player.playerKey}
+                          className="flex items-center justify-between gap-3 text-sm"
+                        >
+                          <span>{formatPenaltyPlayerLabel(player.playerKey, livePenalties)}</span>
+                          <span className="tabular-nums">
+                            {formatClock(
+                              player.segments.reduce(
+                                (sum, segment) => sum + segment.remainingMs,
+                                0,
+                              ),
+                            )}
+                          </span>
+                        </div>
+                      ))
+                    )}
+                    {(livePenalties?.pendingExpirations ?? []).map((pending) => (
+                      <div
+                        key={pending.id}
+                        className="space-y-2 rounded border border-amber-500/50 bg-amber-50 p-2 text-sm"
+                      >
+                        <p>
+                          Goal release: choose a penalty ({formatClock(pending.serviceDurationMs)}).
+                          {pending.requiresOfficialChoice
+                            ? " Complete tie requires official choice."
+                            : ""}
+                        </p>
+                        <div className="flex flex-wrap gap-2">
+                          {pending.candidatePlayerKeys.map((playerKey) => (
+                            <Button
+                              key={playerKey}
+                              size="sm"
+                              variant="outline"
+                              onClick={() =>
+                                resolvePenaltyExpiration(pending.id, pending.scoreFactId, playerKey)
+                              }
+                              disabled={busy}
+                            >
+                              Release {formatPenaltyPlayerLabel(playerKey, livePenalties)}
+                            </Button>
+                          ))}
+                        </div>
+                      </div>
+                    ))}
+                    {(livePenalties?.releases ?? []).map((release) => (
+                      <p key={release.id} className="text-xs text-emerald-700">
+                        Released {formatPenaltyPlayerLabel(release.playerKey, livePenalties)} after
+                        {release.releaseCause === "foul-before-score"
+                          ? " foul-before-score"
+                          : " opposing score"}{" "}
+                        at {formatClock(release.releasedMs)}.
+                      </p>
+                    ))}
+                    {(livePenalties?.cards ?? []).map((card) => (
+                      <div key={card.factId} className="flex flex-wrap items-center gap-2 text-xs">
+                        <span>
+                          {card.cardType} ·{" "}
+                          {formatPenaltyPlayerLabel(card.playerKey, livePenalties, {
+                            gameSideId: card.gameSideId,
+                            playerNumber: card.playerNumber,
+                          })}
+                        </span>
+                        <span>
+                          {card.reason === null
+                            ? skippedPenaltyReasonCardIds.has(card.factId)
+                              ? "reason skipped; add later"
+                              : "reason later/skipped"
+                            : `reason: ${card.reason}`}
+                        </span>
+                        {card.reason === null ? (
+                          <>
+                            {(
+                              [
+                                ["contact-safety", "Contact/Safety"],
+                                ["ball-interaction", "Ball Interaction"],
+                                ["position-boundary", "Position/Boundary"],
+                                ["procedure-substitution", "Procedure/Substitution"],
+                                ["conduct", "Conduct"],
+                                ["skip", "Skip"],
+                              ] as const
+                            ).map(([reason, label]) => (
+                              <Button
+                                key={reason}
+                                size="sm"
+                                variant="ghost"
+                                onClick={() =>
+                                  reason === "skip"
+                                    ? skipPenaltyReason(card.factId)
+                                    : recordPenaltyReason(card.factId, reason as LivePenaltyReason)
+                                }
+                                disabled={busy}
+                              >
+                                {label}
+                              </Button>
+                            ))}
+                          </>
+                        ) : null}
+                      </div>
+                    ))}
+                  </div>
                   <div className="space-y-2 rounded-lg border p-3">
                     <p className="text-sm font-medium">Game Facts</p>
                     {(projection.gameFacts ?? []).length === 0 ? (
@@ -1525,6 +1814,26 @@ function formatClock(milliseconds: number): string {
   const minutes = Math.floor(totalSeconds / 60);
   const seconds = totalSeconds % 60;
   return `${minutes.toString().padStart(2, "0")}:${seconds.toString().padStart(2, "0")}`;
+}
+
+function formatPenaltyPlayerLabel(
+  playerKey: string | null,
+  penalties: LivePenaltyProjection | null | undefined,
+  fallback?: { gameSideId: string; playerNumber: number | null },
+): string {
+  const player =
+    playerKey === null || penalties === null || penalties === undefined
+      ? undefined
+      : penalties.players.find((candidate) => candidate.playerKey === playerKey);
+  const card =
+    player === undefined && playerKey !== null && penalties !== null && penalties !== undefined
+      ? penalties.cards.find((candidate) => candidate.playerKey === playerKey)
+      : undefined;
+  const gameSideId = player?.gameSideId ?? card?.gameSideId ?? fallback?.gameSideId ?? "unknown";
+  const playerNumber = player?.playerNumber ?? card?.playerNumber ?? fallback?.playerNumber ?? null;
+  return `Game Side ${gameSideId} · ${
+    playerNumber === null ? "Player unknown" : `Player #${playerNumber}`
+  }`;
 }
 
 function formatSynchronizationTime(milliseconds: number | null | undefined): string {


### PR DESCRIPTION
## What changed

- Added durable blue, yellow, red, and ejection card handling with ordered penalty-minute service.
- Added Game Clock-backed penalty countdowns, pregame sticks-up timing, and Head Referee-confirmed seeker-floor deferral.
- Added deterministic score-triggered and foul-before-score releases, including complete-tie selection and auditable release consequences.
- Added fixed Penalty Reason follow-up, offline replay causality, correction/rebuild behavior, and Controller/browser presentation.

## Why

Spec #83 requires the live Controller to preserve IQA penalty timing and release semantics across multiple Controllers, reconnects, delayed facts, and Corrections. The previous live Event Game path did not provide this complete durable penalty lifecycle.

## Impact

Controllers can record cards quickly, add or skip a fixed reason without delaying play, see live penalty service, and safely recover delayed or offline release decisions. Existing IQA scoring, Clock authority, and Ad Hoc Game behavior remain intact.

## Validation

- Focused ordinary suites: 152 passed
- Composed live-control suite: 86 passed
- Full ordinary suite: 728 passed
- `bun run check`
- `bun run build`
- `git diff --check`

Closes #91.
