### PR TITLE
Sanitize Technical Admin authentication for Foundation restore

### DIFF
--- a/scripts/test-technical-admin-browser.ts
+++ b/scripts/test-technical-admin-browser.ts
@@ -6,6 +6,11 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { openSqliteFoundationStorage } from "@/lib/foundation-storage-sqlite";
 import { readGrantAuthorityOptions } from "@/lib/grant-runtime";
+import {
+  createSqliteTechnicalAdminAuthRepository,
+  createTechnicalAdminAuth,
+} from "@/lib/technical-admin-auth";
+import { readTechnicalAdminConfig } from "@/lib/technical-admin-config";
 
 const directory = mkdtempSync(join(tmpdir(), "quadball-timer-admin-browser-"));
 const certificatePath = join(directory, "localhost.crt");
@@ -132,6 +137,11 @@ try {
   }, enrollmentToken);
   assert(replayStatus === 401 || replayStatus === 409, "enrollment replay was rejected");
 
+  await page.getByRole("button", { name: "Sign in with passkey" }).click();
+  await page.getByText("Technical Admin administration").waitFor();
+  await prepareTechnicalAdminRestore();
+  await page.reload();
+  await page.getByRole("button", { name: "Sign in with passkey" }).waitFor();
   await page.getByRole("button", { name: "Sign in with passkey" }).click();
   await page.getByText("Technical Admin administration").waitFor();
   const csrfFailureStatus = await page.evaluate(async () => {
@@ -2273,11 +2283,41 @@ async function waitForServer(url: string) {
 }
 
 async function restartServerProcess(serverOrigin: string, serverEnvironment: NodeJS.ProcessEnv) {
+  await stopServerProcess();
+  await Bun.sleep(250);
+  await startServerProcess(serverOrigin, serverEnvironment);
+}
+
+async function prepareTechnicalAdminRestore() {
+  await stopServerProcess();
+  const config = readTechnicalAdminConfig(environment);
+  const repository = createSqliteTechnicalAdminAuthRepository(databasePath, {
+    environment: config.environment,
+    origin: config.origin,
+    rpId: config.rpId,
+  });
+  try {
+    const auth = createTechnicalAdminAuth(config, repository);
+    assert(
+      (await auth.prepareForFoundationRestore({ mode: "preserve-compatible-credential" }))
+        .outcome === "preserved-transients-invalidated",
+      "Technical Admin restore preparation did not preserve the compatible credential",
+    );
+  } finally {
+    repository.close();
+  }
+  await startServerProcess(origin, environment);
+}
+
+async function stopServerProcess() {
   if (server !== null) {
     server.kill();
     await server.exited;
-    await Bun.sleep(250);
+    server = null;
   }
+}
+
+async function startServerProcess(serverOrigin: string, serverEnvironment: NodeJS.ProcessEnv) {
   server = Bun.spawn(["bun", "run", "src/index.ts"], {
     cwd: process.cwd(),
     env: serverEnvironment,

--- a/src/index.ts
+++ b/src/index.ts
@@ -680,8 +680,8 @@ async function startServer() {
           },
         },
         "/api/admin/authentication/options": {
-          POST(req: Request) {
-            const result = technicalAdminAuth.beginAuthentication(requestBinding(req));
+          async POST(req: Request) {
+            const result = await technicalAdminAuth.beginAuthentication(requestBinding(req));
             return result.ok ? sensitiveJson(result.value) : genericAuthFailure(401);
           },
         },

--- a/src/lib/event-catalog.test.ts
+++ b/src/lib/event-catalog.test.ts
@@ -716,8 +716,14 @@ describe("Event operations catalog", () => {
     const verifier: WebAuthnVerifier = {
       async verifyRegistration() {
         return {
-          credentialId: "credential-live",
-          publicKey: { kty: "OKP", crv: "Ed25519", x: "public-key" },
+          credentialId: "credential-1",
+          publicKey: {
+            kty: "OKP",
+            crv: "Ed25519",
+            x: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            alg: "EdDSA",
+            ext: true,
+          },
           signCount: 1,
         };
       },
@@ -727,7 +733,11 @@ describe("Event operations catalog", () => {
     };
     const auth = createTechnicalAdminAuth(
       { environment: "test", origin: binding.origin, rpId: "timer.example" },
-      new MemoryTechnicalAdminAuthRepository(),
+      new MemoryTechnicalAdminAuthRepository({
+        environment: "test",
+        origin: binding.origin,
+        rpId: "timer.example",
+      }),
       verifier,
       () => 1_000,
     );
@@ -742,7 +752,7 @@ describe("Event operations catalog", () => {
         value: undefined,
       },
     );
-    const authenticationOptions = auth.beginAuthentication(binding);
+    const authenticationOptions = await auth.beginAuthentication(binding);
     if (!authenticationOptions.ok) throw new Error("Expected authentication options.");
     const session = await auth.completeAuthentication(
       authenticationOptions.value.challengeId,

--- a/src/lib/technical-admin-auth-sqlite.focused.ts
+++ b/src/lib/technical-admin-auth-sqlite.focused.ts
@@ -13,6 +13,13 @@ import {
 
 const binding = { origin: "https://localhost:39421", host: "localhost:39421" };
 const identity = { environment: "test" as const, origin: binding.origin, rpId: "localhost" };
+const validEd25519PublicKey: JsonWebKey = {
+  kty: "OKP",
+  crv: "Ed25519",
+  x: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+  alg: "EdDSA",
+  ext: true,
+};
 
 function createVerifier(): WebAuthnVerifier {
   let signCount = 1;
@@ -20,7 +27,7 @@ function createVerifier(): WebAuthnVerifier {
     async verifyRegistration() {
       return {
         credentialId: "credential-1",
-        publicKey: { kty: "OKP", crv: "Ed25519", x: "focused-key" },
+        publicKey: { ...validEd25519PublicKey },
         signCount: signCount++,
       };
     },
@@ -42,7 +49,7 @@ async function enrollAndAuthenticate(
   if (!enrollment.ok) throw new Error("Expected enrollment options.");
   const completed = await auth.completeEnrollment(enrollment.value.challengeId, {}, binding);
   if (!completed.ok) throw new Error("Expected enrollment completion.");
-  const options = auth.beginAuthentication(binding);
+  const options = await auth.beginAuthentication(binding);
   if (!options.ok) throw new Error("Expected authentication options.");
   const session = await auth.completeAuthentication(options.value.challengeId, {}, binding);
   if (!session.ok) throw new Error("Expected authenticated session.");
@@ -54,12 +61,7 @@ function insertCredential(databasePath: string, count = 1) {
   for (let index = 0; index < count; index++) {
     database
       .query("INSERT INTO technical_admin_credentials VALUES (?, ?, ?, ?)")
-      .run(
-        `credential-${index}`,
-        JSON.stringify({ kty: "OKP", crv: "Ed25519", x: `key-${index}` }),
-        1,
-        0,
-      );
+      .run(`credential-${index}`, JSON.stringify({ ...validEd25519PublicKey }), 1, 0);
   }
   database.close();
 }
@@ -135,6 +137,351 @@ async function withTempDirectory<T>(
 }
 
 describe("focused Technical Admin SQLite boundary", () => {
+  test("preserves the credential across sanitation and restart while requiring fresh sign-in", async () => {
+    await withTempDirectory("technical-admin-restore-focused-", async (directory) => {
+      const databasePath = join(directory, "auth.sqlite");
+      let repository: SqliteTechnicalAdminAuthRepository | undefined;
+      let restarted: SqliteTechnicalAdminAuthRepository | undefined;
+      try {
+        repository = new SqliteTechnicalAdminAuthRepository(databasePath, identity);
+        const { auth, session } = await enrollAndAuthenticate(repository, () => 1_000);
+        const pending = await auth.beginAuthentication(binding);
+        if (!pending.ok) throw new Error("Expected a pending authentication challenge.");
+        repository.issueEnrollment("pending-enrollment", 61_000);
+        const credentialBefore = structuredClone(repository.getCredential());
+
+        expect(
+          await auth.prepareForFoundationRestore({ mode: "preserve-compatible-credential" }),
+        ).toEqual({ outcome: "preserved-transients-invalidated" });
+        expect(repository.getCredential()).toEqual(credentialBefore);
+        expect(auth.authenticateSession(session.token)).toBe(false);
+        expect(auth.verifyCsrf(session.token, session.csrfToken)).toBe(false);
+        expect(auth.resolveCurrentAuthority(session.token)).toBeNull();
+        expect(await auth.beginAuthentication(binding)).toMatchObject({ ok: true });
+
+        repository.close();
+        repository = undefined;
+        restarted = new SqliteTechnicalAdminAuthRepository(databasePath, identity);
+        const restartedAuth = createTechnicalAdminAuth(
+          identity,
+          restarted,
+          createVerifier(),
+          () => 2_000,
+        );
+        expect(restarted.getCredential()).toMatchObject({
+          credentialId: credentialBefore?.credentialId,
+          publicKey: credentialBefore?.publicKey,
+          createdAtMs: credentialBefore?.createdAtMs,
+        });
+        const freshOptions = await restartedAuth.beginAuthentication(binding);
+        if (!freshOptions.ok) throw new Error("Expected fresh authentication options.");
+        expect(
+          await restartedAuth.completeAuthentication(freshOptions.value.challengeId, {}, binding),
+        ).toMatchObject({ ok: true });
+      } finally {
+        repository?.close();
+        restarted?.close();
+      }
+    });
+  });
+
+  test("classifies readable invalid state while sanitizing its old authority", async () => {
+    await withTempDirectory("technical-admin-restore-invalid-focused-", async (directory) => {
+      const databasePath = join(directory, "auth.sqlite");
+      let repository: SqliteTechnicalAdminAuthRepository | undefined;
+      let reopened: SqliteTechnicalAdminAuthRepository | undefined;
+      try {
+        repository = new SqliteTechnicalAdminAuthRepository(databasePath, identity);
+        const { auth, session } = await enrollAndAuthenticate(repository, () => 1_000);
+        const pending = await auth.beginAuthentication(binding);
+        if (!pending.ok) throw new Error("Expected a pending authentication challenge.");
+        repository.issueEnrollment("pending-enrollment", 61_000);
+        repository.close();
+        repository = undefined;
+
+        const database = new Database(databasePath);
+        database
+          .query("UPDATE technical_admin_credentials SET public_key_json = ?, credential_id = ?")
+          .run(JSON.stringify({ ...validEd25519PublicKey, key_ops: ["sign"] }), "credential-live");
+        database.close();
+
+        reopened = new SqliteTechnicalAdminAuthRepository(databasePath);
+        const reopenedAuth = createTechnicalAdminAuth(
+          identity,
+          reopened,
+          createVerifier(),
+          () => 2_000,
+        );
+        const challengeCountBefore = Number(
+          (
+            reopened.database
+              .query("SELECT COUNT(*) AS count FROM technical_admin_challenges")
+              .get() as { count: number }
+          ).count,
+        );
+        expect(await reopenedAuth.beginAuthentication(binding)).toEqual({
+          ok: false,
+          error: "invalid-credentials",
+        });
+        expect(
+          Number(
+            (
+              reopened.database
+                .query("SELECT COUNT(*) AS count FROM technical_admin_challenges")
+                .get() as { count: number }
+            ).count,
+          ),
+        ).toBe(challengeCountBefore);
+        expect(
+          await reopenedAuth.prepareForFoundationRestore({
+            mode: "preserve-compatible-credential",
+          }),
+        ).toEqual({ outcome: "re-enrollment-required", reason: "invalid" });
+        expect(reopenedAuth.authenticateSession(session.token)).toBe(false);
+        expect(await reopenedAuth.beginAuthentication(binding)).toEqual({
+          ok: false,
+          error: "invalid-credentials",
+        });
+      } finally {
+        repository?.close();
+        reopened?.close();
+      }
+    });
+  });
+
+  test("classifies compatible explicit reset atomically and removes the credential", async () => {
+    await withTempDirectory("technical-admin-restore-reset-focused-", async (directory) => {
+      const databasePath = join(directory, "auth.sqlite");
+      let repository: SqliteTechnicalAdminAuthRepository | undefined;
+      try {
+        repository = new SqliteTechnicalAdminAuthRepository(databasePath, identity);
+        const { auth, session } = await enrollAndAuthenticate(repository, () => 1_000);
+        const pending = await auth.beginAuthentication(binding);
+        if (!pending.ok) throw new Error("Expected a pending authentication challenge.");
+        repository.issueEnrollment("pending-enrollment", 61_000);
+
+        expect(await auth.prepareForFoundationRestore({ mode: "explicit-reset" })).toEqual({
+          outcome: "re-enrollment-required",
+          reason: "explicit-reset",
+        });
+        expect(repository.getCredential()).toBeNull();
+        expect(auth.authenticateSession(session.token)).toBe(false);
+        expect(await auth.beginAuthentication(binding)).toEqual({
+          ok: false,
+          error: "invalid-credentials",
+        });
+      } finally {
+        repository?.close();
+      }
+    });
+  });
+
+  test("explicit reset removes the credential when storage identity is incompatible", async () => {
+    await withTempDirectory(
+      "technical-admin-restore-reset-incompatible-focused-",
+      async (directory) => {
+        const databasePath = join(directory, "auth.sqlite");
+        let repository: SqliteTechnicalAdminAuthRepository | undefined;
+        try {
+          repository = new SqliteTechnicalAdminAuthRepository(databasePath, identity);
+          const { auth, session } = await enrollAndAuthenticate(repository, () => 1_000);
+          repository.issueEnrollment("pending-enrollment", 61_000);
+          const pending = await auth.beginAuthentication(binding);
+          if (!pending.ok) throw new Error("Expected pending authentication challenge.");
+          repository.close();
+          repository = new SqliteTechnicalAdminAuthRepository(databasePath);
+          const incompatibleAuth = createTechnicalAdminAuth(
+            { environment: "test", origin: "https://localhost:49421", rpId: "localhost" },
+            repository,
+            createVerifier(),
+            () => 2_000,
+          );
+
+          expect(
+            await incompatibleAuth.prepareForFoundationRestore({ mode: "explicit-reset" }),
+          ).toEqual({
+            outcome: "re-enrollment-required",
+            reason: "explicit-reset",
+          });
+          expect(repository.getCredential()).toBeNull();
+          expect(incompatibleAuth.authenticateSession(session.token)).toBe(false);
+          expect(incompatibleAuth.issueEnrollmentAuthorization().ok).toBe(true);
+        } finally {
+          repository?.close();
+        }
+      },
+    );
+  });
+
+  test("rolls back an incompatible explicit reset when credential deletion fails", async () => {
+    await withTempDirectory(
+      "technical-admin-restore-reset-rollback-focused-",
+      async (directory) => {
+        const databasePath = join(directory, "auth.sqlite");
+        let repository: SqliteTechnicalAdminAuthRepository | undefined;
+        try {
+          repository = new SqliteTechnicalAdminAuthRepository(databasePath, identity);
+          const { auth, session } = await enrollAndAuthenticate(repository, () => 1_000);
+          repository.issueEnrollment("pending-enrollment", 61_000);
+          const pending = await auth.beginAuthentication(binding);
+          if (!pending.ok) throw new Error("Expected pending authentication challenge.");
+          repository.close();
+          repository = new SqliteTechnicalAdminAuthRepository(databasePath);
+          const incompatibleAuth = createTechnicalAdminAuth(
+            { environment: "test", origin: "https://localhost:49421", rpId: "localhost" },
+            repository,
+            createVerifier(),
+            () => 2_000,
+          );
+          repository.database.exec(
+            "CREATE TRIGGER fail_restore_credential_delete BEFORE DELETE ON technical_admin_credentials BEGIN SELECT RAISE(ABORT, 'injected restore delete failure'); END",
+          );
+
+          expect(
+            await incompatibleAuth.prepareForFoundationRestore({ mode: "explicit-reset" }),
+          ).toEqual({
+            outcome: "sanitation-failed",
+          });
+          expect(repository.getCredential()).not.toBeNull();
+          expect(incompatibleAuth.authenticateSession(session.token)).toBe(true);
+          expect(
+            Number(
+              (
+                repository.database
+                  .query("SELECT COUNT(*) AS count FROM technical_admin_challenges")
+                  .get() as { count: number }
+              ).count,
+            ),
+          ).toBeGreaterThan(0);
+          expect(
+            Number(
+              (
+                repository.database
+                  .query("SELECT COUNT(*) AS count FROM technical_admin_enrollment")
+                  .get() as { count: number }
+              ).count,
+            ),
+          ).toBeGreaterThan(0);
+        } finally {
+          repository?.close();
+        }
+      },
+    );
+  });
+
+  test("classifies readable incompatible storage without preserving authority", async () => {
+    await withTempDirectory("technical-admin-restore-incompatible-focused-", async (directory) => {
+      const databasePath = join(directory, "auth.sqlite");
+      let repository: SqliteTechnicalAdminAuthRepository | undefined;
+      try {
+        repository = new SqliteTechnicalAdminAuthRepository(databasePath, identity);
+        const { session } = await enrollAndAuthenticate(repository, () => 1_000);
+        repository.close();
+        repository = new SqliteTechnicalAdminAuthRepository(databasePath);
+        const incompatibleAuth = createTechnicalAdminAuth(
+          { environment: "test", origin: "https://localhost:49421", rpId: "localhost" },
+          repository,
+          createVerifier(),
+          () => 2_000,
+        );
+
+        expect(
+          await incompatibleAuth.prepareForFoundationRestore({
+            mode: "preserve-compatible-credential",
+          }),
+        ).toEqual({ outcome: "re-enrollment-required", reason: "incompatible" });
+        expect(incompatibleAuth.authenticateSession(session.token)).toBe(false);
+      } finally {
+        repository?.close();
+      }
+    });
+  });
+
+  test("does not adopt a missing storage identity for an existing credential store", async () => {
+    await withTempDirectory(
+      "technical-admin-restore-missing-identity-focused-",
+      async (directory) => {
+        const databasePath = join(directory, "auth.sqlite");
+        let repository: SqliteTechnicalAdminAuthRepository | undefined;
+        try {
+          repository = new SqliteTechnicalAdminAuthRepository(databasePath, identity);
+          await enrollAndAuthenticate(repository, () => 1_000);
+          repository.close();
+          const database = new Database(databasePath);
+          database.query("DELETE FROM technical_admin_storage_identity").run();
+          database.close();
+
+          repository = new SqliteTechnicalAdminAuthRepository(databasePath, identity);
+          const auth = createTechnicalAdminAuth(
+            identity,
+            repository,
+            createVerifier(),
+            () => 2_000,
+          );
+          expect(
+            await auth.prepareForFoundationRestore({ mode: "preserve-compatible-credential" }),
+          ).toEqual({ outcome: "re-enrollment-required", reason: "incompatible" });
+        } finally {
+          repository?.close();
+        }
+      },
+    );
+  });
+
+  test("fails closed without mutation for read-only and unreadable stores", async () => {
+    await withTempDirectory("technical-admin-restore-failure-focused-", async (directory) => {
+      const readOnlyPath = join(directory, "readonly.sqlite");
+      let writable: SqliteTechnicalAdminAuthRepository | undefined;
+      let readOnly: SqliteTechnicalAdminAuthRepository | undefined;
+      let unreadable: SqliteTechnicalAdminAuthRepository | undefined;
+      try {
+        writable = new SqliteTechnicalAdminAuthRepository(readOnlyPath, identity);
+        await enrollAndAuthenticate(writable, () => 1_000);
+        writable.close();
+        writable = undefined;
+        readOnly = new SqliteTechnicalAdminAuthRepository(readOnlyPath, undefined, {
+          readwrite: false,
+        });
+        const readOnlyAuth = createTechnicalAdminAuth(
+          identity,
+          readOnly,
+          createVerifier(),
+          () => 2_000,
+        );
+        expect(
+          await readOnlyAuth.prepareForFoundationRestore({
+            mode: "preserve-compatible-credential",
+          }),
+        ).toEqual({ outcome: "sanitation-failed" });
+
+        const unreadablePath = join(directory, "unreadable.sqlite");
+        const initialized = new SqliteTechnicalAdminAuthRepository(unreadablePath, identity);
+        initialized.close();
+        const database = new Database(unreadablePath);
+        database.exec("DROP TABLE technical_admin_credentials");
+        database.close();
+        unreadable = new SqliteTechnicalAdminAuthRepository(unreadablePath, undefined, {
+          readwrite: false,
+        });
+        const unreadableAuth = createTechnicalAdminAuth(
+          identity,
+          unreadable,
+          createVerifier(),
+          () => 2_000,
+        );
+        expect(
+          await unreadableAuth.prepareForFoundationRestore({
+            mode: "preserve-compatible-credential",
+          }),
+        ).toEqual({ outcome: "sanitation-failed" });
+      } finally {
+        writable?.close();
+        readOnly?.close();
+        unreadable?.close();
+      }
+    });
+  });
+
   test("persists purpose-bound step-up and its authenticator counter across restart", async () => {
     await withTempDirectory("technical-admin-focused-", async (directory) => {
       const databasePath = join(directory, "auth.sqlite");

--- a/src/lib/technical-admin-auth.test.ts
+++ b/src/lib/technical-admin-auth.test.ts
@@ -13,17 +13,36 @@ import {
 } from "@/lib/technical-admin-auth";
 
 const binding = { origin: "https://timer.example", host: "timer.example" };
+const validEd25519PublicKey: JsonWebKey = {
+  kty: "OKP",
+  crv: "Ed25519",
+  x: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+  alg: "EdDSA",
+  ext: true,
+};
+const validP256PublicKey: JsonWebKey = {
+  kty: "EC",
+  crv: "P-256",
+  x: "axfR8uEsQkf4vOblY6RA8ncDfYEt6zOg9KE5RdiYwpY",
+  y: "T-NC4v4af5uO5-tKfA-eFivOM1drMV7Oy7ZAaDe_UfU",
+  alg: "ES256",
+  ext: true,
+};
 
 function createFixture() {
   let nowMs = 1_000;
   let registrationCredentialId = "credential-1";
   let authenticationSignCount = 2;
-  const repository = new MemoryTechnicalAdminAuthRepository();
+  const repository = new MemoryTechnicalAdminAuthRepository({
+    environment: "production",
+    origin: binding.origin,
+    rpId: "timer.example",
+  });
   const verifier: WebAuthnVerifier = {
     async verifyRegistration() {
       return {
         credentialId: registrationCredentialId,
-        publicKey: { kty: "OKP", crv: "Ed25519", x: "public-key" },
+        publicKey: { ...validEd25519PublicKey },
         signCount: 1,
       };
     },
@@ -175,7 +194,7 @@ describe("Technical Admin authentication", () => {
     const token = decodeURIComponent(issued.value.url.split("token=")[1] ?? "");
     const enrollment = fixture.auth.beginEnrollment(token, binding);
     if (!enrollment.ok) throw new Error("Expected enrollment options.");
-    expect(fixture.auth.beginAuthentication(binding)).toEqual({
+    expect(await fixture.auth.beginAuthentication(binding)).toEqual({
       ok: false,
       error: "invalid-credentials",
     });
@@ -196,7 +215,7 @@ describe("Technical Admin authentication", () => {
     if (!enrollment.ok) throw new Error("Expected enrollment options.");
     await fixture.auth.completeEnrollment(enrollment.value.challengeId, {}, binding);
 
-    const authentication = fixture.auth.beginAuthentication(binding);
+    const authentication = await fixture.auth.beginAuthentication(binding);
     if (!authentication.ok) throw new Error("Expected authentication options.");
     const session = await fixture.auth.completeAuthentication(
       authentication.value.challengeId,
@@ -220,7 +239,7 @@ describe("Technical Admin authentication", () => {
   test("rejects authentication replay and enforces the absolute deadline despite activity", async () => {
     const fixture = createFixture();
     await enroll(fixture);
-    const options = fixture.auth.beginAuthentication(binding);
+    const options = await fixture.auth.beginAuthentication(binding);
     if (!options.ok) throw new Error("Expected authentication options.");
     const first = await fixture.auth.completeAuthentication(options.value.challengeId, {}, binding);
     expect(first.ok).toBe(true);
@@ -396,7 +415,7 @@ describe("Technical Admin authentication", () => {
       );
     }
     fixture.advance(1_000);
-    const options = fixture.auth.beginAuthentication(binding);
+    const options = await fixture.auth.beginAuthentication(binding);
     if (!options.ok) throw new Error("Expected authentication options.");
     expect(
       await fixture.auth.completeAuthentication(options.value.challengeId, {}, binding, "source-a"),
@@ -654,6 +673,344 @@ describe("Technical Admin authentication", () => {
     expect(fixture.repository.alerts.some((alert) => alert.event === "reset-failure")).toBe(true);
   });
 
+  test("preserves the exact credential and invalidates every transient authority", async () => {
+    const fixture = createFixture();
+    const artifacts = await createRestoreArtifacts(fixture);
+    const credentialBefore = structuredClone(fixture.repository.getCredential());
+
+    expect(
+      await fixture.auth.prepareForFoundationRestore({ mode: "preserve-compatible-credential" }),
+    ).toEqual({ outcome: "preserved-transients-invalidated" });
+    expect(fixture.repository.getCredential()).toEqual(credentialBefore);
+    expect(fixture.repository.enrollment).toBeNull();
+    expect(fixture.repository.challenges.size).toBe(0);
+    expect(fixture.auth.authenticateSession(artifacts.session.token)).toBe(false);
+    expect(fixture.auth.verifyCsrf(artifacts.session.token, artifacts.session.csrfToken)).toBe(
+      false,
+    );
+    expect(fixture.auth.resolveCurrentAuthority(artifacts.session.token)).toBeNull();
+    expect(
+      fixture.auth.beginFreshVerification(artifacts.session.token, "replace-credential", binding),
+    ).toEqual({ ok: false, error: "not-authenticated" });
+    expect(await fixture.auth.completeAuthentication(artifacts.challengeId, {}, binding)).toEqual({
+      ok: false,
+      error: "invalid-ceremony",
+    });
+    expect(fixture.auth.beginEnrollment(artifacts.enrollmentToken, binding)).toEqual({
+      ok: false,
+      error: "invalid-enrollment",
+    });
+
+    const freshSignIn = await authenticate(fixture);
+    expect(freshSignIn.token).not.toBe(artifacts.session.token);
+    expect(fixture.repository.getCredential()).toMatchObject({
+      credentialId: credentialBefore?.credentialId,
+      publicKey: credentialBefore?.publicKey,
+    });
+  });
+
+  test("sanitizes readable missing credential state before requiring re-enrollment", async () => {
+    const fixture = createFixture();
+    const artifacts = await createRestoreArtifacts(fixture);
+    fixture.repository.credential = null;
+
+    expect(
+      await fixture.auth.prepareForFoundationRestore({ mode: "preserve-compatible-credential" }),
+    ).toEqual({ outcome: "re-enrollment-required", reason: "missing" });
+    expect(fixture.repository.enrollment).toBeNull();
+    expect(fixture.repository.challenges.size).toBe(0);
+    await expectRestoreArtifactsRejected(fixture, artifacts);
+  });
+
+  test("sanitizes readable invalid credential state before requiring re-enrollment", async () => {
+    const fixture = createFixture();
+    const artifacts = await createRestoreArtifacts(fixture);
+    fixture.repository.credential = {
+      credentialId: "",
+      publicKey: { kty: "unsupported" },
+      signCount: -1,
+      createdAtMs: Number.NaN,
+    };
+
+    expect(
+      await fixture.auth.prepareForFoundationRestore({ mode: "preserve-compatible-credential" }),
+    ).toEqual({ outcome: "re-enrollment-required", reason: "invalid" });
+    expect(fixture.repository.enrollment).toBeNull();
+    expect(fixture.repository.challenges.size).toBe(0);
+    await expectRestoreArtifactsRejected(fixture, artifacts);
+  });
+
+  test("sanitizes readable incompatible storage before requiring re-enrollment", async () => {
+    const fixture = createFixture();
+    const artifacts = await createRestoreArtifacts(fixture);
+    fixture.repository.storageIdentity = {
+      environment: "test",
+      origin: "https://other.example",
+      rpId: "other.example",
+    };
+
+    expect(
+      await fixture.auth.prepareForFoundationRestore({ mode: "preserve-compatible-credential" }),
+    ).toEqual({ outcome: "re-enrollment-required", reason: "incompatible" });
+    expect(fixture.repository.enrollment).toBeNull();
+    expect(fixture.repository.challenges.size).toBe(0);
+    await expectRestoreArtifactsRejected(fixture, artifacts);
+  });
+
+  test("explicit reset removes the credential even when storage identity is incompatible", async () => {
+    const fixture = createFixture();
+    const artifacts = await createRestoreArtifacts(fixture);
+    fixture.repository.storageIdentity = {
+      environment: "test",
+      origin: "https://other.example",
+      rpId: "other.example",
+    };
+
+    expect(await fixture.auth.prepareForFoundationRestore({ mode: "explicit-reset" })).toEqual({
+      outcome: "re-enrollment-required",
+      reason: "explicit-reset",
+    });
+    expect(fixture.repository.getCredential()).toBeNull();
+    expect(fixture.repository.generation).toBe(1);
+    await expectRestoreArtifactsRejected(fixture, artifacts);
+    expect(fixture.auth.issueEnrollmentAuthorization().ok).toBe(true);
+  });
+
+  test("rolls back an incompatible explicit reset when its commit fails", async () => {
+    const fixture = createFixture();
+    const artifacts = await createRestoreArtifacts(fixture);
+    const before = {
+      credential: structuredClone(fixture.repository.credential),
+      enrollment: structuredClone(fixture.repository.enrollment),
+      challenges: structuredClone([...fixture.repository.challenges]),
+      sessions: structuredClone([...fixture.repository.sessions]),
+      generation: fixture.repository.generation,
+    };
+    fixture.repository.storageIdentity = {
+      environment: "test",
+      origin: "https://other.example",
+      rpId: "other.example",
+    };
+    fixture.repository.failRestoreCommit = true;
+
+    expect(await fixture.auth.prepareForFoundationRestore({ mode: "explicit-reset" })).toEqual({
+      outcome: "sanitation-failed",
+    });
+    expect(fixture.repository.credential).toEqual(before.credential);
+    expect(fixture.repository.enrollment).toEqual(before.enrollment);
+    expect([...fixture.repository.challenges]).toEqual(before.challenges);
+    expect([...fixture.repository.sessions]).toEqual(before.sessions);
+    expect(fixture.repository.generation).toBe(before.generation);
+    expect(fixture.auth.authenticateSession(artifacts.session.token)).toBe(true);
+  });
+
+  test("accepts only canonical supported credential key records before issuing a challenge", async () => {
+    const supported = [
+      validEd25519PublicKey,
+      { ...validEd25519PublicKey, use: "sig", key_ops: ["verify"] },
+      validP256PublicKey,
+      { ...validP256PublicKey, use: "sig", key_ops: ["verify"] },
+    ];
+    for (const publicKey of supported) {
+      const fixture = createFixture();
+      fixture.repository.credential = {
+        credentialId: "credential-1",
+        publicKey: { ...publicKey },
+        signCount: 1,
+        createdAtMs: fixture.now(),
+      };
+      const authentication = await fixture.auth.beginAuthentication(binding);
+      expect(authentication.ok).toBe(true);
+      expect(fixture.repository.challenges.size).toBe(1);
+    }
+
+    const invalidKeys: JsonWebKey[] = [
+      { kty: "EC", crv: "P-256", x: "AA", y: validP256PublicKey.y },
+      { kty: "EC", crv: "P-256", x: validP256PublicKey.x, y: "AA" },
+      {
+        kty: "EC",
+        crv: "P-256",
+        x: `${validP256PublicKey.x}=`,
+        y: validP256PublicKey.y,
+      },
+      { kty: "EC", crv: "Ed25519", x: validP256PublicKey.x, y: validP256PublicKey.y },
+      {
+        kty: "EC",
+        crv: "P-256",
+        x: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        y: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      },
+      { kty: "OKP", crv: "Ed25519", x: "AA", y: validEd25519PublicKey.x },
+      { kty: "OKP", crv: "P-256", x: validEd25519PublicKey.x },
+      { kty: "OKP", crv: "Ed25519", x: `${validEd25519PublicKey.x}=`, alg: "ES256" },
+      { kty: "RSA", n: validEd25519PublicKey.x, e: "AQAB", alg: "RS256" },
+      { kty: "unsupported", x: validEd25519PublicKey.x },
+    ];
+    for (const publicKey of invalidKeys) {
+      const fixture = createFixture();
+      fixture.repository.credential = {
+        credentialId: "credential-1",
+        publicKey,
+        signCount: 1,
+        createdAtMs: fixture.now(),
+      };
+      expect(await fixture.auth.beginAuthentication(binding)).toEqual({
+        ok: false,
+        error: "invalid-credentials",
+      });
+      expect(fixture.repository.challenges.size).toBe(0);
+      expect(
+        await fixture.auth.prepareForFoundationRestore({ mode: "preserve-compatible-credential" }),
+      ).toEqual({ outcome: "re-enrollment-required", reason: "invalid" });
+    }
+  });
+
+  test("rejects invalid credential IDs before challenge creation and classifies them during restore", async () => {
+    for (const credentialId of ["", "AA=", "credential-live", "!"]) {
+      const fixture = createFixture();
+      fixture.repository.credential = {
+        credentialId,
+        publicKey: { ...validEd25519PublicKey },
+        signCount: 1,
+        createdAtMs: fixture.now(),
+      };
+
+      expect(await fixture.auth.beginAuthentication(binding)).toEqual({
+        ok: false,
+        error: "invalid-credentials",
+      });
+      expect(fixture.repository.challenges.size).toBe(0);
+      expect(
+        await fixture.auth.prepareForFoundationRestore({ mode: "preserve-compatible-credential" }),
+      ).toEqual({ outcome: "re-enrollment-required", reason: "invalid" });
+    }
+  });
+
+  test("rejects private, symmetric, cross-family, and unknown JWK fields", async () => {
+    const forbiddenFields = ["d", "n", "e", "p", "q", "dp", "dq", "qi", "oth", "k", "unexpected"];
+    for (const publicKey of [validP256PublicKey, validEd25519PublicKey]) {
+      for (const field of forbiddenFields) {
+        const fixture = createFixture();
+        fixture.repository.credential = {
+          credentialId: "credential-1",
+          publicKey: { ...publicKey, [field]: "forbidden" } as JsonWebKey,
+          signCount: 1,
+          createdAtMs: fixture.now(),
+        };
+
+        expect(await fixture.auth.beginAuthentication(binding)).toEqual({
+          ok: false,
+          error: "invalid-credentials",
+        });
+        expect(fixture.repository.challenges.size).toBe(0);
+        expect(
+          await fixture.auth.prepareForFoundationRestore({
+            mode: "preserve-compatible-credential",
+          }),
+        ).toEqual({ outcome: "re-enrollment-required", reason: "invalid" });
+        expect(fixture.repository.enrollment).toBeNull();
+        expect(fixture.repository.sessions.size).toBe(0);
+      }
+    }
+  });
+
+  test("rejects WebCrypto-incompatible JWK metadata before challenge creation", async () => {
+    const invalidMetadata: JsonWebKey[] = [
+      { ...validEd25519PublicKey, alg: undefined },
+      { ...validEd25519PublicKey, ext: undefined },
+      { ...validEd25519PublicKey, alg: "ES256" },
+      { ...validEd25519PublicKey, ext: false },
+      { ...validEd25519PublicKey, use: "enc" },
+      { ...validEd25519PublicKey, key_ops: ["sign"] },
+      { ...validEd25519PublicKey, key_ops: ["verify", "sign"] },
+    ];
+    for (const publicKey of invalidMetadata) {
+      const fixture = createFixture();
+      fixture.repository.credential = {
+        credentialId: "credential-1",
+        publicKey,
+        signCount: 1,
+        createdAtMs: fixture.now(),
+      };
+
+      expect(await fixture.auth.beginAuthentication(binding)).toEqual({
+        ok: false,
+        error: "invalid-credentials",
+      });
+      expect(fixture.repository.challenges.size).toBe(0);
+      expect(
+        await fixture.auth.prepareForFoundationRestore({ mode: "preserve-compatible-credential" }),
+      ).toEqual({ outcome: "re-enrollment-required", reason: "invalid" });
+    }
+  });
+
+  test("performs explicit reset atomically and returns the deliberate reset classification", async () => {
+    const fixture = createFixture();
+    const artifacts = await createRestoreArtifacts(fixture);
+
+    expect(await fixture.auth.prepareForFoundationRestore({ mode: "explicit-reset" })).toEqual({
+      outcome: "re-enrollment-required",
+      reason: "explicit-reset",
+    });
+    expect(fixture.repository.getCredential()).toBeNull();
+    expect(fixture.repository.enrollment).toBeNull();
+    expect(fixture.repository.challenges.size).toBe(0);
+    await expectRestoreArtifactsRejected(fixture, artifacts);
+  });
+
+  test("rolls back the credential and every transient collection when sanitation cannot commit", async () => {
+    const fixture = createFixture();
+    await createRestoreArtifacts(fixture);
+    const before = {
+      credential: structuredClone(fixture.repository.credential),
+      enrollment: structuredClone(fixture.repository.enrollment),
+      challenges: structuredClone([...fixture.repository.challenges]),
+      sessions: structuredClone([...fixture.repository.sessions]),
+      generation: fixture.repository.generation,
+    };
+    fixture.repository.failRestoreCommit = true;
+
+    expect(
+      await fixture.auth.prepareForFoundationRestore({ mode: "preserve-compatible-credential" }),
+    ).toEqual({ outcome: "sanitation-failed" });
+    expect(fixture.repository.credential).toEqual(before.credential);
+    expect(fixture.repository.enrollment).toEqual(before.enrollment);
+    expect([...fixture.repository.challenges]).toEqual(before.challenges);
+    expect([...fixture.repository.sessions]).toEqual(before.sessions);
+    expect(fixture.repository.generation).toBe(before.generation);
+  });
+
+  test("rolls back an explicit reset when credential removal cannot commit", async () => {
+    const fixture = createFixture();
+    await createRestoreArtifacts(fixture);
+    const credentialBefore = structuredClone(fixture.repository.credential);
+    const sessionsBefore = structuredClone([...fixture.repository.sessions]);
+    fixture.repository.failRestoreCommit = true;
+
+    expect(await fixture.auth.prepareForFoundationRestore({ mode: "explicit-reset" })).toEqual({
+      outcome: "sanitation-failed",
+    });
+    expect(fixture.repository.credential).toEqual(credentialBefore);
+    expect([...fixture.repository.sessions]).toEqual(sessionsBefore);
+    expect(fixture.repository.enrollment).not.toBeNull();
+    expect(fixture.repository.challenges.size).toBeGreaterThan(0);
+  });
+
+  test("does not expose storage details when the sanitation operation is unreadable", async () => {
+    const fixture = createFixture();
+    const auth = createTechnicalAdminAuth(
+      { environment: "production", origin: binding.origin, rpId: "timer.example" },
+      throwingRepository("prepareForFoundationRestore", fixture.repository),
+    );
+
+    const result = await auth.prepareForFoundationRestore({
+      mode: "preserve-compatible-credential",
+    });
+    expect(result).toEqual({ outcome: "sanitation-failed" });
+    expect(JSON.stringify(result)).not.toMatch(/credential|sqlite|path|schema|injected/u);
+    expect(Object.keys(result)).toEqual(["outcome"]);
+  });
+
   test("does not issue enrollment when reset evidence cannot be recorded", async () => {
     const fixture = createFixture();
     await enroll(fixture);
@@ -784,6 +1141,42 @@ describe("Technical Admin authentication", () => {
     expect(String(wrongRpError)).toContain("Invalid RP ID");
   });
 
+  test("native verification explicitly rejects unsupported RSA dispatch", async () => {
+    const verifier = new NativeWebAuthnVerifier();
+    const challenge = "Y2hhbGxlbmdl";
+    const clientDataJSON = encodeBase64Url(
+      JSON.stringify({ type: "webauthn.get", challenge, origin: binding.origin }),
+    );
+    const authData = new Uint8Array(37);
+    authData.set(new Uint8Array(new Bun.CryptoHasher("sha256").update("timer.example").digest()));
+    authData[32] = 0x05;
+
+    await expect(
+      verifier.verifyAuthentication(
+        {
+          id: "credential-1",
+          response: {
+            clientDataJSON,
+            authenticatorData: encodeBase64Url(authData),
+            signature: encodeBase64Url(new Uint8Array()),
+          },
+        },
+        {
+          challenge,
+          origin: binding.origin,
+          rpId: "timer.example",
+          credential: {
+            credentialId: "credential-1",
+            publicKey: { kty: "RSA", n: "AA", e: "AQAB", alg: "RS256" },
+            signCount: 0,
+            createdAtMs: 0,
+          },
+          requireUserVerification: true,
+        },
+      ),
+    ).rejects.toThrow("Unsupported public key.");
+  });
+
   test("contains storage and commit failures without acknowledging state", async () => {
     const issueFailure = createTechnicalAdminAuth(
       { environment: "test", origin: binding.origin, rpId: "timer.example" },
@@ -796,7 +1189,7 @@ describe("Technical Admin authentication", () => {
 
     const fixture = createFixture();
     await enroll(fixture);
-    const enrolledOptions = fixture.auth.beginAuthentication(binding);
+    const enrolledOptions = await fixture.auth.beginAuthentication(binding);
     if (!enrolledOptions.ok) throw new Error("Expected authentication options.");
     const enrolledSession = await fixture.auth.completeAuthentication(
       enrolledOptions.value.challengeId,
@@ -809,16 +1202,16 @@ describe("Technical Admin authentication", () => {
       throwingRepository("getCredential", fixture.repository),
       fixture.verifier,
     );
-    expect(credentialReadFailure.beginAuthentication(binding)).toEqual({
+    expect(await credentialReadFailure.beginAuthentication(binding)).toEqual({
       ok: false,
       error: "storage-failure",
     });
     const commitFailure = createTechnicalAdminAuth(
-      { environment: "test", origin: binding.origin, rpId: "timer.example" },
+      { environment: "production", origin: binding.origin, rpId: "timer.example" },
       throwingRepository("commitAuthentication", fixture.repository),
       fixture.verifier,
     );
-    const authentication = commitFailure.beginAuthentication(binding);
+    const authentication = await commitFailure.beginAuthentication(binding);
     if (!authentication.ok) throw new Error("Expected authentication options.");
     expect(
       await commitFailure.completeAuthentication(authentication.value.challengeId, {}, binding),
@@ -857,11 +1250,55 @@ async function enroll(fixture: ReturnType<typeof createFixture>) {
 }
 
 async function authenticate(fixture: ReturnType<typeof createFixture>) {
-  const options = fixture.auth.beginAuthentication(binding);
+  const options = await fixture.auth.beginAuthentication(binding);
   if (!options.ok) throw new Error("Expected authentication options.");
   const session = await fixture.auth.completeAuthentication(options.value.challengeId, {}, binding);
   if (!session.ok) throw new Error("Expected authenticated session.");
   return session.value;
+}
+
+async function createRestoreArtifacts(fixture: ReturnType<typeof createFixture>) {
+  await enroll(fixture);
+  const session = await authenticate(fixture);
+  await authenticate(fixture);
+  const fresh = fixture.auth.beginFreshVerification(session.token, "replace-credential", binding);
+  if (!fresh.ok) throw new Error("Expected fresh verification options.");
+  expect(
+    await fixture.auth.completeFreshVerification(
+      session.token,
+      fresh.value.challengeId,
+      {},
+      binding,
+    ),
+  ).toEqual({ ok: true, value: undefined });
+  const pendingAuthentication = await fixture.auth.beginAuthentication(binding);
+  if (!pendingAuthentication.ok) throw new Error("Expected pending authentication challenge.");
+  fixture.repository.issueEnrollment("pending-enrollment", fixture.now() + 60_000);
+  return {
+    session,
+    challengeId: pendingAuthentication.value.challengeId,
+    enrollmentToken: "pending-enrollment",
+  };
+}
+
+async function expectRestoreArtifactsRejected(
+  fixture: ReturnType<typeof createFixture>,
+  artifacts: Awaited<ReturnType<typeof createRestoreArtifacts>>,
+) {
+  expect(fixture.auth.authenticateSession(artifacts.session.token)).toBe(false);
+  expect(fixture.auth.verifyCsrf(artifacts.session.token, artifacts.session.csrfToken)).toBe(false);
+  expect(fixture.auth.resolveCurrentAuthority(artifacts.session.token)).toBeNull();
+  expect(
+    fixture.auth.beginFreshVerification(artifacts.session.token, "replace-credential", binding),
+  ).toEqual({ ok: false, error: "not-authenticated" });
+  expect(await fixture.auth.completeAuthentication(artifacts.challengeId, {}, binding)).toEqual({
+    ok: false,
+    error: "invalid-ceremony",
+  });
+  expect(fixture.auth.beginEnrollment(artifacts.enrollmentToken, binding)).toEqual({
+    ok: false,
+    error: "invalid-enrollment",
+  });
 }
 
 function encodeBase64Url(value: string | Uint8Array) {
@@ -909,6 +1346,11 @@ function throwingRepository(
       failure === "resetAuthority" || failure === "appendOperationalLog"
         ? fail
         : (...args) => base.resetAuthority(...args),
+    prepareForFoundationRestore:
+      failure === "prepareForFoundationRestore"
+        ? fail
+        : (...args) => base.prepareForFoundationRestore(...args),
+    getStorageIdentity: () => base.getStorageIdentity(),
     getStorageStatus:
       failure === "getStorageStatus" ? fail : (...args) => base.getStorageStatus(...args),
     appendOperationalLog:

--- a/src/lib/technical-admin-auth.ts
+++ b/src/lib/technical-admin-auth.ts
@@ -1,6 +1,7 @@
 import { Database } from "bun:sqlite";
 import { mkdirSync } from "node:fs";
 import { dirname } from "node:path";
+import { parseTechnicalAdminCredentialId } from "@/lib/technical-admin-credential";
 
 export type TechnicalAdminEnvironment = "production" | "test";
 
@@ -92,6 +93,24 @@ export type TechnicalAdminStorageStatus = {
   activeSessionCount: number;
   generation: number;
 };
+
+export type TechnicalAdminRestorePreparationRequest = {
+  mode: "preserve-compatible-credential" | "explicit-reset";
+};
+
+export type TechnicalAdminRestoreReEnrollmentReason =
+  | "missing"
+  | "invalid"
+  | "incompatible"
+  | "explicit-reset";
+
+export type TechnicalAdminRestorePreparationResult =
+  | { outcome: "preserved-transients-invalidated" }
+  | {
+      outcome: "re-enrollment-required";
+      reason: TechnicalAdminRestoreReEnrollmentReason;
+    }
+  | { outcome: "sanitation-failed" };
 
 export type TechnicalAdminOperationalLog = {
   atMs: number;
@@ -204,6 +223,12 @@ export interface TechnicalAdminAuthRepository {
   activeSessionCount(nowMs: number): number;
   getGeneration(): number;
   resetAuthority(nowMs: number, resetLog: TechnicalAdminOperationalLog): boolean;
+  prepareForFoundationRestore(
+    request: TechnicalAdminRestorePreparationRequest,
+    expectedIdentity: TechnicalAdminStorageIdentity,
+    _nowMs: number,
+  ): Promise<TechnicalAdminRestorePreparationResult>;
+  getStorageIdentity(): TechnicalAdminStorageIdentity | null;
   getStorageStatus(nowMs: number): TechnicalAdminStorageStatus;
   appendOperationalLog(log: TechnicalAdminOperationalLog): void;
   appendAlert(alert: TechnicalAdminAlert): void;
@@ -689,12 +714,12 @@ export function createTechnicalAdminAuth(
           rpId: config.rpId,
           requireUserVerification: true,
         });
-        if (
-          !repository.commitEnrollment(challengeId, {
-            ...credential,
-            createdAtMs: now(),
-          })
-        ) {
+        const storedCredential = { ...credential, createdAtMs: now() };
+        if (!(await isValidCredentialRecord(storedCredential))) {
+          noteFailure(sourceCorrelation, "enrollment-completed");
+          return { ok: false, error: "invalid-ceremony" };
+        }
+        if (!repository.commitEnrollment(challengeId, storedCredential)) {
           noteFailure(sourceCorrelation, "enrollment-completed");
           return { ok: false, error: "invalid-ceremony" };
         }
@@ -706,13 +731,27 @@ export function createTechnicalAdminAuth(
       }
     },
 
-    beginAuthentication(binding: CeremonyBinding): AuthResult<AuthenticationOptions> {
+    async beginAuthentication(
+      binding: CeremonyBinding,
+    ): Promise<AuthResult<AuthenticationOptions>> {
       if (!isExactBinding(binding, expectedOrigin, expectedHost)) {
         return { ok: false, error: "invalid-ceremony" };
       }
       try {
         const credential = repository.getCredential();
-        if (credential === null) return { ok: false, error: "invalid-credentials" };
+        if (credential === null || !(await isValidCredentialRecord(credential))) {
+          return { ok: false, error: "invalid-credentials" };
+        }
+        const storageIdentity = repository.getStorageIdentity();
+        if (
+          !isCompatibleStorageIdentity(storageIdentity, {
+            environment: config.environment,
+            origin: expectedOrigin,
+            rpId: config.rpId,
+          })
+        ) {
+          return { ok: false, error: "invalid-credentials" };
+        }
         const challenge = createChallenge("authentication", now());
         repository.createChallenge(challenge);
         return {
@@ -945,12 +984,17 @@ export function createTechnicalAdminAuth(
           rpId: config.rpId,
           requireUserVerification: true,
         });
+        const storedCredential = { ...replacement, createdAtMs: current };
+        if (!(await isValidCredentialRecord(storedCredential))) {
+          noteFailure(sourceCorrelation, "credential-replaced");
+          return { ok: false, error: "invalid-ceremony" };
+        }
         const created = createSession(current);
         if (
           !repository.commitReplacement(
             challengeId,
             credential.credentialId,
-            { ...replacement, createdAtMs: current },
+            storedCredential,
             created.session,
           )
         ) {
@@ -1095,6 +1139,24 @@ export function createTechnicalAdminAuth(
       }
     },
 
+    async prepareForFoundationRestore(
+      request: TechnicalAdminRestorePreparationRequest,
+    ): Promise<TechnicalAdminRestorePreparationResult> {
+      try {
+        return await repository.prepareForFoundationRestore(
+          request,
+          {
+            environment: config.environment,
+            origin: expectedOrigin,
+            rpId: config.rpId,
+          },
+          now(),
+        );
+      } catch {
+        return { outcome: "sanitation-failed" };
+      }
+    },
+
     revokeOtherSessions(token: string): AuthResult<{ revokedCount: number }> {
       try {
         const current = now();
@@ -1132,7 +1194,7 @@ export interface TechnicalAdminAuth {
     binding: CeremonyBinding,
     sourceCorrelation?: string,
   ): Promise<AuthResult<void>>;
-  beginAuthentication(binding: CeremonyBinding): AuthResult<AuthenticationOptions>;
+  beginAuthentication(binding: CeremonyBinding): Promise<AuthResult<AuthenticationOptions>>;
   completeAuthentication(
     challengeId: string,
     response: unknown,
@@ -1170,6 +1232,9 @@ export interface TechnicalAdminAuth {
   stopRetentionMaintenance(): void;
   close(): void;
   emergencyReset(): AuthResult<EnrollmentAuthorization>;
+  prepareForFoundationRestore(
+    request: TechnicalAdminRestorePreparationRequest,
+  ): Promise<TechnicalAdminRestorePreparationResult>;
   revokeOtherSessions(token: string): AuthResult<{ revokedCount: number }>;
   correlateSource(value: string): string;
   isExpectedBinding(binding: CeremonyBinding): boolean;
@@ -1252,6 +1317,8 @@ export class NativeWebAuthnVerifier implements WebAuthnVerifier {
 }
 
 export class MemoryTechnicalAdminAuthRepository implements TechnicalAdminAuthRepository {
+  storageIdentity: TechnicalAdminStorageIdentity | null;
+  failRestoreCommit = false;
   credential: CredentialRecord | null = null;
   enrollment: EnrollmentRecord | null = null;
   challenges = new Map<string, ChallengeRecord>();
@@ -1259,6 +1326,10 @@ export class MemoryTechnicalAdminAuthRepository implements TechnicalAdminAuthRep
   logs: TechnicalAdminOperationalLog[] = [];
   alerts: TechnicalAdminAlert[] = [];
   generation = 0;
+
+  constructor(storageIdentity: TechnicalAdminStorageIdentity | null = null) {
+    this.storageIdentity = storageIdentity;
+  }
 
   hasCredential() {
     return this.credential !== null;
@@ -1394,6 +1465,58 @@ export class MemoryTechnicalAdminAuthRepository implements TechnicalAdminAuthRep
   getGeneration() {
     return this.generation;
   }
+  getStorageIdentity() {
+    return this.storageIdentity;
+  }
+  async prepareForFoundationRestore(
+    request: TechnicalAdminRestorePreparationRequest,
+    expectedIdentity: TechnicalAdminStorageIdentity,
+    _nowMs: number,
+  ): Promise<TechnicalAdminRestorePreparationResult> {
+    const previousCredential = this.credential;
+    const previousEnrollment = this.enrollment;
+    const previousChallenges = new Map(this.challenges);
+    const previousSessions = new Map(
+      [...this.sessions].map(([id, session]) => [id, { ...session }] as const),
+    );
+    const previousGeneration = this.generation;
+    try {
+      if (request.mode === "explicit-reset") {
+        this.credential = null;
+        this.enrollment = null;
+        this.challenges.clear();
+        this.sessions.clear();
+        this.generation += 1;
+        if (this.failRestoreCommit) throw new Error("injected restore commit failure");
+        return { outcome: "re-enrollment-required", reason: "explicit-reset" };
+      }
+      const compatible = isCompatibleStorageIdentity(this.storageIdentity, expectedIdentity);
+      const credential = this.credential;
+      const credentialReason = !compatible
+        ? ("incompatible" as const)
+        : credential === null
+          ? ("missing" as const)
+          : !(await isValidCredentialRecord(credential))
+            ? ("invalid" as const)
+            : null;
+
+      this.enrollment = null;
+      this.challenges.clear();
+      this.sessions.clear();
+      this.generation += 1;
+      if (this.failRestoreCommit) throw new Error("injected restore commit failure");
+      return credentialReason === null
+        ? { outcome: "preserved-transients-invalidated" }
+        : { outcome: "re-enrollment-required", reason: credentialReason };
+    } catch {
+      this.credential = previousCredential;
+      this.enrollment = previousEnrollment;
+      this.challenges = previousChallenges;
+      this.sessions = previousSessions;
+      this.generation = previousGeneration;
+      return { outcome: "sanitation-failed" };
+    }
+  }
   resetAuthority(nowMs: number, resetLog: TechnicalAdminOperationalLog) {
     const previousCredential = this.credential;
     const previousEnrollment = this.enrollment;
@@ -1521,10 +1644,28 @@ export class SqliteTechnicalAdminAuthRepository implements TechnicalAdminAuthRep
       ) {
         throw new Error("Technical Admin storage identity does not match the environment.");
       }
-      if (!existing)
-        this.database
-          .query("INSERT INTO technical_admin_storage_identity VALUES (1, ?, ?, ?)")
-          .run(identity.environment, identity.origin, identity.rpId);
+      if (!existing) {
+        const hasAuthorityState =
+          Number(
+            (
+              this.database
+                .query(
+                  `SELECT COUNT(*) AS count FROM (
+                  SELECT credential_id AS value FROM technical_admin_credentials
+                  UNION ALL SELECT token_hash FROM technical_admin_enrollment
+                  UNION ALL SELECT challenge_id FROM technical_admin_challenges
+                  UNION ALL SELECT session_id FROM technical_admin_sessions
+                )`,
+                )
+                .get() as { count: number }
+            ).count,
+          ) > 0;
+        if (!hasAuthorityState) {
+          this.database
+            .query("INSERT INTO technical_admin_storage_identity VALUES (1, ?, ?, ?)")
+            .run(identity.environment, identity.origin, identity.rpId);
+        }
+      }
     }
   }
   private addColumnIfMissing(table: string, column: string, definition: string) {
@@ -1816,6 +1957,91 @@ export class SqliteTechnicalAdminAuthRepository implements TechnicalAdminAuthRep
       ).generation,
     );
   }
+  getStorageIdentity() {
+    const row = this.database
+      .query("SELECT environment, origin, rp_id FROM technical_admin_storage_identity WHERE id = 1")
+      .get() as { environment: string; origin: string; rp_id: string } | null;
+    return row === null
+      ? null
+      : {
+          environment: row.environment as TechnicalAdminEnvironment,
+          origin: row.origin,
+          rpId: row.rp_id,
+        };
+  }
+  async prepareForFoundationRestore(
+    request: TechnicalAdminRestorePreparationRequest,
+    expectedIdentity: TechnicalAdminStorageIdentity,
+    _nowMs: number,
+  ): Promise<TechnicalAdminRestorePreparationResult> {
+    let transactionOpen = false;
+    try {
+      this.database.exec("BEGIN IMMEDIATE");
+      transactionOpen = true;
+      const quickCheck = this.database.query("PRAGMA quick_check").get() as {
+        quick_check: string;
+      };
+      if (quickCheck.quick_check !== "ok") throw new Error("Technical Admin storage is corrupt.");
+
+      const storedIdentity = this.getStorageIdentity();
+      const credentialCount = Number(
+        (
+          this.database
+            .query("SELECT COUNT(*) AS count FROM technical_admin_credentials")
+            .get() as { count: number }
+        ).count,
+      );
+      const credential = credentialCount === 1 ? this.getCredential() : null;
+      if (credentialCount > 1 || (credentialCount === 1 && credential === null)) {
+        throw new Error("Technical Admin credential store is unclassifiable.");
+      }
+
+      if (request.mode === "explicit-reset") {
+        this.database.query("DELETE FROM technical_admin_credentials").run();
+        this.database.query("DELETE FROM technical_admin_enrollment").run();
+        this.database.query("DELETE FROM technical_admin_challenges").run();
+        this.database.query("DELETE FROM technical_admin_sessions").run();
+        const generationUpdate = this.database
+          .query("UPDATE technical_admin_state SET generation = generation + 1 WHERE id = 1")
+          .run();
+        if (generationUpdate.changes !== 1) throw new Error("Technical Admin state update failed.");
+        this.database.exec("COMMIT");
+        transactionOpen = false;
+        return { outcome: "re-enrollment-required", reason: "explicit-reset" };
+      }
+
+      const compatible = isCompatibleStorageIdentity(storedIdentity, expectedIdentity);
+      let credentialReason: Exclude<
+        TechnicalAdminRestoreReEnrollmentReason,
+        "explicit-reset"
+      > | null = null;
+      if (!compatible) credentialReason = "incompatible";
+      else if (credentialCount === 0) credentialReason = "missing";
+      else if (!(await isValidCredentialRecord(credential))) credentialReason = "invalid";
+
+      this.database.query("DELETE FROM technical_admin_enrollment").run();
+      this.database.query("DELETE FROM technical_admin_challenges").run();
+      this.database.query("DELETE FROM technical_admin_sessions").run();
+      const generationUpdate = this.database
+        .query("UPDATE technical_admin_state SET generation = generation + 1 WHERE id = 1")
+        .run();
+      if (generationUpdate.changes !== 1) throw new Error("Technical Admin state update failed.");
+      this.database.exec("COMMIT");
+      transactionOpen = false;
+      return credentialReason === null
+        ? { outcome: "preserved-transients-invalidated" }
+        : { outcome: "re-enrollment-required", reason: credentialReason };
+    } catch {
+      if (transactionOpen) {
+        try {
+          this.database.exec("ROLLBACK");
+        } catch {
+          // The public result remains the same fail-closed outcome.
+        }
+      }
+      return { outcome: "sanitation-failed" };
+    }
+  }
   resetAuthority(nowMs: number, resetLog: TechnicalAdminOperationalLog) {
     try {
       return this.database.transaction(() => {
@@ -2005,6 +2231,120 @@ function isExactBinding(binding: CeremonyBinding, origin: string, host: string) 
   return binding.origin === origin && binding.host === host;
 }
 
+function isCompatibleStorageIdentity(
+  actual: TechnicalAdminStorageIdentity | null,
+  expected: TechnicalAdminStorageIdentity,
+) {
+  return (
+    actual !== null &&
+    actual.environment === expected.environment &&
+    actual.origin === expected.origin &&
+    actual.rpId === expected.rpId
+  );
+}
+
+type SupportedPublicKey = {
+  key: CryptoKey;
+  algorithm: AlgorithmIdentifier;
+  kty: "EC" | "OKP";
+};
+
+const EC_PUBLIC_JWK_FIELDS = new Set(["kty", "crv", "x", "y", "alg", "ext", "use", "key_ops"]);
+const OKP_PUBLIC_JWK_FIELDS = new Set(["kty", "crv", "x", "alg", "ext", "use", "key_ops"]);
+
+function hasOnlyAllowedPublicJwkFields(publicKey: JsonWebKey, allowedFields: Set<string>) {
+  return Object.keys(publicKey).every((field) => allowedFields.has(field));
+}
+
+async function isValidCredentialRecord(credential: CredentialRecord | null) {
+  if (
+    credential === null ||
+    typeof credential.credentialId !== "string" ||
+    parseTechnicalAdminCredentialId(credential.credentialId) === null ||
+    !Number.isSafeInteger(credential.signCount) ||
+    credential.signCount < 0 ||
+    !Number.isFinite(credential.createdAtMs) ||
+    !isRecord(credential.publicKey)
+  ) {
+    return false;
+  }
+  return (await parseSupportedPublicKey(credential.publicKey)) !== null;
+}
+
+async function parseSupportedPublicKey(publicKey: JsonWebKey): Promise<SupportedPublicKey | null> {
+  if (publicKey.kty === "EC") {
+    if (
+      !hasOnlyAllowedPublicJwkFields(publicKey, EC_PUBLIC_JWK_FIELDS) ||
+      publicKey.crv !== "P-256" ||
+      typeof publicKey.x !== "string" ||
+      typeof publicKey.y !== "string" ||
+      publicKey.alg !== "ES256" ||
+      publicKey.ext !== true ||
+      (publicKey.use !== undefined && publicKey.use !== "sig") ||
+      (publicKey.key_ops !== undefined &&
+        (!Array.isArray(publicKey.key_ops) ||
+          publicKey.key_ops.length !== 1 ||
+          publicKey.key_ops[0] !== "verify"))
+    ) {
+      return null;
+    }
+    const x = decodeCanonicalBase64Url(publicKey.x, 32);
+    const y = decodeCanonicalBase64Url(publicKey.y, 32);
+    if (x === null || y === null) return null;
+    try {
+      return {
+        key: await crypto.subtle.importKey(
+          "jwk",
+          publicKey,
+          { name: "ECDSA", namedCurve: "P-256" },
+          false,
+          ["verify"],
+        ),
+        algorithm: { name: "ECDSA", hash: "SHA-256" } as AlgorithmIdentifier,
+        kty: "EC",
+      };
+    } catch {
+      return null;
+    }
+  }
+  if (publicKey.kty === "OKP") {
+    if (
+      !hasOnlyAllowedPublicJwkFields(publicKey, OKP_PUBLIC_JWK_FIELDS) ||
+      publicKey.crv !== "Ed25519" ||
+      typeof publicKey.x !== "string" ||
+      publicKey.y !== undefined ||
+      publicKey.alg !== "EdDSA" ||
+      publicKey.ext !== true ||
+      (publicKey.use !== undefined && publicKey.use !== "sig") ||
+      (publicKey.key_ops !== undefined &&
+        (!Array.isArray(publicKey.key_ops) ||
+          publicKey.key_ops.length !== 1 ||
+          publicKey.key_ops[0] !== "verify"))
+    ) {
+      return null;
+    }
+    if (decodeCanonicalBase64Url(publicKey.x, 32) === null) return null;
+    try {
+      return {
+        key: await crypto.subtle.importKey("jwk", publicKey, { name: "Ed25519" }, false, [
+          "verify",
+        ]),
+        algorithm: { name: "Ed25519" },
+        kty: "OKP",
+      };
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+function decodeCanonicalBase64Url(value: string, expectedLength: number) {
+  if (!/^[A-Za-z0-9_-]+$/u.test(value)) return null;
+  const bytes = new Uint8Array(Buffer.from(value, "base64url"));
+  return bytes.length === expectedLength && base64UrlEncode(bytes) === value ? bytes : null;
+}
+
 function randomToken() {
   return base64UrlEncode(crypto.getRandomValues(new Uint8Array(TOKEN_BYTES)));
 }
@@ -2110,13 +2450,12 @@ async function verifyWebAuthnSignature(
   signature: Uint8Array,
   data: Uint8Array,
 ) {
-  const algorithm =
-    publicKey.kty === "EC" ? { name: "ECDSA", namedCurve: "P-256" } : { name: "Ed25519" };
-  const key = await crypto.subtle.importKey("jwk", publicKey, algorithm, false, ["verify"]);
-  const normalizedSignature = publicKey.kty === "EC" ? derToP1363(signature) : signature;
+  const supported = await parseSupportedPublicKey(publicKey);
+  if (supported === null) throw new Error("Unsupported public key.");
+  const normalizedSignature = supported.kty === "EC" ? derToP1363(signature) : signature;
   return crypto.subtle.verify(
-    publicKey.kty === "EC" ? { name: "ECDSA", hash: "SHA-256" } : { name: "Ed25519" },
-    key,
+    supported.algorithm,
+    supported.key,
     normalizedSignature as BufferSource,
     data as BufferSource,
   );

--- a/src/lib/technical-admin-credential.test.ts
+++ b/src/lib/technical-admin-credential.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+import {
+  decodeTechnicalAdminCredentialId,
+  parseTechnicalAdminCredentialId,
+} from "@/lib/technical-admin-credential";
+
+describe("Technical Admin credential ID codec", () => {
+  test("accepts current canonical enrollment IDs and browser-decodes the same bytes", () => {
+    const value = "credential-1";
+    const parsed = parseTechnicalAdminCredentialId(value);
+
+    expect(parsed).not.toBeNull();
+    if (parsed === null) throw new Error("Expected a canonical credential ID.");
+    expect(decodeTechnicalAdminCredentialId(value)).toEqual(parsed);
+  });
+
+  test("rejects empty, padded, noncanonical, illegal, and over-bound IDs", () => {
+    const overBound = "A".repeat(1_368);
+    for (const value of ["", "=", "AA=", "credential-live", "a!", overBound]) {
+      expect(parseTechnicalAdminCredentialId(value)).toBeNull();
+      expect(() => decodeTechnicalAdminCredentialId(value)).toThrow();
+    }
+  });
+});

--- a/src/lib/technical-admin-credential.ts
+++ b/src/lib/technical-admin-credential.ts
@@ -1,0 +1,34 @@
+export const TECHNICAL_ADMIN_CREDENTIAL_ID_MIN_BYTES = 1;
+export const TECHNICAL_ADMIN_CREDENTIAL_ID_MAX_BYTES = 1023;
+
+export function parseTechnicalAdminCredentialId(value: unknown): Uint8Array | null {
+  if (typeof value !== "string" || !/^[A-Za-z0-9_-]+$/u.test(value)) return null;
+  const padded = value.replace(/-/g, "+").replace(/_/g, "/") + "===".slice((value.length + 3) % 4);
+  let binary: string;
+  try {
+    binary = atob(padded);
+  } catch {
+    return null;
+  }
+  const bytes = Uint8Array.from(binary, (character) => character.charCodeAt(0));
+  if (
+    bytes.length < TECHNICAL_ADMIN_CREDENTIAL_ID_MIN_BYTES ||
+    bytes.length > TECHNICAL_ADMIN_CREDENTIAL_ID_MAX_BYTES
+  ) {
+    return null;
+  }
+  return encodeTechnicalAdminCredentialId(bytes) === value ? bytes : null;
+}
+
+export function decodeTechnicalAdminCredentialId(value: string): Uint8Array {
+  const parsed = parseTechnicalAdminCredentialId(value);
+  if (parsed === null) throw new Error("Invalid Technical Admin credential ID.");
+  return parsed;
+}
+
+export function encodeTechnicalAdminCredentialId(value: Uint8Array): string {
+  return btoa(String.fromCharCode(...value))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/u, "");
+}

--- a/src/pages/technical-admin-page.tsx
+++ b/src/pages/technical-admin-page.tsx
@@ -6,6 +6,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { AdministrativeAuditBrowser } from "@/pages/administrative-audit-browser";
 import { createGrantSecretOwner, type GrantSecretToken } from "@/lib/grant-secret-owner";
+import { decodeTechnicalAdminCredentialId } from "@/lib/technical-admin-credential";
 
 export type GrantQrRenderer = (credential: string) => Promise<string>;
 
@@ -1089,7 +1090,10 @@ async function getCredential(options: AuthenticationOptionsResponse) {
     publicKey: {
       ...options,
       challenge: decode(options.challenge),
-      allowCredentials: options.allowCredentials.map((item) => ({ ...item, id: decode(item.id) })),
+      allowCredentials: options.allowCredentials.map((item) => ({
+        ...item,
+        id: decodeTechnicalAdminCredentialId(item.id) as BufferSource,
+      })),
     },
   });
   if (!(credential instanceof PublicKeyCredential)) throw new Error("No passkey returned.");


### PR DESCRIPTION
## Purpose

This stacked PR implements #193 for the Technical Admin authentication sanitation adapter owned by #105. It prepares Technical Admin authority for a future Foundation restore while preserving the sole compatible passkey and invalidating every transient browser authority.

## Adapter contract

`TechnicalAdminAuth.prepareForFoundationRestore({ mode })` is the only public semantic adapter. It returns only:

- `preserved-transients-invalidated`
- `re-enrollment-required` with `missing`, `invalid`, `incompatible`, or `explicit-reset`
- `sanitation-failed`

The compatible-preserve path validates the Environment/origin/RP binding, preserves the exact credential/storage identity, and atomically deletes sessions, fresh verification, challenges, and enrollment authorizations. Explicit reset is deliberate, precedence-first, and atomically removes the credential. Readable invalid or missing state sanitizes transient authority before returning its bounded re-enrollment result. Corrupt, unreadable, read-only, I/O, or commit failures fail closed and roll back.

## Credential validation

Stored credential IDs use one strict canonical unpadded base64url parser shared by storage validation, restore preparation, ordinary authentication, and browser conversion. Public keys accept only WebCrypto-importable EC P-256/ES256 and OKP Ed25519/EdDSA records with canonical metadata and explicit public-field allowlists. Private, symmetric, cross-family, unsupported, unknown, or mismatched fields are rejected before challenge creation or restore preservation.

Memory and SQLite seams cover atomic sanitation, rollback, restart preservation, fresh sign-in, redacted finite results, explicit reset, invalid credential classification, and transient authority rejection. Browser coverage includes the same-passkey sanitation/fresh-sign-in scenario and inherited Access Sheet/audit behavior.

## Downstream boundary and exclusions

Foundation restore orchestration remains #192’s responsibility. Its future consumer must use only this finite semantic adapter result and must not inspect Technical Admin tables, schema, paths, credential fields, counts, or raw errors. This PR does not implement #192, migrations, deployment, fallback authentication, extra credentials, production operations, or issue merging.

## Checks

- `bun test --isolate ./src/lib/technical-admin-auth.test.ts` — 39 passed
- `bun test --isolate ./src/lib/technical-admin-credential.test.ts` — 2 passed
- `bun test --isolate ./src/lib/technical-admin-auth-sqlite.focused.ts` — 13 passed
- `bun run test:focused:technical-admin-browser` — passed, including Access Sheet/audit coverage
- `bun run test` — 703 passed, 0 failed
- `bun run check` — passed with existing non-failing lint warnings
- `bun run build` — passed
- `git diff --check` — passed

No Qualification Tests were run.
