### PR TITLE
Restore Ad Hoc Games from snapshots

### DIFF
--- a/scripts/test-ad-hoc-browser.ts
+++ b/scripts/test-ad-hoc-browser.ts
@@ -1,10 +1,14 @@
 #!/usr/bin/env bun
 import { chromium, type Page } from "playwright";
 import { Database } from "bun:sqlite";
-import { mkdtempSync, rmSync } from "node:fs";
+import { copyFileSync, existsSync, mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { createAdHocGamesService, openSqliteAdHocStore } from "@/lib/ad-hoc-games";
+import {
+  createAdHocGamesService,
+  createSqliteAdHocRecoveryAdapter,
+  openSqliteAdHocStore,
+} from "@/lib/ad-hoc-games";
 
 let directory = "";
 let certificatePath = "";
@@ -200,6 +204,44 @@ async function run() {
         await waitForGameRoute(second, gameId);
         await second.getByText("Paused", { exact: true }).waitFor();
         await assertAccessibleQr(second, "recreated second browser after restart");
+
+        const recoverySnapshotPath = join(directory, "ad-hoc-recovery.snapshot.sqlite");
+        const recoveryAdapter = createSqliteAdHocRecoveryAdapter(
+          databasePath,
+          "adhoc-browser-test",
+        );
+        await recoveryAdapter.createRecoveryVacuumSnapshot(recoverySnapshotPath);
+        await stopServer();
+        await secondContext.setOffline(true);
+        await second.getByRole("button", { name: "Start game" }).click();
+        await second.getByText(/Offline 1/u).waitFor();
+        replaceAdHocDatabaseFromSnapshot(recoverySnapshotPath);
+        await startServer();
+        await first.reload();
+        await waitForGameRoute(first, gameId);
+        await first.waitForFunction(async (id) => {
+          const response = await fetch(`/api/games/${id}`);
+          if (!response.ok) return false;
+          const payload = (await response.json()) as {
+            game?: { state?: { isRunning?: unknown } };
+          };
+          return payload.game?.state?.isRunning === false;
+        }, gameId);
+        const restoredServerState = await first.evaluate(async (id) => {
+          const response = await fetch(`/api/games/${id}`);
+          return (await response.json()) as { game?: { state?: { isRunning?: boolean } } };
+        }, gameId);
+        if (restoredServerState.game?.state?.isRunning !== false) {
+          throw new Error("Restored server state was silently overwritten by newer local state.");
+        }
+        await second.getByText(/Offline 1/u).waitFor();
+        await secondContext.setOffline(false);
+        await second.reload();
+        await waitForGameRoute(second, gameId);
+        await second.getByText("Live", { exact: true }).waitFor();
+        await first.getByText("Running", { exact: true }).waitFor();
+        await second.getByRole("button", { name: "Pause game" }).click();
+        await first.getByText("Paused", { exact: true }).waitFor();
 
         await second.getByRole("button", { name: "Start game" }).click();
         await first.getByText("Running", { exact: true }).waitFor();
@@ -536,6 +578,14 @@ async function waitForUnfinishedGame(page: Page, gameId: string) {
     };
     return payload.game?.state?.isFinished === false && typeof payload.game.controlQr === "string";
   }, gameId);
