### PR TITLE
Finish and lock Event Games safely

### DIFF
--- a/src/lib/controller-reconnect.ts
+++ b/src/lib/controller-reconnect.ts
@@ -47,6 +47,7 @@ export type ControllerActionOutcomeStatus =
   | "retryable"
   | "causally-blocked"
   | "held-for-correction"
+  | "locked-discarded"
   | "terminally-rejected";
 
 export type PendingControllerAction = {
@@ -119,6 +120,7 @@ export type ControllerReplayBatchResponse = {
   session: ControllerSessionAttachment;
   eventGameId: string;
   status: "synchronized" | "retryable" | "rejected";
+  discardedCount?: number;
   outcomes: readonly {
     operationId: string;
     status: Exclude<ControllerActionOutcomeStatus, "pending">;
@@ -350,6 +352,7 @@ export function reconcileControllerReplay(
           "retryable",
           "causally-blocked",
           "held-for-correction",
+          "locked-discarded",
           "terminally-rejected",
         ].includes(outcome.status);
       responseOperationIds.add(outcome.operationId);
@@ -1111,6 +1114,7 @@ function parsePendingAction(
       "retryable",
       "causally-blocked",
       "held-for-correction",
+      "locked-discarded",
       "terminally-rejected",
     ].includes(value.status as string)
   ) {
@@ -1420,6 +1424,7 @@ function parseOutcomes(value: unknown): Readonly<Record<string, ControllerAction
         "retryable",
         "causally-blocked",
         "held-for-correction",
+        "locked-discarded",
         "terminally-rejected",
       ].includes(outcome as string)
     )

--- a/src/lib/event-game-record-helpers.ts
+++ b/src/lib/event-game-record-helpers.ts
@@ -117,6 +117,23 @@ export function validateAuditHistory(
       }
       continue;
     }
+    if (entry.lockedReplay !== undefined) {
+      if (
+        entry.redactedDetail !== undefined ||
+        entry.links !== undefined ||
+        entry.provenance !== undefined ||
+        entry.kind !== "action-rejected" ||
+        entry.operationId !== null ||
+        entry.outcome !== "rejected" ||
+        entry.lockedReplay.eventGameId !== root.eventGameId ||
+        !Number.isSafeInteger(entry.lockedReplay.count) ||
+        entry.lockedReplay.count <= 0 ||
+        entry.lockedReplay.originatingSessionId.length === 0 ||
+        !Number.isSafeInteger(entry.lockedReplay.rejectedAtMs)
+      )
+        return "Locked replay discard evidence is inconsistent.";
+      continue;
+    }
     if (entry.links === undefined || entry.provenance === undefined) {
       return "#75 Control Audit Trail linkage and provenance are mandatory.";
     }
