### PR TITLE
Compose Technical Admin sanitation with Foundation restore

### DIFF
--- a/docs/adr/technical-admin-authentication-across-foundation-restore.md
+++ b/docs/adr/technical-admin-authentication-across-foundation-restore.md
@@ -1,0 +1,86 @@
+# ADR: Technical Admin authentication across Foundation restore
+
+- Status: accepted
+- Date: 2026-08-15
+- Scope: Foundation backup and restore composition for #192, #193, #81, and #70
+
+## Decision
+
+Use Policy A: keep Foundation and Technical Admin authentication in separate SQLite stores.
+Foundation backup uses a closed Foundation-only relation allowlist. It validates the live
+Foundation schema before `VACUUM INTO`; every relation must be explicitly included. A
+`technical_admin_*` relation or any other unclassified authentication relation inside Foundation
+fails closed before backup publication.
+
+Foundation backup never opens, reads, copies, filters, sanitizes, or restores the separate
+Technical Admin database. The separate auth path is not a backup input, and no auth relation is
+dropped from a Foundation snapshot. The allowlist is structural exclusion rather than a
+post-copy removal step.
+
+During restore, after Foundation staging and verification and after both writer domains are
+quiesced, Foundation consumes only
+`TechnicalAdminAuth.prepareForFoundationRestore({ mode })`. The adapter is the sole owner of
+credential validation, compatibility classification, and atomic invalidation of sessions,
+fresh-verification state, challenges, and enrollment authorizations.
+
+The finite adapter result remains separate from Foundation outcome:
+
+- `preserved-transients-invalidated` preserves the exact compatible credential and storage
+  identity while invalidating all transient authority.
+- `re-enrollment-required` represents only `missing`, `invalid`, `incompatible`, or
+  `explicit-reset`; Foundation never fabricates or resets credentials.
+- `sanitation-failed` aborts before Foundation replacement.
+
+The sanitized auth store remains at its live path on successful Foundation replacement and on
+Foundation rollback. A later Foundation failure rolls back only Foundation state and never
+revives pre-sanitation sessions, challenges, enrollment authorizations, or fresh-verification
+authority. Evidence exposes only the finite auth outcome and allowlisted reason.
+
+## Context
+
+Foundation records, Grants, and their lifecycle evidence have a different recovery authority and
+retention boundary from browser Technical Admin authentication. Copying authentication tables into
+a Foundation image, then dropping them, creates both an avoidable secret-residue problem and a
+false impression that the backup owns auth state. It also makes future auth-schema additions easy
+to miss.
+
+A closed allowlist makes an unexpected auth relation a backup policy violation at the source. The
+separate auth store can then remain wholly owned by the Technical Admin module, including its
+SQLite identity and sidecars.
+
+## Consequences
+
+Positive consequences:
+
+- An auth relation accidentally added to Foundation cannot be published in a backup.
+- The separate auth database has no Foundation backup read or mutation path.
+- Credential/storage identity survives normal restore without copying auth state.
+- A failed Foundation cutover cannot restore pre-sanitation transient authority.
+- New Foundation relations require an explicit backup-policy decision.
+
+Tradeoffs:
+
+- The Foundation relation allowlist must be updated when an intentional Foundation relation is
+  added.
+- A malformed or unexpectedly extended Foundation schema fails backup rather than producing a
+  partial snapshot.
+- Re-enrollment remains an operator-owned Technical Admin action outside Foundation restore.
+
+## Superseded alternatives
+
+The following alternatives are superseded:
+
+1. Copy the full Foundation database, drop known Technical Admin relations from the copy, and
+   publish the filtered result.
+2. Treat a separate Technical Admin database as a Foundation backup input or restore image.
+3. Move the sanitized auth database to a Foundation failed-image path and restore it during
+   Foundation rollback.
+4. Let Foundation inspect Technical Admin tables or duplicate the #193 validation/sanitation
+   implementation.
+
+## Verification
+
+The focused recovery suite rejects synthetic Technical Admin and other unclassified relations
+inside Foundation before publication and proves that a real separate auth SQLite file keeps its
+inode and bytes unchanged. The accepted #193-backed composition test separately proves credential
+and storage-identity preservation, transient invalidation, restart, and fresh ordinary sign-in.

--- a/docs/agents/issue-81-design-gate.md
+++ b/docs/agents/issue-81-design-gate.md
@@ -16,25 +16,27 @@ Gaps are durable 0600 sidecars rather than a new application relation.
 
 ## Backup policy and integrity
 
-`foundation-backup-policy-v1` is a closed relation allowlist. It includes all Event Game Record,
-Control Action, idempotency, replay, Event catalog, non-Technical-Admin Grant, Grant Session,
-credential/verifier, audit, integrity-anchor, admission, and migration-ledger relations. It excludes
-the exact Technical Admin credential, enrollment, challenge, browser-session, identity/state, log,
-and alert relations. A new or otherwise unclassified table/view fails the backup before retention can
-change.
+`foundation-backup-policy-v2` is a closed Foundation-only relation allowlist. It includes only the
+Event Game Record, Control Action, idempotency, replay, Event catalog, non-Technical-Admin Grant,
+Grant Session, credential/verifier, audit, integrity-anchor, admission, and migration-ledger
+relations owned by Foundation. Any relation outside that allowlist—including any `technical_admin_*`
+or other authentication relation—fails the backup before `VACUUM INTO` or publication can change
+state. The separate Technical Admin database is outside this database boundary and is never opened,
+read, copied, filtered, or sanitized by Foundation backup.
 
-The live writer queue drains and remains held while `VACUUM INTO` creates a consistent raw snapshot
-outside the live database directory. Explicitly excluded relations are removed only from that raw
-snapshot. A second `VACUUM INTO` creates the compact retained image, so deleted Technical Admin
-payload is absent from free pages as well as logical rows.
+The live writer queue drains and remains held while `VACUUM INTO` creates a consistent Foundation
+snapshot outside the live database directory. No relation is dropped or filtered from that image:
+the closed allowlist has already established that the source is Foundation-only. A second
+`VACUUM INTO` creates the compact retained image. This structural boundary ensures that no
+Technical Admin payload is ever copied into, or sanitized out of, the backup.
 
 The backup workspace is a physically separate, caller-owned, non-symlink `0700` directory. Raw,
 staged, retained, manifest, evidence, and failed-image destinations fail closed on pre-existing or
-symlink paths. The raw unsanitized image is tightened to `0600` before the SQLite writer queue yields;
+symlink paths. The raw Foundation image is tightened to `0600` before the SQLite writer queue yields;
 all other files are `0600`. Verification and restore copy from no-follow file handles whose inode,
 size, and modification identity remain stable, into exclusively created private files. Published
 files are rechecked against the opened inode; failed/live image moves use exclusive same-filesystem
-links before unlinking the source. Every owned Event, Technical Admin, WAL/SHM, and quarantine source
+links before unlinking the source. Every owned Event, WAL/SHM, and quarantine source
 is tightened and verified as a non-symlink `0600` regular file before preservation; the linked
 destination is verified at the same private mode. Rollback repeats that identity and mode check.
 Cleanup unlinks only the inode recovery created. Existing,
@@ -48,7 +50,7 @@ Verification uses a separate database handle and disposable copy. It requires:
   Game replay through the existing readiness verifier;
 - every encryption, lookup, and audit key version represented in retained rows to exist in the
   separately supplied key ring;
-- no Technical Admin relation after compaction.
+- no relation outside the closed Foundation-only allowlist.
 
 Grant credential/session lookup versions are lookup-key requirements. The accepted Grant Code format
 derives its stored lookup/fingerprint material from the audit ring, so its represented lookup-version
@@ -63,9 +65,11 @@ manifest have both passed verification and their directory entry is synced.
 ## Restore and authority policy
 
 Restore verifies the retained snapshot before touching the live database and copies it to an
-exclusive staging path beside the live file. Technical Admin and Event authoritative writers then
-stop, drain, and close before the one final current-authority evaluation immediately preceding
-replacement. Expired Grants are cryptographically erased through the existing lifecycle
+exclusive staging path beside the live file. Foundation storage is quiesced and closed for
+replacement. Technical Admin authentication is exclusively quiesced and drained, but remains
+adapter-usable until `prepareForFoundationRestore` commits. The one final current-authority
+evaluation then immediately precedes replacement. Expired Grants are cryptographically erased
+through the existing lifecycle
 implementation; stale Event Admin sessions are expired. Every active Control Session is resolved
 through `resolveSession(scope, session.eventGameId)`: exact current, pinned, and switchable sessions
 remain usable; only the exact session reported terminal for Game Lock or past Game Day is terminated.
