### PR TITLE
Fix late Docker create cleanup for #179

### DIFF
--- a/scripts/test-focused-admission.ts
+++ b/scripts/test-focused-admission.ts
@@ -6,9 +6,12 @@ import {
   cleanupOwnedDockerContainer,
   parseContainerId,
   DockerAdmissionError,
+  SQLITE_FOUNDATION_PROBE_DOCKER_FINAL_CLEANUP_SLICE_MS,
   runDockerCommand,
+  SQLITE_FOUNDATION_PROBE_DOCKER_CREATE_RECONCILIATION_MS,
   verifyDockerContainerConfiguration,
   type DockerAdmissionDisposition,
+  type DockerProbeLifecycle,
 } from "@/lib/sqlite-foundation-probe-docker";
 import {
   focusedAdmissionExitCode,
@@ -37,9 +40,23 @@ let descendantsTerminated: boolean | null = null;
 let descendantsReaped = false;
 let temporaryDataRemoved = false;
 const workAbort = new AbortController();
+const admissionAbort = new AbortController();
+const reconciliationAbort = new AbortController();
 const hardAbort = new AbortController();
 const workTimer = setTimeout(() => workAbort.abort(), 3_000);
+const admissionTimer = setTimeout(
+  () => admissionAbort.abort(),
+  3_000 + SQLITE_FOUNDATION_PROBE_DOCKER_CREATE_RECONCILIATION_MS,
+);
+const reconciliationTimer = setTimeout(
+  () => reconciliationAbort.abort(),
+  5_000 - SQLITE_FOUNDATION_PROBE_DOCKER_FINAL_CLEANUP_SLICE_MS,
+);
 const hardTimer = setTimeout(() => hardAbort.abort(), 5_000);
+const abortAdmissionAtHardDeadline = () => admissionAbort.abort();
+hardAbort.signal.addEventListener("abort", abortAdmissionAtHardDeadline, { once: true });
+const abortReconciliationAtHardDeadline = () => reconciliationAbort.abort();
+hardAbort.signal.addEventListener("abort", abortReconciliationAtHardDeadline, { once: true });
 let execution: Awaited<ReturnType<typeof createHarmlessExecution>> | undefined;
 
 try {
@@ -49,12 +66,12 @@ try {
   const command = buildFocusedDockerCommand(`quadball-timer-focused-${invocationId}`, invocationId);
   if (command.includes("--sqlite-foundation-probe"))
     throw new Error("focused command contains the qualification workload");
-  execution = await createHarmlessExecution(
-    command,
-    invocationId,
-    workAbort.signal,
-    hardAbort.signal,
-  );
+  execution = await createHarmlessExecution(command, invocationId, {
+    workSignal: workAbort.signal,
+    admissionSignal: admissionAbort.signal,
+    reconciliationSignal: reconciliationAbort.signal,
+    cleanupSignal: hardAbort.signal,
+  });
   workloadLaunched = true;
   const result = await execution.run();
   if (result.exitCode !== 0) throw new Error("Docker containment helper failed");
@@ -64,6 +81,10 @@ try {
   else if (error instanceof FocusedAdmissionError) {
     errorReference = error.name;
     temporaryDataRemoved = error.disposition !== "unverified";
+    if (error.disposition === "removed") {
+      identityVerified = true;
+      containerRemoved = true;
+    }
   } else errorReference = error instanceof Error ? error.name : "UnknownError";
   outcome = engine === null ? "blocked" : "failed";
 } finally {
@@ -93,7 +114,13 @@ try {
     }
   }
   clearTimeout(workTimer);
+  clearTimeout(admissionTimer);
+  clearTimeout(reconciliationTimer);
   clearTimeout(hardTimer);
+  hardAbort.signal.removeEventListener("abort", abortAdmissionAtHardDeadline);
+  hardAbort.signal.removeEventListener("abort", abortReconciliationAtHardDeadline);
+  admissionAbort.abort();
+  reconciliationAbort.abort();
 }
 
 const evidence = {
@@ -124,17 +151,20 @@ process.exitCode = focusedAdmissionExitCode(outcome);
 async function createHarmlessExecution(
   command: string[],
   capability: string,
-  workSignal: AbortSignal,
-  cleanupSignal: AbortSignal,
+  lifecycle: DockerProbeLifecycle,
 ) {
   const name = command[command.indexOf("--name") + 1] ?? `quadball-timer-focused-${capability}`;
-  const create = await runDockerCommand(command, { signal: workSignal }).catch(() => null);
+  // Allow only the short admission grace after the work deadline; cleanup keeps
+  // the remaining reserve for exact ownership and absence proof.
+  const create = await runDockerCommand(command, { signal: lifecycle.admissionSignal }).catch(
+    () => null,
+  );
   if (create === null || create.exitCode !== 0 || create.outputExceeded) {
     const cleanupDisposition = await cleanupMalformedCreateOutput(
       runDockerCommand,
       name,
       capability,
-      cleanupSignal,
+      lifecycle,
     );
     throw new FocusedAdmissionError(
       "Docker could not create focused container",
@@ -147,7 +177,7 @@ async function createHarmlessExecution(
       runDockerCommand,
       name,
       capability,
-      cleanupSignal,
+      lifecycle,
     );
     throw new FocusedAdmissionError(
       "Docker returned an invalid focused container identity",
@@ -157,7 +187,7 @@ async function createHarmlessExecution(
   const admitted = await verifyDockerContainerConfiguration(
     runDockerCommand,
     { id, name, capability },
-    workSignal,
+    lifecycle.admissionSignal,
     null,
   );
   if (!admitted) {
@@ -165,7 +195,7 @@ async function createHarmlessExecution(
       runDockerCommand,
       name,
       capability,
-      cleanupSignal,
+      lifecycle,
     );
     throw new FocusedAdmissionError(
       "Docker focused containment configuration could not be verified",
@@ -176,14 +206,16 @@ async function createHarmlessExecution(
   const execution = {
     container: { id, name, capability, artifactPath: "", identityVerified: false },
     async run() {
-      const start = await runDockerCommand(["start", id], { signal: workSignal });
+      const start = await runDockerCommand(["start", id], { signal: lifecycle.workSignal });
       if (start.exitCode !== 0) throw new Error("Docker could not start focused container");
       await Bun.sleep(25);
-      const stop = await runDockerCommand(["stop", "--time", "1", id], { signal: workSignal });
+      const stop = await runDockerCommand(["stop", "--time", "1", id], {
+        signal: lifecycle.workSignal,
+      });
       if (stop.exitCode !== 0) {
-        await runDockerCommand(["kill", id], { signal: workSignal });
+        await runDockerCommand(["kill", id], { signal: lifecycle.workSignal });
       }
-      const wait = await runDockerCommand(["wait", id], { signal: workSignal });
+      const wait = await runDockerCommand(["wait", id], { signal: lifecycle.workSignal });
       parseFocusedWaitExitCode(wait);
       stopVerified = true;
       return {
@@ -210,7 +242,7 @@ async function createHarmlessExecution(
       const cleanup = await cleanupOwnedDockerContainer(
         runDockerCommand,
         { id, name, capability },
-        cleanupSignal,
+        lifecycle.cleanupSignal,
       );
       if (!cleanup.identityVerified) throw new Error("focused container ownership failed");
       return {

--- a/src/lib/sqlite-foundation-probe-docker.test.ts
+++ b/src/lib/sqlite-foundation-probe-docker.test.ts
@@ -22,6 +22,31 @@ import {
 const capability = "00000000-0000-0000-0000-000000000000";
 const containerId = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 
+function cleanupLifecycle(reconciliationMs = 40) {
+  const reconciliation = new AbortController();
+  const cleanupTimer = setTimeout(() => reconciliation.abort(), reconciliationMs);
+  return {
+    cleanupSignal: new AbortController().signal,
+    reconciliationSignal: reconciliation.signal,
+    cleanupTimer,
+  };
+}
+
+function dockerResult(stdout = "", exitCode = 0) {
+  return {
+    exitCode,
+    stdout,
+    stderr: "",
+    stdoutBytes: stdout.length,
+    stderrBytes: 0,
+    outputExceeded: false,
+  };
+}
+
+function emptyDockerResult() {
+  return dockerResult();
+}
+
 function admittedContainerInspection(artifactPath: string): string {
   return JSON.stringify({
     Id: containerId,
@@ -223,6 +248,10 @@ describe("Docker SQLite qualification boundary", () => {
   test("fails the start barrier before the artifact can run", async () => {
     const artifactPath = await realpath("/bin/sh");
     const calls: string[][] = [];
+    const workSignal = new AbortController().signal;
+    const admissionSignal = new AbortController().signal;
+    const cleanupSignal = new AbortController().signal;
+    let createSignal: AbortSignal | undefined;
     const responses = [
       { exitCode: 0, stdout: JSON.stringify({ OSType: "linux", Architecture: "x86_64" }) },
       { exitCode: 0, stdout: JSON.stringify({ Os: "linux", Arch: "amd64" }) },
@@ -243,8 +272,12 @@ describe("Docker SQLite qualification boundary", () => {
       platform: "linux",
       architecture: "x64",
       invocationId: capability,
-      runCommand: async (arguments_) => {
+      signal: workSignal,
+      admissionSignal,
+      cleanupSignal,
+      runCommand: async (arguments_, options) => {
         calls.push([...arguments_]);
+        if (arguments_[0] === "create") createSignal = options?.signal;
         const response = responses.shift();
         if (response === undefined) throw new Error("unexpected Docker command");
         return {
@@ -269,6 +302,7 @@ describe("Docker SQLite qualification boundary", () => {
     ]);
     expect(calls[2]).toContain(`type=bind,src=${artifactPath},dst=/opt/quadball-timer,readonly`);
     expect(calls.map((value) => value[0])).not.toContain("start");
+    expect(createSignal).toBe(admissionSignal);
   });
 
   test("uses production stop, kill, wait, removal, and exact absence in order", async () => {
@@ -665,6 +699,7 @@ describe("Docker SQLite qualification boundary", () => {
       { exitCode: 0, stdout: JSON.stringify({ Os: "linux", Arch: "amd64" }) },
       { exitCode: 0, stdout: "" },
       { exitCode: 0, stdout: `${executionId}\n` },
+      { exitCode: 0, stdout: `${executionId}\n` },
       {
         exitCode: 0,
         stdout: JSON.stringify({
@@ -700,10 +735,297 @@ describe("Docker SQLite qualification boundary", () => {
       "version",
       "create",
       "ps",
+      "ps",
       "inspect",
       "rm",
       "ps",
     ]);
+  });
+
+  test("reconciles a focused-style late create after the first absence observation", async () => {
+    const name = `quadball-timer-focused-${capability}`;
+    const calls: string[] = [];
+    const responses = [
+      { stdout: "" },
+      { stdout: "" },
+      { stdout: `${containerId}\n` },
+      { stdout: "" },
+      { stdout: `${containerId}\n` },
+      { stdout: `${containerId}\n` },
+      {
+        stdout: JSON.stringify({
+          Id: containerId,
+          Name: `/${name}`,
+          Config: { Labels: { ["com.quadball-timer.sqlite-probe"]: capability } },
+        }),
+      },
+      { stdout: "" },
+      { stdout: "" },
+    ];
+    const cleanup = await cleanupMalformedCreateOutput(
+      async (arguments_) => {
+        calls.push(arguments_[0] ?? "");
+        const response = responses.shift();
+        if (response === undefined) throw new Error("unexpected Docker command");
+        return {
+          exitCode: 0,
+          stdout: response.stdout,
+          stderr: "",
+          stdoutBytes: response.stdout.length,
+          stderrBytes: 0,
+          outputExceeded: false,
+        };
+      },
+      name,
+      capability,
+      cleanupLifecycle(100),
+    );
+    expect(cleanup).toBe("removed");
+    expect(calls).toEqual(["ps", "ps", "ps", "ps", "ps", "ps", "inspect", "rm", "ps"]);
+  });
+
+  test("classifies explicit pre-create empty observations as not-created", async () => {
+    const calls: string[] = [];
+    const cleanup = await cleanupMalformedCreateOutput(
+      async (arguments_) => {
+        calls.push(arguments_[0] ?? "");
+        return {
+          exitCode: 0,
+          stdout: "",
+          stderr: "",
+          stdoutBytes: 0,
+          stderrBytes: 0,
+          outputExceeded: false,
+        };
+      },
+      "quadball-timer-focused-empty",
+      capability,
+      { ...cleanupLifecycle(35), preCreateConfirmed: true },
+    );
+    expect(cleanup).toBe("not-created");
+    expect(calls.length).toBeGreaterThanOrEqual(4);
+    expect(calls.length % 2).toBe(0);
+  });
+
+  test("fails closed when reconciliation cuts off between independent dimensions", async () => {
+    const reconciliation = new AbortController();
+    const calls: string[] = [];
+    const cleanup = await cleanupMalformedCreateOutput(
+      async (arguments_) => {
+        calls.push(arguments_[0] ?? "");
+        if (arguments_.includes("name=^/partial$")) return emptyDockerResult();
+        reconciliation.abort();
+        return emptyDockerResult();
+      },
+      "partial",
+      capability,
+      {
+        cleanupSignal: new AbortController().signal,
+        reconciliationSignal: reconciliation.signal,
+        preCreateConfirmed: true,
+      },
+    );
+    expect(cleanup).toBe("unverified");
+    expect(calls).toEqual(["ps", "ps"]);
+  });
+
+  test("does not claim absence when a container can materialize after cutoff", async () => {
+    const reconciliation = new AbortController();
+    const calls: string[] = [];
+    let materializedAfterCutoff = false;
+    const cleanup = await cleanupMalformedCreateOutput(
+      async (arguments_) => {
+        calls.push(arguments_[0] ?? "");
+        const result = emptyDockerResult();
+        if (calls.length === 2) {
+          reconciliation.abort();
+          materializedAfterCutoff = true;
+        }
+        return result;
+      },
+      "late-materialization",
+      capability,
+      {
+        cleanupSignal: new AbortController().signal,
+        reconciliationSignal: reconciliation.signal,
+      },
+    );
+    expect(cleanup).toBe("unverified");
+    expect(materializedAfterCutoff).toBe(true);
+    expect(calls).toEqual(["ps", "ps"]);
+  });
+
+  test("finishes exact cleanup after discovery reaches the cutoff", async () => {
+    const reconciliation = new AbortController();
+    const calls: string[] = [];
+    const inspection = JSON.stringify({
+      Id: containerId,
+      Name: "/owned",
+      Config: { Labels: { ["com.quadball-timer.sqlite-probe"]: capability } },
+    });
+    const cleanup = await cleanupMalformedCreateOutput(
+      async (arguments_) => {
+        calls.push(arguments_[0] ?? "");
+        if (arguments_[0] === "inspect") {
+          await Bun.sleep(10);
+          return dockerResult(inspection);
+        }
+        if (arguments_[0] === "rm") {
+          await Bun.sleep(10);
+          return dockerResult();
+        }
+        if (arguments_[0] === "ps" && arguments_.includes("name=^/owned$"))
+          return dockerResult(`${containerId}\n`);
+        if (
+          arguments_[0] === "ps" &&
+          arguments_.includes(`label=${"com.quadball-timer.sqlite-probe=" + capability}`)
+        ) {
+          reconciliation.abort();
+          return dockerResult(`${containerId}\n`);
+        }
+        await Bun.sleep(10);
+        return dockerResult();
+      },
+      "owned",
+      capability,
+      {
+        cleanupSignal: new AbortController().signal,
+        reconciliationSignal: reconciliation.signal,
+      },
+    );
+    expect(cleanup).toBe("removed");
+    expect(calls).toEqual(["ps", "ps", "inspect", "rm", "ps"]);
+  });
+
+  test("keeps an exact first-dimension ID when the second query sees cutoff", async () => {
+    const reconciliation = new AbortController();
+    const calls: string[] = [];
+    const inspection = JSON.stringify({
+      Id: containerId,
+      Name: "/owned",
+      Config: { Labels: { ["com.quadball-timer.sqlite-probe"]: capability } },
+    });
+    const cleanup = await cleanupMalformedCreateOutput(
+      async (arguments_) => {
+        calls.push(arguments_[0] ?? "");
+        if (arguments_[0] === "ps" && arguments_.includes("name=^/owned$")) {
+          reconciliation.abort();
+          return dockerResult(`${containerId}\n`);
+        }
+        if (arguments_[0] === "inspect") return dockerResult(inspection);
+        if (arguments_[0] === "rm") return dockerResult();
+        return dockerResult();
+      },
+      "owned",
+      capability,
+      {
+        cleanupSignal: new AbortController().signal,
+        reconciliationSignal: reconciliation.signal,
+      },
+    );
+    expect(cleanup).toBe("removed");
+    expect(calls).toEqual(["ps", "inspect", "rm", "ps"]);
+  });
+
+  test("keeps an exact second-dimension ID when the first query is empty", async () => {
+    const reconciliation = new AbortController();
+    const calls: string[] = [];
+    const inspection = JSON.stringify({
+      Id: containerId,
+      Name: "/owned",
+      Config: { Labels: { ["com.quadball-timer.sqlite-probe"]: capability } },
+    });
+    const cleanup = await cleanupMalformedCreateOutput(
+      async (arguments_) => {
+        calls.push(arguments_[0] ?? "");
+        if (arguments_[0] === "ps" && arguments_.includes("name=^/owned$")) return dockerResult();
+        if (
+          arguments_[0] === "ps" &&
+          arguments_.includes(`label=${"com.quadball-timer.sqlite-probe=" + capability}`)
+        ) {
+          reconciliation.abort();
+          return dockerResult(`${containerId}\n`);
+        }
+        if (arguments_[0] === "inspect") return dockerResult(inspection);
+        if (arguments_[0] === "rm") return dockerResult();
+        return dockerResult();
+      },
+      "owned",
+      capability,
+      {
+        cleanupSignal: new AbortController().signal,
+        reconciliationSignal: reconciliation.signal,
+      },
+    );
+    expect(cleanup).toBe("removed");
+    expect(calls).toEqual(["ps", "ps", "inspect", "rm", "ps"]);
+  });
+
+  test("fails closed at the reconciliation cutoff for persistent one-sided visibility", async () => {
+    const changedLabelCommands: string[] = [];
+    const changedLabel = await cleanupMalformedCreateOutput(
+      async (arguments_) => {
+        changedLabelCommands.push(arguments_[0] ?? "");
+        return {
+          exitCode: 0,
+          stdout:
+            arguments_[0] === "ps" && arguments_.includes("name=^/owned$")
+              ? `${containerId}\n`
+              : "",
+          stderr: "",
+          stdoutBytes: 65,
+          stderrBytes: 0,
+          outputExceeded: false,
+        };
+      },
+      "owned",
+      capability,
+      cleanupLifecycle(35),
+    );
+    expect(changedLabel).toBe("unverified");
+    expect(changedLabelCommands).not.toContain("inspect");
+    expect(changedLabelCommands).not.toContain("rm");
+
+    const changedNameCommands: string[] = [];
+    const changedName = await cleanupMalformedCreateOutput(
+      async (arguments_) => {
+        changedNameCommands.push(arguments_[0] ?? "");
+        return {
+          exitCode: 0,
+          stdout:
+            arguments_[0] === "ps" &&
+            arguments_.includes(`label=com.quadball-timer.sqlite-probe=${capability}`)
+              ? `${containerId}\n`
+              : "",
+          stderr: "",
+          stdoutBytes: 65,
+          stderrBytes: 0,
+          outputExceeded: false,
+        };
+      },
+      "owned",
+      capability,
+      cleanupLifecycle(35),
+    );
+    expect(changedName).toBe("unverified");
+    expect(changedNameCommands).not.toContain("inspect");
+    expect(changedNameCommands).not.toContain("rm");
+
+    const otherContainerId = "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210";
+    const mismatched = await cleanupMalformedCreateOutput(
+      async (arguments_) => ({
+        exitCode: 0,
+        stdout: arguments_.includes("name=^/owned$") ? `${containerId}\n` : `${otherContainerId}\n`,
+        stderr: "",
+        stdoutBytes: 65,
+        stderrBytes: 0,
+        outputExceeded: false,
+      }),
+      "owned",
+      capability,
+      cleanupLifecycle(35),
+    );
+    expect(mismatched).toBe("unverified");
   });
 
   test("does not clean up from failed or ambiguous discovery output", async () => {
@@ -722,6 +1044,7 @@ describe("Docker SQLite qualification boundary", () => {
       },
       "owned",
       capability,
+      cleanupLifecycle(35),
     );
     expect(failed).toBe("unverified");
     expect(commandNames).toEqual(["ps"]);

--- a/src/lib/sqlite-foundation-probe-docker.ts
+++ b/src/lib/sqlite-foundation-probe-docker.ts
@@ -20,6 +20,9 @@ export const SQLITE_FOUNDATION_PROBE_DOCKER_PROCESS_LIMIT =
 export const SQLITE_FOUNDATION_PROBE_DOCKER_TMPFS = `/tmp:rw,size=${SQLITE_FOUNDATION_PROBE_MAX_DISK_BYTES},mode=1777`;
 export const SQLITE_FOUNDATION_PROBE_DOCKER_LOG_MAX_SIZE = "4k";
 export const SQLITE_FOUNDATION_PROBE_DOCKER_LOG_MAX_FILE = "1";
+export const SQLITE_FOUNDATION_PROBE_DOCKER_CREATE_RECONCILIATION_MS = 250;
+export const SQLITE_FOUNDATION_PROBE_DOCKER_RECONCILIATION_INTERVAL_MS = 25;
+export const SQLITE_FOUNDATION_PROBE_DOCKER_FINAL_CLEANUP_SLICE_MS = 1_000;
 export const SQLITE_FOUNDATION_PROBE_DOCKER_INFO_IDENTITY_FORMAT =
   '{"OSType":{{json .OSType}},"Architecture":{{json .Architecture}}}';
 export const SQLITE_FOUNDATION_PROBE_DOCKER_VERSION_IDENTITY_FORMAT =
@@ -79,12 +82,28 @@ export type DockerProbeExecution = {
 export type DockerProbeDependencies = {
   runCommand?: DockerCommandRunner;
   signal?: AbortSignal;
+  admissionSignal?: AbortSignal;
+  reconciliationSignal?: AbortSignal;
   platform?: NodeJS.Platform;
   architecture?: string;
   invocationId?: string;
   image?: string;
   cleanupSignal?: AbortSignal;
   expectedBunVersion?: string;
+};
+
+export type DockerProbeLifecycle = {
+  workSignal: AbortSignal;
+  admissionSignal: AbortSignal;
+  reconciliationSignal: AbortSignal;
+  cleanupSignal: AbortSignal;
+};
+
+export type DockerCleanupLifecycle = {
+  cleanupSignal: AbortSignal;
+  reconciliationSignal: AbortSignal;
+  /** True only when the caller has proved create never reached the daemon. */
+  preCreateConfirmed?: boolean;
 };
 
 export type DockerContainerArguments = {
@@ -216,6 +235,8 @@ export async function createDockerProbeExecution(
 ): Promise<DockerProbeExecution> {
   const runCommand = dependencies.runCommand ?? runDockerCommand;
   const cleanupSignal = dependencies.cleanupSignal ?? new AbortController().signal;
+  const reconciliationSignal = dependencies.reconciliationSignal ?? cleanupSignal;
+  const admissionSignal = dependencies.admissionSignal ?? dependencies.signal;
   await admitDockerEngine({ ...dependencies, runCommand });
   const artifactPath = await validateArtifactPath(executablePath);
   const expectedBunVersion = dependencies.expectedBunVersion ?? expectedPackageBunVersion();
@@ -229,15 +250,16 @@ export async function createDockerProbeExecution(
       command: ["/opt/quadball-timer", "--sqlite-foundation-probe"],
       image: dependencies.image,
     }),
-    { signal: dependencies.signal },
+    // A work-timeout may race the daemon-side create request. Keep the Docker
+    // client alive only through the short admission grace; cleanup owns the
+    // remaining reserve for exact identity and absence proof.
+    { signal: admissionSignal },
   ).catch(() => null);
   if (create === null || create.exitCode !== 0 || create.outputExceeded) {
-    const cleanupDisposition = await cleanupMalformedCreateOutput(
-      runCommand,
-      name,
-      capability,
+    const cleanupDisposition = await cleanupMalformedCreateOutput(runCommand, name, capability, {
       cleanupSignal,
-    );
+      reconciliationSignal,
+    });
     throw new DockerAdmissionError(
       "Docker could not create the owned qualification container.",
       cleanupDisposition,
@@ -245,12 +267,10 @@ export async function createDockerProbeExecution(
   }
   const id = parseContainerId(create.stdout);
   if (id === null) {
-    const cleanupDisposition = await cleanupMalformedCreateOutput(
-      runCommand,
-      name,
-      capability,
+    const cleanupDisposition = await cleanupMalformedCreateOutput(runCommand, name, capability, {
       cleanupSignal,
-    );
+      reconciliationSignal,
+    });
     throw new DockerAdmissionError(
       "Docker returned an invalid qualification container identity.",
       cleanupDisposition,
@@ -266,7 +286,7 @@ export async function createDockerProbeExecution(
   const admitted = await verifyDockerContainerConfiguration(
     runCommand,
     container,
-    dependencies.signal,
+    admissionSignal,
     artifactPath,
   );
   if (!admitted) {
@@ -791,39 +811,129 @@ export async function cleanupMalformedCreateOutput(
   runCommand: DockerCommandRunner,
   name: string,
   capability: string,
-  signal?: AbortSignal,
+  lifecycle: DockerCleanupLifecycle,
 ): Promise<DockerAdmissionDisposition> {
+  let observedEmpty = false;
+  let observedNonEmpty = false;
+  while (!lifecycle.reconciliationSignal.aborted) {
+    const discovery = await discoverMalformedCreateContainer(
+      runCommand,
+      name,
+      capability,
+      lifecycle.reconciliationSignal,
+    );
+    if (discovery.kind === "unverified") return "unverified";
+    if (discovery.kind === "cutoff") break;
+    if (discovery.kind === "empty") {
+      observedEmpty = true;
+    } else if (discovery.kind === "found") {
+      const candidate: DockerProbeContainer = {
+        id: discovery.id,
+        name,
+        capability,
+        artifactPath: "",
+        identityVerified: false,
+      };
+      const cleanup = await cleanupOwnedDockerContainer(
+        runCommand,
+        candidate,
+        lifecycle.cleanupSignal,
+      );
+      return cleanup.identityVerified && cleanup.removed ? "removed" : "unverified";
+    } else {
+      observedNonEmpty = true;
+    }
+    if (!(await waitForDockerReconciliationInterval(lifecycle.reconciliationSignal))) break;
+  }
+  return observedEmpty && !observedNonEmpty && lifecycle.preCreateConfirmed === true
+    ? "not-created"
+    : "unverified";
+}
+
+async function discoverMalformedCreateContainer(
+  runCommand: DockerCommandRunner,
+  name: string,
+  capability: string,
+  signal?: AbortSignal,
+): Promise<
+  | { kind: "empty" }
+  | { kind: "found"; id: string; atCutoff?: boolean }
+  | { kind: "one-sided" }
+  | { kind: "cutoff" }
+  | { kind: "unverified" }
+> {
+  const byName = await discoverDockerContainerDimension(runCommand, ["name", `^/${name}$`], signal);
+  if (byName.kind === "cutoff") return byName;
+  if (byName.kind === "unverified") return byName;
+  const byCapability = await discoverDockerContainerDimension(
+    runCommand,
+    ["label", `${SQLITE_FOUNDATION_PROBE_DOCKER_LABEL}=${capability}`],
+    signal,
+  );
+  if (byCapability.kind === "cutoff")
+    return byName.kind === "found" ? { kind: "found", id: byName.id } : byCapability;
+  if (byCapability.kind === "unverified") return byCapability;
+  if (byName.kind === "empty" && byCapability.kind === "empty") return { kind: "empty" };
+  if (byName.kind === "found" && byCapability.kind === "found") {
+    return byName.id === byCapability.id
+      ? { kind: "found", id: byName.id }
+      : { kind: "unverified" };
+  }
+  if (byCapability.kind === "found" && byCapability.atCutoff)
+    return { kind: "found", id: byCapability.id };
+  if (byName.kind === "found" && byName.atCutoff) return { kind: "found", id: byName.id };
+  if (byName.kind === "found" || byCapability.kind === "found") return { kind: "one-sided" };
+  return { kind: "unverified" };
+}
+
+async function discoverDockerContainerDimension(
+  runCommand: DockerCommandRunner,
+  filter: readonly ["name" | "label", string],
+  signal?: AbortSignal,
+): Promise<
+  | { kind: "empty" }
+  | { kind: "found"; id: string; atCutoff?: boolean }
+  | { kind: "cutoff" }
+  | { kind: "unverified" }
+> {
+  if (signal?.aborted) return { kind: "cutoff" };
   const discovered = await runCommand(
-    [
-      "ps",
-      "--all",
-      "--no-trunc",
-      "--filter",
-      `name=^/${name}$`,
-      "--filter",
-      `label=${SQLITE_FOUNDATION_PROBE_DOCKER_LABEL}=${capability}`,
-      "--format",
-      "{{.ID}}",
-    ],
+    ["ps", "--all", "--no-trunc", "--filter", `${filter[0]}=${filter[1]}`, "--format", "{{.ID}}"],
     { signal },
   ).catch(() => null);
-  if (discovered === null || discovered.exitCode !== 0 || discovered.outputExceeded)
-    return "unverified";
+  if (discovered === null) return signal?.aborted ? { kind: "cutoff" } : { kind: "unverified" };
+  if (discovered.exitCode !== 0 || discovered.outputExceeded) return { kind: "unverified" };
+  const completedAfterCutoff = signal?.aborted === true;
   const lines = discovered.stdout
     .split(/\r?\n/)
     .map((line) => line.trim())
     .filter(Boolean);
+  if (lines.length === 0) return completedAfterCutoff ? { kind: "cutoff" } : { kind: "empty" };
   const id = lines.length === 1 ? parseContainerId(lines[0] ?? "") : null;
-  if (id === null) return "unverified";
-  const candidate: DockerProbeContainer = {
-    id,
-    name,
-    capability,
-    artifactPath: "",
-    identityVerified: false,
-  };
-  const cleanup = await cleanupOwnedDockerContainer(runCommand, candidate, signal);
-  return cleanup.identityVerified && cleanup.removed ? "removed" : "unverified";
+  return id === null
+    ? { kind: "unverified" }
+    : { kind: "found", id, atCutoff: completedAfterCutoff };
+}
+
+async function waitForDockerReconciliationInterval(signal: AbortSignal): Promise<boolean> {
+  if (signal?.aborted) return false;
+  return await new Promise<boolean>((resolve) => {
+    let settled = false;
+    let timer: ReturnType<typeof setTimeout>;
+    const onAbort = () => finish(false);
+    const finish = (value: boolean) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", onAbort);
+      resolve(value);
+    };
+    timer = setTimeout(
+      () => finish(true),
+      SQLITE_FOUNDATION_PROBE_DOCKER_RECONCILIATION_INTERVAL_MS,
+    );
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
 }
 
 export function parseDockerArtifactIdentity(

--- a/src/lib/sqlite-foundation-probe-runner.test.ts
+++ b/src/lib/sqlite-foundation-probe-runner.test.ts
@@ -104,24 +104,27 @@ describe("Docker qualification orchestration", () => {
     const events: string[] = [];
     await expect(
       runCompiledSqliteFoundationProbe("/owned/artifact", {
-        timeoutMs: 80,
-        createExecution: async (_path, workSignal, _cleanupSignal) =>
+        timeoutMs: 160,
+        createExecution: async (_path, { workSignal }) =>
           new Promise((resolve) => {
             workSignal?.addEventListener(
               "abort",
               () => {
-                events.push("admission-resolved");
-                resolve(
-                  fakeExecution({
-                    stop: async () => {
-                      events.push("stop");
-                    },
-                    cleanup: async (signal) => {
-                      events.push(`cleanup:${signal?.aborted === false}`);
-                      return { identityVerified: true, removed: true };
-                    },
-                  }),
-                );
+                events.push("work-aborted");
+                setTimeout(() => {
+                  events.push("admission-resolved");
+                  resolve(
+                    fakeExecution({
+                      stop: async () => {
+                        events.push("stop");
+                      },
+                      cleanup: async (signal) => {
+                        events.push(`cleanup:${signal?.aborted === false}`);
+                        return { identityVerified: true, removed: true };
+                      },
+                    }),
+                  );
+                }, 5);
               },
               { once: true },
             );
@@ -131,7 +134,14 @@ describe("Docker qualification orchestration", () => {
         },
       }),
     ).rejects.toBeInstanceOf(Error);
-    expect(events).toEqual(["admission-resolved", "stop", "pre-cleanup", "cleanup:true", "final"]);
+    expect(events).toEqual([
+      "work-aborted",
+      "admission-resolved",
+      "stop",
+      "pre-cleanup",
+      "cleanup:true",
+      "final",
+    ]);
   });
 
   test("retains verified cleanup when late admission rejects after timeout", async () => {
@@ -146,10 +156,10 @@ describe("Docker qualification orchestration", () => {
     }> = [];
     await expect(
       runCompiledSqliteFoundationProbe("/owned/artifact", {
-        timeoutMs: 80,
-        createExecution: async (_path, workSignal) =>
+        timeoutMs: 160,
+        createExecution: async (_path, { admissionSignal }) =>
           new Promise((_resolve, reject) => {
-            workSignal?.addEventListener(
+            admissionSignal?.addEventListener(
               "abort",
               () => reject(new DockerAdmissionError("late create cleaned", "removed")),
               { once: true },
@@ -166,6 +176,39 @@ describe("Docker qualification orchestration", () => {
       containerRemoved: true,
       failures: [],
     });
+  });
+
+  test("fails closed at the admission boundary without claiming removal", async () => {
+    const events: string[] = [];
+    const emitted: Array<{ cleanup: { status: string; containerRemoved: boolean | null } }> = [];
+    await expect(
+      runCompiledSqliteFoundationProbe("/owned/artifact", {
+        timeoutMs: 1_000,
+        createExecution: async (_path, { cleanupSignal, admissionSignal }) =>
+          new Promise((_resolve, reject) => {
+            cleanupSignal?.addEventListener("abort", () => events.push("hard-aborted"), {
+              once: true,
+            });
+            admissionSignal?.addEventListener(
+              "abort",
+              () => {
+                events.push("admission-aborted");
+                reject(new DockerAdmissionError("late create unresolved", "unverified"));
+              },
+              { once: true },
+            );
+          }),
+        emitResult: (value) => {
+          events.push(value.phase);
+          emitted.push({ cleanup: value.cleanup });
+        },
+      }),
+    ).rejects.toThrow("timed out");
+    expect(emitted.at(-1)?.cleanup).toMatchObject({
+      status: "failed",
+      containerRemoved: null,
+    });
+    expect(events).toEqual(["admission-aborted", "pre-cleanup", "final", "hard-aborted"]);
   });
 
   test("does not claim malformed admission cleanup when ownership removal was unverified", async () => {

--- a/src/lib/sqlite-foundation-probe-runner.ts
+++ b/src/lib/sqlite-foundation-probe-runner.ts
@@ -5,8 +5,11 @@ import {
   createDockerProbeExecution,
   DockerExecutionError,
   DockerResourceLimitError,
+  SQLITE_FOUNDATION_PROBE_DOCKER_CREATE_RECONCILIATION_MS,
+  SQLITE_FOUNDATION_PROBE_DOCKER_FINAL_CLEANUP_SLICE_MS,
   type DockerProbeDependencies,
   type DockerProbeExecution,
+  type DockerProbeLifecycle,
 } from "@/lib/sqlite-foundation-probe-docker";
 import {
   SQLITE_FOUNDATION_PROBE_CLEANUP_RESERVE_MS,
@@ -35,8 +38,7 @@ export type CompiledSqliteFoundationProbeOptions = {
   docker?: DockerProbeDependencies;
   createExecution?: (
     executablePath: string,
-    signal?: AbortSignal,
-    cleanupSignal?: AbortSignal,
+    lifecycle: DockerProbeLifecycle,
   ) => Promise<DockerProbeExecution>;
   command?: string;
   commit?: string | ((signal?: AbortSignal) => string | Promise<string>);
@@ -58,14 +60,36 @@ export async function runCompiledSqliteFoundationProbe(
   const invocationId = crypto.randomUUID();
   const timeoutMs = options.timeoutMs ?? SQLITE_FOUNDATION_PROBE_TIMEOUT_MS;
   const workAbort = new AbortController();
+  const admissionAbort = new AbortController();
+  const reconciliationAbort = new AbortController();
   const hardAbort = new AbortController();
   const removeCallerSignal = forwardAbort(options.signal, workAbort);
+  const removeCallerAdmissionSignal = forwardAbort(options.signal, admissionAbort);
+  const removeCallerReconciliationSignal = forwardAbort(options.signal, reconciliationAbort);
   const cleanupReserveMs = Math.min(
     SQLITE_FOUNDATION_PROBE_CLEANUP_RESERVE_MS,
     Math.floor(timeoutMs / 2),
   );
+  const admissionGraceMs = Math.min(
+    SQLITE_FOUNDATION_PROBE_DOCKER_CREATE_RECONCILIATION_MS,
+    Math.max(1, Math.floor(cleanupReserveMs / 2)),
+  );
+  const finalCleanupSliceMs = Math.min(
+    SQLITE_FOUNDATION_PROBE_DOCKER_FINAL_CLEANUP_SLICE_MS,
+    Math.max(1, Math.floor(cleanupReserveMs / 2)),
+  );
   const workTimer = setTimeout(() => workAbort.abort(), Math.max(1, timeoutMs - cleanupReserveMs));
+  const admissionTimer = setTimeout(
+    () => admissionAbort.abort(),
+    Math.max(1, timeoutMs - cleanupReserveMs + admissionGraceMs),
+  );
+  const reconciliationTimer = setTimeout(
+    () => reconciliationAbort.abort(),
+    Math.max(1, timeoutMs - finalCleanupSliceMs),
+  );
   const hardTimer = setTimeout(() => hardAbort.abort(), timeoutMs);
+  const removeHardAdmissionSignal = forwardAbort(hardAbort.signal, admissionAbort);
+  const removeHardReconciliationSignal = forwardAbort(hardAbort.signal, reconciliationAbort);
   let execution: DockerProbeExecution | undefined;
   let result: ProbeWorkerResult | undefined;
   let terminalError: unknown;
@@ -92,11 +116,18 @@ export async function runCompiledSqliteFoundationProbe(
 
   try {
     const admission = options.createExecution
-      ? options.createExecution(executablePath, workAbort.signal, hardAbort.signal)
+      ? options.createExecution(executablePath, {
+          workSignal: workAbort.signal,
+          admissionSignal: admissionAbort.signal,
+          reconciliationSignal: reconciliationAbort.signal,
+          cleanupSignal: hardAbort.signal,
+        })
       : createDockerProbeExecution(executablePath, {
           ...options.docker,
           invocationId,
           signal: workAbort.signal,
+          admissionSignal: admissionAbort.signal,
+          reconciliationSignal: reconciliationAbort.signal,
           cleanupSignal: hardAbort.signal,
         });
     try {
@@ -209,9 +240,17 @@ export async function runCompiledSqliteFoundationProbe(
     );
   await emitResult("final");
   clearTimeout(workTimer);
+  clearTimeout(admissionTimer);
+  clearTimeout(reconciliationTimer);
   clearTimeout(hardTimer);
   removeCallerSignal();
+  removeCallerAdmissionSignal();
+  removeCallerReconciliationSignal();
+  removeHardAdmissionSignal();
+  removeHardReconciliationSignal();
   hardAbort.abort();
+  reconciliationAbort.abort();
+  admissionAbort.abort();
   workAbort.abort();
   if (probeError !== undefined) throw probeError;
   if (result === undefined)

--- a/src/lib/sqlite-foundation-probe.ts
+++ b/src/lib/sqlite-foundation-probe.ts
@@ -81,7 +81,9 @@ export type {
   DockerAdmissionDisposition,
   DockerCommandResult,
   DockerArtifactIdentity,
+  DockerCleanupLifecycle,
   DockerProbeDependencies,
+  DockerProbeLifecycle,
   DockerProbeExecution,
 } from "@/lib/sqlite-foundation-probe-docker";
 export {


### PR DESCRIPTION
Closes #179.

## What changed

- reconciles Docker `create` requests that time out locally but may complete later in the daemon;
- keeps admission, reconciliation, final cleanup, and evidence emission on separate bounded lifecycle phases;
- discovers the generated name and capability independently, then requires exact container ID, name, and capability inspection before removal;
- removes only the exact owned container and proves exact absence before reporting successful cleanup;
- keeps ambiguous, one-sided, malformed, truncated, and cutoff outcomes fail-closed without claiming removal;
- preserves truthful focused-admission and final Qualification evidence.

## Why

The VPS admission probe exposed a real late-create race: Docker could leave a container in `Created` state after the client-side timeout. This correction makes that boundary deterministic and cleanup-verifiable without weakening the registered Qualification workload or its limits.

## Validation

- `bun install --frozen-lockfile`
- `bun audit`
- `bun run check`
- `bun test --isolate` — 762 passed, 0 failed
- focused Docker/runner tests — 35 passed, repeated five times by the implementation task
- `bun run test:focused-admission` — expected harmless Darwin `native-linux-x64-required` blocker; workload not launched
- `bun run test:focused-signal`
- `bun run build`
- `bun run build:executable`
- `git diff --check`

No Qualification workload and no `bun run check:sqlite-runtime` invocation was run.
