### PR TITLE
Fix Docker probe artifact paths in CI

### DIFF
--- a/src/lib/sqlite-foundation-probe-docker.test.ts
+++ b/src/lib/sqlite-foundation-probe-docker.test.ts
@@ -219,6 +219,7 @@ describe("Docker SQLite qualification boundary", () => {
   });
 
   test("fails the start barrier before the artifact can run", async () => {
+    const artifactPath = await realpath("/bin/sh");
     const calls: string[][] = [];
     const responses = [
       { exitCode: 0, stdout: JSON.stringify({ OSType: "linux", Architecture: "x86_64" }) },
@@ -236,25 +237,35 @@ describe("Docker SQLite qualification boundary", () => {
       { exitCode: 0, stdout: "" },
       { exitCode: 0, stdout: "" },
     ];
-    await expect(
-      createDockerProbeExecution("/bin/sh", {
-        platform: "linux",
-        architecture: "x64",
-        invocationId: capability,
-        runCommand: async (arguments_) => {
-          calls.push([...arguments_]);
-          const response = responses.shift();
-          if (response === undefined) throw new Error("unexpected Docker command");
-          return {
-            ...response,
-            stderr: "",
-            stdoutBytes: response.stdout.length,
-            stderrBytes: 0,
-            outputExceeded: false,
-          };
-        },
-      }),
-    ).rejects.toBeInstanceOf(DockerAdmissionError);
+    const error = await createDockerProbeExecution(artifactPath, {
+      platform: "linux",
+      architecture: "x64",
+      invocationId: capability,
+      runCommand: async (arguments_) => {
+        calls.push([...arguments_]);
+        const response = responses.shift();
+        if (response === undefined) throw new Error("unexpected Docker command");
+        return {
+          ...response,
+          stderr: "",
+          stdoutBytes: response.stdout.length,
+          stderrBytes: 0,
+          outputExceeded: false,
+        };
+      },
+    }).catch((value) => value);
+    expect(error).toBeInstanceOf(DockerAdmissionError);
+    expect((error as DockerAdmissionError).disposition).toBe("removed");
+    expect(calls.map((value) => value[0])).toEqual([
+      "info",
+      "version",
+      "create",
+      "inspect",
+      "inspect",
+      "rm",
+      "ps",
+    ]);
+    expect(calls[2]).toContain(`type=bind,src=${artifactPath},dst=/opt/quadball-timer,readonly`);
     expect(calls.map((value) => value[0])).not.toContain("start");
   });
 
@@ -270,7 +281,7 @@ describe("Docker SQLite qualification boundary", () => {
       stderrBytes: 0,
       outputExceeded: false,
     });
-    const execution = await createDockerProbeExecution("/bin/sh", {
+    const execution = await createDockerProbeExecution(artifactPath, {
       platform: "linux",
       architecture: "x64",
       invocationId: capability,
@@ -317,7 +328,7 @@ describe("Docker SQLite qualification boundary", () => {
         stderrBytes: stderr.length,
         outputExceeded: false,
       });
-      const execution = await createDockerProbeExecution("/bin/sh", {
+      const execution = await createDockerProbeExecution(artifactPath, {
         platform: "linux",
         architecture: "x64",
         invocationId: capability,
@@ -581,6 +592,7 @@ describe("Docker SQLite qualification boundary", () => {
   });
 
   test("discovers and verifies cleanup after malformed Docker create output", async () => {
+    const artifactPath = await realpath("/bin/sh");
     const calls: string[][] = [];
     const executionId = containerId;
     const responses = [
@@ -599,7 +611,7 @@ describe("Docker SQLite qualification boundary", () => {
       { exitCode: 0, stdout: "" },
       { exitCode: 0, stdout: "" },
     ];
-    const error = await createDockerProbeExecution("/bin/sh", {
+    const error = await createDockerProbeExecution(artifactPath, {
       platform: "linux",
       architecture: "x64",
       invocationId: capability,


### PR DESCRIPTION
## What changed

- Resolve `/bin/sh` to its canonical regular-file path in Docker-probe tests that intentionally proceed beyond artifact admission.
- Use that canonical path in start-barrier, cleanup, bounded-log, and malformed-create-output coverage.
- Strengthen the start-barrier regression to prove Docker inspection and verified cleanup occurred while `docker start` remained blocked.

## Why

Ubuntu exposes `/bin/sh` as a symlink. Production correctly rejects symlinked exact-artifact paths, but four tests accidentally passed `/bin/sh` while expecting later Docker admission or cleanup behavior. The merged test failure blocked the release build and skipped both deployment jobs.

## Impact

This is test-only. Production artifact validation remains fail-closed and continues rejecting symlinks. The corrected tests now exercise their intended Docker boundaries on Linux CI.

## Verification

- `bun install --frozen-lockfile`
- `bun audit` — no vulnerabilities
- `bun run check`
- focused Docker probe/runner/policy Fast tests — 46 passed
- independent `bun test --isolate src/lib/sqlite-foundation-probe-docker.test.ts` — 15 passed
- `bun run test` — 670 passed
- `git diff --check`

No Qualification Test, Docker Qualification workload, or `bun run check:sqlite-runtime` was run.
