### PR TITLE
Render the Daylight Arena Event schedule

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -164,6 +164,10 @@ _Avoid_: Mutable command, audit entry
 The current score, phase, overtime target, result, stoppages, and other game state rebuilt from effective Game Facts and Locked-Game Corrections whenever either changes the record. Its scoring bounds and lifecycle must agree with the durable Event Game Record root.
 _Avoid_: Stored result, patched state
 
+**Game Phase**:
+The sporting phase of an Event Game: Seeker Floor, Seekers Released, or Overtime. Game Phase describes the rule sequence of play and is distinct from operational status, which describes whether the Game is scheduled, running, paused, suspended, or finished.
+_Avoid_: Operational status, lifecycle phase, game status
+
 **Controller Device**:
 A Controller's personally supplied, working, sufficiently charged phone used to access the app. Each Controller arranges their own device and power; no phone is designated as the primary or backup device, and another person's phone may take over through the same Control Grant.
 _Avoid_: Primary phone, backup phone, dedicated timer phone

--- a/scripts/test-public-event-browser.ts
+++ b/scripts/test-public-event-browser.ts
@@ -2,8 +2,18 @@ import { chromium, type Page } from "playwright";
 import { mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { createEventCatalog, createFoundationEventCatalogStorage } from "@/lib/event-catalog";
+import {
+  createEventCatalog,
+  createFoundationEventCatalogStorage,
+  type EventGame,
+} from "@/lib/event-catalog";
+import { createEventGameRecord, type ExternalScopeResolver } from "@/lib/event-game-record";
+import type { ControlActionInput } from "@/lib/event-game-actions";
+import type { EventGameRecordRoot } from "@/lib/foundation-record-types";
+import { createGrantKeyRingDocument, writeGrantKeyRingFile } from "@/lib/grant-key-ring-custody";
 import { openSqliteFoundationStorage } from "@/lib/foundation-storage-sqlite";
+import { readGrantAuthorityOptions } from "@/lib/grant-runtime";
+import { createLiveEventGameIqaInterpreter } from "@/lib/live-event-game-control";
 import {
   MemoryTechnicalAdminAuthRepository,
   createTechnicalAdminAuth,
@@ -13,6 +23,8 @@ import {
 const directory = mkdtempSync(join(tmpdir(), "quadball-timer-public-browser-"));
 const foundationDatabase = join(directory, "foundation.sqlite");
 const technicalAdminDatabase = join(directory, "technical-admin.sqlite");
+const grantKeyRingFile = join(directory, "grant-key-ring.json");
+writeGrantKeyRingFile(grantKeyRingFile, createGrantKeyRingDocument("test"));
 const port = 38_000 + Math.floor(Math.random() * 1_000);
 const origin = `http://127.0.0.1:${port}`;
 const environment = {
@@ -22,6 +34,7 @@ const environment = {
   PUBLIC_ORIGIN: "https://timer.example",
   FOUNDATION_DATABASE: foundationDatabase,
   TECHNICAL_ADMIN_DATABASE: technicalAdminDatabase,
+  GRANT_KEY_RING_FILE: grantKeyRingFile,
   PORT: String(port),
   HOST: "127.0.0.1",
 };
@@ -41,9 +54,10 @@ try {
   });
   serverStderr = new Response(server.stderr as unknown as BodyInit).text();
   await waitForServer(`${origin}/internal/healthz`);
+  await seedCommittedGameRecords(seeded);
 
   browser = await chromium.launch({ headless: true });
-  const context = await browser.newContext();
+  const context = await browser.newContext({ viewport: { width: 390, height: 844 } });
   const page = await context.newPage();
   page.setDefaultTimeout(5_000);
   browserPage = page;
@@ -68,7 +82,52 @@ try {
   await page.goto(`${origin}/events`);
   await page.waitForURL(`${origin}${current.canonicalPath}`);
   await page.getByRole("heading", { name: "Published Current" }).waitFor();
-
+  await page.getByRole("heading", { name: "Coming up" }).waitFor();
+  await page.getByRole("heading", { name: "Event schedule" }).waitFor();
+  const liveNow = page.locator('[data-schedule-group="live-now"]');
+  await liveNow.locator('[data-game-code="BUSY-2"]').waitFor();
+  await liveNow.locator('[data-game-code="BUSY-3"]').waitFor();
+  assert(
+    (await liveNow.locator('[data-schedule-card][data-schedule-status="running"]').count()) === 2,
+    "both committed running Games were not shown in Live now",
+  );
+  const liveCardClasses = await liveNow
+    .locator("[data-schedule-card]")
+    .evaluateAll((cards) =>
+      cards.map((card) => card.firstElementChild?.getAttribute("class") ?? ""),
+    );
+  assert(new Set(liveCardClasses).size === 1, "running Games did not receive equal card treatment");
+  const schedule = page.locator('[data-schedule-group="event-schedule"]');
+  for (const [code, status] of [
+    ["BUSY-1", "past"],
+    ["BUSY-2", "running"],
+    ["BUSY-4", "awaiting-start"],
+    ["BUSY-5", "future"],
+  ] as const) {
+    assert(
+      (await schedule
+        .locator(`[data-game-code="${code}"][data-schedule-status="${status}"]`)
+        .count()) === 1,
+      `${code} did not retain chronological status ${status}`,
+    );
+  }
+  assert(
+    (await page.locator('[data-schedule-group="coming-up"] h3').count()) === 1,
+    "Coming up Games were not grouped by Expected Start",
+  );
+  await page.getByText("Pitch Pitch 1").first().waitFor();
+  await page.getByText("Pitch Pitch 2").first().waitFor();
+  await page.getByText("Scheduled Start").first().waitFor();
+  assert(
+    (await page.locator("body").innerText()).includes("Expected Start"),
+    "Expected Start was not rendered",
+  );
+  assert(
+    await page.evaluate(
+      () => document.documentElement.scrollWidth <= document.documentElement.clientWidth,
+    ),
+    "phone-sized Event schedule overflows horizontally",
+  );
   const canonicalResponse = await page.goto(`${origin}${current.canonicalPath}`);
   await page.getByRole("heading", { name: "Published Current" }).waitFor();
   assert(
@@ -185,6 +244,7 @@ try {
       zeroCurrent: true,
       oneCurrentAutoOpen: true,
       multipleCurrentDiscovery: true,
+      busyPhoneSchedule: true,
       canonicalNavigation: true,
       unavailableHiddenUnknown: true,
       unavailableDatabaseFailure: true,
@@ -221,7 +281,9 @@ type PublicEventFixture = {
 };
 
 async function seedDatabase() {
-  const foundation = openSqliteFoundationStorage(foundationDatabase);
+  const foundation = openSqliteFoundationStorage(foundationDatabase, {
+    grantKeyRing: readGrantAuthorityOptions("test", environment).keyRing,
+  });
   await foundation.applyMigrations();
   const catalog = createEventCatalog(createFoundationEventCatalogStorage(foundation), {});
   const hostAuth = createTechnicalAdminAuth(
@@ -230,12 +292,17 @@ async function seedDatabase() {
   );
   const authority = hostAuth.resolveHostLocalAuthority();
   try {
-    const current = await createPublishedEvent(catalog, authority, "Published Current", 0);
+    const current = await createPublishedEvent(catalog, authority, "Published Current", 0, true);
     await createPublishedEvent(catalog, authority, "Published Future", 1);
     await createPublishedEvent(catalog, authority, "Published Past", -1);
     const hidden = await catalog.createEvent({ name: "Hidden Event", timeZone: "UTC" }, authority);
     if (hidden.status !== "accepted") throw new Error("hidden Event creation failed");
-    return { currentId: current, hiddenId: hidden.value.eventId };
+    return {
+      currentId: current.eventId,
+      currentGameDayId: current.gameDayId,
+      currentGames: current.games,
+      hiddenId: hidden.value.eventId,
+    };
   } finally {
     hostAuth.close();
     foundation.close();
@@ -247,6 +314,7 @@ async function createPublishedEvent(
   authority: TechnicalAdminAuthority,
   name: string,
   dayOffset: number,
+  withSchedule = false,
 ) {
   const event = await catalog.createEvent({ name, timeZone: "UTC" }, authority);
   if (event.status !== "accepted") throw new Error(`${name} creation failed`);
@@ -256,13 +324,244 @@ async function createPublishedEvent(
     authority,
   );
   if (day.status !== "accepted") throw new Error(`${name} Game Day creation failed`);
+  const games = withSchedule
+    ? await createBusySchedule(catalog, authority, event.value.eventId, day.value.gameDayId)
+    : [];
   const published = await catalog.changePublicationStatus(
     event.value.eventId,
     { status: "published", impactConfirmed: true },
     authority,
   );
   if (published.status !== "accepted") throw new Error(`${name} publication failed`);
-  return event.value.eventId;
+  return { eventId: event.value.eventId, gameDayId: day.value.gameDayId, games };
+}
+
+async function createBusySchedule(
+  catalog: ReturnType<typeof createEventCatalog>,
+  authority: TechnicalAdminAuthority,
+  eventId: string,
+  gameDayId: string,
+) {
+  const firstPitch = await catalog.createPitch(eventId, { name: "Pitch 1" }, authority);
+  const secondPitch = await catalog.createPitch(eventId, { name: "Pitch 2" }, authority);
+  if (firstPitch.status !== "accepted" || secondPitch.status !== "accepted") {
+    throw new Error("busy Event Pitch creation failed");
+  }
+  const now = Date.now();
+  const starts = [
+    now - 90 * 60_000,
+    now - 30 * 60_000,
+    now - 30 * 60_000,
+    now - 5 * 60_000,
+    now + 20 * 60_000,
+    now + 90 * 60_000,
+  ];
+  const created: Array<{ game: EventGame; pitchId: string; pitchSlotId: string }> = [];
+  for (const [index, startMs] of starts.entries()) {
+    const slot = await catalog.createGameplaySlot(
+      eventId,
+      gameDayId,
+      { sequence: index + 1, scheduledStart: new Date(startMs).toISOString().slice(0, 16) },
+      authority,
+    );
+    if (slot.status !== "accepted") throw new Error("busy Event Gameplay Slot creation failed");
+    if (index === 2) {
+      const delayed = await catalog.setGameplaySlotExpectedDelay(
+        eventId,
+        gameDayId,
+        slot.value.gameplaySlotId,
+        { expectedDelayMs: 5 * 60_000 },
+        authority,
+      );
+      if (delayed.status !== "accepted") throw new Error("busy Event delay change failed");
+    }
+    const inspected = await catalog.inspectEvent(eventId, authority);
+    if (inspected.status !== "accepted") throw new Error("busy Event inspection failed");
+    const pitchSlots = inspected.value.pitchSlots.filter(
+      (candidate) => candidate.gameplaySlotId === slot.value.gameplaySlotId,
+    );
+    const pitchSlot = pitchSlots[index % pitchSlots.length];
+    if (pitchSlot === undefined) throw new Error("busy Event Pitch Slot creation failed");
+    const game = await catalog.createEventGame(
+      eventId,
+      gameDayId,
+      {
+        gameplaySlotId: slot.value.gameplaySlotId,
+        pitchSlotId: pitchSlot.pitchSlotId,
+        gameCode: `BUSY-${index + 1}`,
+        gameDesignation: `Busy Game ${index + 1}`,
+        sideA: { sourceLabel: `Blue ${index + 1}` },
+        sideB: { sourceLabel: `Red ${index + 1}` },
+      },
+      authority,
+    );
+    if (game.status !== "accepted") throw new Error("busy Event Game creation failed");
+    created.push({
+      game: game.value,
+      pitchId: pitchSlot.pitchId,
+      pitchSlotId: pitchSlot.pitchSlotId,
+    });
+  }
+
+  return created;
+}
+
+async function seedCommittedGameRecords(seeded: {
+  currentId: string;
+  currentGameDayId: string;
+  currentGames: readonly { game: EventGame; pitchId: string; pitchSlotId: string }[];
+}) {
+  const foundation = openSqliteFoundationStorage(foundationDatabase, {
+    grantKeyRing: readGrantAuthorityOptions("test", environment).keyRing,
+  });
+  const resolver = createSeedScopeResolver();
+  for (const [index, entry] of seeded.currentGames.entries()) {
+    if (index > 2) continue;
+    const root = createSeedRoot(
+      seeded.currentId,
+      seeded.currentGameDayId,
+      entry.game.eventGameId,
+      entry.pitchId,
+      entry.pitchSlotId,
+    );
+    const record = createEventGameRecord(foundation, {
+      externalScopeResolver: resolver,
+      interpreter: createLiveEventGameIqaInterpreter(),
+      clock: () => Date.now(),
+    });
+    const registered = await record.registerRoot(root);
+    if (registered.status !== "registered") throw new Error("busy Event root registration failed");
+    const action = await record.acceptAction(
+      index === 0 ? createSeedForfeitAction(root) : createSeedClockAction(root),
+    );
+    if (action.status !== "accepted") throw new Error("busy Event action commit failed");
+    if (index === 0) {
+      const finished = await record.transitionLifecycle({
+        ...root.lifecycle,
+        phase: "finished",
+        finishedAtMs: Date.now(),
+      });
+      if (finished.status !== "updated") throw new Error("busy Event finish commit failed");
+    }
+  }
+  foundation.close();
+}
+
+function createSeedScopeResolver(): ExternalScopeResolver {
+  return {
+    resolve(scope, snapshot) {
+      const pitchSlot = snapshot.findPitchSlot?.(scope.pitchSlotId) ?? null;
+      return pitchSlot !== null &&
+        pitchSlot.eventId === scope.eventId &&
+        pitchSlot.gameDayId === scope.gameDayId &&
+        pitchSlot.pitchId === scope.pitchId
+        ? { status: "resolved", scope: structuredClone(scope) }
+        : { status: "mismatch", detail: "Seed Event Game Pitch Slot is unavailable." };
+    },
+    resolveEventTeam(eventId, eventTeamId) {
+      return eventId.length > 0 && eventTeamId.length > 0
+        ? { status: "resolved" }
+        : { status: "missing", detail: "Seed Event Team is unavailable." };
+    },
+  };
+}
+
+function createSeedRoot(
+  eventId: string,
+  gameDayId: string,
+  eventGameId: string,
+  pitchId: string,
+  pitchSlotId: string,
+): EventGameRecordRoot {
+  const createdAtMs = Date.now();
+  return {
+    recordId: `seed-record-${eventGameId}`,
+    eventId,
+    eventGameId,
+    ownership: { eventId, eventGameId },
+    externalScope: {
+      eventId,
+      gameDayId,
+      pitchId,
+      pitchSlotId,
+    },
+    gameSides: [
+      {
+        id: `seed-side-${eventGameId}-a`,
+        eventTeamId: `seed-team-${eventGameId}-a`,
+        teamInterpretationRef: "seed-team-a-v1",
+      },
+      {
+        id: `seed-side-${eventGameId}-b`,
+        eventTeamId: `seed-team-${eventGameId}-b`,
+        teamInterpretationRef: "seed-team-b-v1",
+      },
+    ],
+    lifecycle: {
+      phase: "in-progress",
+      commencedAtMs: createdAtMs,
+      finishedAtMs: null,
+      lockedAtMs: null,
+      lockReason: null,
+    },
+    compatibility: {
+      recordVersion: "event-game-record-v1",
+      schemaVersion: "event-game-record-v1",
+      interpreterVersion: "live-event-iqa-v1",
+    },
+    creationEvidence: {
+      operationId: `seed-create-${eventGameId}`,
+      actorReference: "public-browser-test",
+      source: "event-game-registration",
+      createdAtMs,
+    },
+  };
+}
+
+function createSeedClockAction(root: EventGameRecordRoot): ControlActionInput {
+  return createSeedAction(root, `seed-clock-${root.eventGameId}`, "clock", null, {
+    command: "set-running",
+    running: true,
+    gameTimeMs: 0,
+    sportingOrder: 0,
+  });
+}
+
+function createSeedForfeitAction(root: EventGameRecordRoot): ControlActionInput {
+  return createSeedAction(
+    root,
+    `seed-forfeit-${root.eventGameId}`,
+    "forfeit",
+    root.gameSides[1].id,
+    { resultKind: "forfeit", sportingOrder: 0 },
+  );
+}
+
+function createSeedAction(
+  root: EventGameRecordRoot,
+  operationId: string,
+  factType: string,
+  gameSideId: string | null,
+  data: Record<string, unknown>,
+): ControlActionInput {
+  const trustedAtMs = Date.now();
+  return {
+    recordId: root.recordId,
+    eventGameId: root.eventGameId,
+    operationId,
+    kind: { id: "game-fact", version: "1" },
+    payload: {
+      factId: operationId,
+      factType,
+      gameSideId,
+      gameTimeMs: 0,
+      data,
+    },
+    causalPredecessorIds: [],
+    occurrence: { trustedAtMs, clientOriginAtMs: trustedAtMs, source: "online" },
+    grant: { sessionId: "public-browser-seed", versionId: "public-browser-seed-v1" },
+    lifecycle: structuredClone(root.lifecycle),
+  };
 }
 
 function dateOffset(offset: number) {

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1209,6 +1209,13 @@ describe("App", () => {
               canonicalPath: "/events/visible-event",
               teams: [],
               pitches: [],
+              schedule: {
+                asOfMs: 0,
+                runningGames: [],
+                upcomingGames: [],
+                scheduleGames: [],
+                focusIndex: null,
+              },
             },
           }),
           { status: 200, headers: { "content-type": "application/json" } },

--- a/src/index-public-event.test.ts
+++ b/src/index-public-event.test.ts
@@ -11,6 +11,13 @@ const publishedEvent = {
   canonicalPath: "/events/event-published",
   teams: [],
   pitches: [],
+  schedule: {
+    asOfMs: 0,
+    runningGames: [],
+    upcomingGames: [],
+    scheduleGames: [],
+    focusIndex: null,
+  },
 };
 
 describe("public Event browser responses", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,8 @@ import {
 } from "@/lib/administrative-audit";
 import { createGrantAuthority } from "@/lib/grant-authority";
 import { readGrantAuthorityOptions } from "@/lib/grant-runtime";
+import { createControlActionCodecRegistry } from "@/lib/event-game-actions";
+import { createLiveEventGameIqaInterpreter } from "@/lib/live-event-game-control";
 import type {
   TypedGrantMutation,
   TypedGrantReveal,
@@ -236,6 +238,10 @@ async function startServer() {
           : openSqliteFoundationStorage(foundationDatabasePath, {
               grantKeyRing: grantAuthorityOptions.keyRing,
             });
+      candidateFoundation.setReadinessContext?.({
+        actionCodecRegistry: createControlActionCodecRegistry(),
+        interpreter: createLiveEventGameIqaInterpreter(),
+      });
       const readiness = await candidateFoundation.readiness();
       if ((readiness.evidence?.keys?.missingCount ?? 0) > 0) {
         throw new GrantKeyRingCustodyError("missing-key-version");

--- a/src/lib/audience-projection.test.ts
+++ b/src/lib/audience-projection.test.ts
@@ -1,13 +1,23 @@
 import { describe, expect, test } from "bun:test";
 import { createAudienceProjection, PUBLIC_AUDIENCE_ABSENCE } from "@/lib/audience-projection";
 import {
+  createControlActionCodecRegistry,
+  materializeControlAction,
+  prepareControlAction,
+  type ControlActionInput,
+} from "@/lib/event-game-actions";
+import {
   createEventCatalog,
   createFoundationEventCatalogStorage,
   createUnavailableEventCatalogStorage,
   type EventCatalogFoundationStorage,
   type EventCatalogStorageSnapshot,
+  type EventGame,
+  type GameplaySlot,
+  type PitchSlot,
   type StoredEvent,
 } from "@/lib/event-catalog";
+import type { EventGameRecordRoot } from "@/lib/foundation-record-types";
 import { createInMemoryFoundationStorage } from "@/lib/foundation-storage-memory";
 import {
   MemoryTechnicalAdminAuthRepository,
@@ -21,6 +31,238 @@ const authority = createTechnicalAdminAuth(
 ).resolveHostLocalAuthority();
 
 describe("Audience Publication Projection", () => {
+  test("groups every running Game, uses a half-open one-hour horizon, and orders the schedule", async () => {
+    const now = Date.parse("2026-08-14T10:00:00.000Z");
+    const snapshot = createScheduleSnapshot({
+      pitches: ["Pitch 1", "Pitch 2"],
+      games: [
+        createScheduleGame("past", "2026-08-14T08:00:00.000Z", "Pitch 1"),
+        createScheduleGame("running-a", "2026-08-14T09:00:00.000Z", "Pitch 1"),
+        createScheduleGame("running-b", "2026-08-14T09:00:00.000Z", "Pitch 2"),
+        createScheduleGame("awaiting", "2026-08-14T09:30:00.000Z", "Pitch 1"),
+        createScheduleGame("upcoming", "2026-08-14T10:30:00.000Z", "Pitch 2"),
+        createScheduleGame("boundary", "2026-08-14T11:00:00.000Z", "Pitch 1"),
+      ],
+      roots: new Map([
+        ["past", createScheduleRoot("past", "finished")],
+        ["running-a", createScheduleRoot("running-a", "in-progress")],
+        ["running-b", createScheduleRoot("running-b", "in-progress")],
+      ]),
+    });
+    const audience = createAudienceProjection(
+      { snapshot: async () => snapshot } as unknown as EventCatalogFoundationStorage,
+      { now: () => now },
+    );
+
+    const result = await audience.read("event-schedule");
+    expect(result).toMatchObject({ status: "accepted" });
+    if (result.status !== "accepted") return;
+    const schedule = result.value.schedule;
+    expect(schedule).toBeDefined();
+    if (schedule === undefined) return;
+    expect(schedule.runningGames.map((game) => game.gameCode)).toEqual(["running-a", "running-b"]);
+    expect(schedule.upcomingGames.map((game) => game.gameCode)).toEqual(["upcoming"]);
+    expect(schedule.scheduleGames.map((game) => game.gameCode)).toEqual([
+      "past",
+      "running-a",
+      "running-b",
+      "awaiting",
+      "upcoming",
+      "boundary",
+    ]);
+    expect(schedule.scheduleGames.map((game) => game.scheduleStatus)).toEqual([
+      "past",
+      "running",
+      "running",
+      "awaiting-start",
+      "future",
+      "future",
+    ]);
+    expect(schedule.focusIndex).toBe(1);
+    expect(schedule.runningGames[0]?.pitch).toBe("Pitch 1");
+    expect(schedule.runningGames[1]?.pitch).toBe("Pitch 2");
+    expect(schedule.runningGames.map((game) => game.phase)).toEqual([
+      "seeker-floor",
+      "seeker-floor",
+    ]);
+    expect(schedule.runningGames.map((game) => game.operationalStatus)).toEqual([
+      "paused",
+      "paused",
+    ]);
+  });
+
+  test("projects sporting Game Phase separately from operational status", async () => {
+    const roots = new Map([
+      ["floor", createScheduleRoot("floor", "in-progress")],
+      ["released", createScheduleRoot("released", "in-progress")],
+      ["overtime", createScheduleRoot("overtime", "in-progress")],
+    ]);
+    const snapshot = createScheduleSnapshot({
+      pitches: ["Pitch 1"],
+      games: [
+        createScheduleGame("floor", "2026-08-14T10:00:00.000Z", "Pitch 1"),
+        createScheduleGame("released", "2026-08-14T10:01:00.000Z", "Pitch 1"),
+        createScheduleGame("overtime", "2026-08-14T10:02:00.000Z", "Pitch 1"),
+      ],
+      roots,
+      actions: (root) => {
+        if (root.eventGameId === "released") return [createClockAction(root)];
+        if (root.eventGameId === "overtime") {
+          return [
+            ...Array.from({ length: 4 }, (_, index) =>
+              createGoalAction(root, root.gameSides[1].id, `opponent-goal-${index}`),
+            ),
+            createFlagCatchAction(root),
+          ];
+        }
+        return [];
+      },
+    });
+    const audience = createAudienceProjection(
+      { snapshot: async () => snapshot } as unknown as EventCatalogFoundationStorage,
+      { now: () => Date.parse("2026-08-14T10:00:00.000Z") },
+    );
+
+    const result = await audience.read("event-schedule");
+    expect(result).toMatchObject({ status: "accepted" });
+    if (result.status !== "accepted") return;
+    expect(result.value.schedule.scheduleGames.map((game) => [game.gameCode, game.phase])).toEqual([
+      ["floor", "seeker-floor"],
+      ["released", "seekers-released"],
+      ["overtime", "overtime"],
+    ]);
+    expect(result.value.schedule.scheduleGames.map((game) => game.operationalStatus)).toEqual([
+      "paused",
+      "paused",
+      "paused",
+    ]);
+  });
+
+  test("regenerates Expected Start and omits redundant single-Pitch labels", async () => {
+    let expectedDelayMs = 0;
+    const base = createScheduleGame("changed", "2026-08-14T10:30:00.000Z", "Pitch 1");
+    const snapshot = createScheduleSnapshot({
+      pitches: ["Pitch 1"],
+      games: [base],
+      expectedDelay: () => expectedDelayMs,
+    });
+    const audience = createAudienceProjection(
+      { snapshot: async () => snapshot } as unknown as EventCatalogFoundationStorage,
+      { now: () => Date.parse("2026-08-14T10:00:00.000Z") },
+    );
+
+    const before = await audience.read("event-schedule");
+    expect(before).toMatchObject({
+      status: "accepted",
+      value: {
+        schedule: {
+          scheduleGames: [
+            {
+              scheduledStartMs: Date.parse("2026-08-14T10:30:00.000Z"),
+              expectedStartMs: Date.parse("2026-08-14T10:30:00.000Z"),
+              pitch: null,
+            },
+          ],
+        },
+      },
+    });
+
+    expectedDelayMs = 20 * 60_000;
+    const after = await audience.read("event-schedule");
+    expect(after).toMatchObject({
+      status: "accepted",
+      value: {
+        schedule: {
+          scheduleGames: [
+            {
+              scheduledStartMs: Date.parse("2026-08-14T10:30:00.000Z"),
+              expectedStartMs: Date.parse("2026-08-14T10:50:00.000Z"),
+              pitch: null,
+            },
+          ],
+        },
+      },
+    });
+  });
+
+  test("regenerates committed Game State and Pitch reassignment", async () => {
+    let includeGoal = false;
+    let reassigned = false;
+    const game = createScheduleGame("mutable", "2026-08-14T10:30:00.000Z", "Pitch 1");
+    const root = createScheduleRoot("mutable", "in-progress");
+    const snapshot = createScheduleSnapshot({
+      pitches: ["Pitch 1", "Pitch 2"],
+      games: () => [game],
+      roots: new Map([["mutable", root]]),
+      placement: () => ({
+        pitchSlotId: reassigned ? `${game.pitchSlotId}-2` : game.pitchSlotId,
+      }),
+      actions: (currentRoot) => (includeGoal ? [createGoalAction(currentRoot)] : []),
+    });
+    const audience = createAudienceProjection(
+      { snapshot: async () => snapshot } as unknown as EventCatalogFoundationStorage,
+      { now: () => Date.parse("2026-08-14T10:00:00.000Z") },
+    );
+
+    const before = await audience.read("event-schedule");
+    expect(before).toMatchObject({
+      status: "accepted",
+      value: {
+        schedule: {
+          scheduleGames: [
+            {
+              pitch: "Pitch 1",
+              expectedStartMs: Date.parse("2026-08-14T10:30:00.000Z"),
+              sideA: { score: 0 },
+            },
+          ],
+        },
+      },
+    });
+
+    includeGoal = true;
+    reassigned = true;
+    const after = await audience.read("event-schedule");
+    expect(after).toMatchObject({
+      status: "accepted",
+      value: {
+        schedule: {
+          scheduleGames: [
+            {
+              pitch: "Pitch 2",
+              expectedStartMs: Date.parse("2026-08-14T10:30:00.000Z"),
+              sideA: { score: 10 },
+            },
+          ],
+        },
+      },
+    });
+  });
+
+  test("returns empty running and upcoming groups while retaining an all-past schedule", async () => {
+    const snapshot = createScheduleSnapshot({
+      pitches: ["Pitch 1"],
+      games: [createScheduleGame("finished", "2026-08-14T08:00:00.000Z", "Pitch 1")],
+      roots: new Map([["finished", createScheduleRoot("finished", "finished")]]),
+    });
+    const audience = createAudienceProjection(
+      { snapshot: async () => snapshot } as unknown as EventCatalogFoundationStorage,
+      { now: () => Date.parse("2026-08-14T12:00:00.000Z") },
+    );
+
+    const result = await audience.read("event-schedule");
+    expect(result).toMatchObject({
+      status: "accepted",
+      value: {
+        schedule: {
+          runningGames: [],
+          upcomingGames: [],
+          scheduleGames: [{ gameCode: "finished", scheduleStatus: "past" }],
+        },
+      },
+    });
+  });
+
   test("keeps a zero-Day Published Event explicitly unscheduled", async () => {
     const event: StoredEvent = {
       eventId: "event-unscheduled",
@@ -107,6 +349,13 @@ describe("Audience Publication Projection", () => {
               canonicalPath: "/events/event-public",
               teams: [],
               pitches: [],
+              schedule: {
+                asOfMs: 0,
+                runningGames: [],
+                upcomingGames: [],
+                scheduleGames: [],
+                focusIndex: null,
+              },
             },
           ],
         },
@@ -259,3 +508,261 @@ describe("Audience Publication Projection", () => {
     expect(failureBody).not.toContain("private storage detail");
   });
 });
+
+function createScheduleSnapshot(input: {
+  pitches: string[];
+  games: EventGame[] | (() => EventGame[]);
+  roots?: Map<string, EventGameRecordRoot>;
+  expectedDelay?: () => number;
+  placement?: (game: EventGame) => { pitchSlotId?: string; gameplaySlotId?: string };
+  actions?: (root: EventGameRecordRoot) => ReturnType<typeof createFinishedAction>[];
+}): EventCatalogStorageSnapshot {
+  const event: StoredEvent = {
+    eventId: "event-schedule",
+    name: "Schedule Event",
+    timeZone: "UTC",
+    publicationStatus: "published",
+    createdAtMs: 1,
+    updatedAtMs: 1,
+  };
+  const gameDay = {
+    gameDayId: "day-1",
+    eventId: event.eventId,
+    date: "2026-08-14",
+    createdAtMs: 1,
+    updatedAtMs: 1,
+  };
+  const pitchRows = input.pitches.map((name, index) => ({
+    pitchId: `pitch-${index + 1}`,
+    eventId: event.eventId,
+    name,
+    createdAtMs: 1,
+    updatedAtMs: 1,
+  }));
+  const initialGames = typeof input.games === "function" ? input.games() : input.games;
+  const currentGames = () =>
+    (typeof input.games === "function" ? input.games() : input.games).map((game) => ({
+      ...game,
+      ...input.placement?.(game),
+    }));
+  const gameplaySlots = new Map(
+    initialGames.map((game) => [
+      game.gameplaySlotId,
+      {
+        gameplaySlotId: game.gameplaySlotId,
+        eventId: event.eventId,
+        gameDayId: gameDay.gameDayId,
+        sequence: Number(game.gameCode?.replace(/\\D/g, "")) || 1,
+        scheduledStartMs: Date.parse(game.gameDesignation ?? "2026-08-14T10:00:00.000Z"),
+        expectedDelayMs: input.expectedDelay?.() ?? 0,
+        createdAtMs: 1,
+        updatedAtMs: 1,
+      },
+    ]),
+  );
+  const pitchSlots = new Map(
+    initialGames.flatMap((game) =>
+      pitchRows.map((pitch, index) => {
+        const pitchSlotId =
+          index === pitchRows.findIndex((candidate) => candidate.name === game.sideA.sourceLabel)
+            ? game.pitchSlotId
+            : `${game.pitchSlotId}-${index + 1}`;
+        return [
+          pitchSlotId,
+          {
+            pitchSlotId,
+            eventId: event.eventId,
+            gameDayId: gameDay.gameDayId,
+            pitchId: pitch.pitchId,
+            gameplaySlotId: game.gameplaySlotId,
+            sequence: 1,
+            expectedDelayMs: 0,
+            createdAtMs: 1,
+            updatedAtMs: 1,
+          },
+        ];
+      }),
+    ),
+  );
+  return {
+    findEvent: (eventId: string) => (eventId === event.eventId ? event : null),
+    listEvents: () => [event],
+    listGameDays: () => [gameDay],
+    findEventTeam: () => null,
+    listEventTeams: () => [],
+    listRoster: () => [],
+    findRosterEntry: () => null,
+    findPitch: (pitchId: string) => pitchRows.find((pitch) => pitch.pitchId === pitchId) ?? null,
+    listPitches: () => pitchRows,
+    findGameplaySlot: (slotId: string): GameplaySlot | null => {
+      const slot = gameplaySlots.get(slotId);
+      return slot === undefined
+        ? null
+        : { ...slot, expectedDelayMs: input.expectedDelay?.() ?? slot.expectedDelayMs };
+    },
+    listGameplaySlots: () =>
+      [...gameplaySlots.values()].map((slot) => ({
+        ...slot,
+        expectedDelayMs: input.expectedDelay?.() ?? slot.expectedDelayMs,
+      })),
+    findPitchSlot: (slotId: string): PitchSlot | null => pitchSlots.get(slotId) ?? null,
+    listPitchSlots: () => [...pitchSlots.values()],
+    findEventGame: (gameId: string) =>
+      currentGames().find((game) => game.eventGameId === gameId) ?? null,
+    listEventGames: () => currentGames(),
+    findRootByEventGameId: (gameId: string) => input.roots?.get(gameId) ?? null,
+    listActions: (recordId: string) => {
+      const root = [...(input.roots?.values() ?? [])].find(
+        (candidate) => candidate.recordId === recordId,
+      );
+      if (root === undefined) return [];
+      return (
+        input.actions?.(root) ??
+        (root.lifecycle.phase === "finished" ? [createFinishedAction(root)] : [])
+      );
+    },
+    listAuditTrail: () => [],
+  } as unknown as EventCatalogStorageSnapshot;
+}
+
+function createGoalAction(
+  root: EventGameRecordRoot,
+  gameSideId = root.gameSides[0]?.id ?? "side-a",
+  suffix = "goal",
+) {
+  return createStoredAction(root, `${suffix}-${root.eventGameId}`, {
+    factId: `${suffix}-fact-${root.eventGameId}`,
+    factType: "goal",
+    gameSideId,
+    gameTimeMs: 1,
+    data: { points: 10, sportingOrder: 1 },
+  });
+}
+
+function createClockAction(root: EventGameRecordRoot) {
+  return createStoredAction(root, `clock-${root.eventGameId}`, {
+    factId: `clock-fact-${root.eventGameId}`,
+    factType: "clock",
+    gameSideId: null,
+    gameTimeMs: 20 * 60 * 1000,
+    data: {
+      command: "correct",
+      gameTimeMs: 20 * 60 * 1000,
+      running: false,
+      sportingOrder: 20 * 60 * 1000,
+    },
+  });
+}
+
+function createFlagCatchAction(root: EventGameRecordRoot) {
+  return createStoredAction(root, `catch-${root.eventGameId}`, {
+    factId: `catch-fact-${root.eventGameId}`,
+    factType: "flag-catch",
+    gameSideId: root.gameSides[0]?.id ?? "side-a",
+    gameTimeMs: 20 * 60 * 1000,
+    data: { points: 30, sportingOrder: 5 },
+  });
+}
+
+function createFinishedAction(root: EventGameRecordRoot) {
+  return createStoredAction(root, `finish-${root.eventGameId}`, {
+    factId: `finish-fact-${root.eventGameId}`,
+    factType: "result",
+    gameSideId: root.gameSides[0]?.id ?? "side-a",
+    gameTimeMs: 0,
+    data: { resultKind: "concession", sportingOrder: 0 },
+  });
+}
+
+function createStoredAction(
+  root: EventGameRecordRoot,
+  operationId: string,
+  payload: Record<string, unknown>,
+) {
+  const input: ControlActionInput = {
+    recordId: root.recordId,
+    eventGameId: root.eventGameId,
+    operationId,
+    kind: { id: "game-fact", version: "1" },
+    payload,
+    causalPredecessorIds: [],
+    occurrence: { trustedAtMs: 3, clientOriginAtMs: 3, source: "online" },
+    grant: { sessionId: "test-session", versionId: "test-version" },
+    lifecycle: structuredClone(root.lifecycle),
+  };
+  const prepared = prepareControlAction(input, root, createControlActionCodecRegistry(), 3);
+  if (!prepared.ok) throw new Error(`Could not prepare finished fixture: ${prepared.error}`);
+  return {
+    action: materializeControlAction(prepared.value, 3),
+    canonicalContent: prepared.value.canonicalContent,
+    contentFingerprint: prepared.value.contentFingerprint,
+  };
+}
+
+function createScheduleGame(code: string, scheduledStart: string, pitchName: string): EventGame {
+  return {
+    eventGameId: code,
+    eventId: "event-schedule",
+    gameDayId: "day-1",
+    gameplaySlotId: `gameplay-${code}`,
+    pitchSlotId: `pitch-slot-${code}`,
+    gameCode: code,
+    gameDesignation: scheduledStart,
+    sideA: {
+      sideId: `${code}-a`,
+      eventTeamId: null,
+      eventTeamName: "Blue",
+      sourceLabel: pitchName,
+      confirmedAtMs: null,
+    },
+    sideB: {
+      sideId: `${code}-b`,
+      eventTeamId: null,
+      eventTeamName: "Red",
+      sourceLabel: null,
+      confirmedAtMs: null,
+    },
+    createdAtMs: 1,
+    updatedAtMs: 1,
+  };
+}
+
+function createScheduleRoot(
+  eventGameId: string,
+  phase: EventGameRecordRoot["lifecycle"]["phase"],
+): EventGameRecordRoot {
+  return {
+    recordId: `record-${eventGameId}`,
+    eventId: "event-schedule",
+    eventGameId,
+    ownership: { eventId: "event-schedule", eventGameId },
+    externalScope: {
+      eventId: "event-schedule",
+      gameDayId: "day-1",
+      pitchId: "pitch-1",
+      pitchSlotId: `pitch-slot-${eventGameId}`,
+    },
+    gameSides: [
+      { id: `${eventGameId}-a`, eventTeamId: "team-a", teamInterpretationRef: "team-a-v1" },
+      { id: `${eventGameId}-b`, eventTeamId: "team-b", teamInterpretationRef: "team-b-v1" },
+    ],
+    lifecycle: {
+      phase,
+      commencedAtMs: phase === "scheduled" ? null : 2,
+      finishedAtMs: phase === "finished" ? 3 : null,
+      lockedAtMs: null,
+      lockReason: null,
+    },
+    compatibility: {
+      recordVersion: "event-game-record-v1",
+      schemaVersion: "event-game-record-v1",
+      interpreterVersion: "live-event-iqa-v1",
+    },
+    creationEvidence: {
+      operationId: `create-${eventGameId}`,
+      actorReference: "test",
+      source: "event-game-registration",
+      createdAtMs: 1,
+    },
+  };
+}

--- a/src/lib/audience-projection.ts
+++ b/src/lib/audience-projection.ts
@@ -1,8 +1,16 @@
 import type {
   EventCatalogFoundationStorage,
   EventCatalogStorageSnapshot,
+  EventGame,
+  ProjectedEventGame,
   StoredEvent,
 } from "@/lib/event-catalog";
+import { projectScheduleGames } from "@/lib/event-catalog";
+import { projectClockBaseline } from "@/lib/clock-authority";
+import {
+  projectLiveEventGameDerivedState,
+  type LiveEventGameDerivedState,
+} from "@/lib/live-event-game-control";
 
 export type PublicAudienceEventLifecycle = "unscheduled" | "current" | "future" | "past";
 
@@ -13,6 +21,58 @@ export type PublicAudienceEventTeam = {
 
 export type PublicAudiencePitch = {
   name: string;
+};
+
+export type PublicAudienceGameScheduleStatus = "past" | "running" | "awaiting-start" | "future";
+
+export type PublicAudienceGamePhase = "seeker-floor" | "seekers-released" | "overtime";
+
+export type PublicAudienceGameOperationalStatus =
+  | "scheduled"
+  | "running"
+  | "paused"
+  | "suspended"
+  | "finished";
+
+export type PublicAudienceGameSide = {
+  name: string | null;
+  color: string | null;
+  score: number | null;
+  flagCatch: boolean;
+};
+
+export type PublicAudienceClockProjection = {
+  gameTimeMs: number;
+  activePenaltyTimeMs: number;
+  running: boolean;
+  projectedAtMs: number;
+  synchronization: "synchronized" | "estimated" | "stale" | "unavailable";
+  lastSynchronizedAtMs: number | null;
+  cues: LiveEventGameDerivedState["clock"]["cues"];
+};
+
+export type PublicAudienceGameProjection = {
+  gameCode: string | null;
+  gameDesignation: string | null;
+  scheduledStartMs: number;
+  expectedStartMs: number;
+  scheduleStatus: PublicAudienceGameScheduleStatus;
+  phase: PublicAudienceGamePhase;
+  operationalStatus: PublicAudienceGameOperationalStatus;
+  pitch: string | null;
+  sideA: PublicAudienceGameSide;
+  sideB: PublicAudienceGameSide;
+  winner: "side-a" | "side-b" | null;
+  overtimeTarget: number | null;
+  clock: PublicAudienceClockProjection | null;
+};
+
+export type PublicAudienceScheduleProjection = {
+  asOfMs: number;
+  runningGames: readonly PublicAudienceGameProjection[];
+  upcomingGames: readonly PublicAudienceGameProjection[];
+  scheduleGames: readonly PublicAudienceGameProjection[];
+  focusIndex: number | null;
 };
 
 /** The narrow publication contract consumed by the future public Event experience. */
@@ -26,6 +86,7 @@ export type PublicAudienceEventProjection = {
   canonicalPath: string;
   teams: readonly PublicAudienceEventTeam[];
   pitches: readonly PublicAudiencePitch[];
+  schedule: PublicAudienceScheduleProjection;
 };
 
 export type PublicAudienceEventList = {
@@ -118,7 +179,205 @@ function projectPublicEvent(
       color: defaultColor,
     })),
     pitches: snapshot.listPitches(event.eventId).map(({ name }) => ({ name })),
+    schedule: projectSchedule(snapshot, event.eventId, nowMs),
   };
+}
+
+function projectSchedule(
+  snapshot: EventCatalogStorageSnapshot,
+  eventId: string,
+  nowMs: number,
+): PublicAudienceScheduleProjection {
+  const gamesById = new Map<string, EventGame>();
+  for (const gameDay of snapshot.listGameDays(eventId)) {
+    for (const game of snapshot.listEventGames(gameDay.gameDayId)) {
+      if (game.eventId !== eventId || gamesById.has(game.eventGameId)) continue;
+      gamesById.set(game.eventGameId, game);
+    }
+  }
+
+  const multiplePitches = snapshot.listPitches(eventId).length > 1;
+  const projected = projectScheduleGames(snapshot, [...gamesById.values()])
+    .map((game) => projectAudienceGame(snapshot, game, nowMs, multiplePitches))
+    .sort(compareAudienceGames);
+  const runningGames = projected.filter((game) => game.scheduleStatus === "running");
+  const upcomingGames = projected.filter(
+    (game) =>
+      game.scheduleStatus === "future" &&
+      game.expectedStartMs >= nowMs &&
+      game.expectedStartMs < nowMs + 60 * 60 * 1000,
+  );
+  const focusIndex = findScheduleFocusIndex(projected);
+
+  return {
+    asOfMs: nowMs,
+    runningGames,
+    upcomingGames,
+    scheduleGames: projected,
+    focusIndex,
+  };
+}
+
+function projectAudienceGame(
+  snapshot: EventCatalogStorageSnapshot,
+  game: ProjectedEventGame,
+  nowMs: number,
+  multiplePitches: boolean,
+): PublicAudienceGameProjection {
+  const root = snapshot.findRootByEventGameId(game.eventGameId);
+  const derived = root === null ? null : readDerivedState(snapshot, root);
+  const lifecyclePhase = derived?.phase ?? root?.lifecycle.phase ?? "scheduled";
+  const phase = projectGamePhase(derived);
+  const pitchSlot = snapshot.findPitchSlot(game.pitchSlotId);
+  const pitch = pitchSlot === null ? null : (snapshot.findPitch(pitchSlot.pitchId)?.name ?? null);
+  const sideA = projectAudienceGameSide(snapshot, game.sideA, derived, root, "a");
+  const sideB = projectAudienceGameSide(snapshot, game.sideB, derived, root, "b");
+  const winner = winnerSide(derived, root);
+
+  return {
+    gameCode: game.gameCode,
+    gameDesignation: game.gameDesignation,
+    scheduledStartMs: scheduledStartForGame(snapshot, game),
+    expectedStartMs: game.expectedStartMs,
+    scheduleStatus: classifyScheduleStatus(lifecyclePhase, game.expectedStartMs, nowMs),
+    phase,
+    operationalStatus: operationalStatus(lifecyclePhase, derived),
+    pitch: multiplePitches ? pitch : null,
+    sideA,
+    sideB,
+    winner,
+    overtimeTarget: derived?.overtimeTarget ?? null,
+    clock: projectClock(
+      derived === null ? null : projectClockBaseline(derived.clock.baseline, nowMs),
+    ),
+  };
+}
+
+function readDerivedState(
+  snapshot: EventCatalogStorageSnapshot,
+  root: NonNullable<ReturnType<EventCatalogStorageSnapshot["findRootByEventGameId"]>>,
+): LiveEventGameDerivedState {
+  const derived = projectLiveEventGameDerivedState(root, snapshot.listActions(root.recordId));
+  if (derived === null) {
+    throw new Error("Committed Event Game state cannot be rebuilt.");
+  }
+  return derived;
+}
+
+function projectAudienceGameSide(
+  snapshot: EventCatalogStorageSnapshot,
+  side: EventGame["sideA"],
+  derived: LiveEventGameDerivedState | null,
+  root: ReturnType<EventCatalogStorageSnapshot["findRootByEventGameId"]>,
+  sideLabel: "a" | "b",
+): PublicAudienceGameSide {
+  const color =
+    side.eventTeamId === null
+      ? null
+      : (snapshot.findEventTeam(side.eventTeamId)?.defaultColor ?? null);
+  const rootSide = root?.gameSides[sideLabel === "a" ? 0 : 1];
+  const score =
+    derived === null || rootSide === undefined
+      ? null
+      : (derived.scoreByGameSide[rootSide.id] ?? null);
+  const flagCatch =
+    derived?.catch !== null &&
+    derived?.catch !== undefined &&
+    rootSide !== undefined &&
+    derived.catch.catchingGameSideId === rootSide.id;
+  return {
+    name: side.eventTeamName ?? side.sourceLabel,
+    color,
+    score,
+    flagCatch,
+  };
+}
+
+function scheduledStartForGame(snapshot: EventCatalogStorageSnapshot, game: ProjectedEventGame) {
+  return snapshot.findGameplaySlot(game.gameplaySlotId)?.scheduledStartMs ?? game.expectedStartMs;
+}
+
+function projectGamePhase(derived: LiveEventGameDerivedState | null): PublicAudienceGamePhase {
+  if (derived?.overtime === true) return "overtime";
+  return derived?.clock.cues.seekerRelease === "released" ? "seekers-released" : "seeker-floor";
+}
+
+function classifyScheduleStatus(
+  phase: LiveEventGameDerivedState["phase"] | "scheduled",
+  expectedStartMs: number,
+  nowMs: number,
+): PublicAudienceGameScheduleStatus {
+  if (phase === "finished") return "past";
+  if (phase === "in-progress" || phase === "suspended") return "running";
+  return expectedStartMs <= nowMs ? "awaiting-start" : "future";
+}
+
+function operationalStatus(
+  phase: LiveEventGameDerivedState["phase"] | "scheduled",
+  derived: LiveEventGameDerivedState | null,
+): PublicAudienceGameOperationalStatus {
+  return phase === "in-progress"
+    ? derived?.clock.running === false
+      ? "paused"
+      : "running"
+    : phase === "suspended"
+      ? "suspended"
+      : phase === "finished"
+        ? "finished"
+        : "scheduled";
+}
+
+function winnerSide(
+  derived: LiveEventGameDerivedState | null,
+  root: ReturnType<EventCatalogStorageSnapshot["findRootByEventGameId"]>,
+): "side-a" | "side-b" | null {
+  if (
+    derived?.winnerGameSideId === null ||
+    derived?.winnerGameSideId === undefined ||
+    root === null
+  )
+    return null;
+  if (root.gameSides[0]?.id === derived.winnerGameSideId) return "side-a";
+  if (root.gameSides[1]?.id === derived.winnerGameSideId) return "side-b";
+  return null;
+}
+
+function projectClock(
+  clock: LiveEventGameDerivedState["clock"] | null,
+): PublicAudienceClockProjection | null {
+  if (clock === null) return null;
+  return {
+    gameTimeMs: clock.gameTimeMs,
+    activePenaltyTimeMs: clock.activePenaltyTimeMs,
+    running: clock.running,
+    projectedAtMs: clock.projectedAtMs,
+    synchronization: clock.synchronization,
+    lastSynchronizedAtMs: clock.lastSynchronizedAtMs,
+    cues: structuredClone(clock.cues),
+  };
+}
+
+function compareAudienceGames(
+  left: PublicAudienceGameProjection,
+  right: PublicAudienceGameProjection,
+): number {
+  return (
+    left.expectedStartMs - right.expectedStartMs ||
+    left.scheduledStartMs - right.scheduledStartMs ||
+    (left.gameCode ?? left.gameDesignation ?? "").localeCompare(
+      right.gameCode ?? right.gameDesignation ?? "",
+    )
+  );
+}
+
+function findScheduleFocusIndex(games: readonly PublicAudienceGameProjection[]): number | null {
+  if (games.length === 0) return null;
+  const active = games.findIndex(
+    (game) => game.scheduleStatus === "running" || game.scheduleStatus === "awaiting-start",
+  );
+  if (active >= 0) return active;
+  const future = games.findIndex((game) => game.scheduleStatus === "future");
+  return future >= 0 ? future : games.length - 1;
 }
 
 function classifyLifecycle(

--- a/src/lib/event-catalog.ts
+++ b/src/lib/event-catalog.ts
@@ -32,6 +32,7 @@ import type {
   StoredPitchSlot,
   StoredEventCatalogGame,
   StoredEventGameSide,
+  StoredControlAction,
 } from "@/lib/foundation-storage";
 import type { EventGameRecordRoot } from "@/lib/foundation-record-types";
 import { createInMemoryFoundationStorage } from "@/lib/foundation-storage-memory";
@@ -308,6 +309,7 @@ export type EventCatalogStorageSnapshot = {
   findEventGame(eventGameId: string): EventGame | null;
   listEventGames(gameDayId: string): EventGame[];
   findRootByEventGameId(eventGameId: string): EventGameRecordRoot | null;
+  listActions(recordId: string): StoredControlAction[];
   listAuditTrail(eventId: string): EventAdministrationAuditEntry[];
 };
 
@@ -2864,6 +2866,7 @@ function eventCatalogSnapshot(transaction: FoundationStorageSnapshot): EventCata
     findEventGame: (eventGameId) => transaction.findEventGame?.(eventGameId) ?? null,
     listEventGames: (gameDayId) => transaction.listEventGames?.(gameDayId) ?? [],
     findRootByEventGameId: (eventGameId) => transaction.findRootByEventGameId(eventGameId),
+    listActions: (recordId) => transaction.listActions(recordId),
     listAuditTrail: (eventId) => transaction.listEventAuditTrail(eventId),
   };
 }

--- a/src/lib/live-event-game-control.ts
+++ b/src/lib/live-event-game-control.ts
@@ -208,6 +208,21 @@ export type LiveEventGameDerivedState = {
   penalties: LivePenaltyProjection;
 };
 
+/**
+ * Rebuild the public-safe sporting state from the committed Event Game Record inputs.
+ * Audience projections use this instead of reimplementing scoring or correction semantics.
+ */
+export function projectLiveEventGameDerivedState(
+  root: EventGameRecordRoot,
+  storedActions: readonly {
+    action: ControlAction;
+    canonicalContent: string;
+    contentFingerprint: string;
+  }[],
+): LiveEventGameDerivedState | null {
+  return rebuildLiveDerivedState(root, storedActions);
+}
+
 export type LiveTimeoutState = {
   status: "inactive" | "started";
   factId: string | null;

--- a/src/pages/public-event-page.tsx
+++ b/src/pages/public-event-page.tsx
@@ -4,7 +4,11 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { getAdHocBrowserId } from "@/lib/ad-hoc-handoff";
-import type { PublicAudienceEventProjection } from "@/lib/audience-projection";
+import type {
+  PublicAudienceEventProjection,
+  PublicAudienceGameProjection,
+  PublicAudienceScheduleProjection,
+} from "@/lib/audience-projection";
 import { DEFAULT_AWAY_TEAM_COLOR, DEFAULT_HOME_TEAM_COLOR } from "@/lib/team-colors";
 
 export function PublicEventHomePage({ showAll = false }: { showAll?: boolean }) {
@@ -98,6 +102,8 @@ export function PublicEventPage({ eventId }: { eventId: string }) {
     );
   }
 
+  const schedule = event.schedule;
+
   return (
     <PublicShell title={event.name} description={`Published Event · ${event.timeZone}`}>
       <div className="space-y-4">
@@ -107,6 +113,7 @@ export function PublicEventPage({ eventId }: { eventId: string }) {
             All events
           </Button>
         </div>
+        <ScheduleBoard schedule={schedule} timeZone={event.timeZone} />
         <Card>
           <CardHeader>
             <CardTitle>Game Days</CardTitle>
@@ -141,7 +148,7 @@ export function PublicEventPage({ eventId }: { eventId: string }) {
                 </ul>
               </div>
             )}
-            {event.pitches.length > 0 && (
+            {event.pitches.length > 1 && (
               <div>
                 <h2 className="text-sm font-semibold">Pitches</h2>
                 <ul className="mt-2 flex flex-wrap gap-2">
@@ -158,6 +165,329 @@ export function PublicEventPage({ eventId }: { eventId: string }) {
       </div>
     </PublicShell>
   );
+}
+
+function ScheduleBoard({
+  schedule,
+  timeZone,
+}: {
+  schedule: PublicAudienceScheduleProjection;
+  timeZone: string;
+}) {
+  const focusRef = useRef<HTMLLIElement | null>(null);
+
+  useEffect(() => {
+    if (schedule.focusIndex === null) return;
+    focusRef.current?.scrollIntoView({ block: "nearest", inline: "nearest" });
+  }, [schedule.asOfMs, schedule.focusIndex]);
+
+  return (
+    <div className="space-y-6">
+      <ScheduleGroup
+        title="Live now"
+        description="Every running Game has equal prominence."
+        games={schedule.runningGames}
+        timeZone={timeZone}
+        empty="No Games are running now."
+        dataGroup="live-now"
+      />
+      <ScheduleGroup
+        title="Coming up"
+        description="Games with an Expected Start in the next hour."
+        games={schedule.upcomingGames}
+        timeZone={timeZone}
+        empty="No Games are expected in the next hour."
+        dataGroup="coming-up"
+        groupByExpectedStart
+      />
+      <section
+        aria-labelledby="event-schedule-heading"
+        className="space-y-3"
+        data-schedule-group="event-schedule"
+      >
+        <div>
+          <h2 id="event-schedule-heading" className="text-xl font-semibold">
+            Event schedule
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            Chronological schedule positioned around the Event&apos;s current time.
+          </p>
+        </div>
+        {schedule.scheduleGames.length === 0 ? (
+          <p className="rounded-2xl border border-dashed p-4 text-sm text-muted-foreground">
+            No Games have been scheduled.
+          </p>
+        ) : (
+          <ol className="space-y-3">
+            {schedule.scheduleGames.map((game, index) => (
+              <li
+                key={scheduleGameKey(game, index)}
+                ref={index === schedule.focusIndex ? focusRef : undefined}
+                data-schedule-card
+                data-game-code={game.gameCode ?? undefined}
+                data-schedule-status={game.scheduleStatus}
+              >
+                <GameCard game={game} timeZone={timeZone} compact />
+              </li>
+            ))}
+          </ol>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function ScheduleGroup({
+  title,
+  description,
+  games,
+  timeZone,
+  empty,
+  dataGroup,
+  groupByExpectedStart = false,
+}: {
+  title: string;
+  description: string;
+  games: readonly PublicAudienceGameProjection[];
+  timeZone: string;
+  empty: string;
+  dataGroup: string;
+  groupByExpectedStart?: boolean;
+}) {
+  return (
+    <section
+      aria-labelledby={title.toLowerCase().replaceAll(" ", "-")}
+      className="space-y-3"
+      data-schedule-group={dataGroup}
+    >
+      <div>
+        <h2 id={title.toLowerCase().replaceAll(" ", "-")} className="text-xl font-semibold">
+          {title}
+        </h2>
+        <p className="text-sm text-muted-foreground">{description}</p>
+      </div>
+      {games.length === 0 ? (
+        <p className="rounded-2xl border border-dashed p-4 text-sm text-muted-foreground">
+          {empty}
+        </p>
+      ) : groupByExpectedStart ? (
+        <div className="space-y-4">
+          {groupGamesByExpectedStart(games).map((group) => (
+            <section
+              key={group.expectedStartMs}
+              aria-labelledby={`expected-${group.expectedStartMs}`}
+            >
+              <h3
+                id={`expected-${group.expectedStartMs}`}
+                className="text-sm font-semibold text-muted-foreground"
+              >
+                Expected Start {formatScheduleTime(group.expectedStartMs, timeZone)}
+              </h3>
+              <div className="mt-2 grid gap-3 md:grid-cols-2">
+                {group.games.map((game, index) => (
+                  <div
+                    key={scheduleGameKey(game, index)}
+                    data-schedule-card
+                    data-game-code={game.gameCode ?? undefined}
+                    data-schedule-status={game.scheduleStatus}
+                  >
+                    <GameCard game={game} timeZone={timeZone} />
+                  </div>
+                ))}
+              </div>
+            </section>
+          ))}
+        </div>
+      ) : (
+        <div className="grid gap-3 md:grid-cols-2">
+          {games.map((game, index) => (
+            <div
+              key={scheduleGameKey(game, index)}
+              data-schedule-card
+              data-game-code={game.gameCode ?? undefined}
+              data-schedule-status={game.scheduleStatus}
+            >
+              <GameCard game={game} timeZone={timeZone} />
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function GameCard({
+  game,
+  timeZone,
+  compact = false,
+}: {
+  game: PublicAudienceGameProjection;
+  timeZone: string;
+  compact?: boolean;
+}) {
+  const winnerName =
+    game.winner === "side-a" ? game.sideA.name : game.winner === "side-b" ? game.sideB.name : null;
+  return (
+    <Card className={compact ? "bg-card/70" : "border-primary/40 bg-card shadow-md"}>
+      <CardHeader className={compact ? "pb-3" : undefined}>
+        <div className="flex flex-wrap items-start justify-between gap-2">
+          <div>
+            <CardTitle className={compact ? "text-base" : "text-lg"}>
+              {game.gameDesignation ?? game.gameCode ?? "Scheduled Game"}
+            </CardTitle>
+            {game.gameDesignation !== null && game.gameCode !== null ? (
+              <CardDescription>Game {game.gameCode}</CardDescription>
+            ) : null}
+          </div>
+          <span
+            className={`rounded-full px-2.5 py-1 text-xs font-semibold ${scheduleStatusClass(game.scheduleStatus)}`}
+          >
+            {scheduleStatusLabel(game.scheduleStatus)}
+          </span>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div className="grid grid-cols-[1fr_auto] items-center gap-x-3 gap-y-2">
+          <GameSideRow side={game.sideA} label="Side A" />
+          <GameSideRow side={game.sideB} label="Side B" />
+        </div>
+        <div className="flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted-foreground">
+          <span>Scheduled Start {formatScheduleTime(game.scheduledStartMs, timeZone)}</span>
+          {game.expectedStartMs !== game.scheduledStartMs ? (
+            <span>Expected Start {formatScheduleTime(game.expectedStartMs, timeZone)}</span>
+          ) : null}
+          {game.pitch !== null ? <span>Pitch {game.pitch}</span> : null}
+        </div>
+        <div className="flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted-foreground">
+          <span>Game Phase: {gamePhaseLabel(game.phase)}</span>
+          <span>Operational status: {operationalStatusLabel(game.operationalStatus)}</span>
+          {game.overtimeTarget !== null ? (
+            <span>Overtime target: {game.overtimeTarget}</span>
+          ) : null}
+          {winnerName !== null ? <span>Winner: {winnerName}</span> : null}
+          {game.clock !== null ? (
+            game.clock.synchronization === "unavailable" ? (
+              <span>Clock unavailable · manual timing required</span>
+            ) : (
+              <span>
+                Clock {formatClock(game.clock.gameTimeMs)} ·{" "}
+                {clockStatusLabel(game.clock.synchronization)}
+              </span>
+            )
+          ) : null}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function GameSideRow({
+  side,
+  label,
+}: {
+  side: PublicAudienceGameProjection["sideA"];
+  label: string;
+}) {
+  return (
+    <>
+      <span
+        className="min-w-0 truncate"
+        style={
+          side.color === null
+            ? undefined
+            : { borderInlineStart: `0.3rem solid ${side.color}`, paddingInlineStart: "0.5rem" }
+        }
+      >
+        <span className="sr-only">{label}: </span>
+        {side.name ?? "TBD"}
+        {side.flagCatch ? <span className="ml-2 text-xs font-semibold">Flag catch</span> : null}
+      </span>
+      <span
+        className="text-right text-2xl font-semibold tabular-nums"
+        aria-label={`${label} score`}
+      >
+        {side.score ?? "—"}
+      </span>
+    </>
+  );
+}
+
+function scheduleGameKey(game: PublicAudienceGameProjection, index: number) {
+  return `${game.gameCode ?? game.gameDesignation ?? "game"}-${index}`;
+}
+
+function groupGamesByExpectedStart(games: readonly PublicAudienceGameProjection[]) {
+  const groups = new Map<number, PublicAudienceGameProjection[]>();
+  for (const game of games) {
+    const group = groups.get(game.expectedStartMs) ?? [];
+    group.push(game);
+    groups.set(game.expectedStartMs, group);
+  }
+  return [...groups.entries()].map(([expectedStartMs, groupedGames]) => ({
+    expectedStartMs,
+    games: groupedGames,
+  }));
+}
+
+function scheduleStatusClass(status: PublicAudienceGameProjection["scheduleStatus"]) {
+  return GAME_SCHEDULE_STATUS_META[status].className;
+}
+
+function scheduleStatusLabel(status: PublicAudienceGameProjection["scheduleStatus"]) {
+  return GAME_SCHEDULE_STATUS_META[status].label;
+}
+
+function gamePhaseLabel(phase: PublicAudienceGameProjection["phase"]) {
+  return phase === "seeker-floor"
+    ? "Seeker Floor"
+    : phase === "seekers-released"
+      ? "Seekers Released"
+      : "Overtime";
+}
+
+function operationalStatusLabel(status: PublicAudienceGameProjection["operationalStatus"]) {
+  return status === "paused"
+    ? "Paused"
+    : status === "suspended"
+      ? "Suspended"
+      : status === "finished"
+        ? "Finished"
+        : status === "running"
+          ? "Running"
+          : "Scheduled";
+}
+
+const GAME_SCHEDULE_STATUS_META = {
+  running: { label: "Running", className: "bg-primary text-primary-foreground" },
+  "awaiting-start": {
+    label: "Awaiting start",
+    className: "bg-amber-100 text-amber-950 dark:bg-amber-950 dark:text-amber-100",
+  },
+  past: { label: "Past", className: "bg-muted text-muted-foreground" },
+  future: { label: "Future", className: "bg-secondary text-secondary-foreground" },
+} satisfies Record<
+  PublicAudienceGameProjection["scheduleStatus"],
+  { label: string; className: string }
+>;
+
+function formatScheduleTime(milliseconds: number, timeZone: string) {
+  return new Intl.DateTimeFormat(undefined, {
+    timeZone,
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(new Date(milliseconds));
+}
+
+function formatClock(milliseconds: number) {
+  const minutes = Math.floor(milliseconds / 60_000);
+  const seconds = Math.floor((milliseconds % 60_000) / 1_000);
+  return `${minutes}:${String(seconds).padStart(2, "0")}`;
+}
+
+function clockStatusLabel(
+  status: NonNullable<PublicAudienceGameProjection["clock"]>["synchronization"],
+) {
+  return status === "synchronized" ? "synced" : status;
 }
 
 function EventDiscovery({ events }: { events: readonly PublicAudienceEventProjection[] }) {


### PR DESCRIPTION
## Summary

- extend Audience Projections with the committed Daylight Arena Event schedule
- show simultaneous running Games equally, group next-hour Games by Expected Start, and keep one chronological schedule around current Event time
- project sporting Game Phase separately from operational status while preserving Scheduled Start, Expected Start, Pitch, score, Clock, overtime, and result context
- add focused projection regeneration and phone-sized browser coverage

## Why

Spectators at SQM need one public Event view that immediately shows every live Pitch and the next hour of play without exposing Controller authority or private operational evidence. This consumes the accepted #90 Derived Game State and #112 schedule contracts instead of recreating their rules in the browser.

## Impact

Published Event pages now provide the current database-backed schedule on narrow screens. Single-Pitch Events stay visually quiet, multi-Pitch Events identify placement, and public semantic absence/allowlisting remain unchanged. Live WebSocket delivery remains owned by #137.

## Testing

- `bun run check` (passed with existing warnings only)
- `bun run test` (698 tests, 18,311 expectations)
- `bun run build`
- focused projection/App/index-public-event tests (40 tests, 166 expectations)
- `bun run test:focused:public-event-browser` at 390x844 with two committed simultaneous running Games
- `git diff --check`

Stacked on #211.

Closes #134