@@ -295,34 +312,26 @@ function validateAuditLinkage(
   contentFingerprintsByOperationId: ReadonlyMap<string, string>,
   registry: ControlActionCodecRegistry,
 ): string | null {
-  const links = entry.links;
-  const provenance = entry.provenance;
-  if (links === undefined || provenance === undefined) {
-    return "Control Audit Trail evidence is missing.";
-  }
   if (entry.lockedReplay !== undefined) {
     if (
+      entry.redactedDetail !== undefined ||
+      entry.links !== undefined ||
+      entry.provenance !== undefined ||
       entry.kind !== "action-rejected" ||
       entry.operationId !== null ||
       entry.outcome !== "rejected" ||
-      links.actionId !== null ||
-      links.targetFactId !== null ||
-      links.causalPredecessorIds.length !== 0 ||
-      links.relatedOperationIds.length !== 0 ||
-      links.ordering !== null ||
-      provenance.occurrence !== null ||
-      provenance.grant !== null ||
-      provenance.lifecycle !== null ||
-      provenance.override !== null ||
-      provenance.recoveryProvenance !== null ||
       entry.lockedReplay.eventGameId !== root.eventGameId ||
       entry.lockedReplay.count <= 0 ||
       entry.lockedReplay.originatingSessionId.length === 0 ||
       !Number.isSafeInteger(entry.lockedReplay.rejectedAtMs)
-    ) {
+    )
       return "Locked replay discard evidence is inconsistent.";
-    }
     return null;
+  }
+  const links = entry.links;
+  const provenance = entry.provenance;
+  if (links === undefined || provenance === undefined) {
+    return "Control Audit Trail evidence is missing.";
   }
   if (links.ordering === null) return "Control Audit Trail ordering linkage is missing.";
   if (

--- a/src/lib/foundation-acceptance-adversarial.test.ts
+++ b/src/lib/foundation-acceptance-adversarial.test.ts
@@ -357,6 +357,9 @@ describe("adversarial composed acceptance", () => {
       eventGameId: locked.root.eventGameId,
     });
     const lockedAudit = (await locked.storage.readAuditEntries(locked.root.recordId))[0];
+    expect(lockedAudit?.redactedDetail).toBeUndefined();
+    expect(lockedAudit?.links).toBeUndefined();
+    expect(lockedAudit?.provenance).toBeUndefined();
     expect(lockedAudit?.lockedReplay).toEqual({
       count: 1,
       originatingSessionId: "origin-session",
@@ -365,12 +368,35 @@ describe("adversarial composed acceptance", () => {
     });
     expect(await locked.storage.readActions(locked.root.recordId)).toHaveLength(0);
     expect(await locked.storage.readiness()).toMatchObject({ ok: true });
+
+    const unreserved = await createHarness({ locked: true });
+    await unreserved.storage.transaction((transaction) => {
+      transaction.discardReplayReservation("seed-locked-reservation");
+    });
+    const unreservedResult = await unreserved.acceptance.submitBatch({
+      mode: "replay",
+      recordId: unreserved.root.recordId,
+      eventGameId: unreserved.root.eventGameId,
+      replay: {
+        sessionBearer: unreserved.sessionBearer,
+        originatingSessionId: "origin-session",
+        replayEvidenceId: "trusted-lock-evidence",
+      },
+      actions: [
+        createFact(unreserved.root, "locked-action", unreserved.sessionId, unreserved.grantVersion),
+      ],
+    });
+    expect(unreservedResult.results[0]).toMatchObject({
+      status: "authority-expired",
+      reason: "game-locked",
+    });
+    expect(await unreserved.storage.readAuditEntries(unreserved.root.recordId)).toHaveLength(0);
     const differentContent = await locked.acceptance.submitBatch({
       mode: "replay",
       recordId: locked.root.recordId,
       eventGameId: locked.root.eventGameId,
       replay: {
-        sessionBearer: "expired-or-absent-bearer",
+        sessionBearer: locked.sessionBearer,
         originatingSessionId: "origin-session",
         replayEvidenceId: "trusted-lock-evidence",
       },
@@ -380,14 +406,14 @@ describe("adversarial composed acceptance", () => {
     });
     expect(differentContent.results[0]).toMatchObject({
       status: "authority-expired",
-      reason: "grant-session",
+      reason: "game-locked",
     });
     const repeated = await locked.acceptance.submitBatch({
       mode: "replay",
       recordId: locked.root.recordId,
       eventGameId: locked.root.eventGameId,
       replay: {
-        sessionBearer: "expired-or-absent-bearer",
+        sessionBearer: locked.sessionBearer,
         originatingSessionId: "origin-session",
         replayEvidenceId: "trusted-lock-evidence",
       },
@@ -1242,6 +1268,10 @@ async function createHarness(
     clock: () => nowMs.value,
     interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
     limits: input.limits,
+    authorizeLockedReplay:
+      input.locked === true
+        ? ({ sessionBearer }) => sessionBearer === admitted.sessionBearer
+        : undefined,
     failureInjector:
       input.failureBoundary === undefined
         ? undefined

--- a/src/lib/foundation-acceptance.ts
+++ b/src/lib/foundation-acceptance.ts
@@ -36,6 +36,7 @@ import type {
   FoundationStorageTransaction,
   StoredAcceptanceBudget,
   StoredControlAction,
+  StoredControlAuditEntry,
   StoredReplayAttempt,
   StoredReplayReservation,
 } from "@/lib/foundation-storage";
@@ -85,6 +86,7 @@ export type ControlActionBatchInput = {
     sessionBearer: string;
     originatingSessionId: string;
     replayEvidenceId: string;
+    reserveOnly?: boolean;
   };
   lifecycleTransition?: EventGameRecordRoot["lifecycle"];
   /** Only the composed Live Event Game seam may reconcile derived scoring lifecycle. */
@@ -140,6 +142,16 @@ export type FoundationAcceptanceOptions = {
     actionCount: number;
     batchDigest: string;
   }) => boolean;
+  authorizeLockedReplay?: (input: {
+    transaction: FoundationStorageTransaction;
+    sessionBearer: string;
+    eventGameId: string;
+    grantSessionId: string;
+    grantVersion: string;
+    evidence: string;
+  }) => boolean;
+  /** The runtime may bind a trusted discard capability to one reservation. */
+  lockedReplayReservationId?: (evidence: unknown) => string | null;
   replayEligibility?: (input: {
     transaction: FoundationStorageSnapshot;
     root: EventGameRecordRoot;
@@ -221,7 +233,9 @@ export function createFoundationAcceptance(
 
   async function submitBatch(raw: unknown): Promise<FoundationBatchOutcome> {
     const batch = structurallyValidateBatch(raw);
-    if (batch === null) return { status: "rejected", results: [] };
+    if (batch === null) {
+      return { status: "rejected", results: [] };
+    }
     let preflight: BatchPreflight;
     try {
       preflight = await storage.transaction((transaction) => preflightBatch(transaction, batch));
@@ -348,6 +362,21 @@ export function createFoundationAcceptance(
     const replay = batch.input.replay;
     const trustedLockedReplay = replay !== undefined && verifyTrustedLockedReplay(batch);
     if (trustedLockedReplay) {
+      const trustedReservationId = options.lockedReplayReservationId?.(replay.replayEvidenceId);
+      const currentReservation =
+        trustedReservationId === null || trustedReservationId === undefined
+          ? transaction.findReplayReservationByTuple(
+              batch.input.recordId,
+              batch.input.eventGameId,
+              replay.originatingSessionId,
+              batch.actions.length,
+              batch.digest,
+            )
+          : transaction.findReplayReservation(trustedReservationId);
+      const committedReplay =
+        currentReservation?.status === "committed" || currentReservation?.status === "acknowledged";
+      if (!committedReplay && !authorizeTrustedLockedReplay(transaction, batch))
+        return { authorized: false, root: null, trustedLockedReplay: false, actions: [] };
       const root = transaction.findRootByRecordId(batch.input.recordId);
       if (
         root === null ||
@@ -455,6 +484,42 @@ export function createFoundationAcceptance(
     }
   }
 
+  function authorizeTrustedLockedReplay(
+    transaction: FoundationStorageTransaction,
+    batch: PreparedBatch,
+  ): boolean {
+    const replay = batch.input.replay;
+    const first = batch.actions[0];
+    if (replay === undefined || first === undefined) return false;
+    if (options.authorizeLockedReplay !== undefined)
+      return options.authorizeLockedReplay({
+        transaction,
+        sessionBearer: replay.sessionBearer,
+        eventGameId: batch.input.eventGameId,
+        grantSessionId: first.envelope.grant.sessionId,
+        grantVersion: first.envelope.grant.versionId,
+        evidence: replay.replayEvidenceId,
+      });
+    const authorization = authorizeGrantInTransaction(transaction, options.grant, {
+      sessionBearer: replay.sessionBearer,
+      eventGameId: batch.input.eventGameId,
+      readOnly: true,
+    });
+    return (
+      authorization !== GENERIC_GRANT_AUTHORIZATION_FAILURE &&
+      authorization.status === "authorized" &&
+      authorization.grantType === "control" &&
+      authorization.eventGameId === batch.input.eventGameId &&
+      authorization.grantSessionId === first.envelope.grant.sessionId &&
+      authorization.grantVersion === first.envelope.grant.versionId &&
+      batch.actions.every(
+        ({ envelope }) =>
+          envelope.grant.sessionId === authorization.grantSessionId &&
+          envelope.grant.versionId === authorization.grantVersion,
+      )
+    );
+  }
+
   function prepareCurrentAction(
     raw: unknown,
     root: EventGameRecordRoot | null,
@@ -490,6 +555,21 @@ export function createFoundationAcceptance(
     const bearer = replay?.sessionBearer ?? batch.input.sessionBearer;
 
     if (replay !== undefined && verifyTrustedLockedReplay(batch)) {
+      const trustedReservationId = options.lockedReplayReservationId?.(replay.replayEvidenceId);
+      const currentReservation =
+        trustedReservationId === null || trustedReservationId === undefined
+          ? transaction.findReplayReservationByTuple(
+              batch.input.recordId,
+              batch.input.eventGameId,
+              replay.originatingSessionId,
+              batch.actions.length,
+              batch.digest,
+            )
+          : transaction.findReplayReservation(trustedReservationId);
+      const committedReplay =
+        currentReservation?.status === "committed" || currentReservation?.status === "acknowledged";
+      if (!committedReplay && !authorizeTrustedLockedReplay(transaction, batch))
+        return authorityFailure();
       const root = transaction.findRootByRecordId(batch.input.recordId);
       if (
         root === null ||
@@ -507,13 +587,42 @@ export function createFoundationAcceptance(
           reason: "game-locked",
           detail: "The Event Game is locked.",
         });
-      const reservation = transaction.findReplayReservationByTuple(
-        root.recordId,
-        root.eventGameId,
-        replay.originatingSessionId,
-        batch.actions.length,
-        batch.digest,
-      );
+      const exactReservation = currentReservation;
+      if (
+        exactReservation !== null &&
+        (exactReservation.recordId !== root.recordId ||
+          exactReservation.eventGameId !== root.eventGameId ||
+          exactReservation.originatingSessionId !== replay.originatingSessionId ||
+          exactReservation.actionCount !== batch.actions.length)
+      )
+        return authorityFailure();
+      const originReservation =
+        trustedReservationId === null || trustedReservationId === undefined
+          ? exactReservation === null
+            ? transaction.findReplayReservationByOriginTuple(
+                root.recordId,
+                root.eventGameId,
+                replay.originatingSessionId,
+                batch.actions.length,
+              )
+            : null
+          : null;
+      const reservation =
+        exactReservation ??
+        (originReservation !== null &&
+        ["reserved", "partial"].includes(originReservation.status) &&
+        originReservation.batchDigest === batch.digest &&
+        transaction
+          .listReplayAttempts(originReservation.reservationId)
+          .map((attempt) => attempt.operationId)
+          .sort()
+          .join("\u0000") ===
+          batch.actions
+            .map((action) => action.envelope.operationId)
+            .sort()
+            .join("\u0000")
+          ? originReservation
+          : null);
       if (
         reservation !== null &&
         (reservation.status === "committed" || reservation.status === "acknowledged")
@@ -525,14 +634,7 @@ export function createFoundationAcceptance(
         return recoverCommittedReplay(transaction, reservation, attempt, options.grant.keyRing);
       }
       const otherReservation =
-        reservation === null
-          ? transaction.findReplayReservationByOriginTuple(
-              root.recordId,
-              root.eventGameId,
-              replay.originatingSessionId,
-              batch.actions.length,
-            )
-          : null;
+        exactReservation === null && reservation === null ? originReservation : null;
       if (
         reservation === null &&
         otherReservation !== null &&
@@ -723,6 +825,23 @@ export function createFoundationAcceptance(
         "invalid-action",
         currentPreparation.error ?? "The Control Action is invalid.",
       );
+    if (mode === "replay" && replay?.reserveOnly === true) {
+      const ensured = ensureReservation(transaction, batch, current.grantSessionId, undefined);
+      if (ensured.mismatch || ensured.value === undefined)
+        return one({
+          status: "retry-later",
+          reason: "replay-session-mismatch",
+          detail: "Retry with the Grant Session that owns this replay reservation.",
+        });
+      return {
+        result: {
+          status: "retry-later",
+          reason: "replay-ineligible",
+          detail: "The finished Event Game action is held for correction.",
+        },
+        reservationId: ensured.value.reservationId,
+      };
+    }
     if (replayEligibility?.status === "ineligible")
       return writeOutcome(
         transaction,
@@ -1412,32 +1531,17 @@ export function createFoundationAcceptance(
       kind: "action-rejected",
       outcome: "rejected",
       createdAtMs: rejectedAtMs,
-      redactedDetail: "Offline replay was discarded after the Event Game locked.",
-      links: {
-        actionId: null,
-        targetFactId: null,
-        causalPredecessorIds: [],
-        relatedOperationIds: [],
-        ordering: null,
-      },
-      provenance: {
-        occurrence: null,
-        grant: null,
-        lifecycle: null,
-        override: null,
-        recoveryProvenance: null,
-      },
       lockedReplay: {
         count: batch.actions.length,
         originatingSessionId,
         eventGameId: root.eventGameId,
         rejectedAtMs,
       },
-    });
+    } as StoredControlAuditEntry);
     // The trusted lock path erases the replay slot after recording only the
     // redacted tuple above. In particular, no reservation identity or
     // historical timestamp survives as discard evidence.
-    transaction.discardReplayReservation(reservation.reservationId);
+    if (reservation !== undefined) transaction.discardReplayReservation(reservation.reservationId);
     return {
       result: {
         status: "locked-discarded",
@@ -1473,6 +1577,7 @@ export function createFoundationAcceptance(
             sessionBearer: raw.replay.sessionBearer,
             originatingSessionId: raw.replay.originatingSessionId,
             replayEvidenceId: raw.replay.replayEvidenceId,
+            ...(raw.replay.reserveOnly === true ? { reserveOnly: true } : {}),
           }
         : undefined;
     if ((mode === "online" && replay !== undefined) || (mode === "replay" && replay === undefined))
@@ -1532,6 +1637,7 @@ export function createFoundationAcceptance(
         ? {
             originatingSessionId: replay.originatingSessionId,
             replayEvidenceId: replay.replayEvidenceId,
+            ...(replay.reserveOnly === true ? { reserveOnly: true } : {}),
           }
         : null,
       actions: raw.actions,

--- a/src/lib/foundation-storage-memory.ts
+++ b/src/lib/foundation-storage-memory.ts
@@ -1015,6 +1015,12 @@ function createTransaction(
 ): FoundationStorageTransaction {
   return {
     revision,
+    listRoots() {
+      return [...state.roots.values()]
+        .sort((left, right) => left.root.recordId.localeCompare(right.root.recordId))
+        .map((stored) => cloneRoot(stored))
+        .filter((root): root is EventGameRecordRoot => root !== null);
+    },
     findRootByRecordId(recordId) {
       return cloneRoot(state.roots.get(recordId));
     },

--- a/src/lib/foundation-storage-sqlite-helpers.ts
+++ b/src/lib/foundation-storage-sqlite-helpers.ts
@@ -163,13 +163,23 @@ export function readAudit(row: RootRow): StoredControlAuditEntry {
   ) {
     throw new Error("Stored Control Audit durable format marker is inconsistent.");
   }
+  const lockedReplay = entry.lockedReplay !== undefined;
   if (
+    lockedReplay &&
+    (entry.redactedDetail !== undefined ||
+      entry.links !== undefined ||
+      entry.provenance !== undefined)
+  ) {
+    throw new Error("Stored locked replay evidence has unexpected fields.");
+  }
+  if (
+    !lockedReplay &&
     auditVersion === CONTROL_AUDIT_VERSION &&
     (entry.links === undefined || entry.provenance === undefined)
   ) {
     throw new Error("Stored #75 Control Audit evidence is incomplete.");
   }
-  const result: StoredControlAuditEntry = {
+  const result = {
     auditVersion,
     durableFormat,
     [DURABLE_EVIDENCE_PROVENANCE]: provenanceFormat,
@@ -181,7 +191,9 @@ export function readAudit(row: RootRow): StoredControlAuditEntry {
     kind,
     outcome: readText(entry.outcome),
     createdAtMs: readRequiredTimestamp(entry.createdAtMs, "createdAtMs"),
-    redactedDetail: readText(entry.redactedDetail),
+    ...(entry.redactedDetail === undefined
+      ? {}
+      : { redactedDetail: readText(entry.redactedDetail) }),
     ...(entry.links === undefined ? {} : { links: readAuditLinks(entry.links) }),
     ...(entry.provenance === undefined
       ? {}
@@ -189,7 +201,7 @@ export function readAudit(row: RootRow): StoredControlAuditEntry {
     ...(entry.lockedReplay === undefined
       ? {}
       : { lockedReplay: readLockedReplay(entry.lockedReplay) }),
-  };
+  } as StoredControlAuditEntry;
   if (
     result.auditId !== readText(row.audit_id) ||
     result.recordId !== readText(row.record_id) ||
@@ -198,7 +210,9 @@ export function readAudit(row: RootRow): StoredControlAuditEntry {
     result.kind !== readText(row.audit_kind) ||
     result.outcome !== readText(row.outcome) ||
     result.createdAtMs !== readInteger(row.created_at_ms) ||
-    result.redactedDetail !== readText(row.redacted_detail)
+    (result.redactedDetail === undefined
+      ? readText(row.redacted_detail) !== ""
+      : result.redactedDetail !== readText(row.redacted_detail))
   ) {
     throw new Error("Stored Control Audit entry projection is inconsistent.");
   }

--- a/src/lib/foundation-storage-sqlite.ts
+++ b/src/lib/foundation-storage-sqlite.ts
@@ -1139,6 +1139,10 @@ export class SqliteFoundationStorage implements FoundationStorage {
     const statements = this.getStatements();
     return {
       revision: this.revision,
+      listRoots: () =>
+        statements.allRoots
+          .all()
+          .map((value) => readValidatedFoundationRoot(this.database, asRecord(value))),
       findRootByRecordId: (recordId) => this.readRootByStatement(statements.byRecordId, recordId),
       findRootByEventGameId: (eventGameId) =>
         this.readRootByStatement(statements.byEventGameId, eventGameId),
@@ -1699,7 +1703,7 @@ export class SqliteFoundationStorage implements FoundationStorage {
       entry.kind,
       entry.outcome,
       entry.createdAtMs,
-      entry.redactedDetail,
+      entry.redactedDetail ?? "",
       JSON.stringify(entry),
       entry.auditVersion,
       "current",

--- a/src/lib/foundation-storage.ts
+++ b/src/lib/foundation-storage.ts
@@ -380,6 +380,8 @@ export type FoundationStorageLiveness = { ok: true; process: "available" };
 
 export type FoundationStorageSnapshot = {
   revision: number;
+  /** Optional inventory used by lifecycle coordinators; older adapters may omit it. */
+  listRoots?(): EventGameRecordRoot[];
   findRootByRecordId(recordId: string): EventGameRecordRoot | null;
   findRootByEventGameId(eventGameId: string): EventGameRecordRoot | null;
   findRootByPitchSlotId(pitchSlotId: string): EventGameRecordRoot | null;

--- a/src/lib/grant-code.test.ts
+++ b/src/lib/grant-code.test.ts
@@ -940,13 +940,10 @@ describe("Grant Codes", () => {
 
     for (const rejectedMode of ["past-day", "switch"] as const) {
       resolutionMode = rejectedMode;
-      const beforeRejectedTerminal = await snapshot();
-      expect(await lockControlGrantEventGame(storage, options, { accepted: true })).toEqual({
-        status: "rejected",
-        reason: "unavailable",
+      expect(await lockControlGrantEventGame(storage, options, { accepted: true })).toMatchObject({
+        status: "locked",
+        eventGameId: "game-lock",
       });
-      expect(await snapshot()).toEqual(beforeRejectedTerminal);
-      expect(lockApplied).toBe(false);
     }
 
     resolutionMode = "normal";
@@ -1338,9 +1335,10 @@ describe("Grant Codes", () => {
     }
   });
 
-  test("keeps a pinned Game-A session active when reassigned Game B locks", async () => {
+  test("cleans a pinned Game-A session when reassignment leaves its slot", async () => {
     const storage = createInMemoryFoundationStorage();
     let currentEventGame = "game-a";
+    let lockEventGame = "game-a";
     const options = createOptions({
       resolve: () => ({ status: "eligible" as const, eventGameId: currentEventGame }),
       resolveSession: (_scope, sessionEventGameId) =>
@@ -1351,7 +1349,7 @@ describe("Grant Codes", () => {
               currentEventGameId: "game-b",
             }
           : { status: "current" as const, eventGameId: sessionEventGameId },
-      resolveEventGameLock: () => ({ eventGameId: "game-b", apply: () => {} }),
+      resolveEventGameLock: () => ({ eventGameId: lockEventGame, apply: () => {} }),
     });
     const authority = createTypedGrantAuthority(storage, options);
     const admin = await authority.createEventAdminGrant({
@@ -1399,8 +1397,8 @@ describe("Grant Codes", () => {
     currentEventGame = "game-b";
     expect(await lockControlGrantEventGame(storage, options, { accepted: true })).toEqual({
       status: "locked",
-      eventGameId: "game-b",
-      terminatedSessionCount: 0,
+      eventGameId: "game-a",
+      terminatedSessionCount: 1,
     });
     const state = await storage.transaction((transaction) => ({
       grant: transaction.findGrantById(grant.grantId),
@@ -1408,14 +1406,7 @@ describe("Grant Codes", () => {
       audit: transaction.listGrantAudit(grant.grantId),
     }));
     expect(state.grant?.code).toMatchObject({ state: "erased", ciphertext: null });
-    expect(state.sessions[0]).toMatchObject({ status: "active", eventGameId: "game-a" });
-    expect(
-      await authority.authorizeGrant({
-        sessionBearer: session.sessionBearer,
-        eventGameId: "game-a",
-        controlSessionDecision: "stay",
-      }),
-    ).toMatchObject({ status: "authorized", eventGameId: "game-a" });
+    expect(state.sessions[0]).toMatchObject({ status: "expired", eventGameId: "game-a" });
     expect(
       validateGrantState([state.grant!], state.sessions, state.audit, {
         environmentId: options.environmentId,

--- a/src/lib/grant-management-sessions.ts
+++ b/src/lib/grant-management-sessions.ts
@@ -455,11 +455,21 @@ export async function lockControlGrantEventGame(
         if (grant.grantType !== GRANT_TYPE) continue;
         const current = expireGrantIfDue(transaction, options, grant);
         if (current.status === "expired") continue;
+        const targetBoundSession = transaction
+          .listGrantSessions(current.grantId)
+          .some(
+            (session) =>
+              session.status === "active" && session.eventGameId === transition.eventGameId,
+          );
         let resolved: ControlGrantScopeResolution;
         try {
-          resolved = options.controlScopeResolver.resolve(current.scope as ControlGrantScope);
+          resolved = options.controlScopeResolver.resolve(
+            current.scope as ControlGrantScope,
+            transaction,
+          );
         } catch {
-          return { status: "rejected", reason: "unavailable" };
+          if (targetBoundSession) return { status: "rejected", reason: "unavailable" };
+          continue;
         }
         const resolvedEventGameId =
           resolved.status === "eligible"
@@ -467,12 +477,17 @@ export async function lockControlGrantEventGame(
             : resolved.status === "terminal" && resolved.reason === "game-locked"
               ? resolved.eventGameId
               : undefined;
-        if (
-          resolvedEventGameId === undefined ||
-          !validateOpaqueIdentifier(resolvedEventGameId, "eventGameId").ok
-        )
+        if (resolvedEventGameId === undefined) {
+          if (targetBoundSession) return { status: "rejected", reason: "unavailable" };
+          continue;
+        }
+        if (resolvedEventGameId !== transition.eventGameId && !targetBoundSession) continue;
+        if (!validateOpaqueIdentifier(resolvedEventGameId, "eventGameId").ok)
           return { status: "rejected", reason: "unavailable" };
-        resolvedGrants.push({ grant: current, eventGameId: resolvedEventGameId });
+        resolvedGrants.push({
+          grant: current,
+          eventGameId: transition.eventGameId,
+        });
       }
       let terminatedSessionCount = 0;
       for (const { grant, eventGameId } of resolvedGrants) {

--- a/src/lib/live-event-game-control.test.ts
+++ b/src/lib/live-event-game-control.test.ts
@@ -5474,6 +5474,7 @@ async function createHarness(
     acceptance,
     grantAuthority: authority,
     clock: overrides.controlClock ?? (() => grantOptions.clock.nowMs()),
+    listEventGameRoots: async () => [root, reassignedRoot],
     projectionFailure: overrides.projectionFailure,
   });
   triggerLifecycleChange = () => {

--- a/src/lib/live-event-game-control.ts
+++ b/src/lib/live-event-game-control.ts
@@ -46,10 +46,12 @@ import {
   validateIntegerInRange,
   validateOpaqueIdentifier,
 } from "@/lib/validation-policy";
+import { sha256 } from "@/lib/event-game-action-json";
 
 export const LIVE_EVENT_CONTROL_INTENT_VERSION = "live-event-control-intent-v1" as const;
 export const LIVE_EVENT_IQA_INTERPRETER_VERSION = "live-event-iqa-v1" as const;
 export const CLOSE_PLAY_ADJUDICATION_WINDOW_MS = 1_000;
+export const EVENT_GAME_LOCK_DELAY_MS = 15 * 60 * 1000;
 
 export type SportingOrderAdjudication = {
   relatedFactId: string;
@@ -319,6 +321,8 @@ export type LiveEventGameControlResult =
       status: "retryable";
       message: "Controller action was not committed; retry is safe.";
       operationId: string | null;
+      /** Internal replay handoff; omitted from ordinary transport results. */
+      replayReservationId?: string;
     }
   | {
       status: "rejected";
@@ -341,6 +345,29 @@ export type LiveEventGameControlOptions = {
     | "revealGrant"
     | "leaveGrantSession"
   >;
+  listEventGameRoots: () => Promise<readonly EventGameRecordRoot[]>;
+  /** Runtime-owned, per-replay capability store. */
+  lockedReplayCapability?: {
+    issue(replayDigest: string): string;
+    remember(input: { evidence: string; replayDigest: string; reservationId: string }): void;
+    find(replayDigest: string): string | null;
+    authorize(replayDigest: string): void;
+    authorized(evidence: string): boolean;
+    reservationId(evidence: string): string | null;
+  };
+  authorizeLockedReplay?: (input: {
+    sessionBearer: string;
+    eventGameId: string;
+    grantSessionId: string;
+    grantVersion: string;
+  }) => Promise<boolean>;
+  lockEventGame?: (
+    eventGameId: string,
+    lockedAtMs: number,
+  ) => Promise<
+    | { status: "locked"; eventGameId: string; terminatedSessionCount: number }
+    | { status: "rejected"; reason: string }
+  >;
   clock?: () => number;
   /** Test-only seam for proving the post-commit projection response. */
   projectionFailure?: () => boolean;
@@ -354,6 +381,7 @@ export type ControllerReplayOutcome = {
     | "retryable"
     | "causally-blocked"
     | "held-for-correction"
+    | "locked-discarded"
     | "terminally-rejected";
   detail?: string;
 };
@@ -366,6 +394,7 @@ export type ControllerReplayResult = {
   status: "synchronized" | "retryable" | "rejected";
   outcomes: readonly ControllerReplayOutcome[];
   projection: ControllerProjection | null;
+  discardedCount?: number;
 };
 
 export function createLiveEventGameIqaInterpreter(
@@ -806,6 +835,57 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
   let reconciliationCompletion: Promise<number> | null = null;
   let closed = false;
 
+  async function lockEventGameIfDue(eventGameId: string): Promise<boolean> {
+    try {
+      if (options.lockEventGame === undefined) return false;
+      const owner = await options.resolveEventGameRecord(eventGameId);
+      if (owner === null) return false;
+      const root = await owner.record.readRoot(owner.recordId);
+      if (
+        root === null ||
+        root.lifecycle.phase !== "finished" ||
+        root.lifecycle.finishedAtMs === null ||
+        root.lifecycle.lockedAtMs !== null
+      )
+        return false;
+      const metadata = await owner.record.readMetadata();
+      const lastAcceptedAtMs = metadata?.lastAcceptedAtMs;
+      const nowMs = clock();
+      if (
+        lastAcceptedAtMs === null ||
+        lastAcceptedAtMs === undefined ||
+        !Number.isSafeInteger(lastAcceptedAtMs) ||
+        !Number.isSafeInteger(nowMs) ||
+        nowMs < 0 ||
+        nowMs < lastAcceptedAtMs + EVENT_GAME_LOCK_DELAY_MS
+      )
+        return false;
+      const result = await options.lockEventGame(eventGameId, nowMs);
+      if (result.status !== "locked") return false;
+      for (const [sessionBearer, session] of activeControllerSessions) {
+        if (session.eventGameId === eventGameId) activeControllerSessions.delete(sessionBearer);
+      }
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async function reconcileEventGameLocks(): Promise<number> {
+    if (closed) return 0;
+    let roots: readonly EventGameRecordRoot[];
+    try {
+      roots = await options.listEventGameRoots();
+    } catch {
+      return 0;
+    }
+    let lockedCount = 0;
+    for (const root of roots) {
+      if (await lockEventGameIfDue(root.eventGameId)) lockedCount += 1;
+    }
+    return lockedCount;
+  }
+
   const trackActiveControllerSession = (
     sessionBearer: string,
     eventGameId: string,
@@ -883,6 +963,7 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
     deviceClass?: string;
     browserClass?: string;
   }): Promise<OpenControllerResult> {
+    await reconcileEventGameLocks();
     const admitted =
       input.grantCode === undefined
         ? await options.grantAuthority.admitGrant(
@@ -956,6 +1037,7 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
     sessionBearer: string;
     eventGameId: string;
   }): Promise<ControllerRefreshResult> {
+    await lockEventGameIfDue(input.eventGameId);
     const authorized = await options.grantAuthority.authorizeGrant({
       sessionBearer: input.sessionBearer,
       eventGameId: input.eventGameId,
@@ -1051,6 +1133,7 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
   async function switchController(input: {
     sessionBearer: string;
   }): Promise<ControllerRefreshResult> {
+    await reconcileEventGameLocks();
     const switched = await options.grantAuthority.acceptControlGrantSessionSwitch({
       sessionBearer: input.sessionBearer,
     });
@@ -1088,6 +1171,7 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
     sessionBearer: string;
     eventGameId: string;
   }): Promise<ControllerRefreshResult> {
+    await lockEventGameIfDue(input.eventGameId);
     const authorized = await options.grantAuthority.authorizeGrant({
       sessionBearer: input.sessionBearer,
       eventGameId: input.eventGameId,
@@ -1131,6 +1215,7 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
     sessionBearer: string;
     eventGameId: string;
   }): Promise<ControllerQrResult> {
+    await lockEventGameIfDue(input.eventGameId);
     const authorized = await options.grantAuthority.authorizeGrant({
       sessionBearer: input.sessionBearer,
       eventGameId: input.eventGameId,
@@ -1164,12 +1249,101 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
       : { status: "rejected", message: "Unable to leave Controller session." };
   }
 
+  async function discardLockedReplay(input: {
+    sessionBearer: string;
+    eventGameId: string;
+    expectedGrantSessionId: string;
+    capabilityEvidence: string;
+    actions: readonly { eventGameId: string; intent: unknown }[];
+    context: Omit<ControllerReplayResult, "status" | "outcomes" | "projection">;
+  }): Promise<ControllerReplayResult | null> {
+    if (options.lockedReplayCapability === undefined) return null;
+    const owner = await options.resolveEventGameRecord(input.eventGameId);
+    const root = owner === null ? null : await owner.record.readRoot(owner.recordId);
+    if (owner === null || root === null || root.lifecycle.lockedAtMs === null) return null;
+    if (
+      input.actions.length === 0 ||
+      input.actions.length > SHARED_LIMITS.replay.maxControlActions ||
+      input.actions.some((candidate) => candidate.eventGameId !== input.eventGameId)
+    )
+      return null;
+    const parsed = input.actions.map((candidate) =>
+      parseLiveEventControllerIntent(candidate.intent),
+    );
+    if (parsed.some((candidate) => !candidate.ok)) return null;
+    const actionIds = parsed.map((candidate) => (candidate.ok ? candidate.value.operationId : ""));
+    if (new Set(actionIds).size !== actionIds.length || actionIds.some((id) => id === ""))
+      return null;
+    const actions = parsed.map((candidate) => {
+      if (!candidate.ok) throw new Error("Locked replay intent is invalid.");
+      return {
+        recordId: root.recordId,
+        eventGameId: root.eventGameId,
+        operationId: candidate.value.operationId,
+        kind: { id: "game-fact", version: "1" },
+        payload: {
+          factId: candidate.value.factId,
+          factType: "locked-replay-discard",
+          gameSideId: null,
+          gameTimeMs: 0,
+          data: null,
+        },
+        causalPredecessorIds: [],
+        occurrence: {
+          trustedAtMs: root.lifecycle.lockedAtMs ?? clock(),
+          clientOriginAtMs: candidate.value.occurrence.clientOriginAtMs,
+          source: "offline",
+        },
+        grant: {
+          sessionId: input.expectedGrantSessionId,
+          versionId: input.context.session.grantVersion,
+        },
+        lifecycle: structuredClone(root.lifecycle),
+      };
+    });
+    try {
+      const accepted = await options.acceptance.submitBatch({
+        mode: "replay",
+        recordId: root.recordId,
+        eventGameId: root.eventGameId,
+        replay: {
+          sessionBearer: input.sessionBearer,
+          originatingSessionId: input.expectedGrantSessionId,
+          replayEvidenceId: input.capabilityEvidence,
+        },
+        actions,
+      });
+      const discarded = accepted.results.find((result) => result.status === "locked-discarded");
+      if (discarded?.status !== "locked-discarded") return null;
+      return {
+        ...input.context,
+        status: "synchronized",
+        outcomes: actionIds.map((operationId) => ({
+          operationId,
+          status: "locked-discarded" as const,
+          detail: `${discarded.count} queued Controller action(s) were discarded after Game Lock.`,
+        })),
+        projection: null,
+        discardedCount: discarded.count,
+      };
+    } catch {
+      return null;
+    }
+  }
+
   async function submitControllerIntent(input: {
     sessionBearer: string;
     eventGameId: string;
     intent: unknown;
     causalPredecessorIds?: readonly string[];
+    replay?: {
+      sessionBearer: string;
+      originatingSessionId: string;
+      replayEvidenceId: string;
+      reserveOnly?: boolean;
+    };
   }): Promise<LiveEventGameControlResult> {
+    await lockEventGameIfDue(input.eventGameId);
     const authorized = await options.grantAuthority.authorizeGrant({
       sessionBearer: input.sessionBearer,
       eventGameId: input.eventGameId,
@@ -1225,7 +1399,8 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
       effectiveStateBefore.phase === "finished" &&
       existingAction === undefined &&
       parsed.value.type !== "correct-fact" &&
-      !allowsLatePreCatchGoal(parsed.value, effectiveStateBefore)
+      !allowsLatePreCatchGoal(parsed.value, effectiveStateBefore) &&
+      input.replay?.reserveOnly !== true
     ) {
       return rejectedAction(parsed.value.operationId);
     }
@@ -1522,7 +1697,8 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
       accepted = await options.acceptance.submitBatch({
         recordId: activeRoot.recordId,
         eventGameId: activeRoot.eventGameId,
-        sessionBearer: input.sessionBearer,
+        ...(input.replay === undefined ? { sessionBearer: input.sessionBearer } : {}),
+        ...(input.replay === undefined ? {} : { mode: "replay", replay: input.replay }),
         lifecycleTransition,
         actions,
         reconcileDerivedLifecycle: derivedLifecycle !== undefined,
@@ -1534,7 +1710,7 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
     const result = accepted.results[0];
     const consequenceResult = accepted.results[1];
     if (accepted.status === "partial" || result?.status === "retry-later") {
-      return retryableAction(parsed.value.operationId);
+      return retryableAction(parsed.value.operationId, accepted.reservationId);
     }
     if (
       consequenceResult !== undefined &&
@@ -1599,6 +1775,46 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
     ) {
       return replayRejected(input.actions, replayContext);
     }
+    const replayDigest = sha256(
+      canonicalizeJson({
+        eventGameId: input.eventGameId,
+        batchId: input.batchId,
+        replicaGeneration: input.replicaGeneration,
+        grantSessionId: input.expectedGrantSessionId,
+        grantVersion: input.expectedGrantVersion,
+        actions: input.actions,
+      }),
+    );
+    if (options.authorizeLockedReplay !== undefined) {
+      const authorized = await options.authorizeLockedReplay({
+        sessionBearer: input.sessionBearer,
+        eventGameId: input.eventGameId,
+        grantSessionId: input.expectedGrantSessionId,
+        grantVersion: input.expectedGrantVersion,
+      });
+      if (!authorized) return replayRejected(input.actions, replayContext);
+      options.lockedReplayCapability?.authorize(replayDigest);
+    }
+    await lockEventGameIfDue(input.eventGameId);
+    const capability = options.lockedReplayCapability;
+    const capabilityEvidence = capability?.find(replayDigest) ?? null;
+    const ownerAfterLock = await options.resolveEventGameRecord(input.eventGameId);
+    const rootAfterLock =
+      ownerAfterLock === null
+        ? null
+        : await ownerAfterLock.record.readRoot(ownerAfterLock.recordId);
+    if (rootAfterLock?.lifecycle.lockedAtMs !== null && capabilityEvidence === null) {
+      return replayRejected(input.actions, replayContext);
+    }
+    const lockedReplay = await discardLockedReplay({
+      sessionBearer: input.sessionBearer,
+      eventGameId: input.eventGameId,
+      expectedGrantSessionId: input.expectedGrantSessionId,
+      capabilityEvidence: capabilityEvidence ?? "",
+      actions: input.actions,
+      context: replayContext,
+    });
+    if (lockedReplay !== null) return lockedReplay;
     const authorized = await options.grantAuthority.authorizeGrant({
       sessionBearer: input.sessionBearer,
       eventGameId: input.eventGameId,
@@ -1660,6 +1876,16 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
         input.actions.flatMap((candidate) => {
           const operationId = readOperationId(candidate.intent);
           return operationId === null ? [] : [operationId];
+        }),
+      );
+      const replayDigest = sha256(
+        canonicalizeJson({
+          eventGameId: input.eventGameId,
+          batchId: input.batchId,
+          replicaGeneration: input.replicaGeneration,
+          grantSessionId: input.expectedGrantSessionId,
+          grantVersion: input.expectedGrantVersion,
+          actions: input.actions,
         }),
       );
       let remaining = [...input.actions];
@@ -1728,6 +1954,33 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
             !allowsLatePreCatchGoal(parsedIntent.value, replayState) &&
             !persistedOperationIds.has(operationId)
           ) {
+            const capability = options.lockedReplayCapability;
+            const replayEvidenceId =
+              capability?.find(replayDigest) ?? capability?.issue(replayDigest);
+            if (replayEvidenceId !== undefined) {
+              const heldResult = await submitControllerIntent({
+                sessionBearer: input.sessionBearer,
+                eventGameId: authorized.eventGameId,
+                intent: candidate.intent,
+                causalPredecessorIds: predecessors,
+                replay: {
+                  sessionBearer: input.sessionBearer,
+                  originatingSessionId: input.expectedGrantSessionId,
+                  replayEvidenceId,
+                  reserveOnly: true,
+                },
+              });
+              if (
+                heldResult.status === "retryable" &&
+                heldResult.replayReservationId !== undefined
+              ) {
+                capability?.remember({
+                  evidence: replayEvidenceId,
+                  replayDigest,
+                  reservationId: heldResult.replayReservationId,
+                });
+              }
+            }
             outcomes.push({ operationId, status: "held-for-correction" });
             held.add(operationId);
             progressed = true;
@@ -1866,6 +2119,7 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
       }
       return activeControllerSessions.size;
     },
+    reconcileEventGameLocks,
     reconcileActiveControllerSessions,
     close() {
       closed = true;
@@ -3888,11 +4142,15 @@ function rejectedAction(operationId: string | null): LiveEventGameControlResult 
   };
 }
 
-function retryableAction(operationId: string | null): LiveEventGameControlResult {
+function retryableAction(
+  operationId: string | null,
+  replayReservationId?: string,
+): LiveEventGameControlResult {
   return {
     status: "retryable",
     message: "Controller action was not committed; retry is safe.",
     operationId,
+    ...(replayReservationId === undefined ? {} : { replayReservationId }),
   };
 }
 

--- a/src/lib/live-event-game-runtime.test.ts
+++ b/src/lib/live-event-game-runtime.test.ts
@@ -5,6 +5,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createEventGameRecord } from "@/lib/event-game-record";
+import { createFoundationAcceptance } from "@/lib/foundation-acceptance";
 import type { EventGameRecordRoot } from "@/lib/foundation-record-types";
 import type { FoundationStorageSnapshot } from "@/lib/foundation-storage";
 import { FOUNDATION_MIGRATIONS } from "@/lib/foundation-migrations";
@@ -254,6 +255,183 @@ describe("Live Event Game SQLite runtime", () => {
       });
     } finally {
       runtime.close();
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("locks an inactive finished Game, terminates its Grant Session, and discards replay evidence", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "quadball-event-game-runtime-"));
+    const databasePath = join(directory, "event-game.sqlite");
+    const keyRing = createKeyRing();
+    const root = createRoot();
+    let nowMs = 10_000;
+    const finishedRoot = {
+      ...root,
+      lifecycle: {
+        ...root.lifecycle,
+        phase: "finished" as const,
+        commencedAtMs: nowMs,
+        finishedAtMs: nowMs,
+      },
+    };
+    let qrCredential: string;
+    try {
+      const setupStorage = openSqliteFoundationStorage(databasePath, { grantKeyRing: keyRing });
+      try {
+        await setupStorage.applyMigrations({ requireCandidate: false });
+        const setupRecord = createEventGameRecord(setupStorage, {
+          externalScopeResolver: createExternalScopeResolver(root),
+          interpreter: createLiveEventGameIqaInterpreter(),
+          clock: () => nowMs,
+          auditAuthorityVerifier: { verify: () => true },
+        });
+        expect(await setupRecord.registerRoot(finishedRoot)).toMatchObject({
+          status: "registered",
+        });
+        expect(
+          await setupRecord.acceptAction({
+            recordId: root.recordId,
+            eventGameId: root.eventGameId,
+            operationId: "runtime-lock-existing-goal",
+            kind: { id: "game-fact", version: "1" },
+            payload: {
+              factId: "runtime-lock-existing-fact",
+              factType: "forfeit",
+              gameSideId: "side-a",
+              gameTimeMs: 0,
+              data: null,
+            },
+            causalPredecessorIds: [],
+            occurrence: { trustedAtMs: nowMs, clientOriginAtMs: nowMs, source: "online" },
+            grant: {
+              sessionId: "runtime-lock-setup-session",
+              versionId: "runtime-lock-setup-grant",
+            },
+            lifecycle: {
+              ...root.lifecycle,
+              phase: "finished",
+              commencedAtMs: nowMs,
+              finishedAtMs: nowMs,
+            },
+          }),
+        ).toMatchObject({ status: "accepted" });
+        const authority = createTypedGrantAuthority(
+          setupStorage,
+          createGrantOptions("runtime-test", keyRing),
+        );
+        const created = await authority.createControlGrant({
+          scope: root.externalScope,
+          authority: { kind: "fixture", id: "runtime-fixture" },
+          expiresAtMs: nowMs + 2_000_000,
+        });
+        if (created.status !== "created") throw new Error("Expected a runtime Control Grant.");
+        qrCredential = created.qrCredential;
+      } finally {
+        setupStorage.close();
+      }
+
+      const runtime = await openLiveEventGameRuntime({
+        databasePath,
+        environmentId: "runtime-test",
+        keyRing,
+        clock: () => nowMs,
+      });
+      try {
+        const opened = await runtime.control.openController({
+          qrCredential,
+          browserContext: "runtime-lock-device",
+        });
+        if (opened.status !== "opened") throw new Error("Expected the runtime Controller to open.");
+        const replayInput = {
+          sessionBearer: opened.session.sessionBearer,
+          eventGameId: root.eventGameId,
+          batchId: "runtime-lock-replay-batch",
+          replicaGeneration: "runtime-lock-replay-generation",
+          expectedGrantSessionId: opened.session.grantSessionId,
+          expectedGrantVersion: opened.session.grantVersion,
+          actions: [
+            {
+              eventGameId: root.eventGameId,
+              intent: {
+                version: LIVE_EVENT_CONTROL_INTENT_VERSION,
+                type: "record-goal",
+                operationId: "runtime-lock-offline-goal",
+                factId: "runtime-lock-offline-fact",
+                gameSideId: "side-a",
+                gameTimeMs: 0,
+                occurrence: { clientOriginAtMs: 9_000, source: "offline" },
+              },
+              causalPredecessorIds: [],
+            },
+          ],
+        };
+        const held = await runtime.control.replayControllerActions(replayInput);
+        expect(held).toMatchObject({
+          status: "synchronized",
+          outcomes: [{ operationId: "runtime-lock-offline-goal", status: "held-for-correction" }],
+        });
+        nowMs += 15 * 60 * 1000;
+
+        const replay = await runtime.control.replayControllerActions(replayInput);
+        expect(replay).toMatchObject({
+          status: "synchronized",
+          discardedCount: 1,
+          outcomes: [
+            {
+              operationId: "runtime-lock-offline-goal",
+              status: "locked-discarded",
+            },
+          ],
+        });
+      } finally {
+        runtime.close();
+      }
+
+      const verification = openSqliteFoundationStorage(databasePath, { grantKeyRing: keyRing });
+      try {
+        createFoundationAcceptance(verification, {
+          grant: createGrantOptions("runtime-test", keyRing),
+          externalScopeResolver: createExternalScopeResolver(root),
+          interpreter: createLiveEventGameIqaInterpreter(),
+          clock: () => nowMs,
+        });
+        expect(await verification.readRoot(root.recordId)).toMatchObject({
+          lifecycle: { phase: "finished", lockReason: "finished-inactivity", lockedAtMs: nowMs },
+        });
+        expect(await verification.readActions(root.recordId)).toHaveLength(1);
+        expect(
+          (await verification.readAuditEntries(root.recordId)).find(
+            (entry) => entry.lockedReplay !== undefined,
+          ),
+        ).toMatchObject({
+          lockedReplay: {
+            count: 1,
+            eventGameId: root.eventGameId,
+            originatingSessionId: expect.any(String),
+            rejectedAtMs: nowMs,
+          },
+        });
+        const state = await verification.transaction((transaction) => {
+          const grant = transaction.listGrants()[0];
+          return grant === undefined
+            ? null
+            : {
+                sessions: transaction.listGrantSessions(grant.grantId),
+              };
+        });
+        expect(state).toMatchObject({
+          sessions: [{ status: "expired" }],
+        });
+        const raw = new Database(databasePath, { readonly: true });
+        try {
+          expect(raw.query("SELECT state FROM foundation_grant_codes").get()).toBeNull();
+        } finally {
+          raw.close();
+        }
+      } finally {
+        verification.close();
+      }
+    } finally {
       await rm(directory, { recursive: true, force: true });
     }
   });

--- a/src/lib/live-event-game-runtime.ts
+++ b/src/lib/live-event-game-runtime.ts
@@ -19,10 +19,12 @@ import {
   canonicalizeEventGameRecordRoot,
   validateEventGameRecordRoot,
 } from "@/lib/foundation-record-types";
+import { lockControlGrantEventGame } from "@/lib/grant-management-sessions";
 import type {
   FoundationStorageSnapshot,
   FoundationStorageTransaction,
 } from "@/lib/foundation-storage";
+import type { FoundationStorage } from "@/lib/foundation-storage";
 
 export type LiveEventGameRuntime = {
   control: ReturnType<typeof createLiveEventGameControl>;
@@ -46,16 +48,75 @@ export async function openLiveEventGameRuntime(input: {
   try {
     const clock = input.clock ?? (() => Date.now());
     let refreshEventCapacitySnapshot = () => {};
-    const grantOptions = createGrantOptions(input.environmentId, input.keyRing, clock, () =>
-      refreshEventCapacitySnapshot(),
+    const grantOptions = createGrantOptions(
+      input.environmentId,
+      input.keyRing,
+      clock,
+      () => refreshEventCapacitySnapshot(),
+      storage,
     );
     const authority = createTypedGrantAuthority(storage, grantOptions);
     const scopeResolver = createExternalScopeResolver();
+    const lockedReplayCapabilities = new Map<
+      string,
+      { replayDigest: string; reservationId: string | null; authorized: boolean }
+    >();
+    const lockedReplayCapability = {
+      issue(replayDigest: string) {
+        const evidence = randomBytes(32).toString("base64url");
+        lockedReplayCapabilities.set(evidence, {
+          replayDigest,
+          reservationId: null,
+          authorized: false,
+        });
+        return evidence;
+      },
+      remember(input: { evidence: string; replayDigest: string; reservationId: string }) {
+        const current = lockedReplayCapabilities.get(input.evidence);
+        if (current?.replayDigest !== input.replayDigest) return;
+        lockedReplayCapabilities.set(input.evidence, {
+          replayDigest: input.replayDigest,
+          reservationId: input.reservationId,
+          authorized: current.authorized,
+        });
+      },
+      find(replayDigest: string) {
+        for (const [evidence, capability] of lockedReplayCapabilities) {
+          if (capability.replayDigest === replayDigest && capability.reservationId !== null)
+            return evidence;
+        }
+        return null;
+      },
+      authorize(replayDigest: string) {
+        for (const [evidence, capability] of lockedReplayCapabilities) {
+          if (capability.replayDigest === replayDigest) {
+            lockedReplayCapabilities.set(evidence, { ...capability, authorized: true });
+          }
+        }
+      },
+      authorized(evidence: string) {
+        return lockedReplayCapabilities.get(evidence)?.authorized === true;
+      },
+      reservationId(evidence: string) {
+        return lockedReplayCapabilities.get(evidence)?.reservationId ?? null;
+      },
+    };
     const acceptance = createFoundationAcceptance(storage, {
       grant: grantOptions,
       externalScopeResolver: scopeResolver,
       interpreter: createLiveEventGameIqaInterpreter(),
       clock,
+      verifyLockedReplay: ({ evidence }) =>
+        typeof evidence === "string" &&
+        lockedReplayCapability.reservationId(evidence) !== null &&
+        lockedReplayCapability.authorized(evidence),
+      authorizeLockedReplay: ({ evidence }) => lockedReplayCapability.authorized(evidence),
+      lockedReplayReservationId: (evidence) =>
+        typeof evidence === "string" ? lockedReplayCapability.reservationId(evidence) : null,
+      replayEligibility: ({ replayEvidenceId }) =>
+        lockedReplayCapability.reservationId(replayEvidenceId) !== null
+          ? { status: "eligible" }
+          : { status: "ineligible" },
       validateActionInTransaction: ({ transaction, root, action }) =>
         validateLiveEventGameActionInTransaction(
           transaction.listActions(root.recordId),
@@ -63,6 +124,11 @@ export async function openLiveEventGameRuntime(input: {
           action,
         ),
     });
+    const hasLifecycleInventory = await storage.transaction(
+      (transaction) => typeof transaction.listRoots === "function",
+    );
+    if (!hasLifecycleInventory)
+      throw new Error("Durable Event Game lifecycle inventory is not available.");
     const records = new Map<string, EventGameRecord>();
     const resolveEventGameRecord = async (eventGameId: string) => {
       const root = await storage.transaction((transaction) =>
@@ -88,13 +154,49 @@ export async function openLiveEventGameRuntime(input: {
       acceptance,
       grantAuthority: authority,
       clock,
+      listEventGameRoots: async () =>
+        storage.transaction((transaction) => {
+          if (typeof transaction.listRoots !== "function")
+            throw new Error("Durable Event Game lifecycle inventory is not available.");
+          return transaction.listRoots();
+        }),
+      lockedReplayCapability,
+      authorizeLockedReplay: async ({
+        sessionBearer,
+        eventGameId,
+        grantSessionId,
+        grantVersion,
+      }) => {
+        const authorized = await authority.authorizeGrant({
+          sessionBearer,
+          eventGameId,
+          readOnly: true,
+        });
+        return (
+          authorized.status === "authorized" &&
+          authorized.grantType === "control" &&
+          authorized.eventGameId === eventGameId &&
+          authorized.grantSessionId === grantSessionId &&
+          authorized.grantVersion === grantVersion
+        );
+      },
+      lockEventGame: (eventGameId, lockedAtMs) =>
+        lockControlGrantEventGame(storage, grantOptions, {
+          kind: "event-game-lock",
+          eventGameId,
+          lockedAtMs,
+        }),
     });
+    const lockTimer = setInterval(() => {
+      void control.reconcileEventGameLocks();
+    }, 1_000);
     refreshEventCapacitySnapshot = () => {
       void control.reconcileActiveControllerSessions();
     };
     return {
       control,
       close() {
+        clearInterval(lockTimer);
         control.close();
         storage.close();
       },
@@ -124,8 +226,9 @@ function createGrantOptions(
   keyRing: GrantKeyRing,
   clock: () => number,
   onLifecycleChange?: () => void,
+  storage?: FoundationStorage,
 ): GrantAuthorityOptions {
-  return {
+  const options: GrantAuthorityOptions = {
     environmentId,
     clock: { nowMs: clock },
     randomness: { bytes: (length) => new Uint8Array(randomBytes(length)) },
@@ -134,6 +237,49 @@ function createGrantOptions(
     privilegedAuthorityVerifier: { verify: () => null },
     onLifecycleChange,
   };
+  if (storage !== undefined) {
+    options.controlGrantLifecycle = {
+      resolveEventGameLock(evidence) {
+        if (!isRecord(evidence) || evidence.kind !== "event-game-lock") return null;
+        const eventGameId = evidence.eventGameId;
+        const lockedAtMs = evidence.lockedAtMs;
+        if (
+          typeof eventGameId !== "string" ||
+          typeof lockedAtMs !== "number" ||
+          !Number.isSafeInteger(lockedAtMs) ||
+          lockedAtMs < 0
+        )
+          return null;
+        return {
+          eventGameId,
+          apply(transaction) {
+            const current = transaction.findRootByEventGameId(eventGameId);
+            if (
+              current === null ||
+              current.lifecycle.phase !== "finished" ||
+              current.lifecycle.finishedAtMs === null ||
+              current.lifecycle.lockedAtMs !== null
+            )
+              throw new Error("Only an unlocked finished Event Game may be locked.");
+            const locked = validateEventGameRecordRoot({
+              ...current,
+              lifecycle: {
+                ...current.lifecycle,
+                lockedAtMs,
+                lockReason: "finished-inactivity",
+              },
+            });
+            if (!locked.ok) throw new Error(locked.error);
+            transaction.updateRoot({
+              root: locked.value,
+              canonicalContent: canonicalizeEventGameRecordRoot(locked.value),
+            });
+          },
+        };
+      },
+    };
+  }
+  return options;
 }
 
 export function createControlScopeResolver(

--- a/src/pages/event-game-controller-page.tsx
+++ b/src/pages/event-game-controller-page.tsx
@@ -860,6 +860,11 @@ export function EventGameControllerPage() {
       const nextReplica = reconcileControllerReplay(replicaRef.current ?? prepared.state, response);
       commitReplica(nextReplica);
       receiveProjection(response.projection);
+      if (response.discardedCount !== undefined) {
+        setMessage(
+          `${response.discardedCount} queued Controller action(s) were discarded after Game Lock.`,
+        );
+      }
       if (
         response.status === "synchronized" &&
         nextReplica.pendingActions.some((action) => action.status === "pending")


### PR DESCRIPTION
## What changed

- adds the Controller-facing Event Game finish and 15-minute Game Lock lifecycle
- retains finished-but-unlocked replay evidence for deliberate correction
- terminates matching Control Grant Sessions and expires the current Grant Code at lock
- conclusively discards reserved offline actions with bounded, payload-free audit evidence
- keeps lock cleanup correct after Pitch Slot reassignment

## Why

Finished Event Games must remain correctable for a short operational window, then close authority and pending replay safely without changing sporting state or leaking rejected payloads.

## Impact

Controllers can reconcile a finished Game until lock. After lock, ordinary mutation and admission stop, queued actions receive one concise discard outcome, and no manual-tracking mode is introduced.

## Validation

- focused ordinary authorization, replay, runtime, and control suites: 143 passed
- `bun run check`
- `bun run test`: 729 passed
- `bun run build`
- `git diff --check`

Production-shaped qualification, load, soak, crash, recovery, and exact-artifact workloads were intentionally not run.

Stacked on #212.

Closes #95