### PR TITLE
Recover timeouts and suspended Games

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -36,6 +36,22 @@ _Avoid_: Automatic stoppage, heat timer
 A complete stoppage started by a Controller on Head Referee direction after a Heat Stoppage Trigger. The first actual Heat Stoppage normally lasts four minutes and later ones two minutes. A required within-one-goal skip and the permitted following extension are ordinary rule operation; suppressing another required trigger, ending early, or extending beyond the rulebook allowance is an Official Override. Disabling Heat Stoppage Mode ends an active heat timer but does not resume play.
 _Avoid_: Team timeout, automatic clock pause
 
+**Team Timeout**:
+One Game Side's single timeout entitlement in an Event Game. Its stoppage procedure and separate 60-second timeout minute are recorded as immutable Game Facts; the long-whistle cue is due at 45 seconds, and correction or reinstatement rebuilds the entitlement and elapsed state.
+_Avoid_: Automatic stoppage, mutable timeout flag
+
+**Game Suspension**:
+A Head Referee-directed stoppage of an Event Game while the Game Clock is stopped. It blocks Clock restart until a Controller records a resume targeting the effective suspension Game Fact and does not replace the Game Clock, score, penalties, or possession evidence.
+_Avoid_: Pause, inactivity timeout, discarded game state
+
+**Suspension Recovery Snapshot**:
+The versioned `live-suspension-snapshot-v1` Game Fact data attached to a Game Suspension. It records the accepted Game Clock and score, every actual remaining penalty segment including simultaneous or queued segments, confirmed volleyball possession, and one entry for every recorded dodgeball possession so another Controller can verify recovery before resume.
+_Avoid_: Raw card facts, partial possession list, device snapshot
+
+**Known Game Ball Set**:
+The authoritative dodgeball identities configured for one Event Game or recovered from its accepted durable suspension history, including corrected facts. A new Suspension Recovery Snapshot must list each known dodgeball exactly once and cannot introduce an extra identity. Before the first suspension, Event Administration must provide the Event-Game-scoped set; without it, suspension admission fails closed.
+_Avoid_: Client-entered ball list, partial possession list, device snapshot
+
 **Gameplay Slot**:
 A tournament-system-defined row in a Game Day schedule that groups up to one Event Game per Pitch, usually under one Scheduled Start. A general Expected Delay can move its Games together while allowing a more-delayed Pitch Slot to remain later.
 _Avoid_: Game Slot, round, timeslot, batch

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "event:admin": "bun scripts/event-admin.ts",
     "test:focused:technical-admin-browser": "bun scripts/test-technical-admin-browser.ts",
     "test:focused:public-event-browser": "bun scripts/test-public-event-browser.ts",
+    "test:focused:event-game-controller-browser": "bun scripts/test-event-game-controller-browser.ts",
     "test:focused:technical-admin": "bun test --isolate ./src/lib/technical-admin-auth-sqlite.focused.ts",
     "test:focused:startup": "bun test --isolate ./src/index-startup.focused.ts",
     "build": "bun run build.ts",

--- a/scripts/test-event-game-controller-browser.ts
+++ b/scripts/test-event-game-controller-browser.ts
@@ -1,0 +1,331 @@
+#!/usr/bin/env bun
+import { chromium, type BrowserContext, type Page } from "playwright";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createGrantKeyRingDocument, writeGrantKeyRingFile } from "@/lib/grant-key-ring-custody";
+import { createInitialClockBaseline, projectClockBaseline } from "@/lib/clock-authority";
+import type { ControllerProjection, LiveSuspensionSnapshot } from "@/lib/live-event-game-control";
+import type { LivePenaltyProjection } from "@/lib/live-event-penalties";
+
+const directory = mkdtempSync(join(tmpdir(), "quadball-timer-controller-browser-"));
+const certificatePath = join(directory, "localhost.crt");
+const keyPath = join(directory, "localhost.key");
+const grantKeyRingPath = join(directory, "grant-key-ring.json");
+const port = 39_000 + Math.floor(Math.random() * 500);
+const origin = `https://localhost:${port}`;
+const environment = {
+  ...process.env,
+  NODE_ENV: "test",
+  QUADBALL_ENVIRONMENT: "test",
+  PUBLIC_ORIGIN: origin,
+  WEBAUTHN_RP_ID: "localhost",
+  PORT: String(port),
+  TECHNICAL_ADMIN_DATABASE: join(directory, "technical-admin.sqlite"),
+  FOUNDATION_DATABASE: join(directory, "foundation.sqlite"),
+  EVENT_GAME_DATABASE: join(directory, "event-game.sqlite"),
+  AD_HOC_DATABASE: join(directory, "ad-hoc.sqlite"),
+  TLS_CERT_FILE: certificatePath,
+  TLS_KEY_FILE: keyPath,
+  GRANT_KEY_RING_FILE: grantKeyRingPath,
+};
+
+let server: Bun.Subprocess | null = null;
+let browser: Awaited<ReturnType<typeof chromium.launch>> | null = null;
+let currentProjection = createProjection();
+
+try {
+  const certificate = Bun.spawnSync([
+    "openssl",
+    "req",
+    "-x509",
+    "-newkey",
+    "rsa:2048",
+    "-nodes",
+    "-subj",
+    "/CN=localhost",
+    "-addext",
+    "subjectAltName=DNS:localhost",
+    "-days",
+    "1",
+    "-keyout",
+    keyPath,
+    "-out",
+    certificatePath,
+  ]);
+  if (certificate.exitCode !== 0)
+    throw new Error("openssl could not create a temporary certificate.");
+  writeGrantKeyRingFile(grantKeyRingPath, createGrantKeyRingDocument("test"));
+  server = Bun.spawn(["bun", "run", "src/index.ts"], {
+    cwd: process.cwd(),
+    env: environment,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  await waitForServer(`${origin}/internal/healthz`);
+
+  browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({ ignoreHTTPSErrors: true });
+  await installControllerApi(context);
+  const controller = await context.newPage();
+  await completeSuspendReviewResume(controller);
+
+  const secondContext = await browser.newContext({ ignoreHTTPSErrors: true });
+  await installControllerApi(secondContext);
+  const reviewingController = await secondContext.newPage();
+  await reviewAndResume(reviewingController);
+
+  console.log(
+    "Focused Integration Test passed: 360x640 suspend/review/resume with two known balls.",
+  );
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  if (server !== null) {
+    server.kill("SIGTERM");
+    const stderr = await new Response(server.stderr as unknown as BodyInit).text();
+    if (stderr.trim() !== "") console.error(stderr.slice(-2_000));
+  }
+  process.exitCode = 1;
+} finally {
+  await browser?.close();
+  if (server !== null) {
+    server.kill("SIGTERM");
+    await server.exited;
+  }
+  rmSync(directory, { recursive: true, force: true });
+}
+
+async function completeSuspendReviewResume(page: Page) {
+  page.setDefaultTimeout(5_000);
+  await page.setViewportSize({ width: 360, height: 640 });
+  await page.goto(`${origin}/event-control`);
+  await page.getByLabel("Active Pitch Slot Control Grant QR").fill("disposable-grant");
+  await page.getByRole("button", { name: "Open Controller Device" }).click();
+  await page.getByRole("button", { name: "Review suspension recovery" }).click();
+  await page.locator("#volleyball-possession").selectOption("side-a");
+  await page.locator("#dodgeball-possession-ball-1").selectOption("side-b");
+  await page.locator("#dodgeball-possession-ball-2").selectOption("side-a");
+  await page.getByRole("button", { name: "Suspend with verified snapshot" }).click();
+  const snapshot = page.locator('[data-suspension-snapshot="effective"]');
+  await snapshot.waitFor();
+  const snapshotText = await snapshot.innerText();
+  assert(
+    (await page.locator("[data-dodgeball-id]").count()) === 2,
+    "configured ball set was incomplete",
+  );
+  assert(snapshotText.includes("ball-1=side-b"), "ball-1 recovery was not shown");
+  assert(snapshotText.includes("ball-2=side-a"), "ball-2 recovery was not shown");
+  await assertNoDocumentScroll(page);
+}
+
+async function reviewAndResume(page: Page) {
+  await page.setViewportSize({ width: 360, height: 640 });
+  await page.goto(`${origin}/event-control`);
+  await page.getByLabel("Active Pitch Slot Control Grant QR").fill("disposable-grant");
+  await page.getByRole("button", { name: "Open Controller Device" }).click();
+  await page.locator('[data-suspension-snapshot="effective"]').waitFor();
+  const snapshotText = await page.locator('[data-suspension-snapshot="effective"]').innerText();
+  assert(snapshotText.includes("Volleyball: side-a"), "volleyball recovery was not shown");
+  assert(snapshotText.includes("ball-1=side-b"), "review missed ball-1");
+  assert(snapshotText.includes("ball-2=side-a"), "review missed ball-2");
+  const resumeResponse = page.waitForResponse((response) =>
+    response.url().endsWith("/api/event-control/replay"),
+  );
+  await page.getByRole("button", { name: "Resume verified suspension" }).click();
+  const resumed = (await (await resumeResponse).json()) as {
+    projection?: { suspension?: { status?: string } };
+  };
+  assert(resumed.projection?.suspension?.status === "none", "resume did not clear suspension");
+  await assertNoDocumentScroll(page);
+}
+
+async function installControllerApi(context: BrowserContext) {
+  await context.route("**/api/event-control/**", async (route) => {
+    const url = new URL(route.request().url());
+    const body = route.request().postDataJSON() as Record<string, unknown> | null;
+    if (url.pathname.endsWith("/open")) {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          status: "opened",
+          eventGameId: "game-browser-focused",
+          session: {
+            sessionBearer: "bearer",
+            grantSessionId: "session",
+            grantVersion: "version",
+          },
+          projection: currentProjection,
+          projectionStatus: "available",
+        }),
+      });
+      return;
+    }
+    if (url.pathname.endsWith("/refresh")) {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          status: "authorized",
+          session: {
+            eventGameId: "game-browser-focused",
+            grantSessionId: "session",
+            grantVersion: "version",
+          },
+          projection: currentProjection,
+          projectionStatus: "available",
+        }),
+      });
+      return;
+    }
+    if (url.pathname.endsWith("/replay")) {
+      const actions = Array.isArray(body?.actions) ? body.actions.filter(isRecord) : [];
+      for (const action of actions) {
+        const intent = isRecord(action.intent) ? action.intent : undefined;
+        if (intent?.suspensionAction === "start") {
+          const snapshot = intent.suspensionSnapshot as LiveSuspensionSnapshot;
+          currentProjection = {
+            ...currentProjection,
+            phase: "suspended",
+            suspension: { status: "suspended", factId: "fact-focused-suspension", snapshot },
+            stoppage: { status: "suspension", factId: "fact-focused-suspension" },
+          };
+        } else if (intent?.suspensionAction === "resume") {
+          currentProjection = {
+            ...currentProjection,
+            phase: "in-progress",
+            suspension: { status: "none", factId: null, snapshot: null },
+            stoppage: { status: "none", factId: null },
+          };
+        }
+      }
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          status: "synchronized",
+          batchId: body?.batchId,
+          replicaGeneration: body?.replicaGeneration,
+          eventGameId: "game-browser-focused",
+          session: {
+            eventGameId: "game-browser-focused",
+            grantSessionId: "session",
+            grantVersion: "version",
+          },
+          outcomes: actions.flatMap((action) =>
+            isRecord(action.intent) && typeof action.intent.operationId === "string"
+              ? [{ operationId: action.intent.operationId, status: "accepted" as const }]
+              : [],
+          ),
+          projection: currentProjection,
+        }),
+      });
+      return;
+    }
+    if (url.pathname.endsWith("/intent")) {
+      const intent = isRecord(body?.intent) ? body.intent : undefined;
+      if (intent?.suspensionAction === "start") {
+        const snapshot = intent.suspensionSnapshot as LiveSuspensionSnapshot;
+        currentProjection = {
+          ...currentProjection,
+          phase: "suspended",
+          suspension: { status: "suspended", factId: "fact-focused-suspension", snapshot },
+          stoppage: { status: "suspension", factId: "fact-focused-suspension" },
+        };
+      } else if (intent?.suspensionAction === "resume") {
+        currentProjection = {
+          ...currentProjection,
+          phase: "in-progress",
+          suspension: { status: "none", factId: null, snapshot: null },
+          stoppage: { status: "none", factId: null },
+        };
+      }
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          status: "accepted",
+          acknowledgement: { status: "acknowledged", operationId: intent?.operationId },
+          projection: currentProjection,
+          projectionStatus: "available",
+          synchronization: { status: "synchronized", pendingCount: 0 },
+          auditReference: { kind: "control", id: "audit-focused" },
+        }),
+      });
+      return;
+    }
+    await route.fulfill({ status: 404, body: "not found" });
+  });
+}
+
+async function assertNoDocumentScroll(page: Page) {
+  const metrics = await page.evaluate(() => ({
+    scrollTop: document.scrollingElement?.scrollTop ?? 0,
+    scrollHeight: document.scrollingElement?.scrollHeight ?? 0,
+    clientHeight: document.scrollingElement?.clientHeight ?? 0,
+  }));
+  assert(
+    metrics.scrollTop === 0,
+    `document was scrolled during the phone workflow (${JSON.stringify(metrics)})`,
+  );
+  assert(
+    metrics.scrollHeight <= metrics.clientHeight,
+    `document overflowed the viewport (${JSON.stringify(metrics)})`,
+  );
+}
+
+function createProjection(): ControllerProjection {
+  const baseline = createInitialClockBaseline();
+  baseline.holderGrantSessionId = "session";
+  baseline.holderGeneration = 1;
+  baseline.authorityGeneration = 1;
+  return {
+    eventGameId: "game-browser-focused",
+    phase: "in-progress",
+    scoreByGameSide: { "side-a": 0, "side-b": 0 },
+    goalCount: 0,
+    knownDodgeballIds: ["ball-1", "ball-2"],
+    penalties: {
+      cards: [],
+      players: [],
+      pendingExpirations: [],
+      releases: [],
+    } satisfies LivePenaltyProjection,
+    timeout: {
+      status: "inactive",
+      factId: null,
+      gameSideId: null,
+      usedGameSideIds: [],
+      startedAtMs: null,
+      remainingMs: null,
+      longWhistleCue: "not-applicable",
+    },
+    suspension: { status: "none", factId: null, snapshot: null },
+    stoppage: { status: "none", factId: null },
+    heat: { status: "inactive", factId: null, startedAtGameTimeMs: null, nominalDurationMs: null },
+    result: null,
+    gameFacts: [],
+    guardrails: [],
+    commencement: {
+      status: "commenced",
+      commencedAtMs: 0,
+      provisionalRunningSinceMs: null,
+      provisionalElapsedMs: 0,
+    },
+    clock: projectClockBaseline(baseline, 0),
+  };
+}
+
+async function waitForServer(url: string) {
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    const response = Bun.spawnSync(["curl", "-k", "-sSf", "-H", `host: localhost:${port}`, url]);
+    if (response.exitCode === 0) return;
+    await Bun.sleep(50);
+  }
+  throw new Error("Focused browser server did not become ready.");
+}
+
+function assert(condition: boolean, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import { createLiveEventGameControlTransport } from "@/lib/live-event-game-trans
 import {
   openLiveEventGameRuntime,
   createControlScopeResolver,
+  readLiveEventDodgeballIdsByEventGame,
   readLiveEventGrantKeyRing,
   type LiveEventGameRuntime,
 } from "@/lib/live-event-game-runtime";
@@ -308,6 +309,7 @@ async function startServer() {
           databasePath: liveEventDatabasePath,
           environmentId: environment,
           keyRing: liveEventKeyRing,
+          knownDodgeballIdsForEventGame: readLiveEventDodgeballIdsByEventGame(),
         });
         startupCleanup.add(() => liveEventRuntime?.close());
       } catch (error) {

--- a/src/lib/controller-reconnect.test.ts
+++ b/src/lib/controller-reconnect.test.ts
@@ -13,7 +13,10 @@ import {
   serializeControllerReplica,
   type ControllerReplicaStorage,
 } from "@/lib/controller-reconnect";
-import { LIVE_EVENT_CONTROL_INTENT_VERSION } from "@/lib/live-event-game-control";
+import {
+  LIVE_EVENT_CONTROL_INTENT_VERSION,
+  LIVE_SUSPENSION_SNAPSHOT_VERSION,
+} from "@/lib/live-event-game-control";
 import { createInitialClockBaseline, projectClockBaseline } from "@/lib/clock-authority";
 
 describe("Controller reconnect replica", () => {
@@ -709,6 +712,22 @@ function substantive(
     factId: `fact-${operationId}`,
     gameTimeMs: 0,
     ...(gameSideId === undefined ? {} : { gameSideId }),
+    ...(trigger === "timeout"
+      ? { timeoutAction: "stoppage" as const, timeoutGameSideId: "side-a" }
+      : {}),
+    ...(trigger === "suspension"
+      ? {
+          suspensionAction: "start" as const,
+          suspensionSnapshot: {
+            version: LIVE_SUSPENSION_SNAPSHOT_VERSION,
+            gameTimeMs: 0,
+            scoreByGameSide: { "side-a": 0, "side-b": 0 },
+            penalties: { segments: [] },
+            volleyballPossession: "side-a",
+            dodgeballPossession: { "ball-1": "side-a" },
+          },
+        }
+      : {}),
     occurrence: { clientOriginAtMs: 0, source: "offline" as const },
   };
 }

--- a/src/lib/controller-reconnect.ts
+++ b/src/lib/controller-reconnect.ts
@@ -6,6 +6,8 @@ import type {
   LiveHeatState,
   LiveCatchState,
   LiveResultState,
+  LiveSuspensionPenaltyState,
+  LiveSuspensionState,
   LiveStoppageState,
   LiveTimeoutState,
 } from "@/lib/live-event-game-control";
@@ -18,6 +20,7 @@ import {
 } from "@/lib/clock-authority";
 import {
   orderControllerGameFacts,
+  LIVE_SUSPENSION_SNAPSHOT_VERSION,
   parseLiveEventControllerIntent,
 } from "@/lib/live-event-game-control";
 import {
@@ -738,27 +741,11 @@ function applyOptimisticAction(
         },
       );
     }
-    return {
-      ...state,
-      projection: {
-        ...state.projection,
-        phase:
-          state.projection.commencement.status === "provisional"
-            ? "in-progress"
-            : state.projection.phase,
-        commencement:
-          commencementAtDispatch.status === "provisional"
-            ? {
-                ...commencementAtDispatch,
-                status: "commenced",
-                commencedAtMs: action.dispatchedAtMs,
-                provisionalRunningSinceMs: null,
-              }
-            : commencementAtDispatch,
-        gameFacts: nextFacts,
-        penalties: deriveLivePenaltyProjection(nextFacts, state.projection.clock.gameTimeMs),
-      },
-    };
+    return rebuildOptimisticProjection(
+      state,
+      nextFacts,
+      commencementAtDispatch.commencedAtMs ?? action.dispatchedAtMs,
+    );
   }
   if (intent.type === "record-penalty-reason") {
     const nextFacts = appendOptimisticFact(state.projection, {
@@ -773,14 +760,7 @@ function applyOptimisticAction(
         sportingOrder: intent.sportingOrder ?? intent.gameTimeMs,
       },
     });
-    return {
-      ...state,
-      projection: {
-        ...state.projection,
-        gameFacts: nextFacts,
-        penalties: deriveLivePenaltyProjection(nextFacts, state.projection.clock.gameTimeMs),
-      },
-    };
+    return rebuildOptimisticProjection(state, nextFacts, action.dispatchedAtMs);
   }
   if (intent.type === "resolve-penalty-expiration") {
     const scoreFact = (state.projection.gameFacts ?? []).find(
@@ -801,14 +781,7 @@ function applyOptimisticAction(
         sportingOrder: scoreSportingOrder,
       },
     });