@@ -75,14 +79,17 @@ resolved current scope is Game-locked, with that exact current Game recorded as 
 unavailable, conflicted, malformed, or identity-mismatched resolution aborts restore.
 
 The staging database passes readiness again, is sealed into a portable checkpointed image, and is
-confirmed free of Technical Admin state. The injected Technical Admin auth adapter then stops new
-auth writes and drains/closes its separate database before authoritative Event writes are drained.
-The live Event image, Technical Admin auth image, and any sidecars/quarantine marker move exclusively
-to unique failed-image paths; only the staged Event image moves exclusively into active use. On next startup the
-auth repository therefore creates empty auth state rather than reviving the former passkey, sessions,
-challenges, or enrollment authorization. A replacement failure removes only the installed inode and
-moves both failed images back without overwriting a competing path. The caller must reopen storage
-after either outcome.
+confirmed free of Technical Admin state. After both authoritative stores are quiesced, Foundation
+calls the injected Technical Admin auth adapter with the selected semantic mode, normally
+preserve-compatible-credential. The adapter preserves a validated compatible live credential
+while atomically invalidating sessions, fresh-verification state, challenges, and enrollment
+authorizations; missing, invalid, incompatible, or explicitly reset state is classified as
+re-enrollment-required. sanitation-failed aborts before Foundation replacement. The live Event
+image and any Event sidecars/quarantine marker move exclusively to unique failed-image paths; the
+sanitized Technical Admin auth store remains at its live path, and only the staged Event image moves
+exclusively into active use. A replacement failure removes only the installed Foundation inode and
+rolls back Foundation files; it does not move, reopen, or restore the already-sanitized auth store.
+The caller must reopen storage after either outcome.
 
 Before cutover, recovery writes and syncs one immutable private pending record. After successful live
 replacement it atomically adds a separate synced `0600` completion record. A completion-record I/O
@@ -91,10 +98,12 @@ failure cannot turn the already completed restore into a reported failure: the r
 retains the cutover identity for reconciliation and prevents an unsafe blind retry.
 
 Redacted restore evidence records snapshot time, snapshot/current action counts, whether potentially
-newer work existed, the preserved failed-image path, and restored Grant type/version tuples with
-Grant IDs hashed. This is the accepted older-snapshot resurrection-risk evidence for later Technical
-Admin review. It never claims that restored authority was current at snapshot time; current lifecycle
-reevaluation remains decisive.
+newer work existed, the preserved failed-image path, restored Grant type/version tuples with Grant
+IDs hashed, and only the finite Technical Admin auth outcome plus its allowlisted re-enrollment
+reason when present. It contains no credential, RP/origin, session/challenge, auth path/schema, or
+raw adapter error. This is the accepted older-snapshot resurrection-risk evidence for later
+Technical Admin review. It never claims that restored authority was current at snapshot time;
+current lifecycle reevaluation remains decisive.
 
 ## Recovery import and Recovery Gaps
 
@@ -126,14 +135,17 @@ Score Sheet, recording Recovery Gaps. This is not an automatic failover or a sec
 
 ## Fast-test evidence
 
-Ordinary hermetic tests cover SQLite snapshot/compaction, synthetic Technical Admin rows and physical
-canaries, unclassified relations, independent verification, retained predecessor backups, staged
+Ordinary hermetic tests cover SQLite snapshot/compaction, rejection of synthetic Technical Admin and
+other unclassified relations, separate-auth inode/content preservation, independent verification,
+retained predecessor backups, staged
 replacement, failed replacement rollback, failed-image preservation, restart, current lifecycle
 reevaluation, redacted evidence, explicit gaps, and real composed-acceptance import with durable
 SQLite mutation. They do not run Qualification, soak, load, crash, or exact-production-artifact
 workloads.
 
-The corrected suite additionally covers the synchronized final-evaluation/cutover race; a pinned old
+The corrected suite additionally covers the synchronized final-evaluation/cutover race; semantic
+Technical Admin restore ordering, abort-before-replacement, finite re-enrollment classification,
+and rollback without cross-database transient revival; a pinned old
 Game beside multiple exact locked and past-Game-Day sessions on one reused Grant; one truthful current
 Game Code erasure across memory, SQLite, and restart; rejected/malformed per-session
 resolution; private/no-follow filesystem behavior including synchronized backup-final replacement,

--- a/docs/agents/issue-81-handoff.md
+++ b/docs/agents/issue-81-handoff.md
@@ -3,9 +3,10 @@
 ## Result
 
 `FoundationRecovery` implements the minimum Event recovery operation required by #81/#70:
-verified sanitized `VACUUM INTO` snapshots, independent replay/key/schema verification, conservative
-retention, staged reversible restore, current Grant lifecycle reevaluation, redacted resurrection-risk
-evidence, and current-authority Controller recovery with explicit Recovery Gaps. The correction from
+verified Foundation-only `VACUUM INTO` snapshots, independent replay/key/schema verification, conservative
+retention, staged reversible restore, current Grant lifecycle reevaluation, semantic Technical Admin
+restore preparation, redacted resurrection-risk evidence, and current-authority Controller recovery
+with explicit Recovery Gaps. The correction from
 candidate `1be460d6749aa98d96189fce88356a83d854ee37` closes the cutover-authority race, resolves every
 active Control Session by its own Event Game identity, binds real composed acceptance at construction,
 hardens the local filesystem boundary, completes rejected-batch gaps, and corrects Grant Code lookup
@@ -16,8 +17,8 @@ private failed-image modes, and separates immutable pending from atomic completi
 ## Review seams
 
 - `src/lib/foundation-recovery.ts` — the single public recovery interface and orchestration.
-- `src/lib/foundation-recovery-sqlite.ts` — closed policy, deterministic snapshot facts, key-version
-  discovery, sanitization, and SQLite quoting.
+- `src/lib/foundation-recovery-sqlite.ts` — closed Foundation-only policy, deterministic snapshot
+  facts, key-version discovery, and SQLite quoting.
 - `src/lib/foundation-storage-sqlite.ts` — only two recovery primitives: queued `VACUUM INTO` and
   drained/checkpointed close before replacement.
 - `src/lib/foundation-recovery.test.ts` — SQLite, restart, sanitization, retention, lifecycle,
@@ -38,9 +39,17 @@ resolved current Game Lock as truthful evidence.
 ## Explicit boundaries
 
 - Migrations 001–021 are unchanged; no migration 022 was necessary.
-- Technical Admin authentication state is never restored from this backup set.
-- Restore requires a Technical Admin auth adapter that stops/drains auth writes and preserves the
-  separate auth database as a failed image while leaving no active auth database to revive.
+- Technical Admin authentication state is never restored from the Foundation backup set. A normal
+  restore calls the #193 semantic adapter against the live auth store after quiescence, preserving
+  a validated compatible credential while invalidating all transient authority and requiring fresh
+  sign-in. Missing, invalid, incompatible, or explicit-reset state remains a separate
+  re-enrollment-required outcome; sanitation-failed aborts before Foundation replacement.
+- Foundation backup uses a closed Foundation-only relation allowlist. Any `technical_admin_*` or
+  other authentication relation inside Foundation fails before publication; backup never opens,
+  reads, copies, filters, or sanitizes the separate auth database.
+- The sanitized live auth database remains at its live path throughout Foundation cutover. A later
+  Foundation rollback changes only Foundation files and leaves that sanitized auth store untouched,
+  never reviving pre-sanitation transient authority.
 - Encryption/lookup/audit keys stay outside database, manifests, and evidence.
 - There is no backup schedule, Event-handoff/off-host backup, production cutover, deployment change,
   Technical Admin enrollment/reset, distributed failover, or automatic corruption repair.
@@ -49,16 +58,21 @@ resolved current Game Lock as truthful evidence.
 - The owned backup workspace is physically outside the live database directory, non-symlink `0700`;
   all file material is `0600`, exclusive/no-follow sources and destinations reject unsafe paths, and
   verification/copy/publication/cleanup bind to stable file identity without overwriting competing
-  replacements. Failed Event/Technical Admin databases, sidecars, and quarantine images are tightened
+  replacements. Failed Event database, sidecars, and quarantine images are tightened
   and verified before preservation and again on rollback.
 - Restore evidence uses one immutable synced pending record plus an atomic separate completion record.
   Completion-record I/O failure is returned as a completed cutover with explicit evidence status, not
   as a failed restore that could invite an unsafe retry.
