### PR TITLE
Bound Docker identity admission for SQLite qualification

### DIFF
--- a/src/lib/sqlite-foundation-probe-docker.test.ts
+++ b/src/lib/sqlite-foundation-probe-docker.test.ts
@@ -10,6 +10,8 @@ import {
   isOwnedDockerContainerInspection,
   isDockerResourceViolation,
   isDockerContainerConfigurationAdmitted,
+  SQLITE_FOUNDATION_PROBE_DOCKER_INFO_IDENTITY_FORMAT,
+  SQLITE_FOUNDATION_PROBE_DOCKER_VERSION_IDENTITY_FORMAT,
   parseDockerEngineIdentity,
   parseDockerArtifactIdentity,
   parseDockerResourceMeasurement,
@@ -428,6 +430,69 @@ describe("Docker SQLite qualification boundary", () => {
         }),
       }),
     ).rejects.toBeInstanceOf(DockerAdmissionError);
+  });
+
+  test("keeps oversized full info outside the reader while accepting bounded identity output", async () => {
+    const oversizedInfo = JSON.stringify({
+      OSType: "linux",
+      Architecture: "x86_64",
+      diagnostics: "x".repeat(10_422),
+    });
+    const boundedInfo = JSON.stringify({ OSType: "linux", Architecture: "x86_64" });
+    const boundedVersion = JSON.stringify({ Os: "linux", Arch: "amd64" });
+    expect(new TextEncoder().encode(oversizedInfo).byteLength).toBeGreaterThan(4 * 1024);
+    expect(new TextEncoder().encode(boundedInfo).byteLength).toBeLessThan(4 * 1024);
+    expect(new TextEncoder().encode(boundedVersion).byteLength).toBeLessThan(4 * 1024);
+
+    await expect(
+      admitDockerEngine({
+        platform: "linux",
+        architecture: "x64",
+        runCommand: async (arguments_) => ({
+          exitCode: 0,
+          stdout: arguments_[0] === "info" ? oversizedInfo : boundedVersion,
+          stderr: "",
+          stdoutBytes: arguments_[0] === "info" ? oversizedInfo.length : boundedVersion.length,
+          stderrBytes: 0,
+          outputExceeded: arguments_[0] === "info",
+        }),
+      }),
+    ).rejects.toBeInstanceOf(DockerAdmissionError);
+
+    const calls: string[][] = [];
+    await expect(
+      admitDockerEngine({
+        platform: "linux",
+        architecture: "x64",
+        runCommand: async (arguments_) => {
+          calls.push([...arguments_]);
+          const stdout = arguments_[0] === "info" ? boundedInfo : boundedVersion;
+          return {
+            exitCode: 0,
+            stdout,
+            stderr: "",
+            stdoutBytes: stdout.length,
+            stderrBytes: 0,
+            outputExceeded: false,
+          };
+        },
+      }),
+    ).resolves.toEqual({
+      os: "linux",
+      serverArchitecture: "amd64",
+      hostArchitecture: "x86_64",
+    });
+    expect(calls).toEqual([
+      ["info", "--format", SQLITE_FOUNDATION_PROBE_DOCKER_INFO_IDENTITY_FORMAT],
+      ["version", "--format", SQLITE_FOUNDATION_PROBE_DOCKER_VERSION_IDENTITY_FORMAT],
+    ]);
+    expect(parseDockerEngineIdentity(boundedInfo, boundedVersion)).not.toBeNull();
+    expect(
+      parseDockerEngineIdentity(JSON.stringify({ OSType: "linux" }), boundedVersion),
+    ).toBeNull();
+    expect(
+      parseDockerEngineIdentity(boundedInfo, JSON.stringify({ Os: "linux", Arch: "arm64" })),
+    ).toBeNull();
   });
 
   test("keeps the focused command harmless and separate from the SQLite workload", () => {

--- a/src/lib/sqlite-foundation-probe-docker.ts
+++ b/src/lib/sqlite-foundation-probe-docker.ts
@@ -20,6 +20,10 @@ export const SQLITE_FOUNDATION_PROBE_DOCKER_PROCESS_LIMIT =
 export const SQLITE_FOUNDATION_PROBE_DOCKER_TMPFS = `/tmp:rw,size=${SQLITE_FOUNDATION_PROBE_MAX_DISK_BYTES},mode=1777`;
 export const SQLITE_FOUNDATION_PROBE_DOCKER_LOG_MAX_SIZE = "4k";
 export const SQLITE_FOUNDATION_PROBE_DOCKER_LOG_MAX_FILE = "1";
+export const SQLITE_FOUNDATION_PROBE_DOCKER_INFO_IDENTITY_FORMAT =
+  '{"OSType":{{json .OSType}},"Architecture":{{json .Architecture}}}';
+export const SQLITE_FOUNDATION_PROBE_DOCKER_VERSION_IDENTITY_FORMAT =
+  '{"Os":{{json .Server.Os}},"Arch":{{json .Server.Arch}}}';
 
 export type DockerCommandResult = {
   exitCode: number;
@@ -182,8 +186,12 @@ export async function admitDockerEngine(
   }
   const runCommand = dependencies.runCommand ?? runDockerCommand;
   const [info, version] = await Promise.all([
-    runCommand(["info", "--format", "{{json .}}"], { signal: dependencies.signal }),
-    runCommand(["version", "--format", "{{json .Server}}"], { signal: dependencies.signal }),
+    runCommand(["info", "--format", SQLITE_FOUNDATION_PROBE_DOCKER_INFO_IDENTITY_FORMAT], {
+      signal: dependencies.signal,
+    }),
+    runCommand(["version", "--format", SQLITE_FOUNDATION_PROBE_DOCKER_VERSION_IDENTITY_FORMAT], {
+      signal: dependencies.signal,
+    }),
   ]);
   if (
     info.exitCode !== 0 ||


### PR DESCRIPTION
## What changed

- Query only the bounded Docker engine identity fields required by the SQLite qualification admission check.
- Preserve exact Linux x86-64 validation, the 4 KiB diagnostic bound, fail-closed parsing, cleanup, and no-retry behavior.
- Add regression coverage for oversized full `docker info` output and bounded identity responses.

## Why

The VPS Docker daemon returns valid full `docker info` JSON larger than the harness's intentional 4 KiB output ceiling. The admission check therefore rejected the native Linux x86-64 host before creating a container or running the qualification workload. Requesting only the required identity fields keeps the safety bound without rejecting a valid engine.

## Impact

This unblocks the explicitly invoked exact-artifact SQLite Docker qualification on the existing VPS. It does not run or weaken the qualification workload itself.

## Verification

- `bun install --frozen-lockfile`
- `bun audit`
- `bun run check`
- `bun test --isolate` — 660 tests passed
- `bun test --isolate src/lib/sqlite-foundation-probe-docker.test.ts` — 16 tests passed in coordinator verification
- `bun run build`
- `bun run build:executable`
- Harmless focused admission on Darwin arm64 failed closed before container creation with `workloadLaunched: false` and `qualificationWorkloadRan: false`
- `git diff --check`

No Qualification Test and no `bun run check:sqlite-runtime` workload was run.

Closes #179.