-    return {
-      ...state,
-      projection: {
-        ...state.projection,
-        gameFacts: nextFacts,
-        penalties: deriveLivePenaltyProjection(nextFacts, state.projection.clock.gameTimeMs),
-      },
-    };
+    return rebuildOptimisticProjection(state, nextFacts, action.dispatchedAtMs);
   }
   if (
     intent.type === "record-flag-catch" ||
@@ -1033,6 +1006,7 @@ function sameProjection(left: ControllerProjection, right: ControllerProjection)
   const rightFacts = JSON.stringify(right.gameFacts ?? []);
   const leftDependent = JSON.stringify([
     left.timeout ?? null,
+    left.suspension ?? null,
     left.stoppage ?? null,
     left.heat ?? null,
     left.result ?? null,
@@ -1043,6 +1017,7 @@ function sameProjection(left: ControllerProjection, right: ControllerProjection)
   ]);
   const rightDependent = JSON.stringify([
     right.timeout ?? null,
+    right.suspension ?? null,
     right.stoppage ?? null,
     right.heat ?? null,
     right.result ?? null,
@@ -1200,7 +1175,10 @@ function parseProjection(value: unknown): ControllerProjection {
     : projectClockBaseline(createInitialClockBaseline(), 0);
   const gameFacts = parseGameFacts(value.gameFacts);
   const guardrails = parseGuardrails(value.guardrails);
+  const knownDodgeballIds = parseKnownDodgeballIds(value.knownDodgeballIds);
   const timeout = value.timeout === undefined ? undefined : parseTimeoutState(value.timeout);
+  const suspension =
+    value.suspension === undefined ? undefined : parseSuspensionState(value.suspension);
   const stoppage = value.stoppage === undefined ? undefined : parseStoppageState(value.stoppage);
   const heat = value.heat === undefined ? undefined : parseHeatState(value.heat);
   const result = value.result === undefined ? undefined : parseResultState(value.result);
@@ -1221,7 +1199,10 @@ function parseProjection(value: unknown): ControllerProjection {
     phase,
     scoreByGameSide: scores,
     goalCount: goalCount.value,
+    ...(value.knownDodgeballIds === undefined ? {} : { knownDodgeballIds }),
+    ...(value.penalties === undefined ? {} : { penalties }),
     ...(value.timeout === undefined ? {} : { timeout }),
+    ...(value.suspension === undefined ? {} : { suspension }),
     ...(value.stoppage === undefined ? {} : { stoppage }),
     ...(value.heat === undefined ? {} : { heat }),
     ...(value.result === undefined ? {} : { result }),
@@ -1230,7 +1211,6 @@ function parseProjection(value: unknown): ControllerProjection {
     ...(winnerGameSideId === undefined ? {} : { winnerGameSideId }),
     ...(catchState === undefined ? {} : { catch: catchState }),
     ...(value.gameFacts === undefined ? {} : { gameFacts }),
-    ...(penalties === undefined ? {} : { penalties }),
     ...(value.guardrails === undefined ? {} : { guardrails }),
     clock,
     commencement: {
@@ -1285,10 +1265,177 @@ function parseOptionalCatch(value: unknown): LiveCatchState | null | undefined {
 }
 
 function parseTimeoutState(value: unknown): LiveTimeoutState {
-  if (!isRecord(value) || (value.status !== "inactive" && value.status !== "started")) {
+  if (
+    !isRecord(value) ||
+    (value.status !== "inactive" &&
+      value.status !== "stoppage" &&
+      value.status !== "started" &&
+      value.status !== "completed")
+  ) {
     throw new Error("Projection timeout state is invalid.");
   }
-  return { status: value.status, factId: parseNullableFactId(value.factId, "timeout.factId") };
+  return {
+    ...structuredClone(value),
+    status: value.status,
+    factId: parseNullableFactId(value.factId, "timeout.factId"),
+  } as LiveTimeoutState;
+}
+
+function parseSuspensionState(value: unknown): LiveSuspensionState {
+  if (!isRecord(value) || (value.status !== "none" && value.status !== "suspended")) {
+    throw new Error("Projection suspension state is invalid.");
+  }
+  const factId = parseNullableFactId(value.factId, "suspension.factId");
+  if (value.snapshot === null || value.snapshot === undefined) {
+    if (value.status === "suspended") {
+      throw new Error("Suspended projection must include a recovery snapshot.");
+    }
+    return { status: value.status, factId, snapshot: null };
+  }
+  if (!isRecord(value.snapshot) || !isRecord(value.snapshot.scoreByGameSide)) {
+    throw new Error("Projection suspension snapshot is invalid.");
+  }
+  if (value.snapshot.version !== LIVE_SUSPENSION_SNAPSHOT_VERSION) {
+    throw new Error("Projection suspension snapshot version is invalid.");
+  }
+  const parsedScores: Record<string, number> = {};
+  for (const [sideId, score] of Object.entries(value.snapshot.scoreByGameSide)) {
+    if (!validateOpaqueIdentifier(sideId, "suspension.snapshot.gameSideId").ok) {
+      throw new Error("Projection suspension side is invalid.");
+    }
+    const parsed = validateIntegerInRange(score, 0, SHARED_LIMITS.score.max, "suspension.score");
+    if (!parsed.ok) throw new Error(parsed.error);
+    parsedScores[sideId] = parsed.value;
+  }
+  const penalties = parsePenaltyState(value.snapshot.penalties);
+  const volleyballPossession = value.snapshot.volleyballPossession;
+  if (typeof volleyballPossession !== "string" || volleyballPossession.length === 0) {
+    throw new Error("Projection volleyball possession is invalid.");
+  }
+  if (!isRecord(value.snapshot.dodgeballPossession)) {
+    throw new Error("Projection dodgeball possession is invalid.");
+  }
+  if (Object.keys(value.snapshot.dodgeballPossession).length === 0) {
+    throw new Error("Projection dodgeball possession is incomplete.");
+  }
+  const knownGameSideIds = new Set(Object.keys(parsedScores));
+  if (!knownGameSideIds.has(volleyballPossession)) {
+    throw new Error("Projection volleyball possession is not an admitted Game Side.");
+  }
+  const dodgeballPossession: Record<string, string | null> = {};
+  for (const [ballId, possession] of Object.entries(value.snapshot.dodgeballPossession)) {
+    if (!validateOpaqueIdentifier(ballId, "suspension.snapshot.dodgeballId").ok) {
+      throw new Error("Projection dodgeball id is invalid.");
+    }
+    if (possession !== null && typeof possession !== "string") {
+      throw new Error("Projection dodgeball possession is invalid.");
+    }
+    if (possession !== null && !knownGameSideIds.has(possession)) {
+      throw new Error("Projection dodgeball possession is not an admitted Game Side.");
+    }
+    dodgeballPossession[ballId] = possession;
+  }
+  const gameTimeMs = validateIntegerInRange(
+    value.snapshot.gameTimeMs,
+    0,
+    SHARED_LIMITS.clock.maxMs,
+    "suspension.snapshot.gameTimeMs",
+  );
+  if (!gameTimeMs.ok) throw new Error(gameTimeMs.error);
+  return {
+    status: value.status,
+    factId,
+    snapshot: {
+      version: LIVE_SUSPENSION_SNAPSHOT_VERSION,
+      gameTimeMs: gameTimeMs.value,
+      scoreByGameSide: parsedScores,
+      penalties,
+      volleyballPossession,
+      dodgeballPossession,
+    },
+  };
+}
+
+function parseKnownDodgeballIds(value: unknown): string[] {
+  if (value === undefined) return [];
+  if (!Array.isArray(value)) {
+    throw new Error("Projection known dodgeball identities are invalid.");
+  }
+  const ids = value.map((candidate) => requireIdentifier(candidate, "knownDodgeballId"));
+  if (new Set(ids).size !== ids.length) {
+    throw new Error("Projection known dodgeball identities are duplicated.");
+  }
+  return ids;
+}
+
+function parsePenaltyState(value: unknown): LiveSuspensionPenaltyState {
+  if (!isRecord(value) || !Array.isArray(value.segments)) {
+    throw new Error("Projection suspension penalties are invalid.");
+  }
+  const seen = new Set<string>();
+  const segments = value.segments.map((segment) => {
+    if (!isRecord(segment)) throw new Error("Projection suspension penalty is invalid.");
+    const sourceFactId = requireIdentifier(segment.sourceFactId, "suspension.penalty.sourceFactId");
+    const elapsedMs = validateIntegerInRange(
+      segment.elapsedMs,
+      0,
+      60_000,
+      "suspension.penalty.elapsedMs",
+    );
+    const remainingMs = validateIntegerInRange(
+      segment.remainingMs,
+      1,
+      60_000,
+      "suspension.penalty.remainingMs",
+    );
+    if (
+      !elapsedMs.ok ||
+      !remainingMs.ok ||
+      elapsedMs.value + remainingMs.value !== 60_000 ||
+      seen.has(sourceFactId) ||
+      typeof segment.expirableByScore !== "boolean"
+    ) {
+      throw new Error("Projection suspension penalty timing is invalid.");
+    }
+    seen.add(sourceFactId);
+    return {
+      sourceFactId,
+      elapsedMs: elapsedMs.value,
+      remainingMs: remainingMs.value,
+      expirableByScore: segment.expirableByScore,
+      ...(segment.cardFactId === undefined
+        ? {}
+        : { cardFactId: requireIdentifier(segment.cardFactId, "suspension.penalty.cardFactId") }),
+      ...(segment.cardType === undefined
+        ? {}
+        : {
+            cardType:
+              segment.cardType as LiveSuspensionPenaltyState["segments"][number]["cardType"],
+          }),
+      ...(segment.gameSideId === undefined
+        ? {}
+        : { gameSideId: requireIdentifier(segment.gameSideId, "suspension.penalty.gameSideId") }),
+      ...(segment.playerKey === undefined
+        ? {}
+        : { playerKey: requireIdentifier(segment.playerKey, "suspension.penalty.playerKey") }),
+      ...(segment.playerNumber === undefined
+        ? {}
+        : { playerNumber: segment.playerNumber as number | null }),
+      ...(segment.eligibleForScoreAtGameTimeMs === undefined
+        ? {}
+        : { eligibleForScoreAtGameTimeMs: segment.eligibleForScoreAtGameTimeMs as number }),
+      ...(segment.notBeforeGameTimeMs === undefined
+        ? {}
+        : { notBeforeGameTimeMs: segment.notBeforeGameTimeMs as number }),
+      ...(segment.startsAtGameTimeMs === undefined
+        ? {}
+        : { startsAtGameTimeMs: segment.startsAtGameTimeMs as number }),
+      ...(segment.endsAtGameTimeMs === undefined
+        ? {}
+        : { endsAtGameTimeMs: segment.endsAtGameTimeMs as number }),
+    };
+  });
+  return { segments };
 }
 
 function parseStoppageState(value: unknown): LiveStoppageState {
@@ -1660,20 +1807,21 @@ function rebuildOptimisticProjection(
       winnerGameSideId,
       catch: catchState,
       gameFacts: structuredClone(gameFacts),
+      penalties: deriveLivePenaltyProjection(gameFacts, projection.clock.gameTimeMs),
     },
   };
 }
 
 function deriveOptimisticDependentState(facts: readonly ControllerGameFact[]): {
   timeout: LiveTimeoutState;
+  suspension: LiveSuspensionState;
   stoppage: LiveStoppageState;
   heat: LiveHeatState;
   result: LiveResultState;
 } {
   const latest = (factType: string) =>
     facts.filter((fact) => fact.effective && fact.factType === factType).at(-1) ?? null;
-  const timeoutFact = latest("timeout");
-  const suspensionFact = latest("suspension");
+  const timeoutFacts = facts.filter((fact) => fact.effective && fact.factType === "timeout");
   const heatFact = latest("heat-stoppage");
   const resultFact = latest("result");
   const heatData =
@@ -1724,14 +1872,32 @@ function deriveOptimisticDependentState(facts: readonly ControllerGameFact[]): {
     startedAtGameTimeMs,
     nominalDurationMs,
   };
+  let suspension: LiveSuspensionState = { status: "none", factId: null, snapshot: null };
+  for (const fact of facts.filter(
+    (candidate) => candidate.effective && candidate.factType === "suspension",
+  )) {
+    const data = isRecord(fact.data) ? (fact.data as Record<string, unknown>) : null;
+    if (data?.suspensionAction === "resume") {
+      if (data.resumesSuspensionFactId === suspension.factId) {
+        suspension = { status: "none", factId: null, snapshot: null };
+      }
+      continue;
+    }
+    if (data?.suspensionAction !== "start") continue;
+    if (suspension.status === "suspended") continue;
+    const rawSnapshot = data?.suspensionSnapshot;
+    const snapshot =
+      isRecord(rawSnapshot) && isRecord(rawSnapshot.scoreByGameSide)
+        ? (structuredClone(rawSnapshot) as LiveSuspensionState["snapshot"])
+        : null;
+    suspension = { status: "suspended", factId: fact.factId, snapshot };
+  }
   return {
-    timeout: {
-      status: timeoutFact === null ? "inactive" : "started",
-      factId: timeoutFact?.factId ?? null,
-    },
+    timeout: deriveOptimisticTimeoutState(timeoutFacts),
+    suspension,
     stoppage:
-      suspensionFact !== null
-        ? { status: "suspension", factId: suspensionFact.factId }
+      suspension.status === "suspended"
+        ? { status: "suspension", factId: suspension.factId }
         : heat.status === "started" || heat.status === "extended"
           ? { status: "heat-stoppage", factId: heat.factId }
           : { status: "none", factId: null },
@@ -1741,6 +1907,46 @@ function deriveOptimisticDependentState(facts: readonly ControllerGameFact[]): {
         ? null
         : { factId: resultFact.factId, data: structuredClone(resultFact.data) },
   };
+}
+
+function deriveOptimisticTimeoutState(facts: readonly ControllerGameFact[]): LiveTimeoutState {
+  const usedGameSideIds = new Set<string>();
+  let timeout: LiveTimeoutState = {
+    status: "inactive",
+    factId: null,
+    gameSideId: null,
+    usedGameSideIds: [],
+    startedAtMs: null,
+    remainingMs: null,
+    longWhistleCue: "not-applicable",
+  };
+  for (const fact of facts) {
+    const data = isRecord(fact.data) ? (fact.data as Record<string, unknown>) : null;
+    if (data === null || typeof data.timeoutGameSideId !== "string") continue;
+    const gameSideId = data.timeoutGameSideId;
+    if (gameSideId !== null) usedGameSideIds.add(gameSideId);
+    const action =
+      data?.timeoutAction === "stoppage" ||
+      data?.timeoutAction === "complete" ||
+      data?.timeoutAction === "start"
+        ? data.timeoutAction
+        : null;
+    if (action === null) continue;
+    timeout = {
+      status: action === "stoppage" ? "stoppage" : action === "complete" ? "completed" : "started",
+      factId: fact.factId,
+      gameSideId,
+      usedGameSideIds: [...usedGameSideIds].sort(),
+      startedAtMs:
+        action === "start" && data !== null && typeof data.timeoutStartedAtMs === "number"
+          ? data.timeoutStartedAtMs
+          : null,
+      remainingMs: action === "start" ? 60_000 : action === "complete" ? 0 : null,
+      longWhistleCue:
+        action === "start" ? "pending" : action === "complete" ? "passed" : "not-applicable",
+    };
+  }
+  return timeout;
 }
 
 function isRecord(value: unknown): value is Record<string, any> {

--- a/src/lib/event-game-actions.ts
+++ b/src/lib/event-game-actions.ts
@@ -54,6 +54,14 @@ export type ControlActionGrantProvenance = {
   authorityReference?: string;
 };
 
+export const SYSTEM_TIMEOUT_COMPLETION_GRANT: Readonly<{
+  sessionId: "system-timeout-completion";
+  versionId: "system-v1";
+}> = Object.freeze({
+  sessionId: "system-timeout-completion",
+  versionId: "system-v1",
+});
+
 export type ControlActionLifecycleContext = {
   phase: EventGameLifecyclePhase;
   commencedAtMs: number | null;

--- a/src/lib/foundation-acceptance.ts
+++ b/src/lib/foundation-acceptance.ts
@@ -16,6 +16,7 @@ import {
   materializeControlAction,
   prepareControlAction,
   sha256,
+  SYSTEM_TIMEOUT_COMPLETION_GRANT,
   validateControlActionEnvelope,
 } from "@/lib/event-game-actions";
 import { appendConcurrentCorrectionAudits } from "@/lib/event-game-record";
@@ -91,6 +92,7 @@ export type ControlActionBatchInput = {
   lifecycleTransition?: EventGameRecordRoot["lifecycle"];
   /** Only the composed Live Event Game seam may reconcile derived scoring lifecycle. */
   reconcileDerivedLifecycle?: boolean;
+  systemOperation?: "timeout-completion";
 };
 
 export type FoundationActionResult =
@@ -200,6 +202,10 @@ type BatchPreflight = {
   trustedLockedReplay: boolean;
   actions: readonly { prepared: PreparedControlAction | null; error: string | null }[];
 };
+
+function isSystemTimeoutCompletionBatch(batch: PreparedBatch): boolean {
+  return batch.input.systemOperation === "timeout-completion";
+}
 type OneOutcome = { result: FoundationActionResult; reservationId?: string; receipt?: string };
 type AuthorizedControl = {
   grant: StoredGrant;
@@ -407,15 +413,21 @@ export function createFoundationAcceptance(
       authorization.status !== "authorized" ||
       authorization.grantType !== "control" ||
       authorization.eventGameId !== batch.input.eventGameId ||
-      authorization.grantSessionId !== first.envelope.grant.sessionId ||
-      authorization.grantVersion !== first.envelope.grant.versionId
+      (!isSystemTimeoutCompletionBatch(batch) &&
+        (authorization.grantSessionId !== first.envelope.grant.sessionId ||
+          authorization.grantVersion !== first.envelope.grant.versionId)) ||
+      (isSystemTimeoutCompletionBatch(batch) &&
+        (first.envelope.grant.sessionId !== SYSTEM_TIMEOUT_COMPLETION_GRANT.sessionId ||
+          first.envelope.grant.versionId !== SYSTEM_TIMEOUT_COMPLETION_GRANT.versionId))
     )
       return { authorized: false, root: null, trustedLockedReplay: false, actions: [] };
     if (
-      batch.actions.some(
-        ({ envelope }) =>
-          envelope.grant.sessionId !== authorization.grantSessionId ||
-          envelope.grant.versionId !== authorization.grantVersion,
+      batch.actions.some(({ envelope }) =>
+        isSystemTimeoutCompletionBatch(batch)
+          ? envelope.grant.sessionId !== SYSTEM_TIMEOUT_COMPLETION_GRANT.sessionId ||
+            envelope.grant.versionId !== SYSTEM_TIMEOUT_COMPLETION_GRANT.versionId
+          : envelope.grant.sessionId !== authorization.grantSessionId ||
+            envelope.grant.versionId !== authorization.grantVersion,
       )
     )
       return { authorized: false, root: null, trustedLockedReplay: false, actions: [] };
@@ -671,8 +683,12 @@ export function createFoundationAcceptance(
       authorization.status !== "authorized" ||
       authorization.grantType !== "control" ||
       authorization.eventGameId !== batch.input.eventGameId ||
-      authorization.grantSessionId !== structural.envelope.grant.sessionId ||
-      authorization.grantVersion !== structural.envelope.grant.versionId
+      (!isSystemTimeoutCompletionBatch(batch) &&
+        (authorization.grantSessionId !== structural.envelope.grant.sessionId ||
+          authorization.grantVersion !== structural.envelope.grant.versionId)) ||
+      (isSystemTimeoutCompletionBatch(batch) &&
+        (structural.envelope.grant.sessionId !== SYSTEM_TIMEOUT_COMPLETION_GRANT.sessionId ||
+          structural.envelope.grant.versionId !== SYSTEM_TIMEOUT_COMPLETION_GRANT.versionId))
     )
       return authorityFailure();
     const root = transaction.findRootByRecordId(batch.input.recordId);
@@ -750,8 +766,12 @@ export function createFoundationAcceptance(
       currentAuthorization.status !== "authorized" ||
       currentAuthorization.grantType !== "control" ||
       currentAuthorization.eventGameId !== batch.input.eventGameId ||
-      currentAuthorization.grantSessionId !== structural.envelope.grant.sessionId ||
-      currentAuthorization.grantVersion !== structural.envelope.grant.versionId
+      (!isSystemTimeoutCompletionBatch(batch) &&
+        (currentAuthorization.grantSessionId !== structural.envelope.grant.sessionId ||
+          currentAuthorization.grantVersion !== structural.envelope.grant.versionId)) ||
+      (isSystemTimeoutCompletionBatch(batch) &&
+        (structural.envelope.grant.sessionId !== SYSTEM_TIMEOUT_COMPLETION_GRANT.sessionId ||
+          structural.envelope.grant.versionId !== SYSTEM_TIMEOUT_COMPLETION_GRANT.versionId))
     )
       return authorityFailure();
     const grant = transaction.findGrantById(currentAuthorization.grantId);
@@ -981,6 +1001,7 @@ export function createFoundationAcceptance(
         existing.action,
         batch.input.lifecycleTransition,
         batch.input.reconcileDerivedLifecycle === true,
+        batch.input.systemOperation,
       );
     if (existing !== null)
       return writeOutcome(
@@ -1070,6 +1091,7 @@ export function createFoundationAcceptance(
       replayState,
       batch.input.lifecycleTransition,
       batch.input.reconcileDerivedLifecycle === true,
+      batch.input.systemOperation,
     );
   }
 
@@ -1084,6 +1106,7 @@ export function createFoundationAcceptance(
     reservation: StoredReplayReservation | undefined,
     lifecycleTransition: EventGameRecordRoot["lifecycle"] | undefined,
     reconcileDerivedLifecycle: boolean,
+    systemOperation?: ControlActionBatchInput["systemOperation"],
   ): OneOutcome {
     const acceptanceId = `accept-${sha256(`${root.recordId}:${action.operationId}:${action.grant.sessionId}`)}`;
     const grantAudit = linkedGrantAudit(
@@ -1098,6 +1121,7 @@ export function createFoundationAcceptance(
       action.acceptedAtMs,
       null,
       ACCEPTED_AUDIT_DETAIL,
+      systemOperation,
     );
     controlAudit.links = {
       ...controlAudit.links!,
@@ -1252,6 +1276,7 @@ export function createFoundationAcceptance(
     existing: ControlAction,
     lifecycleTransition: EventGameRecordRoot["lifecycle"] | undefined,
     reconcileDerivedLifecycle: boolean,
+    systemOperation?: ControlActionBatchInput["systemOperation"],
   ): OneOutcome {
     const nowMs = readNow(clock);
     const controlAudit = createControlAudit(
@@ -1278,6 +1303,7 @@ export function createFoundationAcceptance(
       nowMs,
       null,
       "The Control Action was already committed.",
+      systemOperation,
     );
     controlAudit.links = {
       ...controlAudit.links!,
@@ -1658,6 +1684,9 @@ export function createFoundationAcceptance(
         lifecycleTransition: isRecord(raw.lifecycleTransition)
           ? (structuredClone(raw.lifecycleTransition) as EventGameRecordRoot["lifecycle"])
           : undefined,
+        ...(raw.systemOperation === "timeout-completion"
+          ? { systemOperation: raw.systemOperation }
+          : {}),
       },
       actions,
       order,
@@ -2082,6 +2111,7 @@ function linkedGrantAudit(
   createdAtMs: number,
   reason: FoundationRejectionReason | null,
   detail: string | null = null,
+  systemOperation?: ControlActionBatchInput["systemOperation"],
 ) {
   const action =
     outcome === "accepted"
@@ -2099,13 +2129,15 @@ function linkedGrantAudit(
       auditInput(
         action,
         grant,
-        {
-          kind: "session",
-          sessionId: session.sessionId,
-          pseudonymKeyVersion: session.browserContextKeyVersion,
-        },
+        systemOperation === "timeout-completion"
+          ? { kind: "system", value: "timeout-completion" as const }
+          : {
+              kind: "session",
+              sessionId: session.sessionId,
+              pseudonymKeyVersion: session.browserContextKeyVersion,
+            },
         grant.status,
-        session.sessionId,
+        systemOperation === "timeout-completion" ? null : session.sessionId,
         null,
         session.eventGameId,
         grant.status,
@@ -2124,6 +2156,9 @@ function linkedGrantAudit(
       status: outcome,
       reason,
       detail: detail ?? "",
+      ...(systemOperation === "timeout-completion"
+        ? { provenance: "system-timeout-completion" }
+        : {}),
     }),
     createdAtMs,
   };

--- a/src/lib/grant-lifecycle.ts
+++ b/src/lib/grant-lifecycle.ts
@@ -32,7 +32,10 @@ export function createAuditEntry(
     actor:
       | { kind: "authority"; value: GrantAuthorityActor }
       | { kind: "session"; sessionId: string; pseudonymKeyVersion: string }
-      | { kind: "system"; value: "grant-expiry" | "grant-session-termination" }
+      | {
+          kind: "system";
+          value: "grant-expiry" | "grant-session-termination" | "timeout-completion";
+        }
       | { kind: "external"; value: string };
     grant: StoredGrant;
     sessionId: string | null;
@@ -193,7 +196,10 @@ function deriveAuditActorReference(
   actor:
     | { kind: "authority"; value: GrantAuthorityActor }
     | { kind: "session"; sessionId: string; pseudonymKeyVersion: string }
-    | { kind: "system"; value: "grant-expiry" | "grant-session-termination" }
+    | {
+        kind: "system";
+        value: "grant-expiry" | "grant-session-termination" | "timeout-completion";
+      }
     | { kind: "external"; value: string },
 ): string {
   const source =

--- a/src/lib/grant-management-audit.ts
+++ b/src/lib/grant-management-audit.ts
@@ -16,6 +16,7 @@ export function auditInput(
     | TrustedGrantAuthority
     | GrantAuthorityActor
     | { kind: "session"; sessionId: string; pseudonymKeyVersion: string }
+    | { kind: "system"; value: "timeout-completion" }
     | { kind: "external"; value: string },
   afterStatus: StoredGrant["status"],
   sessionId: string | null = null,
@@ -31,6 +32,7 @@ export function auditInput(
   let actor:
     | { kind: "authority"; value: GrantAuthorityActor }
     | { kind: "session"; sessionId: string; pseudonymKeyVersion: string }
+    | { kind: "system"; value: "timeout-completion" }
     | { kind: "external"; value: string };
   if (authority.kind === "grant-session") {
     if (authority.sessionId === undefined || authority.pseudonymKeyVersion === undefined)
@@ -43,6 +45,8 @@ export function auditInput(
   } else if (authority.kind === "session") {
     actor = authority;
   } else if (authority.kind === "external") {
+    actor = authority;
+  } else if (authority.kind === "system") {
     actor = authority;
   } else {
     actor = { kind: "authority", value: authorityToActor(authority) as GrantAuthorityActor };

--- a/src/lib/live-event-game-control.test.ts
+++ b/src/lib/live-event-game-control.test.ts
@@ -12,7 +12,9 @@ import {
   createLiveEventGameControl,
   createLiveEventGameIqaInterpreter,
   LIVE_EVENT_CONTROL_INTENT_VERSION,
+  LIVE_SUSPENSION_SNAPSHOT_VERSION,
   parseLiveEventControllerIntent,
+  suspensionPenaltyStateFromProjection,
   type LiveEventControllerIntent,
   validateLiveEventGameActionInTransaction,
 } from "@/lib/live-event-game-control";
@@ -2980,7 +2982,7 @@ describe("Live Event Game control", () => {
   });
 
   test("rebuilds penalty, timeout, stoppage, heat, and result state through Corrections", async () => {
-    const harness = await createHarness();
+    const harness = await createHarness({ knownDodgeballIds: ["ball-1"] });
     const opened = await harness.control.openController({
       qrCredential: harness.qrCredential,
       browserContext: "dependent-state-corrections",
@@ -2995,11 +2997,36 @@ describe("Live Event Game control", () => {
       });
     await submit(clockIntent("dependent-clock-start", true));
     harness.setNow(11_000);
-    await submit(substantiveIntent("card-state", "card"));
+    await submit(
+      cardIntent({ operationId: "card-state", factId: "fact-card-state", gameTimeMs: 0 }),
+    );
     harness.setNow(12_000);
-    await submit(clockIntent("dependent-clock-pause", false));
-    await submit(substantiveIntent("timeout-state", "timeout"));
-    await submit(substantiveIntent("suspension-state", "suspension"));
+    const pausedState = await submit(clockIntent("dependent-clock-pause", false));
+    if (pausedState.status !== "accepted" || pausedState.projection === null) {
+      throw new Error("Expected the paused projection.");
+    }
+    await submit({
+      ...substantiveIntent("timeout-stoppage-state", "timeout"),
+      timeoutAction: "stoppage",
+      timeoutGameSideId: "side-a",
+    });
+    await submit({
+      ...substantiveIntent("timeout-state", "timeout"),
+      timeoutAction: "start",
+      timeoutGameSideId: "side-a",
+    });
+    await submit({
+      ...substantiveIntent("suspension-state", "suspension"),
+      suspensionAction: "start",
+      suspensionSnapshot: {
+        version: LIVE_SUSPENSION_SNAPSHOT_VERSION,
+        gameTimeMs: pausedState.projection.clock.gameTimeMs,
+        scoreByGameSide: pausedState.projection.scoreByGameSide,
+        penalties: suspensionPenaltyStateFromProjection(pausedState.projection.penalties!),
+        volleyballPossession: "side-a",
+        dodgeballPossession: { "ball-1": "side-a" },
+      },
+    });
     await submit({
       ...substantiveIntent("heat-state", "heat-stoppage"),
       heatAction: "start",
@@ -3022,7 +3049,7 @@ describe("Live Event Game control", () => {
     if (finished.status !== "authorized" || finished.projection === null) {
       throw new Error("Expected the finished Controller projection.");
     }
-    expect(finished.projection.clock.activePenaltyTimeMs).toBe(1_000);
+    expect(finished.projection.clock.activePenaltyTimeMs).toBe(0);
 
     await submit(
       correctionIntent("correct-card-state", "correction-card-state", false, "fact-card-state"),
@@ -3033,6 +3060,14 @@ describe("Live Event Game control", () => {
         "correction-timeout-state",
         false,
         "fact-timeout-state",
+      ),
+    );
+    await submit(
+      correctionIntent(
+        "correct-timeout-stoppage-state",
+        "correction-timeout-stoppage-state",
+        false,
+        "fact-timeout-stoppage-state",
       ),
     );
     await submit(
@@ -3133,7 +3168,7 @@ describe("Live Event Game control", () => {
           gameTimeMs: 15_000,
           reason: "head-referee-direction",
           beforeValue: { running: true },
-          afterValue: { timeout: "started" },
+          afterValue: { timeout: "stoppage" },
         },
       },
     });
@@ -3145,7 +3180,7 @@ describe("Live Event Game control", () => {
       authorityReference: "head-referee",
       reason: "head-referee-direction",
       beforeValue: { running: true },
-      afterValue: { timeout: "started" },
+      afterValue: { timeout: "stoppage" },
     });
     expect(acceptedAction?.grant.sessionId).toBe(opened.session.grantSessionId);
 
@@ -3162,7 +3197,7 @@ describe("Live Event Game control", () => {
           gameTimeMs: 0,
           reason: "head-referee-direction",
           beforeValue: { running: false },
-          afterValue: { timeout: "started" },
+          afterValue: { timeout: "stoppage" },
         },
       },
     });
@@ -3480,7 +3515,9 @@ describe("Live Event Game control", () => {
   test.each(["card", "timeout", "suspension", "result"] as const)(
     "commences irreversibly on the first %s trigger",
     async (trigger) => {
-      const harness = await createHarness();
+      const harness = await createHarness(
+        trigger === "suspension" ? { knownDodgeballIds: ["ball-1"] } : {},
+      );
       const opened = await harness.control.openController({
         qrCredential: harness.qrCredential,
         browserContext: `trigger-${trigger}`,
@@ -3491,6 +3528,8 @@ describe("Live Event Game control", () => {
         eventGameId: harness.root.eventGameId,
         intent: substantiveIntent(`trigger-${trigger}`, trigger),
       });
+      if (result.status !== "accepted")
+        throw new Error(`trigger rejected: ${JSON.stringify(result)}`);
       expect(result.status).toBe("accepted");
       expect((await harness.record.readRoot(harness.root.recordId))?.lifecycle.commencedAtMs).toBe(
         10_000,
@@ -5392,6 +5431,7 @@ async function createHarness(
     projectionFailure?: () => boolean;
     scopeStatus?: "empty" | "conflict";
     controlClock?: () => number;
+    knownDodgeballIds?: readonly string[];
     sessionResolution?: ControlGrantSessionResolution;
     acceptanceLimits?: AcceptanceLimits;
   } = {},
@@ -5461,6 +5501,7 @@ async function createHarness(
         transaction.listActions(root.recordId),
         root,
         action,
+        overrides.knownDodgeballIds ?? null,
       ),
     limits: overrides.acceptanceLimits,
   });
@@ -5475,6 +5516,8 @@ async function createHarness(
     grantAuthority: authority,
     clock: overrides.controlClock ?? (() => grantOptions.clock.nowMs()),
     listEventGameRoots: async () => [root, reassignedRoot],
+    knownDodgeballIdsForEventGame:
+      overrides.knownDodgeballIds === undefined ? undefined : () => overrides.knownDodgeballIds!,
     projectionFailure: overrides.projectionFailure,
   });
   triggerLifecycleChange = () => {
@@ -5745,6 +5788,22 @@ function substantiveIntent(
     operationId,
     factId: `fact-${operationId}`,
     gameTimeMs,
+    ...(trigger === "timeout"
+      ? { timeoutAction: "stoppage" as const, timeoutGameSideId: "side-a" }
+      : {}),
+    ...(trigger === "suspension"
+      ? {
+          suspensionAction: "start" as const,
+          suspensionSnapshot: {
+            version: LIVE_SUSPENSION_SNAPSHOT_VERSION,
+            gameTimeMs,
+            scoreByGameSide: { "side-a": 0, "side-b": 0 },
+            penalties: { segments: [] },
+            volleyballPossession: "side-a",
+            dodgeballPossession: { "ball-1": "side-a" },
+          },
+        }
+      : {}),
     occurrence: { clientOriginAtMs: null },
   };
 }

--- a/src/lib/live-event-game-control.ts
+++ b/src/lib/live-event-game-control.ts
@@ -11,6 +11,7 @@ import {
   materializeControlAction,
   prepareControlAction,
   rebuildControlActionHistory,
+  SYSTEM_TIMEOUT_COMPLETION_GRANT,
 } from "@/lib/event-game-actions";
 import { parseJsonValue, validateOverride } from "@/lib/event-game-action-codecs";
 import { DEFAULT_IQA_SPORTING_RULES } from "@/lib/iqa-game-rules";
@@ -52,6 +53,8 @@ export const LIVE_EVENT_CONTROL_INTENT_VERSION = "live-event-control-intent-v1" 
 export const LIVE_EVENT_IQA_INTERPRETER_VERSION = "live-event-iqa-v1" as const;
 export const CLOSE_PLAY_ADJUDICATION_WINDOW_MS = 1_000;
 export const EVENT_GAME_LOCK_DELAY_MS = 15 * 60 * 1000;
+export const LIVE_SUSPENSION_SNAPSHOT_VERSION = "live-suspension-snapshot-v1" as const;
+const PENALTY_DURATION_MS = 60_000;
 
 export type SportingOrderAdjudication = {
   relatedFactId: string;
@@ -142,7 +145,14 @@ export type LiveEventControllerIntent =
         | "forfeit"
         | "double-forfeit";
       gameSideId?: string;
+      penaltyCardType?: "blue" | "yellow" | "red" | "ejection";
+      penaltyPlayerKey?: string;
       heatAction?: "start" | "end" | "skip-required" | "extend-permitted";
+      timeoutAction?: "stoppage" | "start" | "complete";
+      timeoutGameSideId?: string;
+      suspensionAction?: "start" | "resume";
+      suspensionSnapshot?: LiveSuspensionSnapshot;
+      resumesSuspensionFactId?: string;
     })
   | (ControllerIntentBase & {
       type: "reset" | "undo";
@@ -197,6 +207,7 @@ export type LiveEventGameDerivedState = {
   goalCount: number;
   clock: ClockProjection;
   timeout: LiveTimeoutState;
+  suspension: LiveSuspensionState;
   stoppage: LiveStoppageState;
   heat: LiveHeatState;
   result: LiveResultState;
@@ -224,8 +235,46 @@ export function projectLiveEventGameDerivedState(
 }
 
 export type LiveTimeoutState = {
-  status: "inactive" | "started";
+  status: "inactive" | "stoppage" | "started" | "completed";
   factId: string | null;
+  gameSideId?: string | null;
+  usedGameSideIds?: readonly string[];
+  startedAtMs?: number | null;
+  remainingMs?: number | null;
+  longWhistleCue?: "not-applicable" | "pending" | "due" | "passed";
+};
+
+export type LiveSuspensionSnapshot = {
+  version: typeof LIVE_SUSPENSION_SNAPSHOT_VERSION;
+  gameTimeMs: number;
+  scoreByGameSide: Readonly<Record<string, number>>;
+  penalties: LiveSuspensionPenaltyState;
+  volleyballPossession: string;
+  dodgeballPossession: Readonly<Record<string, string | null>>;
+};
+
+export type LiveSuspensionPenaltyState = {
+  segments: readonly {
+    sourceFactId: string;
+    elapsedMs: number;
+    remainingMs: number;
+    expirableByScore: boolean;
+    cardFactId?: string;
+    cardType?: Exclude<LiveCardType, "ejection">;
+    gameSideId?: string;
+    playerKey?: string;
+    playerNumber?: number | null;
+    eligibleForScoreAtGameTimeMs?: number;
+    notBeforeGameTimeMs?: number;
+    startsAtGameTimeMs?: number;
+    endsAtGameTimeMs?: number;
+  }[];
+};
+
+export type LiveSuspensionState = {
+  status: "none" | "suspended";
+  factId: string | null;
+  snapshot: LiveSuspensionSnapshot | null;
 };
 
 export type LiveStoppageState = {
@@ -276,7 +325,9 @@ export type ControllerProjection = {
   phase: EventGameLifecyclePhase;
   scoreByGameSide: Readonly<Record<string, number>>;
   goalCount: number;
+  knownDodgeballIds?: readonly string[];
   timeout?: LiveTimeoutState;
+  suspension?: LiveSuspensionState;
   stoppage?: LiveStoppageState;
   heat?: LiveHeatState;
   result?: LiveResultState;
@@ -292,6 +343,16 @@ export type ControllerProjection = {
   commencement: ControllerCommencement;
   clock: ClockProjection;
 };
+
+type LiveMaterializationAuthority = {
+  sessionBearer: string;
+  grantSessionId: string;
+  grantVersion: string;
+};
+
+type TimeoutMaterializationResult =
+  | { status: "ready"; root: EventGameRecordRoot }
+  | { status: "failed"; root: EventGameRecordRoot };
 
 export type ControllerSynchronization = {
   status: "synchronized";
@@ -384,6 +445,8 @@ export type LiveEventGameControlOptions = {
     | { status: "rejected"; reason: string }
   >;
   clock?: () => number;
+  /** Event-Game-scoped authoritative dodgeball identities; required for a first suspension. */
+  knownDodgeballIdsForEventGame?: (eventGameId: string) => readonly string[] | undefined;
   /** Test-only seam for proving the post-commit projection response. */
   projectionFailure?: () => boolean;
 };
@@ -665,7 +728,14 @@ export function parseLiveEventControllerIntent(
     | "forfeit"
     | "double-forfeit"
     | undefined;
+  let penaltyCardType: "blue" | "yellow" | "red" | "ejection" | undefined;
+  let penaltyPlayerKey: string | undefined;
   let heatAction: "start" | "end" | "skip-required" | "extend-permitted" | undefined;
+  let timeoutAction: "stoppage" | "start" | "complete" | undefined;
+  let timeoutGameSideId: string | undefined;
+  let suspensionAction: "start" | "resume" | undefined;
+  let suspensionSnapshot: LiveSuspensionSnapshot | undefined;
+  let resumesSuspensionFactId: string | undefined;
   if (value.type === "substantive") {
     if (
       value.trigger !== "card" &&
@@ -680,6 +750,23 @@ export function parseLiveEventControllerIntent(
     )
       return invalid("substantive trigger is unsupported.");
     trigger = value.trigger;
+    if (trigger === "card") {
+      if (
+        value.penaltyCardType !== undefined &&
+        value.penaltyCardType !== "blue" &&
+        value.penaltyCardType !== "yellow" &&
+        value.penaltyCardType !== "red" &&
+        value.penaltyCardType !== "ejection"
+      ) {
+        return invalid("penaltyCardType is unsupported.");
+      }
+      penaltyCardType = value.penaltyCardType;
+      if (value.penaltyPlayerKey !== undefined) {
+        const playerKey = validateOpaqueIdentifier(value.penaltyPlayerKey, "penaltyPlayerKey");
+        if (!playerKey.ok) return invalid(playerKey.error);
+        penaltyPlayerKey = playerKey.value;
+      }
+    }
     if (trigger === "heat-stoppage") {
       if (
         value.heatAction !== undefined &&
@@ -691,6 +778,44 @@ export function parseLiveEventControllerIntent(
         return invalid("heatAction is unsupported.");
       }
       heatAction = value.heatAction;
+    }
+    if (trigger === "timeout") {
+      if (
+        value.timeoutAction !== "stoppage" &&
+        value.timeoutAction !== "start" &&
+        value.timeoutAction !== "complete"
+      ) {
+        return invalid("timeoutAction is unsupported.");
+      }
+      timeoutAction = value.timeoutAction;
+      const parsedSide = validateOpaqueIdentifier(value.timeoutGameSideId, "timeoutGameSideId");
+      if (!parsedSide.ok) return invalid(parsedSide.error);
+      timeoutGameSideId = parsedSide.value;
+    }
+    if (trigger === "suspension") {
+      if (value.suspensionAction !== "start" && value.suspensionAction !== "resume") {
+        return invalid("suspensionAction is unsupported.");
+      }
+      suspensionAction = value.suspensionAction;
+      if (suspensionAction === "start" && value.suspensionSnapshot === undefined) {
+        return invalid("suspensionSnapshot is required when suspending.");
+      }
+      if (value.suspensionSnapshot !== undefined) {
+        const parsedSnapshot = parseLiveSuspensionSnapshot(value.suspensionSnapshot);
+        if (!parsedSnapshot.ok) return invalid(parsedSnapshot.error);
+        suspensionSnapshot = parsedSnapshot.value;
+      }
+      if (value.resumesSuspensionFactId !== undefined) {
+        const parsedFact = validateOpaqueIdentifier(
+          value.resumesSuspensionFactId,
+          "resumesSuspensionFactId",
+        );
+        if (!parsedFact.ok) return invalid(parsedFact.error);
+        resumesSuspensionFactId = parsedFact.value;
+      }
+      if (suspensionAction === "resume" && resumesSuspensionFactId === undefined) {
+        return invalid("resumesSuspensionFactId is required when resuming.");
+      }
     }
   }
 
@@ -748,7 +873,9 @@ export function parseLiveEventControllerIntent(
       ...(effective === undefined ? {} : { effective }),
       ...(gameSideId === undefined ? {} : { gameSideId }),
       ...(playerNumber === undefined ? {} : { playerNumber }),
-      ...(cardType === undefined ? {} : { cardType }),
+      ...(cardType === undefined
+        ? {}
+        : { cardType: cardType as Exclude<LiveCardType, "ejection"> }),
       ...(foulBeforeScore === undefined ? {} : { foulBeforeScore }),
       ...(seekerPenalty === undefined ? {} : { seekerPenalty }),
       ...(targetCardFactId === undefined ? {} : { targetCardFactId }),
@@ -763,7 +890,14 @@ export function parseLiveEventControllerIntent(
       ...(confirmation === undefined ? {} : { confirmation }),
       ...(clockGeneration === undefined ? {} : { clockGeneration }),
       ...(trigger === undefined ? {} : { trigger }),
+      ...(penaltyCardType === undefined ? {} : { penaltyCardType }),
+      ...(penaltyPlayerKey === undefined ? {} : { penaltyPlayerKey }),
       ...(heatAction === undefined ? {} : { heatAction }),
+      ...(timeoutAction === undefined ? {} : { timeoutAction }),
+      ...(timeoutGameSideId === undefined ? {} : { timeoutGameSideId }),
+      ...(suspensionAction === undefined ? {} : { suspensionAction }),
+      ...(suspensionSnapshot === undefined ? {} : { suspensionSnapshot }),
+      ...(resumesSuspensionFactId === undefined ? {} : { resumesSuspensionFactId }),
       ...(overrideResult.value === undefined ? {} : { override: overrideResult.value }),
     } as LiveEventControllerIntent,
   };
@@ -830,15 +964,236 @@ export function explainLiveEventGuardrail(intent: {
   };
 }
 
+function parseLiveSuspensionSnapshot(
+  value: unknown,
+): { ok: true; value: LiveSuspensionSnapshot } | { ok: false; error: string } {
+  if (!isRecord(value)) return invalid("suspensionSnapshot must be an object.");
+  const allowedKeys = new Set([
+    "version",
+    "gameTimeMs",
+    "scoreByGameSide",
+    "penalties",
+    "volleyballPossession",
+    "dodgeballPossession",
+  ]);
+  if (Object.keys(value).some((key) => !allowedKeys.has(key))) {
+    return invalid("suspensionSnapshot contains unsupported fields.");
+  }
+  if (value.version !== LIVE_SUSPENSION_SNAPSHOT_VERSION) {
+    return invalid("suspensionSnapshot version is unsupported.");
+  }
+  const gameTimeMs = validateGameClock(value.gameTimeMs);
+  if (!gameTimeMs.ok) return invalid(gameTimeMs.error);
+  if (!isRecord(value.scoreByGameSide)) {
+    return invalid("suspensionSnapshot.scoreByGameSide must be an object.");
+  }
+  const scoreByGameSide: Record<string, number> = {};
+  for (const [gameSideId, score] of Object.entries(value.scoreByGameSide)) {
+    if (!validateOpaqueIdentifier(gameSideId, "suspensionSnapshot.gameSideId").ok) {
+      return invalid("suspensionSnapshot.gameSideId is invalid.");
+    }
+    const parsedScore = validateIntegerInRange(
+      score,
+      0,
+      SHARED_LIMITS.score.max,
+      "suspensionSnapshot.score",
+    );
+    if (!parsedScore.ok) return invalid(parsedScore.error);
+    scoreByGameSide[gameSideId] = parsedScore.value;
+  }
+  const penalties = parseLiveSuspensionPenaltyState(value.penalties);
+  if (!penalties.ok) return penalties;
+  const volleyballPossession = parsePossessionValue(
+    value.volleyballPossession,
+    "suspensionSnapshot.volleyballPossession",
+  );
+  if (!volleyballPossession.ok || volleyballPossession.value === null) {
+    return invalid("suspensionSnapshot.volleyballPossession must be confirmed.");
+  }
+  const rawDodgeballPossession = value.dodgeballPossession;
+  if (!isRecord(rawDodgeballPossession)) {
+    return invalid("suspensionSnapshot.dodgeballPossession must be an object.");
+  }
+  if (Object.keys(rawDodgeballPossession).length === 0) {
+    return invalid("suspensionSnapshot.dodgeballPossession must list every dodgeball.");
+  }
+  const dodgeballPossession: Record<string, string | null> = {};
+  for (const [ballId, possession] of Object.entries(rawDodgeballPossession)) {
+    if (!validateOpaqueIdentifier(ballId, "suspensionSnapshot.dodgeballId").ok) {
+      return invalid("suspensionSnapshot.dodgeballId is invalid.");
+    }
+    const parsedPossession = parsePossessionValue(
+      possession,
+      "suspensionSnapshot.dodgeballPossession",
+    );
+    if (!parsedPossession.ok) return parsedPossession;
+    dodgeballPossession[ballId] = parsedPossession.value;
+  }
+  return {
+    ok: true,
+    value: {
+      version: LIVE_SUSPENSION_SNAPSHOT_VERSION,
+      gameTimeMs: gameTimeMs.value,
+      scoreByGameSide,
+      penalties: penalties.value,
+      volleyballPossession: volleyballPossession.value,
+      dodgeballPossession,
+    },
+  };
+}
+
+function parseLiveSuspensionPenaltyState(
+  value: unknown,
+): { ok: true; value: LiveSuspensionPenaltyState } | { ok: false; error: string } {
+  if (!isRecord(value)) return invalid("suspensionSnapshot.penalties must be an object.");
+  if (Object.keys(value).some((key) => key !== "segments") || !Array.isArray(value.segments)) {
+    return invalid("suspensionSnapshot.penalties.segments must be an array.");
+  }
+  const segments: LiveSuspensionPenaltyState["segments"][number][] = [];
+  const sourceFactIds = new Set<string>();
+  for (const segment of value.segments) {
+    if (
+      !isRecord(segment) ||
+      Object.keys(segment).some(
+        (key) =>
+          ![
+            "sourceFactId",
+            "elapsedMs",
+            "remainingMs",
+            "expirableByScore",
+            "cardFactId",
+            "cardType",
+            "gameSideId",
+            "playerKey",
+            "playerNumber",
+            "eligibleForScoreAtGameTimeMs",
+            "notBeforeGameTimeMs",
+            "startsAtGameTimeMs",
+            "endsAtGameTimeMs",
+          ].includes(key),
+      )
+    ) {
+      return invalid("suspensionSnapshot.penalties segment is invalid.");
+    }
+    const sourceFactId = validateOpaqueIdentifier(
+      segment.sourceFactId,
+      "suspensionSnapshot.penalties.sourceFactId",
+    );
+    const elapsedMs = validateIntegerInRange(
+      segment.elapsedMs,
+      0,
+      PENALTY_DURATION_MS,
+      "suspensionSnapshot.penalties.elapsedMs",
+    );
+    const remainingMs = validateIntegerInRange(
+      segment.remainingMs,
+      1,
+      PENALTY_DURATION_MS,
+      "suspensionSnapshot.penalties.remainingMs",
+    );
+    if (!sourceFactId.ok) return sourceFactId;
+    if (!elapsedMs.ok) return elapsedMs;
+    if (!remainingMs.ok) return remainingMs;
+    if (typeof segment.expirableByScore !== "boolean") {
+      return invalid("suspensionSnapshot.penalties.expirableByScore is required.");
+    }
+    if (sourceFactIds.has(sourceFactId.value)) {
+      return invalid("suspensionSnapshot.penalties must list each penalty once.");
+    }
+    if (elapsedMs.value + remainingMs.value !== PENALTY_DURATION_MS) {
+      return invalid("suspensionSnapshot.penalties elapsed and remaining time must agree.");
+    }
+    const optionalIdentifier = (field: string): string | undefined => {
+      if (segment[field] === undefined) return undefined;
+      const parsed = validateOpaqueIdentifier(segment[field], field);
+      if (!parsed.ok) throw new Error(parsed.error);
+      return parsed.value;
+    };
+    const cardType = segment.cardType;
+    if (
+      cardType !== undefined &&
+      cardType !== "blue" &&
+      cardType !== "yellow" &&
+      cardType !== "red"
+    ) {
+      return invalid("suspensionSnapshot.penalties.cardType is invalid.");
+    }
+    const playerNumber = segment.playerNumber;
+    if (
+      playerNumber !== undefined &&
+      playerNumber !== null &&
+      !validateIntegerInRange(playerNumber, 0, 99, "suspensionSnapshot.penalties.playerNumber").ok
+    ) {
+      return invalid("suspensionSnapshot.penalties.playerNumber is invalid.");
+    }
+    const optionalTime = (field: string): number | undefined => {
+      if (segment[field] === undefined) return undefined;
+      const parsed = validateIntegerInRange(
+        segment[field],
+        0,
+        SHARED_LIMITS.clock.maxMs,
+        `suspensionSnapshot.penalties.${field}`,
+      );
+      if (!parsed.ok) throw new Error(parsed.error);
+      return parsed.value;
+    };
+    sourceFactIds.add(sourceFactId.value);
+    segments.push({
+      sourceFactId: sourceFactId.value,
+      elapsedMs: elapsedMs.value,
+      remainingMs: remainingMs.value,
+      expirableByScore: segment.expirableByScore,
+      ...(optionalIdentifier("cardFactId") === undefined
+        ? {}
+        : { cardFactId: optionalIdentifier("cardFactId") }),
+      ...(cardType === undefined
+        ? {}
+        : { cardType: cardType as Exclude<LiveCardType, "ejection"> }),
+      ...(optionalIdentifier("gameSideId") === undefined
+        ? {}
+        : { gameSideId: optionalIdentifier("gameSideId") }),
+      ...(optionalIdentifier("playerKey") === undefined
+        ? {}
+        : { playerKey: optionalIdentifier("playerKey") }),
+      ...(playerNumber === undefined ? {} : { playerNumber }),
+      ...(optionalTime("eligibleForScoreAtGameTimeMs") === undefined
+        ? {}
+        : { eligibleForScoreAtGameTimeMs: optionalTime("eligibleForScoreAtGameTimeMs") }),
+      ...(optionalTime("notBeforeGameTimeMs") === undefined
+        ? {}
+        : { notBeforeGameTimeMs: optionalTime("notBeforeGameTimeMs") }),
+      ...(optionalTime("startsAtGameTimeMs") === undefined
+        ? {}
+        : { startsAtGameTimeMs: optionalTime("startsAtGameTimeMs") }),
+      ...(optionalTime("endsAtGameTimeMs") === undefined
+        ? {}
+        : { endsAtGameTimeMs: optionalTime("endsAtGameTimeMs") }),
+    } as LiveSuspensionPenaltyState["segments"][number]);
+  }
+  return { ok: true, value: { segments } };
+}
+
+function parsePossessionValue(
+  value: unknown,
+  label: string,
+): { ok: true; value: string | null } | { ok: false; error: string } {
+  if (value === undefined || value === null) return { ok: true, value: null };
+  const parsed = validateOpaqueIdentifier(value, label);
+  return parsed.ok ? parsed : invalid(parsed.error);
+}
+
 export function createLiveEventGameControl(options: LiveEventGameControlOptions) {
   const clock = options.clock ?? (() => Date.now());
+  const configuredDodgeballIdsFor = (eventGameId: string) =>
+    normalizeConfiguredDodgeballIds(options.knownDodgeballIdsForEventGame?.(eventGameId));
   const gameFactCodec = createDefaultControlActionCodecs().find(
     (codec) => codec.kind === "game-fact" && codec.version === "1",
   );
   if (gameFactCodec === undefined) {
     throw new Error("The game-fact runtime codec is unavailable.");
   }
-  const goalCodec = gameFactCodec;
+  const gameFactCodecKind = gameFactCodec.kind;
+  const gameFactCodecVersion = gameFactCodec.version;
   const replayingSessions = new Set<string>();
   const activeControllerSessions = new Map<
     string,
@@ -1027,15 +1382,22 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
       return rejectedOpen();
     }
 
-    const projection = await readProjection(owner.record, commenced.root);
+    const materialized = await materializeExpiredTimeout(owner, commenced.root, {
+      sessionBearer: admitted.sessionBearer,
+      grantSessionId: authorized.grantSessionId,
+      grantVersion: authorized.grantVersion,
+    });
+    if (materialized.status === "failed") return rejectedOpen();
+    const materializedRoot = materialized.root;
+    const projection = await readProjection(owner.record, materializedRoot);
     trackActiveControllerSession(
       admitted.sessionBearer,
-      commenced.root.eventGameId,
+      materializedRoot.eventGameId,
       authorized.sessionExpiresAtMs,
     );
     return {
       status: "opened",
-      eventGameId: commenced.root.eventGameId,
+      eventGameId: materializedRoot.eventGameId,
       session: {
         sessionBearer: admitted.sessionBearer,
         grantSessionId: authorized.grantSessionId,
@@ -1051,6 +1413,7 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
   async function refreshController(input: {
     sessionBearer: string;
     eventGameId: string;
+    deferTimeoutMaterialization?: boolean;
   }): Promise<ControllerRefreshResult> {
     await lockEventGameIfDue(input.eventGameId);
     const authorized = await options.grantAuthority.authorizeGrant({
@@ -1081,16 +1444,27 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
             const owner = await options.resolveEventGameRecord(pinned.eventGameId);
             const root = owner === null ? null : await owner.record.readRoot(owner.recordId);
             if (owner !== null && root !== null) {
-              const projection = await readProjection(owner.record, root);
+              const materialized = input.deferTimeoutMaterialization
+                ? { status: "ready" as const, root }
+                : await materializeExpiredTimeout(owner, root, {
+                    sessionBearer: input.sessionBearer,
+                    grantSessionId: pinned.grantSessionId,
+                    grantVersion: pinned.grantVersion,
+                  });
+              if (materialized.status === "failed") {
+                return { status: "rejected", message: "Unable to refresh Controller session." };
+              }
+              const materializedRoot = materialized.root;
+              const projection = await readProjection(owner.record, materializedRoot);
               trackActiveControllerSession(
                 input.sessionBearer,
-                root.eventGameId,
+                materializedRoot.eventGameId,
                 pinned.sessionExpiresAtMs,
               );
               return {
                 status: "authorized",
                 session: {
-                  eventGameId: root.eventGameId,
+                  eventGameId: materializedRoot.eventGameId,
                   grantSessionId: pinned.grantSessionId,
                   grantVersion: pinned.grantVersion,
                 },
@@ -1127,16 +1501,27 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
     if (commenced.status === "rejected") {
       return { status: "rejected", message: "Unable to refresh Controller session." };
     }
-    const projection = await readProjection(owner.record, commenced.root);
+    const materialized = input.deferTimeoutMaterialization
+      ? { status: "ready" as const, root: commenced.root }
+      : await materializeExpiredTimeout(owner, commenced.root, {
+          sessionBearer: input.sessionBearer,
+          grantSessionId: authorized.grantSessionId,
+          grantVersion: authorized.grantVersion,
+        });
+    if (materialized.status === "failed") {
+      return { status: "rejected", message: "Unable to refresh Controller session." };
+    }
+    const materializedRoot = materialized.root;
+    const projection = await readProjection(owner.record, materializedRoot);
     trackActiveControllerSession(
       input.sessionBearer,
-      commenced.root.eventGameId,
+      materializedRoot.eventGameId,
       authorized.sessionExpiresAtMs,
     );
     return {
       status: "authorized",
       session: {
-        eventGameId: commenced.root.eventGameId,
+        eventGameId: materializedRoot.eventGameId,
         grantSessionId: authorized.grantSessionId,
         grantVersion: authorized.grantVersion,
       },
@@ -1164,16 +1549,25 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
     if (commenced.status === "rejected") {
       return { status: "rejected", message: "Unable to refresh Controller session." };
     }
-    const projection = await readProjection(owner.record, commenced.root);
+    const materialized = await materializeExpiredTimeout(owner, commenced.root, {
+      sessionBearer: input.sessionBearer,
+      grantSessionId: switched.grantSessionId,
+      grantVersion: switched.grantVersion,
+    });
+    if (materialized.status === "failed") {
+      return { status: "rejected", message: "Unable to refresh Controller session." };
+    }
+    const materializedRoot = materialized.root;
+    const projection = await readProjection(owner.record, materializedRoot);
     trackActiveControllerSession(
       input.sessionBearer,
-      commenced.root.eventGameId,
+      materializedRoot.eventGameId,
       switched.sessionExpiresAtMs,
     );
     return {
       status: "authorized",
       session: {
-        eventGameId: commenced.root.eventGameId,
+        eventGameId: materializedRoot.eventGameId,
         grantSessionId: switched.grantSessionId,
         grantVersion: switched.grantVersion,
       },
@@ -1208,16 +1602,25 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
     if (commenced.status === "rejected") {
       return { status: "rejected", message: "Unable to refresh Controller session." };
     }
-    const projection = await readProjection(owner.record, commenced.root);
+    const materialized = await materializeExpiredTimeout(owner, commenced.root, {
+      sessionBearer: input.sessionBearer,
+      grantSessionId: authorized.grantSessionId,
+      grantVersion: authorized.grantVersion,
+    });
+    if (materialized.status === "failed") {
+      return { status: "rejected", message: "Unable to refresh Controller session." };
+    }
+    const materializedRoot = materialized.root;
+    const projection = await readProjection(owner.record, materializedRoot);
     trackActiveControllerSession(
       input.sessionBearer,
-      commenced.root.eventGameId,
+      materializedRoot.eventGameId,
       authorized.sessionExpiresAtMs,
     );
     return {
       status: "authorized",
       session: {
-        eventGameId: commenced.root.eventGameId,
+        eventGameId: materializedRoot.eventGameId,
         grantSessionId: authorized.grantSessionId,
         grantVersion: authorized.grantVersion,
       },
@@ -1357,6 +1760,7 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
       replayEvidenceId: string;
       reserveOnly?: boolean;
     };
+    deferTimeoutMaterialization?: boolean;
   }): Promise<LiveEventGameControlResult> {
     await lockEventGameIfDue(input.eventGameId);
     const authorized = await options.grantAuthority.authorizeGrant({
@@ -1383,7 +1787,15 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
     }
     const commenced = await ensureClockCommencement(owner, root, clock());
     if (commenced.status === "rejected") return retryableAction(parsed.value.operationId);
-    const activeRoot = commenced.root;
+    const materialized = input.deferTimeoutMaterialization
+      ? { status: "ready" as const, root: commenced.root }
+      : await materializeExpiredTimeout(owner, commenced.root, {
+          sessionBearer: input.sessionBearer,
+          grantSessionId: authorized.grantSessionId,
+          grantVersion: authorized.grantVersion,
+        });
+    if (materialized.status === "failed") return retryableAction(parsed.value.operationId);
+    const activeRoot = materialized.root;
 
     if (
       parsed.value.type === "record-goal" ||
@@ -1458,6 +1870,22 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
     if (clockData.status === "rejected") {
       return rejectedAction(parsed.value.operationId);
     }
+    let suspensionSnapshot: LiveSuspensionSnapshot | undefined;
+    if (
+      parsed.value.type === "substantive" &&
+      parsed.value.trigger === "suspension" &&
+      parsed.value.suspensionAction === "start" &&
+      parsed.value.suspensionSnapshot !== undefined
+    ) {
+      const canonicalSnapshot = canonicalizeLiveSuspensionSnapshot(
+        parsed.value.suspensionSnapshot,
+        effectiveStateBefore,
+        nowMs,
+        configuredDodgeballIdsFor(activeRoot.eventGameId),
+      );
+      if (!canonicalSnapshot.ok) return rejectedAction(parsed.value.operationId);
+      suspensionSnapshot = canonicalSnapshot.value;
+    }
     if (isClockIntent(parsed.value)) {
       if (
         parsed.value.type === "clock-takeover" &&
@@ -1490,13 +1918,35 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
     const gameSideId =
       parsed.value.type === "record-card"
         ? parsed.value.gameSideId
-        : controllerGameSideId(parsed.value);
+        : parsed.value.type === "substantive" && parsed.value.trigger === "timeout"
+          ? (parsed.value.timeoutGameSideId ?? controllerGameSideId(parsed.value))
+          : controllerGameSideId(parsed.value);
     const isCorrection = parsed.value.type === "correct-fact";
     let override: OfficialOverrideMetadata | undefined;
     try {
       override = buildLiveOfficialOverride(parsed.value, authorized.grantSessionId);
     } catch {
       return rejectedAction(parsed.value.operationId);
+    }
+
+    const causalPredecessorIds = new Set(input.causalPredecessorIds ?? []);
+    const requiredPredecessorFactId =
+      parsed.value.type === "substantive" &&
+      parsed.value.trigger === "timeout" &&
+      parsed.value.timeoutAction === "start"
+        ? effectiveStateBefore.timeout.factId
+        : parsed.value.type === "substantive" &&
+            parsed.value.trigger === "suspension" &&
+            parsed.value.suspensionAction === "resume"
+          ? effectiveStateBefore.suspension.factId
+          : null;
+    if (requiredPredecessorFactId !== null) {
+      const predecessor = actionsBefore.find(
+        ({ action: storedAction }) =>
+          storedAction.interpretation.type === "fact" &&
+          storedAction.interpretation.factId === requiredPredecessorFactId,
+      );
+      if (predecessor !== undefined) causalPredecessorIds.add(predecessor.action.operationId);
     }
 
     const action = {
@@ -1506,7 +1956,7 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
       kind:
         parsed.value.type === "correct-fact"
           ? { id: "correction", version: "1" }
-          : { id: goalCodec.kind, version: goalCodec.version },
+          : { id: gameFactCodecKind, version: gameFactCodecVersion },
       payload:
         parsed.value.type === "correct-fact"
           ? {
@@ -1618,10 +2068,34 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
                                     ...(parsed.value.heatAction === undefined
                                       ? {}
                                       : { heatAction: parsed.value.heatAction }),
+                                    ...(parsed.value.penaltyCardType === undefined
+                                      ? {}
+                                      : { penaltyCardType: parsed.value.penaltyCardType }),
+                                    ...(parsed.value.penaltyPlayerKey === undefined
+                                      ? {}
+                                      : { penaltyPlayerKey: parsed.value.penaltyPlayerKey }),
+                                    ...(parsed.value.timeoutAction === undefined
+                                      ? {}
+                                      : { timeoutAction: parsed.value.timeoutAction }),
+                                    ...(parsed.value.timeoutGameSideId === undefined
+                                      ? {}
+                                      : { timeoutGameSideId: parsed.value.timeoutGameSideId }),
+                                    ...(parsed.value.suspensionAction === undefined
+                                      ? {}
+                                      : { suspensionAction: parsed.value.suspensionAction }),
+                                    ...(suspensionSnapshot === undefined
+                                      ? {}
+                                      : { suspensionSnapshot }),
+                                    ...(parsed.value.resumesSuspensionFactId === undefined
+                                      ? {}
+                                      : {
+                                          resumesSuspensionFactId:
+                                            parsed.value.resumesSuspensionFactId,
+                                        }),
                                   }
                                 : null,
             },
-      causalPredecessorIds: [...(input.causalPredecessorIds ?? [])],
+      causalPredecessorIds: [...causalPredecessorIds],
       occurrence: {
         trustedAtMs: nowMs,
         clientOriginAtMs: parsed.value.occurrence.clientOriginAtMs,
@@ -1659,7 +2133,7 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
             action,
             {
               ...automaticConsequenceBase,
-              kind: { id: goalCodec.kind, version: goalCodec.version },
+              kind: { id: gameFactCodecKind, version: gameFactCodecVersion },
               operationId: automaticPenaltyConsequence.operationId,
               causalPredecessorIds: [
                 ...new Set([
@@ -1859,12 +2333,12 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
     try {
       const replayOwner = await options.resolveEventGameRecord(authorized.eventGameId);
       if (replayOwner === null) return replayRetryable(input.actions, replayContext);
+      const replayRoot = await replayOwner.record.readRoot(replayOwner.recordId);
+      if (replayRoot === null) return replayRetryable(input.actions, replayContext);
       const persistedActions = await replayOwner.record.readActions();
       const persistedOperationIds = new Set(
         persistedActions.map((stored) => stored.action.operationId),
       );
-      const replayRoot = await replayOwner.record.readRoot(replayOwner.recordId);
-      if (replayRoot === null) return replayRetryable(input.actions, replayContext);
       let replayState = rebuildLiveDerivedState(replayRoot, persistedActions);
       if (replayState === null) return replayRetryable(input.actions, replayContext);
       let finishedUnlocked =
@@ -2006,6 +2480,7 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
             eventGameId: authorized.eventGameId,
             intent: candidate.intent,
             causalPredecessorIds: predecessors,
+            deferTimeoutMaterialization: true,
           });
           if (result.status === "accepted") {
             outcomes.push({ operationId, status: "accepted" });
@@ -2044,8 +2519,40 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
       }
       const owner = await options.resolveEventGameRecord(authorized.eventGameId);
       const root = owner === null ? null : await owner.record.readRoot(owner.recordId);
+      const unresolvedTimeoutEvidence = outcomes.some((outcome) => {
+        if (
+          outcome.status !== "retryable" &&
+          outcome.status !== "causally-blocked" &&
+          outcome.status !== "held-for-correction"
+        ) {
+          return false;
+        }
+        const candidate = input.actions.find(
+          (action) => readOperationId(action.intent) === outcome.operationId,
+        );
+        if (candidate === undefined) return false;
+        const parsed = parseLiveEventControllerIntent(candidate.intent);
+        return (
+          parsed.ok &&
+          (parsed.value.type === "correct-fact" ||
+            (parsed.value.type === "substantive" && parsed.value.trigger === "timeout"))
+        );
+      });
+      const materialized =
+        owner === null || root === null || unresolvedTimeoutEvidence
+          ? root === null
+            ? null
+            : { status: "ready" as const, root }
+          : await materializeExpiredTimeout(owner, root, {
+              sessionBearer: input.sessionBearer,
+              grantSessionId: authorized.grantSessionId,
+              grantVersion: authorized.grantVersion,
+            });
+      if (materialized?.status === "failed") return replayRetryable(input.actions, replayContext);
       const projection =
-        owner === null || root === null ? null : await readProjection(owner.record, root);
+        owner === null || materialized === null
+          ? null
+          : await readProjection(owner.record, materialized.root);
       return {
         ...replayContext,
         session: {
@@ -2062,6 +2569,89 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
     } finally {
       replayingSessions.delete(authorized.grantSessionId);
     }
+  }
+
+  async function materializeExpiredTimeout(
+    owner: { recordId: string; record: EventGameRecord },
+    root: EventGameRecordRoot,
+    authority: LiveMaterializationAuthority,
+  ): Promise<TimeoutMaterializationResult> {
+    const actions = await owner.record.readActions();
+    const derived = rebuildLiveDerivedState(root, actions);
+    const startedAtMs = derived?.timeout.startedAtMs;
+    if (
+      derived === null ||
+      derived.timeout.status !== "started" ||
+      derived.timeout.factId === null ||
+      startedAtMs === null ||
+      startedAtMs === undefined ||
+      clock() - startedAtMs < 60_000
+    ) {
+      return { status: "ready", root };
+    }
+
+    const sourceFact = derived.gameFacts.find(
+      (fact) => fact.factId === derived.timeout.factId && fact.effective,
+    );
+    const sourceAction = actions.find(
+      (stored) =>
+        stored.action.interpretation.type === "fact" &&
+        stored.action.interpretation.factId === derived.timeout.factId,
+    );
+    if (sourceFact === undefined || sourceAction === undefined) {
+      return { status: "failed", root };
+    }
+
+    const completionFactId = `timeout-completion-fact-${derived.timeout.factId}`;
+    const completionOperationId = `timeout-completion-operation-${derived.timeout.factId}`;
+    if (actions.some((stored) => stored.action.operationId === completionOperationId)) {
+      return { status: "ready", root };
+    }
+
+    const completedAtMs = clock();
+    const accepted = await options.acceptance.submitBatch({
+      recordId: owner.recordId,
+      eventGameId: root.eventGameId,
+      sessionBearer: authority.sessionBearer,
+      systemOperation: "timeout-completion",
+      actions: [
+        {
+          recordId: owner.recordId,
+          eventGameId: root.eventGameId,
+          operationId: completionOperationId,
+          kind: { id: gameFactCodecKind, version: gameFactCodecVersion },
+          payload: {
+            factId: completionFactId,
+            factType: "timeout",
+            gameSideId: derived.timeout.gameSideId,
+            gameTimeMs: sourceFact.gameTimeMs ?? 0,
+            data: {
+              trigger: "timeout",
+              sportingOrder: sourceFact.sportingOrder,
+              timeoutAction: "complete",
+              timeoutGameSideId: derived.timeout.gameSideId,
+              timeoutSourceFactId: derived.timeout.factId,
+              timeoutCompletedAtMs: completedAtMs,
+            },
+          },
+          causalPredecessorIds: [sourceAction.action.operationId],
+          occurrence: {
+            trustedAtMs: completedAtMs,
+            clientOriginAtMs: null,
+            source: "online",
+          },
+          grant: {
+            ...SYSTEM_TIMEOUT_COMPLETION_GRANT,
+          },
+          lifecycle: structuredClone(root.lifecycle),
+        },
+      ],
+    });
+    const result = accepted.results[0];
+    if (result?.status !== "accepted" && result?.status !== "duplicate-accepted") {
+      return { status: "failed", root };
+    }
+    return { status: "ready", root: (await owner.record.readRoot(owner.recordId)) ?? root };
   }
 
   async function readProjection(
@@ -2086,7 +2676,13 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
         phase: derived.phase,
         scoreByGameSide: structuredClone(derived.scoreByGameSide),
         goalCount: derived.goalCount,
-        timeout: structuredClone(derived.timeout),
+        knownDodgeballIds: [
+          ...(configuredDodgeballIdsFor(root.eventGameId) ??
+            knownDodgeballIdsFromFacts(derived.gameFacts) ??
+            []),
+        ].sort(),
+        timeout: projectLiveTimeout(derived.timeout, clock()),
+        suspension: structuredClone(derived.suspension),
         stoppage: structuredClone(derived.stoppage),
         heat: structuredClone(derived.heat),
         result: structuredClone(derived.result),
@@ -2147,24 +2743,176 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
   };
 }
 
+function projectLiveTimeout(timeout: LiveTimeoutState, nowMs: number): LiveTimeoutState {
+  if (
+    timeout.status !== "started" ||
+    timeout.startedAtMs === null ||
+    timeout.startedAtMs === undefined
+  ) {
+    return structuredClone(timeout);
+  }
+  const remainingMs = Math.max(0, 60_000 - Math.max(0, nowMs - timeout.startedAtMs));
+  if (remainingMs === 0) {
+    return {
+      ...structuredClone(timeout),
+      status: "completed",
+      remainingMs: 0,
+      longWhistleCue: "passed",
+    };
+  }
+  return {
+    ...structuredClone(timeout),
+    remainingMs,
+    longWhistleCue: remainingMs <= 15_000 ? "due" : "pending",
+  };
+}
+
+function readSuspensionSnapshotData(value: unknown): LiveSuspensionSnapshot {
+  const parsed = parseLiveSuspensionSnapshot(value);
+  if (!parsed.ok) throw new Error(parsed.error);
+  return parsed.value;
+}
+
+function canonicalizeLiveSuspensionSnapshot(
+  snapshot: LiveSuspensionSnapshot,
+  current: LiveEventGameDerivedState,
+  atMs: number,
+  configuredDodgeballIds: readonly string[] | null,
+): { ok: true; value: LiveSuspensionSnapshot } | { ok: false; error: string } {
+  const clock = projectClockBaseline(current.clock.baseline, atMs);
+  if (snapshot.gameTimeMs !== clock.gameTimeMs) {
+    return { ok: false, error: "Suspension snapshot Game Clock is stale." };
+  }
+  if (!sameNumberRecord(snapshot.scoreByGameSide, current.scoreByGameSide)) {
+    return { ok: false, error: "Suspension snapshot score is stale." };
+  }
+  const actualPenalty = suspensionPenaltyStateFromProjection(
+    deriveLivePenaltyProjection(current.gameFacts, clock.gameTimeMs),
+  );
+  if (canonicalizeJson(snapshot.penalties) !== canonicalizeJson(actualPenalty)) {
+    return { ok: false, error: "Suspension snapshot penalty state is stale." };
+  }
+
+  const gameSideIds = new Set(Object.keys(current.scoreByGameSide));
+  if (!gameSideIds.has(snapshot.volleyballPossession)) {
+    return { ok: false, error: "Volleyball possession must name an admitted Game Side." };
+  }
+  for (const [ballId, gameSideId] of Object.entries(snapshot.dodgeballPossession)) {
+    if (gameSideId !== null && !gameSideIds.has(gameSideId)) {
+      return {
+        ok: false,
+        error: `Dodgeball ${ballId} possession must name an admitted Game Side.`,
+      };
+    }
+  }
+
+  const knownDodgeballIds = configuredDodgeballIds
+    ? new Set(configuredDodgeballIds)
+    : knownDodgeballIdsFromFacts(current.gameFacts);
+  if (knownDodgeballIds === null) {
+    return { ok: false, error: "Authoritative dodgeball identities are unavailable." };
+  }
+  const suppliedDodgeballIds = Object.keys(snapshot.dodgeballPossession);
+  if (
+    knownDodgeballIds.size > 0 &&
+    (knownDodgeballIds.size !== suppliedDodgeballIds.length ||
+      suppliedDodgeballIds.some((ballId) => !knownDodgeballIds.has(ballId)))
+  ) {
+    return { ok: false, error: "Suspension snapshot must list every known dodgeball." };
+  }
+  return {
+    ok: true,
+    value: {
+      version: LIVE_SUSPENSION_SNAPSHOT_VERSION,
+      gameTimeMs: clock.gameTimeMs,
+      scoreByGameSide: structuredClone(current.scoreByGameSide),
+      penalties: actualPenalty,
+      volleyballPossession: snapshot.volleyballPossession,
+      dodgeballPossession: structuredClone(snapshot.dodgeballPossession),
+    },
+  };
+}
+
+function normalizeConfiguredDodgeballIds(
+  value: readonly string[] | undefined,
+): readonly string[] | null {
+  if (value === undefined) return null;
+  if (value.length === 0 || new Set(value).size !== value.length) {
+    throw new Error("The configured dodgeball identity set must be non-empty and unique.");
+  }
+  for (const ballId of value) {
+    if (!validateOpaqueIdentifier(ballId, "knownDodgeballIds").ok) {
+      throw new Error("The configured dodgeball identity set is invalid.");
+    }
+  }
+  return [...value].sort();
+}
+
+function knownDodgeballIdsFromFacts(facts: readonly ControllerGameFact[]): Set<string> | null {
+  const ids = new Set<string>();
+  for (const fact of facts) {
+    if (fact.factType !== "suspension") continue;
+    const data = isRecord(fact.data) ? fact.data : null;
+    if (data?.suspensionSnapshot === undefined) continue;
+    const snapshot = parseLiveSuspensionSnapshot(data.suspensionSnapshot);
+    if (!snapshot.ok) continue;
+    for (const ballId of Object.keys(snapshot.value.dodgeballPossession)) ids.add(ballId);
+  }
+  return ids.size === 0 ? null : ids;
+}
+
+export function suspensionPenaltyStateFromProjection(
+  projection: LivePenaltyProjection,
+): LiveSuspensionPenaltyState {
+  return {
+    segments: projection.players.flatMap((player) =>
+      player.segments.map((segment) => ({
+        sourceFactId: segment.id,
+        cardFactId: segment.cardFactId,
+        cardType: segment.cardType,
+        gameSideId: player.gameSideId,
+        playerKey: player.playerKey,
+        playerNumber: player.playerNumber,
+        eligibleForScoreAtGameTimeMs: segment.eligibleForScoreAtGameTimeMs,
+        notBeforeGameTimeMs: segment.notBeforeGameTimeMs,
+        startsAtGameTimeMs: segment.startsAtGameTimeMs,
+        endsAtGameTimeMs: segment.endsAtGameTimeMs,
+        elapsedMs: Math.max(
+          0,
+          segment.endsAtGameTimeMs - segment.startsAtGameTimeMs - segment.remainingMs,
+        ),
+        remainingMs: segment.remainingMs,
+        expirableByScore: segment.expirableByScore,
+      })),
+    ),
+  };
+}
+
+function sameNumberRecord(
+  left: Readonly<Record<string, number>>,
+  right: Readonly<Record<string, number>>,
+): boolean {
+  const leftKeys = Object.keys(left).sort();
+  const rightKeys = Object.keys(right).sort();
+  return (
+    leftKeys.length === rightKeys.length &&
+    leftKeys.every((key, index) => key === rightKeys[index] && left[key] === right[key])
+  );
+}
+
 function deriveLiveEventGameState(
   root: EventGameRecordRoot,
   canonicalActions: readonly { action: import("@/lib/event-game-actions").ControlAction }[],
   effectiveFacts: readonly EffectiveGameFact[],
   version: string,
+  projectedAtMs = 0,
 ): LiveEventGameDerivedState {
   const scoreByGameSide: Record<string, number> = Object.fromEntries(
     root.gameSides.map((side) => [side.id, 0]),
   );
   const effectiveFactIds = new Set(effectiveFacts.map((fact) => fact.factId));
   const synchronizationOrderByOperationId = new Map(
-    [...canonicalActions]
-      .sort(
-        ({ action: left }, { action: right }) =>
-          left.acceptedAtMs - right.acceptedAtMs ||
-          left.operationId.localeCompare(right.operationId),
-      )
-      .map(({ action }, index) => [action.operationId, index + 1]),
+    canonicalActions.map(({ action }, index) => [action.operationId, index + 1]),
   );
   const gameFacts = orderControllerGameFacts(
     canonicalActions
@@ -2284,10 +3032,119 @@ function deriveLiveEventGameState(
       if (winnerGameSideId !== null) winnerFactId = fact.factId;
     }
   }
+  const effectiveGameFacts = gameFacts.filter((fact) => fact.effective);
   const latestEffectiveFact = (factType: string): ControllerGameFact | null =>
-    gameFacts.filter((fact) => fact.effective && fact.factType === factType).at(-1) ?? null;
-  const timeoutFact = latestEffectiveFact("timeout");
-  const suspensionFact = latestEffectiveFact("suspension");
+    effectiveGameFacts.filter((fact) => fact.factType === factType).at(-1) ?? null;
+  const timeoutFacts = effectiveGameFacts.filter((fact) => fact.factType === "timeout");
+  const usedTimeoutGameSideIds = new Set<string>();
+  let timeout: LiveTimeoutState = {
+    status: "inactive",
+    factId: null,
+    gameSideId: null,
+    usedGameSideIds: [],
+    startedAtMs: null,
+    remainingMs: null,
+    longWhistleCue: "not-applicable",
+  };
+  for (const fact of timeoutFacts) {
+    const data = isRecord(fact.data) ? fact.data : null;
+    if (data === null || typeof data.timeoutGameSideId !== "string") {
+      throw new Error("Effective timeout Fact has no explicit Game Side.");
+    }
+    const gameSideId = data.timeoutGameSideId;
+    const timeoutAction = readTimeoutAction(data);
+    if (timeoutAction === null) throw new Error("Effective timeout Fact has no explicit action.");
+    if (timeoutAction === "stoppage") {
+      if (timeout.status === "stoppage" || timeout.status === "started") {
+        throw new Error("An effective timeout procedure cannot replace another active timeout.");
+      }
+      if (usedTimeoutGameSideIds.has(gameSideId)) {
+        throw new Error("Each Game Side may use only one timeout.");
+      }
+      usedTimeoutGameSideIds.add(gameSideId);
+      timeout = {
+        status: "stoppage",
+        factId: fact.factId,
+        gameSideId,
+        usedGameSideIds: [...usedTimeoutGameSideIds].sort(),
+        startedAtMs: null,
+        remainingMs: null,
+        longWhistleCue: "not-applicable",
+      };
+    } else if (timeoutAction === "start") {
+      if (timeout.status !== "stoppage" || timeout.gameSideId !== gameSideId) {
+        throw new Error("A timeout minute must match its active stoppage Game Side.");
+      }
+      const action = effectiveFacts.find((candidate) => candidate.factId === fact.factId)?.action;
+      const startedAtMs =
+        data !== null && typeof data.timeoutStartedAtMs === "number"
+          ? data.timeoutStartedAtMs
+          : (action?.acceptedAtMs ?? null);
+      timeout = {
+        status: "started",
+        factId: fact.factId,
+        gameSideId,
+        usedGameSideIds: [...usedTimeoutGameSideIds].sort(),
+        startedAtMs,
+        remainingMs: 60_000,
+        longWhistleCue: "pending",
+      };
+    } else {
+      if (
+        timeout.status !== "started" ||
+        timeout.factId === null ||
+        data.timeoutSourceFactId !== timeout.factId
+      ) {
+        throw new Error("A timeout completion must target its effective timeout minute.");
+      }
+      timeout = {
+        status: "completed",
+        factId: fact.factId,
+        gameSideId,
+        usedGameSideIds: [...usedTimeoutGameSideIds].sort(),
+        startedAtMs: null,
+        remainingMs: 0,
+        longWhistleCue: "passed",
+      };
+    }
+  }
+  timeout = {
+    ...timeout,
+    usedGameSideIds: [...usedTimeoutGameSideIds].sort(),
+  };
+
+  let suspension: LiveSuspensionState = {
+    status: "none",
+    factId: null,
+    snapshot: null,
+  };
+  for (const fact of effectiveGameFacts) {
+    if (fact.factType !== "suspension") continue;
+    const data = isRecord(fact.data) ? fact.data : null;
+    const action =
+      data?.suspensionAction === "start" || data?.suspensionAction === "resume"
+        ? data.suspensionAction
+        : null;
+    if (action === null) throw new Error("Effective suspension Fact has no explicit action.");
+    if (action === "resume") {
+      const target = data?.resumesSuspensionFactId;
+      if (suspension.factId === null || target !== suspension.factId) {
+        throw new Error("Effective resume does not target the effective suspension Fact.");
+      }
+      suspension = { status: "none", factId: null, snapshot: null };
+      continue;
+    }
+    if (suspension.status === "suspended") {
+      throw new Error("Effective suspension Facts cannot start a second suspension.");
+    }
+    const snapshot = readSuspensionSnapshotData(data?.suspensionSnapshot);
+    suspension = { status: "suspended", factId: fact.factId, snapshot };
+  }
+
+  const suspensionFact =
+    suspension.status === "suspended" && suspension.factId !== null
+      ? (gameFacts.find((fact) => fact.factId === suspension.factId) ?? null)
+      : null;
   const heatFact = latestEffectiveFact("heat-stoppage");
   const latestResultFact = latestEffectiveFact("result");
   const heatAction =
@@ -2329,16 +3186,21 @@ function deriveLiveEventGameState(
     heatNominalDurationMs === null || heatFact?.gameTimeMs === null
       ? null
       : (heatFact?.gameTimeMs ?? null);
-  const timeout: LiveTimeoutState = {
-    status: timeoutFact === null ? "inactive" : "started",
-    factId: timeoutFact?.factId ?? null,
-  };
   const heat: LiveHeatState = {
     status: heatStatus,
     factId: heatFact?.factId ?? null,
     startedAtGameTimeMs: heatStartedAtGameTimeMs,
     nominalDurationMs: heatNominalDurationMs,
   };
+  const clock = projectClockBaseline(
+    deriveClockAuthority(
+      readClockAuthorityActions(effectiveFacts.map((fact) => ({ action: fact.action }))),
+    ),
+    projectedAtMs,
+  );
+  if (suspension.status === "suspended" && clock.running) {
+    throw new Error("Effective suspension cannot coexist with a running Game Clock.");
+  }
   const stoppage: LiveStoppageState =
     suspensionFact !== null
       ? { status: "suspension", factId: suspensionFact.factId }
@@ -2358,9 +3220,7 @@ function deriveLiveEventGameState(
           ),
         };
   const effectiveResult = result !== null || winnerGameSideId !== null;
-  const effectiveSuspension = gameFacts.some(
-    (fact) => fact.effective && fact.factType === "suspension",
-  );
+  const effectiveSuspension = suspension.status === "suspended";
   const phase = effectiveResult
     ? "finished"
     : effectiveSuspension && root.lifecycle.phase !== "finished"
@@ -2368,18 +3228,13 @@ function deriveLiveEventGameState(
       : root.lifecycle.phase === "scheduled"
         ? "scheduled"
         : "in-progress";
-  const clock = projectClockBaseline(
-    deriveClockAuthority(
-      readClockAuthorityActions(effectiveFacts.map((fact) => ({ action: fact.action }))),
-    ),
-    0,
-  );
   return {
     interpreterVersion: version,
     phase,
     scoreByGameSide,
     goalCount,
     timeout,
+    suspension,
     stoppage,
     heat,
     result,
@@ -2391,6 +3246,16 @@ function deriveLiveEventGameState(
     penalties: deriveLivePenaltyProjection(gameFacts, clock.gameTimeMs),
     clock,
   };
+}
+
+function readTimeoutAction(
+  data: Record<string, unknown> | null,
+): "stoppage" | "start" | "complete" | null {
+  return data?.timeoutAction === "stoppage" ||
+    data?.timeoutAction === "start" ||
+    data?.timeoutAction === "complete"
+    ? data.timeoutAction
+    : null;
 }
 
 function controllerFactType(intent: LiveEventControllerIntent): string {
@@ -2862,6 +3727,7 @@ function readDerivedState(value: unknown): LiveEventGameDerivedState | null {
   const clock = readClockProjection(value.clock);
   if (clock === null) return null;
   const timeout = readLiveTimeoutState(value.timeout);
+  const suspension = readLiveSuspensionState(value.suspension);
   const stoppage = readLiveStoppageState(value.stoppage);
   const heat = readLiveHeatState(value.heat);
   const result = readLiveResultState(value.result);
@@ -2881,6 +3747,7 @@ function readDerivedState(value: unknown): LiveEventGameDerivedState | null {
     scoreByGameSide,
     goalCount: value.goalCount,
     timeout,
+    suspension,
     stoppage,
     heat,
     result,
@@ -2951,13 +3818,79 @@ function readControllerGameFacts(value: unknown): ControllerGameFact[] | null {
 function readLiveTimeoutState(value: unknown): LiveTimeoutState {
   if (value === undefined) return { status: "inactive", factId: null };
   if (!isRecord(value)) throw new Error("Derived timeout state is invalid.");
-  if (value.status !== "inactive" && value.status !== "started") {
+  if (
+    value.status !== "inactive" &&
+    value.status !== "stoppage" &&
+    value.status !== "started" &&
+    value.status !== "completed"
+  ) {
     throw new Error("Derived timeout status is invalid.");
   }
   const factId =
     value.factId === null ? null : validateOpaqueIdentifier(value.factId, "timeout.factId");
   if (factId !== null && !factId.ok) throw new Error("Derived timeout fact is invalid.");
-  return { status: value.status, factId: factId === null ? null : factId.value };
+  const gameSideId =
+    value.gameSideId === undefined || value.gameSideId === null
+      ? null
+      : validateOpaqueIdentifier(value.gameSideId, "timeout.gameSideId");
+  if (gameSideId !== null && !gameSideId.ok) throw new Error("Derived timeout side is invalid.");
+  const usedGameSideIds = value.usedGameSideIds === undefined ? [] : value.usedGameSideIds;
+  if (
+    !Array.isArray(usedGameSideIds) ||
+    usedGameSideIds.some((sideId) => !validateOpaqueIdentifier(sideId, "timeout.usedGameSideId").ok)
+  ) {
+    throw new Error("Derived timeout entitlements are invalid.");
+  }
+  const startedAtMs =
+    value.startedAtMs === undefined || value.startedAtMs === null
+      ? null
+      : validateIntegerInRange(
+          value.startedAtMs,
+          0,
+          Number.MAX_SAFE_INTEGER,
+          "timeout.startedAtMs",
+        );
+  const remainingMs =
+    value.remainingMs === undefined || value.remainingMs === null
+      ? null
+      : validateIntegerInRange(value.remainingMs, 0, 60_000, "timeout.remainingMs");
+  if (startedAtMs !== null && !startedAtMs.ok) throw new Error("Derived timeout start is invalid.");
+  if (remainingMs !== null && !remainingMs.ok)
+    throw new Error("Derived timeout remaining time is invalid.");
+  const cue = value.longWhistleCue ?? "not-applicable";
+  if (cue !== "not-applicable" && cue !== "pending" && cue !== "due" && cue !== "passed") {
+    throw new Error("Derived timeout cue is invalid.");
+  }
+  return {
+    status: value.status,
+    factId: factId === null ? null : factId.value,
+    gameSideId: gameSideId === null ? null : gameSideId.value,
+    usedGameSideIds: usedGameSideIds as string[],
+    startedAtMs: startedAtMs === null ? null : startedAtMs.value,
+    remainingMs: remainingMs === null ? null : remainingMs.value,
+    longWhistleCue: cue,
+  };
+}
+
+function readLiveSuspensionState(value: unknown): LiveSuspensionState {
+  if (value === undefined) return { status: "none", factId: null, snapshot: null };
+  if (!isRecord(value)) throw new Error("Derived suspension state is invalid.");
+  if (value.status !== "none" && value.status !== "suspended") {
+    throw new Error("Derived suspension status is invalid.");
+  }
+  const factId =
+    value.factId === null ? null : validateOpaqueIdentifier(value.factId, "suspension.factId");
+  if (factId !== null && !factId.ok) throw new Error("Derived suspension fact is invalid.");
+  if (value.snapshot === null || value.snapshot === undefined) {
+    return { status: value.status, factId: factId === null ? null : factId.value, snapshot: null };
+  }
+  const parsed = parseLiveSuspensionSnapshot(value.snapshot);
+  if (!parsed.ok) throw new Error("Derived suspension snapshot is invalid.");
+  return {
+    status: value.status,
+    factId: factId === null ? null : factId.value,
+    snapshot: parsed.value,
+  };
 }
 
 function readLiveStoppageState(value: unknown): LiveStoppageState {
@@ -3140,20 +4073,26 @@ function rebuildLiveDerivedState(
     canonicalContent: string;
     contentFingerprint: string;
   }[],
+  projectedAtMs = 0,
 ): LiveEventGameDerivedState | null {
-  const rebuilt = rebuildControlActionHistory(
-    root,
-    actions,
-    createControlActionCodecRegistry(createDefaultControlActionCodecs()),
-    createLiveEventGameIqaInterpreter(),
-  );
-  if (rebuilt.status !== "ready") return null;
-  return deriveLiveEventGameState(
-    root,
-    rebuilt.canonicalActions.map((action) => ({ action })),
-    rebuilt.effectiveFacts,
-    LIVE_EVENT_IQA_INTERPRETER_VERSION,
-  );
+  try {
+    const rebuilt = rebuildControlActionHistory(
+      root,
+      actions,
+      createControlActionCodecRegistry(createDefaultControlActionCodecs()),
+      createLiveEventGameIqaInterpreter(),
+    );
+    if (rebuilt.status !== "ready") return null;
+    return deriveLiveEventGameState(
+      root,
+      rebuilt.canonicalActions.map((action) => ({ action })),
+      rebuilt.effectiveFacts,
+      LIVE_EVENT_IQA_INTERPRETER_VERSION,
+      projectedAtMs,
+    );
+  } catch {
+    return null;
+  }
 }
 
 function rebuildLiveDerivedStateWithCandidate(
@@ -3285,6 +4224,7 @@ export function validateLiveEventGameActionInTransaction(
   }[],
   root: EventGameRecordRoot,
   candidate: ControlAction,
+  configuredDodgeballIds: readonly string[] | null = null,
 ): { status: "accepted" } | { status: "rejected"; reason: "invalid-action"; detail: string } {
   const clockValidation = validateLiveEventClockActionInTransaction(actions, candidate);
   if (clockValidation.status === "rejected") return clockValidation;
@@ -3300,6 +4240,34 @@ export function validateLiveEventGameActionInTransaction(
   const scoreValidation = validateDerivedScoreUpperBound(current, candidate);
   if (scoreValidation.status === "rejected") return scoreValidation;
   if (candidate.interpretation.type === "correction") {
+    if (candidate.override !== undefined) {
+      return rejectedLiveAction("Official Overrides cannot be attached to a Correction.");
+    }
+    const prepared = prepareControlAction(
+      candidate,
+      { ...root, lifecycle: candidate.lifecycle },
+      createControlActionCodecRegistry(createDefaultControlActionCodecs()),
+      candidate.occurrence.trustedAtMs,
+      { allowConcurrentTeamAssignment: true },
+    );
+    if (!prepared.ok) return rejectedLiveAction("The Correction could not be prepared.");
+    const prospective = rebuildLiveDerivedState(
+      root,
+      [
+        ...actions,
+        {
+          action: candidate,
+          canonicalContent: prepared.value.canonicalContent,
+          contentFingerprint: prepared.value.contentFingerprint,
+        },
+      ],
+      candidate.acceptedAtMs,
+    );
+    if (prospective === null) {
+      return rejectedLiveAction(
+        "The Correction would leave suspension and Clock state inconsistent.",
+      );
+    }
     const rebuilt = rebuildLiveDerivedStateWithCandidate(actions, root, candidate);
     if (rebuilt === null) {
       return rejectedLiveAction("The corrected live Game state cannot be rebuilt authoritatively.");
@@ -3321,6 +4289,9 @@ export function validateLiveEventGameActionInTransaction(
     return candidate.override === undefined
       ? { status: "accepted" }
       : rejectedLiveAction("Official Overrides cannot be attached to a Correction.");
+    return candidate.override === undefined
+      ? { status: "accepted" }
+      : rejectedLiveAction("Official Overrides cannot be attached to a Correction.");
   }
   if (candidate.interpretation.type !== "fact") {
     return candidate.override === undefined
@@ -3331,6 +4302,14 @@ export function validateLiveEventGameActionInTransaction(
   if (!isRecord(payload)) return rejectedLiveAction("The live Game Fact payload is invalid.");
   const gameTimeMs = typeof payload.gameTimeMs === "number" ? payload.gameTimeMs : null;
   const data = isRecord(payload.data) ? payload.data : null;
+  const currentPhaseIsSuspended = current.phase === "suspended";
+  if (
+    candidate.interpretation.factType === "clock" &&
+    data?.running === true &&
+    currentPhaseIsSuspended
+  ) {
+    return rejectedLiveAction("A suspended game must be resumed before the clock can restart.");
+  }
   if (candidate.interpretation.factType === "penalty-reason") {
     const targetCardFactId = data?.targetCardFactId;
     if (
@@ -3502,6 +4481,78 @@ export function validateLiveEventGameActionInTransaction(
       return rejectedLiveAction("A normal timeout requires paused play.");
     }
   }
+  if (candidate.interpretation.factType === "timeout") {
+    if (data === null) return rejectedLiveAction("Timeout action and Game Side are required.");
+    const timeoutAction = readTimeoutAction(data);
+    if (timeoutAction === null || typeof data.timeoutGameSideId !== "string") {
+      return rejectedLiveAction("Timeout action and Game Side are required.");
+    }
+    if (timeoutAction === "stoppage") {
+      if (current.timeout.status === "stoppage" || current.timeout.status === "started") {
+        return rejectedLiveAction("Another Team Timeout procedure is already active.");
+      }
+      if (current.timeout.usedGameSideIds?.includes(data.timeoutGameSideId)) {
+        return rejectedLiveAction("Each Game Side may use only one timeout.");
+      }
+    }
+    if (timeoutAction === "start") {
+      if (current.clock.running) {
+        return rejectedLiveAction("The timeout minute cannot start while play is running.");
+      }
+      if (
+        current.timeout.status !== "stoppage" ||
+        current.timeout.gameSideId !== data.timeoutGameSideId
+      ) {
+        return rejectedLiveAction("The timeout minute must match its active stoppage Game Side.");
+      }
+    }
+    if (timeoutAction === "complete") {
+      if (
+        current.timeout.status !== "started" ||
+        current.timeout.factId === null ||
+        data.timeoutSourceFactId !== current.timeout.factId
+      ) {
+        return rejectedLiveAction("Timeout completion must target the effective timeout minute.");
+      }
+    }
+  }
+  if (candidate.interpretation.factType === "suspension") {
+    const suspensionAction =
+      data?.suspensionAction === "start" || data?.suspensionAction === "resume"
+        ? data.suspensionAction
+        : null;
+    if (suspensionAction === null) {
+      return rejectedLiveAction("Suspension action is required.");
+    }
+    if (suspensionAction === "start" && current.suspension.status === "suspended") {
+      return rejectedLiveAction("An effective suspension is already active.");
+    }
+    if (suspensionAction === "start" && current.clock.running) {
+      return rejectedLiveAction("A Game may be suspended only while play is stopped.");
+    }
+    if (suspensionAction === "resume") {
+      if (current.phase !== "suspended" || current.suspension.factId === null) {
+        return rejectedLiveAction("A resume requires an effective suspension.");
+      }
+      if (data?.resumesSuspensionFactId !== current.suspension.factId) {
+        return rejectedLiveAction("Resume must target the effective suspension fact.");
+      }
+    }
+    if (suspensionAction === "start") {
+      if (data?.suspensionSnapshot === undefined) {
+        return rejectedLiveAction("Suspension snapshot is required.");
+      }
+      const parsedSnapshot = parseLiveSuspensionSnapshot(data.suspensionSnapshot);
+      if (!parsedSnapshot.ok) return rejectedLiveAction(parsedSnapshot.error);
+      const canonicalSnapshot = canonicalizeLiveSuspensionSnapshot(
+        parsedSnapshot.value,
+        current,
+        candidate.acceptedAtMs,
+        configuredDodgeballIds,
+      );
+      if (!canonicalSnapshot.ok) return rejectedLiveAction(canonicalSnapshot.error);
+    }
+  }
   const expected =
     candidate.interpretation.factType === "penalty-release-consequence"
       ? null
@@ -3559,12 +4610,13 @@ function expectedLiveOverride(
   }
   if (factType === "timeout") {
     if (!current.clock.running) return null;
+    if (data?.timeoutAction !== "stoppage") return null;
     return {
       required: true,
       guardrail: "timeout-requires-paused-play",
       direction: "head-referee-directed-timeout-while-running",
       beforeValue: { running: current.clock.running },
-      afterValue: { timeout: "started" },
+      afterValue: { timeout: "stoppage" },
       gameTimeMs,
     };
   }

--- a/src/lib/live-event-game-runtime.test.ts
+++ b/src/lib/live-event-game-runtime.test.ts
@@ -17,6 +17,7 @@ import type { GrantKeyRing } from "@/lib/grant-types";
 import {
   createControlScopeResolver,
   openLiveEventGameRuntime,
+  readLiveEventDodgeballIdsByEventGame,
   readLiveEventGrantKeyRing,
 } from "@/lib/live-event-game-runtime";
 import {
@@ -25,6 +26,20 @@ import {
 } from "@/lib/live-event-game-control";
 
 describe("Live Event Game SQLite runtime", () => {
+  test("resolves known dodgeballs by Event Game and ignores the removed process-wide list", () => {
+    const resolve = readLiveEventDodgeballIdsByEventGame({
+      EVENT_GAME_DODGEBALL_IDS: "ball-old",
+      EVENT_GAME_DODGEBALL_IDS_BY_EVENT_GAME: JSON.stringify({
+        "game-a": ["ball-2", "ball-1", "ball-1"],
+      }),
+    });
+    expect(resolve?.("game-a")).toEqual(["ball-1", "ball-2"]);
+    expect(resolve?.("game-b")).toBeUndefined();
+    expect(
+      readLiveEventDodgeballIdsByEventGame({ EVENT_GAME_DODGEBALL_IDS: "ball-old" }),
+    ).toBeUndefined();
+  });
+
   test("fails closed when any required runtime secret is absent", () => {
     expect(
       readLiveEventGrantKeyRing({

--- a/src/lib/live-event-game-runtime.ts
+++ b/src/lib/live-event-game-runtime.ts
@@ -36,6 +36,7 @@ export async function openLiveEventGameRuntime(input: {
   environmentId: string;
   keyRing: GrantKeyRing;
   clock?: () => number;
+  knownDodgeballIdsForEventGame?: (eventGameId: string) => readonly string[] | undefined;
 }): Promise<LiveEventGameRuntime> {
   const readiness = await readSqliteFoundationStorageReadiness(input.databasePath, {
     grantKeyRing: input.keyRing,
@@ -122,6 +123,7 @@ export async function openLiveEventGameRuntime(input: {
           transaction.listActions(root.recordId),
           root,
           action,
+          input.knownDodgeballIdsForEventGame?.(root.eventGameId) ?? null,
         ),
     });
     const hasLifecycleInventory = await storage.transaction(
@@ -186,6 +188,7 @@ export async function openLiveEventGameRuntime(input: {
           eventGameId,
           lockedAtMs,
         }),
+      knownDodgeballIdsForEventGame: input.knownDodgeballIdsForEventGame,
     });
     const lockTimer = setInterval(() => {
       void control.reconcileEventGameLocks();
@@ -280,6 +283,34 @@ function createGrantOptions(
     };
   }
   return options;
+}
+
+export function readLiveEventDodgeballIdsByEventGame(
+  environmentVariables: Record<string, string | undefined> = process.env,
+): ((eventGameId: string) => readonly string[] | undefined) | undefined {
+  const configured = environmentVariables.EVENT_GAME_DODGEBALL_IDS_BY_EVENT_GAME?.trim();
+  if (configured === undefined || configured === "") return undefined;
+  try {
+    const parsed: unknown = JSON.parse(configured);
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) return undefined;
+    const entries = Object.entries(parsed);
+    const map = new Map<string, readonly string[]>();
+    for (const [eventGameId, value] of entries) {
+      if (
+        !Array.isArray(value) ||
+        value.length === 0 ||
+        value.some((ballId) => typeof ballId !== "string" || ballId.trim() === "")
+      )
+        return undefined;
+      map.set(
+        eventGameId,
+        [...new Set(value)].sort((left, right) => left.localeCompare(right)),
+      );
+    }
+    return (eventGameId) => map.get(eventGameId);
+  } catch {
+    return undefined;
+  }
 }
 
 export function createControlScopeResolver(

--- a/src/lib/live-event-game-suspension.test.ts
+++ b/src/lib/live-event-game-suspension.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from "bun:test";
+import {
+  LIVE_EVENT_CONTROL_INTENT_VERSION,
+  LIVE_SUSPENSION_SNAPSHOT_VERSION,
+  parseLiveEventControllerIntent,
+  suspensionPenaltyStateFromProjection,
+} from "@/lib/live-event-game-control";
+import type { LivePenaltyProjection } from "@/lib/live-event-penalties";
+
+describe("Live Event Game suspension recovery", () => {
+  test("round-trips every remaining penalty segment and score-expiry meaning", () => {
+    const projection: LivePenaltyProjection = {
+      cards: [],
+      players: [
+        {
+          playerKey: "side-a:4",
+          gameSideId: "side-a",
+          playerNumber: 4,
+          segments: [
+            {
+              id: "red-card:1",
+              cardFactId: "red-card",
+              cardType: "red",
+              expirableByScore: false,
+              eligibleForScoreAtGameTimeMs: 0,
+              notBeforeGameTimeMs: 0,
+              startsAtGameTimeMs: 0,
+              endsAtGameTimeMs: 60_000,
+              remainingMs: 45_000,
+            },
+            {
+              id: "red-card:2",
+              cardFactId: "red-card",
+              cardType: "red",
+              expirableByScore: false,
+              eligibleForScoreAtGameTimeMs: 60_000,
+              notBeforeGameTimeMs: 60_000,
+              startsAtGameTimeMs: 60_000,
+              endsAtGameTimeMs: 120_000,
+              remainingMs: 60_000,
+            },
+          ],
+        },
+      ],
+      pendingExpirations: [],
+      releases: [],
+    };
+
+    const snapshot = suspensionPenaltyStateFromProjection(projection);
+    expect(snapshot.segments).toMatchObject([
+      {
+        sourceFactId: "red-card:1",
+        cardFactId: "red-card",
+        cardType: "red",
+        remainingMs: 45_000,
+        expirableByScore: false,
+      },
+      {
+        sourceFactId: "red-card:2",
+        cardFactId: "red-card",
+        cardType: "red",
+        remainingMs: 60_000,
+        expirableByScore: false,
+      },
+    ]);
+  });
+
+  test("requires explicit timeout and suspension lifecycle fields", () => {
+    const base = {
+      version: LIVE_EVENT_CONTROL_INTENT_VERSION,
+      type: "substantive" as const,
+      operationId: "missing-lifecycle-field",
+      factId: "missing-lifecycle-fact",
+      gameTimeMs: 0,
+      occurrence: { clientOriginAtMs: null },
+    };
+
+    expect(parseLiveEventControllerIntent({ ...base, trigger: "timeout" })).toMatchObject({
+      ok: false,
+    });
+    expect(
+      parseLiveEventControllerIntent({
+        ...base,
+        trigger: "timeout",
+        timeoutAction: "stoppage",
+      }),
+    ).toMatchObject({ ok: false });
+    expect(parseLiveEventControllerIntent({ ...base, trigger: "suspension" })).toMatchObject({
+      ok: false,
+    });
+    expect(
+      parseLiveEventControllerIntent({
+        ...base,
+        trigger: "suspension",
+        suspensionAction: "resume",
+      }),
+    ).toMatchObject({ ok: false });
+  });
+
+  test("keeps the versioned possession snapshot shape explicit", () => {
+    const parsed = parseLiveEventControllerIntent({
+      version: LIVE_EVENT_CONTROL_INTENT_VERSION,
+      type: "substantive",
+      trigger: "suspension",
+      operationId: "snapshot-shape",
+      factId: "snapshot-shape-fact",
+      gameTimeMs: 0,
+      suspensionAction: "start",
+      suspensionSnapshot: {
+        version: LIVE_SUSPENSION_SNAPSHOT_VERSION,
+        gameTimeMs: 0,
+        scoreByGameSide: { "side-a": 0, "side-b": 0 },
+        penalties: { segments: [] },
+        volleyballPossession: "side-a",
+        dodgeballPossession: { "ball-1": "side-a" },
+      },
+      occurrence: { clientOriginAtMs: null },
+    });
+    expect(parsed.ok).toBe(true);
+  });
+});

--- a/src/lib/live-event-game-transport.ts
+++ b/src/lib/live-event-game-transport.ts
@@ -29,6 +29,7 @@ export type LiveEventGameControlTransportTarget = {
   refreshController(input: {
     sessionBearer: string;
     eventGameId: string;
+    deferTimeoutMaterialization?: boolean;
   }): Promise<ControllerRefreshResult>;
   switchController(input: { sessionBearer: string }): Promise<ControllerRefreshResult>;
   stayController(input: {
@@ -168,6 +169,7 @@ export function createLiveEventGameControlTransport(
       const result = await control.refreshController({
         sessionBearer: input.sessionBearer,
         eventGameId: input.eventGameId,
+        deferTimeoutMaterialization: input.deferTimeoutMaterialization,
       });
       return noStoreJson(result, controllerResultStatus(result));
     },
@@ -221,12 +223,22 @@ export function createLiveEventGameControlTransport(
 async function readSessionInput(
   request: Request,
   isAllowedRequest: (request: Request) => boolean,
-): Promise<{ sessionBearer: string; eventGameId?: string } | null> {
+): Promise<{
+  sessionBearer: string;
+  eventGameId?: string;
+  deferTimeoutMaterialization?: boolean;
+} | null> {
   if (!isAllowedRequest(request)) return null;
   const body = await readJsonBodyWithinLimit(request, SHARED_LIMITS.transport.httpJsonBodyBytes);
   if (!body.ok || !isRecord(body.body) || typeof body.body.sessionBearer !== "string") return null;
   if (typeof body.body.eventGameId === "string") {
-    return { sessionBearer: body.body.sessionBearer, eventGameId: body.body.eventGameId };
+    return {
+      sessionBearer: body.body.sessionBearer,
+      eventGameId: body.body.eventGameId,
+      ...(body.body.deferTimeoutMaterialization === true
+        ? { deferTimeoutMaterialization: true }
+        : {}),
+    };
   }
   return { sessionBearer: body.body.sessionBearer };
 }

--- a/src/pages/event-game-controller-page.tsx
+++ b/src/pages/event-game-controller-page.tsx
@@ -18,6 +18,8 @@ import type { OfficialOverrideMetadata } from "@/lib/event-game-actions";
 import {
   CLOSE_PLAY_ADJUDICATION_WINDOW_MS,
   LIVE_EVENT_CONTROL_INTENT_VERSION,
+  LIVE_SUSPENSION_SNAPSHOT_VERSION,
+  suspensionPenaltyStateFromProjection,
 } from "@/lib/live-event-game-control";
 import {
   deriveLivePenaltyProjection,
@@ -77,6 +79,8 @@ type ReplayRequest = { state: ControllerReplicaState; authority: ReplayAuthority
 
 type ActiveReplay = ReplayRequest & { requestToken: symbol };
 
+type PossessionSelection = Record<string, string | null>;
+
 type PendingClosePlayAdjudication = {
   intentType: "record-goal" | "record-flag-catch";
   gameSideId: string;
@@ -135,6 +139,9 @@ export function EventGameControllerPage() {
   const [skippedPenaltyReasonCardIds, setSkippedPenaltyReasonCardIds] = useState<
     ReadonlySet<string>
   >(() => new Set());
+  const [volleyballPossession, setVolleyballPossession] = useState("");
+  const [dodgeballPossession, setDodgeballPossession] = useState<PossessionSelection>({});
+  const [showSuspensionRecovery, setShowSuspensionRecovery] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [pendingClosePlayAdjudication, setPendingClosePlayAdjudication] =
@@ -752,9 +759,42 @@ export function EventGameControllerPage() {
     });
   }
 
-  function trigger(type: "card" | "timeout" | "suspension" | "result") {
+  function trigger(
+    type: "card" | "timeout" | "suspension" | "result",
+    options: {
+      timeoutAction?: "stoppage" | "start" | "complete";
+      timeoutGameSideId?: string;
+      suspensionAction?: "start" | "resume";
+      resumesSuspensionFactId?: string;
+    } = {},
+  ) {
     const gameTimeMs = currentSportingTimeMs();
     if (gameTimeMs === null) return;
+    if (type === "suspension" && options.suspensionAction !== "resume") {
+      if (projection === null || projection.penalties === undefined) {
+        setMessage("A current authoritative projection is required before suspending.");
+        return;
+      }
+      if (volleyballPossession === "") {
+        setMessage("Confirm volleyball possession before suspending.");
+        return;
+      }
+      if ((projection.knownDodgeballIds ?? []).some((ballId) => !(ballId in dodgeballPossession))) {
+        setMessage("Confirm every known dodgeball possession before suspending.");
+        return;
+      }
+    }
+    const suspensionSnapshot =
+      type === "suspension" && options.suspensionAction !== "resume" && projection !== null
+        ? {
+            version: LIVE_SUSPENSION_SNAPSHOT_VERSION,
+            gameTimeMs,
+            scoreByGameSide: projection.scoreByGameSide,
+            penalties: suspensionPenaltyStateFromProjection(projection.penalties!),
+            volleyballPossession,
+            dodgeballPossession,
+          }
+        : undefined;
     queueIntent({
       version: LIVE_EVENT_CONTROL_INTENT_VERSION,
       type: "substantive",
@@ -764,6 +804,8 @@ export function EventGameControllerPage() {
       gameTimeMs,
       sportingOrder: gameTimeMs,
       occurrence: { clientOriginAtMs: Date.now() },
+      ...options,
+      ...(suspensionSnapshot === undefined ? {} : { suspensionSnapshot }),
     });
   }
 
@@ -1207,7 +1249,7 @@ export function EventGameControllerPage() {
   }
 
   return (
-    <main className="mx-auto w-full max-w-xl p-4 pb-12 sm:p-6">
+    <main className="mx-auto max-h-[calc(100vh-1rem)] w-full max-w-xl overflow-y-auto p-4 pb-12 sm:max-h-none sm:overflow-visible sm:p-6">
       <Card>
         <CardHeader>
           <CardTitle>Event Game Controller</CardTitle>
@@ -1262,7 +1304,7 @@ export function EventGameControllerPage() {
                   <p className="mt-1 text-muted-foreground">Projection temporarily unavailable.</p>
                 ) : null}
               </div>
-              <div className="flex flex-wrap gap-2">
+              <div className="flex flex-wrap gap-2 max-[639px]:hidden">
                 <Button variant="outline" onClick={() => void revealQr()} disabled={busy}>
                   Reveal active Grant QR
                 </Button>
@@ -1312,7 +1354,7 @@ export function EventGameControllerPage() {
                 </p>
               </div>
               {clockProjection === null ? null : (
-                <div className="space-y-1 rounded-lg border border-amber-500/50 bg-amber-50 p-3 text-sm text-amber-950">
+                <div className="space-y-1 rounded-lg border border-amber-500/50 bg-amber-50 p-3 text-sm text-amber-950 max-[639px]:hidden">
                   <p data-clock-cue="flag-runner">
                     {clockProjection.cues.flagRunnerEntry === "pending"
                       ? "Flag-runner entry pending at 19:00"
@@ -1354,7 +1396,7 @@ export function EventGameControllerPage() {
                     {Math.abs(adjustmentMs) / 1000}s
                   </Button>
                 ))}
-                <div className="flex w-full flex-wrap items-end gap-2 rounded border p-2 text-left">
+                <div className="flex w-full flex-wrap items-end gap-2 rounded border p-2 text-left max-[639px]:hidden">
                   <div className="min-w-48 flex-1 space-y-1">
                     <Label htmlFor="clock-correction">Set game clock (milliseconds)</Label>
                     <Input
@@ -1375,7 +1417,7 @@ export function EventGameControllerPage() {
                     Correct clock
                   </Button>
                 </div>
-                <div className="flex w-full flex-wrap items-end gap-2 rounded border border-amber-500/50 p-2 text-left">
+                <div className="flex w-full flex-wrap items-end gap-2 rounded border border-amber-500/50 p-2 text-left max-[639px]:hidden">
                   <div className="min-w-48 flex-1 space-y-1">
                     <Label htmlFor="clock-takeover-adjustment">
                       Emergency takeover adjustment (ms)
@@ -1398,7 +1440,7 @@ export function EventGameControllerPage() {
                     Emergency clock takeover
                   </Button>
                 </div>
-                <div className="flex w-full flex-wrap items-end gap-2 rounded border p-2 text-left">
+                <div className="flex w-full flex-wrap items-end gap-2 rounded border p-2 text-left max-[639px]:hidden">
                   <div className="min-w-32 flex-1 space-y-1">
                     <Label htmlFor="penalty-game-side">Penalized Game Side</Label>
                     <select
@@ -1478,18 +1520,145 @@ export function EventGameControllerPage() {
                     Penalized player is the seeker (Head Referee confirmed)
                   </label>
                 </div>
-                <Button variant="outline" onClick={() => trigger("timeout")} disabled={busy}>
-                  Start timeout
+                {projection === null
+                  ? null
+                  : Object.keys(projection.scoreByGameSide).map((gameSideId) => {
+                      const timeout = projection.timeout;
+                      const isStoppageForSide =
+                        timeout?.status === "stoppage" && timeout.gameSideId === gameSideId;
+                      const used = timeout?.usedGameSideIds?.includes(gameSideId) === true;
+                      const anotherSideActive =
+                        (timeout?.status === "stoppage" || timeout?.status === "started") &&
+                        timeout.gameSideId !== gameSideId;
+                      return (
+                        <Button
+                          key={gameSideId}
+                          variant="outline"
+                          onClick={() =>
+                            trigger("timeout", {
+                              timeoutAction: isStoppageForSide ? "start" : "stoppage",
+                              timeoutGameSideId: gameSideId,
+                            })
+                          }
+                          disabled={busy || anotherSideActive || (used && !isStoppageForSide)}
+                        >
+                          {isStoppageForSide
+                            ? `Start timeout minute: ${gameSideId}`
+                            : used
+                              ? `Timeout used: ${gameSideId}`
+                              : `Timeout stoppage: ${gameSideId}`}
+                        </Button>
+                      );
+                    })}
+                <Button
+                  variant="outline"
+                  onClick={() => setShowSuspensionRecovery(true)}
+                  disabled={busy}
+                >
+                  Review suspension recovery
                 </Button>
-                <Button variant="outline" onClick={() => trigger("suspension")} disabled={busy}>
-                  Suspend game
-                </Button>
+                {showSuspensionRecovery || projection?.suspension?.status === "suspended" ? (
+                  <div className="w-full space-y-2 rounded-lg border p-3 text-left">
+                    <p className="text-sm font-medium">Suspension recovery review</p>
+                    <p className="text-xs text-muted-foreground">
+                      Verify the effective snapshot with another Controller before resuming.
+                    </p>
+                    {projection?.suspension?.snapshot === null ||
+                    projection?.suspension?.snapshot === undefined ? (
+                      <div className="grid gap-2 sm:grid-cols-2">
+                        <div className="space-y-1">
+                          <Label htmlFor="volleyball-possession">Volleyball possession</Label>
+                          <select
+                            id="volleyball-possession"
+                            className="h-9 w-full rounded-md border bg-background px-3 text-sm"
+                            value={volleyballPossession}
+                            onChange={(event) => setVolleyballPossession(event.target.value)}
+                            disabled={busy}
+                          >
+                            <option value="">Select Game Side</option>
+                            {Object.keys(projection?.scoreByGameSide ?? {}).map((sideId) => (
+                              <option key={sideId} value={sideId}>
+                                {sideId}
+                              </option>
+                            ))}
+                          </select>
+                        </div>
+                        <div className="space-y-1">
+                          <p className="text-sm font-medium">Dodgeball possession</p>
+                          {(projection?.knownDodgeballIds ?? []).map((ballId) => (
+                            <div key={ballId} className="space-y-1">
+                              <Label htmlFor={`dodgeball-possession-${ballId}`}>{ballId}</Label>
+                              <select
+                                id={`dodgeball-possession-${ballId}`}
+                                className="h-9 w-full rounded-md border bg-background px-3 text-sm"
+                                value={dodgeballPossession[ballId] ?? ""}
+                                onChange={(event) =>
+                                  setDodgeballPossession((current) => ({
+                                    ...current,
+                                    [ballId]: event.target.value || null,
+                                  }))
+                                }
+                                disabled={busy}
+                              >
+                                <option value="">No confirmed side</option>
+                                {Object.keys(projection?.scoreByGameSide ?? {}).map((sideId) => (
+                                  <option key={sideId} value={sideId}>
+                                    {sideId}
+                                  </option>
+                                ))}
+                              </select>
+                            </div>
+                          ))}
+                        </div>
+                        <Button
+                          variant="outline"
+                          onClick={() => trigger("suspension", { suspensionAction: "start" })}
+                          disabled={busy}
+                        >
+                          Suspend with verified snapshot
+                        </Button>
+                      </div>
+                    ) : (
+                      <div className="space-y-2">
+                        <div
+                          data-suspension-snapshot="effective"
+                          className="rounded-md bg-muted p-2 text-xs"
+                        >
+                          <p>Volleyball: {projection.suspension.snapshot.volleyballPossession}</p>
+                          {Object.entries(projection.suspension.snapshot.dodgeballPossession).map(
+                            ([ballId, gameSideId]) => (
+                              <p key={ballId} data-dodgeball-id={ballId}>
+                                {ballId}={gameSideId ?? "unconfirmed"}
+                              </p>
+                            ),
+                          )}
+                          <p>
+                            Penalty segments:{" "}
+                            {projection.suspension.snapshot.penalties.segments.length}
+                          </p>
+                        </div>
+                        <Button
+                          variant="outline"
+                          onClick={() =>
+                            trigger("suspension", {
+                              suspensionAction: "resume",
+                              resumesSuspensionFactId: projection.suspension?.factId ?? undefined,
+                            })
+                          }
+                          disabled={busy || projection.suspension?.factId === null}
+                        >
+                          Resume verified suspension
+                        </Button>
+                      </div>
+                    )}
+                  </div>
+                ) : null}
                 <Button variant="outline" onClick={() => trigger("result")} disabled={busy}>
                   Record result
                 </Button>
               </div>
               {projection === null ? null : (
-                <div className="space-y-3">
+                <div className="space-y-3 max-[639px]:hidden">
                   <p className="text-sm text-muted-foreground">
                     Phase: {projection.phase} · Goals: {projection.goalCount}
                     {projection.overtime ? " · Overtime" : ""}


### PR DESCRIPTION
## What changed

- adds durable Team Timeout stoppage, minute, completion, correction, and entitlement recovery
- records complete versioned suspension snapshots for Clock, score, effective remaining penalties, volleyball possession, and configured dodgeballs
- blocks suspension while play is running and requires an explicit effective Suspension Fact for resume
- preserves timeout and suspension work through reconnect, replay, correction, reinstatement, and restart
- provides the contextual 360 × 640 Controller recovery flow with Event-Game-scoped known-ball controls

## Why

Controllers need to stop and recover a live Event Game without losing authoritative timing, penalty service, or ball possession. Recovery must remain durable and replay-safe while using the accepted #91 penalty model.

## Impact

A Controller can record each Game Side’s one timeout, suspend a stopped Game with a complete authoritative snapshot, review the retained recovery state, and resume from the exact effective Suspension Fact. Missing or inconsistent authoritative state fails closed.

## Validation

- focused #90/#91/#92/#95 ordinary seams: 205 passed
- named 360 × 640 Controller browser Focused test passed
- `bun run check`
- `bun run test`: 757 passed
- `bun run build`
- `git diff --check`

Production-shaped qualification, load, soak, crash, recovery, browser-qualification, and exact-artifact workloads were intentionally not run.

Closes #92