+- Restore evidence exposes only the finite Technical Admin auth outcome and allowlisted reason. It
+  contains no credential, RP/origin, session/challenge, auth path/schema, or raw adapter error.
 - Recovery import has no per-call acceptance adapter. Construction composes acceptance from this
   storage and Grant environment, and tests prove current bearer authorization plus SQLite mutation
   visible after reopen.
 
-## Gate record
+## Historical #81 gate record
+
+The following gate record is historical evidence for the original #81 integration. It does not
+prove the later #192 composition or correction claims below.
 
 Base: `066365aa070018f858e4a067191bedd5726a0124` (accepted #80 integration). Candidate:
 `1be460d6749aa98d96189fce88356a83d854ee37`. The correction commit is the commit containing this
@@ -84,3 +98,18 @@ handoff.
 - `git diff --check` — passed.
 
 No Qualification Test and no `bun run check:sqlite-runtime` were run or added for this issue.
+
+## #192 correction gate/evidence
+
+- Base: `051829ed4dbd0c02660031f98fc7380e42b380f1`; final amended correction commit is the
+  current single `HEAD`; branch:
+  `codex/192-compose-technical-admin-restore`.
+- Correction scope: Foundation backup uses a closed Foundation-only relation allowlist and never
+  opens or reads the separate Technical Admin database; restore keeps the sanitized auth store at
+  its live path, with the accepted restart/fresh-sign-in composition preserved.
+- Prior correction evidence: `bun run check` passed; Foundation recovery 14 tests, Technical Admin
+  13 tests, SQLite 21 tests, and acceptance 10 tests passed; both builds and `git diff --check`
+  passed. The focused Grant 35/36 mismatch remains a base-pre-existing fixture/migration issue.
+- This attempt changes only agent/research documentation and the compatibility JSDoc for
+  `failedTechnicalAdminDatabasePath`; no Qualification Test or `bun run check:sqlite-runtime` was
+  run. The amended commit and final check results are recorded in the coordinator handoff.

--- a/docs/research/planned-control-recovery-security-design-audit.md
+++ b/docs/research/planned-control-recovery-security-design-audit.md
@@ -136,18 +136,22 @@ privileged mutation remain fail-closed until the selected recovery authority acc
 Grant recovery and Technical Admin authentication must not be accidentally normalized into one
 generic restore rule:
 
-- a full restore invalidates every Grant Session; affected Grants are reissued, and a stale backup
-  must not silently revive a revoked Grant;
-- Technical Admin WebAuthn state is deliberately restored as ordinary data, including the sole
-  credential, sessions, challenges, enrollment authorizations, logs, and generation marker. Jannis
-  explicitly accepted that a sufficiently recent older snapshot can resurrect authority that had
-  been replaced, revoked, or consumed.
+- a full restore reevaluates each Grant Session against current lifecycle facts: exact-current,
+  pinned, and switchable sessions are preserved, while only sessions whose exact resolved Event
+  Game is terminal for Game Lock or past Game Day are terminated. A stale backup must not silently
+  revive a revoked or terminal authority;
+- Technical Admin authentication remains a separate live store and is never imported from the
+  Foundation snapshot. A normal restore preserves the live, validated, environment/RP-compatible
+  sole credential through the semantic adapter while invalidating sessions, challenges, enrollment
+  authorizations, and fresh-verification state. Missing, invalid, incompatible, or explicitly
+  reset state requires separate re-enrollment; sanitation failure aborts before Foundation
+  replacement.
 
-The second rule is an accepted security exception, not a recommendation to silently “fix” the
-decision. Delivery must name it in restore previews and runbooks, identify the snapshot time and
-restored security-state generation, emit the selected redacted operational evidence, and test the
-resurrection behavior without claiming that ordinary project gates prove it. Production and
-rehearsal remain isolated by database, origin, RP ID, credential, and environment-bound secrets.
+The live-store rule is an explicit ownership boundary, not a generic reset operation. Delivery must
+name the selected auth outcome and any allowlisted re-enrollment reason in redacted restore
+evidence, without exposing credential, RP/origin, session/challenge, path/schema, or raw error
+details. Production and rehearsal remain isolated by database, origin, RP ID, credential, and
+environment-bound secrets.
 [Choose capability grant format, lifecycle, and recovery](https://github.com/netzhuffle/quadball-timer/issues/20#issuecomment-5246643038),
 [Choose durable storage and migration strategy](https://github.com/netzhuffle/quadball-timer/issues/45#issuecomment-5254581794),
 [Define Technical Admin passkey authentication](https://github.com/netzhuffle/quadball-timer/issues/46#issuecomment-5253530941),

--- a/src/lib/ad-hoc-games.focused.ts
+++ b/src/lib/ad-hoc-games.focused.ts
@@ -798,7 +798,15 @@ describe("Ad Hoc SQLite focused integration", () => {
           clock: () => 10,
           interpreter: readinessContext.interpreter,
         },
-        technicalAdminAuth: { databasePath: technicalAdminPath, async quiesce() {} },
+        technicalAdminAuth: {
+          databasePath: technicalAdminPath,
+          async quiesce() {},
+          adapter: {
+            async prepareForFoundationRestore() {
+              return { outcome: "preserved-transients-invalidated" as const };
+            },
+          },
+        },
         nowMs: () => 10,
       };
       let recovery = createFoundationRecovery(foundationStorage, {

--- a/src/lib/foundation-recovery-sqlite.ts
+++ b/src/lib/foundation-recovery-sqlite.ts
@@ -1,12 +1,11 @@
 import { createHash } from "node:crypto";
 import { Database } from "bun:sqlite";
 
-export const FOUNDATION_BACKUP_POLICY_VERSION = "foundation-backup-policy-v1" as const;
+export const FOUNDATION_BACKUP_POLICY_VERSION = "foundation-backup-policy-v2" as const;
 
 export type FoundationBackupPolicy = {
   version: typeof FOUNDATION_BACKUP_POLICY_VERSION;
   includedRelations: readonly string[];
-  excludedRelations: readonly string[];
 };
 
 const INCLUDED_RELATIONS = Object.freeze([
@@ -48,28 +47,15 @@ const INCLUDED_RELATIONS = Object.freeze([
   "foundation_replay_reservations",
 ] as const);
 
-const EXCLUDED_RELATIONS = Object.freeze([
-  "technical_admin_alerts",
-  "technical_admin_challenges",
-  "technical_admin_credentials",
-  "technical_admin_enrollment",
-  "technical_admin_operational_logs",
-  "technical_admin_sessions",
-  "technical_admin_state",
-  "technical_admin_storage_identity",
-] as const);
-
 export const FOUNDATION_BACKUP_POLICY: FoundationBackupPolicy = Object.freeze({
   version: FOUNDATION_BACKUP_POLICY_VERSION,
   includedRelations: INCLUDED_RELATIONS,
-  excludedRelations: EXCLUDED_RELATIONS,
 });
 
 export type RecoverySnapshotFacts = {
   logicalDigest: string;
   actionCount: number;
   grantVersions: readonly { grantId: string; grantType: string; grantVersion: string }[];
-  excludedRelations: readonly string[];
 };
 
 export type RepresentedKeyVersions = {
@@ -96,10 +82,9 @@ export function inspectRecoveryDatabase(
     throw new Error("Unsupported SQLite backup inclusion policy.");
   }
   const included = new Set(policy.includedRelations);
-  const excluded = new Set(policy.excludedRelations);
   const relations = listRelations(database);
   for (const relation of relations) {
-    if (!included.has(relation) && !excluded.has(relation)) {
+    if (!included.has(relation)) {
       throw new FoundationBackupPolicyError(relation);
     }
   }
@@ -133,29 +118,7 @@ export function inspectRecoveryDatabase(
     logicalDigest: logicalDigest.digest("hex"),
     actionCount,
     grantVersions,
-    excludedRelations: relations.filter((relation) => excluded.has(relation)),
   };
-}
-
-export function removeExcludedRelations(
-  database: Database,
-  policy: FoundationBackupPolicy = FOUNDATION_BACKUP_POLICY,
-): void {
-  const facts = inspectRecoveryDatabase(database, policy);
-  database.exec("PRAGMA foreign_keys = OFF; BEGIN IMMEDIATE;");
-  try {
-    for (const relation of facts.excludedRelations) {
-      database.exec(`DROP TABLE ${quoteIdentifier(relation)};`);
-    }
-    database.exec("COMMIT; PRAGMA foreign_keys = ON;");
-  } catch (error) {
-    try {
-      database.exec("ROLLBACK; PRAGMA foreign_keys = ON;");
-    } catch {
-      // The original sanitization failure is the useful boundary.
-    }
-    throw error;
-  }
 }
 
 export function readRepresentedKeyVersions(database: Database): RepresentedKeyVersions {

--- a/src/lib/foundation-recovery.test.ts
+++ b/src/lib/foundation-recovery.test.ts
@@ -31,15 +31,91 @@ import {
 } from "@/lib/ad-hoc-games";
 import { FoundationBackupPolicyError } from "@/lib/foundation-recovery-sqlite";
 import { openSqliteFoundationStorage } from "@/lib/foundation-storage-sqlite";
+import {
+  SqliteTechnicalAdminAuthRepository,
+  createTechnicalAdminAuth,
+  type WebAuthnVerifier,
+} from "@/lib/technical-admin-auth";
 
-const CURRENT_MIGRATION_COUNT = FOUNDATION_MIGRATIONS.length;
 const CURRENT_SCHEMA_VERSION = String(FOUNDATION_MIGRATIONS.at(-1)?.schemaVersion ?? 0);
+const technicalAdminBinding = {
+  origin: "https://localhost:39421",
+  host: "localhost:39421",
+};
+const technicalAdminIdentity = {
+  environment: "test" as const,
+  origin: technicalAdminBinding.origin,
+  rpId: "localhost",
+};
+const validTechnicalAdminPublicKey: JsonWebKey = {
+  kty: "OKP",
+  crv: "Ed25519",
+  x: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+  alg: "EdDSA",
+  ext: true,
+};
+
+function createTechnicalAdminTestVerifier(): WebAuthnVerifier {
+  let signCount = 1;
+  return {
+    async verifyRegistration() {
+      return {
+        credentialId: "credential-1",
+        publicKey: { ...validTechnicalAdminPublicKey },
+        signCount: signCount++,
+      };
+    },
+    async verifyAuthentication() {
+      return { signCount: signCount++ };
+    },
+  };
+}
+
+async function enrollTechnicalAdmin(
+  repository: SqliteTechnicalAdminAuthRepository,
+  now: () => number,
+) {
+  const auth = createTechnicalAdminAuth(
+    technicalAdminIdentity,
+    repository,
+    createTechnicalAdminTestVerifier(),
+    now,
+  );
+  const issued = auth.issueEnrollmentAuthorization();
+  if (!issued.ok) throw new Error("Expected enrollment authorization.");
+  const token = decodeURIComponent(issued.value.url.split("token=")[1] ?? "");
+  const enrollment = auth.beginEnrollment(token, technicalAdminBinding);
+  if (!enrollment.ok) throw new Error("Expected enrollment options.");
+  const completed = await auth.completeEnrollment(
+    enrollment.value.challengeId,
+    {},
+    technicalAdminBinding,
+  );
+  if (!completed.ok) throw new Error("Expected enrollment completion.");
+  const authentication = await auth.beginAuthentication(technicalAdminBinding);
+  if (!authentication.ok) throw new Error("Expected authentication options.");
+  const session = await auth.completeAuthentication(
+    authentication.value.challengeId,
+    {},
+    technicalAdminBinding,
+  );
+  if (!session.ok) throw new Error("Expected authenticated session.");
+  return { auth, session: session.value };
+}
 
 describe("Event foundation recovery", () => {
-  test("sanitizes Technical Admin auth physically and verifies a retained VACUUM snapshot", async () => {
+  test("rejects auth relations in Foundation and leaves the separate auth store untouched", async () => {
     await withRecoveryPaths(async ({ livePath, backupDirectory }) => {
       const harness = await createHarness(livePath, backupDirectory);
-      const canary = "synthetic-passkey-canary-never-in-backup";
+      const technicalAdminPath = harness.options.technicalAdminAuth.databasePath;
+      const authRepository = new SqliteTechnicalAdminAuthRepository(
+        technicalAdminPath,
+        technicalAdminIdentity,
+      );
+      authRepository.issueEnrollment("separate-auth-canary", 61_000);
+      authRepository.close();
+      const authBefore = readFileSync(technicalAdminPath);
+      const authIdentityBefore = lstatSync(technicalAdminPath);
       const injected = new Database(livePath);
       injected.exec(`
         CREATE TABLE technical_admin_credentials (credential_id TEXT PRIMARY KEY, public_key_json TEXT);
@@ -47,38 +123,27 @@ describe("Event foundation recovery", () => {
       `);
       injected
         .query("INSERT INTO technical_admin_credentials VALUES (?, ?)")
-        .run("credential", canary);
+        .run("credential", "synthetic-foundation-auth");
       injected
         .query("INSERT INTO technical_admin_sessions VALUES (?, ?)")
-        .run("session", `${canary}-session`);
+        .run("session", "synthetic-session");
       injected.close();
 
-      const manifest = await harness.recovery.createPreDeploymentBackup();
-      const manifestPath = join(backupDirectory, `${manifest.snapshotId}.manifest.json`);
-      const databasePath = join(backupDirectory, manifest.databaseFile);
-      expect(await harness.recovery.verifyBackup(manifestPath)).toEqual(manifest);
-      const manifestAlias = join(backupDirectory, "manifest-alias.json");
-      await symlink(manifestPath, manifestAlias);
-      expect(harness.recovery.verifyBackup(manifestAlias)).rejects.toThrow();
-      const compactedBytes = readFileSync(databasePath);
-      expect(compactedBytes.includes(Buffer.from(canary))).toBe(false);
-      const verified = new Database(databasePath, { readonly: true });
-      expect(
-        verified
-          .query(
-            "SELECT name FROM sqlite_master WHERE type = 'table' AND name LIKE 'technical_admin_%'",
-          )
-          .all(),
-      ).toEqual([]);
-      expect(
-        verified.query("SELECT COUNT(*) AS count FROM foundation_migration_ledger").get(),
-      ).toEqual({ count: CURRENT_MIGRATION_COUNT });
-      verified.close();
+      expect(harness.recovery.createPreDeploymentBackup()).rejects.toBeInstanceOf(
+        FoundationBackupPolicyError,
+      );
+      expect(existsSync(join(backupDirectory, "recovery-1.sqlite"))).toBe(false);
+      expect(existsSync(join(backupDirectory, "recovery-1.manifest.json"))).toBe(false);
+      expect(readFileSync(technicalAdminPath)).toEqual(authBefore);
+      expect(lstatSync(technicalAdminPath)).toMatchObject({
+        dev: authIdentityBefore.dev,
+        ino: authIdentityBefore.ino,
+      });
       harness.storage.close();
     });
   });
 
-  test("fails closed on an unclassified authority relation and retains the prior verified backup", async () => {
+  test("fails closed on any other authority relation and retains the prior verified backup", async () => {
     await withRecoveryPaths(async ({ livePath, backupDirectory }) => {
       const ids = ["first", "verify-first", "second"];
       const harness = await createHarness(livePath, backupDirectory, () => ids.shift() ?? "extra");
@@ -219,7 +284,7 @@ describe("Event foundation recovery", () => {
     });
   });
 
-  test("stages restore, preserves the failed database, and rolls replacement failures back", async () => {
+  test("stages restore, preserves the failed database, and keeps sanitized auth live", async () => {
     await withRecoveryPaths(async ({ livePath, backupDirectory }) => {
       const ids = ["snapshot", "verify-backup", "verify-before-restore", "restore"];
       const harness = await createHarness(livePath, backupDirectory, () => ids.shift() ?? "extra");
@@ -231,44 +296,42 @@ describe("Event foundation recovery", () => {
         .run("newer-event", "Potentially newer work", "Europe/Zurich", 20, 20);
       live.close();
       const technicalAdminPath = harness.options.technicalAdminAuth.databasePath;
-      const technicalAdmin = new Database(technicalAdminPath, { create: true });
-      technicalAdmin.exec(
-        "CREATE TABLE technical_admin_credentials (credential_id TEXT PRIMARY KEY, public_key_json TEXT);",
+      const repository = new SqliteTechnicalAdminAuthRepository(
+        technicalAdminPath,
+        technicalAdminIdentity,
       );
-      technicalAdmin
-        .query("INSERT INTO technical_admin_credentials VALUES (?, ?)")
-        .run("active-passkey", "must-not-revive");
-      technicalAdmin.close();
-
-      const technicalAdminWalPath = `${technicalAdminPath}-wal`;
-      const technicalAdminShmPath = `${technicalAdminPath}-shm`;
-      const quarantinePath = `${livePath}.quarantine`;
+      const { auth, session } = await enrollTechnicalAdmin(repository, () => 1_000);
+      const pending = await auth.beginAuthentication(technicalAdminBinding);
+      if (!pending.ok) throw new Error("Expected pending authentication challenge.");
+      repository.issueEnrollment("pending-enrollment", 61_000);
+      const credentialBefore = structuredClone(repository.getCredential());
+      const storageIdentityBefore = structuredClone(repository.getStorageIdentity());
+      const authFileBefore = lstatSync(technicalAdminPath);
       const recovery = createFoundationRecovery(harness.storage, {
         ...harness.options,
-        faultInjector(phase) {
-          if (phase !== "after-final-authority-evaluation") return;
-          chmodSync(livePath, 0o644);
-          chmodSync(technicalAdminPath, 0o644);
-          writeFileSync(technicalAdminWalPath, "technical-admin-wal", { mode: 0o644 });
-          writeFileSync(technicalAdminShmPath, "technical-admin-shm", { mode: 0o644 });
-          writeFileSync(quarantinePath, "quarantine", { mode: 0o644 });
+        technicalAdminAuth: {
+          ...harness.options.technicalAdminAuth,
+          adapter: auth,
         },
       });
       const restored = await recovery.restore(manifestPath);
       expect(restored.potentiallyNewerWork).toBe(true);
       expect(existsSync(restored.failedDatabasePath)).toBe(true);
-      expect(existsSync(technicalAdminPath)).toBe(false);
-      expect(restored.failedTechnicalAdminDatabasePath).not.toBeNull();
-      expect(existsSync(restored.failedTechnicalAdminDatabasePath ?? "")).toBe(true);
-      for (const privatePath of [
-        restored.failedDatabasePath,
-        restored.failedTechnicalAdminDatabasePath ?? "",
-        `${restored.failedTechnicalAdminDatabasePath ?? ""}-wal`,
-        `${restored.failedTechnicalAdminDatabasePath ?? ""}-shm`,
-        `${restored.failedDatabasePath}.quarantine`,
-      ]) {
-        expect(lstatSync(privatePath).mode & 0o777).toBe(0o600);
-      }
+      expect(restored.failedTechnicalAdminDatabasePath).toBeNull();
+      expect(existsSync(technicalAdminPath)).toBe(true);
+      expect(lstatSync(technicalAdminPath)).toMatchObject({
+        dev: authFileBefore.dev,
+        ino: authFileBefore.ino,
+      });
+      expect(repository.getCredential()).toEqual(credentialBefore);
+      expect(repository.getStorageIdentity()).toEqual(storageIdentityBefore);
+      expect(auth.authenticateSession(session.token)).toBe(false);
+      expect(auth.verifyCsrf(session.token, session.csrfToken)).toBe(false);
+      expect(auth.resolveCurrentAuthority(session.token)).toBeNull();
+      expect(
+        await auth.completeAuthentication(pending.value.challengeId, {}, technicalAdminBinding),
+      ).toEqual({ ok: false, error: "invalid-ceremony" });
+      expect(lstatSync(restored.failedDatabasePath).mode & 0o777).toBe(0o600);
       expect(existsSync(livePath)).toBe(true);
       const current = new Database(livePath);
       expect(
@@ -295,10 +358,45 @@ describe("Event foundation recovery", () => {
       expect(lstatSync(restored.completionEvidencePath).mode & 0o777).toBe(0o600);
       expect(JSON.parse(readFileSync(restored.completionEvidencePath, "utf8"))).toMatchObject({
         status: "completed",
-        technicalAdminAuthRevived: false,
+        technicalAdminAuth: {
+          outcome: "preserved-transients-invalidated",
+        },
         potentiallyNewerWork: true,
         snapshotAtMs: manifest.snapshotAtMs,
       });
+      expect(
+        JSON.stringify(JSON.parse(readFileSync(restored.completionEvidencePath, "utf8"))),
+      ).not.toMatch(/credential|origin|session|challenge|auth path|schema/i);
+      auth.close();
+      repository.close();
+      harness.storage.close();
+      const restartedRepository = new SqliteTechnicalAdminAuthRepository(
+        technicalAdminPath,
+        technicalAdminIdentity,
+      );
+      const restartedAuth = createTechnicalAdminAuth(
+        technicalAdminIdentity,
+        restartedRepository,
+        createTechnicalAdminTestVerifier(),
+        () => 2_000,
+      );
+      expect(restartedRepository.getCredential()).toEqual(credentialBefore);
+      expect(restartedRepository.getStorageIdentity()).toEqual(storageIdentityBefore);
+      expect(lstatSync(technicalAdminPath)).toMatchObject({
+        dev: authFileBefore.dev,
+        ino: authFileBefore.ino,
+      });
+      const fresh = await restartedAuth.beginAuthentication(technicalAdminBinding);
+      if (!fresh.ok) throw new Error("Expected fresh authentication options after restore.");
+      expect(
+        await restartedAuth.completeAuthentication(
+          fresh.value.challengeId,
+          {},
+          technicalAdminBinding,
+        ),
+      ).toMatchObject({ ok: true });
+      restartedAuth.close();
+      restartedRepository.close();
     });
 
     await withRecoveryPaths(async ({ livePath, backupDirectory }) => {
@@ -307,18 +405,22 @@ describe("Event foundation recovery", () => {
       const manifest = await initial.recovery.createPreDeploymentBackup();
       const manifestPath = join(backupDirectory, `${manifest.snapshotId}.manifest.json`);
       const technicalAdminPath = initial.options.technicalAdminAuth.databasePath;
-      const technicalAdmin = new Database(technicalAdminPath, { create: true });
-      technicalAdmin.exec("CREATE TABLE technical_admin_credentials (credential_id TEXT);");
-      technicalAdmin.close();
+      writeFileSync(technicalAdminPath, "pre-sanitation-auth", { mode: 0o600 });
       const recovery = createFoundationRecovery(initial.storage, {
         ...initial.options,
+        technicalAdminAuth: {
+          ...initial.options.technicalAdminAuth,
+          adapter: {
+            async prepareForFoundationRestore() {
+              writeFileSync(technicalAdminPath, "sanitized-auth", { mode: 0o600 });
+              return { outcome: "preserved-transients-invalidated" as const };
+            },
+          },
+        },
         createId: () => ids.shift() ?? "extra",
         faultInjector(phase) {
           if (phase === "after-final-authority-evaluation") {
             chmodSync(livePath, 0o644);
-            chmodSync(technicalAdminPath, 0o644);
-            writeFileSync(`${technicalAdminPath}-wal`, "rollback-wal", { mode: 0o644 });
-            writeFileSync(`${technicalAdminPath}-shm`, "rollback-shm", { mode: 0o644 });
             writeFileSync(`${livePath}.quarantine`, "rollback-quarantine", { mode: 0o644 });
           }
           if (phase === "before-live-replacement") throw new Error("injected replacement failure");
@@ -327,15 +429,10 @@ describe("Event foundation recovery", () => {
       expect(recovery.restore(manifestPath)).rejects.toThrow("injected replacement failure");
       expect(existsSync(livePath)).toBe(true);
       expect(existsSync(technicalAdminPath)).toBe(true);
-      for (const privatePath of [
-        livePath,
-        technicalAdminPath,
-        `${technicalAdminPath}-wal`,
-        `${technicalAdminPath}-shm`,
-        `${livePath}.quarantine`,
-      ]) {
+      for (const privatePath of [livePath, `${livePath}.quarantine`]) {
         expect(lstatSync(privatePath).mode & 0o777).toBe(0o600);
       }
+      expect(readFileSync(technicalAdminPath, "utf8")).toBe("sanitized-auth");
       await rm(`${livePath}.quarantine`);
       const reopened = openSqliteFoundationStorage(livePath, {
         grantKeyRing: initial.keyRing,
@@ -490,6 +587,170 @@ describe("Event foundation recovery", () => {
       reopened.setReadinessContext(initial.readinessContext);
       expect(await reopened.readiness()).toMatchObject({ ok: true });
       reopened.close();
+    });
+  });
+
+  test("quiesces both stores before invoking the semantic auth adapter", async () => {
+    await withRecoveryPaths(async ({ livePath, backupDirectory }) => {
+      const ids = ["snapshot", "verify-backup", "restore", "verify-restore"];
+      const harness = await createHarness(livePath, backupDirectory, () => ids.shift() ?? "extra");
+      const manifest = await harness.recovery.createPreDeploymentBackup();
+      const events: string[] = [];
+      const recovery = createFoundationRecovery(harness.storage, {
+        ...harness.options,
+        technicalAdminAuth: {
+          ...harness.options.technicalAdminAuth,
+          async quiesce() {
+            events.push("technical-admin-quiesced");
+          },
+          adapter: {
+            async prepareForFoundationRestore(request) {
+              events.push("auth:" + request.mode);
+              return { outcome: "preserved-transients-invalidated" as const };
+            },
+          },
+        },
+        faultInjector(phase) {
+          if (phase === "after-authoritative-quiescence") events.push("foundation-quiesced");
+          if (phase === "before-live-replacement") events.push("before-replacement");
+        },
+      });
+
+      await recovery.restore(join(backupDirectory, manifest.snapshotId + ".manifest.json"));
+      expect(events).toEqual([
+        "technical-admin-quiesced",
+        "foundation-quiesced",
+        "auth:preserve-compatible-credential",
+        "before-replacement",
+      ]);
+      harness.storage.close();
+    });
+  });
+
+  test("records exceptional re-enrollment separately from a successful Foundation restore", async () => {
+    await withRecoveryPaths(async ({ livePath, backupDirectory }) => {
+      const ids = ["snapshot", "verify-backup", "restore", "verify-restore"];
+      const harness = await createHarness(livePath, backupDirectory, () => ids.shift() ?? "extra");
+      const manifest = await harness.recovery.createPreDeploymentBackup();
+      let requestedMode: string | null = null;
+      const recovery = createFoundationRecovery(harness.storage, {
+        ...harness.options,
+        technicalAdminAuth: {
+          ...harness.options.technicalAdminAuth,
+          adapter: {
+            async prepareForFoundationRestore(request) {
+              requestedMode = request.mode;
+              return { outcome: "re-enrollment-required", reason: "explicit-reset" as const };
+            },
+          },
+        },
+      });
+
+      const restored = await recovery.restore(
+        join(backupDirectory, manifest.snapshotId + ".manifest.json"),
+        { technicalAdminAuthMode: "explicit-reset" },
+      );
+      if (requestedMode !== "explicit-reset") {
+        throw new Error("Foundation did not pass the explicit-reset mode to the auth adapter.");
+      }
+      if (restored.completionEvidencePath === null) {
+        throw new Error("Expected completed restore evidence.");
+      }
+      expect(JSON.parse(readFileSync(restored.completionEvidencePath, "utf8"))).toMatchObject({
+        status: "completed",
+        technicalAdminAuth: {
+          outcome: "re-enrollment-required",
+          reason: "explicit-reset",
+        },
+      });
+      harness.storage.close();
+    });
+  });
+
+  test("aborts before Foundation replacement on auth sanitation failure with bounded evidence", async () => {
+    await withRecoveryPaths(async ({ livePath, backupDirectory }) => {
+      const ids = ["snapshot", "verify-backup", "restore", "verify-restore"];
+      const harness = await createHarness(livePath, backupDirectory, () => ids.shift() ?? "extra");
+      const manifest = await harness.recovery.createPreDeploymentBackup();
+      let replacementAttempted = false;
+      const recovery = createFoundationRecovery(harness.storage, {
+        ...harness.options,
+        technicalAdminAuth: {
+          ...harness.options.technicalAdminAuth,
+          adapter: {
+            async prepareForFoundationRestore() {
+              return { outcome: "sanitation-failed" as const };
+            },
+          },
+        },
+        faultInjector(phase) {
+          if (phase === "before-live-replacement") replacementAttempted = true;
+        },
+      });
+
+      const sanitationFailure = await recovery
+        .restore(join(backupDirectory, manifest.snapshotId + ".manifest.json"))
+        .then(
+          () => null,
+          (error: unknown) => error,
+        );
+      if (!(sanitationFailure instanceof Error)) {
+        throw new Error("Expected auth sanitation to abort the restore.");
+      }
+      expect(sanitationFailure.message).toContain("sanitation failed before replacement");
+      expect(replacementAttempted).toBe(false);
+      expect(existsSync(livePath + ".failed-restore")).toBe(false);
+      const evidence = JSON.parse(
+        readFileSync(join(backupDirectory, "restore.restore-evidence.json"), "utf8"),
+      );
+      expect(evidence).toMatchObject({
+        status: "aborted-auth-sanitation",
+        technicalAdminAuth: { outcome: "sanitation-failed" },
+      });
+      expect(JSON.stringify(evidence)).not.toMatch(/credential|origin|session|schema|path/i);
+      harness.storage.close();
+    });
+  });
+
+  test("Foundation rollback never restores pre-sanitation Technical Admin transients", async () => {
+    await withRecoveryPaths(async ({ livePath, backupDirectory }) => {
+      const ids = ["snapshot", "verify-backup", "restore", "verify-restore"];
+      const harness = await createHarness(livePath, backupDirectory, () => ids.shift() ?? "extra");
+      const manifest = await harness.recovery.createPreDeploymentBackup();
+      const technicalAdminPath = harness.options.technicalAdminAuth.databasePath;
+      writeFileSync(technicalAdminPath, "pre-sanitation-transients", { mode: 0o600 });
+      const recovery = createFoundationRecovery(harness.storage, {
+        ...harness.options,
+        technicalAdminAuth: {
+          ...harness.options.technicalAdminAuth,
+          adapter: {
+            async prepareForFoundationRestore() {
+              writeFileSync(technicalAdminPath, "preserved-credential-no-transients", {
+                mode: 0o600,
+              });
+              return { outcome: "preserved-transients-invalidated" as const };
+            },
+          },
+        },
+        faultInjector(phase) {
+          if (phase === "before-live-replacement") {
+            throw new Error("injected Foundation replacement failure");
+          }
+        },
+      });
+
+      const replacementFailure = await recovery
+        .restore(join(backupDirectory, manifest.snapshotId + ".manifest.json"))
+        .then(
+          () => null,
+          (error: unknown) => error,
+        );
+      if (!(replacementFailure instanceof Error)) {
+        throw new Error("Expected Foundation replacement to fail.");
+      }
+      expect(replacementFailure.message).toContain("injected Foundation replacement failure");
+      expect(readFileSync(technicalAdminPath, "utf8")).toBe("preserved-credential-no-transients");
+      harness.storage.close();
     });
   });
 
@@ -724,6 +985,11 @@ describe("Event foundation recovery", () => {
         technicalAdminAuth: {
           databasePath: join(dirname(livePath), "technical-admin.sqlite"),
           async quiesce() {},
+          adapter: {
+            async prepareForFoundationRestore() {
+              return { outcome: "preserved-transients-invalidated" as const };
+            },
+          },
         },
         nowMs: () => now,
         faultInjector(phase) {
@@ -1213,6 +1479,11 @@ async function createHarness(
     technicalAdminAuth: {
       databasePath: join(dirname(livePath), "technical-admin.sqlite"),
       async quiesce() {},
+      adapter: {
+        async prepareForFoundationRestore() {
+          return { outcome: "preserved-transients-invalidated" as const };
+        },
+      },
     },
     nowMs: () => 10,
     createId,

--- a/src/lib/foundation-recovery.ts
+++ b/src/lib/foundation-recovery.ts
@@ -43,11 +43,15 @@ import {
 import type { FoundationStorageReadinessContext } from "@/lib/foundation-storage";
 import type { FoundationStorageTransaction } from "@/lib/foundation-storage";
 import type { AdHocRecoveryAdapter, AdHocRecoveryFacts } from "@/lib/ad-hoc-games";
+import type {
+  TechnicalAdminAuth,
+  TechnicalAdminRestorePreparationRequest,
+  TechnicalAdminRestorePreparationResult,
+} from "@/lib/technical-admin-auth";
 import {
   FOUNDATION_BACKUP_POLICY_VERSION,
   inspectRecoveryDatabase,
   readRepresentedKeyVersions,
-  removeExcludedRelations,
   quoteRecoverySqliteString,
   type RepresentedKeyVersions,
   type RecoverySnapshotFacts,
@@ -72,7 +76,6 @@ export type FoundationRecoveryManifest = {
     grantType: string;
     grantVersion: string;
   }[];
-  excludedRelations: readonly string[];
   adHoc?: {
     databaseFile: string;
     databaseSha256: string;
@@ -89,10 +92,12 @@ export type FoundationRecoveryOptions = {
   /** Composed once against this recovery's storage and Grant environment. */
   acceptance: Omit<FoundationAcceptanceOptions, "grant">;
   technicalAdminAuth: {
-    /** Separate Technical Admin auth database; it is preserved but never restored as active. */
+    /** Separate Technical Admin auth database; it is preserved but never restored from Foundation. */
     databasePath: string;
-    /** Stops new auth writes and drains/closes the repository before replacement. */
+    /** Stops new auth writes and drains the auth store before semantic restore preparation. */
     quiesce(): Promise<void>;
+    /** The sole semantic auth boundary consumed by Foundation recovery. */
+    adapter: Pick<TechnicalAdminAuth, "prepareForFoundationRestore">;
   };
   /** Optional Ad Hoc database included in the same staged recovery boundary. */
   adHoc?: AdHocRecoveryAdapter;
@@ -101,7 +106,7 @@ export type FoundationRecoveryOptions = {
   faultInjector?: (
     phase:
       | "after-vacuum"
-      | "after-sanitize"
+      | "after-compaction"
       | "after-verification"
       | "after-restore-staging"
       | "after-authoritative-quiescence"
@@ -137,9 +142,16 @@ export type RecoveryImportInput = {
 export type FoundationRecovery = {
   createPreDeploymentBackup(): Promise<FoundationRecoveryManifest>;
   verifyBackup(manifestPath: string): Promise<FoundationRecoveryManifest>;
-  restore(manifestPath: string): Promise<{
+  restore(
+    manifestPath: string,
+    options?: FoundationRestoreOptions,
+  ): Promise<{
     restoreId: string;
     failedDatabasePath: string;
+    /**
+     * @deprecated Compatibility-only field. Policy A never moves the separate Technical Admin
+     * store and always returns null.
+     */
     failedTechnicalAdminDatabasePath: string | null;
     failedAdHocDatabasePath: string | null;
     completed: true;
@@ -151,6 +163,10 @@ export type FoundationRecovery = {
   importControllerRecovery(
     input: RecoveryImportInput,
   ): Promise<{ outcome: FoundationBatchOutcome; evidencePath: string }>;
+};
+
+export type FoundationRestoreOptions = {
+  technicalAdminAuthMode?: TechnicalAdminRestorePreparationRequest["mode"];
 };
 
 export function createFoundationRecovery(
@@ -195,7 +211,7 @@ export function createFoundationRecovery(
     let completed = false;
     try {
       await assertPathAbsent(rawPath, "raw recovery snapshot");
-      await assertPathAbsent(stagedPath, "sanitized recovery snapshot");
+      await assertPathAbsent(stagedPath, "compacted recovery snapshot");
       await assertPathAbsent(databasePath, "verified recovery snapshot");
       await assertPathAbsent(manifestPath, "recovery manifest");
       if (options.adHoc !== undefined) {
@@ -207,14 +223,13 @@ export function createFoundationRecovery(
       options.faultInjector?.("after-vacuum");
       const raw = new Database(rawPath);
       try {
-        removeExcludedRelations(raw);
         raw.exec(`VACUUM INTO ${quoteRecoverySqliteString(stagedPath)};`);
       } finally {
         raw.close();
       }
       await chmod(stagedPath, 0o600);
-      options.faultInjector?.("after-sanitize");
-      stagedIdentity = await assertOwnedPrivateFile(stagedPath, "sanitized recovery snapshot");
+      options.faultInjector?.("after-compaction");
+      stagedIdentity = await assertOwnedPrivateFile(stagedPath, "compacted recovery snapshot");
       const verified = await verifyDatabase(stagedPath, sourceFacts);
       options.faultInjector?.("after-verification");
       if (options.adHoc !== undefined) {
@@ -239,7 +254,6 @@ export function createFoundationRecovery(
         actionCount: verified.facts.actionCount,
         representedKeyVersions: verified.keyVersions,
         restoredGrantVersions: redactGrantVersions(verified.facts),
-        excludedRelations: sourceFacts.excludedRelations,
         ...(options.adHoc === undefined || adHocFacts === null
           ? {}
           : {
@@ -297,7 +311,6 @@ export function createFoundationRecovery(
         logicalDigest: manifest.logicalDigest,
         actionCount: manifest.actionCount,
         grantVersions: [],
-        excludedRelations: manifest.excludedRelations,
       });
       if (
         JSON.stringify(verified.keyVersions) !== JSON.stringify(manifest.representedKeyVersions)
@@ -327,14 +340,13 @@ export function createFoundationRecovery(
     }
   }
 
-  async function restore(manifestPath: string) {
+  async function restore(manifestPath: string, restoreOptions: FoundationRestoreOptions = {}) {
     await prepareBackupWorkspace(liveDirectory, backupDirectory);
     const manifest = await readManifest(manifestPath, backupDirectory);
     const backupPath = resolveBackupDatabasePath(manifestPath, manifest, backupDirectory);
     const restoreId = boundedId(createId(), "restoreId");
     const stagedPath = join(liveDirectory, `.${basename(livePath)}.${restoreId}.staged`);
     const failedDatabasePath = `${livePath}.failed-${restoreId}`;
-    const failedTechnicalAdminDatabasePath = `${technicalAdminPath}.failed-${restoreId}`;
     const adHocLivePath = options.adHoc?.databasePath ?? null;
     const stagedAdHocPath =
       adHocLivePath === null
@@ -353,7 +365,6 @@ export function createFoundationRecovery(
     let evidenceIdentity: StableFileIdentity | null = null;
     try {
       await assertPathAbsent(failedDatabasePath, "failed Event foundation image");
-      await assertPathAbsent(failedTechnicalAdminDatabasePath, "failed Technical Admin image");
       if (failedAdHocDatabasePath !== null)
         await assertPathAbsent(failedAdHocDatabasePath, "failed Ad Hoc image");
       await assertPathAbsent(evidencePath, "restore evidence");
@@ -363,7 +374,6 @@ export function createFoundationRecovery(
         logicalDigest: manifest.logicalDigest,
         actionCount: manifest.actionCount,
         grantVersions: [],
-        excludedRelations: manifest.excludedRelations,
       });
       if (
         JSON.stringify(verified.keyVersions) !== JSON.stringify(manifest.representedKeyVersions)
@@ -396,7 +406,6 @@ export function createFoundationRecovery(
         snapshotId: manifest.snapshotId,
         snapshotAtMs: manifest.snapshotAtMs,
         snapshotActionCount: manifest.actionCount,
-        technicalAdminAuthRevived: false,
         restoredGrantVersions: manifest.restoredGrantVersions,
       });
 
@@ -407,6 +416,51 @@ export function createFoundationRecovery(
       await storage.quiesceForRecovery();
       await options.adHoc?.quiesceForRecovery();
       options.faultInjector?.("after-authoritative-quiescence");
+
+      const technicalAdminAuthResult = await prepareTechnicalAdminForRestore(
+        options.technicalAdminAuth.adapter,
+        restoreOptions.technicalAdminAuthMode ?? "preserve-compatible-credential",
+      );
+      const technicalAdminAuthEvidence =
+        redactTechnicalAdminRestoreResult(technicalAdminAuthResult);
+      if (technicalAdminAuthResult.outcome === "sanitation-failed") {
+        evidenceIdentity = await writeJsonFile(
+          evidencePath,
+          {
+            version: RECOVERY_EVIDENCE_VERSION,
+            kind: "restore",
+            status: "aborted-auth-sanitation",
+            restoreId,
+            snapshotId: manifest.snapshotId,
+            snapshotAtMs: manifest.snapshotAtMs,
+            snapshotActionCount: manifest.actionCount,
+            technicalAdminAuth: technicalAdminAuthEvidence,
+            restoredGrantVersions: manifest.restoredGrantVersions,
+          },
+          "replace-owned",
+          evidenceIdentity,
+        );
+        throw new Error("Technical Admin authentication sanitation failed before replacement.");
+      }
+      // The finite auth result is committed to the pending record before any
+      // Foundation replacement. A later replacement rollback changes only
+      // Foundation state and leaves the already-sanitized auth store untouched.
+      evidenceIdentity = await writeJsonFile(
+        evidencePath,
+        {
+          version: RECOVERY_EVIDENCE_VERSION,
+          kind: "restore",
+          status: "pending-replacement",
+          restoreId,
+          snapshotId: manifest.snapshotId,
+          snapshotAtMs: manifest.snapshotAtMs,
+          snapshotActionCount: manifest.actionCount,
+          technicalAdminAuth: technicalAdminAuthEvidence,
+          restoredGrantVersions: manifest.restoredGrantVersions,
+        },
+        "replace-owned",
+        evidenceIdentity,
+      );
 
       await assertStablePrivateFile(
         stagedPath,
@@ -428,7 +482,6 @@ export function createFoundationRecovery(
       }
       await staged.quiesceForRecovery();
       staged = undefined;
-      assertNoTechnicalAdminRelations(stagedPath);
       const reevaluatedStagedIdentity = await assertOwnedPrivateFile(
         stagedPath,
         "verified restore staging image",
@@ -487,33 +540,8 @@ export function createFoundationRecovery(
           );
           movedSidecars.push({ from: failed, to: source, identity: failedIdentity });
         }
-        if (await pathExists(technicalAdminPath)) {
-          const technicalAdminIdentity = stableIdentity(await lstat(technicalAdminPath));
-          const failedIdentity = await moveToExclusivePath(
-            technicalAdminPath,
-            failedTechnicalAdminDatabasePath,
-            "failed Technical Admin image",
-            technicalAdminIdentity,
-          );
-          movedSidecars.push({
-            from: failedTechnicalAdminDatabasePath,
-            to: technicalAdminPath,
-            identity: failedIdentity,
-          });
-        }
-        for (const suffix of ["-wal", "-shm"] as const) {
-          const source = `${technicalAdminPath}${suffix}`;
-          if (!(await pathExists(source))) continue;
-          const failed = `${failedTechnicalAdminDatabasePath}${suffix}`;
-          const sourceIdentity = stableIdentity(await lstat(source));
-          const failedIdentity = await moveToExclusivePath(
-            source,
-            failed,
-            "failed Technical Admin sidecar",
-            sourceIdentity,
-          );
-          movedSidecars.push({ from: failed, to: source, identity: failedIdentity });
-        }
+        // Policy A keeps the already-sanitized Technical Admin store at its live
+        // path. Foundation replacement must not displace or reopen that store.
         if (
           manifest.adHoc !== undefined &&
           adHocLivePath !== null &&
@@ -607,9 +635,6 @@ export function createFoundationRecovery(
           }
         }
         await syncDirectory(liveDirectory);
-        if (dirname(technicalAdminPath) !== liveDirectory) {
-          await syncDirectory(dirname(technicalAdminPath));
-        }
         if (adHocLivePath !== null && dirname(adHocLivePath) !== liveDirectory) {
           await syncDirectory(dirname(adHocLivePath));
         }
@@ -626,9 +651,6 @@ export function createFoundationRecovery(
             );
         }
         await syncDirectory(liveDirectory);
-        if (dirname(technicalAdminPath) !== liveDirectory) {
-          await syncDirectory(dirname(technicalAdminPath));
-        }
         if (adHocLivePath !== null && dirname(adHocLivePath) !== liveDirectory) {
           await syncDirectory(dirname(adHocLivePath));
         }
@@ -660,14 +682,11 @@ export function createFoundationRecovery(
                 restoredLogicalDigest: restoredAdHocFacts?.logicalDigest ?? null,
               },
         failedDatabasePath,
-        failedTechnicalAdminDatabasePath: (await pathExists(failedTechnicalAdminDatabasePath))
-          ? failedTechnicalAdminDatabasePath
-          : null,
         failedAdHocDatabasePath:
           failedAdHocDatabasePath !== null && (await pathExists(failedAdHocDatabasePath))
             ? failedAdHocDatabasePath
             : null,
-        technicalAdminAuthRevived: false,
+        technicalAdminAuth: technicalAdminAuthEvidence,
         restoredGrantVersions:
           restoredFacts === null
             ? manifest.restoredGrantVersions
@@ -689,9 +708,7 @@ export function createFoundationRecovery(
       return {
         restoreId,
         failedDatabasePath,
-        failedTechnicalAdminDatabasePath: (await pathExists(failedTechnicalAdminDatabasePath))
-          ? failedTechnicalAdminDatabasePath
-          : null,
+        failedTechnicalAdminDatabasePath: null,
         failedAdHocDatabasePath:
           failedAdHocDatabasePath !== null && (await pathExists(failedAdHocDatabasePath))
             ? failedAdHocDatabasePath
@@ -797,7 +814,6 @@ export function createFoundationRecovery(
     const verificationIdentity = await copyStablePrivateFile(databasePath, verificationPath);
     let verifier: SqliteFoundationStorage | undefined;
     try {
-      assertNoTechnicalAdminRelations(verificationPath);
       const inspection = new Database(verificationPath, { readonly: true });
       let facts: RecoverySnapshotFacts;
       let keyVersions: RepresentedKeyVersions;
@@ -839,6 +855,38 @@ export function createFoundationRecovery(
   }
 
   return { createPreDeploymentBackup, verifyBackup, restore, importControllerRecovery };
+}
+
+async function prepareTechnicalAdminForRestore(
+  adapter: Pick<TechnicalAdminAuth, "prepareForFoundationRestore">,
+  mode: TechnicalAdminRestorePreparationRequest["mode"],
+): Promise<TechnicalAdminRestorePreparationResult> {
+  try {
+    const result = await adapter.prepareForFoundationRestore({ mode });
+    if (result.outcome === "preserved-transients-invalidated") {
+      return result;
+    }
+    if (
+      result.outcome === "re-enrollment-required" &&
+      (result.reason === "missing" ||
+        result.reason === "invalid" ||
+        result.reason === "incompatible" ||
+        result.reason === "explicit-reset")
+    ) {
+      return result;
+    }
+  } catch {
+    // The composition boundary deliberately exposes no adapter or storage error.
+  }
+  return { outcome: "sanitation-failed" };
+}
+
+function redactTechnicalAdminRestoreResult(
+  result: TechnicalAdminRestorePreparationResult,
+): TechnicalAdminRestorePreparationResult {
+  return result.outcome === "re-enrollment-required"
+    ? { outcome: result.outcome, reason: result.reason }
+    : { outcome: result.outcome };
 }
 
 async function reevaluateRestoredAuthority(
@@ -1042,18 +1090,6 @@ function requireRepresentedKeys(versions: RepresentedKeyVersions, keyRing: Grant
         );
       }
     }
-  }
-}
-
-function assertNoTechnicalAdminRelations(databasePath: string): void {
-  const database = new Database(databasePath, { readonly: true });
-  try {
-    const facts = inspectRecoveryDatabase(database);
-    if (facts.excludedRelations.length !== 0) {
-      throw new Error("Technical Admin authentication state survived backup sanitization.");
-    }
-  } finally {
-    database.close();
   }
 }
 

--- a/src/lib/foundation-storage-sqlite.ts
+++ b/src/lib/foundation-storage-sqlite.ts
@@ -933,7 +933,7 @@ export class SqliteFoundationStorage implements FoundationStorage {
         process.umask(previousUmask);
       }
       // The destination lives in the recovery-owned 0700 workspace. Tighten
-      // and verify the raw unsanitized image before yielding the writer queue.
+      // and verify the raw Foundation image before yielding the writer queue.
       chmodSync(destinationPath, 0o600);
       return facts;
     });


### PR DESCRIPTION
## What changed

- compose Foundation restore with the #193 Technical Admin restore-preparation adapter
- preserve the validated live credential and storage identity while invalidating transient browser authority
- keep Foundation backup structurally separate through a closed Foundation-only relation allowlist
- reject unexpected authentication or unclassified relations before snapshot creation
- document the Policy A restore decision and corrected recovery lifecycle

## Why

Foundation restore must never restore Technical Admin authentication from a snapshot. A normal restore should retain the current validated Passkey, require fresh sign-in, and fail closed before Foundation replacement when authentication sanitation cannot commit.

## Impact

Operators keep the same compatible Passkey after a normal Foundation restore. Existing sessions, challenges, enrollment authorization, CSRF and fresh-verification authority are invalidated. Missing, invalid, incompatible, or explicitly reset authentication state is reported through the finite re-enrollment outcome.

## Validation

- `bun install --frozen-lockfile`
- `bun audit`
- `bun run check`
- `bun run test` — 707 passed
- Foundation recovery — 14 passed
- focused Technical Admin — 13 passed
- focused SQLite — 21 passed
- focused acceptance — 10 passed
- `bun run build`
- `bun run build:executable`
- `git diff --check`

The focused Grant suite retains one base-pre-existing migration-fixture mismatch (35/36); this change does not modify that fixture or migration ledger. No Qualification Test or `bun run check:sqlite-runtime` was run.

Closes #192