+}
+
+function replaceAdHocDatabaseFromSnapshot(snapshotPath: string) {
+  for (const sidecar of [`${databasePath}-wal`, `${databasePath}-shm`]) {
+    rmSync(sidecar, { force: true });
+  }
+  if (!existsSync(snapshotPath)) throw new Error("Ad Hoc recovery snapshot was not created.");
+  copyFileSync(snapshotPath, databasePath);
 }
 
 async function seedCapacity(connected: boolean) {

--- a/src/lib/ad-hoc-games.focused.ts
+++ b/src/lib/ad-hoc-games.focused.ts
@@ -1,12 +1,24 @@
 import { describe, expect, test } from "bun:test";
 import { Database } from "bun:sqlite";
-import { existsSync, writeFileSync } from "node:fs";
+import { chmodSync, copyFileSync, existsSync, readFileSync, writeFileSync } from "node:fs";
 import { createHash } from "node:crypto";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { applyGameCommand, createInitialGameState } from "@/lib/game-engine";
+import {
+  createControlActionCodecRegistry,
+  createDeterministicTestIqaInterpreter,
+} from "@/lib/event-game-actions";
 import { createEventCatalog, createInMemoryEventCatalogStorage } from "@/lib/event-catalog";
+import type { GrantAuthorityOptions } from "@/lib/grant-authority";
+import { createGrantTestKeyRing, createGrantTestRandomness } from "@/lib/grant-authority-contract";
+import { createGrantTestAuthorityVerifier } from "@/lib/grant-authority-test-support";
+import {
+  createFoundationRecovery,
+  type FoundationRecoveryOptions,
+} from "@/lib/foundation-recovery";
+import { openSqliteFoundationStorage } from "@/lib/foundation-storage-sqlite";
 import {
   MemoryTechnicalAdminAuthRepository,
   createTechnicalAdminAuth,
@@ -14,6 +26,7 @@ import {
 import {
   AD_HOC_DISCONNECTED_GRACE_MS,
   createAdHocGamesService,
+  createSqliteAdHocRecoveryAdapter,
   createInMemoryAdHocStore,
   openSqliteAdHocStore,
 } from "@/lib/ad-hoc-games";
@@ -580,7 +593,347 @@ describe("Ad Hoc SQLite focused integration", () => {
     });
     eventAuth.close();
   });
+
+  test("rejects mixed-environment recovery images before publication or activation", async () => {
+    const root = await mkdtemp(join(tmpdir(), "quadball-timer-adhoc-recovery-focused-"));
+    const livePath = join(root, "ad-hoc.sqlite");
+    const validSnapshotPath = join(root, "valid-snapshot.sqlite");
+    const contaminatedPath = join(root, "contaminated.sqlite");
+    const rejectedPublicationPath = join(root, "rejected-publication.sqlite");
+    const environmentIdentity = "sqm-test";
+    try {
+      const store = openSqliteAdHocStore(livePath, environmentIdentity);
+      const service = createAdHocGamesService({
+        store,
+        environmentIdentity,
+        now: () => 2_000,
+      });
+      const created = await service.create({
+        homeName: "Home",
+        awayName: "Away",
+        sourceKey: "recovery-focused-source",
+        nowMs: 1_000,
+      });
+      if (created.status !== "accepted") throw new Error("recovery setup creation failed");
+      const secondCreated = await service.create({
+        homeName: "Second Home",
+        awayName: "Second Away",
+        sourceKey: "recovery-focused-second-source",
+        nowMs: 1_001,
+      });
+      if (secondCreated.status !== "accepted")
+        throw new Error("second recovery setup creation failed");
+      const recovery = store.recovery;
+      if (recovery === undefined) throw new Error("SQLite recovery adapter is unavailable");
+      const validFacts = await recovery.createRecoveryVacuumSnapshot(validSnapshotPath);
+      expect(validFacts).toMatchObject({
+        environmentIdentity,
+        retainedGameCount: 2,
+        unfinishedGameCount: 2,
+        creationEventCount: 2,
+      });
+      await recovery.quiesceForRecovery();
+      service.close();
+
+      copyFileSync(validSnapshotPath, contaminatedPath);
+      const otherStore = openSqliteAdHocStore(contaminatedPath, "other-environment");
+      const otherService = createAdHocGamesService({
+        store: otherStore,
+        environmentIdentity: "other-environment",
+        now: () => 2_000,
+      });
+      const otherCreated = await otherService.create({
+        homeName: "Other Home",
+        awayName: "Other Away",
+        sourceKey: "other-recovery-focused-source",
+        nowMs: 1_001,
+      });
+      if (otherCreated.status !== "accepted") throw new Error("mixed-environment setup failed");
+      otherService.close();
+      const contaminatedRecovery = createSqliteAdHocRecoveryAdapter(
+        contaminatedPath,
+        environmentIdentity,
+      );
+      await expectRejected(
+        contaminatedRecovery.createRecoveryVacuumSnapshot(rejectedPublicationPath),
+      );
+      expect(existsSync(rejectedPublicationPath)).toBe(false);
+      await expectRejected(
+        contaminatedRecovery.verifyRecoverySnapshot(contaminatedPath, validFacts),
+      );
+      expect(contaminatedRecovery.readiness(contaminatedPath)).toMatchObject({
+        ok: false,
+        status: "integrity-failure",
+      });
+
+      const validLiveFacts = createSqliteAdHocRecoveryAdapter(
+        livePath,
+        environmentIdentity,
+      ).inspectRecoveryDatabase(livePath);
+      expect(validLiveFacts).toEqual(validFacts);
+      expect(validLiveFacts.retainedGameCount).toBe(2);
+      expect(validLiveFacts.creationEventCount).toBe(2);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("requires authoritative Ad Hoc writeability for readiness", async () => {
+    const root = await mkdtemp(join(tmpdir(), "quadball-timer-adhoc-readiness-focused-"));
+    const databasePath = join(root, "ad-hoc.sqlite");
+    try {
+      const store = openSqliteAdHocStore(databasePath, "sqm-test");
+      const service = createAdHocGamesService({
+        store,
+        environmentIdentity: "sqm-test",
+        now: () => 3_000,
+      });
+      expect((await service.create({ homeName: "Home", awayName: "Away" })).status).toBe(
+        "accepted",
+      );
+      service.close();
+
+      const adapter = createSqliteAdHocRecoveryAdapter(databasePath, "sqm-test");
+      chmodSync(databasePath, 0o444);
+      expect(adapter.readiness()).toMatchObject({ ok: false, status: "unavailable" });
+      chmodSync(databasePath, 0o600);
+      for (const sidecar of [`${databasePath}-wal`, `${databasePath}-shm`]) {
+        if (existsSync(sidecar)) chmodSync(sidecar, 0o600);
+      }
+
+      const locker = new Database(databasePath, { create: false, strict: true });
+      locker.run("PRAGMA busy_timeout = 0");
+      locker.run("BEGIN IMMEDIATE");
+      try {
+        expect(adapter.readiness()).toMatchObject({ ok: false, status: "unavailable" });
+      } finally {
+        locker.run("ROLLBACK");
+        locker.close();
+      }
+
+      const injected = createSqliteAdHocRecoveryAdapter(databasePath, "sqm-test", {
+        recoveryWriteabilityProbe: () => {
+          throw new Error("ENOSPC injected for readiness probe");
+        },
+      });
+      expect(injected.readiness()).toMatchObject({ ok: false, status: "unavailable" });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("restores Ad Hoc through the composed Foundation recovery boundary", async () => {
+    const root = await mkdtemp(join(tmpdir(), "quadball-timer-adhoc-foundation-focused-"));
+    const liveDirectory = join(root, "live");
+    await mkdir(liveDirectory, { recursive: true });
+    const foundationPath = join(liveDirectory, "foundation.sqlite");
+    const adHocPath = join(liveDirectory, "ad-hoc.sqlite");
+    const backupDirectory = join(root, "backup");
+    const technicalAdminPath = join(root, "technical-admin.sqlite");
+    let foundationStorage: ReturnType<typeof openSqliteFoundationStorage> | null = null;
+    let adHocService: ReturnType<typeof createAdHocGamesService> | null = null;
+    try {
+      const keyRing = createGrantTestKeyRing();
+      const readinessContext = {
+        actionCodecRegistry: createControlActionCodecRegistry(),
+        interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
+      };
+      const grant: GrantAuthorityOptions = {
+        environmentId: "test",
+        clock: { nowMs: () => 10 },
+        randomness: createGrantTestRandomness(),
+        keyRing,
+        controlScopeResolver: {
+          resolve: () => ({ status: "eligible", eventGameId: "game-1" }),
+          resolveSession: (_scope, sessionEventGameId) => ({
+            status: "current",
+            eventGameId: sessionEventGameId,
+          }),
+        },
+        privilegedAuthorityVerifier: createGrantTestAuthorityVerifier(),
+      };
+      foundationStorage = openSqliteFoundationStorage(foundationPath, {
+        grantKeyRing: keyRing,
+        grantValidationContext: { environmentId: "test", keyRing },
+      });
+      await foundationStorage.applyMigrations({ requireCandidate: false });
+      foundationStorage.setReadinessContext(readinessContext);
+
+      const adHocStore = openSqliteAdHocStore(adHocPath, "sqm-test");
+      adHocService = createAdHocGamesService({
+        store: adHocStore,
+        environmentIdentity: "sqm-test",
+        now: () => 2_000,
+      });
+      const created = await adHocService.create({
+        homeName: "Home",
+        awayName: "Away",
+        sourceKey: "foundation-composed-source",
+        nowMs: 1_000,
+      });
+      if (created.status !== "accepted") throw new Error("composed setup creation failed");
+      const snapshotOperation = await adHocService.apply({
+        gameId: created.gameId,
+        sessionId: created.sessionId,
+        operations: [
+          {
+            id: "snapshot-operation",
+            clientSentAtMs: 1_100,
+            command: { type: "change-score", team: "home", delta: 1, reason: "goal" },
+          },
+        ],
+      });
+      expect(snapshotOperation.status).toBe("accepted");
+
+      const foundationOptions: FoundationRecoveryOptions = {
+        backupDirectory,
+        keyRing,
+        readinessContext,
+        grant,
+        acceptance: {
+          externalScopeResolver: {
+            resolve: (scope) => ({ status: "resolved" as const, scope: structuredClone(scope) }),
+            resolveEventTeam: () => ({ status: "resolved" as const }),
+          },
+          clock: () => 10,
+          interpreter: readinessContext.interpreter,
+        },
+        technicalAdminAuth: { databasePath: technicalAdminPath, async quiesce() {} },
+        nowMs: () => 10,
+      };
+      let recovery = createFoundationRecovery(foundationStorage, {
+        ...foundationOptions,
+        adHoc: adHocStore.recovery,
+        createId: () => "composed-snapshot",
+      });
+      const manifest = await recovery.createPreDeploymentBackup();
+      const manifestPath = join(backupDirectory, `${manifest.snapshotId}.manifest.json`);
+      expect(manifest.adHoc).toBeDefined();
+      expect(await recovery.verifyBackup(manifestPath)).toEqual(manifest);
+      const adHocBackupPath = join(backupDirectory, manifest.adHoc!.databaseFile);
+      const validAdHocBackup = readFileSync(adHocBackupPath);
+
+      const finished = await adHocService.apply({
+        gameId: created.gameId,
+        sessionId: created.sessionId,
+        operations: [
+          {
+            id: "finish-after-snapshot",
+            clientSentAtMs: 1_200,
+            command: { type: "record-double-forfeit" },
+          },
+        ],
+      });
+      expect(finished.status).toBe("accepted");
+      if (finished.status === "accepted") expect(finished.game.state.isFinished).toBe(true);
+      expect(
+        await adHocService.leave({ gameId: created.gameId, sessionId: created.sessionId }),
+      ).toBe(true);
+
+      const tampered = Buffer.from(validAdHocBackup);
+      writeFileSync(adHocBackupPath, tampered);
+      const invalidDatabase = new Database(adHocBackupPath, { create: false, strict: true });
+      invalidDatabase.run("UPDATE adhoc_games SET control_qr_hash = ?", ["0".repeat(64)]);
+      invalidDatabase.close();
+      await expectRejected(recovery.restore(manifestPath));
+      expect(adHocStore.readGame(created.gameId)?.state.isFinished).toBe(true);
+      writeFileSync(adHocBackupPath, validAdHocBackup);
+
+      const rollbackRecovery = createFoundationRecovery(foundationStorage, {
+        ...foundationOptions,
+        adHoc: adHocStore.recovery,
+        createId: () => "composed-rollback",
+        faultInjector(phase) {
+          if (phase === "before-live-replacement") throw new Error("composed rollback");
+        },
+      });
+      await expectRejected(rollbackRecovery.restore(manifestPath), "composed rollback");
+      expect(existsSync(adHocPath)).toBe(true);
+      expect(existsSync(`${adHocPath}.failed-composed-rollback`)).toBe(false);
+      expect(existsSync(foundationPath)).toBe(true);
+      expect(existsSync(`${foundationPath}.failed-composed-rollback`)).toBe(false);
+
+      adHocService = null;
+      foundationStorage = null;
+      const reopenedAdHocStore = openSqliteAdHocStore(adHocPath, "sqm-test");
+      const reopenedAdHoc = createAdHocGamesService({
+        store: reopenedAdHocStore,
+        environmentIdentity: "sqm-test",
+        now: () => 2_001,
+      });
+      const reopenedFoundation = openSqliteFoundationStorage(foundationPath, {
+        grantKeyRing: keyRing,
+        grantValidationContext: { environmentId: "test", keyRing },
+      });
+      reopenedFoundation.setReadinessContext(readinessContext);
+      recovery = createFoundationRecovery(reopenedFoundation, {
+        ...foundationOptions,
+        adHoc: reopenedAdHocStore.recovery,
+        createId: () => "composed-restore",
+      });
+      const restored = await recovery.restore(manifestPath);
+      expect(restored.failedAdHocDatabasePath).not.toBeNull();
+      reopenedAdHoc.close();
+      reopenedFoundation.close();
+
+      const restoredAdHocStore = openSqliteAdHocStore(adHocPath, "sqm-test");
+      const restoredAdHoc = createAdHocGamesService({
+        store: restoredAdHocStore,
+        environmentIdentity: "sqm-test",
+        now: () => 2_002,
+      });
+      const resumed = await restoredAdHoc.read({
+        gameId: created.gameId,
+        sessionId: created.sessionId,
+        nowMs: 2_002,
+      });
+      expect(resumed).toMatchObject({
+        status: "accepted",
+        game: { gameId: created.gameId, controlQr: created.controlQr },
+      });
+      if (resumed.status !== "accepted") throw new Error("restored session did not resume");
+      expect(resumed.game.state.isFinished).toBe(false);
+      expect(
+        (
+          await restoredAdHoc.admit({
+            gameId: created.gameId,
+            controlQr: created.controlQr,
+            browserId: "restored-browser",
+            nowMs: 2_003,
+          })
+        ).status,
+      ).toBe("accepted");
+      const postSnapshot = await restoredAdHoc.apply({
+        gameId: created.gameId,
+        sessionId: created.sessionId,
+        operations: [
+          {
+            id: "finish-after-snapshot",
+            clientSentAtMs: 1_200,
+            command: { type: "record-double-forfeit" },
+          },
+        ],
+      });
+      expect(postSnapshot.status).toBe("accepted");
+      restoredAdHoc.close();
+    } finally {
+      adHocService?.close();
+      foundationStorage?.close();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
 });
+
+async function expectRejected(promise: Promise<unknown>, message?: string): Promise<void> {
+  let failure: unknown;
+  try {
+    await promise;
+  } catch (error) {
+    failure = error;
+  }
+  expect(failure).toBeInstanceOf(Error);
+  if (message !== undefined) expect((failure as Error).message).toContain(message);
+}
 
 async function runWorker(worker: string, databasePath: string, mode: string, ...args: string[]) {
   return await startWorker(worker, databasePath, mode, ...args).result;

--- a/src/lib/ad-hoc-games.ts
+++ b/src/lib/ad-hoc-games.ts
@@ -1,6 +1,6 @@
 import { Database } from "bun:sqlite";
 import { createHash, randomBytes } from "node:crypto";
-import { mkdirSync } from "node:fs";
+import { chmodSync, mkdirSync } from "node:fs";
 import { dirname } from "node:path";
 import { createInitialGameState } from "@/lib/game-engine";
 import type { GameCommand, GameState, GameView } from "@/lib/game-types";
@@ -178,6 +178,46 @@ export type AdHocStore = {
     | { status: "rate-limited"; retryAfterMs: number }
     | { status: "accepted"; removedGameId: string | null };
   mutateGame<T>(gameId: string, mutation: (game: StoredAdHocGame) => T): T | null;
+  /** Optional recovery boundary exposed by the SQLite adapter. */
+  recovery?: AdHocRecoveryAdapter;
+};
+
+export const AD_HOC_RECOVERY_MANIFEST_VERSION = "ad-hoc-recovery-manifest-v1" as const;
+
+export type AdHocRecoveryFacts = {
+  version: typeof AD_HOC_RECOVERY_MANIFEST_VERSION;
+  schemaVersion: number;
+  environmentIdentity: string;
+  retainedGameCount: number;
+  unfinishedGameCount: number;
+  creationEventCount: number;
+  logicalDigest: string;
+  capacityEvidenceDigest: string;
+};
+
+export type AdHocRecoveryReadiness =
+  | {
+      ok: true;
+      status: "ready";
+      facts: AdHocRecoveryFacts;
+    }
+  | {
+      ok: false;
+      status: "unavailable" | "incompatible-schema" | "integrity-failure";
+      detail: string;
+    };
+
+export type AdHocRecoveryAdapter = {
+  readonly databasePath: string;
+  readonly environmentIdentity: string;
+  createRecoveryVacuumSnapshot(destinationPath: string): Promise<AdHocRecoveryFacts>;
+  verifyRecoverySnapshot(
+    databasePath: string,
+    expected: AdHocRecoveryFacts,
+  ): Promise<AdHocRecoveryFacts>;
+  inspectRecoveryDatabase(databasePath: string): AdHocRecoveryFacts;
+  readiness(databasePath?: string): AdHocRecoveryReadiness;
+  quiesceForRecovery(): Promise<void>;
 };
 
 export type AdHocLiveSessionIdentity = {
@@ -385,6 +425,7 @@ export type AdHocSqliteStoreOptions = {
   reconcileConnectionsAtStartup?: boolean;
   startupNowMs?: number;
   beforeCapacityCommit?: () => void;
+  recoveryWriteabilityProbe?: () => void;
 };
 
 export type AdHocGamesServiceOptions = {
@@ -1384,6 +1425,79 @@ export function createInMemoryAdHocStore(): AdHocStore {
   };
 }
 
+export function inspectAdHocRecoveryDatabase(
+  databasePath: string,
+  expectedEnvironmentIdentity?: string,
+): AdHocRecoveryFacts {
+  const database = new Database(databasePath, { readonly: true, strict: true });
+  try {
+    return inspectAdHocRecoveryDatabaseHandle(database, expectedEnvironmentIdentity);
+  } finally {
+    database.close();
+  }
+}
+
+export function createSqliteAdHocRecoveryAdapter(
+  databasePath: string,
+  environmentIdentity = "test",
+  options: Pick<AdHocSqliteStoreOptions, "recoveryWriteabilityProbe"> = {},
+): AdHocRecoveryAdapter {
+  const normalizedEnvironment = environmentIdentity.trim() || "test";
+  return {
+    databasePath,
+    environmentIdentity: normalizedEnvironment,
+    async createRecoveryVacuumSnapshot(destinationPath) {
+      const database = new Database(databasePath, { create: false, strict: true });
+      try {
+        return createAdHocRecoveryVacuumSnapshot(database, destinationPath, normalizedEnvironment);
+      } finally {
+        database.close();
+      }
+    },
+    async verifyRecoverySnapshot(databasePathToVerify, expected) {
+      const actual = inspectAdHocRecoveryDatabase(databasePathToVerify, normalizedEnvironment);
+      if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+        throw new Error("Ad Hoc recovery snapshot facts changed.");
+      }
+      return actual;
+    },
+    inspectRecoveryDatabase(path) {
+      return inspectAdHocRecoveryDatabase(path, normalizedEnvironment);
+    },
+    readiness(path = databasePath) {
+      try {
+        const facts = inspectAdHocRecoveryDatabase(path, normalizedEnvironment);
+        const writable = new Database(path, { create: false, strict: true });
+        try {
+          writable.run("PRAGMA busy_timeout = 0");
+          probeAdHocRecoveryWriteability(writable, options.recoveryWriteabilityProbe);
+        } finally {
+          writable.close();
+        }
+        return {
+          ok: true,
+          status: "ready",
+          facts,
+        };
+      } catch (error) {
+        return {
+          ok: false,
+          status: classifyAdHocRecoveryReadinessError(error),
+          detail: "Ad Hoc storage readiness verification failed.",
+        };
+      }
+    },
+    async quiesceForRecovery() {
+      const database = new Database(databasePath, { create: false, strict: true });
+      try {
+        sealAdHocRecoveryDatabase(database);
+      } finally {
+        database.close();
+      }
+    },
+  };
+}
+
 export function openSqliteAdHocStore(
   databasePath: string,
   environmentIdentity = "test",
@@ -1391,6 +1505,39 @@ export function openSqliteAdHocStore(
 ): AdHocStore {
   mkdirSync(dirname(databasePath), { recursive: true });
   const db = new Database(databasePath, { create: true, strict: true });
+  let closed = false;
+  const genericRecovery = createSqliteAdHocRecoveryAdapter(
+    databasePath,
+    environmentIdentity,
+    options,
+  );
+  const recovery: AdHocRecoveryAdapter = {
+    ...genericRecovery,
+    async createRecoveryVacuumSnapshot(destinationPath) {
+      if (closed) throw new Error("Ad Hoc SQLite store is closed.");
+      return createAdHocRecoveryVacuumSnapshot(db, destinationPath, environmentIdentity);
+    },
+    readiness(path = databasePath) {
+      if (path !== databasePath) return genericRecovery.readiness(path);
+      try {
+        const facts = inspectAdHocRecoveryDatabaseHandle(db, environmentIdentity);
+        probeAdHocRecoveryWriteability(db, options.recoveryWriteabilityProbe);
+        return { ok: true, status: "ready", facts };
+      } catch (error) {
+        return {
+          ok: false,
+          status: classifyAdHocRecoveryReadinessError(error),
+          detail: "Ad Hoc storage readiness verification failed.",
+        };
+      }
+    },
+    async quiesceForRecovery() {
+      if (closed) return;
+      sealAdHocRecoveryDatabase(db);
+      closed = true;
+      db.close();
+    },
+  };
   db.run("PRAGMA journal_mode = WAL");
   db.run("PRAGMA foreign_keys = ON");
   db.run("PRAGMA busy_timeout = 0");
@@ -1493,6 +1640,8 @@ export function openSqliteAdHocStore(
   const transaction = db.transaction((work: () => unknown) => work());
   return {
     close() {
+      if (closed) return;
+      closed = true;
       db.close();
     },
     listGames() {
@@ -1647,6 +1796,7 @@ export function openSqliteAdHocStore(
         return result;
       }) as T | null;
     },
+    recovery,
   };
 }
 
@@ -1672,6 +1822,165 @@ function parseStoredRow(row: Record<string, string | number>): StoredAdHocGame {
     operations,
   };
   return validateStoredGame(parsed);
+}
+
+function createAdHocRecoveryVacuumSnapshot(
+  database: Database,
+  destinationPath: string,
+  expectedEnvironmentIdentity: string,
+): AdHocRecoveryFacts {
+  const facts = inspectAdHocRecoveryDatabaseHandle(database, expectedEnvironmentIdentity);
+  const previousUmask = process.umask(0o177);
+  try {
+    database.exec(`VACUUM INTO ${quoteAdHocSqliteString(destinationPath)};`);
+  } finally {
+    process.umask(previousUmask);
+  }
+  chmodSync(destinationPath, 0o600);
+  return facts;
+}
+
+function probeAdHocRecoveryWriteability(database: Database, injectedFailure?: () => void): void {
+  let transactionStarted = false;
+  try {
+    database.run("BEGIN IMMEDIATE");
+    transactionStarted = true;
+    injectedFailure?.();
+    database.run("UPDATE adhoc_schema SET version = version WHERE id = 1");
+  } catch (error) {
+    if (transactionStarted) database.run("ROLLBACK");
+    throw new Error("Ad Hoc recovery writeability probe failed.", { cause: error });
+  }
+  database.run("ROLLBACK");
+}
+
+function sealAdHocRecoveryDatabase(database: Database): void {
+  const checkpoint = database.query("PRAGMA wal_checkpoint(TRUNCATE)").get() as {
+    busy?: number;
+  } | null;
+  if (checkpoint?.busy !== undefined && checkpoint.busy !== 0) {
+    throw new Error("Ad Hoc recovery quiescence could not checkpoint the database.");
+  }
+  const journalMode = String(
+    (database.query("PRAGMA journal_mode = DELETE").get() as { journal_mode?: string } | null)
+      ?.journal_mode ?? "",
+  );
+  if (journalMode.toLowerCase() !== "delete") {
+    throw new Error("Ad Hoc recovery quiescence could not seal a portable database image.");
+  }
+}
+
+function classifyAdHocRecoveryReadinessError(
+  error: unknown,
+): Extract<AdHocRecoveryReadiness, { ok: false }>["status"] {
+  const message = error instanceof Error ? error.message : "";
+  if (
+    message.includes("writeability") ||
+    message.includes("database is locked") ||
+    message.includes("attempt to write a readonly database") ||
+    message.includes("readonly database") ||
+    message.includes("no such file") ||
+    message.includes("unable to open")
+  )
+    return "unavailable";
+  if (message.includes("schema") || message.includes("relation set")) return "incompatible-schema";
+  return "integrity-failure";
+}
+
+function inspectAdHocRecoveryDatabaseHandle(
+  database: Database,
+  expectedEnvironmentIdentity?: string,
+): AdHocRecoveryFacts {
+  const integrity = database.query("PRAGMA integrity_check").get() as {
+    integrity_check?: string;
+  } | null;
+  if (integrity?.integrity_check !== "ok") {
+    throw new Error("Ad Hoc recovery database integrity verification failed.");
+  }
+  const relations = (
+    database
+      .query(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%' ORDER BY name",
+      )
+      .all() as Array<{ name: string }>
+  ).map((row) => row.name);
+  const expectedRelations = ["adhoc_creation_events", "adhoc_games", "adhoc_schema"];
+  if (JSON.stringify(relations) !== JSON.stringify(expectedRelations)) {
+    throw new Error("Ad Hoc recovery database contains an unsupported relation set.");
+  }
+  const schema = database.query("SELECT version FROM adhoc_schema WHERE id = 1").get() as {
+    version?: number | string;
+  } | null;
+  const schemaVersion = Number(schema?.version ?? NaN);
+  if (schemaVersion !== SCHEMA_VERSION) {
+    throw new Error("Ad Hoc recovery database schema is incompatible.");
+  }
+  const games = database.query("SELECT * FROM adhoc_games ORDER BY game_id").all() as Record<
+    string,
+    string | number
+  >[];
+  const canonical = createHash("sha256");
+  const capacityEvidence = createHash("sha256");
+  const normalizedExpectedEnvironment = expectedEnvironmentIdentity?.trim() || undefined;
+  let unfinishedGameCount = 0;
+  for (const row of games) {
+    const game = parseStoredRow(row);
+    if (
+      normalizedExpectedEnvironment !== undefined &&
+      game.environmentIdentity !== normalizedExpectedEnvironment
+    ) {
+      throw new Error("Ad Hoc recovery database environment identity is inconsistent.");
+    }
+    if (game.state.isFinished === false) unfinishedGameCount += 1;
+    canonical.update(JSON.stringify(row));
+    canonical.update("\n");
+    capacityEvidence.update(
+      JSON.stringify({
+        gameId: game.gameId,
+        createdAtMs: game.createdAtMs,
+        sessions: game.sessions,
+      }),
+    );
+    capacityEvidence.update("\n");
+  }
+  const creationEvents = database
+    .query(
+      "SELECT source_hash, successful, occurred_at_ms, retry_until_ms FROM adhoc_creation_events ORDER BY occurred_at_ms, source_hash, successful, retry_until_ms",
+    )
+    .all() as Array<Record<string, string | number | null>>;
+  for (const event of creationEvents) {
+    if (
+      typeof event.source_hash !== "string" ||
+      !/^[a-f0-9]{64}$/u.test(event.source_hash) ||
+      (event.successful !== 0 && event.successful !== 1) ||
+      !Number.isSafeInteger(Number(event.occurred_at_ms)) ||
+      Number(event.occurred_at_ms) < 0 ||
+      (event.retry_until_ms !== null &&
+        event.retry_until_ms !== undefined &&
+        (!Number.isSafeInteger(Number(event.retry_until_ms)) || Number(event.retry_until_ms) < 0))
+    ) {
+      throw new Error("Ad Hoc recovery capacity evidence is invalid.");
+    }
+    canonical.update(JSON.stringify(event));
+    canonical.update("\n");
+    capacityEvidence.update(JSON.stringify(event));
+    capacityEvidence.update("\n");
+  }
+  return {
+    version: AD_HOC_RECOVERY_MANIFEST_VERSION,
+    schemaVersion,
+    environmentIdentity:
+      normalizedExpectedEnvironment || String(games[0]?.environment_identity ?? ""),
+    retainedGameCount: games.length,
+    unfinishedGameCount,
+    creationEventCount: creationEvents.length,
+    logicalDigest: canonical.digest("hex"),
+    capacityEvidenceDigest: capacityEvidence.digest("hex"),
+  };
+}
+
+function quoteAdHocSqliteString(value: string): string {
+  return `'${value.replaceAll("'", "''")}'`;
 }
 
 function projectAuthorizedGame(
@@ -1711,6 +2020,8 @@ function validateStoredGame(game: StoredAdHocGame): StoredAdHocGame {
     throw new Error("Stored control QR is invalid.");
   if (!/^[a-f0-9]{64}$/u.test(game.controlQrHash))
     throw new Error("Stored control QR hash is invalid.");
+  if (digest(game.controlQr) !== game.controlQrHash)
+    throw new Error("Stored control QR authority reference is inconsistent.");
   if (!Array.isArray(game.sessions)) throw new Error("Stored sessions are invalid.");
   for (const session of game.sessions) validateStoredSession(session);
   if (!isRecord(game.operations)) throw new Error("Stored operations are invalid.");

--- a/src/lib/foundation-recovery.test.ts
+++ b/src/lib/foundation-recovery.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { Database } from "bun:sqlite";
+import { createHash } from "node:crypto";
 import {
   chmodSync,
   copyFileSync,
@@ -23,6 +24,11 @@ import { createEventGameRecord } from "@/lib/event-game-record";
 import type { EventGameRecordRoot } from "@/lib/foundation-record-types";
 import { FOUNDATION_MIGRATIONS } from "@/lib/foundation-migrations";
 import { createFoundationRecovery } from "@/lib/foundation-recovery";
+import {
+  AD_HOC_RECOVERY_MANIFEST_VERSION,
+  type AdHocRecoveryAdapter,
+  type AdHocRecoveryFacts,
+} from "@/lib/ad-hoc-games";
 import { FoundationBackupPolicyError } from "@/lib/foundation-recovery-sqlite";
 import { openSqliteFoundationStorage } from "@/lib/foundation-storage-sqlite";
 
@@ -155,6 +161,60 @@ describe("Event foundation recovery", () => {
       expect(harness.recovery.createPreDeploymentBackup()).rejects.toThrow(
         "owned non-symlink 0700",
       );
+      harness.storage.close();
+    });
+  });
+
+  test("composes Ad Hoc backup, cutover, failed-image preservation, and rollback", async () => {
+    await withRecoveryPaths(async ({ livePath, backupDirectory }) => {
+      const harness = await createHarness(livePath, backupDirectory, () => "fast-composed");
+      const adHocPath = join(dirname(livePath), "ad-hoc.sqlite");
+      const adHoc = await createFastAdHocRecoveryAdapter(adHocPath, "snapshot");
+      const recovery = createFoundationRecovery(harness.storage, {
+        ...harness.options,
+        adHoc: adHoc.adapter,
+        createId: () => "fast-composed",
+      });
+      const manifest = await recovery.createPreDeploymentBackup();
+      const manifestPath = join(backupDirectory, `${manifest.snapshotId}.manifest.json`);
+      expect(manifest.adHoc).toMatchObject({
+        databaseFile: `${manifest.snapshotId}.ad-hoc.sqlite`,
+        facts: { retainedGameCount: 1 },
+      });
+      expect(await recovery.verifyBackup(manifestPath)).toEqual(manifest);
+      adHoc.setLive("newer-live-state");
+      const restored = await recovery.restore(manifestPath);
+      expect(restored).toMatchObject({ completed: true, potentiallyNewerWork: true });
+      expect(adHoc.readLive()).toBe("snapshot");
+      expect(restored.failedAdHocDatabasePath).not.toBeNull();
+      expect(await readFile(restored.failedAdHocDatabasePath!, "utf8")).toBe("newer-live-state");
+      harness.storage.close();
+    });
+
+    await withRecoveryPaths(async ({ livePath, backupDirectory }) => {
+      const harness = await createHarness(livePath, backupDirectory, () => "fast-rollback");
+      const adHocPath = join(dirname(livePath), "ad-hoc.sqlite");
+      const adHoc = await createFastAdHocRecoveryAdapter(adHocPath, "snapshot");
+      const initial = createFoundationRecovery(harness.storage, {
+        ...harness.options,
+        adHoc: adHoc.adapter,
+        createId: () => "fast-rollback",
+      });
+      const manifest = await initial.createPreDeploymentBackup();
+      const manifestPath = join(backupDirectory, `${manifest.snapshotId}.manifest.json`);
+      adHoc.setLive("newer-live-state");
+      const rollback = createFoundationRecovery(harness.storage, {
+        ...harness.options,
+        adHoc: adHoc.adapter,
+        createId: () => "fast-rollback-restore",
+        faultInjector(phase) {
+          if (phase === "before-live-replacement") throw new Error("fast rollback");
+        },
+      });
+      await expectRejected(rollback.restore(manifestPath), "fast rollback");
+      expect(adHoc.readLive()).toBe("newer-live-state");
+      expect(existsSync(`${adHocPath}.failed-fast-rollback-restore`)).toBe(false);
+      expect(existsSync(`${livePath}.failed-fast-rollback-restore`)).toBe(false);
       harness.storage.close();
     });
   });
@@ -1030,6 +1090,63 @@ describe("Event foundation recovery", () => {
     });
   });
 });
+
+async function createFastAdHocRecoveryAdapter(databasePath: string, liveContent: string) {
+  const factsFor = (content: string): AdHocRecoveryFacts => ({
+    version: AD_HOC_RECOVERY_MANIFEST_VERSION,
+    schemaVersion: 1,
+    environmentIdentity: "test",
+    retainedGameCount: 1,
+    unfinishedGameCount: 1,
+    creationEventCount: 1,
+    logicalDigest: createHash("sha256").update(content).digest("hex"),
+    capacityEvidenceDigest: createHash("sha256").update(`capacity:${content}`).digest("hex"),
+  });
+  await writeFile(databasePath, liveContent, { mode: 0o600 });
+  let current = liveContent;
+  const adapter: AdHocRecoveryAdapter = {
+    databasePath,
+    environmentIdentity: "test",
+    async createRecoveryVacuumSnapshot(destinationPath) {
+      await writeFile(destinationPath, current, { mode: 0o600 });
+      return factsFor(current);
+    },
+    async verifyRecoverySnapshot(path, expected) {
+      const actual = factsFor(await readFile(path, "utf8"));
+      if (JSON.stringify(actual) !== JSON.stringify(expected))
+        throw new Error("Fast Ad Hoc snapshot facts changed.");
+      return actual;
+    },
+    inspectRecoveryDatabase(path) {
+      return factsFor(readFileSync(path, "utf8"));
+    },
+    readiness() {
+      return { ok: true, status: "ready", facts: factsFor(current) };
+    },
+    async quiesceForRecovery() {},
+  };
+  return {
+    adapter,
+    setLive(content: string) {
+      current = content;
+      writeFileSync(databasePath, content, { mode: 0o600 });
+    },
+    readLive() {
+      return readFileSync(databasePath, "utf8");
+    },
+  };
+}
+
+async function expectRejected(promise: Promise<unknown>, message?: string): Promise<void> {
+  let failure: unknown;
+  try {
+    await promise;
+  } catch (error) {
+    failure = error;
+  }
+  expect(failure).toBeInstanceOf(Error);
+  if (message !== undefined) expect((failure as Error).message).toContain(message);
+}
 
 async function withRecoveryPaths(
   work: (paths: { livePath: string; backupDirectory: string }) => Promise<void>,

--- a/src/lib/foundation-recovery.ts
+++ b/src/lib/foundation-recovery.ts
@@ -42,6 +42,7 @@ import {
 } from "@/lib/foundation-storage-sqlite";
 import type { FoundationStorageReadinessContext } from "@/lib/foundation-storage";
 import type { FoundationStorageTransaction } from "@/lib/foundation-storage";
+import type { AdHocRecoveryAdapter, AdHocRecoveryFacts } from "@/lib/ad-hoc-games";
 import {
   FOUNDATION_BACKUP_POLICY_VERSION,
   inspectRecoveryDatabase,
@@ -72,6 +73,11 @@ export type FoundationRecoveryManifest = {
     grantVersion: string;
   }[];
   excludedRelations: readonly string[];
+  adHoc?: {
+    databaseFile: string;
+    databaseSha256: string;
+    facts: AdHocRecoveryFacts;
+  };
   verifiedAtMs: number;
 };
 
@@ -88,6 +94,8 @@ export type FoundationRecoveryOptions = {
     /** Stops new auth writes and drains/closes the repository before replacement. */
     quiesce(): Promise<void>;
   };
+  /** Optional Ad Hoc database included in the same staged recovery boundary. */
+  adHoc?: AdHocRecoveryAdapter;
   nowMs?: () => number;
   createId?: () => string;
   faultInjector?: (
@@ -133,6 +141,7 @@ export type FoundationRecovery = {
     restoreId: string;
     failedDatabasePath: string;
     failedTechnicalAdminDatabasePath: string | null;
+    failedAdHocDatabasePath: string | null;
     completed: true;
     evidencePath: string;
     completionEvidencePath: string | null;
@@ -173,17 +182,26 @@ export function createFoundationRecovery(
     const stagedPath = join(backupDirectory, `.${snapshotId}.staged.sqlite`);
     const databasePath = join(backupDirectory, `${snapshotId}.sqlite`);
     const manifestPath = join(backupDirectory, `${snapshotId}.manifest.json`);
+    const adHocRawPath = join(backupDirectory, `.${snapshotId}.ad-hoc.raw.sqlite`);
+    const adHocDatabasePath = join(backupDirectory, `${snapshotId}.ad-hoc.sqlite`);
     const snapshotAtMs = readTime(nowMs);
     let publishedDatabaseIdentity: StableFileIdentity | null = null;
     let publishedManifestIdentity: StableFileIdentity | null = null;
     let rawIdentity: StableFileIdentity | null = null;
     let stagedIdentity: StableFileIdentity | null = null;
+    let adHocRawIdentity: StableFileIdentity | null = null;
+    let publishedAdHocIdentity: StableFileIdentity | null = null;
+    let adHocFacts: AdHocRecoveryFacts | null = null;
     let completed = false;
     try {
       await assertPathAbsent(rawPath, "raw recovery snapshot");
       await assertPathAbsent(stagedPath, "sanitized recovery snapshot");
       await assertPathAbsent(databasePath, "verified recovery snapshot");
       await assertPathAbsent(manifestPath, "recovery manifest");
+      if (options.adHoc !== undefined) {
+        await assertPathAbsent(adHocRawPath, "raw Ad Hoc recovery snapshot");
+        await assertPathAbsent(adHocDatabasePath, "verified Ad Hoc recovery snapshot");
+      }
       const sourceFacts = await storage.createRecoveryVacuumSnapshot(rawPath);
       rawIdentity = await assertOwnedPrivateFile(rawPath, "raw recovery snapshot");
       options.faultInjector?.("after-vacuum");
@@ -199,6 +217,17 @@ export function createFoundationRecovery(
       stagedIdentity = await assertOwnedPrivateFile(stagedPath, "sanitized recovery snapshot");
       const verified = await verifyDatabase(stagedPath, sourceFacts);
       options.faultInjector?.("after-verification");
+      if (options.adHoc !== undefined) {
+        adHocFacts = await options.adHoc.createRecoveryVacuumSnapshot(adHocRawPath);
+        adHocRawIdentity = await assertOwnedPrivateFile(
+          adHocRawPath,
+          "raw Ad Hoc recovery snapshot",
+        );
+        await options.adHoc.verifyRecoverySnapshot(adHocRawPath, adHocFacts);
+        publishedAdHocIdentity = await copyStablePrivateFile(adHocRawPath, adHocDatabasePath);
+        await removeStablePath(adHocRawPath, adHocRawIdentity);
+        adHocRawIdentity = null;
+      }
       const manifest: FoundationRecoveryManifest = {
         version: RECOVERY_MANIFEST_VERSION,
         snapshotId,
@@ -211,6 +240,15 @@ export function createFoundationRecovery(
         representedKeyVersions: verified.keyVersions,
         restoredGrantVersions: redactGrantVersions(verified.facts),
         excludedRelations: sourceFacts.excludedRelations,
+        ...(options.adHoc === undefined || adHocFacts === null
+          ? {}
+          : {
+              adHoc: {
+                databaseFile: basename(adHocDatabasePath),
+                databaseSha256: await sha256File(adHocDatabasePath),
+                facts: adHocFacts,
+              },
+            }),
         verifiedAtMs: readTime(nowMs),
       };
       publishedDatabaseIdentity = await copyStablePrivateFile(stagedPath, databasePath);
@@ -223,8 +261,11 @@ export function createFoundationRecovery(
     } finally {
       if (rawIdentity !== null) await removeStablePath(rawPath, rawIdentity);
       if (stagedIdentity !== null) await removeStablePath(stagedPath, stagedIdentity);
+      if (adHocRawIdentity !== null) await removeStablePath(adHocRawPath, adHocRawIdentity);
       if (!completed && publishedDatabaseIdentity !== null)
         await removeStablePath(databasePath, publishedDatabaseIdentity);
+      if (!completed && publishedAdHocIdentity !== null)
+        await removeStablePath(adHocDatabasePath, publishedAdHocIdentity);
       if (!completed && publishedManifestIdentity !== null)
         await removeStablePath(manifestPath, publishedManifestIdentity);
     }
@@ -237,7 +278,15 @@ export function createFoundationRecovery(
       backupDirectory,
       `.${manifest.snapshotId}.verify-${boundedId(createId(), "verificationId")}.sqlite`,
     );
+    const adHocVerificationPath =
+      manifest.adHoc === undefined
+        ? null
+        : join(
+            backupDirectory,
+            `.${manifest.snapshotId}.verify-${boundedId(createId(), "verificationId")}.ad-hoc.sqlite`,
+          );
     let verificationIdentity: StableFileIdentity | null = null;
+    let adHocVerificationIdentity: StableFileIdentity | null = null;
     try {
       verificationIdentity = await copyStablePrivateFile(
         resolveBackupDatabasePath(manifestPath, manifest, backupDirectory),
@@ -255,10 +304,23 @@ export function createFoundationRecovery(
       ) {
         throw new Error("Verified backup key-version representation changed.");
       }
+      if (manifest.adHoc !== undefined) {
+        if (options.adHoc === undefined || adHocVerificationPath === null) {
+          throw new Error("Ad Hoc recovery adapter is required to verify this backup.");
+        }
+        adHocVerificationIdentity = await copyStablePrivateFile(
+          resolveBackupAdHocDatabasePath(manifestPath, manifest, backupDirectory),
+          adHocVerificationPath,
+          manifest.adHoc.databaseSha256,
+        );
+        await options.adHoc.verifyRecoverySnapshot(adHocVerificationPath, manifest.adHoc.facts);
+      }
       return manifest;
     } finally {
       if (verificationIdentity !== null)
         await removeStablePath(verificationPath, verificationIdentity);
+      if (adHocVerificationIdentity !== null && adHocVerificationPath !== null)
+        await removeStablePath(adHocVerificationPath, adHocVerificationIdentity);
       await rm(`${verificationPath}-wal`, { force: true });
       await rm(`${verificationPath}-shm`, { force: true });
       await rm(`${verificationPath}.quarantine`, { force: true });
@@ -273,6 +335,13 @@ export function createFoundationRecovery(
     const stagedPath = join(liveDirectory, `.${basename(livePath)}.${restoreId}.staged`);
     const failedDatabasePath = `${livePath}.failed-${restoreId}`;
     const failedTechnicalAdminDatabasePath = `${technicalAdminPath}.failed-${restoreId}`;
+    const adHocLivePath = options.adHoc?.databasePath ?? null;
+    const stagedAdHocPath =
+      adHocLivePath === null
+        ? null
+        : join(dirname(adHocLivePath), `.${basename(adHocLivePath)}.${restoreId}.staged`);
+    const failedAdHocDatabasePath =
+      adHocLivePath === null ? null : `${adHocLivePath}.failed-${restoreId}`;
     const evidencePath = join(backupDirectory, `${restoreId}.restore-evidence.json`);
     const completionEvidenceCandidatePath = join(
       backupDirectory,
@@ -280,10 +349,13 @@ export function createFoundationRecovery(
     );
     let staged: SqliteFoundationStorage | undefined;
     let stagedIdentity: StableFileIdentity | null = null;
+    let stagedAdHocIdentity: StableFileIdentity | null = null;
     let evidenceIdentity: StableFileIdentity | null = null;
     try {
       await assertPathAbsent(failedDatabasePath, "failed Event foundation image");
       await assertPathAbsent(failedTechnicalAdminDatabasePath, "failed Technical Admin image");
+      if (failedAdHocDatabasePath !== null)
+        await assertPathAbsent(failedAdHocDatabasePath, "failed Ad Hoc image");
       await assertPathAbsent(evidencePath, "restore evidence");
       await assertPathAbsent(completionEvidenceCandidatePath, "completed restore evidence");
       stagedIdentity = await copyStablePrivateFile(backupPath, stagedPath, manifest.databaseSha256);
@@ -297,6 +369,22 @@ export function createFoundationRecovery(
         JSON.stringify(verified.keyVersions) !== JSON.stringify(manifest.representedKeyVersions)
       ) {
         throw new Error("Verified backup key-version representation changed.");
+      }
+      if (manifest.adHoc !== undefined) {
+        if (
+          options.adHoc === undefined ||
+          adHocLivePath === null ||
+          stagedAdHocPath === null ||
+          failedAdHocDatabasePath === null
+        ) {
+          throw new Error("Ad Hoc recovery adapter is required to restore this backup.");
+        }
+        stagedAdHocIdentity = await copyStablePrivateFile(
+          resolveBackupAdHocDatabasePath(manifestPath, manifest, backupDirectory),
+          stagedAdHocPath,
+          manifest.adHoc.databaseSha256,
+        );
+        await options.adHoc.verifyRecoverySnapshot(stagedAdHocPath, manifest.adHoc.facts);
       }
       options.faultInjector?.("after-restore-staging");
 
@@ -317,6 +405,7 @@ export function createFoundationRecovery(
       // later writer is rejected by the closed repositories.
       await options.technicalAdminAuth.quiesce();
       await storage.quiesceForRecovery();
+      await options.adHoc?.quiesceForRecovery();
       options.faultInjector?.("after-authoritative-quiescence");
 
       await assertStablePrivateFile(
@@ -354,8 +443,19 @@ export function createFoundationRecovery(
       const liveIdentity = stableIdentity(await lstat(livePath));
       const liveFacts = safelyInspectClosedDatabase(livePath);
       await assertStableFileIdentity(livePath, liveIdentity, "quiesced Event foundation image");
+      const adHocLiveIdentity =
+        adHocLivePath === null ? null : stableIdentity(await lstat(adHocLivePath));
+      const adHocLiveFacts =
+        options.adHoc === undefined || adHocLivePath === null
+          ? null
+          : options.adHoc.inspectRecoveryDatabase(adHocLivePath);
       const potentiallyNewerWork =
-        liveFacts === null ? null : liveFacts.logicalDigest !== manifest.logicalDigest;
+        liveFacts === null
+          ? null
+          : liveFacts.logicalDigest !== manifest.logicalDigest ||
+            (manifest.adHoc !== undefined &&
+              adHocLiveFacts !== null &&
+              JSON.stringify(adHocLiveFacts) !== JSON.stringify(manifest.adHoc.facts));
       const movedSidecars: Array<{
         from: string;
         to: string;
@@ -414,6 +514,37 @@ export function createFoundationRecovery(
           );
           movedSidecars.push({ from: failed, to: source, identity: failedIdentity });
         }
+        if (
+          manifest.adHoc !== undefined &&
+          adHocLivePath !== null &&
+          failedAdHocDatabasePath !== null &&
+          adHocLiveIdentity !== null
+        ) {
+          const failedIdentity = await moveToExclusivePath(
+            adHocLivePath,
+            failedAdHocDatabasePath,
+            "failed Ad Hoc image",
+            adHocLiveIdentity,
+          );
+          movedSidecars.push({
+            from: failedAdHocDatabasePath,
+            to: adHocLivePath,
+            identity: failedIdentity,
+          });
+          for (const suffix of ["-wal", "-shm"] as const) {
+            const source = `${adHocLivePath}${suffix}`;
+            if (!(await pathExists(source))) continue;
+            const failed = `${failedAdHocDatabasePath}${suffix}`;
+            const sourceIdentity = stableIdentity(await lstat(source));
+            const failedIdentity = await moveToExclusivePath(
+              source,
+              failed,
+              "failed Ad Hoc sidecar",
+              sourceIdentity,
+            );
+            movedSidecars.push({ from: failed, to: source, identity: failedIdentity });
+          }
+        }
         options.faultInjector?.("after-live-preserved");
         options.faultInjector?.("before-live-replacement");
         installedPaths.push({
@@ -441,9 +572,46 @@ export function createFoundationRecovery(
             });
           }
         }
+        if (manifest.adHoc !== undefined && stagedAdHocPath !== null && adHocLivePath !== null) {
+          if (stagedAdHocIdentity === null)
+            throw new Error("Ad Hoc restore staging is unavailable.");
+          await assertStablePrivateFile(
+            stagedAdHocPath,
+            stagedAdHocIdentity,
+            "verified Ad Hoc restore staging image",
+          );
+          installedPaths.push({
+            path: adHocLivePath,
+            identity: await moveToExclusivePath(
+              stagedAdHocPath,
+              adHocLivePath,
+              "restored Ad Hoc image",
+              stagedAdHocIdentity,
+            ),
+          });
+          stagedAdHocIdentity = null;
+          for (const suffix of ["-wal", "-shm"] as const) {
+            if (await pathExists(`${stagedAdHocPath}${suffix}`)) {
+              const stagedSidecarPath = `${stagedAdHocPath}${suffix}`;
+              const stagedSidecarIdentity = stableIdentity(await lstat(stagedSidecarPath));
+              installedPaths.push({
+                path: `${adHocLivePath}${suffix}`,
+                identity: await moveToExclusivePath(
+                  stagedSidecarPath,
+                  `${adHocLivePath}${suffix}`,
+                  "restored Ad Hoc sidecar",
+                  stagedSidecarIdentity,
+                ),
+              });
+            }
+          }
+        }
         await syncDirectory(liveDirectory);
         if (dirname(technicalAdminPath) !== liveDirectory) {
           await syncDirectory(dirname(technicalAdminPath));
+        }
+        if (adHocLivePath !== null && dirname(adHocLivePath) !== liveDirectory) {
+          await syncDirectory(dirname(adHocLivePath));
         }
       } catch (error) {
         for (const installed of installedPaths.reverse())
@@ -461,9 +629,16 @@ export function createFoundationRecovery(
         if (dirname(technicalAdminPath) !== liveDirectory) {
           await syncDirectory(dirname(technicalAdminPath));
         }
+        if (adHocLivePath !== null && dirname(adHocLivePath) !== liveDirectory) {
+          await syncDirectory(dirname(adHocLivePath));
+        }
         throw error;
       }
       const restoredFacts = safelyInspectClosedDatabase(livePath);
+      const restoredAdHocFacts =
+        options.adHoc !== undefined && adHocLivePath !== null
+          ? options.adHoc.inspectRecoveryDatabase(adHocLivePath)
+          : null;
       const evidence = {
         version: RECOVERY_EVIDENCE_VERSION,
         kind: "restore",
@@ -475,10 +650,23 @@ export function createFoundationRecovery(
         snapshotActionCount: manifest.actionCount,
         liveActionCountBeforeRestore: liveFacts?.actionCount ?? null,
         potentiallyNewerWork,
+        adHoc:
+          manifest.adHoc === undefined
+            ? null
+            : {
+                retainedGameCount: manifest.adHoc.facts.retainedGameCount,
+                unfinishedGameCount: manifest.adHoc.facts.unfinishedGameCount,
+                resurrectionExposure: "older-snapshot-may-resurrect-departed-session",
+                restoredLogicalDigest: restoredAdHocFacts?.logicalDigest ?? null,
+              },
         failedDatabasePath,
         failedTechnicalAdminDatabasePath: (await pathExists(failedTechnicalAdminDatabasePath))
           ? failedTechnicalAdminDatabasePath
           : null,
+        failedAdHocDatabasePath:
+          failedAdHocDatabasePath !== null && (await pathExists(failedAdHocDatabasePath))
+            ? failedAdHocDatabasePath
+            : null,
         technicalAdminAuthRevived: false,
         restoredGrantVersions:
           restoredFacts === null
@@ -504,6 +692,10 @@ export function createFoundationRecovery(
         failedTechnicalAdminDatabasePath: (await pathExists(failedTechnicalAdminDatabasePath))
           ? failedTechnicalAdminDatabasePath
           : null,
+        failedAdHocDatabasePath:
+          failedAdHocDatabasePath !== null && (await pathExists(failedAdHocDatabasePath))
+            ? failedAdHocDatabasePath
+            : null,
         completed: true as const,
         evidencePath,
         completionEvidencePath,
@@ -513,8 +705,14 @@ export function createFoundationRecovery(
     } finally {
       staged?.close();
       if (stagedIdentity !== null) await removeStablePath(stagedPath, stagedIdentity);
+      if (stagedAdHocIdentity !== null && stagedAdHocPath !== null)
+        await removeStablePath(stagedAdHocPath, stagedAdHocIdentity);
       await rm(`${stagedPath}-wal`, { force: true });
       await rm(`${stagedPath}-shm`, { force: true });
+      if (stagedAdHocPath !== null) {
+        await rm(`${stagedAdHocPath}-wal`, { force: true });
+        await rm(`${stagedAdHocPath}-shm`, { force: true });
+      }
     }
   }
 
@@ -1018,7 +1216,35 @@ async function readManifest(
   if (manifest.databaseFile !== `${manifest.snapshotId}.sqlite`) {
     throw new Error("Recovery manifest database identity is invalid.");
   }
+  if (manifest.adHoc !== undefined) {
+    if (
+      typeof manifest.adHoc !== "object" ||
+      manifest.adHoc === null ||
+      manifest.adHoc.databaseFile !== `${manifest.snapshotId}.ad-hoc.sqlite` ||
+      !/^[a-f0-9]{64}$/.test(manifest.adHoc.databaseSha256) ||
+      manifest.adHoc.facts?.version !== "ad-hoc-recovery-manifest-v1"
+    ) {
+      throw new Error("Recovery manifest Ad Hoc database identity is invalid.");
+    }
+  }
   return manifest;
+}
+
+function resolveBackupAdHocDatabasePath(
+  manifestPath: string,
+  manifest: FoundationRecoveryManifest,
+  backupDirectory: string,
+): string {
+  if (manifest.adHoc === undefined) throw new Error("Recovery manifest has no Ad Hoc database.");
+  const databasePath = resolve(backupDirectory, manifest.adHoc.databaseFile);
+  if (
+    dirname(databasePath) !== backupDirectory ||
+    basename(databasePath) !== manifest.adHoc.databaseFile ||
+    resolve(manifestPath) === databasePath
+  ) {
+    throw new Error("Recovery manifest Ad Hoc database path is invalid.");
+  }
+  return databasePath;
 }
 
 async function pathExists(path: string): Promise<boolean> {


### PR DESCRIPTION
## What changed

- includes the complete Ad Hoc SQLite state in the shared Foundation backup, verification, staged restore, failed-image preservation, and rollback boundary
- restores current Game state, stable operation identities, Control QR authority, Controller sessions, connection protection, and isolated creation/rate evidence to the exact snapshot point
- preserves the accepted older-snapshot resurrection behavior for departed sessions and unfinished QR admission without adding Event recovery semantics
- fails readiness and recovery closed for unsafe writes, corrupt or incompatible images, invalid ownership references, and cross-environment state
- adds deterministic Fast Tests plus separately named SQLite and browser integration coverage for restart, restore, rollback, resumption, and newer local work

## Why

Ad Hoc Games already survive ordinary restarts, but they also need to participate in ordinary full-database backup and staged restore. Recovery must return disposable Ad Hoc state exactly as captured without inventing Technical Admin takeover, Event audit reconstruction, or targeted recovery.

## Impact

Snapshot-eligible Controllers and the unchanged Control QR work again after restore. Older snapshots may intentionally resurrect a departed session or unfinished admission state, and this exposure is reported explicitly. Invalid or unsafe recovery images cannot partially replace live state, cross Production/Test authority boundaries, or affect Event operational budgets.

The exported recovery seam is ready for Production operations to orchestrate without redefining Ad Hoc semantics.

## Validation

- `bun run check`
- `bun run test` — 660 passed, 0 failed
- `bun run test:focused:ad-hoc` — 11 passed, 0 failed
- `bun run test:focused:adhoc-browser`
- `bun run build`
- `git diff --check origin/main...HEAD`

Closes #157
