### PR TITLE
Anchor presentation replay to originating Grant Sessions

### DIFF
--- a/src/lib/foundation-grant-erasure-migration.test.ts
+++ b/src/lib/foundation-grant-erasure-migration.test.ts
@@ -210,7 +210,7 @@ describe("Grant cryptographic erasure migration", () => {
 
       const current = openSqliteFoundationStorage(databasePath);
       await current.applyMigrations({ requireCandidate: false });
-      expect(await current.readiness()).toMatchObject({ ok: true, schemaVersion: "26" });
+      expect(await current.readiness()).toMatchObject({ ok: true, schemaVersion: "27" });
       current.close();
 
       const raw = new Database(databasePath);
@@ -330,7 +330,7 @@ describe("Grant cryptographic erasure migration", () => {
       raw.close();
 
       const reopened = openSqliteFoundationStorage(databasePath);
-      expect(await reopened.readiness()).toMatchObject({ ok: true, schemaVersion: "26" });
+      expect(await reopened.readiness()).toMatchObject({ ok: true, schemaVersion: "27" });
       const restartedAudit = await reopened.transaction((transaction) =>
         transaction.listGrantAudit("grant-expired"),
       );

--- a/src/lib/foundation-migrations.test.ts
+++ b/src/lib/foundation-migrations.test.ts
@@ -13,7 +13,7 @@ const migrations: readonly FoundationMigration[] = [
 ];
 
 describe("foundation migration ledger compatibility", () => {
-  test("keeps accepted migrations 001 through 025 byte-for-byte immutable and pins 026", () => {
+  test("keeps accepted migrations 001 through 026 byte-for-byte immutable and pins 027", () => {
     expect(FOUNDATION_MIGRATIONS.map(({ id, checksum }) => ({ id, checksum }))).toEqual([
       {
         id: "001-foundation-event-game-record-roots",
@@ -118,6 +118,10 @@ describe("foundation migration ledger compatibility", () => {
       {
         id: "026-event-schedule-expected-delays-and-conflicts",
         checksum: "c51d7eade99fe620ee2562013644ec4511ae106ae1b2525dfc3f8381da29f7ff",
+      },
+      {
+        id: "027-event-game-presentation-integrity",
+        checksum: "d2d8b6d5000903573b5b143e5cbec0e05b3c672dc680e9c3058cd02d0a916d43",
       },
     ]);
   });

--- a/src/lib/foundation-migrations.ts
+++ b/src/lib/foundation-migrations.ts
@@ -1883,6 +1883,75 @@ export const FOUNDATION_EVENT_SCHEDULE_EXPECTED_DELAYS_MIGRATION_SQL = `
   ${FOUNDATION_EVENT_CATALOG_GAMES_INDEX_SQL};
 `;
 
+/** Schema-27 publishes the Foundation-owned Game Presentation evidence contract. */
+export const FOUNDATION_PRESENTATION_INTEGRITY_MIGRATION_SQL = `
+  CREATE TABLE foundation_event_game_presentation_changes (
+    record_id TEXT NOT NULL REFERENCES foundation_event_game_record_roots(record_id) ON DELETE CASCADE,
+    event_game_id TEXT NOT NULL,
+    operation_id TEXT NOT NULL,
+    presentation_change_id TEXT NOT NULL,
+    change_json TEXT NOT NULL CHECK (json_valid(change_json)),
+    causal_predecessor_ids_json TEXT NOT NULL CHECK (json_valid(causal_predecessor_ids_json)),
+    occurrence_json TEXT NOT NULL CHECK (json_valid(occurrence_json)),
+    grant_json TEXT NOT NULL CHECK (json_valid(grant_json)),
+    accepted_at_ms INTEGER NOT NULL,
+    canonical_content TEXT NOT NULL,
+    content_fingerprint TEXT NOT NULL CHECK (length(content_fingerprint) = 64),
+    PRIMARY KEY (record_id, operation_id),
+    UNIQUE (record_id, presentation_change_id),
+    UNIQUE (record_id, content_fingerprint),
+    CHECK (event_game_id <> '')
+  ) STRICT;
+  CREATE INDEX foundation_event_game_presentation_changes_record_id
+    ON foundation_event_game_presentation_changes (record_id, accepted_at_ms, operation_id);
+  CREATE TABLE foundation_event_game_presentation_audit (
+    audit_id TEXT PRIMARY KEY,
+    record_id TEXT NOT NULL REFERENCES foundation_event_game_record_roots(record_id) ON DELETE CASCADE,
+    event_game_id TEXT NOT NULL,
+    operation_id TEXT,
+    presentation_change_id TEXT,
+    audit_kind TEXT NOT NULL CHECK (audit_kind IN ('presentation-accepted', 'presentation-duplicate', 'presentation-conflict', 'presentation-rejected')),
+    outcome TEXT NOT NULL CHECK (outcome IN ('accepted', 'duplicate-accepted', 'rejected')),
+    created_at_ms INTEGER NOT NULL,
+    redacted_detail TEXT NOT NULL,
+    change_json TEXT,
+    grant_json TEXT,
+    supersedes_audit_id TEXT,
+    audit_json TEXT NOT NULL CHECK (json_valid(audit_json)),
+    CHECK (event_game_id <> '')
+  ) STRICT;
+  CREATE INDEX foundation_event_game_presentation_audit_record_id
+    ON foundation_event_game_presentation_audit (record_id, created_at_ms, audit_id);
+  CREATE INDEX foundation_event_game_presentation_audit_supersedes
+    ON foundation_event_game_presentation_audit (record_id, supersedes_audit_id);
+  CREATE TABLE foundation_event_game_presentation_integrity (
+    record_id TEXT NOT NULL REFERENCES foundation_event_game_record_roots(record_id) ON DELETE CASCADE,
+    state_revision INTEGER NOT NULL CHECK (state_revision > 0),
+    key_version TEXT NOT NULL,
+    canonical_value TEXT NOT NULL CHECK (json_valid(canonical_value)),
+    integrity_tag TEXT NOT NULL,
+    PRIMARY KEY (record_id, state_revision)
+  ) STRICT;
+  CREATE TRIGGER foundation_event_game_presentation_changes_no_update
+    BEFORE UPDATE ON foundation_event_game_presentation_changes
+    BEGIN SELECT RAISE(ABORT, 'Game Presentation Changes are immutable.'); END;
+  CREATE TRIGGER foundation_event_game_presentation_changes_no_delete
+    BEFORE DELETE ON foundation_event_game_presentation_changes
+    BEGIN SELECT RAISE(ABORT, 'Game Presentation Changes are immutable.'); END;
+  CREATE TRIGGER foundation_event_game_presentation_audit_no_update
+    BEFORE UPDATE ON foundation_event_game_presentation_audit
+    BEGIN SELECT RAISE(ABORT, 'Game Presentation audit evidence is immutable.'); END;
+  CREATE TRIGGER foundation_event_game_presentation_audit_no_delete
+    BEFORE DELETE ON foundation_event_game_presentation_audit
+    BEGIN SELECT RAISE(ABORT, 'Game Presentation audit evidence is immutable.'); END;
+  CREATE TRIGGER foundation_event_game_presentation_integrity_no_update
+    BEFORE UPDATE ON foundation_event_game_presentation_integrity
+    BEGIN SELECT RAISE(ABORT, 'Game Presentation evidence anchors are immutable.'); END;
+  CREATE TRIGGER foundation_event_game_presentation_integrity_no_delete
+    BEFORE DELETE ON foundation_event_game_presentation_integrity
+    BEGIN SELECT RAISE(ABORT, 'Game Presentation evidence anchors are immutable.'); END;
+`;
+
 export const FOUNDATION_MIGRATIONS: readonly FoundationMigration[] = Object.freeze([
   createMigration({
     id: "001-foundation-event-game-record-roots",
@@ -2039,6 +2108,12 @@ export const FOUNDATION_MIGRATIONS: readonly FoundationMigration[] = Object.free
     ordinal: 26,
     schemaVersion: 26,
     sql: FOUNDATION_EVENT_SCHEDULE_EXPECTED_DELAYS_MIGRATION_SQL,
+  }),
+  createMigration({
+    id: "027-event-game-presentation-integrity",
+    ordinal: 27,
+    schemaVersion: 27,
+    sql: FOUNDATION_PRESENTATION_INTEGRITY_MIGRATION_SQL,
   }),
 ]);
 

--- a/src/lib/foundation-recovery-sqlite.ts
+++ b/src/lib/foundation-recovery-sqlite.ts
@@ -22,6 +22,9 @@ const INCLUDED_RELATIONS = Object.freeze([
   "foundation_event_catalog_gameplay_slots",
   "foundation_event_catalog_pitch_slots",
   "foundation_event_catalog_games",
+  "foundation_event_game_presentation_changes",
+  "foundation_event_game_presentation_audit",
+  "foundation_event_game_presentation_integrity",
   "foundation_event_game_record_actions",
   "foundation_event_game_record_audit",
   "foundation_event_game_record_idempotency",
@@ -215,6 +218,12 @@ export function readRepresentedKeyVersions(database: Database): RepresentedKeyVe
   if (relations.has("foundation_replay_receipts")) {
     for (const row of database
       .query("SELECT receipt_key_version AS value FROM foundation_replay_receipts")
+      .all() as Array<{ value: unknown }>)
+      add(audit, row.value);
+  }
+  if (relations.has("foundation_event_game_presentation_integrity")) {
+    for (const row of database
+      .query("SELECT key_version AS value FROM foundation_event_game_presentation_integrity")
       .all() as Array<{ value: unknown }>)
       add(audit, row.value);
   }

--- a/src/lib/foundation-schema.ts
+++ b/src/lib/foundation-schema.ts
@@ -1294,7 +1294,21 @@ export type FoundationSchemaVerification =
     };
 
 export function hasExpectedFoundationSchema(database: Database): boolean {
-  return foundationSchemaFingerprint(database) === FOUNDATION_SCHEMA_FINGERPRINT;
+  if (foundationSchemaFingerprint(database) === FOUNDATION_SCHEMA_FINGERPRINT) return true;
+  const actual = readSchemaManifest(database);
+  const extensionPrefix = "foundation_event_game_presentation_";
+  const withoutPresentation = {
+    ...actual,
+    objects: actual.objects.filter((entry) => !entry.name.startsWith(extensionPrefix)),
+    tables: actual.tables.filter((entry) => !entry.name.startsWith(extensionPrefix)),
+    indexes: actual.indexes.filter((entry) => !entry.name.startsWith(extensionPrefix)),
+  };
+  const hasPresentationObjects = actual.objects.some(
+    (entry) => entry.name === "foundation_event_game_presentation_changes",
+  );
+  return (
+    hasPresentationObjects && fingerprint(withoutPresentation) === FOUNDATION_SCHEMA_FINGERPRINT
+  );
 }
 
 function hasComposedAcceptanceSchema(database: Database): boolean {

--- a/src/lib/foundation-storage-memory.ts
+++ b/src/lib/foundation-storage-memory.ts
@@ -79,6 +79,16 @@ import {
   type GrantStateValidationContext,
 } from "@/lib/grant-state-validation";
 import { bindGrantAuditChain } from "@/lib/grant-audit-chain";
+import {
+  presentationEvidenceFailure,
+  presentationIntegrityAnchorFor,
+  type PresentationIntegrityAnchor,
+} from "@/lib/presentation-integrity";
+import type {
+  StoredGamePresentationAuditEntry,
+  StoredGamePresentationAuditRevision,
+  StoredGamePresentationChange,
+} from "@/lib/game-presentation";
 
 type MemoryState = {
   roots: Map<string, StoredEventGameRecordRoot>;
@@ -86,6 +96,9 @@ type MemoryState = {
   idempotency: Map<string, Map<string, StoredControlIdempotencyEntry>>;
   metadata: Map<string, StoredEventGameRecordMetadata>;
   controlAudits: Map<string, Map<string, StoredControlAuditEntry>>;
+  presentationChanges: Map<string, Map<string, StoredGamePresentationChange>>;
+  presentationAudits: Map<string, Map<string, StoredGamePresentationAuditEntry>>;
+  presentationIntegrityAnchors: Map<string, PresentationIntegrityAnchor[]>;
   actionProvenance: Map<string, Map<string, "current" | "legacy">>;
   auditProvenance: Map<string, Map<string, "current" | "legacy">>;
   grants: Map<string, StoredGrant>;
@@ -132,6 +145,9 @@ class InMemoryFoundationStorage implements FoundationStorage {
     idempotency: new Map(),
     metadata: new Map(),
     controlAudits: new Map(),
+    presentationChanges: new Map(),
+    presentationAudits: new Map(),
+    presentationIntegrityAnchors: new Map(),
     actionProvenance: new Map(),
     auditProvenance: new Map(),
     grants: new Map(),
@@ -179,6 +195,18 @@ class InMemoryFoundationStorage implements FoundationStorage {
           storage: "memory",
         });
       }
+      const presentationFailure = presentationStorageFailure(
+        this.state,
+        this.grantValidationContext.keyRing,
+      );
+      if (presentationFailure !== null) {
+        throw new FoundationStorageNotReadyError({
+          ok: false,
+          status: "integrity-failure",
+          detail: presentationFailure,
+          storage: "memory",
+        });
+      }
       const grantFailure = this.grantStateFailure();
       if (grantFailure !== null) {
         throw new FoundationStorageNotReadyError({
@@ -198,6 +226,18 @@ class InMemoryFoundationStorage implements FoundationStorage {
         );
         if (isThenable(result)) {
           throw new TypeError("Foundation storage transactions must complete synchronously.");
+        }
+        const presentationFailure = presentationStorageFailure(
+          this.state,
+          this.grantValidationContext.keyRing,
+        );
+        if (presentationFailure !== null) {
+          throw new FoundationStorageNotReadyError({
+            ok: false,
+            status: "integrity-failure",
+            detail: presentationFailure,
+            storage: "memory",
+          });
         }
         const semanticFailure = validateGrantState(
           this.state.grants.values(),
@@ -421,6 +461,18 @@ class InMemoryFoundationStorage implements FoundationStorage {
           ok: false,
           status: "integrity-failure",
           detail: acceptanceFailure,
+          storage: "memory",
+        } satisfies FoundationStorageReadiness;
+      }
+      const presentationFailure = presentationStorageFailure(
+        this.state,
+        this.grantValidationContext.keyRing,
+      );
+      if (presentationFailure !== null) {
+        return {
+          ok: false,
+          status: "integrity-failure",
+          detail: presentationFailure,
           storage: "memory",
         } satisfies FoundationStorageReadiness;
       }
@@ -1007,6 +1059,37 @@ function hasCurrentIntegrityAnchor(
   );
 }
 
+function presentationStorageFailure(
+  state: MemoryState,
+  keyRing: GrantKeyRing | undefined,
+): string | null {
+  const recordIds = new Set([
+    ...state.presentationChanges.keys(),
+    ...state.presentationAudits.keys(),
+    ...state.presentationIntegrityAnchors.keys(),
+  ]);
+  for (const recordId of recordIds) {
+    const changes = [...(state.presentationChanges.get(recordId)?.values() ?? [])];
+    const audits = [...(state.presentationAudits.get(recordId)?.values() ?? [])];
+    const anchors = state.presentationIntegrityAnchors.get(recordId) ?? [];
+    const failure = presentationEvidenceFailure({
+      root: state.roots.get(recordId)?.root ?? null,
+      changes,
+      audits,
+      anchors,
+      sessions: [...state.sessions.values()],
+      actionOperationIds: new Set(
+        [...(state.actions.get(recordId)?.values() ?? [])].map(
+          (action) => action.action.operationId,
+        ),
+      ),
+      keyRing,
+    });
+    if (failure !== null) return failure;
+  }
+  return null;
+}
+
 function createTransaction(
   state: MemoryState,
   undo: (() => void)[],
@@ -1052,6 +1135,27 @@ function createTransaction(
     },
     listAuditEntries(recordId) {
       return cloneAudits(state.controlAudits.get(recordId), state.auditProvenance.get(recordId));
+    },
+    findPresentationChangeByOperationId(recordId, operationId) {
+      const change = state.presentationChanges.get(recordId)?.get(operationId);
+      return change === undefined ? null : structuredClone(change);
+    },
+    listPresentationChanges(recordId) {
+      return [...(state.presentationChanges.get(recordId)?.values() ?? [])]
+        .sort(
+          (left, right) =>
+            left.acceptedAtMs - right.acceptedAtMs ||
+            left.operationId.localeCompare(right.operationId),
+        )
+        .map((change) => structuredClone(change));
+    },
+    listPresentationAuditEntries(recordId) {
+      return [...(state.presentationAudits.get(recordId)?.values() ?? [])]
+        .sort(
+          (left, right) =>
+            left.createdAtMs - right.createdAtMs || left.auditId.localeCompare(right.auditId),
+        )
+        .map((audit) => structuredClone(audit));
     },
     findEvent(eventId) {
       const event = state.events.get(eventId);
@@ -1655,6 +1759,69 @@ function createTransaction(
       provenance.set(entry.auditId, "current");
       undo.push(() => provenance?.delete(entry.auditId));
       undo.push(() => audits?.delete(entry.auditId));
+    },
+    insertPresentationChange(change) {
+      if (!state.roots.has(change.recordId))
+        throw new FoundationStorageConstraintError("record-id");
+      let changes = state.presentationChanges.get(change.recordId);
+      if (changes === undefined) {
+        changes = new Map();
+        state.presentationChanges.set(change.recordId, changes);
+        undo.push(() => state.presentationChanges.delete(change.recordId));
+      }
+      if (changes.has(change.operationId))
+        throw new FoundationStorageConstraintError("operation-id");
+      if (
+        [...changes.values()].some(
+          (candidate) => candidate.presentationChangeId === change.presentationChangeId,
+        )
+      )
+        throw new FoundationStorageConstraintError("presentation-change-id");
+      changes.set(change.operationId, structuredClone(change));
+      undo.push(() => changes?.delete(change.operationId));
+    },
+    appendPresentationAuditEntry(entry) {
+      if (!state.roots.has(entry.recordId)) throw new FoundationStorageConstraintError("record-id");
+      let audits = state.presentationAudits.get(entry.recordId);
+      if (audits === undefined) {
+        audits = new Map();
+        state.presentationAudits.set(entry.recordId, audits);
+        undo.push(() => state.presentationAudits.delete(entry.recordId));
+      }
+      if (audits.has(entry.auditId)) throw new FoundationStorageConstraintError("audit-id");
+      audits.set(entry.auditId, structuredClone(entry));
+      undo.push(() => audits?.delete(entry.auditId));
+    },
+    appendPresentationAuditRevision(entry: StoredGamePresentationAuditRevision) {
+      if (entry.supersedesAuditId === entry.auditId)
+        throw new FoundationStorageConstraintError("audit-id");
+      if (!state.roots.has(entry.recordId)) throw new FoundationStorageConstraintError("record-id");
+      let audits = state.presentationAudits.get(entry.recordId);
+      if (audits === undefined) {
+        audits = new Map();
+        state.presentationAudits.set(entry.recordId, audits);
+        undo.push(() => state.presentationAudits.delete(entry.recordId));
+      }
+      if (audits.has(entry.auditId)) throw new FoundationStorageConstraintError("audit-id");
+      audits.set(entry.auditId, structuredClone(entry));
+      undo.push(() => audits?.delete(entry.auditId));
+    },
+    sealPresentationEvidence(recordId) {
+      if (keyRing === undefined)
+        throw new Error("Presentation evidence key material is unavailable.");
+      const changes = [...(state.presentationChanges.get(recordId)?.values() ?? [])];
+      const audits = [...(state.presentationAudits.get(recordId)?.values() ?? [])];
+      const previous = state.presentationIntegrityAnchors.get(recordId) ?? [];
+      const anchor = presentationIntegrityAnchorFor(
+        { recordId, changes, audits },
+        previous.length + 1,
+        keyRing,
+      );
+      state.presentationIntegrityAnchors.set(recordId, [...previous, anchor]);
+      undo.push(() => {
+        if (previous.length === 0) state.presentationIntegrityAnchors.delete(recordId);
+        else state.presentationIntegrityAnchors.set(recordId, previous);
+      });
     },
     findGrantById(grantId) {
       const grant = state.grants.get(grantId);

--- a/src/lib/foundation-storage-sqlite.test.ts
+++ b/src/lib/foundation-storage-sqlite.test.ts
@@ -546,7 +546,7 @@ describe("SQLite foundation storage", () => {
       expect(await reopenedRecord.registerRoot(root)).toMatchObject({ status: "idempotent" });
       expect(await reopened.readiness()).toMatchObject({
         ok: true,
-        schemaVersion: "26",
+        schemaVersion: "27",
         evidence: { replay: { result: "passed", rootCount: 1, durationMs: expect.any(Number) } },
       });
       reopened.close();
@@ -594,12 +594,12 @@ describe("SQLite foundation storage", () => {
       const storage = openSqliteFoundationStorage(databasePath);
       const candidate = await storage.validateCandidate();
       expect(candidate.ready).toBe(true);
-      expect(candidate.readiness).toMatchObject({ ok: true, schemaVersion: "26" });
+      expect(candidate.readiness).toMatchObject({ ok: true, schemaVersion: "27" });
       expect(existsSync(candidate.candidatePath)).toBe(false);
       expect(await storage.readiness()).toMatchObject({ ok: false, status: "pending" });
 
       const migration = await storage.applyMigrations({ requireCandidate: true });
-      expect(migration.schemaVersion).toBe(26);
+      expect(migration.schemaVersion).toBe(27);
       expect(await storage.readiness()).toMatchObject({ ok: true });
       storage.close();
     });
@@ -692,8 +692,9 @@ describe("SQLite foundation storage", () => {
         "024-event-schedule-slots-and-games",
         "025-event-publication-status",
         "026-event-schedule-expected-delays-and-conflicts",
+        "027-event-game-presentation-integrity",
       ]);
-      expect(await current.readiness()).toMatchObject({ ok: true, schemaVersion: "26" });
+      expect(await current.readiness()).toMatchObject({ ok: true, schemaVersion: "27" });
       current.close();
     });
   });
@@ -724,7 +725,7 @@ describe("SQLite foundation storage", () => {
       });
       expect(await priorBinary.readiness()).toMatchObject({
         ok: true,
-        schemaVersion: "26",
+        schemaVersion: "27",
       });
       priorBinary.close();
 
@@ -796,7 +797,7 @@ describe("SQLite foundation storage", () => {
         .query(
           "INSERT INTO foundation_migration_ledger (migration_id, ordinal, schema_version, checksum, status, applied_at_ms) VALUES (?, ?, ?, ?, ?, ?)",
         )
-        .run("future-999", 27, 27, "future-checksum", "complete", 2_000);
+        .run("future-999", 28, 28, "future-checksum", "complete", 2_000);
       futureDatabase.close();
       const future = openSqliteFoundationStorage(databasePath);
       expect(await future.readiness()).toMatchObject({ ok: false });

--- a/src/lib/foundation-storage-sqlite.ts
+++ b/src/lib/foundation-storage-sqlite.ts
@@ -44,6 +44,16 @@ import {
 } from "@/lib/event-game-actions";
 import { validateIdempotencyHistory } from "@/lib/event-game-record-helpers";
 import {
+  presentationEvidenceFailure,
+  presentationIntegrityAnchorFor,
+  type PresentationIntegrityAnchor,
+} from "@/lib/presentation-integrity";
+import type {
+  StoredGamePresentationAuditEntry,
+  StoredGamePresentationAuditRevision,
+  StoredGamePresentationChange,
+} from "@/lib/game-presentation";
+import {
   assessMigrationReadiness,
   FOUNDATION_MIGRATION_LEDGER_SQL,
   FOUNDATION_MIGRATIONS,
@@ -198,6 +208,36 @@ function readBudget(value: unknown): StoredAcceptanceBudget | null {
     updatedAtMs: Number(row.updated_at_ms),
     stateRevision: Number(row.state_revision),
   };
+}
+
+function readPresentationChange(value: unknown): StoredGamePresentationChange {
+  const row = value as Record<string, unknown>;
+  return {
+    recordId: String(row.record_id),
+    eventGameId: String(row.event_game_id),
+    operationId: String(row.operation_id),
+    presentationChangeId: String(row.presentation_change_id),
+    change: JSON.parse(String(row.change_json)) as StoredGamePresentationChange["change"],
+    causalPredecessorIds: JSON.parse(String(row.causal_predecessor_ids_json)) as string[],
+    occurrence: JSON.parse(
+      String(row.occurrence_json),
+    ) as StoredGamePresentationChange["occurrence"],
+    grant: JSON.parse(String(row.grant_json)) as StoredGamePresentationChange["grant"],
+    acceptedAtMs: Number(row.accepted_at_ms),
+    canonicalContent: String(row.canonical_content),
+    contentFingerprint: String(row.content_fingerprint),
+  };
+}
+
+function readPresentationAudit(value: unknown): StoredGamePresentationAuditEntry {
+  const row = value as Record<string, unknown>;
+  const audit = JSON.parse(String(row.audit_json)) as StoredGamePresentationAuditEntry;
+  if (row.supersedes_audit_id === null || row.supersedes_audit_id === undefined) {
+    delete audit.supersedesAuditId;
+  } else {
+    audit.supersedesAuditId = readText(row.supersedes_audit_id);
+  }
+  return audit;
 }
 
 function readReservation(value: unknown): StoredReplayReservation | null {
@@ -418,6 +458,13 @@ type RootStatements = {
   auditByRecordId: SqlStatement;
   idempotencyByRecordId: SqlStatement;
   insertAudit: SqlStatement;
+  presentationChangeByOperationId: SqlStatement;
+  presentationChangesByRecordId: SqlStatement;
+  insertPresentationChange: SqlStatement;
+  presentationAuditsByRecordId: SqlStatement;
+  insertPresentationAudit: SqlStatement;
+  presentationIntegrityByRecordId: SqlStatement;
+  insertPresentationIntegrity: SqlStatement;
   insertEvidenceProvenance: SqlStatement;
   budgetById: SqlStatement;
   upsertBudget: SqlStatement;
@@ -678,6 +725,15 @@ export class SqliteFoundationStorage implements FoundationStorage {
         const result = work(this.createTransaction());
         if (isThenable(result)) {
           throw new TypeError("Foundation storage transactions must complete synchronously.");
+        }
+        const presentationFailure = this.verifyPresentationEvidence();
+        if (presentationFailure !== null) {
+          throw new FoundationStorageNotReadyError({
+            ok: false,
+            status: "integrity-failure",
+            detail: presentationFailure,
+            storage: "sqlite",
+          });
         }
         scanGrantState(this.database, this.grantValidationContext);
         const keyRing = this.grantValidationContext.keyRing;
@@ -1159,6 +1215,14 @@ export class SqliteFoundationStorage implements FoundationStorage {
       },
       listAuditEntries: (recordId) =>
         this.readAuditByRecordId(statements.auditByRecordId, recordId),
+      findPresentationChangeByOperationId: (recordId, operationId) => {
+        const row = statements.presentationChangeByOperationId.get(recordId, operationId);
+        return row === null ? null : readPresentationChange(row);
+      },
+      listPresentationChanges: (recordId) =>
+        statements.presentationChangesByRecordId.all(recordId).map(readPresentationChange),
+      listPresentationAuditEntries: (recordId) =>
+        statements.presentationAuditsByRecordId.all(recordId).map(readPresentationAudit),
       findEvent: (eventId) => readEvent(statements.eventById.get(eventId)),
       listEvents: () =>
         statements.allEvents
@@ -1206,6 +1270,11 @@ export class SqliteFoundationStorage implements FoundationStorage {
       insertAction: (storedAction) => this.insertAction(statements, storedAction),
       upsertRecordMetadata: (metadata) => this.upsertRecordMetadata(statements, metadata),
       appendAuditEntry: (entry) => this.appendAuditEntry(statements, entry),
+      insertPresentationChange: (change) => this.insertPresentationChange(statements, change),
+      appendPresentationAuditEntry: (entry) => this.appendPresentationAuditEntry(statements, entry),
+      appendPresentationAuditRevision: (entry) =>
+        this.appendPresentationAuditRevision(statements, entry),
+      sealPresentationEvidence: (recordId) => this.sealPresentationEvidence(statements, recordId),
       findGrantById: (grantId) =>
         readGrantByStatement(this.getGrantStatements().byGrantId, grantId),
       listGrants: () => listGrants(this.getGrantStatements().allGrants),
@@ -1707,6 +1776,78 @@ export class SqliteFoundationStorage implements FoundationStorage {
     statements.insertEvidenceProvenance.run("audit", entry.auditId);
   }
 
+  private insertPresentationChange(
+    statements: RootStatements,
+    change: StoredGamePresentationChange,
+  ): void {
+    statements.insertPresentationChange.run(
+      change.recordId,
+      change.eventGameId,
+      change.operationId,
+      change.presentationChangeId,
+      JSON.stringify(change.change),
+      JSON.stringify(change.causalPredecessorIds),
+      JSON.stringify(change.occurrence),
+      JSON.stringify(change.grant),
+      change.acceptedAtMs,
+      change.canonicalContent,
+      change.contentFingerprint,
+    );
+  }
+
+  private appendPresentationAuditEntry(
+    statements: RootStatements,
+    entry: StoredGamePresentationAuditEntry,
+  ): void {
+    statements.insertPresentationAudit.run(
+      entry.auditId,
+      entry.recordId,
+      entry.eventGameId,
+      entry.operationId,
+      entry.presentationChangeId,
+      entry.kind,
+      entry.outcome,
+      entry.createdAtMs,
+      entry.redactedDetail,
+      entry.change === null ? null : JSON.stringify(entry.change),
+      entry.grant === null ? null : JSON.stringify(entry.grant),
+      entry.supersedesAuditId ?? null,
+      JSON.stringify(entry),
+    );
+  }
+
+  private appendPresentationAuditRevision(
+    statements: RootStatements,
+    entry: StoredGamePresentationAuditRevision,
+  ): void {
+    this.appendPresentationAuditEntry(statements, entry);
+  }
+
+  private sealPresentationEvidence(statements: RootStatements, recordId: string): void {
+    const keyRing = this.grantValidationContext.keyRing;
+    if (keyRing === undefined)
+      throw new Error("Presentation evidence key material is unavailable.");
+    const changes = statements.presentationChangesByRecordId
+      .all(recordId)
+      .map(readPresentationChange);
+    const audits = statements.presentationAuditsByRecordId.all(recordId).map(readPresentationAudit);
+    const anchors = statements.presentationIntegrityByRecordId.all(recordId) as Array<
+      Record<string, unknown>
+    >;
+    const anchor = presentationIntegrityAnchorFor(
+      { recordId, changes, audits },
+      anchors.length + 1,
+      keyRing,
+    );
+    statements.insertPresentationIntegrity.run(
+      anchor.recordId,
+      anchor.stateRevision,
+      anchor.keyVersion,
+      anchor.canonicalValue,
+      anchor.integrityTag,
+    );
+  }
+
   private readRootByStatement(
     statement: SqlStatement,
     ...parameters: string[]
@@ -1857,6 +1998,49 @@ export class SqliteFoundationStorage implements FoundationStorage {
                created_at_ms, redacted_detail, audit_json, audit_version,
                audit_evidence_format
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `),
+      presentationChangeByOperationId: this.database.query(`
+        SELECT record_id, event_game_id, operation_id, presentation_change_id,
+               change_json, causal_predecessor_ids_json, occurrence_json, grant_json,
+               accepted_at_ms, canonical_content, content_fingerprint
+        FROM foundation_event_game_presentation_changes
+        WHERE record_id = ? AND operation_id = ?
+      `),
+      presentationChangesByRecordId: this.database.query(`
+        SELECT record_id, event_game_id, operation_id, presentation_change_id,
+               change_json, causal_predecessor_ids_json, occurrence_json, grant_json,
+               accepted_at_ms, canonical_content, content_fingerprint
+        FROM foundation_event_game_presentation_changes
+        WHERE record_id = ? ORDER BY rowid
+      `),
+      insertPresentationChange: this.database.query(`
+        INSERT INTO foundation_event_game_presentation_changes (
+          record_id, event_game_id, operation_id, presentation_change_id, change_json,
+          causal_predecessor_ids_json, occurrence_json, grant_json, accepted_at_ms,
+          canonical_content, content_fingerprint
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `),
+      presentationAuditsByRecordId: this.database.query(`
+        SELECT audit_json, supersedes_audit_id
+        FROM foundation_event_game_presentation_audit
+        WHERE record_id = ? ORDER BY rowid
+      `),
+      insertPresentationAudit: this.database.query(`
+        INSERT INTO foundation_event_game_presentation_audit (
+          audit_id, record_id, event_game_id, operation_id, presentation_change_id,
+          audit_kind, outcome, created_at_ms, redacted_detail, change_json, grant_json,
+          supersedes_audit_id, audit_json
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `),
+      presentationIntegrityByRecordId: this.database.query(`
+        SELECT record_id, state_revision, key_version, canonical_value, integrity_tag
+        FROM foundation_event_game_presentation_integrity
+        WHERE record_id = ? ORDER BY state_revision
+      `),
+      insertPresentationIntegrity: this.database.query(`
+        INSERT INTO foundation_event_game_presentation_integrity
+          (record_id, state_revision, key_version, canonical_value, integrity_tag)
+        VALUES (?, ?, ?, ?, ?)
       `),
       insertEvidenceProvenance: this.database.query(`
         INSERT INTO foundation_control_evidence_provenance
@@ -2279,6 +2463,16 @@ export class SqliteFoundationStorage implements FoundationStorage {
       if (!schemaVerification.ok) {
         return { ...schemaVerification, storage: "sqlite", evidence };
       }
+      const presentationFailure = this.verifyPresentationEvidence();
+      if (presentationFailure !== null) {
+        return {
+          ok: false,
+          status: "integrity-failure",
+          detail: presentationFailure,
+          storage: "sqlite",
+          evidence,
+        };
+      }
       const idempotencyFailure = this.verifyIdempotencyParity();
       if (idempotencyFailure !== null) {
         return {
@@ -2668,6 +2862,54 @@ export class SqliteFoundationStorage implements FoundationStorage {
       .query("SELECT 1 AS present FROM sqlite_master WHERE type = 'table' AND name = ?")
       .get(name) as RootRow | null;
     return row !== null;
+  }
+
+  private verifyPresentationEvidence(): string | null {
+    if (
+      !this.tableExists("foundation_event_game_presentation_changes") ||
+      !this.tableExists("foundation_event_game_presentation_audit") ||
+      !this.tableExists("foundation_event_game_presentation_integrity")
+    )
+      return null;
+    const recordIds = new Set<string>();
+    for (const row of this.database
+      .query(
+        "SELECT DISTINCT record_id FROM foundation_event_game_presentation_changes UNION SELECT DISTINCT record_id FROM foundation_event_game_presentation_audit UNION SELECT DISTINCT record_id FROM foundation_event_game_presentation_integrity",
+      )
+      .all() as Array<Record<string, unknown>>) {
+      recordIds.add(String(row.record_id));
+    }
+    if (recordIds.size === 0) return null;
+    const transaction = this.createTransaction();
+    const sessions = listGrants(this.getGrantStatements().allGrants).flatMap((grant) =>
+      listGrantSessions(this.getGrantStatements().sessionsByGrant, grant.grantId),
+    );
+    for (const recordId of recordIds) {
+      const failure = presentationEvidenceFailure({
+        root: transaction.findRootByRecordId(recordId),
+        changes: transaction.listPresentationChanges?.(recordId) ?? [],
+        audits: transaction.listPresentationAuditEntries?.(recordId) ?? [],
+        anchors: (
+          this.getStatements().presentationIntegrityByRecordId.all(recordId) as unknown[]
+        ).map((row) => {
+          const value = row as Record<string, unknown>;
+          return {
+            recordId: String(value.record_id),
+            stateRevision: Number(value.state_revision),
+            keyVersion: String(value.key_version),
+            canonicalValue: String(value.canonical_value),
+            integrityTag: String(value.integrity_tag),
+          } satisfies PresentationIntegrityAnchor;
+        }),
+        sessions,
+        actionOperationIds: new Set(
+          transaction.listActions(recordId).map((action) => action.action.operationId),
+        ),
+        keyRing: this.grantValidationContext.keyRing,
+      });
+      if (failure !== null) return failure;
+    }
+    return null;
   }
 
   private verifyIdempotencyParity(): string | null {

--- a/src/lib/foundation-storage.ts
+++ b/src/lib/foundation-storage.ts
@@ -16,6 +16,11 @@ import type {
   StoredGrantSession,
 } from "@/lib/grant-types";
 import type { GrantStateValidationContext } from "@/lib/grant-state-validation";
+import type {
+  StoredGamePresentationAuditEntry,
+  StoredGamePresentationAuditRevision,
+  StoredGamePresentationChange,
+} from "@/lib/game-presentation";
 
 export type StoredEventGameRecordRoot = {
   root: EventGameRecordRoot;
@@ -389,6 +394,12 @@ export type FoundationStorageSnapshot = {
   listIdempotencyEntries(recordId: string): StoredControlIdempotencyEntry[];
   readRecordMetadata(recordId: string): StoredEventGameRecordMetadata | null;
   listAuditEntries(recordId: string): StoredControlAuditEntry[];
+  findPresentationChangeByOperationId?(
+    recordId: string,
+    operationId: string,
+  ): StoredGamePresentationChange | null;
+  listPresentationChanges?(recordId: string): StoredGamePresentationChange[];
+  listPresentationAuditEntries?(recordId: string): StoredGamePresentationAuditEntry[];
   findGrantById(grantId: string): StoredGrant | null;
   listGrants(): StoredGrant[];
   findGrantByCredentialLookupDigest(lookupDigest: string): StoredGrant | null;
@@ -461,6 +472,10 @@ export type FoundationStorageTransaction = FoundationStorageSnapshot & {
   insertAction(action: StoredControlAction): void;
   upsertRecordMetadata(metadata: StoredEventGameRecordMetadata): void;
   appendAuditEntry(entry: StoredControlAuditEntry): void;
+  insertPresentationChange?(change: StoredGamePresentationChange): void;
+  appendPresentationAuditEntry?(entry: StoredGamePresentationAuditEntry): void;
+  appendPresentationAuditRevision?(entry: StoredGamePresentationAuditRevision): void;
+  sealPresentationEvidence?(recordId: string): void;
   insertGrant(grant: StoredGrant): void;
   updateGrant(grant: StoredGrant): void;
   insertGrantSession(session: StoredGrantSession): void;
@@ -636,6 +651,7 @@ export type FoundationStorageConstraint =
   | "pitch-slot-id"
   | "game-side-id"
   | "operation-id"
+  | "presentation-change-id"
   | "audit-id"
   | "grant-id"
   | "grant-version"

--- a/src/lib/game-presentation.ts
+++ b/src/lib/game-presentation.ts
@@ -1,0 +1,184 @@
+import { canonicalizeJson, sha256 } from "@/lib/event-game-action-json";
+
+export type PitchOrientation = "side-a-left" | "side-b-left";
+
+export type GamePresentation = {
+  readonly gameSideIds: readonly string[];
+  readonly pitchOrientation: PitchOrientation;
+  readonly displayedTeamColors: Readonly<Record<string, string>>;
+};
+
+export type GamePresentationChange =
+  | { type: "pitch-orientation"; pitchOrientation: PitchOrientation }
+  | { type: "displayed-team-color"; gameSideId: string; color: string };
+
+export type GamePresentationOccurrence = {
+  trustedAtMs: number;
+  clientOriginAtMs: number | null;
+  source: "online" | "offline";
+};
+
+export type GamePresentationGrantProvenance = {
+  sessionId: string;
+  versionId: string;
+};
+
+export type StoredGamePresentationChange = {
+  recordId: string;
+  eventGameId: string;
+  operationId: string;
+  presentationChangeId: string;
+  change: GamePresentationChange;
+  causalPredecessorIds: readonly string[];
+  occurrence: GamePresentationOccurrence;
+  grant: GamePresentationGrantProvenance;
+  acceptedAtMs: number;
+  canonicalContent: string;
+  contentFingerprint: string;
+};
+
+export type GamePresentationAuditKind =
+  | "presentation-accepted"
+  | "presentation-duplicate"
+  | "presentation-conflict"
+  | "presentation-rejected";
+
+export type StoredGamePresentationAuditEntry = {
+  auditVersion: "control-audit-v1";
+  auditId: string;
+  recordId: string;
+  eventGameId: string;
+  operationId: string | null;
+  presentationChangeId: string | null;
+  kind: GamePresentationAuditKind;
+  classification: "game-presentation-change";
+  outcome: "accepted" | "duplicate-accepted" | "rejected";
+  createdAtMs: number;
+  redactedDetail: string;
+  previousPresentation: GamePresentation | null;
+  resultingPresentation: GamePresentation | null;
+  change: GamePresentationChange | null;
+  grant: GamePresentationGrantProvenance | null;
+  /** Append-only revision linkage for repaired canonical snapshots. */
+  supersedesAuditId?: string;
+};
+
+export type StoredGamePresentationAuditRevision = StoredGamePresentationAuditEntry & {
+  supersedesAuditId: string;
+};
+
+export function canonicalizeGamePresentationChange(
+  input: Pick<
+    StoredGamePresentationChange,
+    | "recordId"
+    | "eventGameId"
+    | "operationId"
+    | "presentationChangeId"
+    | "change"
+    | "causalPredecessorIds"
+    | "occurrence"
+    | "grant"
+  >,
+): string {
+  return canonicalizeJson({
+    recordId: input.recordId,
+    eventGameId: input.eventGameId,
+    operationId: input.operationId,
+    presentationChangeId: input.presentationChangeId,
+    change: input.change,
+    causalPredecessorIds: [...input.causalPredecessorIds].sort(),
+    occurrence: {
+      clientOriginAtMs: input.occurrence.clientOriginAtMs,
+      source: input.occurrence.source,
+    },
+    grant: input.grant,
+  });
+}
+
+export function fingerprintGamePresentationChange(
+  input: Pick<
+    StoredGamePresentationChange,
+    | "recordId"
+    | "eventGameId"
+    | "operationId"
+    | "presentationChangeId"
+    | "change"
+    | "causalPredecessorIds"
+    | "occurrence"
+    | "grant"
+  >,
+): string {
+  return sha256(canonicalizeGamePresentationChange(input));
+}
+
+export function isValidHexColor(value: unknown): value is string {
+  return typeof value === "string" && /^#?[0-9a-fA-F]{6}$/.test(value.trim());
+}
+
+export function applyGamePresentationChange(
+  presentation: GamePresentation,
+  change: GamePresentationChange,
+): GamePresentation {
+  if (change.type === "pitch-orientation") {
+    return { ...presentation, pitchOrientation: change.pitchOrientation };
+  }
+  return {
+    ...presentation,
+    displayedTeamColors: {
+      ...presentation.displayedTeamColors,
+      [change.gameSideId]: change.color,
+    },
+  };
+}
+
+export function orderGamePresentationChanges(
+  changes: readonly StoredGamePresentationChange[],
+): StoredGamePresentationChange[] {
+  const byOperationId = new Map(changes.map((change) => [change.operationId, change] as const));
+  if (byOperationId.size !== changes.length) {
+    throw new Error("Game Presentation Change operation identities must be unique.");
+  }
+  const dependants = new Map<string, StoredGamePresentationChange[]>();
+  const indegree = new Map<string, number>(
+    changes.map((change) => [change.operationId, 0] as const),
+  );
+  for (const change of changes) {
+    for (const predecessorId of new Set(change.causalPredecessorIds)) {
+      if (!byOperationId.has(predecessorId)) continue;
+      indegree.set(change.operationId, (indegree.get(change.operationId) ?? 0) + 1);
+      const current = dependants.get(predecessorId) ?? [];
+      current.push(change);
+      dependants.set(predecessorId, current);
+    }
+  }
+  const ready = changes
+    .filter((change) => indegree.get(change.operationId) === 0)
+    .sort(compareGamePresentationChanges);
+  const ordered: StoredGamePresentationChange[] = [];
+  while (ready.length > 0) {
+    const next = ready.shift()!;
+    ordered.push(next);
+    for (const dependant of dependants.get(next.operationId) ?? []) {
+      const remaining = (indegree.get(dependant.operationId) ?? 0) - 1;
+      indegree.set(dependant.operationId, remaining);
+      if (remaining === 0) {
+        ready.push(dependant);
+        ready.sort(compareGamePresentationChanges);
+      }
+    }
+  }
+  if (ordered.length !== changes.length) {
+    throw new Error("Game Presentation Change causal history contains a cycle.");
+  }
+  return ordered;
+}
+
+export function compareGamePresentationChanges(
+  left: StoredGamePresentationChange,
+  right: StoredGamePresentationChange,
+): number {
+  return (
+    left.occurrence.trustedAtMs - right.occurrence.trustedAtMs ||
+    (left.operationId < right.operationId ? -1 : left.operationId > right.operationId ? 1 : 0)
+  );
+}

--- a/src/lib/grant-authority-contract.ts
+++ b/src/lib/grant-authority-contract.ts
@@ -611,6 +611,7 @@ export function registerGrantAuthorityContract(
         grantId: created.grantId,
         grantVersion: created.grantVersion,
         grantSessionId: admitted.grantSessionId,
+        replayProvenanceProof: admitted.replayProvenanceProof,
         previousEventGameId: "game-1",
         eventGameId: "game-2",
       });
@@ -846,6 +847,7 @@ export function registerGrantAuthorityContract(
           await authority.authorizeControlGrantReplay({
             sessionBearer: replacement.sessionBearer,
             originatingSessionId: replacement.grantSessionId,
+            originatingSessionProof: replacement.replayProvenanceProof,
             eventGameId: "game-1",
             replayEvidenceId,
           }),
@@ -854,6 +856,7 @@ export function registerGrantAuthorityContract(
           await authority.authorizeControlGrantReplay({
             sessionBearer: replacement.sessionBearer,
             originatingSessionId: originating.grantSessionId,
+            originatingSessionProof: originating.replayProvenanceProof,
             eventGameId: "game-1",
             replayEvidenceId,
           }),
@@ -871,6 +874,7 @@ export function registerGrantAuthorityContract(
           await authority.authorizeControlGrantReplay({
             sessionBearer: replacement.sessionBearer,
             originatingSessionId: unrelated.grantSessionId,
+            originatingSessionProof: unrelated.replayProvenanceProof,
             eventGameId: "game-1",
             replayEvidenceId: "unrelated-content",
           }),
@@ -879,6 +883,7 @@ export function registerGrantAuthorityContract(
           await authority.authorizeControlGrantReplay({
             sessionBearer: replacement.sessionBearer,
             originatingSessionId: originating.grantSessionId,
+            originatingSessionProof: originating.replayProvenanceProof,
             eventGameId: "game-1",
             replayEvidenceId,
           }),
@@ -937,6 +942,7 @@ export function registerGrantAuthorityContract(
           await authority.authorizeControlGrantReplay({
             sessionBearer: replacement.sessionBearer,
             originatingSessionId: originating.grantSessionId,
+            originatingSessionProof: originating.replayProvenanceProof,
             eventGameId: "game-1",
             replayEvidenceId,
           }),
@@ -968,6 +974,7 @@ export function registerGrantAuthorityContract(
           await authority.authorizeControlGrantReplay({
             sessionBearer: postRotation.sessionBearer,
             originatingSessionId: originating.grantSessionId,
+            originatingSessionProof: originating.replayProvenanceProof,
             eventGameId: "game-1",
             replayEvidenceId,
           }),
@@ -976,6 +983,7 @@ export function registerGrantAuthorityContract(
           await authority.authorizeControlGrantReplay({
             sessionBearer: postRotation.sessionBearer,
             originatingSessionId: originating.grantSessionId,
+            originatingSessionProof: originating.replayProvenanceProof,
             eventGameId: "game-2",
             replayEvidenceId,
           }),
@@ -996,6 +1004,7 @@ export function registerGrantAuthorityContract(
           await authority.authorizeControlGrantReplay({
             sessionBearer: postRotation.sessionBearer,
             originatingSessionId: otherOrigin.grantSessionId,
+            originatingSessionProof: otherOrigin.replayProvenanceProof,
             eventGameId: "game-1",
             replayEvidenceId,
           }),
@@ -1024,6 +1033,7 @@ export function registerGrantAuthorityContract(
           await authority.authorizeControlGrantReplay({
             sessionBearer: revokedReplacement.sessionBearer,
             originatingSessionId: revokedOrigin.grantSessionId,
+            originatingSessionProof: revokedOrigin.replayProvenanceProof,
             eventGameId: "game-1",
             replayEvidenceId,
           }),
@@ -1035,6 +1045,7 @@ export function registerGrantAuthorityContract(
           await unavailableReplayAuthority.authorizeControlGrantReplay({
             sessionBearer: postRotation.sessionBearer,
             originatingSessionId: originating.grantSessionId,
+            originatingSessionProof: originating.replayProvenanceProof,
             eventGameId: "game-1",
             replayEvidenceId,
           }),

--- a/src/lib/grant-authority-types.ts
+++ b/src/lib/grant-authority-types.ts
@@ -68,6 +68,7 @@ export type AdmitControlGrantResult =
       eventGameId: string;
       grantSessionId: string;
       sessionBearer: string;
+      replayProvenanceProof: string;
     }
   | typeof GENERIC_GRANT_ADMISSION_FAILURE;
 
@@ -86,6 +87,7 @@ export type AuthorizeControlGrantResult =
       scope: ControlGrantScope;
       eventGameId: string;
       grantSessionId: string;
+      replayProvenanceProof: string;
     }
   | typeof GENERIC_GRANT_AUTHORIZATION_FAILURE;
 
@@ -95,6 +97,7 @@ export type ControlGrantSessionSwitchResult =
       grantId: string;
       grantVersion: string;
       grantSessionId: string;
+      replayProvenanceProof: string;
       previousEventGameId: string;
       eventGameId: string;
     }
@@ -107,6 +110,7 @@ export type ControlGrantReplayAuthorizationResult =
       grantVersion: string;
       grantSessionId: string;
       originatingSessionId: string;
+      originatingGrantVersion: string;
       eventGameId: string;
     }
   | typeof GENERIC_GRANT_AUTHORIZATION_FAILURE;
@@ -165,6 +169,7 @@ export type GrantAuthority = {
   authorizeControlGrantReplay(input: {
     sessionBearer: string;
     originatingSessionId: string;
+    originatingSessionProof?: string;
     eventGameId: string;
     replayEvidenceId: string;
   }): Promise<ControlGrantReplayAuthorizationResult>;

--- a/src/lib/grant-authority.focused.ts
+++ b/src/lib/grant-authority.focused.ts
@@ -364,6 +364,7 @@ describe("focused SQLite Grant authority boundary", () => {
         await authority.authorizeControlGrantReplay({
           sessionBearer: replacement.sessionBearer,
           originatingSessionId: replacement.grantSessionId,
+          originatingSessionProof: replacement.replayProvenanceProof,
           eventGameId: "game-1",
           replayEvidenceId: "replay-sqlite",
         }),
@@ -372,6 +373,7 @@ describe("focused SQLite Grant authority boundary", () => {
         await authority.authorizeControlGrantReplay({
           sessionBearer: replacement.sessionBearer,
           originatingSessionId: origin.grantSessionId,
+          originatingSessionProof: origin.replayProvenanceProof,
           eventGameId: "game-1",
           replayEvidenceId: "replay-sqlite",
         }),
@@ -381,6 +383,7 @@ describe("focused SQLite Grant authority boundary", () => {
         await authority.authorizeControlGrantReplay({
           sessionBearer: replacement.sessionBearer,
           originatingSessionId: origin.grantSessionId,
+          originatingSessionProof: origin.replayProvenanceProof,
           eventGameId: "game-1",
           replayEvidenceId: "replay-sqlite",
         }),
@@ -652,6 +655,11 @@ describe("focused SQLite Grant authority boundary", () => {
           "020-grant-codes-and-admission-telemetry",
           "021-grant-code-game-lock-erasure-evidence",
           "022-control-session-stay-binding",
+          "023-event-teams-rosters-and-pitches",
+          "024-event-schedule-slots-and-games",
+          "025-event-publication-status",
+          "026-event-schedule-expected-delays-and-conflicts",
+          "027-event-game-presentation-integrity",
         ]);
         expect(await current.readiness()).toMatchObject({
           ok: true,

--- a/src/lib/grant-management-code.ts
+++ b/src/lib/grant-management-code.ts
@@ -368,6 +368,7 @@ export async function admitGrantCode(
         eventGameId,
         grantSessionId: session.sessionId,
         sessionBearer: bearer,
+        replayProvenanceProof: session.bearerLookupVerifier!,
         sessionExpiresAtMs: sessionExpiresAtMsForGrant(grant, nowMs),
       };
     });

--- a/src/lib/grant-management-sessions.ts
+++ b/src/lib/grant-management-sessions.ts
@@ -2,6 +2,7 @@ import {
   computeBrowserContextDigest,
   computeSessionVerifier,
   createRandomIdentifier,
+  listLookupKeyVersions,
 } from "@/lib/grant-crypto";
 import type { FoundationStorage, FoundationStorageTransaction } from "@/lib/foundation-storage";
 import type { GrantAuthorityOptions } from "@/lib/grant-authority";
@@ -185,6 +186,7 @@ export async function admitGrant(
         eventGameId,
         grantSessionId: session.sessionId,
         sessionBearer: bearer,
+        replayProvenanceProof: session.bearerLookupVerifier!,
         sessionExpiresAtMs: sessionExpiresAtMsForGrant(current, nowMs),
       };
     });
@@ -306,6 +308,7 @@ export function authorizeGrantInTransaction(
           grantType: GRANT_TYPE,
           scope: structuredClone(grant.scope as ControlGrantScope),
           grantSessionId: session.sessionId,
+          replayProvenanceProof: session.bearerLookupVerifier!,
           previousEventGameId: relationship.previousEventGameId,
           currentEventGameId: relationship.currentEventGameId,
         } satisfies TypedGrantAuthorization;
@@ -333,6 +336,7 @@ export function authorizeGrantInTransaction(
     scope: structuredClone(grant.scope),
     eventGameId,
     grantSessionId: session.sessionId,
+    replayProvenanceProof: session.bearerLookupVerifier!,
     sessionExpiresAtMs:
       grant.grantType === EVENT_ADMIN_GRANT_TYPE
         ? Math.min(
@@ -404,6 +408,7 @@ export async function acceptControlGrantSessionSwitch(
         grantId: grant.grantId,
         grantVersion: grant.grantVersion,
         grantSessionId: session.sessionId,
+        replayProvenanceProof: session.bearerLookupVerifier!,
         previousEventGameId: relationship.previousEventGameId,
         eventGameId: relationship.currentEventGameId,
         ...(grant.expiresAtMs === null ? {} : { sessionExpiresAtMs: grant.expiresAtMs }),
@@ -525,12 +530,14 @@ export async function authorizeControlGrantReplay(
   input: {
     sessionBearer: string;
     originatingSessionId: string;
+    originatingSessionProof?: string;
     eventGameId: string;
     replayEvidenceId: string;
   },
 ): Promise<TypedGrantReplayAuthorization> {
   if (
     !isValidGrantSecret(input.sessionBearer) ||
+    !isValidGrantSecret(input.originatingSessionProof ?? "") ||
     !validateOpaqueIdentifier(input.originatingSessionId, "originatingSessionId").ok ||
     !validateOpaqueIdentifier(input.eventGameId, "eventGameId").ok ||
     !validateOpaqueIdentifier(input.replayEvidenceId, "replayEvidenceId").ok
@@ -559,11 +566,15 @@ export async function authorizeControlGrantReplay(
       if (replay === undefined) return GENERIC_GRANT_AUTHORIZATION_FAILURE;
       if (replay.status !== "eligible" || replay.eventGameId !== input.eventGameId)
         return GENERIC_GRANT_AUTHORIZATION_FAILURE;
-      const originating = transaction
-        .listGrantSessions(grant.grantId)
-        .find((candidate) => candidate.sessionId === input.originatingSessionId);
+      const originating = listLookupKeyVersions(options.keyRing).reduce<StoredGrantSession | null>(
+        (found, keyVersion) =>
+          found ??
+          transaction.findSessionByBearerVerifier(input.originatingSessionProof ?? "", keyVersion),
+        null,
+      );
       if (
-        originating === undefined ||
+        originating === null ||
+        originating.sessionId !== input.originatingSessionId ||
         originating.sessionId === replacement.sessionId ||
         originating.status === "active" ||
         originating.grantId !== grant.grantId ||
@@ -615,6 +626,7 @@ export async function authorizeControlGrantReplay(
         grantVersion: grant.grantVersion,
         grantSessionId: replacement.sessionId,
         originatingSessionId: originating.sessionId,
+        originatingGrantVersion: originating.grantVersion,
         eventGameId: input.eventGameId,
         replayEvidenceId: input.replayEvidenceId,
       } satisfies TypedGrantReplayAuthorization;

--- a/src/lib/grant-management-types.ts
+++ b/src/lib/grant-management-types.ts
@@ -47,6 +47,7 @@ export type TypedGrantAdmission =
       eventGameId: string | null;
       grantSessionId: string;
       sessionBearer: string;
+      replayProvenanceProof: string;
       sessionExpiresAtMs?: number | null;
     }
   | typeof GENERIC_GRANT_ADMISSION_FAILURE;
@@ -89,6 +90,7 @@ export type TypedGrantAuthorization =
       scope: GrantScope;
       eventGameId: string | null;
       grantSessionId: string;
+      replayProvenanceProof: string;
       sessionExpiresAtMs?: number | null;
     }
   | {
@@ -98,6 +100,7 @@ export type TypedGrantAuthorization =
       grantType: "control";
       scope: ControlGrantScope;
       grantSessionId: string;
+      replayProvenanceProof: string;
       previousEventGameId: string;
       currentEventGameId: string;
     }
@@ -109,6 +112,7 @@ export type TypedControlGrantSwitch =
       grantId: string;
       grantVersion: string;
       grantSessionId: string;
+      replayProvenanceProof: string;
       previousEventGameId: string;
       eventGameId: string;
       sessionExpiresAtMs?: number | null;
@@ -122,6 +126,7 @@ export type TypedGrantReplayAuthorization =
       grantVersion: string;
       grantSessionId: string;
       originatingSessionId: string;
+      originatingGrantVersion: string;
       eventGameId: string;
       replayEvidenceId: string;
     }
@@ -255,6 +260,7 @@ export type TypedGrantAuthority = {
   authorizeControlGrantReplay(input: {
     sessionBearer: string;
     originatingSessionId: string;
+    originatingSessionProof?: string;
     eventGameId: string;
     replayEvidenceId: string;
   }): Promise<TypedGrantReplayAuthorization>;

--- a/src/lib/presentation-integrity.test.ts
+++ b/src/lib/presentation-integrity.test.ts
@@ -1,0 +1,606 @@
+import { describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { canonicalizeJson } from "@/lib/event-game-action-json";
+import { createDeterministicTestIqaInterpreter } from "@/lib/event-game-actions";
+import { createEventGameRecord } from "@/lib/event-game-record";
+import { createInMemoryFoundationStorage } from "@/lib/foundation-storage-memory";
+import { createGrantTestKeyRing, createGrantTestRandomness } from "@/lib/grant-authority-contract";
+import {
+  createGrantTestAuthorityVerifier,
+  createLegacyControlGrantTestAuthority,
+} from "@/lib/grant-authority-test-support";
+import { openSqliteFoundationStorage } from "@/lib/foundation-storage-sqlite";
+import type { FoundationStorage } from "@/lib/foundation-storage";
+import type { GrantAuthorityOptions } from "@/lib/grant-authority";
+import {
+  applyGamePresentationChange,
+  canonicalizeGamePresentationChange,
+  fingerprintGamePresentationChange,
+  type GamePresentation,
+  type StoredGamePresentationAuditEntry,
+  type StoredGamePresentationChange,
+} from "@/lib/game-presentation";
+import {
+  presentationEvidenceFailure,
+  presentationIntegrityAnchorFor,
+} from "@/lib/presentation-integrity";
+import type { EventGameRecordRoot } from "@/lib/foundation-record-types";
+import type { GrantKeyRing, StoredGrantSession } from "@/lib/grant-types";
+
+const root: EventGameRecordRoot = {
+  recordId: "record-1",
+  eventId: "event-1",
+  eventGameId: "game-1",
+  ownership: { eventId: "event-1", eventGameId: "game-1" },
+  externalScope: {
+    eventId: "event-1",
+    gameDayId: "day-1",
+    pitchId: "pitch-1",
+    pitchSlotId: "slot-1",
+  },
+  gameSides: [
+    { id: "side-a", eventTeamId: "team-a", teamInterpretationRef: "team-a" },
+    { id: "side-b", eventTeamId: "team-b", teamInterpretationRef: "team-b" },
+  ],
+  lifecycle: {
+    phase: "scheduled",
+    commencedAtMs: null,
+    finishedAtMs: null,
+    lockedAtMs: null,
+    lockReason: null,
+  },
+  compatibility: {
+    recordVersion: "record-v1",
+    schemaVersion: "schema-v1",
+    interpreterVersion: "rules-v1",
+  },
+  creationEvidence: {
+    operationId: "register-1",
+    actorReference: "test",
+    source: "event-game-registration",
+    createdAtMs: 1,
+  },
+};
+
+const keyRing: GrantKeyRing = {
+  encryption: {
+    currentVersion: "enc-v1",
+    keys: new Map([["enc-v1", new Uint8Array(32).fill(1)]]),
+  },
+  lookup: {
+    currentVersion: "lookup-v1",
+    keys: new Map([["lookup-v1", new Uint8Array(32).fill(2)]]),
+  },
+  audit: {
+    currentVersion: "audit-v1",
+    keys: new Map([["audit-v1", new Uint8Array(32).fill(3)]]),
+  },
+};
+
+const session: StoredGrantSession = {
+  sessionId: "session-1",
+  grantId: "grant-1",
+  grantVersion: "grant-version-1",
+  eventGameId: root.eventGameId,
+  browserContextDigest: "browser-digest",
+  browserContextKeyVersion: "lookup-v1",
+  bearerMaterialState: "present",
+  bearerLookupVerifier: "origin-proof",
+  bearerLookupKeyVersion: "lookup-v1",
+  status: "active",
+  createdAtMs: 1,
+  lastActiveAtMs: 1,
+  revokedAtMs: null,
+};
+
+const initialPresentation: GamePresentation = {
+  gameSideIds: root.gameSides.map((side) => side.id),
+  pitchOrientation: "side-a-left",
+  displayedTeamColors: { "side-a": "#112233", "side-b": "#445566" },
+};
+
+function createEvidence(
+  grant = { sessionId: session.sessionId, versionId: session.grantVersion },
+  evidenceKeyRing = keyRing,
+  causalPredecessorIds = ["control-op-1"],
+) {
+  const changeWithoutIntegrity = {
+    recordId: root.recordId,
+    eventGameId: root.eventGameId,
+    operationId: "presentation-op-1",
+    presentationChangeId: "presentation-change-1",
+    change: { type: "pitch-orientation", pitchOrientation: "side-b-left" } as const,
+    causalPredecessorIds,
+    occurrence: { trustedAtMs: 2, clientOriginAtMs: 2, source: "online" as const },
+    grant,
+  };
+  const change: StoredGamePresentationChange = {
+    ...changeWithoutIntegrity,
+    acceptedAtMs: 3,
+    canonicalContent: canonicalizeGamePresentationChange(changeWithoutIntegrity),
+    contentFingerprint: fingerprintGamePresentationChange(changeWithoutIntegrity),
+  };
+  const resultingPresentation = applyGamePresentationChange(initialPresentation, change.change);
+  const audit: StoredGamePresentationAuditEntry = {
+    auditVersion: "control-audit-v1",
+    auditId: "presentation-audit-1",
+    recordId: root.recordId,
+    eventGameId: root.eventGameId,
+    operationId: change.operationId,
+    presentationChangeId: change.presentationChangeId,
+    kind: "presentation-accepted",
+    classification: "game-presentation-change",
+    outcome: "accepted",
+    createdAtMs: 3,
+    redactedDetail: "accepted",
+    previousPresentation: initialPresentation,
+    resultingPresentation,
+    change: change.change,
+    grant: change.grant,
+  };
+  const evidence = { recordId: root.recordId, changes: [change], audits: [audit] };
+  return {
+    change,
+    audit,
+    anchor: presentationIntegrityAnchorFor(evidence, 1, evidenceKeyRing),
+    actionOperationIds: new Set(["control-op-1"]),
+  };
+}
+
+describe("Game Presentation integrity", () => {
+  test("accepts anchored evidence linked to the exact Grant Session and action causal predecessor", () => {
+    const evidence = createEvidence();
+    expect(
+      presentationEvidenceFailure({
+        root,
+        changes: [evidence.change],
+        audits: [evidence.audit],
+        anchors: [evidence.anchor],
+        sessions: [session],
+        actionOperationIds: evidence.actionOperationIds,
+        keyRing,
+      }),
+    ).toBeNull();
+  });
+
+  test("rejects altered snapshots and cross-session Grant provenance", () => {
+    const evidence = createEvidence();
+    const alteredAudit = {
+      ...evidence.audit,
+      resultingPresentation: {
+        ...evidence.audit.resultingPresentation!,
+        pitchOrientation: "side-a-left",
+      } satisfies GamePresentation,
+    };
+    expect(
+      presentationEvidenceFailure({
+        root,
+        changes: [evidence.change],
+        audits: [alteredAudit],
+        anchors: [evidence.anchor],
+        sessions: [session],
+        actionOperationIds: evidence.actionOperationIds,
+        keyRing,
+      }),
+    ).not.toBeNull();
+
+    const crossSession = {
+      ...session,
+      sessionId: "session-2",
+      eventGameId: "other-game",
+    };
+    expect(
+      presentationEvidenceFailure({
+        root,
+        changes: [evidence.change],
+        audits: [evidence.audit],
+        anchors: [evidence.anchor],
+        sessions: [crossSession],
+        actionOperationIds: evidence.actionOperationIds,
+        keyRing,
+      }),
+    ).not.toBeNull();
+  });
+
+  test("anchors the complete immutable evidence set", () => {
+    const evidence = createEvidence();
+    expect(JSON.parse(evidence.anchor.canonicalValue)).toEqual({
+      audits: [evidence.audit],
+      changes: [evidence.change],
+      domain: "game-presentation-evidence-v1",
+      recordId: root.recordId,
+      stateRevision: 1,
+    });
+    expect(canonicalizeJson(JSON.parse(evidence.anchor.canonicalValue))).toBe(
+      evidence.anchor.canonicalValue,
+    );
+  });
+
+  test("rejects impossible audit kind and outcome combinations and causal cycles", () => {
+    const evidence = createEvidence();
+    expect(
+      presentationEvidenceFailure({
+        root,
+        changes: [evidence.change],
+        audits: [{ ...evidence.audit, outcome: "rejected" }],
+        anchors: [evidence.anchor],
+        sessions: [session],
+        actionOperationIds: evidence.actionOperationIds,
+        keyRing,
+      }),
+    ).not.toBeNull();
+
+    const second = {
+      ...evidence.change,
+      operationId: "presentation-op-2",
+      presentationChangeId: "presentation-change-2",
+      causalPredecessorIds: [evidence.change.operationId],
+      occurrence: { ...evidence.change.occurrence, trustedAtMs: 1 },
+    };
+    const first = {
+      ...evidence.change,
+      causalPredecessorIds: [second.operationId],
+    };
+    expect(
+      presentationEvidenceFailure({
+        root,
+        changes: [first, second],
+        audits: [evidence.audit],
+        anchors: [evidence.anchor],
+        sessions: [session],
+        actionOperationIds: evidence.actionOperationIds,
+        keyRing,
+      }),
+    ).not.toBeNull();
+  });
+
+  test.each(["memory", "sqlite"] as const)(
+    "%s validates presentation evidence after work and rolls back malformed transactions",
+    async (kind) => {
+      const harness = await createPresentationStorage(kind);
+      try {
+        const grant = harness.grant;
+        const evidence = createEvidence(
+          { sessionId: grant.grantSessionId, versionId: grant.grantVersion },
+          harness.keyRing,
+          [],
+        );
+        await harness.storage.transaction((transaction) => {
+          transaction.insertPresentationChange!(evidence.change);
+          transaction.appendPresentationAuditEntry!(evidence.audit);
+          transaction.sealPresentationEvidence!(root.recordId);
+        });
+        expect(await harness.storage.readiness()).toMatchObject({ ok: true });
+        expect(
+          await harness.storage.transaction((transaction) =>
+            transaction.listPresentationChanges!(root.recordId),
+          ),
+        ).toHaveLength(1);
+
+        let malformedTransactionRejected = false;
+        try {
+          await harness.storage.transaction((transaction) => {
+            const malformed = createEvidence(
+              {
+                sessionId: grant.grantSessionId,
+                versionId: grant.grantVersion,
+              },
+              harness.keyRing,
+              [],
+            );
+            const malformedChange = {
+              ...malformed.change,
+              operationId: "presentation-op-malformed",
+              presentationChangeId: "presentation-change-malformed",
+            };
+            malformedChange.canonicalContent = canonicalizeGamePresentationChange(malformedChange);
+            malformedChange.contentFingerprint = fingerprintGamePresentationChange(malformedChange);
+            transaction.insertPresentationChange!(malformedChange);
+            transaction.appendPresentationAuditEntry!({
+              ...malformed.audit,
+              auditId: "presentation-audit-malformed",
+              operationId: malformedChange.operationId,
+              presentationChangeId: malformedChange.presentationChangeId,
+              change: malformedChange.change,
+              outcome: "rejected",
+            });
+            const prior = transaction.listPresentationAuditEntries!(root.recordId).find(
+              (audit) => audit.kind === "presentation-accepted",
+            );
+            if (prior === undefined) throw new Error("Expected the prior accepted audit.");
+            transaction.appendPresentationAuditRevision!({
+              ...prior,
+              auditId: "presentation-audit-unsealed-revision",
+              supersedesAuditId: prior.auditId,
+            });
+          });
+        } catch {
+          malformedTransactionRejected = true;
+        }
+        expect(malformedTransactionRejected).toBe(true);
+        expect(
+          await harness.storage.transaction((transaction) =>
+            transaction.listPresentationChanges!(root.recordId),
+          ),
+        ).toHaveLength(1);
+        expect(
+          await harness.storage.transaction((transaction) =>
+            transaction.listPresentationAuditEntries!(root.recordId),
+          ),
+        ).toHaveLength(1);
+        expect(await harness.storage.readiness()).toMatchObject({ ok: true });
+      } finally {
+        await harness.cleanup();
+      }
+    },
+  );
+
+  test("keeps healthy SQLite presentation evidence ready across restart and freezes after raw anchor deletion", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "quadball-timer-presentation-integrity-"));
+    const databasePath = join(directory, "foundation.sqlite");
+    try {
+      const first = await createPresentationStorage("sqlite", databasePath);
+      const grant = first.grant;
+      const evidence = createEvidence(
+        { sessionId: grant.grantSessionId, versionId: grant.grantVersion },
+        first.keyRing,
+        [],
+      );
+      await first.storage.transaction((transaction) => {
+        transaction.insertPresentationChange!(evidence.change);
+        transaction.appendPresentationAuditEntry!(evidence.audit);
+        transaction.sealPresentationEvidence!(root.recordId);
+      });
+      expect(await first.storage.readiness()).toMatchObject({ ok: true });
+      first.storage.close();
+
+      const restarted = openSqliteFoundationStorage(databasePath, {
+        grantKeyRing: first.keyRing,
+        requireReplayContext: false,
+      });
+      expect(await restarted.readiness()).toMatchObject({ ok: true });
+      restarted.close();
+
+      const raw = new Database(databasePath);
+      raw.exec("DROP TRIGGER foundation_event_game_presentation_integrity_no_delete");
+      raw
+        .query("DELETE FROM foundation_event_game_presentation_integrity WHERE record_id = ?")
+        .run(root.recordId);
+      raw.close();
+
+      const frozen = openSqliteFoundationStorage(databasePath, {
+        grantKeyRing: first.keyRing,
+        requireReplayContext: false,
+      });
+      expect(await frozen.readiness()).toMatchObject({
+        ok: false,
+        status: "integrity-failure",
+      });
+      frozen.close();
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  test.each(["memory", "sqlite"] as const)(
+    "%s repairs a same-time z-first/a-later presentation audit with an append-only revision",
+    async (kind) => {
+      const harness = await createPresentationStorage(kind);
+      try {
+        await installSameTimeRepair(harness);
+        expect(await harness.storage.readiness()).toMatchObject({ ok: true });
+        const audits = await harness.storage.transaction((transaction) =>
+          transaction.listPresentationAuditEntries!(root.recordId),
+        );
+        expect(audits).toHaveLength(3);
+        expect(audits.filter((audit) => audit.supersedesAuditId !== undefined)).toHaveLength(1);
+      } finally {
+        await harness.cleanup();
+      }
+    },
+  );
+
+  test("freezes SQLite readiness when a presentation audit revision is deleted", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "quadball-timer-presentation-revision-"));
+    const databasePath = join(directory, "foundation.sqlite");
+    try {
+      const first = await createPresentationStorage("sqlite", databasePath);
+      await installSameTimeRepair(first);
+      expect(await first.storage.readiness()).toMatchObject({ ok: true });
+      first.storage.close();
+      const raw = new Database(databasePath);
+      raw.exec("DROP TRIGGER foundation_event_game_presentation_audit_no_delete");
+      raw
+        .query(
+          "DELETE FROM foundation_event_game_presentation_audit WHERE supersedes_audit_id IS NOT NULL",
+        )
+        .run();
+      raw.close();
+      const frozen = openSqliteFoundationStorage(databasePath, {
+        grantKeyRing: first.keyRing,
+        requireReplayContext: false,
+      });
+      expect(await frozen.readiness()).toMatchObject({
+        ok: false,
+        status: "integrity-failure",
+      });
+      frozen.close();
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("freezes SQLite readiness when a presentation audit revision is altered", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "quadball-timer-presentation-revision-alter-"));
+    const databasePath = join(directory, "foundation.sqlite");
+    try {
+      const first = await createPresentationStorage("sqlite", databasePath);
+      await installSameTimeRepair(first);
+      expect(await first.storage.readiness()).toMatchObject({ ok: true });
+      first.storage.close();
+      const raw = new Database(databasePath);
+      raw.exec("DROP TRIGGER foundation_event_game_presentation_audit_no_update");
+      raw
+        .query(
+          "UPDATE foundation_event_game_presentation_audit SET supersedes_audit_id = NULL WHERE supersedes_audit_id IS NOT NULL",
+        )
+        .run();
+      raw.close();
+      const frozen = openSqliteFoundationStorage(databasePath, {
+        grantKeyRing: first.keyRing,
+        requireReplayContext: false,
+      });
+      expect(await frozen.readiness()).toMatchObject({
+        ok: false,
+        status: "integrity-failure",
+      });
+      frozen.close();
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+});
+
+async function installSameTimeRepair(harness: {
+  storage: FoundationStorage;
+  keyRing: GrantKeyRing;
+  grant: { grantSessionId: string; grantVersion: string };
+}) {
+  const grant = { sessionId: harness.grant.grantSessionId, versionId: harness.grant.grantVersion };
+  const base = createEvidence(grant, harness.keyRing, []);
+  const zChange = {
+    ...base.change,
+    operationId: "z-presentation-operation",
+    presentationChangeId: "z-presentation-change",
+    occurrence: { ...base.change.occurrence, trustedAtMs: 2 },
+  };
+  zChange.canonicalContent = canonicalizeGamePresentationChange(zChange);
+  zChange.contentFingerprint = fingerprintGamePresentationChange(zChange);
+  const zAudit = {
+    ...base.audit,
+    auditId: "z-presentation-audit",
+    operationId: zChange.operationId,
+    presentationChangeId: zChange.presentationChangeId,
+    change: zChange.change,
+  };
+  await harness.storage.transaction((transaction) => {
+    transaction.insertPresentationChange!(zChange);
+    transaction.appendPresentationAuditEntry!(zAudit);
+    transaction.sealPresentationEvidence!(root.recordId);
+  });
+
+  const aChange = {
+    ...zChange,
+    operationId: "a-presentation-operation",
+    presentationChangeId: "a-presentation-change",
+    change: { type: "displayed-team-color", gameSideId: "side-a", color: "#778899" } as const,
+  };
+  aChange.canonicalContent = canonicalizeGamePresentationChange(aChange);
+  aChange.contentFingerprint = fingerprintGamePresentationChange(aChange);
+  const aResult = applyGamePresentationChange(initialPresentation, aChange.change);
+  const aAudit = {
+    ...zAudit,
+    auditId: "a-presentation-audit",
+    operationId: aChange.operationId,
+    presentationChangeId: aChange.presentationChangeId,
+    change: aChange.change,
+    resultingPresentation: aResult,
+  };
+  const repairedZAudit = {
+    ...zAudit,
+    auditId: "z-presentation-audit-revision-1",
+    supersedesAuditId: zAudit.auditId,
+    previousPresentation: aResult,
+    resultingPresentation: applyGamePresentationChange(aResult, zChange.change),
+  };
+  await harness.storage.transaction((transaction) => {
+    transaction.insertPresentationChange!(aChange);
+    transaction.appendPresentationAuditEntry!(aAudit);
+    transaction.appendPresentationAuditRevision!(repairedZAudit);
+    transaction.sealPresentationEvidence!(root.recordId);
+  });
+}
+
+async function createPresentationStorage(
+  kind: "memory" | "sqlite",
+  databasePath?: string,
+): Promise<{
+  storage: FoundationStorage;
+  keyRing: GrantKeyRing;
+  grant: { grantSessionId: string; grantVersion: string };
+  cleanup(): Promise<void>;
+}> {
+  const keyRing = createGrantTestKeyRing();
+  if (kind === "memory") {
+    const storage = createInMemoryFoundationStorage();
+    const cleanup = async () => storage.close();
+    const grant = await preparePresentationStorage(storage, keyRing);
+    return { storage, keyRing, grant, cleanup };
+  }
+  let ownedDirectory: string | undefined;
+  if (databasePath === undefined) {
+    ownedDirectory = await mkdtemp(join(tmpdir(), "quadball-timer-presentation-sqlite-"));
+    databasePath = join(ownedDirectory, "foundation.sqlite");
+  }
+  const storage = openSqliteFoundationStorage(databasePath, { grantKeyRing: keyRing });
+  await storage.applyMigrations();
+  const grant = await preparePresentationStorage(storage, keyRing);
+  return {
+    storage,
+    keyRing,
+    grant,
+    cleanup: async () => {
+      storage.close();
+      if (ownedDirectory !== undefined) await rm(ownedDirectory, { recursive: true, force: true });
+    },
+  };
+}
+
+async function preparePresentationStorage(
+  storage: FoundationStorage,
+  keyRing: GrantKeyRing,
+): Promise<{ grantSessionId: string; grantVersion: string }> {
+  const record = createEventGameRecord(storage, {
+    externalScopeResolver: {
+      resolve(scope) {
+        return JSON.stringify(scope) === JSON.stringify(root.externalScope)
+          ? { status: "resolved", scope: structuredClone(scope) }
+          : { status: "mismatch", detail: "scope mismatch" };
+      },
+      resolveEventTeam() {
+        return { status: "resolved" };
+      },
+    },
+    interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
+  });
+  const authority = createLegacyControlGrantTestAuthority(storage, {
+    environmentId: "presentation-integrity-test",
+    clock: { nowMs: () => 1_000 },
+    randomness: createGrantTestRandomness(7),
+    keyRing,
+    controlScopeResolver: {
+      resolve: () => ({ status: "eligible", eventGameId: root.eventGameId }),
+    },
+    privilegedAuthorityVerifier: createGrantTestAuthorityVerifier(),
+  } satisfies GrantAuthorityOptions);
+  const created = await authority.createControlGrant({
+    scope: root.externalScope,
+    actor: { kind: "fixture", id: "presentation-integrity" },
+  });
+  if (created.status !== "created") throw new Error("Expected a presentation test Grant.");
+  const admitted = await authority.admitControlGrant({
+    qrCredential: created.qrCredential,
+    browserContext: "presentation-integrity-browser",
+  });
+  if (admitted.status !== "admitted") throw new Error("Expected a presentation test Session.");
+  if ((await record.registerRoot(root)).status !== "registered") {
+    throw new Error("Expected a presentation test root.");
+  }
+  return {
+    grantSessionId: admitted.grantSessionId,
+    grantVersion: created.grantVersion,
+  };
+}

--- a/src/lib/presentation-integrity.ts
+++ b/src/lib/presentation-integrity.ts
@@ -1,0 +1,396 @@
+import { canonicalizeJson } from "@/lib/event-game-action-json";
+import { computeAcceptanceIntegrityTag } from "@/lib/grant-crypto";
+import {
+  normalizeBoundedText,
+  validateIntegerInRange,
+  validateOpaqueIdentifier,
+} from "@/lib/validation-policy";
+import type { GrantKeyRing, StoredGrantSession } from "@/lib/grant-types";
+import type { EventGameRecordRoot } from "@/lib/foundation-record-types";
+import {
+  canonicalizeGamePresentationChange,
+  fingerprintGamePresentationChange,
+  isValidHexColor,
+  applyGamePresentationChange,
+  orderGamePresentationChanges,
+  type StoredGamePresentationAuditEntry,
+  type StoredGamePresentationChange,
+  type GamePresentationGrantProvenance,
+  type GamePresentationOccurrence,
+  type GamePresentation,
+} from "@/lib/game-presentation";
+
+export type PresentationIntegrityAnchor = {
+  recordId: string;
+  stateRevision: number;
+  keyVersion: string;
+  canonicalValue: string;
+  integrityTag: string;
+};
+
+export type PresentationIntegrityEvidence = {
+  recordId: string;
+  changes: readonly StoredGamePresentationChange[];
+  audits: readonly StoredGamePresentationAuditEntry[];
+};
+
+export function presentationIntegrityAnchorFor(
+  evidence: PresentationIntegrityEvidence,
+  stateRevision: number,
+  keyRing: GrantKeyRing,
+  keyVersion = keyRing.audit.currentVersion,
+): PresentationIntegrityAnchor {
+  const canonicalValue = canonicalizeJson({
+    domain: "game-presentation-evidence-v1",
+    recordId: evidence.recordId,
+    stateRevision,
+    changes: evidence.changes,
+    audits: evidence.audits,
+  });
+  return {
+    recordId: evidence.recordId,
+    stateRevision,
+    keyVersion,
+    canonicalValue,
+    integrityTag: computeAcceptanceIntegrityTag(
+      canonicalizeJson({
+        domain: "game-presentation-evidence-anchor-v1",
+        recordId: evidence.recordId,
+        stateRevision,
+        value: JSON.parse(canonicalValue),
+      }),
+      keyRing,
+      keyVersion,
+    ),
+  };
+}
+
+export function presentationEvidenceFailure(input: {
+  root: EventGameRecordRoot | null;
+  changes: readonly StoredGamePresentationChange[];
+  audits: readonly StoredGamePresentationAuditEntry[];
+  anchors: readonly PresentationIntegrityAnchor[];
+  sessions: readonly StoredGrantSession[];
+  actionOperationIds: ReadonlySet<string>;
+  keyRing: GrantKeyRing | undefined;
+}): string | null {
+  const { root, changes, audits, anchors, sessions, actionOperationIds, keyRing } = input;
+  if (changes.length === 0 && audits.length === 0 && anchors.length === 0) return null;
+  if (root === null) return "Game Presentation evidence references an invalid root.";
+  if (keyRing === undefined || anchors.length === 0)
+    return "Game Presentation evidence is unanchored.";
+  const sideIds = root.gameSides.map((side) => side.id);
+  const operations = new Set(changes.map((change) => change.operationId));
+  const sessionById = new Map(sessions.map((session) => [session.sessionId, session]));
+  for (const change of changes) {
+    if (
+      change.recordId !== root.recordId ||
+      change.eventGameId !== root.eventGameId ||
+      !isValidIdentifier(change.recordId) ||
+      !isValidIdentifier(change.eventGameId) ||
+      !isValidIdentifier(change.operationId) ||
+      !isValidIdentifier(change.presentationChangeId) ||
+      !isValidTimestamp(change.acceptedAtMs) ||
+      !Array.isArray(change.causalPredecessorIds) ||
+      change.causalPredecessorIds.length > 100 ||
+      new Set(change.causalPredecessorIds).size !== change.causalPredecessorIds.length ||
+      change.causalPredecessorIds.some(
+        (predecessor) => !isValidIdentifier(predecessor) || predecessor === change.operationId,
+      ) ||
+      !isValidPresentationChange(change.change, sideIds) ||
+      !isValidOccurrence(change.occurrence) ||
+      !isValidGrantProvenance(change.grant) ||
+      change.canonicalContent !== canonicalizeGamePresentationChange(change) ||
+      !/^[0-9a-f]{64}$/.test(change.contentFingerprint) ||
+      change.contentFingerprint !== fingerprintGamePresentationChange(change)
+    )
+      return "Game Presentation Change evidence is inconsistent.";
+    if (
+      change.causalPredecessorIds.some(
+        (predecessor) =>
+          predecessor === change.operationId ||
+          (predecessor !== change.operationId &&
+            !operations.has(predecessor) &&
+            !actionOperationIds.has(predecessor)),
+      )
+    )
+      return "Game Presentation Change causal linkage is invalid.";
+    const session = sessionById.get(change.grant.sessionId);
+    if (
+      session === undefined ||
+      session.grantVersion !== change.grant.versionId ||
+      session.eventGameId !== root.eventGameId
+    )
+      return "Game Presentation Change Grant Session linkage is invalid.";
+  }
+  let accepted: Map<string, StoredGamePresentationAuditEntry>;
+  for (const audit of audits) {
+    if (
+      audit.auditVersion !== "control-audit-v1" ||
+      audit.classification !== "game-presentation-change" ||
+      !isValidIdentifier(audit.auditId) ||
+      audit.recordId !== root.recordId ||
+      audit.eventGameId !== root.eventGameId ||
+      !isValidIdentifier(audit.recordId) ||
+      !isValidIdentifier(audit.eventGameId) ||
+      !isValidTimestamp(audit.createdAtMs) ||
+      normalizeBoundedText(audit.redactedDetail, 240, "redactedDetail").ok === false ||
+      (audit.operationId !== null &&
+        (!isValidIdentifier(audit.operationId) || !operations.has(audit.operationId))) ||
+      (audit.presentationChangeId !== null && !isValidIdentifier(audit.presentationChangeId)) ||
+      (audit.supersedesAuditId !== undefined && !isValidIdentifier(audit.supersedesAuditId))
+    )
+      return "Game Presentation audit evidence is inconsistent.";
+    if (!hasExactAuditShape(audit)) return "Game Presentation audit evidence is inconsistent.";
+    if (audit.grant !== null) {
+      if (!isValidIdentifier(audit.grant.sessionId) || !isValidIdentifier(audit.grant.versionId))
+        return "Game Presentation audit Grant Session linkage is invalid.";
+      const session = sessionById.get(audit.grant.sessionId);
+      if (
+        session === undefined ||
+        session.grantVersion !== audit.grant.versionId ||
+        session.eventGameId !== root.eventGameId
+      )
+        return "Game Presentation audit Grant Session linkage is invalid.";
+    }
+  }
+  const effectiveAccepted = effectiveAcceptedAudits(audits);
+  if (typeof effectiveAccepted === "string") return effectiveAccepted;
+  accepted = effectiveAccepted;
+  if (
+    accepted.size !== changes.length ||
+    changes.some((change) => !accepted.has(change.operationId))
+  )
+    return "Game Presentation accepted audit linkage is incomplete.";
+  let orderedChanges: StoredGamePresentationChange[];
+  try {
+    orderedChanges = orderGamePresentationChanges(changes);
+  } catch {
+    return "Game Presentation Change causal history is not a valid order.";
+  }
+  const orderIndex = new Map(orderedChanges.map((change, index) => [change.operationId, index]));
+  for (const change of orderedChanges) {
+    const index = orderIndex.get(change.operationId)!;
+    if (
+      change.causalPredecessorIds.some(
+        (predecessor) =>
+          operations.has(predecessor) && (orderIndex.get(predecessor) ?? index) >= index,
+      )
+    )
+      return "Game Presentation Change causal history is not ordered.";
+  }
+  let previousSnapshot: GamePresentation | null = null;
+  for (const change of orderedChanges) {
+    const audit = accepted.get(change.operationId)!;
+    if (
+      audit.presentationChangeId !== change.presentationChangeId ||
+      canonicalizeJson(audit.change) !== canonicalizeJson(change.change) ||
+      canonicalizeJson(audit.grant) !== canonicalizeJson(change.grant) ||
+      audit.previousPresentation === null ||
+      audit.resultingPresentation === null ||
+      !isValidPresentation(audit.previousPresentation, sideIds) ||
+      !isValidPresentation(audit.resultingPresentation, sideIds) ||
+      canonicalizeJson(audit.previousPresentation.gameSideIds) !== canonicalizeJson(sideIds) ||
+      canonicalizeJson(audit.resultingPresentation.gameSideIds) !== canonicalizeJson(sideIds)
+    )
+      return "Game Presentation accepted audit snapshots are inconsistent.";
+    if (
+      previousSnapshot !== null &&
+      canonicalizeJson(audit.previousPresentation) !== canonicalizeJson(previousSnapshot)
+    )
+      return "Game Presentation accepted audit sequence is inconsistent.";
+    if (
+      canonicalizeJson(applyGamePresentationChange(audit.previousPresentation, change.change)) !==
+      canonicalizeJson(audit.resultingPresentation)
+    )
+      return "Game Presentation accepted audit transition is inconsistent.";
+    previousSnapshot = audit.resultingPresentation;
+  }
+  for (const [index, anchor] of anchors.entries()) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(anchor.canonicalValue);
+    } catch {
+      return "Game Presentation evidence anchor is not canonical JSON.";
+    }
+    if (
+      anchor.recordId !== root.recordId ||
+      !isValidIdentifier(anchor.recordId) ||
+      !isValidIdentifier(anchor.keyVersion) ||
+      typeof anchor.canonicalValue !== "string" ||
+      anchor.canonicalValue.length > 256 * 1024 ||
+      typeof anchor.integrityTag !== "string" ||
+      anchor.integrityTag.length > 256 ||
+      anchor.stateRevision !== index + 1 ||
+      canonicalizeJson(parsed) !== anchor.canonicalValue
+    )
+      return "Game Presentation evidence anchor is inconsistent.";
+    let expectedTag: string;
+    try {
+      expectedTag = computeAcceptanceIntegrityTag(
+        canonicalizeJson({
+          domain: "game-presentation-evidence-anchor-v1",
+          recordId: root.recordId,
+          stateRevision: anchor.stateRevision,
+          value: parsed,
+        }),
+        keyRing,
+        anchor.keyVersion,
+      );
+    } catch {
+      return "Game Presentation evidence anchor key is unavailable.";
+    }
+    if (anchor.integrityTag !== expectedTag) return "Game Presentation evidence anchor is altered.";
+  }
+  const latest = anchors.at(-1)!;
+  const expected = presentationIntegrityAnchorFor(
+    { recordId: root.recordId, changes, audits },
+    latest.stateRevision,
+    keyRing,
+    latest.keyVersion,
+  );
+  return expected.canonicalValue === latest.canonicalValue &&
+    expected.integrityTag === latest.integrityTag
+    ? null
+    : "Game Presentation evidence anchor does not cover the current evidence.";
+}
+
+function isValidIdentifier(value: unknown): value is string {
+  return validateOpaqueIdentifier(value).ok;
+}
+
+function isValidTimestamp(value: unknown): value is number {
+  return validateIntegerInRange(value, 0, Number.MAX_SAFE_INTEGER, "timestamp").ok;
+}
+
+function isValidOccurrence(value: unknown): value is GamePresentationOccurrence {
+  if (value === null || typeof value !== "object") return false;
+  const occurrence = value as Partial<GamePresentationOccurrence>;
+  return (
+    isValidTimestamp(occurrence.trustedAtMs) &&
+    (occurrence.clientOriginAtMs === null || isValidTimestamp(occurrence.clientOriginAtMs)) &&
+    (occurrence.source === "online" || occurrence.source === "offline")
+  );
+}
+
+function isValidGrantProvenance(value: unknown): value is GamePresentationGrantProvenance {
+  if (value === null || typeof value !== "object") return false;
+  const grant = value as Partial<GamePresentationGrantProvenance>;
+  return isValidIdentifier(grant.sessionId) && isValidIdentifier(grant.versionId);
+}
+
+function isValidPresentationChange(
+  change: StoredGamePresentationChange["change"],
+  sideIds: readonly string[],
+): boolean {
+  if (change === null || typeof change !== "object") return false;
+  if (change.type === "pitch-orientation") {
+    return change.pitchOrientation === "side-a-left" || change.pitchOrientation === "side-b-left";
+  }
+  return (
+    change.type === "displayed-team-color" &&
+    isValidIdentifier(change.gameSideId) &&
+    sideIds.includes(change.gameSideId) &&
+    isValidHexColor(change.color)
+  );
+}
+
+function isValidPresentation(presentation: GamePresentation, sideIds: readonly string[]): boolean {
+  if (
+    presentation === null ||
+    typeof presentation !== "object" ||
+    !Array.isArray(presentation.gameSideIds) ||
+    presentation.gameSideIds.length !== sideIds.length ||
+    new Set(presentation.gameSideIds).size !== sideIds.length ||
+    presentation.gameSideIds.some((sideId) => !isValidIdentifier(sideId)) ||
+    !presentation.gameSideIds.every((sideId, index) => sideId === sideIds[index]) ||
+    (presentation.pitchOrientation !== "side-a-left" &&
+      presentation.pitchOrientation !== "side-b-left") ||
+    presentation.displayedTeamColors === null ||
+    typeof presentation.displayedTeamColors !== "object"
+  )
+    return false;
+  const colorEntries = Object.entries(presentation.displayedTeamColors);
+  return (
+    colorEntries.length === sideIds.length &&
+    colorEntries.every(([sideId, color]) => sideIds.includes(sideId) && isValidHexColor(color))
+  );
+}
+
+function hasExactAuditShape(audit: StoredGamePresentationAuditEntry): boolean {
+  const linked =
+    audit.operationId !== null &&
+    audit.presentationChangeId !== null &&
+    audit.previousPresentation !== null &&
+    audit.resultingPresentation !== null &&
+    audit.change !== null &&
+    audit.grant !== null;
+  if (audit.kind === "presentation-accepted") return audit.outcome === "accepted" && linked;
+  if (audit.kind === "presentation-duplicate")
+    return audit.outcome === "duplicate-accepted" && linked;
+  if (audit.kind === "presentation-conflict") return audit.outcome === "rejected" && linked;
+  return (
+    audit.kind === "presentation-rejected" &&
+    audit.outcome === "rejected" &&
+    audit.operationId === null &&
+    audit.presentationChangeId === null &&
+    audit.previousPresentation === null &&
+    audit.resultingPresentation === null &&
+    audit.change === null &&
+    audit.grant === null
+  );
+}
+
+function effectiveAcceptedAudits(
+  audits: readonly StoredGamePresentationAuditEntry[],
+): Map<string, StoredGamePresentationAuditEntry> | string {
+  const byId = new Map<string, StoredGamePresentationAuditEntry>();
+  for (const audit of audits) {
+    if (byId.has(audit.auditId)) return "Game Presentation audit identity is duplicated.";
+    byId.set(audit.auditId, audit);
+  }
+  const supersededBy = new Map<string, string>();
+  for (const revision of audits) {
+    if (revision.supersedesAuditId === undefined) continue;
+    if (revision.kind !== "presentation-accepted" || revision.operationId === null)
+      return "Game Presentation audit revision has the wrong shape.";
+    const prior = byId.get(revision.supersedesAuditId);
+    if (prior === undefined || prior.kind !== "presentation-accepted")
+      return "Game Presentation audit revision target is dangling.";
+    if (
+      prior.recordId !== revision.recordId ||
+      prior.eventGameId !== revision.eventGameId ||
+      prior.operationId !== revision.operationId ||
+      prior.presentationChangeId !== revision.presentationChangeId ||
+      canonicalizeJson(prior.change) !== canonicalizeJson(revision.change) ||
+      canonicalizeJson(prior.grant) !== canonicalizeJson(revision.grant)
+    )
+      return "Game Presentation audit revision crosses its operation boundary.";
+    if (supersededBy.has(revision.supersedesAuditId))
+      return "Game Presentation audit revision fork is invalid.";
+    supersededBy.set(revision.supersedesAuditId, revision.auditId);
+  }
+  const effective = new Map<string, StoredGamePresentationAuditEntry>();
+  for (const audit of audits) {
+    if (audit.kind !== "presentation-accepted" || audit.operationId === null) continue;
+    if (supersededBy.has(audit.auditId)) continue;
+    if (effective.has(audit.operationId)) return "Game Presentation accepted audit is duplicated.";
+    effective.set(audit.operationId, audit);
+  }
+  for (const audit of audits) {
+    if (audit.kind !== "presentation-accepted") continue;
+    const seen = new Set<string>();
+    let current = audit;
+    while (supersededBy.has(current.auditId)) {
+      if (seen.has(current.auditId))
+        return "Game Presentation audit supersession cycle is invalid.";
+      seen.add(current.auditId);
+      const next = byId.get(supersededBy.get(current.auditId)!);
+      if (next === undefined) return "Game Presentation audit revision target is dangling.";
+      current = next;
+    }
+    if (current.operationId === null || !effective.has(current.operationId))
+      return "Game Presentation audit supersession chain is incomplete.";
+  }
+  return effective;
+}


### PR DESCRIPTION
## What changed

- Add an opaque replay-origin proof to Control Grant admission, authorization, and session-switch results.
- Require replay authorization to resolve that proof to the exact durable inactive originating Grant Session under retained lookup-key versions.
- Add immutable Game Presentation Change, audit, and keyed integrity-anchor storage for memory and SQLite.
- Add `appendPresentationAuditRevision` so later same-time changes can supersede an accepted audit snapshot without mutating or deleting prior evidence.
- Resolve complete acyclic revision chains to one effective accepted audit per operation and validate it against canonical causal order before acknowledgement and during readiness.
- Include the presentation integrity relation in Foundation recovery and key-version inspection.

## Why

Game Presentation Changes must remain permanently attributable to the Controller session that originally queued them, while a current Grant Session authorizes delivery. The published replay contract accepted a caller-selected inactive same-Grant session ID, and existing Foundation anchors did not cover the separate presentation ledger. The initial immutable audit API also could not repair the effective snapshot when a later same-time operation canonically precedes an already accepted operation.

## Impact

This publishes the narrow Foundation contract consumed by #94. Consumers append immutable superseding audit revisions through `FoundationStorageTransaction.appendPresentationAuditRevision`; old audit rows remain intact. Controller transport, UI, projection, presentation policy, and spectator fan-out remain outside this PR. Existing ordinary Control Action replay remains separate and compatible.

## Migration

- Adds append-only migration `027-event-game-presentation-integrity`, including immutable audit supersession linkage.
- Migrations 001–026 remain unchanged.

## Verification

- `bun install --frozen-lockfile`
- `bun audit`
- `bun run check`
- `bun run test` — 671 tests passed
- `bun test --isolate src/lib/presentation-integrity.test.ts` — 11 tests passed
- `bun run test:focused:grant` — 36 tests passed
- `bun run test:focused:sqlite` — 21 tests passed
- `bun run test:focused:acceptance` — 10 tests passed
- `bun run test:focused:grant-code` — 15 tests passed
- `bun run build`
- `bun run build:executable`
- `git diff --check`

No Qualification Test and no `bun run check:sqlite-runtime` workload was run.

Closes #215.