### PR TITLE
Operate live Event Game heat stoppages

### DIFF
--- a/src/lib/controller-reconnect.ts
+++ b/src/lib/controller-reconnect.ts
@@ -21,6 +21,7 @@ import {
 import {
   orderControllerGameFacts,
   LIVE_SUSPENSION_SNAPSHOT_VERSION,
+  deriveHeatStoppageState,
   parseLiveEventControllerIntent,
 } from "@/lib/live-event-game-control";
 import {
@@ -831,6 +832,7 @@ function applyOptimisticAction(
           ? {}
           : { sportingOrderAdjudication: intent.sportingOrderAdjudication }),
         ...(intent.heatAction === undefined ? {} : { heatAction: intent.heatAction }),
+        ...(intent.heatTriggerId === undefined ? {} : { heatTriggerId: intent.heatTriggerId }),
       },
     });
     return rebuildOptimisticProjection(state, nextFacts, action.dispatchedAtMs);
@@ -1458,6 +1460,8 @@ function parseHeatState(value: unknown): LiveHeatState {
       value.status !== "started" &&
       value.status !== "ended" &&
       value.status !== "skipped" &&
+      value.status !== "required-skip" &&
+      value.status !== "suppressed" &&
       value.status !== "extended")
   ) {
     throw new Error("Projection heat state is invalid.");
@@ -1470,11 +1474,92 @@ function parseHeatState(value: unknown): LiveHeatState {
     value.nominalDurationMs,
     "heat.nominalDurationMs",
   );
+  const allowedDurationMs = parseNullableBoundedNumber(
+    value.allowedDurationMs,
+    "heat.allowedDurationMs",
+  );
+  const actualDurationMs = parseNullableBoundedNumber(
+    value.actualDurationMs,
+    "heat.actualDurationMs",
+  );
+  const mode =
+    value.mode === undefined
+      ? undefined
+      : value.mode === "enabled" || value.mode === "disabled"
+        ? value.mode
+        : (() => {
+            throw new Error("Projection heat mode is invalid.");
+          })();
+  const pendingTriggerGameTimeMs = parseNullableBoundedNumber(
+    value.pendingTriggerGameTimeMs,
+    "heat.pendingTriggerGameTimeMs",
+  );
+  const nextTriggerGameTimeMs = parseNullableBoundedNumber(
+    value.nextTriggerGameTimeMs,
+    "heat.nextTriggerGameTimeMs",
+  );
+  const pendingTrigger =
+    value.pendingTrigger === undefined || value.pendingTrigger === null
+      ? null
+      : isRecord(value.pendingTrigger) &&
+          Number.isSafeInteger(value.pendingTrigger.index) &&
+          value.pendingTrigger.index >= 0 &&
+          pendingTriggerGameTimeMs !== null
+        ? { gameTimeMs: pendingTriggerGameTimeMs, index: value.pendingTrigger.index }
+        : (() => {
+            throw new Error("Projection heat pending trigger is invalid.");
+          })();
+  const triggerDecision =
+    value.triggerDecision === undefined || value.triggerDecision === null
+      ? null
+      : value.triggerDecision === "end-of-drive" ||
+          value.triggerDecision === "dead-volleyball" ||
+          value.triggerDecision === "other-stoppage" ||
+          value.triggerDecision === "skip" ||
+          value.triggerDecision === "skip-required"
+        ? value.triggerDecision
+        : (() => {
+            throw new Error("Projection heat trigger decision is invalid.");
+          })();
   return {
     status: value.status,
     factId: parseNullableFactId(value.factId, "heat.factId"),
     startedAtGameTimeMs,
     nominalDurationMs,
+    allowedDurationMs,
+    actualDurationMs,
+    ...(mode === undefined ? {} : { mode }),
+    pendingTriggerId:
+      value.pendingTriggerId === undefined || value.pendingTriggerId === null
+        ? null
+        : requireIdentifier(value.pendingTriggerId, "heat.pendingTriggerId"),
+    pendingTrigger,
+    pendingTriggerGameTimeMs,
+    nextTriggerGameTimeMs,
+    trigger:
+      value.trigger === undefined || value.trigger === null
+        ? null
+        : isRecord(value.trigger) &&
+            typeof value.trigger.id === "string" &&
+            Number.isSafeInteger(value.trigger.gameTimeMs) &&
+            Number.isSafeInteger(value.trigger.index)
+          ? {
+              id: requireIdentifier(value.trigger.id, "heat.trigger.id"),
+              gameTimeMs: value.trigger.gameTimeMs,
+              index: value.trigger.index,
+            }
+          : (() => {
+              throw new Error("Projection heat trigger is invalid.");
+            })(),
+    permittedExtensionTriggerId:
+      value.permittedExtensionTriggerId === undefined || value.permittedExtensionTriggerId === null
+        ? null
+        : requireIdentifier(value.permittedExtensionTriggerId, "heat.permittedExtensionTriggerId"),
+    activeTriggerId:
+      value.activeTriggerId === undefined || value.activeTriggerId === null
+        ? null
+        : requireIdentifier(value.activeTriggerId, "heat.activeTriggerId"),
+    triggerDecision,
   };
 }
 
@@ -1532,6 +1617,12 @@ function parseGameFacts(value: unknown): ControllerProjection["gameFacts"] {
       factId,
       factType,
       gameSideId,
+      ...(typeof candidate.trustedAtMs === "number" && Number.isSafeInteger(candidate.trustedAtMs)
+        ? { trustedAtMs: candidate.trustedAtMs }
+        : {}),
+      ...(typeof candidate.acceptedAtMs === "number" && Number.isSafeInteger(candidate.acceptedAtMs)
+        ? { acceptedAtMs: candidate.acceptedAtMs }
+        : {}),
     };
   });
 }
@@ -1655,6 +1746,8 @@ function appendOptimisticFact(
     gameTimeMs: fact.gameTimeMs,
     sportingOrder: fact.sportingOrder,
     synchronizationOrder,
+    trustedAtMs: 0,
+    acceptedAtMs: 0,
     effective: true,
     data: fact.data as ControllerGameFact["data"],
   });
@@ -1759,7 +1852,17 @@ function rebuildOptimisticProjection(
   if (Object.values(scoreByGameSide).some((score) => score > SHARED_LIMITS.score.max)) {
     return state;
   }
-  const dependentState = deriveOptimisticDependentState(gameFacts);
+  const dependentState = deriveOptimisticDependentState(
+    gameFacts,
+    projection.heat?.mode === "enabled",
+    projection.clock.gameTimeMs,
+  );
+  const hasHeatEvidence = gameFacts.some(
+    (fact) =>
+      fact.effective && (fact.factType === "heat-stoppage" || fact.factType === "heat-mode"),
+  );
+  const optimisticHeat =
+    !hasHeatEvidence && projection.heat?.mode === undefined ? projection.heat : dependentState.heat;
   const commencement =
     projection.commencement.status === "commenced"
       ? projection.commencement
@@ -1799,7 +1902,7 @@ function rebuildOptimisticProjection(
       commencement,
       timeout: dependentState.timeout,
       stoppage: dependentState.stoppage,
-      heat: dependentState.heat,
+      heat: optimisticHeat,
       result,
       overtime,
       overtimeTarget,
@@ -1812,7 +1915,11 @@ function rebuildOptimisticProjection(
   };
 }
 
-function deriveOptimisticDependentState(facts: readonly ControllerGameFact[]): {
+function deriveOptimisticDependentState(
+  facts: readonly ControllerGameFact[],
+  configuredHeatMode = false,
+  gameTimeMs = 0,
+): {
   timeout: LiveTimeoutState;
   suspension: LiveSuspensionState;
   stoppage: LiveStoppageState;
@@ -1822,56 +1929,7 @@ function deriveOptimisticDependentState(facts: readonly ControllerGameFact[]): {
   const latest = (factType: string) =>
     facts.filter((fact) => fact.effective && fact.factType === factType).at(-1) ?? null;
   const timeoutFacts = facts.filter((fact) => fact.effective && fact.factType === "timeout");
-  const heatFact = latest("heat-stoppage");
   const resultFact = latest("result");
-  const heatData =
-    heatFact !== null && isRecord(heatFact.data)
-      ? (heatFact.data as Record<string, unknown>)
-      : null;
-  const heatAction =
-    heatData !== null &&
-    (heatData.heatAction === "end" ||
-      heatData.heatAction === "skip-required" ||
-      heatData.heatAction === "extend-permitted")
-      ? heatData.heatAction
-      : null;
-  const heatStatus: LiveHeatState["status"] =
-    heatFact === null
-      ? "inactive"
-      : heatAction === "end"
-        ? "ended"
-        : heatAction === "skip-required"
-          ? "skipped"
-          : heatAction === "extend-permitted"
-            ? "extended"
-            : "started";
-  const effectiveHeatStarts = facts.filter((fact) => {
-    const data = isRecord(fact.data) ? (fact.data as unknown as Record<string, unknown>) : null;
-    return (
-      fact.effective &&
-      fact.factType === "heat-stoppage" &&
-      (data === null ||
-        (data.heatAction !== "end" &&
-          data.heatAction !== "skip-required" &&
-          data.heatAction !== "extend-permitted"))
-    );
-  });
-  const nominalDurationMs =
-    heatStatus === "started" || heatStatus === "extended"
-      ? effectiveHeatStarts.length <= 1
-        ? 4 * 60 * 1000
-        : 2 * 60 * 1000
-      : null;
-  const startedAtGameTimeMs =
-    nominalDurationMs === null || heatFact?.gameTimeMs === null
-      ? null
-      : (heatFact?.gameTimeMs ?? null);
-  const heat: LiveHeatState = {
-    status: heatStatus,
-    factId: heatFact?.factId ?? null,
-    startedAtGameTimeMs,
-    nominalDurationMs,
-  };
   let suspension: LiveSuspensionState = { status: "none", factId: null, snapshot: null };
   for (const fact of facts.filter(
     (candidate) => candidate.effective && candidate.factType === "suspension",
@@ -1892,6 +1950,7 @@ function deriveOptimisticDependentState(facts: readonly ControllerGameFact[]): {
         : null;
     suspension = { status: "suspended", factId: fact.factId, snapshot };
   }
+  const heat = deriveHeatStoppageState(facts, gameTimeMs, configuredHeatMode);
   return {
     timeout: deriveOptimisticTimeoutState(timeoutFacts),
     suspension,

--- a/src/lib/event-game-action-codecs.ts
+++ b/src/lib/event-game-action-codecs.ts
@@ -13,6 +13,7 @@ import type {
   ControlActionCodecRegistry,
   ControlActionGrantProvenance,
   ControlActionInput,
+  ControlActionOrigin,
   ControlActionInterpretation,
   ControlActionKind,
   ControlActionLifecycleContext,
@@ -578,7 +579,16 @@ export function validateStoredInput(
   const kind = validateKind(value.kind);
   const predecessors = validatePredecessors(value.causalPredecessorIds);
   const occurrence = validateOccurrenceWithoutClock(value.occurrence);
-  const grant = validateGrant(value.grant);
+  const origin: ValidationResult<ControlActionOrigin | undefined> =
+    value.origin === undefined
+      ? valid(undefined)
+      : value.origin === "controller" || value.origin === "system-heat-stoppage"
+        ? valid(value.origin)
+        : invalid("origin is unsupported.");
+  const grant =
+    value.origin === "system-heat-stoppage" && value.grant === null
+      ? valid(null)
+      : validateGrant(value.grant);
   const lifecycle = validateLifecycle(value.lifecycle);
   const payload = parseJsonValue(value.payload, "payload");
   const override = validateOverride(value.override);
@@ -590,6 +600,7 @@ export function validateStoredInput(
   if (!predecessors.ok) return predecessors;
   if (!occurrence.ok) return occurrence;
   if (!grant.ok) return grant;
+  if (!origin.ok) return origin;
   if (!lifecycle.ok) return lifecycle;
   if (!payload.ok) return payload;
   if (!override.ok) return override;
@@ -603,6 +614,7 @@ export function validateStoredInput(
     causalPredecessorIds: predecessors.value,
     occurrence: occurrence.value,
     grant: grant.value,
+    ...(origin.value === undefined ? {} : { origin: origin.value }),
     lifecycle: lifecycle.value,
     ...(override.value === undefined ? {} : { override: override.value }),
     ...(recoveryProvenance.value === undefined

--- a/src/lib/event-game-actions.ts
+++ b/src/lib/event-game-actions.ts
@@ -62,6 +62,8 @@ export const SYSTEM_TIMEOUT_COMPLETION_GRANT: Readonly<{
   versionId: "system-v1",
 });
 
+export type ControlActionOrigin = "controller" | "system-heat-stoppage";
+
 export type ControlActionLifecycleContext = {
   phase: EventGameLifecyclePhase;
   commencedAtMs: number | null;
@@ -99,7 +101,10 @@ export type ControlActionInput = {
   payload: unknown;
   causalPredecessorIds: readonly string[];
   occurrence: ControlActionOccurrence;
-  grant: ControlActionGrantProvenance;
+  /** Controller actions carry Grant provenance; trusted system obligations do not. */
+  grant: ControlActionGrantProvenance | null;
+  /** Explicitly distinguishes derived heat obligations from Controller submissions. */
+  origin?: ControlActionOrigin;
   lifecycle: ControlActionLifecycleContext;
   override?: OfficialOverrideMetadata;
   recoveryProvenance?: ControlActionRecoveryProvenance;
@@ -181,6 +186,7 @@ export type ControlAuditLinkage = {
 export type ControlAuditProvenance = {
   occurrence: ControlActionOccurrence | null;
   grant: ControlActionGrantProvenance | null;
+  origin?: ControlActionOrigin;
   lifecycle: ControlActionLifecycleContext | null;
   override: OfficialOverrideMetadata | null;
   recoveryProvenance: ControlActionRecoveryProvenance | null;
@@ -339,13 +345,23 @@ export function validateControlActionEnvelope(
   };
   const predecessors = validatePredecessors(input.causalPredecessorIds);
   const occurrence = validateOccurrence(input.occurrence, serverNowMs);
-  const grant = validateGrant(input.grant);
+  const originResult: ValidationResult<ControlActionOrigin | undefined> =
+    input.origin === undefined
+      ? valid(undefined)
+      : input.origin === "controller" || input.origin === "system-heat-stoppage"
+        ? valid(input.origin)
+        : invalid("origin is unsupported.");
+  const grant =
+    input.origin === "system-heat-stoppage" && input.grant === null
+      ? valid(null)
+      : validateGrant(input.grant);
   const lifecycle = validateLifecycle(input.lifecycle);
   const override = validateOverride(input.override);
   const recovery = validateRecoveryProvenanceShape(input.recoveryProvenance);
   if (!predecessors.ok) return predecessors;
   if (!occurrence.ok) return occurrence;
   if (!grant.ok) return grant;
+  if (!originResult.ok) return originResult;
   if (!lifecycle.ok) return lifecycle;
   if (!override.ok) return override;
   if (!recovery.ok) return recovery;
@@ -359,6 +375,7 @@ export function validateControlActionEnvelope(
     causalPredecessorIds: predecessors.value,
     occurrence: occurrence.value,
     grant: grant.value,
+    ...(originResult.value === undefined ? {} : { origin: originResult.value }),
     lifecycle: lifecycle.value,
     ...(override.value === undefined ? {} : { override: override.value }),
     ...(recovery.value === undefined ? {} : { recoveryProvenance: recovery.value }),
@@ -470,7 +487,17 @@ export function prepareControlAction(
   if (!predecessorResult.ok) return predecessorResult;
   const occurrenceResult = validateOccurrence(input.occurrence, serverNowMs);
   if (!occurrenceResult.ok) return occurrenceResult;
-  const grantResult = validateGrant(input.grant);
+  const originResult: ValidationResult<ControlActionOrigin | undefined> =
+    input.origin === undefined
+      ? valid(undefined)
+      : input.origin === "controller" || input.origin === "system-heat-stoppage"
+        ? valid(input.origin)
+        : invalid("origin is unsupported.");
+  if (!originResult.ok) return originResult;
+  const grantResult =
+    input.origin === "system-heat-stoppage" && input.grant === null
+      ? valid(null)
+      : validateGrant(input.grant);
   if (!grantResult.ok) return grantResult;
   const lifecycleResult = validateLifecycle(input.lifecycle);
   if (!lifecycleResult.ok) return lifecycleResult;
@@ -494,6 +521,7 @@ export function prepareControlAction(
     causalPredecessorIds: predecessorResult.value,
     occurrence: occurrenceResult.value,
     grant: grantResult.value,
+    ...(originResult.value === undefined ? {} : { origin: originResult.value }),
     lifecycle: lifecycleResult.value,
     ...(overrideResult.value === undefined ? {} : { override: overrideResult.value }),
     ...(recoveryResult.value === undefined ? {} : { recoveryProvenance: recoveryResult.value }),

--- a/src/lib/event-game-record-helpers.ts
+++ b/src/lib/event-game-record-helpers.ts
@@ -543,6 +543,7 @@ function actionProvenance(action: ControlAction): Record<string, unknown> {
   return {
     occurrence: action.occurrence,
     grant: action.grant,
+    ...(action.origin === undefined ? {} : { origin: action.origin }),
     lifecycle: action.lifecycle,
     override: action.override ?? null,
     recoveryProvenance: action.recoveryProvenance ?? null,
@@ -713,6 +714,7 @@ export function createAuditEntry(
     provenance: {
       occurrence: structuredClone(provenanceAction.occurrence),
       grant: structuredClone(provenanceAction.grant),
+      ...(provenanceAction.origin === undefined ? {} : { origin: provenanceAction.origin }),
       lifecycle: structuredClone(provenanceAction.lifecycle),
       override:
         provenanceAction.override === undefined ? null : structuredClone(provenanceAction.override),

--- a/src/lib/foundation-acceptance.ts
+++ b/src/lib/foundation-acceptance.ts
@@ -80,6 +80,8 @@ export type ControlActionBatchInput = {
   recordId: string;
   eventGameId: string;
   actions: readonly unknown[];
+  /** Commit all accepted actions and the lifecycle transition in one storage transaction. */
+  atomic?: boolean;
   sessionBearer?: string;
   controlSessionDecision?: ControlGrantSessionDecision;
   mode?: "online" | "replay";
@@ -100,7 +102,7 @@ export type FoundationActionResult =
       status: "accepted" | "duplicate-accepted";
       action?: ControlAction;
       auditId: string;
-      grantAuditId: string;
+      grantAuditId?: string;
     }
   | {
       status: "rejected" | "dependency-blocked" | "authority-expired" | "retry-later";
@@ -207,6 +209,12 @@ function isSystemTimeoutCompletionBatch(batch: PreparedBatch): boolean {
   return batch.input.systemOperation === "timeout-completion";
 }
 type OneOutcome = { result: FoundationActionResult; reservationId?: string; receipt?: string };
+
+class AtomicBatchAbort extends Error {
+  constructor(readonly outcome: FoundationBatchOutcome) {
+    super("Atomic Control Action batch was rolled back.");
+  }
+}
 type AuthorizedControl = {
   grant: StoredGrant;
   session: StoredGrantSession;
@@ -277,6 +285,7 @@ export function createFoundationAcceptance(
           detail: "The Event Game Record is unavailable.",
         })),
       };
+    if (batch.input.atomic === true) return submitAtomicBatch(batch, preflight);
     const results: FoundationActionResult[] = Array.from({ length: batch.actions.length });
     let reservationId: string | undefined;
     let receipt: string | undefined;
@@ -311,6 +320,69 @@ export function createFoundationAcceptance(
       results,
       ...(reservationId === undefined ? {} : { reservationId }),
     };
+  }
+
+  async function submitAtomicBatch(
+    batch: PreparedBatch,
+    preflight: BatchPreflight,
+  ): Promise<FoundationBatchOutcome> {
+    try {
+      return await storage.transaction((transaction) => {
+        const results: FoundationActionResult[] = Array.from({ length: batch.actions.length });
+        for (const index of batch.order) {
+          const action = batch.actions[index];
+          if (action === undefined) throw new Error("Missing structural action.");
+          const predecessors = predecessorResultsFor(batch, results, index);
+          const one = acceptOne(
+            transaction,
+            batch,
+            index,
+            predecessors,
+            preflight.actions[index],
+            true,
+          );
+          results[index] = one.result;
+          if (one.result.status !== "accepted" && one.result.status !== "duplicate-accepted") {
+            const retry = one.result.status === "retry-later";
+            throw new AtomicBatchAbort({
+              status: retry ? "partial" : "rejected",
+              results: batch.actions.map((_, resultIndex) =>
+                resultIndex === index
+                  ? one.result
+                  : retry
+                    ? {
+                        status: "retry-later",
+                        reason: "causal-predecessor-retry",
+                        detail: "Retry the complete atomic Control Action batch.",
+                      }
+                    : {
+                        status: "dependency-blocked",
+                        reason: "causal-dependency-rejected",
+                        detail: "The complete atomic Control Action batch was rejected.",
+                      },
+              ),
+            });
+          }
+        }
+        applyLifecycleTransition(
+          transaction,
+          batch.input.recordId,
+          batch.input.lifecycleTransition,
+          batch.input.reconcileDerivedLifecycle === true,
+        );
+        return { status: "committed", results };
+      });
+    } catch (error) {
+      if (error instanceof AtomicBatchAbort) return error.outcome;
+      return {
+        status: "partial",
+        results: batch.actions.map(() => ({
+          status: "retry-later",
+          reason: "storage-unavailable",
+          detail: "Retry this atomic batch after authoritative storage recovers.",
+        })),
+      };
+    }
   }
 
   async function acknowledgeReplay(
@@ -414,23 +486,31 @@ export function createFoundationAcceptance(
       authorization.grantType !== "control" ||
       authorization.eventGameId !== batch.input.eventGameId ||
       (!isSystemTimeoutCompletionBatch(batch) &&
-        (authorization.grantSessionId !== first.envelope.grant.sessionId ||
+        !isTrustedSystemAction(first.envelope) &&
+        (first.envelope.grant === null ||
+          authorization.grantSessionId !== first.envelope.grant.sessionId ||
           authorization.grantVersion !== first.envelope.grant.versionId)) ||
       (isSystemTimeoutCompletionBatch(batch) &&
-        (first.envelope.grant.sessionId !== SYSTEM_TIMEOUT_COMPLETION_GRANT.sessionId ||
+        (first.envelope.grant === null ||
+          first.envelope.grant.sessionId !== SYSTEM_TIMEOUT_COMPLETION_GRANT.sessionId ||
           first.envelope.grant.versionId !== SYSTEM_TIMEOUT_COMPLETION_GRANT.versionId))
-    )
+    ) {
       return { authorized: false, root: null, trustedLockedReplay: false, actions: [] };
+    }
     if (
       batch.actions.some(({ envelope }) =>
         isSystemTimeoutCompletionBatch(batch)
-          ? envelope.grant.sessionId !== SYSTEM_TIMEOUT_COMPLETION_GRANT.sessionId ||
+          ? envelope.grant === null ||
+            envelope.grant.sessionId !== SYSTEM_TIMEOUT_COMPLETION_GRANT.sessionId ||
             envelope.grant.versionId !== SYSTEM_TIMEOUT_COMPLETION_GRANT.versionId
-          : envelope.grant.sessionId !== authorization.grantSessionId ||
-            envelope.grant.versionId !== authorization.grantVersion,
+          : envelope.origin !== "system-heat-stoppage" &&
+            (envelope.grant === null ||
+              envelope.grant.sessionId !== authorization.grantSessionId ||
+              envelope.grant.versionId !== authorization.grantVersion),
       )
-    )
+    ) {
       return { authorized: false, root: null, trustedLockedReplay: false, actions: [] };
+    }
     const root = transaction.findRootByRecordId(batch.input.recordId);
     if (root === null || root.eventGameId !== batch.input.eventGameId)
       return {
@@ -503,6 +583,7 @@ export function createFoundationAcceptance(
     const replay = batch.input.replay;
     const first = batch.actions[0];
     if (replay === undefined || first === undefined) return false;
+    if (first.envelope.grant === null) return false;
     if (options.authorizeLockedReplay !== undefined)
       return options.authorizeLockedReplay({
         transaction,
@@ -526,6 +607,7 @@ export function createFoundationAcceptance(
       authorization.grantVersion === first.envelope.grant.versionId &&
       batch.actions.every(
         ({ envelope }) =>
+          envelope.grant !== null &&
           envelope.grant.sessionId === authorization.grantSessionId &&
           envelope.grant.versionId === authorization.grantVersion,
       )
@@ -559,6 +641,7 @@ export function createFoundationAcceptance(
     index: number,
     predecessorResults: readonly FoundationActionResult[],
     preflightAction: { prepared: PreparedControlAction | null; error: string | null } | undefined,
+    deferLifecycleTransition = false,
   ): OneOutcome {
     const structural = batch.actions[index];
     if (structural === undefined) throw new Error("Missing structural action.");
@@ -605,7 +688,8 @@ export function createFoundationAcceptance(
         (exactReservation.recordId !== root.recordId ||
           exactReservation.eventGameId !== root.eventGameId ||
           exactReservation.originatingSessionId !== replay.originatingSessionId ||
-          exactReservation.actionCount !== batch.actions.length)
+          ((trustedReservationId === null || trustedReservationId === undefined) &&
+            exactReservation.actionCount !== batch.actions.length))
       )
         return authorityFailure();
       const originReservation =
@@ -684,10 +768,13 @@ export function createFoundationAcceptance(
       authorization.grantType !== "control" ||
       authorization.eventGameId !== batch.input.eventGameId ||
       (!isSystemTimeoutCompletionBatch(batch) &&
-        (authorization.grantSessionId !== structural.envelope.grant.sessionId ||
+        !isTrustedSystemAction(structural.envelope) &&
+        (structural.envelope.grant === null ||
+          authorization.grantSessionId !== structural.envelope.grant.sessionId ||
           authorization.grantVersion !== structural.envelope.grant.versionId)) ||
       (isSystemTimeoutCompletionBatch(batch) &&
-        (structural.envelope.grant.sessionId !== SYSTEM_TIMEOUT_COMPLETION_GRANT.sessionId ||
+        (structural.envelope.grant === null ||
+          structural.envelope.grant.sessionId !== SYSTEM_TIMEOUT_COMPLETION_GRANT.sessionId ||
           structural.envelope.grant.versionId !== SYSTEM_TIMEOUT_COMPLETION_GRANT.versionId))
     )
       return authorityFailure();
@@ -767,10 +854,13 @@ export function createFoundationAcceptance(
       currentAuthorization.grantType !== "control" ||
       currentAuthorization.eventGameId !== batch.input.eventGameId ||
       (!isSystemTimeoutCompletionBatch(batch) &&
-        (currentAuthorization.grantSessionId !== structural.envelope.grant.sessionId ||
+        !isTrustedSystemAction(structural.envelope) &&
+        (structural.envelope.grant === null ||
+          currentAuthorization.grantSessionId !== structural.envelope.grant.sessionId ||
           currentAuthorization.grantVersion !== structural.envelope.grant.versionId)) ||
       (isSystemTimeoutCompletionBatch(batch) &&
-        (structural.envelope.grant.sessionId !== SYSTEM_TIMEOUT_COMPLETION_GRANT.sessionId ||
+        (structural.envelope.grant === null ||
+          structural.envelope.grant.sessionId !== SYSTEM_TIMEOUT_COMPLETION_GRANT.sessionId ||
           structural.envelope.grant.versionId !== SYSTEM_TIMEOUT_COMPLETION_GRANT.versionId))
     )
       return authorityFailure();
@@ -999,7 +1089,7 @@ export function createFoundationAcceptance(
         mode,
         replayState,
         existing.action,
-        batch.input.lifecycleTransition,
+        deferLifecycleTransition ? undefined : batch.input.lifecycleTransition,
         batch.input.reconcileDerivedLifecycle === true,
         batch.input.systemOperation,
       );
@@ -1089,7 +1179,7 @@ export function createFoundationAcceptance(
       current,
       mode,
       replayState,
-      batch.input.lifecycleTransition,
+      deferLifecycleTransition ? undefined : batch.input.lifecycleTransition,
       batch.input.reconcileDerivedLifecycle === true,
       batch.input.systemOperation,
     );
@@ -1108,6 +1198,27 @@ export function createFoundationAcceptance(
     reconcileDerivedLifecycle: boolean,
     systemOperation?: ControlActionBatchInput["systemOperation"],
   ): OneOutcome {
+    if (action.grant === null) {
+      controlAudit.links = {
+        ...controlAudit.links!,
+        contentFingerprint: fingerprint,
+      };
+      transaction.appendAuditEntry(controlAudit);
+      options.failureInjector?.("after-control-audit");
+      applyLifecycleTransition(
+        transaction,
+        root.recordId,
+        lifecycleTransition,
+        reconcileDerivedLifecycle,
+      );
+      return {
+        result: {
+          status: "accepted",
+          action,
+          auditId: controlAudit.auditId,
+        },
+      };
+    }
     const acceptanceId = `accept-${sha256(`${root.recordId}:${action.operationId}:${action.grant.sessionId}`)}`;
     const grantAudit = linkedGrantAudit(
       options.grant,
@@ -1158,6 +1269,10 @@ export function createFoundationAcceptance(
       controlAudit.auditId,
       grantAudit.auditId,
     );
+  }
+
+  function isTrustedSystemAction(input: ControlActionInput): boolean {
+    return input.origin === "system-heat-stoppage" && input.grant === null;
   }
 
   function recoverExistingOutcome(
@@ -1279,6 +1394,38 @@ export function createFoundationAcceptance(
     systemOperation?: ControlActionBatchInput["systemOperation"],
   ): OneOutcome {
     const nowMs = readNow(clock);
+    if (prepared.input.grant === null) {
+      const controlAudit = createControlAudit(
+        prepared.input,
+        "action-duplicate",
+        "The trusted system obligation was already committed.",
+        nowMs,
+        {
+          interpretation: existing.interpretation,
+          relatedOperationIds: relatedFactOperationIds(transaction, root, existing.interpretation),
+        },
+      );
+      controlAudit.outcome = "accepted";
+      controlAudit.links = {
+        ...controlAudit.links!,
+        contentFingerprint: prepared.contentFingerprint,
+      };
+      transaction.appendAuditEntry(controlAudit);
+      options.failureInjector?.("after-control-audit");
+      applyLifecycleTransition(
+        transaction,
+        root.recordId,
+        lifecycleTransition,
+        reconcileDerivedLifecycle,
+      );
+      return {
+        result: {
+          status: "duplicate-accepted",
+          action: existing,
+          auditId: controlAudit.auditId,
+        },
+      };
+    }
     const controlAudit = createControlAudit(
       prepared.input,
       "action-duplicate",
@@ -1571,7 +1718,7 @@ export function createFoundationAcceptance(
     return {
       result: {
         status: "locked-discarded",
-        count: reservation?.actionCount ?? batch.actions.length,
+        count: batch.actions.length,
         eventGameId: root.eventGameId,
         rejectedAtMs,
       },
@@ -1594,6 +1741,8 @@ export function createFoundationAcceptance(
     )
       return null;
     const mode = raw.mode === "replay" ? "replay" : raw.mode === "online" ? "online" : undefined;
+    if (raw.atomic !== undefined && typeof raw.atomic !== "boolean") return null;
+    const atomic = raw.atomic === true;
     const replay =
       isRecord(raw.replay) &&
       typeof raw.replay.sessionBearer === "string" &&
@@ -1609,6 +1758,7 @@ export function createFoundationAcceptance(
     if ((mode === "online" && replay !== undefined) || (mode === "replay" && replay === undefined))
       return null;
     const effectiveMode = mode ?? (replay === undefined ? "online" : "replay");
+    if (atomic && effectiveMode === "replay") return null;
     let size: number;
     try {
       size = Buffer.byteLength(JSON.stringify(raw), "utf8");
@@ -1631,12 +1781,14 @@ export function createFoundationAcceptance(
         return null;
       const grant = canonicalizeJson(envelope.value.grant);
       const lifecycle = canonicalizeJson(envelope.value.lifecycle);
+      const trustedSystem = isTrustedSystemAction(envelope.value);
+      if (envelope.value.origin === "system-heat-stoppage" && !trustedSystem) return null;
       if (
-        (grantEnvelope !== undefined && grantEnvelope !== grant) ||
+        (!trustedSystem && grantEnvelope !== undefined && grantEnvelope !== grant) ||
         (lifecycleEnvelope !== undefined && lifecycleEnvelope !== lifecycle)
       )
         return null;
-      grantEnvelope ??= grant;
+      if (!trustedSystem) grantEnvelope ??= grant;
       lifecycleEnvelope ??= lifecycle;
       if (
         envelope.value.recoveryProvenance !== undefined &&
@@ -1659,6 +1811,7 @@ export function createFoundationAcceptance(
       recordId,
       eventGameId,
       mode: effectiveMode,
+      ...(atomic ? { atomic: true } : {}),
       replay: replay
         ? {
             originatingSessionId: replay.originatingSessionId,
@@ -1679,6 +1832,7 @@ export function createFoundationAcceptance(
         actions: raw.actions,
         sessionBearer: typeof raw.sessionBearer === "string" ? raw.sessionBearer : undefined,
         mode: effectiveMode,
+        atomic,
         replay,
         reconcileDerivedLifecycle: raw.reconcileDerivedLifecycle === true,
         lifecycleTransition: isRecord(raw.lifecycleTransition)
@@ -1839,436 +1993,441 @@ export function createFoundationAcceptance(
     );
     return { value: created, mismatch: false };
   }
-}
 
-function recoverCommittedReplay(
-  transaction: FoundationStorageTransaction,
-  reservation: StoredReplayReservation,
-  attempt: StoredReplayAttempt,
-  keyRing: GrantAuthorityOptions["keyRing"],
-): OneOutcome {
-  const expectedAction = transaction.findActionByOperationId(
-    reservation.recordId,
-    attempt.operationId,
-  )?.action;
-  const controlAudit = transaction
-    .listAuditEntries(reservation.recordId)
-    .find((entry) => entry.auditId === attempt.controlAuditId);
-  const result = readAttemptResult(attempt, expectedAction, controlAudit?.links?.reason);
-  const receipt = transaction.findReplayReceiptByReservationId(reservation.reservationId);
-  if (receipt === null) throw new Error("Committed replay receipt is missing.");
-  return {
-    result,
-    reservationId: reservation.reservationId,
-    receipt: encodeReceipt(reservation.reservationId, keyRing, receipt.receiptKeyVersion),
-  };
-}
-
-function authorityFailure(): OneOutcome {
-  return {
-    result: {
-      status: "authority-expired",
-      reason: "grant-session",
-      detail: "The Grant Session is no longer current.",
-    },
-  };
-}
-
-function samePreparedAction(
-  left: PreparedControlAction,
-  right: PreparedControlAction | null | undefined,
-): boolean {
-  return (
-    right !== null &&
-    right !== undefined &&
-    left.codecIdentity === right.codecIdentity &&
-    left.canonicalContent === right.canonicalContent &&
-    left.contentFingerprint === right.contentFingerprint &&
-    canonicalizeJson(left.interpretation) === canonicalizeJson(right.interpretation) &&
-    canonicalizeJson(left.input.lifecycle) === canonicalizeJson(right.input.lifecycle)
-  );
-}
-
-function samePreparationResultIgnoringTrustedOccurrence(
-  left: PreparedControlAction | null,
-  right: PreparedControlAction | null,
-): boolean {
-  if (left === null || right === null) return left === right;
-  return (
-    left.codecIdentity === right.codecIdentity &&
-    canonicalizeJson(actionContentWithoutTrustedOccurrence(left.input)) ===
-      canonicalizeJson(actionContentWithoutTrustedOccurrence(right.input)) &&
-    canonicalizeJson(left.interpretation) === canonicalizeJson(right.interpretation) &&
-    canonicalizeJson(left.input.lifecycle) === canonicalizeJson(right.input.lifecycle)
-  );
-}
-
-function sameImmutableActionContent(
-  existing: ControlAction,
-  candidate: ControlActionInput,
-): boolean {
-  return (
-    canonicalizeJson(actionContentWithoutTrustedOccurrence(existing)) ===
-    canonicalizeJson(actionContentWithoutTrustedOccurrence(candidate))
-  );
-}
-
-function actionContentWithoutTrustedOccurrence(
-  action: ControlActionInput,
-): Record<string, unknown> {
-  return {
-    recordId: action.recordId,
-    eventGameId: action.eventGameId,
-    operationId: action.operationId,
-    kind: action.kind,
-    payload: action.payload,
-    causalPredecessorIds: action.causalPredecessorIds,
-    occurrence: {
-      clientOriginAtMs: action.occurrence.clientOriginAtMs,
-      source: action.occurrence.source,
-    },
-    grant: action.grant,
-    lifecycle: action.lifecycle,
-    override: action.override ?? null,
-    recoveryProvenance: action.recoveryProvenance ?? null,
-  };
-}
-
-function withTrustedOccurrence(raw: unknown, trustedAtMs: number): unknown {
-  if (!isRecord(raw) || !isRecord(raw.occurrence)) return raw;
-  return {
-    ...structuredClone(raw),
-    occurrence: {
-      ...structuredClone(raw.occurrence),
-      trustedAtMs,
-    },
-  };
-}
-
-function one(result: FoundationActionResult): OneOutcome {
-  return { result };
-}
-
-function validateCurrentAction(
-  transaction: FoundationStorageTransaction,
-  root: EventGameRecordRoot,
-  prepared: PreparedControlAction,
-  options: FoundationAcceptanceOptions,
-): { reason: string; detail: string } | null {
-  const dependency = validateDependencies(transaction, prepared.input);
-  if (dependency !== null) return dependency;
-  if (
-    prepared.interpretation.type === "correction" &&
-    findFactById(transaction.listActions(root.recordId), prepared.interpretation.targetFactId) ===
-      null
-  )
-    return { reason: "fact-target-missing", detail: "The Correction target is not retained." };
-  if (
-    prepared.interpretation.type === "team-assignment-correction" &&
-    options.externalScopeResolver.resolveEventTeam(
-      root.eventId,
-      prepared.interpretation.eventTeamId,
-      transaction,
-    ).status !== "resolved"
-  )
-    return { reason: "invalid-action", detail: "The Event Team is unavailable." };
-  return null;
-}
-
-function dependencyOutcome(
-  predecessorResults: readonly FoundationActionResult[],
-): { status: "dependency-blocked" | "retry-later"; reason: string; detail: string } | undefined {
-  if (
-    predecessorResults.some(
-      (result) => result.status === "retry-later" || result.status === "authority-expired",
-    )
-  )
+  function recoverCommittedReplay(
+    transaction: FoundationStorageTransaction,
+    reservation: StoredReplayReservation,
+    attempt: StoredReplayAttempt,
+    keyRing: GrantAuthorityOptions["keyRing"],
+  ): OneOutcome {
+    const expectedAction = transaction.findActionByOperationId(
+      reservation.recordId,
+      attempt.operationId,
+    )?.action;
+    const controlAudit = transaction
+      .listAuditEntries(reservation.recordId)
+      .find((entry) => entry.auditId === attempt.controlAuditId);
+    const result = readAttemptResult(attempt, expectedAction, controlAudit?.links?.reason);
+    const receipt = transaction.findReplayReceiptByReservationId(reservation.reservationId);
+    if (receipt === null) throw new Error("Committed replay receipt is missing.");
     return {
-      status: "retry-later",
-      reason: "causal-predecessor-retry",
-      detail: "Retry after the causal predecessor reaches a definitive outcome.",
-    };
-  if (
-    predecessorResults.some(
-      (result) => result.status !== "accepted" && result.status !== "duplicate-accepted",
-    )
-  )
-    return {
-      status: "dependency-blocked",
-      reason: "causal-dependency-rejected",
-      detail: "A causal predecessor did not commit.",
-    };
-  return undefined;
-}
-
-function readAttemptResult(
-  attempt: StoredReplayAttempt,
-  expectedAction?: ControlAction,
-  expectedReason?: string,
-): FoundationActionResult {
-  const failure = replayAttemptResultFailure(attempt, expectedAction, expectedReason);
-  if (failure !== null) throw new Error(failure);
-  return JSON.parse(attempt.resultJson!) as FoundationActionResult;
-}
-function reservationIdFor(batch: PreparedBatch, sessionId: string): string {
-  // The reservation identifies the authenticated replay slot, not its
-  // contents. The batch digest remains authenticated mutable evidence and is
-  // checked by ensureReservation, while a locked delivery can still find and
-  // discard an existing reserved/partial slot without retaining content-derived
-  // identifiers.
-  return `reservation-${sha256(`${batch.input.recordId}:${batch.input.eventGameId}:${batch.input.replay?.originatingSessionId ?? ""}:${sessionId}`)}`;
-}
-
-function rejectionCandidate(
-  prepared: PreparedControlAction | undefined,
-  input: ControlActionEnvelope | ControlActionInput,
-  registry: ControlActionCodecRegistry,
-): {
-  codecIdentity: string;
-  codecFingerprint: string;
-  canonicalContent: string;
-  contentFingerprint: string;
-} {
-  if (prepared !== undefined) {
-    return {
-      codecIdentity: prepared.codecIdentity,
-      codecFingerprint: prepared.codecFingerprint,
-      canonicalContent: prepared.canonicalContent,
-      contentFingerprint: prepared.contentFingerprint,
+      result,
+      reservationId: reservation.reservationId,
+      receipt: encodeReceipt(reservation.reservationId, keyRing, receipt.receiptKeyVersion),
     };
   }
-  const codecIdentity = controlActionCodecIdentity(input.kind, registry);
-  const canonicalContent = canonicalizeJson(input);
-  return {
-    codecIdentity,
-    codecFingerprint: codecIdentity,
-    canonicalContent,
-    contentFingerprint: sha256(`${codecIdentity}:${canonicalContent}`),
-  };
-}
 
-function sameRejectedCandidate(
-  links: NonNullable<ControlAuditEntry["links"]>,
-  candidate: ReturnType<typeof rejectionCandidate>,
-): boolean {
-  const rejected = links.rejectedCandidate;
-  if (
-    rejected === undefined ||
-    rejected.codecIdentity !== candidate.codecIdentity ||
-    rejected.codecFingerprint !== candidate.codecFingerprint ||
-    rejected.canonicalContent !== candidate.canonicalContent ||
-    rejected.contentFingerprint !== candidate.contentFingerprint
-  )
-    return false;
-  const collision = links.collision?.rejectedAttempt;
-  return (
-    collision === undefined ||
-    (collision.codecIdentity === candidate.codecIdentity &&
-      collision.codecFingerprint === candidate.codecFingerprint &&
-      collision.canonicalContent === candidate.canonicalContent &&
-      collision.contentFingerprint === candidate.contentFingerprint)
-  );
-}
-
-function parseGrantOutcomeDetail(value: string | null | undefined): {
-  status: FoundationActionResult["status"];
-  reason: FoundationRejectionReason | null;
-} | null {
-  if (value === null || value === undefined) return null;
-  try {
-    const parsed = JSON.parse(value) as Record<string, unknown>;
-    if (
-      typeof parsed.status !== "string" ||
-      ![
-        "accepted",
-        "duplicate-accepted",
-        "rejected",
-        "dependency-blocked",
-        "authority-expired",
-        "retry-later",
-      ].includes(parsed.status) ||
-      (parsed.reason !== null && typeof parsed.reason !== "string")
-    )
-      return null;
+  function authorityFailure(): OneOutcome {
     return {
-      status: parsed.status as FoundationActionResult["status"],
-      reason: parsed.reason === null ? null : normalizeFoundationRejectionReason(parsed.reason),
+      result: {
+        status: "authority-expired",
+        reason: "grant-session",
+        detail: "The Grant Session is no longer current.",
+      },
     };
-  } catch {
+  }
+
+  function samePreparedAction(
+    left: PreparedControlAction,
+    right: PreparedControlAction | null | undefined,
+  ): boolean {
+    return (
+      right !== null &&
+      right !== undefined &&
+      left.codecIdentity === right.codecIdentity &&
+      left.canonicalContent === right.canonicalContent &&
+      left.contentFingerprint === right.contentFingerprint &&
+      canonicalizeJson(left.interpretation) === canonicalizeJson(right.interpretation) &&
+      canonicalizeJson(left.input.lifecycle) === canonicalizeJson(right.input.lifecycle)
+    );
+  }
+
+  function samePreparationResultIgnoringTrustedOccurrence(
+    left: PreparedControlAction | null,
+    right: PreparedControlAction | null,
+  ): boolean {
+    if (left === null || right === null) return left === right;
+    return (
+      left.codecIdentity === right.codecIdentity &&
+      canonicalizeJson(actionContentWithoutTrustedOccurrence(left.input)) ===
+        canonicalizeJson(actionContentWithoutTrustedOccurrence(right.input)) &&
+      canonicalizeJson(left.interpretation) === canonicalizeJson(right.interpretation) &&
+      canonicalizeJson(left.input.lifecycle) === canonicalizeJson(right.input.lifecycle)
+    );
+  }
+
+  function sameImmutableActionContent(
+    existing: ControlAction,
+    candidate: ControlActionInput,
+  ): boolean {
+    return (
+      canonicalizeJson(actionContentWithoutTrustedOccurrence(existing)) ===
+      canonicalizeJson(actionContentWithoutTrustedOccurrence(candidate))
+    );
+  }
+
+  function actionContentWithoutTrustedOccurrence(
+    action: ControlActionInput,
+  ): Record<string, unknown> {
+    return {
+      recordId: action.recordId,
+      eventGameId: action.eventGameId,
+      operationId: action.operationId,
+      kind: action.kind,
+      payload: action.payload,
+      causalPredecessorIds: action.causalPredecessorIds,
+      occurrence: {
+        clientOriginAtMs: action.occurrence.clientOriginAtMs,
+        source: action.occurrence.source,
+      },
+      grant: action.grant,
+      origin: action.origin ?? null,
+      lifecycle: action.lifecycle,
+      override: action.override ?? null,
+      recoveryProvenance: action.recoveryProvenance ?? null,
+    };
+  }
+
+  function withTrustedOccurrence(raw: unknown, trustedAtMs: number): unknown {
+    if (!isRecord(raw) || !isRecord(raw.occurrence)) return raw;
+    return {
+      ...structuredClone(raw),
+      occurrence: {
+        ...structuredClone(raw.occurrence),
+        trustedAtMs,
+      },
+    };
+  }
+
+  function one(result: FoundationActionResult): OneOutcome {
+    return { result };
+  }
+
+  function validateCurrentAction(
+    transaction: FoundationStorageTransaction,
+    root: EventGameRecordRoot,
+    prepared: PreparedControlAction,
+    options: FoundationAcceptanceOptions,
+  ): { reason: string; detail: string } | null {
+    const dependency = validateDependencies(transaction, prepared.input);
+    if (dependency !== null) return dependency;
+    if (
+      prepared.interpretation.type === "correction" &&
+      findFactById(transaction.listActions(root.recordId), prepared.interpretation.targetFactId) ===
+        null
+    )
+      return { reason: "fact-target-missing", detail: "The Correction target is not retained." };
+    if (
+      prepared.interpretation.type === "team-assignment-correction" &&
+      options.externalScopeResolver.resolveEventTeam(
+        root.eventId,
+        prepared.interpretation.eventTeamId,
+        transaction,
+      ).status !== "resolved"
+    )
+      return { reason: "invalid-action", detail: "The Event Team is unavailable." };
     return null;
   }
-}
 
-function linkedGrantAudit(
-  options: GrantAuthorityOptions,
-  grant: StoredGrant,
-  session: StoredGrantSession,
-  acceptanceId: string,
-  controlAuditId: string,
-  controlActionId: string,
-  outcome: string,
-  contentFingerprint: string,
-  createdAtMs: number,
-  reason: FoundationRejectionReason | null,
-  detail: string | null = null,
-  systemOperation?: ControlActionBatchInput["systemOperation"],
-) {
-  const action =
-    outcome === "accepted"
-      ? "control-action-accepted"
-      : outcome === "duplicate-accepted"
-        ? "control-action-duplicate"
-        : outcome === "retry-later"
-          ? "control-action-retry-later"
-          : outcome === "dependency-blocked"
-            ? "control-action-dependency-blocked"
-            : "control-action-rejected";
-  return {
-    ...createGrantAudit(
-      options,
-      auditInput(
-        action,
-        grant,
-        systemOperation === "timeout-completion"
-          ? { kind: "system", value: "timeout-completion" as const }
-          : {
-              kind: "session",
-              sessionId: session.sessionId,
-              pseudonymKeyVersion: session.browserContextKeyVersion,
-            },
-        grant.status,
-        systemOperation === "timeout-completion" ? null : session.sessionId,
-        null,
-        session.eventGameId,
-        grant.status,
-        null,
-        null,
-        null,
-        null,
-        null,
-      ),
-    ),
-    acceptanceId,
-    controlAuditId,
-    controlActionId,
-    contentFingerprint,
-    outcomeDetail: canonicalizeJson({
-      status: outcome,
-      reason,
-      detail: detail ?? "",
-      ...(systemOperation === "timeout-completion"
-        ? { provenance: "system-timeout-completion" }
-        : {}),
-    }),
-    createdAtMs,
-  };
-}
-
-function takeBudget(
-  transaction: FoundationStorageTransaction,
-  kind: StoredAcceptanceBudget["bucketKind"],
-  subjectId: string,
-  capacity: number,
-  refillPerSecond: number,
-  nowMs: number,
-  keyRing: GrantAuthorityOptions["keyRing"],
-): boolean {
-  const bucketId = `budget-${kind}:${subjectId}`;
-  const previous = transaction.findAcceptanceBudget(bucketId);
-  const elapsed = previous === null ? 0 : Math.max(0, nowMs - previous.updatedAtMs) / 1000;
-  const tokens = Math.min(capacity, (previous?.tokens ?? capacity) + elapsed * refillPerSecond);
-  const allowed = tokens >= 1;
-  transaction.upsertAcceptanceBudget({
-    bucketId,
-    bucketKind: kind,
-    subjectId,
-    capacity,
-    refillPerSecond,
-    tokens: allowed ? tokens - 1 : tokens,
-    updatedAtMs: nowMs,
-    stateRevision: (previous?.stateRevision ?? 0) + 1,
-  });
-  transaction.insertAcceptanceIntegrityAnchor(
-    anchorFor(
-      "budget",
-      {
-        bucketId,
-        bucketKind: kind,
-        subjectId,
-        capacity,
-        refillPerSecond,
-        tokens: allowed ? tokens - 1 : tokens,
-        updatedAtMs: nowMs,
-        stateRevision: (previous?.stateRevision ?? 0) + 1,
-      },
-      keyRing,
-    ),
-  );
-  return allowed;
-}
-
-function topologicalOrder(
-  actions: readonly { operationId: string; predecessors: readonly string[] }[],
-): number[] | null {
-  const byOperation = new Map(actions.map((item, index) => [item.operationId, index]));
-  const indegree = actions.map(
-    (item) => item.predecessors.filter((id) => byOperation.has(id)).length,
-  );
-  const order: number[] = [];
-  while (order.length < actions.length) {
-    const next = actions.findIndex((_, index) => indegree[index] === 0 && !order.includes(index));
-    if (next < 0) return null;
-    order.push(next);
-    const operation = actions[next]?.operationId;
-    for (const [index, item] of actions.entries())
-      if (item.predecessors.includes(operation ?? "")) indegree[index] = (indegree[index] ?? 0) - 1;
-    indegree[next] = -1;
+  function dependencyOutcome(
+    predecessorResults: readonly FoundationActionResult[],
+  ): { status: "dependency-blocked" | "retry-later"; reason: string; detail: string } | undefined {
+    if (
+      predecessorResults.some(
+        (result) => result.status === "retry-later" || result.status === "authority-expired",
+      )
+    )
+      return {
+        status: "retry-later",
+        reason: "causal-predecessor-retry",
+        detail: "Retry after the causal predecessor reaches a definitive outcome.",
+      };
+    if (
+      predecessorResults.some(
+        (result) => result.status !== "accepted" && result.status !== "duplicate-accepted",
+      )
+    )
+      return {
+        status: "dependency-blocked",
+        reason: "causal-dependency-rejected",
+        detail: "A causal predecessor did not commit.",
+      };
+    return undefined;
   }
-  return order;
-}
-function predecessorResultsFor(
-  batch: PreparedBatch,
-  results: readonly FoundationActionResult[],
-  index: number,
-): FoundationActionResult[] {
-  const predecessorResults: FoundationActionResult[] = [];
-  for (const predecessor of batch.actions[index]?.envelope.causalPredecessorIds ?? []) {
-    const predecessorIndex = batch.actions.findIndex(
-      (candidate) => candidate.envelope.operationId === predecessor,
+
+  function readAttemptResult(
+    attempt: StoredReplayAttempt,
+    expectedAction?: ControlAction,
+    expectedReason?: string,
+  ): FoundationActionResult {
+    const failure = replayAttemptResultFailure(attempt, expectedAction, expectedReason);
+    if (failure !== null) throw new Error(failure);
+    return JSON.parse(attempt.resultJson!) as FoundationActionResult;
+  }
+  function reservationIdFor(batch: PreparedBatch, sessionId: string): string {
+    // The reservation identifies the authenticated replay slot, not its
+    // contents. The batch digest remains authenticated mutable evidence and is
+    // checked by ensureReservation, while a locked delivery can still find and
+    // discard an existing reserved/partial slot without retaining content-derived
+    // identifiers.
+    return `reservation-${sha256(`${batch.input.recordId}:${batch.input.eventGameId}:${batch.input.replay?.originatingSessionId ?? ""}:${sessionId}`)}`;
+  }
+
+  function rejectionCandidate(
+    prepared: PreparedControlAction | undefined,
+    input: ControlActionEnvelope | ControlActionInput,
+    registry: ControlActionCodecRegistry,
+  ): {
+    codecIdentity: string;
+    codecFingerprint: string;
+    canonicalContent: string;
+    contentFingerprint: string;
+  } {
+    if (prepared !== undefined) {
+      return {
+        codecIdentity: prepared.codecIdentity,
+        codecFingerprint: prepared.codecFingerprint,
+        canonicalContent: prepared.canonicalContent,
+        contentFingerprint: prepared.contentFingerprint,
+      };
+    }
+    const codecIdentity = controlActionCodecIdentity(input.kind, registry);
+    const canonicalContent = canonicalizeJson(input);
+    return {
+      codecIdentity,
+      codecFingerprint: codecIdentity,
+      canonicalContent,
+      contentFingerprint: sha256(`${codecIdentity}:${canonicalContent}`),
+    };
+  }
+
+  function sameRejectedCandidate(
+    links: NonNullable<ControlAuditEntry["links"]>,
+    candidate: ReturnType<typeof rejectionCandidate>,
+  ): boolean {
+    const rejected = links.rejectedCandidate;
+    if (
+      rejected === undefined ||
+      rejected.codecIdentity !== candidate.codecIdentity ||
+      rejected.codecFingerprint !== candidate.codecFingerprint ||
+      rejected.canonicalContent !== candidate.canonicalContent ||
+      rejected.contentFingerprint !== candidate.contentFingerprint
+    )
+      return false;
+    const collision = links.collision?.rejectedAttempt;
+    return (
+      collision === undefined ||
+      (collision.codecIdentity === candidate.codecIdentity &&
+        collision.codecFingerprint === candidate.codecFingerprint &&
+        collision.canonicalContent === candidate.canonicalContent &&
+        collision.contentFingerprint === candidate.contentFingerprint)
     );
-    if (predecessorIndex >= 0 && results[predecessorIndex] !== undefined)
-      predecessorResults.push(results[predecessorIndex]);
   }
-  return predecessorResults;
-}
-function encodeReceipt(
-  reservationId: string,
-  keyRing: GrantAuthorityOptions["keyRing"],
-  keyVersion = keyRing.lookup.currentVersion,
-): string {
-  return `${reservationId}.${computeLookupDigest(
-    `acceptance-receipt:${reservationId}`,
-    keyRing,
-    keyVersion,
-  )}`;
-}
-function readNow(clock: () => number): number {
-  const nowMs = clock();
-  if (!Number.isSafeInteger(nowMs) || nowMs < 0)
-    throw new Error("Acceptance clock returned an invalid timestamp.");
-  return nowMs;
-}
 
-function relatedFactOperationIds(
-  transaction: FoundationStorageSnapshot,
-  root: EventGameRecordRoot,
-  interpretation: ControlAction["interpretation"],
-): readonly string[] {
-  if (interpretation.type !== "correction") return [];
-  const target = findFactById(transaction.listActions(root.recordId), interpretation.targetFactId);
-  return target === null ? [] : [target.action.operationId];
-}
+  function parseGrantOutcomeDetail(value: string | null | undefined): {
+    status: FoundationActionResult["status"];
+    reason: FoundationRejectionReason | null;
+  } | null {
+    if (value === null || value === undefined) return null;
+    try {
+      const parsed = JSON.parse(value) as Record<string, unknown>;
+      if (
+        typeof parsed.status !== "string" ||
+        ![
+          "accepted",
+          "duplicate-accepted",
+          "rejected",
+          "dependency-blocked",
+          "authority-expired",
+          "retry-later",
+        ].includes(parsed.status) ||
+        (parsed.reason !== null && typeof parsed.reason !== "string")
+      )
+        return null;
+      return {
+        status: parsed.status as FoundationActionResult["status"],
+        reason: parsed.reason === null ? null : normalizeFoundationRejectionReason(parsed.reason),
+      };
+    } catch {
+      return null;
+    }
+  }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
+  function linkedGrantAudit(
+    options: GrantAuthorityOptions,
+    grant: StoredGrant,
+    session: StoredGrantSession,
+    acceptanceId: string,
+    controlAuditId: string,
+    controlActionId: string,
+    outcome: string,
+    contentFingerprint: string,
+    createdAtMs: number,
+    reason: FoundationRejectionReason | null,
+    detail: string | null = null,
+    systemOperation?: ControlActionBatchInput["systemOperation"],
+  ) {
+    const action =
+      outcome === "accepted"
+        ? "control-action-accepted"
+        : outcome === "duplicate-accepted"
+          ? "control-action-duplicate"
+          : outcome === "retry-later"
+            ? "control-action-retry-later"
+            : outcome === "dependency-blocked"
+              ? "control-action-dependency-blocked"
+              : "control-action-rejected";
+    return {
+      ...createGrantAudit(
+        options,
+        auditInput(
+          action,
+          grant,
+          systemOperation === "timeout-completion"
+            ? { kind: "system", value: "timeout-completion" as const }
+            : {
+                kind: "session",
+                sessionId: session.sessionId,
+                pseudonymKeyVersion: session.browserContextKeyVersion,
+              },
+          grant.status,
+          systemOperation === "timeout-completion" ? null : session.sessionId,
+          null,
+          session.eventGameId,
+          grant.status,
+          null,
+          null,
+          null,
+          null,
+          null,
+        ),
+      ),
+      acceptanceId,
+      controlAuditId,
+      controlActionId,
+      contentFingerprint,
+      outcomeDetail: canonicalizeJson({
+        status: outcome,
+        reason,
+        detail: detail ?? "",
+        ...(systemOperation === "timeout-completion"
+          ? { provenance: "system-timeout-completion" }
+          : {}),
+      }),
+      createdAtMs,
+    };
+  }
+
+  function takeBudget(
+    transaction: FoundationStorageTransaction,
+    kind: StoredAcceptanceBudget["bucketKind"],
+    subjectId: string,
+    capacity: number,
+    refillPerSecond: number,
+    nowMs: number,
+    keyRing: GrantAuthorityOptions["keyRing"],
+  ): boolean {
+    const bucketId = `budget-${kind}:${subjectId}`;
+    const previous = transaction.findAcceptanceBudget(bucketId);
+    const elapsed = previous === null ? 0 : Math.max(0, nowMs - previous.updatedAtMs) / 1000;
+    const tokens = Math.min(capacity, (previous?.tokens ?? capacity) + elapsed * refillPerSecond);
+    const allowed = tokens >= 1;
+    transaction.upsertAcceptanceBudget({
+      bucketId,
+      bucketKind: kind,
+      subjectId,
+      capacity,
+      refillPerSecond,
+      tokens: allowed ? tokens - 1 : tokens,
+      updatedAtMs: nowMs,
+      stateRevision: (previous?.stateRevision ?? 0) + 1,
+    });
+    transaction.insertAcceptanceIntegrityAnchor(
+      anchorFor(
+        "budget",
+        {
+          bucketId,
+          bucketKind: kind,
+          subjectId,
+          capacity,
+          refillPerSecond,
+          tokens: allowed ? tokens - 1 : tokens,
+          updatedAtMs: nowMs,
+          stateRevision: (previous?.stateRevision ?? 0) + 1,
+        },
+        keyRing,
+      ),
+    );
+    return allowed;
+  }
+
+  function topologicalOrder(
+    actions: readonly { operationId: string; predecessors: readonly string[] }[],
+  ): number[] | null {
+    const byOperation = new Map(actions.map((item, index) => [item.operationId, index]));
+    const indegree = actions.map(
+      (item) => item.predecessors.filter((id) => byOperation.has(id)).length,
+    );
+    const order: number[] = [];
+    while (order.length < actions.length) {
+      const next = actions.findIndex((_, index) => indegree[index] === 0 && !order.includes(index));
+      if (next < 0) return null;
+      order.push(next);
+      const operation = actions[next]?.operationId;
+      for (const [index, item] of actions.entries())
+        if (item.predecessors.includes(operation ?? ""))
+          indegree[index] = (indegree[index] ?? 0) - 1;
+      indegree[next] = -1;
+    }
+    return order;
+  }
+  function predecessorResultsFor(
+    batch: PreparedBatch,
+    results: readonly FoundationActionResult[],
+    index: number,
+  ): FoundationActionResult[] {
+    const predecessorResults: FoundationActionResult[] = [];
+    for (const predecessor of batch.actions[index]?.envelope.causalPredecessorIds ?? []) {
+      const predecessorIndex = batch.actions.findIndex(
+        (candidate) => candidate.envelope.operationId === predecessor,
+      );
+      if (predecessorIndex >= 0 && results[predecessorIndex] !== undefined)
+        predecessorResults.push(results[predecessorIndex]);
+    }
+    return predecessorResults;
+  }
+  function encodeReceipt(
+    reservationId: string,
+    keyRing: GrantAuthorityOptions["keyRing"],
+    keyVersion = keyRing.lookup.currentVersion,
+  ): string {
+    return `${reservationId}.${computeLookupDigest(
+      `acceptance-receipt:${reservationId}`,
+      keyRing,
+      keyVersion,
+    )}`;
+  }
+  function readNow(clock: () => number): number {
+    const nowMs = clock();
+    if (!Number.isSafeInteger(nowMs) || nowMs < 0)
+      throw new Error("Acceptance clock returned an invalid timestamp.");
+    return nowMs;
+  }
+
+  function relatedFactOperationIds(
+    transaction: FoundationStorageSnapshot,
+    root: EventGameRecordRoot,
+    interpretation: ControlAction["interpretation"],
+  ): readonly string[] {
+    if (interpretation.type !== "correction") return [];
+    const target = findFactById(
+      transaction.listActions(root.recordId),
+      interpretation.targetFactId,
+    );
+    return target === null ? [] : [target.action.operationId];
+  }
+
+  function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null && !Array.isArray(value);
+  }
 }

--- a/src/lib/foundation-storage-sqlite-helpers.ts
+++ b/src/lib/foundation-storage-sqlite-helpers.ts
@@ -362,19 +362,34 @@ function readAuditProvenance(value: unknown): ControlAuditProvenance {
     }
   }
   const occurrence = validateOccurrenceWithoutClock(value.occurrence);
-  const grant = validateGrant(value.grant);
+  const grant =
+    value.grant === null ? ({ ok: true, value: null } as const) : validateGrant(value.grant);
+  const origin =
+    value.origin === undefined
+      ? ({ ok: true, value: undefined } as const)
+      : value.origin === "controller" || value.origin === "system-heat-stoppage"
+        ? ({ ok: true, value: value.origin } as const)
+        : ({ ok: false, error: "Stored Control Audit origin is invalid." } as const);
   const lifecycle = validateLifecycle(value.lifecycle);
   const override = validateOverride(value.override === null ? undefined : value.override);
   const recoveryProvenance =
     value.recoveryProvenance === null
       ? { ok: true as const, value: null }
       : validateRecoveryProvenanceShape(value.recoveryProvenance);
-  if (!occurrence.ok || !grant.ok || !lifecycle.ok || !override.ok || !recoveryProvenance.ok) {
+  if (
+    !occurrence.ok ||
+    !grant.ok ||
+    !origin.ok ||
+    !lifecycle.ok ||
+    !override.ok ||
+    !recoveryProvenance.ok
+  ) {
     throw new Error("Stored Control Audit provenance is invalid.");
   }
   return {
     occurrence: occurrence.value,
     grant: grant.value,
+    ...(origin.value === undefined ? {} : { origin: origin.value }),
     lifecycle: lifecycle.value,
     override: override.value ?? null,
     recoveryProvenance: recoveryProvenance.value ?? null,

--- a/src/lib/foundation-storage-sqlite.test.ts
+++ b/src/lib/foundation-storage-sqlite.test.ts
@@ -780,6 +780,7 @@ describe("SQLite foundation storage", () => {
       const controlSessionStayMigration = FOUNDATION_MIGRATIONS[21];
       const eventTeamsMigration = FOUNDATION_MIGRATIONS[22];
       const removalAuditMigration = FOUNDATION_MIGRATIONS[27];
+      const heatStoppageConfigurationMigration = FOUNDATION_MIGRATIONS[29];
       if (
         initialMigration === undefined ||
         repairMigration === undefined ||
@@ -804,7 +805,8 @@ describe("SQLite foundation storage", () => {
         grantCodeLockMigration === undefined ||
         controlSessionStayMigration === undefined ||
         eventTeamsMigration === undefined ||
-        removalAuditMigration === undefined
+        removalAuditMigration === undefined ||
+        heatStoppageConfigurationMigration === undefined
       ) {
         throw new Error("Expected the foundation migrations.");
       }
@@ -846,7 +848,7 @@ describe("SQLite foundation storage", () => {
         "027-event-game-presentation-integrity",
         removalAuditMigration.id,
         "029-access-sheet-generated-audit-action",
-        "030-heat-stoppage-configuration",
+        heatStoppageConfigurationMigration.id,
       ]);
       expect(await current.readiness()).toMatchObject({ ok: true, schemaVersion: "30" });
       current.close();

--- a/src/lib/live-event-game-control.test.ts
+++ b/src/lib/live-event-game-control.test.ts
@@ -15,7 +15,9 @@ import {
   LIVE_SUSPENSION_SNAPSHOT_VERSION,
   parseLiveEventControllerIntent,
   suspensionPenaltyStateFromProjection,
+  projectLiveHeatState,
   type LiveEventControllerIntent,
+  type ControllerGameFact,
   validateLiveEventGameActionInTransaction,
 } from "@/lib/live-event-game-control";
 import { createLiveEventGameControlTransport } from "@/lib/live-event-game-transport";
@@ -1949,6 +1951,76 @@ describe("Live Event Game control", () => {
     });
     expect(await harness.record.readActions()).toHaveLength(before.length);
   });
+  test("projects natural trigger crossing and a locally advancing active timer", () => {
+    const pending = projectLiveHeatState([], "enabled", 15 * 60 * 1000, 1_000);
+    expect(pending).toMatchObject({
+      status: "inactive",
+      pendingTriggerId: "heat-trigger-900000",
+      pendingTriggerGameTimeMs: 900_000,
+    });
+
+    const start: ControllerGameFact = {
+      factId: "local-heat-start",
+      factType: "heat-stoppage",
+      gameSideId: null,
+      gameTimeMs: 900_000,
+      sportingOrder: 900_000,
+      synchronizationOrder: 1,
+      trustedAtMs: 10_000,
+      effective: true,
+      data: {
+        heatAction: "start",
+        heatTriggerId: "heat-trigger-900000",
+        triggerGameTimeMs: 900_000,
+        heatSequence: 1,
+      },
+    };
+    const atStart = projectLiveHeatState([start], "enabled", 900_000, 10_000);
+    const afterLocalAdvance = projectLiveHeatState([start], "enabled", 900_000, 12_500);
+    expect(atStart).toMatchObject({ status: "started", actualDurationMs: 0 });
+    expect(afterLocalAdvance).toMatchObject({ status: "started", actualDurationMs: 2_500 });
+  });
+
+  test("requires a validated Heat Stoppage action before admission", async () => {
+    const malformed = parseLiveEventControllerIntent({
+      version: LIVE_EVENT_CONTROL_INTENT_VERSION,
+      type: "substantive",
+      trigger: "heat-stoppage",
+      operationId: "missing-heat-action",
+      factId: "missing-heat-action-fact",
+      gameTimeMs: 0,
+      occurrence: { clientOriginAtMs: 1_000 },
+    });
+    expect(malformed).toMatchObject({
+      ok: false,
+      error: "heatAction is required for Heat Stoppage operations.",
+    });
+
+    const harness = await createHarness({ heatStoppageConfiguration: true });
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "missing-heat-action",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+    const rejected = await harness.control.submitControllerIntent({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      intent: {
+        version: LIVE_EVENT_CONTROL_INTENT_VERSION,
+        type: "substantive",
+        trigger: "heat-stoppage",
+        operationId: "missing-heat-action",
+        factId: "missing-heat-action-fact",
+        gameTimeMs: 0,
+        occurrence: { clientOriginAtMs: 1_000 },
+      },
+    });
+    expect(rejected).toMatchObject({ status: "rejected" });
+    expect(
+      (await harness.record.readRoot(harness.root.recordId))?.lifecycle.commencedAtMs,
+    ).toBeNull();
+    expect(await harness.record.readActions()).toHaveLength(0);
+  });
 
   test("exposes stable Game Facts and rebuilds score through contextual correction and reinstatement", async () => {
     const harness = await createHarness();
@@ -3028,8 +3100,25 @@ describe("Live Event Game control", () => {
       },
     });
     await submit({
+      ...clockCorrectionIntent("dependent-heat-clock-15"),
+      clockTimeMs: 15 * 60 * 1000,
+      gameTimeMs: 15 * 60 * 1000,
+    });
+    await submit({
       ...substantiveIntent("heat-state", "heat-stoppage"),
+      gameTimeMs: 15 * 60 * 1000,
       heatAction: "start",
+      heatTriggerId: "heat-trigger-900000",
+      override: {
+        guardrail: "heat-stoppage-rule-deviation",
+        direction: "head-referee-directed-heat-stoppage",
+        confirmation: "head-referee-confirmed",
+        authorityReference: "head-referee",
+        gameTimeMs: 15 * 60 * 1000,
+        beforeValue: { heat: "pending", requiredDecision: "skip" },
+        afterValue: { heat: "start" },
+        reason: "head-referee-direction",
+      },
     });
     await submit(substantiveIntent("result-state", "result"));
 
@@ -3182,7 +3271,7 @@ describe("Live Event Game control", () => {
       beforeValue: { running: true },
       afterValue: { timeout: "stoppage" },
     });
-    expect(acceptedAction?.grant.sessionId).toBe(opened.session.grantSessionId);
+    expect(acceptedAction?.grant?.sessionId).toBe(opened.session.grantSessionId);
 
     const invalidEvidence = await harness.control.submitControllerIntent({
       sessionBearer: opened.session.sessionBearer,
@@ -3203,7 +3292,7 @@ describe("Live Event Game control", () => {
     });
     expect(invalidEvidence).toMatchObject({ status: "rejected" });
 
-    const validHeat = await harness.control.submitControllerIntent({
+    const preTriggerHeat = await harness.control.submitControllerIntent({
       sessionBearer: opened.session.sessionBearer,
       eventGameId: harness.root.eventGameId,
       intent: {
@@ -3212,8 +3301,7 @@ describe("Live Event Game control", () => {
         heatAction: "skip-required",
       },
     });
-    expect(validHeat).toMatchObject({ status: "accepted" });
-    expect((await harness.record.readActions())[2]?.action.override).toBeUndefined();
+    expect(preTriggerHeat).toMatchObject({ status: "rejected" });
 
     const fabricatedHeatOverride = await harness.control.submitControllerIntent({
       sessionBearer: opened.session.sessionBearer,
@@ -3277,7 +3365,787 @@ describe("Live Event Game control", () => {
       },
     });
     expect(clockWithOverride).toMatchObject({ status: "rejected" });
-    expect(await harness.record.readActions()).toHaveLength(4);
+    expect(await harness.record.readActions()).toHaveLength(3);
+  });
+
+  test("freezes Game Day heat mode at commencement and carries durable trigger obligations", async () => {
+    const harness = await createHarness({ heatStoppageConfiguration: true });
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "heat-trigger-boundaries",
+    });
+    if (opened.status !== "opened" || opened.projection === null) {
+      throw new Error("Expected the Controller to open with a projection.");
+    }
+    expect(opened.projection.heat).toMatchObject({
+      mode: "enabled",
+      pendingTriggerGameTimeMs: null,
+      nextTriggerGameTimeMs: 15 * 60 * 1000,
+    });
+
+    const submit = (intent: unknown) =>
+      harness.control.submitControllerIntent({
+        sessionBearer: opened.session.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+        intent,
+      });
+    await submit(clockIntent("heat-commencement-start", true));
+    harness.setNow(20_000);
+    await submit(clockIntent("heat-commencement-pause", false));
+    await submit({
+      ...clockCorrectionIntent("heat-clock-15"),
+      clockTimeMs: 15 * 60 * 1000,
+      gameTimeMs: 15 * 60 * 1000,
+    });
+    const pending = await harness.control.refreshController({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+    });
+    expect(pending).toMatchObject({
+      projection: {
+        clock: { gameTimeMs: 15 * 60 * 1000 },
+        heat: {
+          mode: "enabled",
+          pendingTriggerGameTimeMs: 15 * 60 * 1000,
+        },
+      },
+    });
+
+    const first = await submit({
+      ...substantiveIntent("heat-required-skip", "heat-stoppage"),
+      gameTimeMs: 15 * 60 * 1000,
+      heatAction: "skip-required",
+      heatTriggerId: "heat-trigger-900000",
+    });
+    expect(first).toMatchObject({
+      status: "accepted",
+      projection: {
+        commencement: { status: "commenced" },
+        heat: {
+          status: "required-skip",
+          pendingTriggerGameTimeMs: null,
+        },
+      },
+    });
+
+    await submit({
+      ...clockCorrectionIntent("heat-clock-25"),
+      clockTimeMs: 25 * 60 * 1000,
+      gameTimeMs: 25 * 60 * 1000,
+    });
+    const secondPending = await harness.control.refreshController({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+    });
+    expect(secondPending).toMatchObject({
+      projection: { heat: { pendingTriggerGameTimeMs: 25 * 60 * 1000 } },
+    });
+    const skipped = await submit({
+      ...substantiveIntent("heat-within-one-goal-skip", "heat-stoppage"),
+      gameTimeMs: 25 * 60 * 1000,
+      heatAction: "skip-required",
+    });
+    expect(skipped).toMatchObject({
+      status: "accepted",
+      projection: { heat: { status: "required-skip", pendingTriggerGameTimeMs: null } },
+    });
+    const retainedActions = await harness.record.readActions();
+    expect(retainedActions.map(({ action }) => action.interpretation)).toEqual(
+      expect.arrayContaining([expect.objectContaining({ type: "fact", factType: "heat-mode" })]),
+    );
+    expect(
+      retainedActions.find(
+        ({ action }) =>
+          action.interpretation.type === "fact" && action.interpretation.factType === "heat-mode",
+      )?.action,
+    ).toMatchObject({ origin: "system-heat-stoppage" });
+    expect(
+      retainedActions.find(
+        ({ action }) =>
+          action.interpretation.type === "fact" &&
+          action.interpretation.factType === "heat-trigger",
+      )?.action,
+    ).toMatchObject({ origin: "system-heat-stoppage" });
+  });
+
+  test("starts enabled intervals at the next future trigger and never recreates disabled triggers", async () => {
+    const harness = await createHarness({ heatStoppageConfiguration: false });
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "heat-enabled-intervals",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+    const submit = (intent: unknown) =>
+      harness.control.submitControllerIntent({
+        sessionBearer: opened.session.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+        intent,
+      });
+    await submit(goalIntent({ operationId: "interval-commence", factId: "interval-commence" }));
+    await submit({
+      ...clockCorrectionIntent("interval-clock-20"),
+      clockTimeMs: 20 * 60 * 1000,
+      gameTimeMs: 20 * 60 * 1000,
+    });
+    const enabledAtTwenty = await submit({
+      ...substantiveIntent("interval-enable-20", "heat-stoppage"),
+      gameTimeMs: 20 * 60 * 1000,
+      heatAction: "enable",
+      override: heatModeOverride(20 * 60 * 1000, false, true),
+    });
+    expect(enabledAtTwenty).toMatchObject({
+      status: "accepted",
+      projection: {
+        heat: {
+          mode: "enabled",
+          pendingTriggerId: null,
+          nextTriggerGameTimeMs: 25 * 60 * 1000,
+        },
+      },
+    });
+    await submit({
+      ...clockCorrectionIntent("interval-clock-24"),
+      clockTimeMs: 24 * 60 * 1000,
+      gameTimeMs: 24 * 60 * 1000,
+    });
+    const disabledAtTwentyFour = await submit({
+      ...substantiveIntent("interval-disable-24", "heat-stoppage"),
+      gameTimeMs: 24 * 60 * 1000,
+      heatAction: "disable",
+      override: heatModeOverride(24 * 60 * 1000, true, false),
+    });
+    expect(disabledAtTwentyFour).toMatchObject({
+      status: "accepted",
+      projection: { heat: { mode: "disabled" } },
+    });
+    await submit({
+      ...clockCorrectionIntent("interval-clock-26"),
+      clockTimeMs: 26 * 60 * 1000,
+      gameTimeMs: 26 * 60 * 1000,
+    });
+    const reenabledAtTwentySix = await submit({
+      ...substantiveIntent("interval-enable-26", "heat-stoppage"),
+      gameTimeMs: 26 * 60 * 1000,
+      heatAction: "enable",
+      override: heatModeOverride(26 * 60 * 1000, false, true),
+    });
+    expect(reenabledAtTwentySix).toMatchObject({
+      status: "accepted",
+      projection: {
+        heat: {
+          mode: "enabled",
+          pendingTriggerId: null,
+          nextTriggerGameTimeMs: 30 * 60 * 1000,
+        },
+      },
+    });
+    await submit({
+      ...clockCorrectionIntent("interval-clock-30"),
+      clockTimeMs: 30 * 60 * 1000,
+      gameTimeMs: 30 * 60 * 1000,
+    });
+    const reached = await harness.control.refreshController({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+    });
+    expect(reached).toMatchObject({
+      projection: {
+        heat: {
+          pendingTriggerId: "heat-trigger-1800000",
+          pendingTriggerGameTimeMs: 30 * 60 * 1000,
+        },
+      },
+    });
+    const triggerIds = (await harness.record.readActions()).flatMap(({ action }) =>
+      action.interpretation.type === "fact" && action.interpretation.factType === "heat-trigger"
+        ? [action.operationId]
+        : [],
+    );
+    expect(triggerIds).toEqual(["materialize-heat-trigger-1800000"]);
+  });
+
+  test("covers enable, end-of-drive, dead-volleyball, other-stoppage, and suppression branches", async () => {
+    const harness = await createHarness({ heatStoppageConfiguration: false });
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "heat-decision-branches",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+    const submit = (intent: unknown) =>
+      harness.control.submitControllerIntent({
+        sessionBearer: opened.session.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+        intent,
+      });
+    await submit(goalIntent({ operationId: "branch-commencement", factId: "branch-commencement" }));
+    const enabled = await submit({
+      ...substantiveIntent("branch-enable", "heat-stoppage"),
+      gameTimeMs: 12_000,
+      heatAction: "enable",
+      override: {
+        guardrail: "heat-stoppage-mode-change",
+        direction: "head-referee-directed-heat-mode-change",
+        confirmation: "head-referee-confirmed",
+        authorityReference: "head-referee",
+        gameTimeMs: 12_000,
+        beforeValue: { heatMode: false },
+        afterValue: { heatMode: true },
+        reason: "head-referee-direction",
+      },
+    });
+    expect(enabled).toMatchObject({ projection: { heat: { mode: "enabled" } } });
+    await submit(clockIntent("branch-clock-start", true));
+    harness.setNow(20_000);
+    await submit(clockIntent("branch-clock-pause", false));
+    await submit({
+      ...clockCorrectionIntent("branch-clock-15"),
+      clockTimeMs: 15 * 60 * 1000,
+      gameTimeMs: 15 * 60 * 1000,
+    });
+    await submit(goalIntent({ operationId: "branch-score-a", factId: "branch-score-a" }));
+    await submit(goalIntent({ operationId: "branch-score-b", factId: "branch-score-b" }));
+    const endOfDrive = await submit({
+      ...substantiveIntent("branch-end-of-drive", "heat-stoppage"),
+      gameTimeMs: 15 * 60 * 1000,
+      heatAction: "end-of-drive",
+      heatTriggerId: "heat-trigger-900000",
+    });
+    expect(endOfDrive).toMatchObject({ projection: { heat: { status: "started" } } });
+    await submit({
+      ...clockCorrectionIntent("branch-clock-25"),
+      clockTimeMs: 25 * 60 * 1000,
+      gameTimeMs: 25 * 60 * 1000,
+    });
+    const deadVolleyball = await submit({
+      ...substantiveIntent("branch-dead-volleyball", "heat-stoppage"),
+      gameTimeMs: 25 * 60 * 1000,
+      heatAction: "dead-volleyball",
+      heatTriggerId: "heat-trigger-1500000",
+    });
+    expect(deadVolleyball).toMatchObject({ status: "accepted" });
+    await submit({
+      ...clockCorrectionIntent("branch-clock-30"),
+      clockTimeMs: 30 * 60 * 1000,
+      gameTimeMs: 30 * 60 * 1000,
+    });
+    const otherStoppage = await submit({
+      ...substantiveIntent("branch-other-stoppage", "heat-stoppage"),
+      gameTimeMs: 30 * 60 * 1000,
+      heatAction: "other-stoppage",
+      heatTriggerId: "heat-trigger-1800000",
+    });
+    expect(otherStoppage).toMatchObject({ status: "accepted" });
+    await submit({
+      ...clockCorrectionIntent("branch-clock-35"),
+      clockTimeMs: 35 * 60 * 1000,
+      gameTimeMs: 35 * 60 * 1000,
+    });
+    const suppressed = await submit({
+      ...substantiveIntent("branch-suppress", "heat-stoppage"),
+      gameTimeMs: 35 * 60 * 1000,
+      heatAction: "suppress",
+      heatTriggerId: "heat-trigger-2100000",
+      override: {
+        guardrail: "heat-stoppage-rule-deviation",
+        direction: "head-referee-directed-heat-stoppage",
+        confirmation: "head-referee-confirmed",
+        authorityReference: "head-referee",
+        gameTimeMs: 35 * 60 * 1000,
+        beforeValue: { pendingTriggerGameTimeMs: 35 * 60 * 1000 },
+        afterValue: { trigger: "suppressed" },
+        reason: "head-referee-direction",
+      },
+    });
+    expect(suppressed).toMatchObject({ projection: { heat: { status: "suppressed" } } });
+  });
+
+  test("completes at the allowance after a delayed tap while keeping early end and overrun overrides", async () => {
+    const harness = await createHarness({ heatStoppageConfiguration: true });
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "heat-overrides",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+    const submit = (intent: unknown) =>
+      harness.control.submitControllerIntent({
+        sessionBearer: opened.session.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+        intent,
+      });
+    await submit(goalIntent({ operationId: "override-score-a", factId: "override-score-a" }));
+    await submit(goalIntent({ operationId: "override-score-b", factId: "override-score-b" }));
+    await submit(clockIntent("heat-mode-commencement-start", true));
+    harness.setNow(20_000);
+    await submit(clockIntent("heat-mode-commencement-pause", false));
+    await submit({
+      ...clockCorrectionIntent("heat-clock-start"),
+      clockTimeMs: 15 * 60 * 1000,
+      gameTimeMs: 15 * 60 * 1000,
+    });
+    await submit({
+      ...substantiveIntent("heat-start-override-test", "heat-stoppage"),
+      gameTimeMs: 15 * 60 * 1000,
+      heatAction: "start",
+      heatTriggerId: "heat-trigger-900000",
+    });
+    const modeRejected = await submit({
+      ...substantiveIntent("heat-disable-without-override", "heat-stoppage"),
+      heatAction: "disable",
+    });
+    expect(modeRejected).toMatchObject({ status: "rejected" });
+    const modeChanged = await submit({
+      ...substantiveIntent("heat-disable-with-override", "heat-stoppage"),
+      heatAction: "disable",
+      override: {
+        guardrail: "heat-stoppage-mode-change",
+        direction: "head-referee-directed-heat-mode-change",
+        confirmation: "head-referee-confirmed",
+        authorityReference: "head-referee",
+        gameTimeMs: 15 * 60 * 1000,
+        beforeValue: { heatMode: true },
+        afterValue: { heatMode: false },
+        reason: "head-referee-direction",
+      },
+    });
+    expect(modeChanged).toMatchObject({
+      status: "accepted",
+      projection: { heat: { mode: "disabled", status: "ended" }, stoppage: { status: "none" } },
+    });
+
+    const fresh = await createHarness({ heatStoppageConfiguration: true });
+    const freshOpened = await fresh.control.openController({
+      qrCredential: fresh.qrCredential,
+      browserContext: "heat-early-end",
+    });
+    if (freshOpened.status !== "opened") throw new Error("Expected the Controller to open.");
+    const freshSubmit = (intent: unknown) =>
+      fresh.control.submitControllerIntent({
+        sessionBearer: freshOpened.session.sessionBearer,
+        eventGameId: fresh.root.eventGameId,
+        intent,
+      });
+    await freshSubmit(
+      goalIntent({ operationId: "early-end-score-a", factId: "early-end-score-a" }),
+    );
+    await freshSubmit(
+      goalIntent({ operationId: "early-end-score-b", factId: "early-end-score-b" }),
+    );
+    await freshSubmit(clockIntent("early-end-commencement-start", true));
+    fresh.setNow(20_000);
+    await freshSubmit(clockIntent("early-end-commencement-pause", false));
+    await freshSubmit({
+      ...clockCorrectionIntent("early-end-clock-start"),
+      clockTimeMs: 15 * 60 * 1000,
+      gameTimeMs: 15 * 60 * 1000,
+    });
+    await freshSubmit({
+      ...substantiveIntent("early-end-start", "heat-stoppage"),
+      gameTimeMs: 15 * 60 * 1000,
+      heatAction: "start",
+      heatTriggerId: "heat-trigger-900000",
+    });
+    fresh.setNow(140_000);
+    const earlyEnd = await freshSubmit({
+      ...substantiveIntent("early-end", "heat-stoppage"),
+      gameTimeMs: 17 * 60 * 1000,
+      heatAction: "end",
+      override: {
+        guardrail: "heat-stoppage-rule-deviation",
+        direction: "head-referee-directed-heat-stoppage",
+        confirmation: "head-referee-confirmed",
+        authorityReference: "head-referee",
+        gameTimeMs: 17 * 60 * 1000,
+        beforeValue: { heat: "started" },
+        afterValue: { heat: "ended" },
+        reason: "head-referee-direction",
+      },
+    });
+    expect(earlyEnd).toMatchObject({
+      status: "accepted",
+      projection: {
+        heat: {
+          status: "ended",
+          nominalDurationMs: 4 * 60 * 1000,
+          actualDurationMs: 2 * 60 * 1000,
+        },
+      },
+    });
+
+    const nominal = await createHarness({ heatStoppageConfiguration: true });
+    const nominalOpened = await nominal.control.openController({
+      qrCredential: nominal.qrCredential,
+      browserContext: "heat-nominal-end",
+    });
+    if (nominalOpened.status !== "opened") throw new Error("Expected the Controller to open.");
+    const nominalSubmit = (intent: unknown) =>
+      nominal.control.submitControllerIntent({
+        sessionBearer: nominalOpened.session.sessionBearer,
+        eventGameId: nominal.root.eventGameId,
+        intent,
+      });
+    await nominalSubmit(goalIntent({ operationId: "nominal-score-a", factId: "nominal-score-a" }));
+    await nominalSubmit(goalIntent({ operationId: "nominal-score-b", factId: "nominal-score-b" }));
+    await nominalSubmit({
+      ...clockCorrectionIntent("nominal-clock-15"),
+      clockTimeMs: 15 * 60 * 1000,
+      gameTimeMs: 15 * 60 * 1000,
+    });
+    await nominalSubmit({
+      ...substantiveIntent("nominal-start", "heat-stoppage"),
+      gameTimeMs: 15 * 60 * 1000,
+      heatAction: "start",
+      heatTriggerId: "heat-trigger-900000",
+    });
+    nominal.setNow(250_000 + 2_000);
+    const delayedObservation = await nominal.control.refreshController({
+      sessionBearer: nominalOpened.session.sessionBearer,
+      eventGameId: nominal.root.eventGameId,
+    });
+    expect(delayedObservation).toMatchObject({
+      projection: {
+        clock: { running: false },
+        heat: {
+          status: "ended",
+          allowedDurationMs: 240_000,
+          actualDurationMs: 240_000,
+          completedAtAllowed: true,
+        },
+      },
+    });
+    const nominalEnd = await nominalSubmit({
+      ...substantiveIntent("nominal-end", "heat-stoppage"),
+      gameTimeMs: 15 * 60 * 1000,
+      heatAction: "end",
+    });
+    expect(nominalEnd).toMatchObject({
+      status: "accepted",
+      projection: {
+        heat: {
+          status: "ended",
+          nominalDurationMs: 240_000,
+          allowedDurationMs: 240_000,
+          actualDurationMs: 240_000,
+          completedAtAllowed: true,
+        },
+      },
+    });
+    const deliberateExtension = await nominalSubmit({
+      ...substantiveIntent("delayed-extension", "heat-stoppage"),
+      gameTimeMs: 15 * 60 * 1000,
+      heatAction: "extend",
+      heatTriggerId: "heat-trigger-900000",
+    });
+    expect(deliberateExtension).toMatchObject({ status: "rejected" });
+    const extended = await nominalSubmit({
+      ...substantiveIntent("delayed-extension-override", "heat-stoppage"),
+      gameTimeMs: 15 * 60 * 1000,
+      heatAction: "extend",
+      heatTriggerId: "heat-trigger-900000",
+      override: {
+        guardrail: "heat-stoppage-rule-deviation",
+        direction: "head-referee-directed-heat-stoppage",
+        confirmation: "head-referee-confirmed",
+        authorityReference: "head-referee",
+        gameTimeMs: 15 * 60 * 1000,
+        beforeValue: { heat: "ended", nominalDurationMs: 240_000, actualDurationMs: 240_000 },
+        afterValue: { heat: "extended" },
+        reason: "head-referee-direction",
+      },
+    });
+    expect(extended).toMatchObject({
+      status: "accepted",
+      projection: { heat: { status: "extended" } },
+    });
+  });
+
+  test("keeps durable trigger identity and reached obligations across correction and replay", async () => {
+    const harness = await createHarness({ heatStoppageConfiguration: true });
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "heat-trigger-identity",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+    const submit = (intent: unknown) =>
+      harness.control.submitControllerIntent({
+        sessionBearer: opened.session.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+        intent,
+      });
+    await submit(clockIntent("identity-clock-start", true));
+    harness.setNow(20_000);
+    await submit(clockIntent("identity-clock-pause", false));
+    await submit({
+      ...clockCorrectionIntent("identity-clock-15"),
+      clockTimeMs: 15 * 60 * 1000,
+      gameTimeMs: 15 * 60 * 1000,
+    });
+    const firstPending = await harness.control.refreshController({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+    });
+    expect(firstPending).toMatchObject({
+      projection: {
+        heat: {
+          pendingTriggerId: "heat-trigger-900000",
+          pendingTriggerGameTimeMs: 900000,
+        },
+      },
+    });
+    await submit({
+      ...clockCorrectionIntent("identity-clock-backward"),
+      clockTimeMs: 0,
+      gameTimeMs: 0,
+    });
+    const retainedPending = await harness.control.refreshController({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+    });
+    expect(retainedPending).toMatchObject({
+      projection: { heat: { pendingTriggerId: "heat-trigger-900000" } },
+    });
+
+    const started = await submit({
+      ...substantiveIntent("identity-start", "heat-stoppage"),
+      gameTimeMs: 15 * 60 * 1000,
+      heatAction: "skip-required",
+      heatTriggerId: "heat-trigger-900000",
+    });
+    expect(started).toMatchObject({
+      status: "accepted",
+      projection: { heat: { status: "required-skip" } },
+    });
+    await submit({
+      ...clockCorrectionIntent("identity-clock-25"),
+      clockTimeMs: 25 * 60 * 1000,
+      gameTimeMs: 25 * 60 * 1000,
+    });
+    const stale = await submit({
+      ...substantiveIntent("identity-stale", "heat-stoppage"),
+      gameTimeMs: 25 * 60 * 1000,
+      heatAction: "start",
+      heatTriggerId: "heat-trigger-900000",
+    });
+    expect(stale).toMatchObject({ status: "rejected" });
+    expect(
+      (await harness.record.readActions()).some(
+        ({ action }) => action.operationId === "identity-stale",
+      ),
+    ).toBe(false);
+  });
+
+  test("rejects ended-state extension even when the active trigger identity is retained", async () => {
+    const harness = await createHarness({ heatStoppageConfiguration: true });
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "heat-ended-extension",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+    const submit = (intent: unknown) =>
+      harness.control.submitControllerIntent({
+        sessionBearer: opened.session.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+        intent,
+      });
+    await submit({
+      ...clockCorrectionIntent("ended-extension-clock-15"),
+      clockTimeMs: 15 * 60 * 1000,
+      gameTimeMs: 15 * 60 * 1000,
+    });
+    await submit({
+      ...substantiveIntent("ended-extension-start", "heat-stoppage"),
+      gameTimeMs: 15 * 60 * 1000,
+      heatAction: "start",
+      heatTriggerId: "heat-trigger-900000",
+      override: {
+        guardrail: "heat-stoppage-rule-deviation",
+        direction: "head-referee-directed-heat-stoppage",
+        confirmation: "head-referee-confirmed",
+        authorityReference: "head-referee",
+        gameTimeMs: 15 * 60 * 1000,
+        beforeValue: { heat: "pending", requiredDecision: "skip" },
+        afterValue: { heat: "start" },
+        reason: "head-referee-direction",
+      },
+    });
+    harness.setNow(250_000);
+    const ended = await submit({
+      ...substantiveIntent("ended-extension-end", "heat-stoppage"),
+      gameTimeMs: 15 * 60 * 1000,
+      heatAction: "end",
+      heatTriggerId: "heat-trigger-900000",
+    });
+    expect(ended).toMatchObject({ status: "accepted", projection: { heat: { status: "ended" } } });
+
+    const reopened = await submit({
+      ...substantiveIntent("ended-extension-rejected", "heat-stoppage"),
+      gameTimeMs: 15 * 60 * 1000,
+      heatAction: "extend",
+      heatTriggerId: "heat-trigger-900000",
+    });
+    expect(reopened).toMatchObject({ status: "rejected" });
+    expect(
+      (await harness.record.readActions()).some(
+        ({ action }) => action.operationId === "ended-extension-rejected",
+      ),
+    ).toBe(false);
+  });
+
+  test("keeps ordinary required skip and permitted extension distinct from overridden skip", async () => {
+    const ordinary = await createHarness({ heatStoppageConfiguration: true });
+    const opened = await ordinary.control.openController({
+      qrCredential: ordinary.qrCredential,
+      browserContext: "heat-skip-linkage",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+    const submit = (intent: unknown) =>
+      ordinary.control.submitControllerIntent({
+        sessionBearer: opened.session.sessionBearer,
+        eventGameId: ordinary.root.eventGameId,
+        intent,
+      });
+    await submit(clockIntent("skip-clock-start", true));
+    ordinary.setNow(20_000);
+    await submit(clockIntent("skip-clock-pause", false));
+    await submit({
+      ...clockCorrectionIntent("skip-clock-15"),
+      clockTimeMs: 15 * 60 * 1000,
+      gameTimeMs: 15 * 60 * 1000,
+    });
+    const started = await submit({
+      ...substantiveIntent("skip-start", "heat-stoppage"),
+      gameTimeMs: 15 * 60 * 1000,
+      heatAction: "start",
+      heatTriggerId: "heat-trigger-900000",
+      override: {
+        guardrail: "heat-stoppage-rule-deviation",
+        direction: "head-referee-directed-heat-stoppage",
+        confirmation: "head-referee-confirmed",
+        authorityReference: "head-referee",
+        gameTimeMs: 15 * 60 * 1000,
+        beforeValue: { heat: "pending", requiredDecision: "skip" },
+        afterValue: { heat: "start" },
+        reason: "head-referee-direction",
+      },
+    });
+    expect(started).toMatchObject({ projection: { heat: { status: "started" } } });
+    await submit({
+      ...clockCorrectionIntent("skip-clock-25"),
+      clockTimeMs: 25 * 60 * 1000,
+      gameTimeMs: 25 * 60 * 1000,
+    });
+    const skipped = await submit({
+      ...substantiveIntent("skip-required", "heat-stoppage"),
+      gameTimeMs: 25 * 60 * 1000,
+      heatAction: "skip-required",
+      heatTriggerId: "heat-trigger-1500000",
+    });
+    expect(skipped).toMatchObject({ projection: { heat: { status: "required-skip" } } });
+    await submit({
+      ...clockCorrectionIntent("skip-clock-30"),
+      clockTimeMs: 30 * 60 * 1000,
+      gameTimeMs: 30 * 60 * 1000,
+    });
+    const followingStart = await submit({
+      ...substantiveIntent("skip-following-start", "heat-stoppage"),
+      gameTimeMs: 30 * 60 * 1000,
+      heatAction: "start",
+      heatTriggerId: "heat-trigger-1800000",
+      override: {
+        guardrail: "heat-stoppage-rule-deviation",
+        direction: "head-referee-directed-heat-stoppage",
+        confirmation: "head-referee-confirmed",
+        authorityReference: "head-referee",
+        gameTimeMs: 30 * 60 * 1000,
+        beforeValue: { heat: "pending", requiredDecision: "skip" },
+        afterValue: { heat: "start" },
+        reason: "head-referee-direction",
+      },
+    });
+    expect(followingStart).toMatchObject({ projection: { heat: { status: "started" } } });
+    const extended = await submit({
+      ...substantiveIntent("skip-extension", "heat-stoppage"),
+      gameTimeMs: 30 * 60 * 1000,
+      heatAction: "extend-permitted",
+      heatTriggerId: "heat-trigger-1800000",
+    });
+    expect(extended).toMatchObject({ projection: { heat: { status: "extended" } } });
+    ordinary.setNow(300_000);
+    const overrunRejected = await submit({
+      ...substantiveIntent("skip-overrun", "heat-stoppage"),
+      gameTimeMs: 30 * 60 * 1000,
+      heatAction: "extend",
+    });
+    expect(overrunRejected).toMatchObject({ status: "rejected" });
+    const overrunOverride = await submit({
+      ...substantiveIntent("skip-overrun-override", "heat-stoppage"),
+      gameTimeMs: 30 * 60 * 1000,
+      heatAction: "extend",
+      override: {
+        guardrail: "heat-stoppage-rule-deviation",
+        direction: "head-referee-directed-heat-stoppage",
+        confirmation: "head-referee-confirmed",
+        authorityReference: "head-referee",
+        gameTimeMs: 30 * 60 * 1000,
+        beforeValue: { heat: "ended", nominalDurationMs: 120_000, actualDurationMs: 240_000 },
+        afterValue: { heat: "extended" },
+        reason: "head-referee-direction",
+      },
+    });
+    expect(overrunOverride).toMatchObject({ status: "accepted" });
+
+    const ineligible = await createHarness({ heatStoppageConfiguration: true });
+    const ineligibleOpened = await ineligible.control.openController({
+      qrCredential: ineligible.qrCredential,
+      browserContext: "heat-skip-override",
+    });
+    if (ineligibleOpened.status !== "opened") throw new Error("Expected the Controller to open.");
+    const ineligibleSubmit = (intent: unknown) =>
+      ineligible.control.submitControllerIntent({
+        sessionBearer: ineligibleOpened.session.sessionBearer,
+        eventGameId: ineligible.root.eventGameId,
+        intent,
+      });
+    await ineligibleSubmit({
+      ...goalIntent({ operationId: "skip-goal-a", factId: "skip-goal-a", gameTimeMs: 1_000 }),
+    });
+    await ineligibleSubmit({
+      ...goalIntent({ operationId: "skip-goal-b", factId: "skip-goal-b", gameTimeMs: 2_000 }),
+    });
+    await ineligibleSubmit({
+      ...goalIntent({ operationId: "skip-goal-c", factId: "skip-goal-c", gameTimeMs: 3_000 }),
+    });
+    await ineligibleSubmit(clockIntent("skip-override-clock-start", true));
+    ineligible.setNow(20_000);
+    await ineligibleSubmit(clockIntent("skip-override-clock-pause", false));
+    await ineligibleSubmit({
+      ...clockCorrectionIntent("skip-override-clock-15"),
+      clockTimeMs: 15 * 60 * 1000,
+      gameTimeMs: 15 * 60 * 1000,
+    });
+    const rejected = await ineligibleSubmit({
+      ...substantiveIntent("skip-impermissible", "heat-stoppage"),
+      gameTimeMs: 15 * 60 * 1000,
+      heatAction: "skip",
+      heatTriggerId: "heat-trigger-900000",
+    });
+    expect(rejected).toMatchObject({ status: "rejected" });
+    const overridden = await ineligibleSubmit({
+      ...substantiveIntent("skip-impermissible-override", "heat-stoppage"),
+      gameTimeMs: 15 * 60 * 1000,
+      heatAction: "skip",
+      heatTriggerId: "heat-trigger-900000",
+      override: {
+        guardrail: "heat-stoppage-rule-deviation",
+        direction: "head-referee-directed-heat-stoppage",
+        confirmation: "head-referee-confirmed",
+        authorityReference: "head-referee",
+        gameTimeMs: 15 * 60 * 1000,
+        beforeValue: { scoreDifference: 30 },
+        afterValue: { heat: "skipped" },
+        reason: "head-referee-direction",
+      },
+    });
+    expect(overridden).toMatchObject({ projection: { heat: { status: "skipped" } } });
   });
 
   test("keeps a failed live Correction atomic and safely retryable", async () => {
@@ -4157,8 +5025,11 @@ describe("Live Event Game control", () => {
     });
   });
 
-  test("atomically rolls back the action and commencement at the lifecycle boundary", async () => {
-    const harness = await createHarness({ failureBoundary: "after-lifecycle" });
+  test("atomically rolls back the action, mode snapshot, and commencement at the lifecycle boundary", async () => {
+    const harness = await createHarness({
+      failureBoundary: "after-lifecycle",
+      heatStoppageConfiguration: true,
+    });
     const opened = await harness.control.openController({
       qrCredential: harness.qrCredential,
       browserContext: "controller-phone",
@@ -4261,11 +5132,164 @@ describe("Live Event Game control", () => {
       actions.map((stored) => ({
         operationId: stored.action.operationId,
         clientOriginAtMs: stored.action.occurrence.clientOriginAtMs,
+        trustedAtMs: stored.action.occurrence.trustedAtMs,
+        acceptedAtMs: stored.action.acceptedAtMs,
         source: stored.action.occurrence.source,
       })),
     ).toEqual([
-      { operationId: "online-provenance", clientOriginAtMs: 1_000, source: "online" },
-      { operationId: "offline-provenance", clientOriginAtMs: 2_000, source: "offline" },
+      {
+        operationId: "online-provenance",
+        clientOriginAtMs: 1_000,
+        trustedAtMs: 10_000,
+        acceptedAtMs: 10_000,
+        source: "online",
+      },
+      {
+        operationId: "offline-provenance",
+        clientOriginAtMs: 2_000,
+        trustedAtMs: 2_000,
+        acceptedAtMs: 10_000,
+        source: "offline",
+      },
+    ]);
+  });
+
+  test("preserves offline Heat Stoppage occurrence timing across reordered replay acceptance", async () => {
+    const harness = await createHarness({ heatStoppageConfiguration: true });
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "offline-heat-replay-device",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+    const submit = (intent: unknown) =>
+      harness.control.submitControllerIntent({
+        sessionBearer: opened.session.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+        intent,
+      });
+    await submit(
+      goalIntent({ operationId: "offline-heat-score-a", factId: "offline-heat-score-a" }),
+    );
+    await submit(
+      goalIntent({ operationId: "offline-heat-score-b", factId: "offline-heat-score-b" }),
+    );
+    await submit({
+      ...clockCorrectionIntent("offline-heat-clock-15"),
+      clockTimeMs: 15 * 60 * 1000,
+      gameTimeMs: 15 * 60 * 1000,
+    });
+
+    const start = await harness.control.replayControllerActions({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      batchId: "offline-heat-start-batch",
+      replicaGeneration: "offline-heat-start-generation",
+      expectedGrantSessionId: opened.session.grantSessionId,
+      expectedGrantVersion: opened.session.grantVersion,
+      actions: [
+        {
+          eventGameId: harness.root.eventGameId,
+          intent: {
+            ...substantiveIntent("offline-heat-start", "heat-stoppage"),
+            gameTimeMs: 15 * 60 * 1000,
+            heatAction: "start",
+            heatTriggerId: "heat-trigger-900000",
+            occurrence: { clientOriginAtMs: 100_000, source: "offline" as const },
+          },
+          causalPredecessorIds: [],
+        },
+      ],
+    });
+    expect(start.outcomes).toEqual([{ operationId: "offline-heat-start", status: "accepted" }]);
+
+    harness.setNow(500_000);
+    await submit({
+      ...clockCorrectionIntent("offline-heat-clock-25"),
+      clockTimeMs: 25 * 60 * 1000,
+      gameTimeMs: 25 * 60 * 1000,
+    });
+    const lateWithoutOverride = await harness.control.replayControllerActions({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      batchId: "offline-heat-late-without-override-batch",
+      replicaGeneration: "offline-heat-late-without-override-generation",
+      expectedGrantSessionId: opened.session.grantSessionId,
+      expectedGrantVersion: opened.session.grantVersion,
+      actions: [
+        {
+          eventGameId: harness.root.eventGameId,
+          intent: {
+            ...substantiveIntent("offline-heat-late-without-override", "heat-stoppage"),
+            gameTimeMs: 25 * 60 * 1000,
+            heatAction: "end",
+            heatTriggerId: "heat-trigger-900000",
+            occurrence: { clientOriginAtMs: 400_000, source: "offline" as const },
+          },
+          causalPredecessorIds: ["offline-heat-start"],
+        },
+      ],
+    });
+    expect(lateWithoutOverride.outcomes).toEqual([
+      {
+        operationId: "offline-heat-late-without-override",
+        status: "terminally-rejected",
+        detail: "terminal server rejection",
+      },
+    ]);
+    const end = await harness.control.replayControllerActions({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      batchId: "offline-heat-end-batch",
+      replicaGeneration: "offline-heat-end-generation",
+      expectedGrantSessionId: opened.session.grantSessionId,
+      expectedGrantVersion: opened.session.grantVersion,
+      actions: [
+        {
+          eventGameId: harness.root.eventGameId,
+          intent: {
+            ...substantiveIntent("offline-heat-end", "heat-stoppage"),
+            gameTimeMs: 25 * 60 * 1000,
+            heatAction: "end",
+            heatTriggerId: "heat-trigger-900000",
+            occurrence: { clientOriginAtMs: 400_000, source: "offline" as const },
+            override: {
+              guardrail: "heat-stoppage-rule-deviation",
+              direction: "head-referee-directed-heat-stoppage",
+              confirmation: "head-referee-confirmed",
+              authorityReference: "head-referee",
+              gameTimeMs: 25 * 60 * 1000,
+              beforeValue: {
+                heat: "ended",
+                nominalDurationMs: 240_000,
+                actualDurationMs: 300_000,
+              },
+              afterValue: { heat: "ended" },
+              reason: "head-referee-direction",
+            },
+          },
+          causalPredecessorIds: ["offline-heat-start"],
+        },
+      ],
+    });
+    expect(end.outcomes).toEqual([{ operationId: "offline-heat-end", status: "accepted" }]);
+    expect(end.projection).toMatchObject({
+      heat: { status: "ended", nominalDurationMs: 240_000, actualDurationMs: 300_000 },
+    });
+    expect(
+      (await harness.record.readActions())
+        .filter(
+          ({ action }) =>
+            action.operationId === "offline-heat-start" ||
+            action.operationId === "offline-heat-end",
+        )
+        .map(({ action }) => ({
+          operationId: action.operationId,
+          trustedAtMs: action.occurrence.trustedAtMs,
+          acceptedAtMs: action.acceptedAtMs,
+        })),
+    ).toEqual([
+      { operationId: "offline-heat-start", trustedAtMs: 100_000, acceptedAtMs: 10_000 },
+      { operationId: "offline-heat-end", trustedAtMs: 400_000, acceptedAtMs: 500_000 },
     ]);
   });
 
@@ -5406,13 +6430,13 @@ describe("Live Event Game control", () => {
         operationId: "delayed-offline-card",
         gameTimeMs: 0,
         source: "offline",
-        trustedAtMs: 10_000,
+        trustedAtMs: 1_000,
       },
       {
         operationId: "delayed-offline-goal",
         gameTimeMs: 15_000,
         source: "offline",
-        trustedAtMs: 10_000,
+        trustedAtMs: 2_000,
       },
     ]);
     expect(
@@ -5434,6 +6458,7 @@ async function createHarness(
     knownDodgeballIds?: readonly string[];
     sessionResolution?: ControlGrantSessionResolution;
     acceptanceLimits?: AcceptanceLimits;
+    heatStoppageConfiguration?: boolean;
   } = {},
 ) {
   const root = createRoot(overrides.eventGameId ?? "game-live-control");
@@ -5519,6 +6544,9 @@ async function createHarness(
     knownDodgeballIdsForEventGame:
       overrides.knownDodgeballIds === undefined ? undefined : () => overrides.knownDodgeballIds!,
     projectionFailure: overrides.projectionFailure,
+    ...(overrides.heatStoppageConfiguration === undefined
+      ? {}
+      : { heatStoppageConfiguration: overrides.heatStoppageConfiguration }),
   });
   triggerLifecycleChange = () => {
     void control.reconcileActiveControllerSessions();
@@ -5806,6 +6834,19 @@ function substantiveIntent(
       : {}),
     occurrence: { clientOriginAtMs: null },
   };
+}
+
+function heatModeOverride(gameTimeMs: number, before: boolean, after: boolean) {
+  return {
+    guardrail: "heat-stoppage-mode-change",
+    direction: "head-referee-directed-heat-mode-change",
+    confirmation: "head-referee-confirmed",
+    authorityReference: "head-referee",
+    gameTimeMs,
+    beforeValue: { heatMode: before },
+    afterValue: { heatMode: after },
+    reason: "head-referee-direction",
+  } as const;
 }
 
 function simpleIntent(operationId: string, type: "reset" | "undo") {

--- a/src/lib/live-event-game-control.ts
+++ b/src/lib/live-event-game-control.ts
@@ -27,8 +27,12 @@ import {
 import type { EventGameLifecyclePhase, EventGameRecordRoot } from "@/lib/foundation-record-types";
 import type { EventGameRecord } from "@/lib/event-game-record";
 import type { FoundationAcceptance } from "@/lib/foundation-acceptance";
-import type { ControlAction } from "@/lib/event-game-actions";
+import type { ControlAction, ControlActionInput } from "@/lib/event-game-actions";
 import type { TypedGrantAuthority } from "@/lib/grant-management-types";
+import type {
+  HeatStoppageConfiguration,
+  HeatStoppageConfigurationScope,
+} from "@/lib/heat-stoppage-configuration";
 import {
   compareLivePenaltyFactOrder,
   deriveLivePenaltyProjection,
@@ -61,6 +65,26 @@ export type SportingOrderAdjudication = {
   relation: "before" | "after";
 };
 
+export const HEAT_STOPPAGE_FIRST_TRIGGER_GAME_TIME_MS = 15 * 60 * 1000;
+export const HEAT_STOPPAGE_SECOND_TRIGGER_GAME_TIME_MS = 25 * 60 * 1000;
+export const HEAT_STOPPAGE_TRIGGER_INTERVAL_MS = 5 * 60 * 1000;
+export const HEAT_STOPPAGE_FIRST_NOMINAL_DURATION_MS = 4 * 60 * 1000;
+export const HEAT_STOPPAGE_LATER_NOMINAL_DURATION_MS = 2 * 60 * 1000;
+
+export type LiveHeatAction =
+  | "start"
+  | "end"
+  | "skip-required"
+  | "extend-permitted"
+  | "extend"
+  | "end-of-drive"
+  | "dead-volleyball"
+  | "other-stoppage"
+  | "skip"
+  | "suppress"
+  | "enable"
+  | "disable";
+
 type ControllerIntentBase = {
   version: typeof LIVE_EVENT_CONTROL_INTENT_VERSION;
   operationId: string;
@@ -74,6 +98,7 @@ type ControllerIntentBase = {
     source?: "online" | "offline";
   };
   clockGeneration?: number;
+  heatTriggerId?: string;
   override?: OfficialOverrideMetadata;
 };
 
@@ -147,7 +172,7 @@ export type LiveEventControllerIntent =
       gameSideId?: string;
       penaltyCardType?: "blue" | "yellow" | "red" | "ejection";
       penaltyPlayerKey?: string;
-      heatAction?: "start" | "end" | "skip-required" | "extend-permitted";
+      heatAction?: LiveHeatAction;
       timeoutAction?: "stoppage" | "start" | "complete";
       timeoutGameSideId?: string;
       suspensionAction?: "start" | "resume";
@@ -283,10 +308,37 @@ export type LiveStoppageState = {
 };
 
 export type LiveHeatState = {
-  status: "inactive" | "started" | "ended" | "skipped" | "extended";
+  status:
+    | "inactive"
+    | "started"
+    | "ended"
+    | "skipped"
+    | "required-skip"
+    | "suppressed"
+    | "extended";
   factId: string | null;
   startedAtGameTimeMs: number | null;
   nominalDurationMs: number | null;
+  allowedDurationMs?: number | null;
+  actualDurationMs?: number | null;
+  completedAtAllowed?: boolean;
+  rawActualDurationMs?: number | null;
+  completionAtTrustedAtMs?: number | null;
+  mode?: "enabled" | "disabled";
+  pendingTrigger?: { gameTimeMs: number; index: number } | null;
+  pendingTriggerId?: string | null;
+  pendingTriggerGameTimeMs?: number | null;
+  nextTriggerGameTimeMs?: number | null;
+  trigger?: { id: string; gameTimeMs: number; index: number } | null;
+  permittedExtensionTriggerId?: string | null;
+  activeTriggerId?: string | null;
+  triggerDecision?:
+    | "end-of-drive"
+    | "dead-volleyball"
+    | "other-stoppage"
+    | "skip"
+    | "skip-required"
+    | null;
 };
 
 export type LiveResultState = {
@@ -309,6 +361,8 @@ export type ControllerGameFact = {
   gameTimeMs: number | null;
   sportingOrder: number;
   synchronizationOrder: number;
+  trustedAtMs?: number;
+  acceptedAtMs?: number;
   effective: boolean;
   data: ActionJsonValue;
 };
@@ -436,6 +490,7 @@ export type LiveEventGameControlOptions = {
     eventGameId: string;
     grantSessionId: string;
     grantVersion: string;
+    evidence?: string;
   }) => Promise<boolean>;
   lockEventGame?: (
     eventGameId: string,
@@ -449,6 +504,12 @@ export type LiveEventGameControlOptions = {
   knownDodgeballIdsForEventGame?: (eventGameId: string) => readonly string[] | undefined;
   /** Test-only seam for proving the post-commit projection response. */
   projectionFailure?: () => boolean;
+  /** Production composition seam backed by the Event Admin catalog snapshot. */
+  readHeatStoppageConfiguration?: (
+    scope: HeatStoppageConfigurationScope,
+  ) => HeatStoppageConfiguration | null | Promise<HeatStoppageConfiguration | null>;
+  /** Fixed configuration shortcut for deterministic callers and tests. */
+  heatStoppageConfiguration?: boolean;
 };
 
 export type ControllerReplayOutcome = {
@@ -717,6 +778,12 @@ export function parseLiveEventControllerIntent(
       clockGeneration = generation.value;
     }
   }
+  let heatTriggerId: string | undefined;
+  if (value.heatTriggerId !== undefined) {
+    const parsedTriggerId = validateOpaqueIdentifier(value.heatTriggerId, "heatTriggerId");
+    if (!parsedTriggerId.ok) return invalid(parsedTriggerId.error);
+    heatTriggerId = parsedTriggerId.value;
+  }
   let trigger:
     | "card"
     | "timeout"
@@ -730,7 +797,7 @@ export function parseLiveEventControllerIntent(
     | undefined;
   let penaltyCardType: "blue" | "yellow" | "red" | "ejection" | undefined;
   let penaltyPlayerKey: string | undefined;
-  let heatAction: "start" | "end" | "skip-required" | "extend-permitted" | undefined;
+  let heatAction: LiveHeatAction | undefined;
   let timeoutAction: "stoppage" | "start" | "complete" | undefined;
   let timeoutGameSideId: string | undefined;
   let suspensionAction: "start" | "resume" | undefined;
@@ -768,13 +835,10 @@ export function parseLiveEventControllerIntent(
       }
     }
     if (trigger === "heat-stoppage") {
-      if (
-        value.heatAction !== undefined &&
-        value.heatAction !== "start" &&
-        value.heatAction !== "end" &&
-        value.heatAction !== "skip-required" &&
-        value.heatAction !== "extend-permitted"
-      ) {
+      if (value.heatAction === undefined) {
+        return invalid("heatAction is required for Heat Stoppage operations.");
+      }
+      if (!isLiveHeatAction(value.heatAction)) {
         return invalid("heatAction is unsupported.");
       }
       heatAction = value.heatAction;
@@ -889,6 +953,7 @@ export function parseLiveEventControllerIntent(
       ...(authorityGeneration === undefined ? {} : { authorityGeneration }),
       ...(confirmation === undefined ? {} : { confirmation }),
       ...(clockGeneration === undefined ? {} : { clockGeneration }),
+      ...(heatTriggerId === undefined ? {} : { heatTriggerId }),
       ...(trigger === undefined ? {} : { trigger }),
       ...(penaltyCardType === undefined ? {} : { penaltyCardType }),
       ...(penaltyPlayerKey === undefined ? {} : { penaltyPlayerKey }),
@@ -906,6 +971,7 @@ export function parseLiveEventControllerIntent(
 export function explainLiveEventGuardrail(intent: {
   type: LiveEventControllerIntent["type"];
   trigger?: Extract<LiveEventControllerIntent, { type: "substantive" }>["trigger"];
+  heatAction?: LiveHeatAction;
   gameTimeMs?: number;
   sportingOrder?: number;
 }): LiveEventGuardrailExplanation {
@@ -944,6 +1010,18 @@ export function explainLiveEventGuardrail(intent: {
     return {
       guardrail: "flag-catch-requires-seeker-release-and-stopped-play",
       normalBehavior: "A flag catch is recorded after seeker release and while play is stopped.",
+      overrideAllowed: true,
+      fixedReason: "head-referee-direction",
+    };
+  }
+  if (
+    intent.type === "substantive" &&
+    intent.trigger === "heat-stoppage" &&
+    (intent.heatAction === "enable" || intent.heatAction === "disable")
+  ) {
+    return {
+      guardrail: "heat-stoppage-mode-change",
+      normalBehavior: "Heat Stoppage Mode is fixed at Game Commencement.",
       overrideAllowed: true,
       fixedReason: "head-referee-direction",
     };
@@ -1377,7 +1455,11 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
     if (root === null || root.eventGameId !== authorized.eventGameId) {
       return rejectedOpen();
     }
-    const commenced = await ensureClockCommencement(owner, root, clock());
+    const commenced = await ensureClockCommencement(owner, root, {
+      sessionBearer: admitted.sessionBearer,
+      sessionId: authorized.grantSessionId,
+      grantVersion: authorized.grantVersion,
+    });
     if (commenced.status === "rejected") {
       return rejectedOpen();
     }
@@ -1426,7 +1508,11 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
       const previousRoot =
         previousOwner === null ? null : await previousOwner.record.readRoot(previousOwner.recordId);
       if (previousOwner !== null && previousRoot !== null) {
-        const commenced = await ensureClockCommencement(previousOwner, previousRoot, clock());
+        const commenced = await ensureClockCommencement(previousOwner, previousRoot, {
+          sessionBearer: input.sessionBearer,
+          sessionId: authorized.grantSessionId,
+          grantVersion: authorized.grantVersion,
+        });
         if (commenced.status === "rejected") {
           return { status: "rejected", message: "Unable to refresh Controller session." };
         }
@@ -1497,7 +1583,11 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
     if (owner === null || root === null) {
       return { status: "rejected", message: "Unable to refresh Controller session." };
     }
-    const commenced = await ensureClockCommencement(owner, root, clock());
+    const commenced = await ensureClockCommencement(owner, root, {
+      sessionBearer: input.sessionBearer,
+      sessionId: authorized.grantSessionId,
+      grantVersion: authorized.grantVersion,
+    });
     if (commenced.status === "rejected") {
       return { status: "rejected", message: "Unable to refresh Controller session." };
     }
@@ -1545,7 +1635,11 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
     if (owner === null || root === null || root.eventGameId !== switched.eventGameId) {
       return { status: "rejected", message: "Unable to refresh Controller session." };
     }
-    const commenced = await ensureClockCommencement(owner, root, clock());
+    const commenced = await ensureClockCommencement(owner, root, {
+      sessionBearer: input.sessionBearer,
+      sessionId: switched.grantSessionId,
+      grantVersion: switched.grantVersion,
+    });
     if (commenced.status === "rejected") {
       return { status: "rejected", message: "Unable to refresh Controller session." };
     }
@@ -1598,7 +1692,11 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
     if (owner === null || root === null) {
       return { status: "rejected", message: "Unable to refresh Controller session." };
     }
-    const commenced = await ensureClockCommencement(owner, root, clock());
+    const commenced = await ensureClockCommencement(owner, root, {
+      sessionBearer: input.sessionBearer,
+      sessionId: authorized.grantSessionId,
+      grantVersion: authorized.grantVersion,
+    });
     if (commenced.status === "rejected") {
       return { status: "rejected", message: "Unable to refresh Controller session." };
     }
@@ -1785,7 +1883,11 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
     if (owner === null || root === null) {
       return rejectedAction(parsed.value.operationId);
     }
-    const commenced = await ensureClockCommencement(owner, root, clock());
+    const commenced = await ensureClockCommencement(owner, root, {
+      sessionBearer: input.sessionBearer,
+      sessionId: authorized.grantSessionId,
+      grantVersion: authorized.grantVersion,
+    });
     if (commenced.status === "rejected") return retryableAction(parsed.value.operationId);
     const materialized = input.deferTimeoutMaterialization
       ? { status: "ready" as const, root: commenced.root }
@@ -1818,7 +1920,32 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
     const existingAction = actionsBefore.find(
       (stored) => stored.action.operationId === parsed.value.operationId,
     );
-    const effectiveStateBefore = rebuildLiveDerivedState(activeRoot, actionsBefore);
+    const nowMs = clock();
+    const stateWithFrozenMode = rebuildLiveDerivedState(
+      activeRoot,
+      actionsBefore,
+      nowMs,
+      false,
+      nowMs,
+    );
+    if (stateWithFrozenMode === null) {
+      return retryableAction(parsed.value.operationId);
+    }
+    let configuredHeatMode: boolean;
+    try {
+      const reserveNonHeatReplay =
+        input.replay?.reserveOnly === true &&
+        !(parsed.value.type === "substantive" && parsed.value.trigger === "heat-stoppage");
+      configuredHeatMode = reserveNonHeatReplay
+        ? false
+        : await readConfiguredHeatMode(activeRoot, stateWithFrozenMode.gameFacts);
+    } catch {
+      return retryableAction(parsed.value.operationId);
+    }
+    const effectiveStateBefore =
+      configuredHeatMode === false
+        ? stateWithFrozenMode
+        : rebuildLiveDerivedState(activeRoot, actionsBefore, nowMs, true, nowMs);
     if (effectiveStateBefore === null) {
       return retryableAction(parsed.value.operationId);
     }
@@ -1839,7 +1966,6 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
     ) {
       return rejectedAction(parsed.value.operationId);
     }
-    const nowMs = clock();
     const previousClockStartMs = latestRunningClockStart(effectiveStateBefore.gameFacts);
     const clockAuthorityActionsBefore = readClockAuthorityActions(actionsBefore);
     const clockBefore = projectClockBaseline(
@@ -1949,6 +2075,65 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
       if (predecessor !== undefined) causalPredecessorIds.add(predecessor.action.operationId);
     }
 
+    const heatAction =
+      parsed.value.type === "substantive" && parsed.value.trigger === "heat-stoppage"
+        ? parsed.value.heatAction
+        : undefined;
+    const resolvesHeatTrigger =
+      heatAction === "start" ||
+      heatAction === "end-of-drive" ||
+      heatAction === "dead-volleyball" ||
+      heatAction === "other-stoppage" ||
+      heatAction === "skip-required" ||
+      heatAction === "skip" ||
+      heatAction === "suppress";
+    const requiresHeatTrigger =
+      heatAction !== undefined && heatAction !== "enable" && heatAction !== "disable";
+    const activeHeatTriggerId =
+      heatAction === "extend-permitted"
+        ? effectiveStateBefore.heat.permittedExtensionTriggerId
+        : heatAction === "extend"
+          ? (effectiveStateBefore.heat.activeTriggerId ?? null)
+          : heatAction === "end"
+            ? (effectiveStateBefore.heat.activeTriggerId ?? null)
+            : null;
+    const requestedHeatTriggerId =
+      parsed.value.heatTriggerId ??
+      (resolvesHeatTrigger &&
+      effectiveStateBefore.heat.pendingTriggerId !== null &&
+      effectiveStateBefore.heat.pendingTriggerGameTimeMs === parsed.value.gameTimeMs
+        ? effectiveStateBefore.heat.pendingTriggerId
+        : activeHeatTriggerId);
+    const enforceHeatAdmission = hasHeatStoppageConfiguration() || requestedHeatTriggerId === null;
+    if (
+      enforceHeatAdmission &&
+      requiresHeatTrigger &&
+      (effectiveStateBefore.heat.mode !== "enabled" ||
+        requestedHeatTriggerId === null ||
+        (resolvesHeatTrigger &&
+          (requestedHeatTriggerId !== effectiveStateBefore.heat.pendingTriggerId ||
+            effectiveStateBefore.heat.pendingTriggerGameTimeMs !== parsed.value.gameTimeMs)) ||
+        (heatAction === "end" &&
+          requestedHeatTriggerId !== effectiveStateBefore.heat.activeTriggerId) ||
+        (heatAction === "extend" &&
+          requestedHeatTriggerId !== effectiveStateBefore.heat.activeTriggerId) ||
+        (heatAction === "extend-permitted" &&
+          requestedHeatTriggerId !== effectiveStateBefore.heat.permittedExtensionTriggerId))
+    ) {
+      return rejectedAction(parsed.value.operationId);
+    }
+    const heatTriggerGameTimeMs =
+      requestedHeatTriggerId === effectiveStateBefore.heat.pendingTriggerId
+        ? effectiveStateBefore.heat.pendingTriggerGameTimeMs
+        : undefined;
+    const heatSequence =
+      heatAction === undefined
+        ? undefined
+        : actionsBefore.filter(
+            ({ action }) =>
+              action.interpretation.type === "fact" &&
+              action.interpretation.factType === "heat-stoppage",
+          ).length + 1;
     const action = {
       recordId: owner.recordId,
       eventGameId: activeRoot.eventGameId,
@@ -2068,6 +2253,26 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
                                     ...(parsed.value.heatAction === undefined
                                       ? {}
                                       : { heatAction: parsed.value.heatAction }),
+                                    ...(heatSequence === undefined ? {} : { heatSequence }),
+                                    ...(requestedHeatTriggerId === null ||
+                                    requestedHeatTriggerId === undefined
+                                      ? {}
+                                      : { heatTriggerId: requestedHeatTriggerId }),
+                                    ...(heatTriggerGameTimeMs === undefined
+                                      ? {}
+                                      : { triggerGameTimeMs: heatTriggerGameTimeMs }),
+                                    ...((heatAction === "end" || heatAction === "extend") &&
+                                    typeof effectiveStateBefore.heat.actualDurationMs === "number"
+                                      ? {
+                                          actualDurationMs:
+                                            effectiveStateBefore.heat.actualDurationMs,
+                                        }
+                                      : {}),
+                                    ...(heatAction === "end" &&
+                                    effectiveStateBefore.heat.completedAtAllowed === true &&
+                                    override === undefined
+                                      ? { completionAtAllowed: true }
+                                      : {}),
                                     ...(parsed.value.penaltyCardType === undefined
                                       ? {}
                                       : { penaltyCardType: parsed.value.penaltyCardType }),
@@ -2097,7 +2302,11 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
             },
       causalPredecessorIds: [...causalPredecessorIds],
       occurrence: {
-        trustedAtMs: nowMs,
+        trustedAtMs:
+          parsed.value.occurrence.source === "offline" &&
+          parsed.value.occurrence.clientOriginAtMs !== null
+            ? parsed.value.occurrence.clientOriginAtMs
+            : nowMs,
         clientOriginAtMs: parsed.value.occurrence.clientOriginAtMs,
         source: parsed.value.occurrence.source ?? "online",
       },
@@ -2181,6 +2390,36 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
           }
         : undefined);
 
+    const heatModeSnapshot = hasHeatStoppageConfiguration()
+      ? createHeatModeSnapshotAction({
+          root: activeRoot,
+          nowMs,
+          enabled: configuredHeatMode,
+          gameTimeMs: clockBefore.gameTimeMs,
+          shouldCommence: shouldCommence?.atMs ?? activeRoot.lifecycle.commencedAtMs,
+          existingActions: actionsBefore,
+          causalPredecessorIds: [action.operationId],
+        })
+      : null;
+    const modeTimeline = deriveHeatModeTimeline(effectiveStateBefore.gameFacts, configuredHeatMode);
+    const heatTriggerActions = createHeatTriggerActions({
+      root: activeRoot,
+      nowMs,
+      currentGameTimeMs: clockBefore.gameTimeMs,
+      targetGameTimeMs:
+        typeof clockData.value?.gameTimeMs === "number"
+          ? clockData.value.gameTimeMs
+          : clockBefore.gameTimeMs,
+      enabledAtGameTimeMs: modeTimeline.enabled ? modeTimeline.enabledAtGameTimeMs : null,
+      existingActions: actionsBefore,
+      causalPredecessorIds: [action.operationId],
+    });
+    const batchActions = [
+      ...actions,
+      ...heatTriggerActions,
+      ...(heatModeSnapshot === null ? [] : [heatModeSnapshot]),
+    ];
+
     let accepted;
     try {
       accepted = await options.acceptance.submitBatch({
@@ -2189,13 +2428,13 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
         ...(input.replay === undefined ? { sessionBearer: input.sessionBearer } : {}),
         ...(input.replay === undefined ? {} : { mode: "replay", replay: input.replay }),
         lifecycleTransition,
-        actions,
         reconcileDerivedLifecycle: derivedLifecycle !== undefined,
+        atomic: lifecycleTransition !== undefined && heatModeSnapshot !== null,
+        actions: batchActions,
       });
     } catch {
       return retryableAction(parsed.value.operationId);
     }
-
     const result = accepted.results[0];
     const consequenceResult = accepted.results[1];
     if (accepted.status === "partial" || result?.status === "retry-later") {
@@ -2281,7 +2520,9 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
         grantSessionId: input.expectedGrantSessionId,
         grantVersion: input.expectedGrantVersion,
       });
-      if (!authorized) return replayRejected(input.actions, replayContext);
+      if (!authorized) {
+        return replayRejected(input.actions, replayContext);
+      }
       options.lockedReplayCapability?.authorize(replayDigest);
     }
     await lockEventGameIfDue(input.eventGameId);
@@ -2664,11 +2905,24 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
       if (rebuild.status !== "ready") return null;
       const derived = readDerivedState(rebuild.derivedGameState);
       if (derived === null) return null;
+      const configuredHeatMode = await readConfiguredHeatMode(root, derived.gameFacts);
       const projectedClock = projectClockBaseline(derived.clock.baseline, clock());
       const projectedFacts = derived.gameFacts.map((fact) => ({
         ...fact,
         data: structuredClone(fact.data),
       }));
+      const projectedHeat = deriveHeatStoppageState(
+        derived.gameFacts,
+        projectedClock.gameTimeMs,
+        configuredHeatMode,
+        clock(),
+      );
+      const projectedStoppage: LiveStoppageState =
+        derived.stoppage.status === "suspension"
+          ? derived.stoppage
+          : projectedHeat.status === "started" || projectedHeat.status === "extended"
+            ? { status: "heat-stoppage", factId: projectedHeat.factId }
+            : { status: "none", factId: null };
       const runningSinceMs =
         root.lifecycle.commencedAtMs === null ? latestRunningClockStart(derived.gameFacts) : null;
       const controllerProjection: ControllerProjection = {
@@ -2683,8 +2937,6 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
         ].sort(),
         timeout: projectLiveTimeout(derived.timeout, clock()),
         suspension: structuredClone(derived.suspension),
-        stoppage: structuredClone(derived.stoppage),
-        heat: structuredClone(derived.heat),
         result: structuredClone(derived.result),
         overtime: derived.overtime,
         overtimeTarget: derived.overtimeTarget,
@@ -2693,6 +2945,8 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
         catch: structuredClone(derived.catch),
         gameFacts: projectedFacts,
         penalties: deriveLivePenaltyProjection(projectedFacts, projectedClock.gameTimeMs),
+        stoppage: structuredClone(projectedStoppage),
+        heat: structuredClone(projectedHeat),
         guardrails: [
           explainLiveEventGuardrail({ type: "substantive", trigger: "timeout" }),
           explainLiveEventGuardrail({ type: "substantive", trigger: "suspension" }),
@@ -2711,6 +2965,97 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
     } catch {
       return null;
     }
+  }
+
+  async function ensureClockCommencement(
+    owner: { recordId: string; record: EventGameRecord },
+    root: EventGameRecordRoot,
+    authority: { sessionBearer: string; sessionId: string; grantVersion: string },
+  ): Promise<{ status: "ready"; root: EventGameRecordRoot } | { status: "rejected" }> {
+    if (root.lifecycle.commencedAtMs !== null || root.lifecycle.phase !== "scheduled") {
+      return { status: "ready", root };
+    }
+    const actions = await owner.record.readActions();
+    const nowMs = clock();
+    const fallbackState = rebuildLiveDerivedState(root, actions, nowMs, false, nowMs);
+    if (fallbackState === null) return { status: "rejected" };
+    const runningSinceMs = latestRunningClockStart(fallbackState.gameFacts);
+    if (runningSinceMs === null || nowMs - runningSinceMs < 10_000) {
+      return { status: "ready", root };
+    }
+    const commencementAtMs = runningSinceMs + 10_000;
+    const lifecycleTransition = {
+      ...root.lifecycle,
+      phase: "in-progress" as const,
+      commencedAtMs: commencementAtMs,
+    };
+    let configuredHeatMode: boolean;
+    try {
+      configuredHeatMode = await readConfiguredHeatMode(root, fallbackState.gameFacts);
+    } catch {
+      return { status: "rejected" };
+    }
+    const snapshot = hasHeatStoppageConfiguration()
+      ? createHeatModeSnapshotAction({
+          root,
+          nowMs,
+          enabled: configuredHeatMode,
+          gameTimeMs: fallbackState.clock.gameTimeMs,
+          shouldCommence: commencementAtMs,
+          existingActions: actions,
+          causalPredecessorIds: [],
+        })
+      : null;
+    if (snapshot === null) {
+      const transition = await owner.record.transitionLifecycle(lifecycleTransition);
+      return transition.status === "rejected"
+        ? { status: "rejected" }
+        : { status: "ready", root: transition.root };
+    }
+    const accepted = await options.acceptance.submitBatch({
+      recordId: root.recordId,
+      eventGameId: root.eventGameId,
+      sessionBearer: authority.sessionBearer,
+      lifecycleTransition,
+      atomic: true,
+      actions: [snapshot],
+    });
+    if (
+      accepted.status !== "committed" ||
+      (accepted.results[0]?.status !== "accepted" &&
+        accepted.results[0]?.status !== "duplicate-accepted")
+    ) {
+      return { status: "rejected" };
+    }
+    const updatedRoot = await owner.record.readRoot(owner.recordId);
+    return updatedRoot === null ? { status: "rejected" } : { status: "ready", root: updatedRoot };
+  }
+
+  async function readConfiguredHeatMode(
+    root: EventGameRecordRoot,
+    facts: readonly ControllerGameFact[],
+  ): Promise<boolean> {
+    const snapshot = facts.find((fact) => fact.factType === "heat-mode" && isRecord(fact.data));
+    if (snapshot !== undefined && isRecord(snapshot.data)) {
+      return snapshot.data.enabled === true;
+    }
+    if (options.readHeatStoppageConfiguration !== undefined) {
+      const configured = await options.readHeatStoppageConfiguration({
+        eventId: root.externalScope.eventId,
+        gameDayId: root.externalScope.gameDayId,
+        eventGameId: root.eventGameId,
+      });
+      if (configured === null) throw new Error("Heat Stoppage Configuration is unavailable.");
+      return configured === "enabled";
+    }
+    return options.heatStoppageConfiguration ?? false;
+  }
+
+  function hasHeatStoppageConfiguration(): boolean {
+    return (
+      options.readHeatStoppageConfiguration !== undefined ||
+      options.heatStoppageConfiguration !== undefined
+    );
   }
 
   return {
@@ -2906,6 +3251,8 @@ function deriveLiveEventGameState(
   effectiveFacts: readonly EffectiveGameFact[],
   version: string,
   projectedAtMs = 0,
+  configuredHeatMode = false,
+  nowMs = 0,
 ): LiveEventGameDerivedState {
   const scoreByGameSide: Record<string, number> = Object.fromEntries(
     root.gameSides.map((side) => [side.id, 0]),
@@ -2934,6 +3281,8 @@ function deriveLiveEventGameState(
             gameTimeMs,
             sportingOrder,
             synchronizationOrder: synchronizationOrderByOperationId.get(action.operationId) ?? 0,
+            trustedAtMs: action.occurrence.trustedAtMs,
+            acceptedAtMs: action.acceptedAtMs,
             effective: effectiveFactIds.has(action.interpretation.factId),
             data: isActionJsonValue(data) ? structuredClone(data) : null,
           } satisfies ControllerGameFact,
@@ -3141,69 +3490,20 @@ function deriveLiveEventGameState(
     suspension = { status: "suspended", factId: fact.factId, snapshot };
   }
 
-  const suspensionFact =
-    suspension.status === "suspended" && suspension.factId !== null
-      ? (gameFacts.find((fact) => fact.factId === suspension.factId) ?? null)
-      : null;
-  const heatFact = latestEffectiveFact("heat-stoppage");
   const latestResultFact = latestEffectiveFact("result");
-  const heatAction =
-    isRecord(heatFact?.data) &&
-    (heatFact.data.heatAction === "start" ||
-      heatFact.data.heatAction === "end" ||
-      heatFact.data.heatAction === "skip-required" ||
-      heatFact.data.heatAction === "extend-permitted")
-      ? heatFact.data.heatAction
-      : heatFact === null
-        ? null
-        : "start";
-  const heatStatus: LiveHeatState["status"] =
-    heatFact === null
-      ? "inactive"
-      : heatAction === "end"
-        ? "ended"
-        : heatAction === "skip-required"
-          ? "skipped"
-          : heatAction === "extend-permitted"
-            ? "extended"
-            : "started";
-  const effectiveHeatStarts = gameFacts.filter(
-    (fact) =>
-      fact.effective &&
-      fact.factType === "heat-stoppage" &&
-      (!isRecord(fact.data) ||
-        (fact.data.heatAction !== "end" &&
-          fact.data.heatAction !== "skip-required" &&
-          fact.data.heatAction !== "extend-permitted")),
-  );
-  const heatNominalDurationMs =
-    heatStatus === "started" || heatStatus === "extended"
-      ? effectiveHeatStarts.length <= 1
-        ? 4 * 60 * 1000
-        : 2 * 60 * 1000
-      : null;
-  const heatStartedAtGameTimeMs =
-    heatNominalDurationMs === null || heatFact?.gameTimeMs === null
-      ? null
-      : (heatFact?.gameTimeMs ?? null);
-  const heat: LiveHeatState = {
-    status: heatStatus,
-    factId: heatFact?.factId ?? null,
-    startedAtGameTimeMs: heatStartedAtGameTimeMs,
-    nominalDurationMs: heatNominalDurationMs,
-  };
   const clock = projectClockBaseline(
     deriveClockAuthority(
       readClockAuthorityActions(effectiveFacts.map((fact) => ({ action: fact.action }))),
     ),
     projectedAtMs,
   );
+  const heat = deriveHeatStoppageState(gameFacts, clock.gameTimeMs, configuredHeatMode, nowMs);
   if (suspension.status === "suspended" && clock.running) {
     throw new Error("Effective suspension cannot coexist with a running Game Clock.");
   }
   const stoppage: LiveStoppageState =
-    suspensionFact !== null
-      ? { status: "suspension", factId: suspensionFact.factId }
+    suspension.status === "suspended"
+      ? { status: "suspension", factId: suspension.factId }
       : heat.status === "started" || heat.status === "extended"
         ? { status: "heat-stoppage", factId: heat.factId }
         : { status: "none", factId: null };
@@ -3256,6 +3556,392 @@ function readTimeoutAction(
     data?.timeoutAction === "complete"
     ? data.timeoutAction
     : null;
+}
+export function deriveHeatStoppageState(
+  facts: readonly ControllerGameFact[],
+  gameTimeMs: number,
+  configuredHeatMode: boolean,
+  nowMs = 0,
+): LiveHeatState {
+  const effectiveFacts = facts.filter((fact) => fact.effective);
+  const modeTimeline = deriveHeatModeTimeline(effectiveFacts, configuredHeatMode);
+  const { enabled, configured, enabledAtGameTimeMs, segments } = modeTimeline;
+  const currentIntervalFirstTrigger = enabled ? firstHeatTriggerAfter(enabledAtGameTimeMs) : null;
+  const triggerFacts = effectiveFacts.filter((fact) => fact.factType === "heat-trigger");
+  const triggerById = new Map<string, { id: string; gameTimeMs: number; durable: boolean }>();
+  for (const fact of triggerFacts) {
+    const data = isRecord(fact.data) ? fact.data : null;
+    const triggerGameTimeMs =
+      typeof data?.triggerGameTimeMs === "number" ? data.triggerGameTimeMs : fact.gameTimeMs;
+    const triggerId = typeof data?.triggerId === "string" ? data.triggerId : null;
+    if (triggerId !== null && triggerGameTimeMs !== null) {
+      triggerById.set(triggerId, { id: triggerId, gameTimeMs: triggerGameTimeMs, durable: true });
+    }
+  }
+  const derivedTriggerTimes = new Set<number>();
+  for (const segment of segments) {
+    if (segment.end !== null) continue;
+    const end = Math.max(gameTimeMs, ...effectiveFacts.map((fact) => fact.gameTimeMs ?? 0));
+    for (
+      let trigger = firstHeatTriggerAfter(segment.start);
+      trigger <= end;
+      trigger = nextHeatTrigger(trigger)
+    ) {
+      derivedTriggerTimes.add(trigger);
+    }
+  }
+  for (const triggerGameTimeMs of derivedTriggerTimes) {
+    const triggerId = heatTriggerId(triggerGameTimeMs);
+    if (!triggerById.has(triggerId)) {
+      triggerById.set(triggerId, { id: triggerId, gameTimeMs: triggerGameTimeMs, durable: false });
+    }
+  }
+  const orderedTriggers = [...triggerById.values()].sort(
+    (left, right) => left.gameTimeMs - right.gameTimeMs || left.id.localeCompare(right.id),
+  );
+  const resolvedTriggerIds = new Set<string>();
+  const heatFacts = effectiveFacts.filter((fact) => fact.factType === "heat-stoppage");
+  for (const fact of heatFacts) {
+    const data = isRecord(fact.data) ? fact.data : null;
+    const action = data?.heatAction;
+    if (
+      action === "enable" ||
+      action === "disable" ||
+      action === "end" ||
+      action === "extend-permitted" ||
+      action === "extend"
+    )
+      continue;
+    const triggerTime = typeof data?.triggerGameTimeMs === "number" ? data.triggerGameTimeMs : null;
+    const triggerId =
+      typeof data?.heatTriggerId === "string"
+        ? data.heatTriggerId
+        : typeof data?.triggerId === "string"
+          ? data.triggerId
+          : triggerTime === null
+            ? null
+            : heatTriggerId(triggerTime);
+    if (triggerId !== null) resolvedTriggerIds.add(triggerId);
+  }
+  const pendingTrigger =
+    configured && enabled && currentIntervalFirstTrigger !== null
+      ? (orderedTriggers.find(
+          (trigger) =>
+            trigger.gameTimeMs >= currentIntervalFirstTrigger &&
+            (trigger.durable || trigger.gameTimeMs <= gameTimeMs) &&
+            !resolvedTriggerIds.has(trigger.id),
+        ) ?? null)
+      : null;
+  const nextTrigger =
+    configured && enabled
+      ? (orderedTriggers.find(
+          (trigger) =>
+            trigger.gameTimeMs >= (currentIntervalFirstTrigger ?? 0) &&
+            trigger.gameTimeMs > gameTimeMs &&
+            !resolvedTriggerIds.has(trigger.id),
+        ) ?? {
+          id: heatTriggerId(firstHeatTriggerAfter(Math.max(gameTimeMs, enabledAtGameTimeMs))),
+          gameTimeMs: firstHeatTriggerAfter(Math.max(gameTimeMs, enabledAtGameTimeMs)),
+          durable: false,
+        })
+      : null;
+
+  const starts = heatFacts.filter((fact) => {
+    const action = isRecord(fact.data) ? fact.data.heatAction : null;
+    return (
+      action === "start" ||
+      action === "end-of-drive" ||
+      action === "dead-volleyball" ||
+      action === "other-stoppage"
+    );
+  });
+  const orderedHeatFacts = [...heatFacts].sort(
+    (left, right) =>
+      heatFactSequence(left) - heatFactSequence(right) ||
+      (left.gameTimeMs ?? 0) - (right.gameTimeMs ?? 0) ||
+      left.synchronizationOrder - right.synchronizationOrder,
+  );
+  const latestHeatFact = orderedHeatFacts.at(-1) ?? null;
+  const latestData =
+    latestHeatFact !== null && isRecord(latestHeatFact.data) ? latestHeatFact.data : null;
+  const latestAction = latestData?.heatAction;
+  const latestStart =
+    [...starts]
+      .sort(
+        (left, right) =>
+          heatFactSequence(left) - heatFactSequence(right) ||
+          (left.gameTimeMs ?? 0) - (right.gameTimeMs ?? 0) ||
+          left.synchronizationOrder - right.synchronizationOrder,
+      )
+      .at(-1) ?? null;
+  const latestStartTime = latestStart?.gameTimeMs ?? null;
+  const latestStartData =
+    latestStart !== null && isRecord(latestStart.data) ? latestStart.data : null;
+  const activeTriggerId =
+    typeof latestStartData?.heatTriggerId === "string"
+      ? latestStartData.heatTriggerId
+      : typeof latestStartData?.triggerId === "string"
+        ? latestStartData.triggerId
+        : typeof latestStartData?.triggerGameTimeMs === "number"
+          ? heatTriggerId(latestStartData.triggerGameTimeMs)
+          : null;
+  const nominalDurationMs =
+    latestStart === null
+      ? null
+      : starts.length === 1
+        ? HEAT_STOPPAGE_FIRST_NOMINAL_DURATION_MS
+        : HEAT_STOPPAGE_LATER_NOMINAL_DURATION_MS;
+  const endedBy =
+    latestHeatFact !== null &&
+    (latestAction === "end" || latestAction === "disable") &&
+    latestStart !== null &&
+    (latestHeatFact.gameTimeMs ?? 0) >= (latestStart.gameTimeMs ?? 0) &&
+    latestHeatFact.synchronizationOrder !== latestStart.synchronizationOrder
+      ? latestHeatFact
+      : null;
+  const startTrustedAtMs = latestStart?.trustedAtMs ?? null;
+  const endTrustedAtMs = endedBy?.trustedAtMs ?? null;
+  const rawActualDurationMs =
+    startTrustedAtMs === null
+      ? null
+      : Math.max(0, (endTrustedAtMs ?? (nowMs > 0 ? nowMs : startTrustedAtMs)) - startTrustedAtMs);
+  const decision =
+    latestAction === "end-of-drive" ||
+    latestAction === "dead-volleyball" ||
+    latestAction === "other-stoppage" ||
+    latestAction === "skip" ||
+    latestAction === "skip-required"
+      ? latestAction
+      : null;
+  const pendingIndex = pendingTrigger === null ? -1 : orderedTriggers.indexOf(pendingTrigger);
+  let permittedExtensionTriggerId: string | null = null;
+  let followingExtensionActive = false;
+  let followingExtensionConsumed = false;
+  for (const fact of orderedHeatFacts) {
+    const data = isRecord(fact.data) ? fact.data : null;
+    const action = data?.heatAction;
+    const triggerTime =
+      typeof data?.triggerGameTimeMs === "number"
+        ? data.triggerGameTimeMs
+        : typeof data?.heatTriggerId === "string"
+          ? orderedTriggers.find((trigger) => trigger.id === data.heatTriggerId)?.gameTimeMs
+          : fact.gameTimeMs;
+    const triggerId =
+      typeof data?.heatTriggerId === "string"
+        ? data.heatTriggerId
+        : typeof triggerTime === "number"
+          ? heatTriggerId(triggerTime)
+          : null;
+    if (action === "skip" || action === "skip-required") {
+      permittedExtensionTriggerId =
+        typeof triggerTime === "number" ? heatTriggerId(nextHeatTrigger(triggerTime)) : null;
+      followingExtensionActive = false;
+      followingExtensionConsumed = false;
+    } else if (
+      action === "start" ||
+      action === "end-of-drive" ||
+      action === "dead-volleyball" ||
+      action === "other-stoppage"
+    ) {
+      if (permittedExtensionTriggerId !== null && triggerId !== permittedExtensionTriggerId) {
+        permittedExtensionTriggerId = null;
+        followingExtensionActive = false;
+        followingExtensionConsumed = false;
+      } else if (
+        permittedExtensionTriggerId !== null &&
+        triggerId === permittedExtensionTriggerId
+      ) {
+        followingExtensionActive = true;
+      }
+    } else if (action === "extend-permitted") {
+      if (triggerId === permittedExtensionTriggerId && followingExtensionActive) {
+        followingExtensionConsumed = true;
+        permittedExtensionTriggerId = null;
+      }
+    } else if (action === "extend") {
+      followingExtensionActive = false;
+      followingExtensionConsumed = false;
+      permittedExtensionTriggerId = null;
+    }
+  }
+  const allowedDurationMs =
+    nominalDurationMs === null
+      ? null
+      : followingExtensionActive || followingExtensionConsumed
+        ? HEAT_STOPPAGE_FIRST_NOMINAL_DURATION_MS
+        : nominalDurationMs;
+  const completionRecordedAtAllowed = latestData?.completionAtAllowed === true;
+  const completedAtAllowed =
+    latestStart !== null &&
+    latestAction !== "extend" &&
+    (endedBy === null || completionRecordedAtAllowed) &&
+    allowedDurationMs !== null &&
+    (rawActualDurationMs ?? 0) >= allowedDurationMs;
+  const actualDurationMs =
+    (completedAtAllowed || completionRecordedAtAllowed) && allowedDurationMs !== null
+      ? allowedDurationMs
+      : rawActualDurationMs;
+  const completionAtTrustedAtMs =
+    startTrustedAtMs !== null && allowedDurationMs !== null
+      ? startTrustedAtMs + allowedDurationMs
+      : null;
+  const status: LiveHeatState["status"] =
+    latestHeatFact === null || latestStart === null
+      ? latestAction === "extend-permitted" || latestAction === "extend"
+        ? "extended"
+        : latestAction === "skip-required"
+          ? "required-skip"
+          : latestAction === "skip"
+            ? "skipped"
+            : latestAction === "suppress"
+              ? "suppressed"
+              : "inactive"
+      : latestAction === "skip-required"
+        ? "required-skip"
+        : latestAction === "skip"
+          ? "skipped"
+          : latestAction === "suppress"
+            ? "suppressed"
+            : latestAction === "extend-permitted" || latestAction === "extend"
+              ? completedAtAllowed
+                ? "ended"
+                : "extended"
+              : latestAction === "end" || (configured && !enabled) || endedBy !== null
+                ? "ended"
+                : completedAtAllowed
+                  ? "ended"
+                  : "started";
+  return {
+    status,
+    factId: latestHeatFact?.factId ?? null,
+    startedAtGameTimeMs: latestStartTime,
+    nominalDurationMs,
+    allowedDurationMs,
+    actualDurationMs,
+    completedAtAllowed,
+    rawActualDurationMs,
+    completionAtTrustedAtMs,
+    mode: enabled ? "enabled" : "disabled",
+    pendingTrigger:
+      pendingTrigger === null
+        ? null
+        : {
+            gameTimeMs: pendingTrigger.gameTimeMs,
+            index: pendingIndex,
+          },
+    pendingTriggerId: pendingTrigger?.id ?? null,
+    pendingTriggerGameTimeMs: pendingTrigger?.gameTimeMs ?? null,
+    nextTriggerGameTimeMs: nextTrigger?.gameTimeMs ?? null,
+    trigger:
+      pendingTrigger === null
+        ? null
+        : { id: pendingTrigger.id, gameTimeMs: pendingTrigger.gameTimeMs, index: pendingIndex },
+    permittedExtensionTriggerId,
+    activeTriggerId,
+    triggerDecision: decision,
+  };
+}
+
+/**
+ * Project the Controller's local Heat Stoppage view from its last trusted
+ * projection. Durable admission still validates stable trigger identity on
+ * the server; this helper only updates the browser cue and timer between
+ * server round trips.
+ */
+export function projectLiveHeatState(
+  facts: readonly ControllerGameFact[],
+  currentMode: LiveHeatState["mode"] | undefined,
+  gameTimeMs: number,
+  nowMs: number,
+): LiveHeatState {
+  return deriveHeatStoppageState(facts, gameTimeMs, currentMode === "enabled", nowMs);
+}
+
+function deriveHeatModeTimeline(
+  facts: readonly ControllerGameFact[],
+  configuredHeatMode: boolean,
+): {
+  enabled: boolean;
+  configured: boolean;
+  enabledAtGameTimeMs: number;
+  segments: Array<{ start: number; end: number | null }>;
+} {
+  const effectiveFacts = facts.filter((fact) => fact.effective);
+  const heatModeFacts = effectiveFacts.filter((fact) => fact.factType === "heat-mode");
+  const modeChanges = effectiveFacts
+    .filter((fact) => {
+      if (fact.factType !== "heat-stoppage" || !isRecord(fact.data)) return false;
+      return fact.data.heatAction === "enable" || fact.data.heatAction === "disable";
+    })
+    .sort(
+      (left, right) =>
+        heatFactSequence(left) - heatFactSequence(right) ||
+        (left.gameTimeMs ?? 0) - (right.gameTimeMs ?? 0) ||
+        left.synchronizationOrder - right.synchronizationOrder,
+    );
+  let enabled = configuredHeatMode;
+  let configured = configuredHeatMode || heatModeFacts.length > 0;
+  let enabledAtGameTimeMs = 0;
+  const segments: Array<{ start: number; end: number | null }> = [];
+  const firstModeFact = heatModeFacts[0];
+  if (firstModeFact !== undefined && isRecord(firstModeFact.data)) {
+    configured = true;
+    enabled = firstModeFact.data.enabled === true;
+    enabledAtGameTimeMs = firstModeFact.gameTimeMs ?? 0;
+  }
+  if (enabled) segments.push({ start: enabledAtGameTimeMs, end: null });
+  for (const fact of modeChanges) {
+    const action = isRecord(fact.data) ? fact.data.heatAction : null;
+    const at = fact.gameTimeMs ?? 0;
+    if (action === "enable") {
+      configured = true;
+      if (!enabled) {
+        enabled = true;
+        enabledAtGameTimeMs = at;
+        segments.push({ start: at, end: null });
+      }
+    } else if (action === "disable") {
+      configured = true;
+      if (enabled) {
+        enabled = false;
+        const currentSegment = segments.at(-1);
+        if (currentSegment?.end === null) currentSegment.end = at;
+      }
+    }
+  }
+  return { enabled, configured, enabledAtGameTimeMs, segments };
+}
+
+function heatTriggerId(gameTimeMs: number): string {
+  return `heat-trigger-${gameTimeMs}`;
+}
+
+function heatFactSequence(fact: ControllerGameFact): number {
+  const data = isRecord(fact.data) ? fact.data : null;
+  return typeof data?.heatSequence === "number" ? data.heatSequence : Number.MAX_SAFE_INTEGER;
+}
+
+function firstHeatTriggerAfter(gameTimeMs: number): number {
+  if (gameTimeMs < HEAT_STOPPAGE_FIRST_TRIGGER_GAME_TIME_MS) {
+    return HEAT_STOPPAGE_FIRST_TRIGGER_GAME_TIME_MS;
+  }
+  if (gameTimeMs < HEAT_STOPPAGE_SECOND_TRIGGER_GAME_TIME_MS) {
+    return HEAT_STOPPAGE_SECOND_TRIGGER_GAME_TIME_MS;
+  }
+  return (
+    HEAT_STOPPAGE_SECOND_TRIGGER_GAME_TIME_MS +
+    (Math.floor(
+      (gameTimeMs - HEAT_STOPPAGE_SECOND_TRIGGER_GAME_TIME_MS) / HEAT_STOPPAGE_TRIGGER_INTERVAL_MS,
+    ) +
+      1) *
+      HEAT_STOPPAGE_TRIGGER_INTERVAL_MS
+  );
+}
+
+function nextHeatTrigger(gameTimeMs: number): number {
+  return gameTimeMs < HEAT_STOPPAGE_SECOND_TRIGGER_GAME_TIME_MS
+    ? HEAT_STOPPAGE_SECOND_TRIGGER_GAME_TIME_MS
+    : gameTimeMs + HEAT_STOPPAGE_TRIGGER_INTERVAL_MS;
 }
 
 function controllerFactType(intent: LiveEventControllerIntent): string {
@@ -3478,6 +4164,112 @@ async function ensureClockCommencement(
   });
   if (transition.status === "rejected") return { status: "rejected" };
   return { status: "ready", root: transition.root };
+}
+
+function createHeatModeSnapshotAction(input: {
+  root: EventGameRecordRoot;
+  nowMs: number;
+  enabled: boolean;
+  gameTimeMs: number;
+  shouldCommence: number | null;
+  existingActions: readonly { action: ControlAction }[];
+  causalPredecessorIds: readonly string[];
+}): ControlActionInput | null {
+  if (input.shouldCommence === null) return null;
+  if (
+    input.existingActions.some(
+      ({ action }) =>
+        action.interpretation.type === "fact" && action.interpretation.factType === "heat-mode",
+    )
+  )
+    return null;
+  const operationId = `heat-mode-snapshot-${input.root.eventGameId}`;
+  return {
+    recordId: input.root.recordId,
+    eventGameId: input.root.eventGameId,
+    operationId,
+    kind: { id: "game-fact", version: "1" },
+    payload: {
+      factId: `heat-mode-${input.root.eventGameId}`,
+      factType: "heat-mode",
+      gameSideId: null,
+      gameTimeMs: input.gameTimeMs,
+      data: {
+        enabled: input.enabled,
+        source: "game-day",
+        frozenAtCommencementMs: input.shouldCommence,
+        sportingOrder: input.gameTimeMs,
+      },
+    },
+    causalPredecessorIds: [...input.causalPredecessorIds],
+    occurrence: {
+      trustedAtMs: input.nowMs,
+      clientOriginAtMs: null,
+      source: "online",
+    },
+    grant: null,
+    origin: "system-heat-stoppage",
+    lifecycle: structuredClone(input.root.lifecycle),
+  };
+}
+
+function createHeatTriggerActions(input: {
+  root: EventGameRecordRoot;
+  nowMs: number;
+  currentGameTimeMs: number;
+  targetGameTimeMs: number;
+  enabledAtGameTimeMs: number | null;
+  existingActions: readonly { action: ControlAction }[];
+  causalPredecessorIds: readonly string[];
+}): ControlActionInput[] {
+  if (input.enabledAtGameTimeMs === null) return [];
+  const existingTriggerTimes = new Set<number>();
+  for (const { action } of input.existingActions) {
+    if (
+      action.interpretation.type !== "fact" ||
+      action.interpretation.factType !== "heat-trigger"
+    ) {
+      continue;
+    }
+    const payload = action.interpretation.payload;
+    const data = isRecord(payload) && isRecord(payload.data) ? payload.data : null;
+    if (typeof data?.triggerGameTimeMs === "number")
+      existingTriggerTimes.add(data.triggerGameTimeMs);
+  }
+  const upperBound = Math.max(input.currentGameTimeMs, input.targetGameTimeMs);
+  const triggerTimes: number[] = [];
+  for (
+    let trigger = firstHeatTriggerAfter(input.enabledAtGameTimeMs);
+    trigger <= upperBound;
+    trigger = nextHeatTrigger(trigger)
+  ) {
+    if (!existingTriggerTimes.has(trigger)) triggerTimes.push(trigger);
+  }
+  return triggerTimes.map((triggerGameTimeMs) => {
+    const triggerId = heatTriggerId(triggerGameTimeMs);
+    return {
+      recordId: input.root.recordId,
+      eventGameId: input.root.eventGameId,
+      operationId: `materialize-${triggerId}`,
+      kind: { id: "game-fact", version: "1" },
+      payload: {
+        factId: triggerId,
+        factType: "heat-trigger",
+        gameSideId: null,
+        gameTimeMs: triggerGameTimeMs,
+        data: {
+          triggerId,
+          triggerGameTimeMs,
+          sportingOrder: triggerGameTimeMs,
+        },
+      },
+      causalPredecessorIds: [...input.causalPredecessorIds],
+      occurrence: { trustedAtMs: input.nowMs, clientOriginAtMs: null, source: "online" },
+      grant: null,
+      origin: "system-heat-stoppage",
+      lifecycle: structuredClone(input.root.lifecycle),
+    };
+  });
 }
 
 function latestRunningClockStart(facts: readonly ControllerGameFact[]): number | null {
@@ -3808,6 +4600,14 @@ function readControllerGameFacts(value: unknown): ControllerGameFact[] | null {
       gameTimeMs: gameTimeMsResult.value,
       sportingOrder: sportingOrder.value,
       synchronizationOrder: synchronizationOrder.value,
+      trustedAtMs:
+        typeof candidate.trustedAtMs === "number" && Number.isSafeInteger(candidate.trustedAtMs)
+          ? candidate.trustedAtMs
+          : 0,
+      acceptedAtMs:
+        typeof candidate.acceptedAtMs === "number" && Number.isSafeInteger(candidate.acceptedAtMs)
+          ? candidate.acceptedAtMs
+          : 0,
       effective: candidate.effective,
       data: data.value,
     });
@@ -3919,6 +4719,8 @@ function readLiveHeatState(value: unknown): LiveHeatState {
     value.status !== "started" &&
     value.status !== "ended" &&
     value.status !== "skipped" &&
+    value.status !== "required-skip" &&
+    value.status !== "suppressed" &&
     value.status !== "extended"
   ) {
     throw new Error("Derived heat status is invalid.");
@@ -3944,9 +4746,112 @@ function readLiveHeatState(value: unknown): LiveHeatState {
           SHARED_LIMITS.clock.maxMs,
           "heat.nominalDurationMs",
         );
+  const allowedDurationMs =
+    value.allowedDurationMs === undefined || value.allowedDurationMs === null
+      ? ({ ok: true, value: null } as const)
+      : validateIntegerInRange(
+          value.allowedDurationMs,
+          0,
+          SHARED_LIMITS.clock.maxMs,
+          "heat.allowedDurationMs",
+        );
+  const actualDurationMs =
+    value.actualDurationMs === undefined || value.actualDurationMs === null
+      ? ({ ok: true, value: null } as const)
+      : validateIntegerInRange(
+          value.actualDurationMs,
+          0,
+          SHARED_LIMITS.clock.maxMs,
+          "heat.actualDurationMs",
+        );
+  const rawActualDurationMs =
+    value.rawActualDurationMs === undefined || value.rawActualDurationMs === null
+      ? ({ ok: true, value: null } as const)
+      : validateIntegerInRange(
+          value.rawActualDurationMs,
+          0,
+          SHARED_LIMITS.clock.maxMs,
+          "heat.rawActualDurationMs",
+        );
+  const completionAtTrustedAtMs =
+    value.completionAtTrustedAtMs === undefined || value.completionAtTrustedAtMs === null
+      ? ({ ok: true, value: null } as const)
+      : validateIntegerInRange(
+          value.completionAtTrustedAtMs,
+          0,
+          Number.MAX_SAFE_INTEGER,
+          "heat.completionAtTrustedAtMs",
+        );
+  const mode =
+    value.mode === undefined
+      ? ({ ok: true, value: undefined } as const)
+      : value.mode === "enabled" || value.mode === "disabled"
+        ? ({ ok: true, value: value.mode } as const)
+        : ({ ok: false, error: "heat.mode is invalid." } as const);
+  const completedAtAllowed =
+    value.completedAtAllowed === undefined
+      ? ({ ok: true, value: false } as const)
+      : typeof value.completedAtAllowed === "boolean"
+        ? ({ ok: true, value: value.completedAtAllowed } as const)
+        : ({ ok: false, error: "heat.completedAtAllowed is invalid." } as const);
+  const pendingTriggerGameTimeMs =
+    value.pendingTriggerGameTimeMs === undefined || value.pendingTriggerGameTimeMs === null
+      ? ({ ok: true, value: null } as const)
+      : validateIntegerInRange(
+          value.pendingTriggerGameTimeMs,
+          0,
+          SHARED_LIMITS.clock.maxMs,
+          "heat.pendingTriggerGameTimeMs",
+        );
+  const nextTriggerGameTimeMs =
+    value.nextTriggerGameTimeMs === undefined || value.nextTriggerGameTimeMs === null
+      ? ({ ok: true, value: null } as const)
+      : validateIntegerInRange(
+          value.nextTriggerGameTimeMs,
+          0,
+          SHARED_LIMITS.clock.maxMs,
+          "heat.nextTriggerGameTimeMs",
+        );
+  const pendingTrigger =
+    value.pendingTrigger === undefined || value.pendingTrigger === null
+      ? ({ ok: true, value: null } as const)
+      : isRecord(value.pendingTrigger) &&
+          typeof value.pendingTrigger.index === "number" &&
+          Number.isSafeInteger(value.pendingTrigger.index) &&
+          value.pendingTrigger.index >= 0 &&
+          pendingTriggerGameTimeMs.ok &&
+          pendingTriggerGameTimeMs.value !== null
+        ? ({
+            ok: true,
+            value: {
+              gameTimeMs: pendingTriggerGameTimeMs.value,
+              index: value.pendingTrigger.index,
+            },
+          } as const)
+        : ({ ok: false, error: "heat.pendingTrigger is invalid." } as const);
+  const triggerDecision =
+    value.triggerDecision === undefined || value.triggerDecision === null
+      ? ({ ok: true, value: null } as const)
+      : value.triggerDecision === "end-of-drive" ||
+          value.triggerDecision === "dead-volleyball" ||
+          value.triggerDecision === "other-stoppage" ||
+          value.triggerDecision === "skip" ||
+          value.triggerDecision === "skip-required"
+        ? ({ ok: true, value: value.triggerDecision } as const)
+        : ({ ok: false, error: "heat.triggerDecision is invalid." } as const);
   if (
     !startedAtGameTimeMs.ok ||
     !nominalDurationMs.ok ||
+    !allowedDurationMs.ok ||
+    !actualDurationMs.ok ||
+    !rawActualDurationMs.ok ||
+    !completionAtTrustedAtMs.ok ||
+    !mode.ok ||
+    !completedAtAllowed.ok ||
+    !pendingTriggerGameTimeMs.ok ||
+    !nextTriggerGameTimeMs.ok ||
+    !pendingTrigger.ok ||
+    !triggerDecision.ok ||
     (value.status === "inactive" &&
       (startedAtGameTimeMs.value !== null || nominalDurationMs.value !== null))
   ) {
@@ -3957,7 +4862,49 @@ function readLiveHeatState(value: unknown): LiveHeatState {
     factId: factId === null ? null : factId.value,
     startedAtGameTimeMs: startedAtGameTimeMs.value,
     nominalDurationMs: nominalDurationMs.value,
+    allowedDurationMs: allowedDurationMs.value,
+    actualDurationMs: actualDurationMs.value,
+    completedAtAllowed: completedAtAllowed.value,
+    rawActualDurationMs: rawActualDurationMs.value,
+    completionAtTrustedAtMs: completionAtTrustedAtMs.value,
+    ...(mode.value === undefined ? {} : { mode: mode.value }),
+    pendingTriggerId: readOptionalIdentifier(value.pendingTriggerId, "heat.pendingTriggerId"),
+    pendingTriggerGameTimeMs: pendingTriggerGameTimeMs.value,
+    nextTriggerGameTimeMs: nextTriggerGameTimeMs.value,
+    pendingTrigger: pendingTrigger.value,
+    trigger:
+      value.trigger === undefined || value.trigger === null
+        ? null
+        : isRecord(value.trigger) &&
+            typeof value.trigger.id === "string" &&
+            validateOpaqueIdentifier(value.trigger.id, "heat.trigger.id").ok &&
+            typeof value.trigger.gameTimeMs === "number" &&
+            Number.isSafeInteger(value.trigger.gameTimeMs) &&
+            typeof value.trigger.index === "number" &&
+            Number.isSafeInteger(value.trigger.index) &&
+            value.trigger.index >= 0
+          ? {
+              id: String(value.trigger.id),
+              gameTimeMs: value.trigger.gameTimeMs,
+              index: value.trigger.index,
+            }
+          : (() => {
+              throw new Error("Derived heat trigger is invalid.");
+            })(),
+    permittedExtensionTriggerId: readOptionalIdentifier(
+      value.permittedExtensionTriggerId,
+      "heat.permittedExtensionTriggerId",
+    ),
+    activeTriggerId: readOptionalIdentifier(value.activeTriggerId, "heat.activeTriggerId"),
+    triggerDecision: triggerDecision.value,
   };
+}
+
+function readOptionalIdentifier(value: unknown, field: string): string | null {
+  if (value === undefined || value === null) return null;
+  const parsed = validateOpaqueIdentifier(value, field);
+  if (!parsed.ok) throw new Error(parsed.error);
+  return parsed.value;
 }
 
 function readLiveResultState(value: unknown): LiveResultState {
@@ -4074,6 +5021,8 @@ function rebuildLiveDerivedState(
     contentFingerprint: string;
   }[],
   projectedAtMs = 0,
+  configuredHeatMode = false,
+  nowMs = 0,
 ): LiveEventGameDerivedState | null {
   try {
     const rebuilt = rebuildControlActionHistory(
@@ -4089,6 +5038,8 @@ function rebuildLiveDerivedState(
       rebuilt.effectiveFacts,
       LIVE_EVENT_IQA_INTERPRETER_VERSION,
       projectedAtMs,
+      configuredHeatMode,
+      nowMs,
     );
   } catch {
     return null;
@@ -4229,7 +5180,13 @@ export function validateLiveEventGameActionInTransaction(
   const clockValidation = validateLiveEventClockActionInTransaction(actions, candidate);
   if (clockValidation.status === "rejected") return clockValidation;
 
-  const current = rebuildLiveDerivedState(root, actions);
+  const current = rebuildLiveDerivedState(
+    root,
+    actions,
+    candidate.occurrence.trustedAtMs,
+    false,
+    candidate.occurrence.trustedAtMs,
+  );
   if (current === null) {
     return {
       status: "rejected",
@@ -4399,6 +5356,125 @@ export function validateLiveEventGameActionInTransaction(
       return rejectedLiveAction("The Penalty Release choice is no longer valid.");
     }
   }
+  if (candidate.interpretation.factType === "heat-stoppage") {
+    const heatAction = data?.heatAction;
+    if (!isLiveHeatAction(heatAction)) {
+      return rejectedLiveAction("heatAction is required for Heat Stoppage operations.");
+    }
+    const hasFrozenMode = current.gameFacts.some((fact) => fact.factType === "heat-mode");
+    if (heatAction === "enable" || heatAction === "disable") {
+      if (root.lifecycle.commencedAtMs === null) {
+        return rejectedLiveAction(
+          "Heat Stoppage Mode follows Game Day configuration before commencement.",
+        );
+      }
+    }
+    const requiresTrigger = heatAction !== "enable" && heatAction !== "disable";
+    const resolvesTrigger =
+      heatAction === "start" ||
+      heatAction === "end-of-drive" ||
+      heatAction === "dead-volleyball" ||
+      heatAction === "other-stoppage" ||
+      heatAction === "skip" ||
+      heatAction === "skip-required" ||
+      heatAction === "suppress";
+    if (hasFrozenMode && requiresTrigger && current.heat.mode !== "enabled") {
+      return rejectedLiveAction("Heat Stoppage Mode is disabled.");
+    }
+    if (hasFrozenMode && resolvesTrigger && current.heat.pendingTriggerGameTimeMs === null) {
+      return rejectedLiveAction("A Heat Stoppage Trigger is not pending.");
+    }
+    const suppliedTriggerId =
+      typeof data?.heatTriggerId === "string"
+        ? data.heatTriggerId
+        : typeof data?.triggerId === "string"
+          ? data.triggerId
+          : null;
+    if (hasFrozenMode && resolvesTrigger && suppliedTriggerId !== current.heat.pendingTriggerId) {
+      return rejectedLiveAction("The Heat Stoppage Trigger identity is stale or mismatched.");
+    }
+    if (hasFrozenMode && resolvesTrigger && current.heat.pendingTriggerGameTimeMs !== gameTimeMs) {
+      return rejectedLiveAction("The Heat Stoppage Trigger game time is stale or mismatched.");
+    }
+    if (
+      hasFrozenMode &&
+      heatAction === "end" &&
+      suppliedTriggerId !== current.heat.activeTriggerId
+    ) {
+      return rejectedLiveAction("The Heat Stoppage end is not linked to the active trigger.");
+    }
+    if (
+      hasFrozenMode &&
+      heatAction === "extend" &&
+      ((current.heat.status === "ended" &&
+        !(current.heat.completedAtAllowed === true && candidate.override !== undefined)) ||
+        suppliedTriggerId !== current.heat.activeTriggerId)
+    ) {
+      return rejectedLiveAction(
+        current.heat.status === "ended" && current.heat.completedAtAllowed !== true
+          ? "An ended Heat Stoppage cannot be extended."
+          : "The Heat Stoppage extension is not linked to the active trigger.",
+      );
+    }
+    if (
+      hasFrozenMode &&
+      heatAction === "extend-permitted" &&
+      suppliedTriggerId !== current.heat.permittedExtensionTriggerId
+    ) {
+      return rejectedLiveAction(
+        "The permitted Heat Stoppage extension is linked to another trigger.",
+      );
+    }
+    if (
+      (heatAction === "start" ||
+        heatAction === "end-of-drive" ||
+        heatAction === "dead-volleyball" ||
+        heatAction === "other-stoppage") &&
+      Math.abs(
+        (Object.values(current.scoreByGameSide)[0] ?? 0) -
+          (Object.values(current.scoreByGameSide)[1] ?? 0),
+      ) <= 10 &&
+      candidate.override === undefined
+    ) {
+      return rejectedLiveAction("The within-one-goal Heat Stoppage requires an ordinary skip.");
+    }
+    if (heatAction === "skip" || heatAction === "skip-required") {
+      const scores = Object.values(current.scoreByGameSide);
+      const scoreDifference = Math.abs((scores[0] ?? 0) - (scores[1] ?? 0));
+      if (heatAction === "skip" && scoreDifference <= 10 && candidate.override === undefined) {
+        return rejectedLiveAction("A within-one-goal Heat Stoppage requires skip-required.");
+      }
+      if (scoreDifference > 10 && candidate.override === undefined) {
+        return rejectedLiveAction("A within-one-goal Heat Stoppage skip is not eligible.");
+      }
+    }
+    if (
+      heatAction === "extend-permitted" &&
+      (current.heat.factId === null ||
+        current.heat.startedAtGameTimeMs === null ||
+        (current.heat.status !== "started" &&
+          current.heat.status !== "extended" &&
+          current.heat.status !== "required-skip"))
+    ) {
+      return rejectedLiveAction("A permitted Heat Stoppage extension requires an active timer.");
+    }
+    if (heatAction === "extend-permitted" && current.heat.permittedExtensionTriggerId === null) {
+      if (candidate.override === undefined) {
+        return rejectedLiveAction(
+          "A permitted Heat Stoppage extension must follow the linked required skip.",
+        );
+      }
+    }
+    if (
+      heatAction === "extend-permitted" &&
+      current.heat.permittedExtensionTriggerId !== null &&
+      suppliedTriggerId !== current.heat.permittedExtensionTriggerId
+    ) {
+      return rejectedLiveAction(
+        "The permitted Heat Stoppage extension is linked to another trigger.",
+      );
+    }
+  }
   const sportingOrder =
     data !== null && typeof data.sportingOrder === "number" ? data.sportingOrder : gameTimeMs;
   const sportingOrderDiffers =
@@ -4448,6 +5524,7 @@ export function validateLiveEventGameActionInTransaction(
         false,
         gameTimeMs,
         data,
+        root,
       );
       if (candidate.override === undefined || expectedBoundaryOverride === null) {
         return rejectedLiveAction("A flag catch requires released seekers and stopped play.");
@@ -4558,7 +5635,7 @@ export function validateLiveEventGameActionInTransaction(
       ? null
       : closePair.fact !== null && sportingOrderAdjudication !== null
         ? expectedClosePlayOverride(closePair.fact, gameTimeMs, sportingOrderAdjudication)
-        : expectedLiveOverride(candidate, current, sportingOrderDiffers, gameTimeMs, data);
+        : expectedLiveOverride(candidate, current, sportingOrderDiffers, gameTimeMs, data, root);
   if (sportingOrderOverride !== undefined) {
     return rejectedLiveAction(
       "A separate Sporting Order override is only valid with a flag-catch boundary override.",
@@ -4592,6 +5669,7 @@ function expectedLiveOverride(
   sportingOrderDiffers: boolean,
   gameTimeMs: number | null,
   data: Record<string, unknown> | null,
+  root: EventGameRecordRoot,
 ): LiveOverrideExpectation | null {
   if (gameTimeMs === null) return null;
   if (candidate.interpretation.type !== "fact") return null;
@@ -4638,29 +5716,180 @@ function expectedLiveOverride(
   }
   if (factType === "heat-stoppage") {
     const heatAction = data?.heatAction;
+    if (heatAction === "enable" || heatAction === "disable") {
+      if (root.lifecycle.commencedAtMs === null) return null;
+      return {
+        required: true,
+        guardrail: "heat-stoppage-mode-change",
+        direction: "head-referee-directed-heat-mode-change",
+        beforeValue: { heatMode: current.heat.mode === "enabled" },
+        afterValue: { heatMode: heatAction === "enable" },
+        gameTimeMs,
+      };
+    }
+    if (heatAction === "suppress") {
+      const pendingTriggerGameTimeMs = current.heat.pendingTriggerGameTimeMs;
+      if (typeof pendingTriggerGameTimeMs !== "number") return null;
+      return {
+        required: true,
+        guardrail: "heat-stoppage-rule-deviation",
+        direction: "head-referee-directed-heat-stoppage",
+        beforeValue: { pendingTriggerGameTimeMs },
+        afterValue: { trigger: "suppressed" },
+        gameTimeMs,
+      };
+    }
+    if (
+      heatAction === "start" ||
+      heatAction === "end-of-drive" ||
+      heatAction === "dead-volleyball" ||
+      heatAction === "other-stoppage"
+    ) {
+      const scores = Object.values(current.scoreByGameSide);
+      const scoreDifference = Math.abs((scores[0] ?? 0) - (scores[1] ?? 0));
+      if (scoreDifference <= 10) {
+        return {
+          required: true,
+          guardrail: "heat-stoppage-rule-deviation",
+          direction: "head-referee-directed-heat-stoppage",
+          beforeValue: { heat: "pending", requiredDecision: "skip" },
+          afterValue: { heat: heatAction },
+          gameTimeMs,
+        };
+      }
+    }
+    if (heatAction === "skip" || heatAction === "skip-required") {
+      const scores = Object.values(current.scoreByGameSide);
+      const scoreDifference = Math.abs((scores[0] ?? 0) - (scores[1] ?? 0));
+      if (scoreDifference > 10 || heatAction === "skip") {
+        return {
+          required: true,
+          guardrail: "heat-stoppage-rule-deviation",
+          direction: "head-referee-directed-heat-stoppage",
+          beforeValue: { scoreDifference },
+          afterValue: { heat: "skipped" },
+          gameTimeMs,
+        };
+      }
+    }
+    if (
+      heatAction === "extend-permitted" &&
+      current.heat.nominalDurationMs !== null &&
+      current.heat.allowedDurationMs !== null &&
+      current.heat.allowedDurationMs !== undefined &&
+      (current.heat.actualDurationMs ?? 0) > current.heat.allowedDurationMs
+    ) {
+      return {
+        required: true,
+        guardrail: "heat-stoppage-rule-deviation",
+        direction: "head-referee-directed-heat-stoppage",
+        beforeValue: {
+          heat: current.heat.status,
+          nominalDurationMs: current.heat.nominalDurationMs,
+          actualDurationMs: current.heat.actualDurationMs ?? 0,
+        },
+        afterValue: { heat: "extended" },
+        gameTimeMs,
+      };
+    }
+    if (heatAction === "extend-permitted" && current.heat.permittedExtensionTriggerId === null) {
+      return {
+        required: true,
+        guardrail: "heat-stoppage-rule-deviation",
+        direction: "head-referee-directed-heat-stoppage",
+        beforeValue: { permittedExtensionTriggerId: null },
+        afterValue: { heat: "extended" },
+        gameTimeMs,
+      };
+    }
+    if (heatAction === "extend") {
+      if (
+        (current.heat.status !== "started" &&
+          current.heat.status !== "extended" &&
+          !(current.heat.status === "ended" && current.heat.completedAtAllowed === true)) ||
+        current.heat.startedAtGameTimeMs === null ||
+        current.heat.nominalDurationMs === null
+      ) {
+        return null;
+      }
+      return {
+        required: true,
+        guardrail: "heat-stoppage-rule-deviation",
+        direction: "head-referee-directed-heat-stoppage",
+        beforeValue:
+          typeof current.heat.actualDurationMs === "number" &&
+          current.heat.actualDurationMs >= current.heat.nominalDurationMs
+            ? {
+                heat: current.heat.status,
+                nominalDurationMs: current.heat.nominalDurationMs,
+                actualDurationMs: current.heat.actualDurationMs,
+              }
+            : { heat: current.heat.status },
+        afterValue: { heat: "extended" },
+        gameTimeMs,
+      };
+    }
+    const offlineLateCompletion =
+      current.heat.completedAtAllowed === true &&
+      candidate.occurrence.source === "offline" &&
+      typeof current.heat.completionAtTrustedAtMs === "number" &&
+      candidate.occurrence.trustedAtMs > current.heat.completionAtTrustedAtMs;
     if (
       heatAction !== "end" ||
-      current.heat.status !== "started" ||
+      (current.heat.status !== "started" &&
+        current.heat.status !== "extended" &&
+        !offlineLateCompletion) ||
       current.heat.startedAtGameTimeMs === null ||
       current.heat.nominalDurationMs === null ||
-      gameTimeMs >= current.heat.startedAtGameTimeMs + current.heat.nominalDurationMs
+      current.heat.allowedDurationMs === null ||
+      current.heat.allowedDurationMs === undefined
     ) {
       return null;
     }
-    const afterValue =
-      heatAction === "end"
-        ? "ended"
-        : heatAction === "skip-required"
-          ? "skipped"
-          : heatAction === "extend-permitted"
-            ? "extended"
-            : "started";
+    const actualDurationMs =
+      (offlineLateCompletion ? current.heat.rawActualDurationMs : current.heat.actualDurationMs) ??
+      0;
+    if (current.heat.completedAtAllowed === true && !offlineLateCompletion) {
+      if (candidate.override === undefined) return null;
+      return {
+        required: false,
+        guardrail: "heat-stoppage-rule-deviation",
+        direction: "head-referee-directed-heat-stoppage",
+        beforeValue: {
+          heat: current.heat.status,
+          nominalDurationMs: current.heat.nominalDurationMs,
+          actualDurationMs: current.heat.actualDurationMs ?? current.heat.allowedDurationMs,
+        },
+        afterValue: { heat: "ended" },
+        gameTimeMs,
+      };
+    }
+    if (actualDurationMs < current.heat.allowedDurationMs) {
+      return {
+        required: true,
+        guardrail: "heat-stoppage-rule-deviation",
+        direction: "head-referee-directed-heat-stoppage",
+        beforeValue: { heat: current.heat.status },
+        afterValue: { heat: "ended" },
+        gameTimeMs,
+      };
+    }
+    if (actualDurationMs === current.heat.allowedDurationMs) {
+      return null;
+    }
     return {
       required: true,
       guardrail: "heat-stoppage-rule-deviation",
       direction: "head-referee-directed-heat-stoppage",
-      beforeValue: { heat: current.heat.status },
-      afterValue: { heat: afterValue },
+      beforeValue:
+        actualDurationMs > current.heat.allowedDurationMs
+          ? {
+              heat: current.heat.status,
+              nominalDurationMs: current.heat.nominalDurationMs,
+              actualDurationMs,
+            }
+          : { heat: current.heat.status },
+      afterValue: { heat: "ended" },
       gameTimeMs,
     };
   }
@@ -4711,12 +5940,32 @@ function validateOfficialOverrideEvidence(
     override.gameTimeMs !== expected.gameTimeMs ||
     override.beforeValue === undefined ||
     override.afterValue === undefined ||
-    canonicalizeJson(override.beforeValue) !== canonicalizeJson(expected.beforeValue) ||
+    !matchesLiveOverrideBeforeValue(override.beforeValue, expected) ||
     canonicalizeJson(override.afterValue) !== canonicalizeJson(expected.afterValue)
   ) {
     return rejectedLiveAction("Official Override evidence does not match effective state.");
   }
   return { status: "accepted" };
+}
+
+function matchesLiveOverrideBeforeValue(
+  supplied: ActionJsonValue,
+  expected: LiveOverrideExpectation,
+): boolean {
+  if (canonicalizeJson(supplied) === canonicalizeJson(expected.beforeValue)) return true;
+  if (expected.guardrail !== "heat-stoppage-rule-deviation") return false;
+  if (!isRecord(supplied) || !isRecord(expected.beforeValue)) return false;
+  if (
+    typeof supplied.actualDurationMs !== "number" ||
+    !Number.isFinite(supplied.actualDurationMs) ||
+    supplied.actualDurationMs < 0 ||
+    typeof expected.beforeValue.actualDurationMs !== "number"
+  ) {
+    return false;
+  }
+  const { actualDurationMs: _suppliedActual, ...suppliedGuardrail } = supplied;
+  const { actualDurationMs: _expectedActual, ...expectedGuardrail } = expected.beforeValue;
+  return canonicalizeJson(suppliedGuardrail) === canonicalizeJson(expectedGuardrail);
 }
 
 function rejectedLiveAction(detail: string): {
@@ -5023,13 +6272,13 @@ function readClockAuthorityActions(
       operationId: string;
       occurrence: { trustedAtMs: number; source: "online" | "offline" };
       acceptedAtMs: number;
-      grant: { sessionId: string };
+      grant: { sessionId: string } | null;
       interpretation: unknown;
     };
     operationId?: string;
     occurrence?: { trustedAtMs: number; source: "online" | "offline" };
     acceptedAtMs?: number;
-    grant?: { sessionId: string };
+    grant?: { sessionId: string } | null;
     interpretation?: unknown;
   }[],
 ): ClockAuthorityAction[] {
@@ -5041,6 +6290,7 @@ function readClockAuthorityActions(
       storedAction.occurrence === undefined ||
       storedAction.acceptedAtMs === undefined ||
       storedAction.grant === undefined ||
+      storedAction.grant === null ||
       storedAction.interpretation === undefined
     )
       continue;
@@ -5269,6 +6519,23 @@ function isActionJsonValue(value: unknown): value is ActionJsonValue {
   return isRecord(value) && Object.values(value).every((item) => isActionJsonValue(item));
 }
 
+function isLiveHeatAction(value: unknown): value is LiveHeatAction {
+  return (
+    value === "start" ||
+    value === "end" ||
+    value === "skip-required" ||
+    value === "extend-permitted" ||
+    value === "extend" ||
+    value === "end-of-drive" ||
+    value === "dead-volleyball" ||
+    value === "other-stoppage" ||
+    value === "skip" ||
+    value === "suppress" ||
+    value === "enable" ||
+    value === "disable"
+  );
+}
+
 function buildLiveOfficialOverride(
   intent: LiveEventControllerIntent,
   sessionId: string,
@@ -5298,6 +6565,7 @@ function buildLiveOfficialOverride(
   const expected = explainLiveEventGuardrail({
     type: intent.type,
     ...(intent.type === "substantive" ? { trigger: intent.trigger } : {}),
+    ...(intent.type === "substantive" ? { heatAction: intent.heatAction } : {}),
     gameTimeMs: intent.gameTimeMs,
     sportingOrder: intent.sportingOrder,
   });

--- a/src/lib/live-event-game-runtime.test.ts
+++ b/src/lib/live-event-game-runtime.test.ts
@@ -167,6 +167,77 @@ describe("Live Event Game SQLite runtime", () => {
     let qrCredential: string;
     try {
       await setupStorage.applyMigrations({ requireCandidate: false });
+      await setupStorage.transaction((transaction) => {
+        transaction.insertEvent({
+          eventId: root.eventId,
+          name: "Runtime Event",
+          timeZone: "UTC",
+          publicationStatus: "unpublished",
+          createdAtMs: 1,
+          updatedAtMs: 1,
+        });
+        transaction.insertGameDay({
+          gameDayId: root.externalScope.gameDayId,
+          eventId: root.eventId,
+          date: "2026-08-15",
+          heatStoppageConfiguration: "enabled",
+          createdAtMs: 1,
+          updatedAtMs: 1,
+        });
+        transaction.insertPitch({
+          pitchId: root.externalScope.pitchId,
+          eventId: root.eventId,
+          name: "Runtime Pitch",
+          createdAtMs: 1,
+          updatedAtMs: 1,
+        });
+        transaction.insertGameplaySlot({
+          gameplaySlotId: "runtime-gameplay-slot-1",
+          eventId: root.eventId,
+          gameDayId: root.externalScope.gameDayId,
+          sequence: 1,
+          scheduledStartMs: 1,
+          expectedDelayMs: 0,
+          createdAtMs: 1,
+          updatedAtMs: 1,
+        });
+        transaction.insertPitchSlot({
+          pitchSlotId: root.externalScope.pitchSlotId,
+          eventId: root.eventId,
+          gameDayId: root.externalScope.gameDayId,
+          pitchId: root.externalScope.pitchId,
+          gameplaySlotId: "runtime-gameplay-slot-1",
+          sequence: 1,
+          expectedDelayMs: 0,
+          createdAtMs: 1,
+          updatedAtMs: 1,
+        });
+        transaction.insertEventGame({
+          eventGameId: root.eventGameId,
+          eventId: root.eventId,
+          gameDayId: root.externalScope.gameDayId,
+          gameplaySlotId: "runtime-gameplay-slot-1",
+          pitchSlotId: root.externalScope.pitchSlotId,
+          gameCode: null,
+          gameDesignation: null,
+          sideA: {
+            sideId: "side-a",
+            eventTeamId: null,
+            eventTeamName: null,
+            sourceLabel: "A",
+            confirmedAtMs: null,
+          },
+          sideB: {
+            sideId: "side-b",
+            eventTeamId: null,
+            eventTeamName: null,
+            sourceLabel: "B",
+            confirmedAtMs: null,
+          },
+          createdAtMs: 1,
+          updatedAtMs: 1,
+        });
+      });
       const setupRecord = createEventGameRecord(setupStorage, {
         externalScopeResolver: createExternalScopeResolver(root),
         interpreter: createLiveEventGameIqaInterpreter(),
@@ -202,7 +273,10 @@ describe("Live Event Game SQLite runtime", () => {
         status: "opened",
         eventGameId: root.eventGameId,
         projectionStatus: "available",
-        projection: { scoreByGameSide: { "side-a": 0, "side-b": 0 } },
+        projection: {
+          scoreByGameSide: { "side-a": 0, "side-b": 0 },
+          heat: { mode: "enabled", nextTriggerGameTimeMs: 900_000 },
+        },
       });
       if (opened.status !== "opened") throw new Error("Expected the runtime Controller to open.");
 
@@ -227,6 +301,20 @@ describe("Live Event Game SQLite runtime", () => {
           goalCount: 1,
           commencement: { status: "commenced", commencedAtMs: 10_000 },
         },
+      });
+      const catalogDatabase = new Database(databasePath);
+      catalogDatabase
+        .query(
+          "UPDATE foundation_event_catalog_game_days SET heat_stoppage_configuration = ? WHERE game_day_id = ?",
+        )
+        .run("disabled", root.externalScope.gameDayId);
+      catalogDatabase.close();
+      const afterConfigurationChange = await runtime.control.refreshController({
+        sessionBearer: opened.session.sessionBearer,
+        eventGameId: opened.eventGameId,
+      });
+      expect(afterConfigurationChange).toMatchObject({
+        projection: { heat: { mode: "enabled" } },
       });
 
       const duplicate = await runtime.control.submitControllerIntent({
@@ -552,6 +640,77 @@ describe("Live Event Game SQLite runtime", () => {
     let qrCredential: string;
     try {
       await setupStorage.applyMigrations({ requireCandidate: false });
+      await setupStorage.transaction((transaction) => {
+        transaction.insertEvent({
+          eventId: previous.eventId,
+          name: "Runtime Reassignment Event",
+          timeZone: "UTC",
+          publicationStatus: "unpublished",
+          createdAtMs: 1,
+          updatedAtMs: 1,
+        });
+        transaction.insertGameDay({
+          gameDayId: previous.externalScope.gameDayId,
+          eventId: previous.eventId,
+          date: "2026-08-15",
+          heatStoppageConfiguration: "disabled",
+          createdAtMs: 1,
+          updatedAtMs: 1,
+        });
+        transaction.insertPitch({
+          pitchId: previous.externalScope.pitchId,
+          eventId: previous.eventId,
+          name: "Runtime Reassignment Pitch",
+          createdAtMs: 1,
+          updatedAtMs: 1,
+        });
+        transaction.insertGameplaySlot({
+          gameplaySlotId: "runtime-reassignment-gameplay-slot",
+          eventId: previous.eventId,
+          gameDayId: previous.externalScope.gameDayId,
+          sequence: 1,
+          scheduledStartMs: 1,
+          expectedDelayMs: 0,
+          createdAtMs: 1,
+          updatedAtMs: 1,
+        });
+        transaction.insertPitchSlot({
+          pitchSlotId: previous.externalScope.pitchSlotId,
+          eventId: previous.eventId,
+          gameDayId: previous.externalScope.gameDayId,
+          pitchId: previous.externalScope.pitchId,
+          gameplaySlotId: "runtime-reassignment-gameplay-slot",
+          sequence: 1,
+          expectedDelayMs: 0,
+          createdAtMs: 1,
+          updatedAtMs: 1,
+        });
+        transaction.insertEventGame({
+          eventGameId: previous.eventGameId,
+          eventId: previous.eventId,
+          gameDayId: previous.externalScope.gameDayId,
+          gameplaySlotId: "runtime-reassignment-gameplay-slot",
+          pitchSlotId: previous.externalScope.pitchSlotId,
+          gameCode: null,
+          gameDesignation: null,
+          sideA: {
+            sideId: "side-a",
+            eventTeamId: null,
+            eventTeamName: null,
+            sourceLabel: "A",
+            confirmedAtMs: null,
+          },
+          sideB: {
+            sideId: "side-b",
+            eventTeamId: null,
+            eventTeamName: null,
+            sourceLabel: "B",
+            confirmedAtMs: null,
+          },
+          createdAtMs: 1,
+          updatedAtMs: 1,
+        });
+      });
       for (const root of [previous, current]) {
         const record = createEventGameRecord(setupStorage, {
           externalScopeResolver: createExternalScopeResolver(root),

--- a/src/lib/live-event-game-runtime.ts
+++ b/src/lib/live-event-game-runtime.ts
@@ -24,6 +24,7 @@ import type {
   FoundationStorageSnapshot,
   FoundationStorageTransaction,
 } from "@/lib/foundation-storage";
+import { resolveHeatStoppageConfiguration as resolvePublishedHeatStoppageConfiguration } from "@/lib/heat-stoppage-configuration";
 import type { FoundationStorage } from "@/lib/foundation-storage";
 
 export type LiveEventGameRuntime = {
@@ -119,12 +120,35 @@ export async function openLiveEventGameRuntime(input: {
           ? { status: "eligible" }
           : { status: "ineligible" },
       validateActionInTransaction: ({ transaction, root, action }) =>
-        validateLiveEventGameActionInTransaction(
-          transaction.listActions(root.recordId),
-          root,
-          action,
-          input.knownDodgeballIdsForEventGame?.(root.eventGameId) ?? null,
-        ),
+        (() => {
+          const validation = validateLiveEventGameActionInTransaction(
+            transaction.listActions(root.recordId),
+            root,
+            action,
+            input.knownDodgeballIdsForEventGame?.(root.eventGameId) ?? null,
+          );
+          if (validation.status === "rejected") return validation;
+          if (
+            action.interpretation.type !== "fact" ||
+            action.interpretation.factType !== "heat-mode"
+          )
+            return validation;
+          const payload = action.interpretation.payload;
+          const data = isRecord(payload) && isRecord(payload.data) ? payload.data : null;
+          const configured = resolvePublishedHeatStoppageConfiguration(transaction, {
+            eventId: root.externalScope.eventId,
+            gameDayId: root.externalScope.gameDayId,
+            eventGameId: root.eventGameId,
+          });
+          if (configured === null || data?.enabled !== (configured === "enabled")) {
+            return {
+              status: "rejected",
+              reason: "invalid-action" as const,
+              detail: "Heat Stoppage Configuration changed or is unavailable.",
+            };
+          }
+          return validation;
+        })(),
     });
     const hasLifecycleInventory = await storage.transaction(
       (transaction) => typeof transaction.listRoots === "function",
@@ -168,7 +192,9 @@ export async function openLiveEventGameRuntime(input: {
         eventGameId,
         grantSessionId,
         grantVersion,
+        evidence,
       }) => {
+        if (evidence !== undefined && lockedReplayCapability.authorized(evidence)) return true;
         const authorized = await authority.authorizeGrant({
           sessionBearer,
           eventGameId,
@@ -189,6 +215,14 @@ export async function openLiveEventGameRuntime(input: {
           lockedAtMs,
         }),
       knownDodgeballIdsForEventGame: input.knownDodgeballIdsForEventGame,
+      readHeatStoppageConfiguration: (scope: {
+        eventId: string;
+        gameDayId: string;
+        eventGameId: string;
+      }) =>
+        storage.transaction((snapshot) =>
+          resolvePublishedHeatStoppageConfiguration(snapshot, scope),
+        ),
     });
     const lockTimer = setInterval(() => {
       void control.reconcileEventGameLocks();
@@ -236,7 +270,7 @@ function createGrantOptions(
     clock: { nowMs: clock },
     randomness: { bytes: (length) => new Uint8Array(randomBytes(length)) },
     keyRing,
-    controlScopeResolver: createControlScopeResolver(clock),
+    controlScopeResolver: createControlScopeResolver(clock, false),
     privilegedAuthorityVerifier: { verify: () => null },
     onLifecycleChange,
   };
@@ -315,11 +349,17 @@ export function readLiveEventDodgeballIdsByEventGame(
 
 export function createControlScopeResolver(
   clock: () => number = () => Date.now(),
+  persistPassiveCommencement = true,
 ): GrantAuthorityOptions["controlScopeResolver"] {
   return {
     resolve(scope, snapshot) {
       if (snapshot === undefined) return { status: "unavailable" };
-      const current = resolveCurrentRootForSlot(scope, snapshot, clock());
+      const current = resolveCurrentRootForSlot(
+        scope,
+        snapshot,
+        clock(),
+        persistPassiveCommencement,
+      );
       if (current.status === "conflict") return current;
       const root = current.root;
       if (root === null) return { status: "empty" };
@@ -330,7 +370,12 @@ export function createControlScopeResolver(
     },
     resolveSession(scope, sessionEventGameId, snapshot) {
       if (snapshot === undefined) return { status: "unavailable" };
-      const resolvedCurrent = resolveCurrentRootForSlot(scope, snapshot, clock());
+      const resolvedCurrent = resolveCurrentRootForSlot(
+        scope,
+        snapshot,
+        clock(),
+        persistPassiveCommencement,
+      );
       if (resolvedCurrent.status === "conflict") return resolvedCurrent;
       const current = resolvedCurrent.root;
       if (current === null) {
@@ -338,7 +383,12 @@ export function createControlScopeResolver(
         const sessionRoot =
           sessionRootValue === null
             ? null
-            : materializeCommencement(sessionRootValue, snapshot, clock());
+            : materializeCommencement(
+                sessionRootValue,
+                snapshot,
+                clock(),
+                persistPassiveCommencement,
+              );
         if (sessionRoot !== null && sessionRoot.lifecycle.commencedAtMs !== null) {
           return {
             status: "pinned",
@@ -358,7 +408,12 @@ export function createControlScopeResolver(
       const sessionRoot =
         sessionRootValue === null
           ? null
-          : materializeCommencement(sessionRootValue, snapshot, clock());
+          : materializeCommencement(
+              sessionRootValue,
+              snapshot,
+              clock(),
+              persistPassiveCommencement,
+            );
       return sessionRoot !== null && sessionRoot.lifecycle.commencedAtMs !== null
         ? {
             status: "pinned",
@@ -378,6 +433,7 @@ function resolveCurrentRootForSlot(
   scope: ControlGrantScope,
   snapshot: FoundationStorageSnapshot,
   nowMs: number,
+  persistPassiveCommencement: boolean,
 ): { status: "resolved"; root: EventGameRecordRoot | null } | { status: "conflict" } {
   const catalogGames = snapshot
     .listEventGames?.(scope.gameDayId)
@@ -397,7 +453,7 @@ function resolveCurrentRootForSlot(
       if (!sameScope(legacyRoot.externalScope, scope)) return { status: "conflict" };
       return {
         status: "resolved",
-        root: materializeCommencement(legacyRoot, snapshot, nowMs),
+        root: materializeCommencement(legacyRoot, snapshot, nowMs, persistPassiveCommencement),
       };
     }
     const pitch = snapshot.findPitchSlot?.(game.pitchSlotId);
@@ -412,19 +468,26 @@ function resolveCurrentRootForSlot(
     const storedRoot = snapshot.findRootByEventGameId(game.eventGameId);
     return {
       status: "resolved",
-      root: storedRoot === null ? null : materializeCommencement(storedRoot, snapshot, nowMs),
+      root:
+        storedRoot === null
+          ? null
+          : materializeCommencement(storedRoot, snapshot, nowMs, persistPassiveCommencement),
     };
   }
   const storedRoot = snapshot.findRootByPitchSlotId(scope.pitchSlotId);
   if (storedRoot === null) return { status: "resolved", root: null };
   if (!sameScope(storedRoot.externalScope, scope)) return { status: "conflict" };
-  return { status: "resolved", root: materializeCommencement(storedRoot, snapshot, nowMs) };
+  return {
+    status: "resolved",
+    root: materializeCommencement(storedRoot, snapshot, nowMs, persistPassiveCommencement),
+  };
 }
 
 function materializeCommencement(
   root: EventGameRecordRoot,
   snapshot: FoundationStorageSnapshot,
   nowMs: number,
+  persist: boolean,
 ): EventGameRecordRoot {
   if (root.lifecycle.phase !== "scheduled" || root.lifecycle.commencedAtMs !== null) return root;
   if (typeof snapshot.listActions !== "function") return root;
@@ -441,7 +504,7 @@ function materializeCommencement(
   const validated = validateEventGameRecordRoot(candidate);
   if (!validated.ok) return root;
   const transaction = snapshot as FoundationStorageTransaction;
-  if (typeof transaction.updateRoot === "function") {
+  if (persist && typeof transaction.updateRoot === "function") {
     transaction.updateRoot({
       root: validated.value,
       canonicalContent: canonicalizeEventGameRecordRoot(validated.value),

--- a/src/pages/event-game-controller-page.test.tsx
+++ b/src/pages/event-game-controller-page.test.tsx
@@ -53,7 +53,7 @@ describe("Event Game Controller reconnect browser seam", () => {
     openGrantSessionId = "session";
     openGrantVersion = "version";
     openBearer = "bearer";
-    openProjection = projection();
+    openProjection = null;
     refreshProjection = projection();
     refreshRejected = false;
     switchRequested = false;
@@ -82,7 +82,7 @@ describe("Event Game Controller reconnect browser seam", () => {
                 grantSessionId: openGrantSessionId,
                 grantVersion: openGrantVersion,
               },
-              projection: openProjection ?? projection(),
+              projection: openProjection ?? refreshProjection ?? projection(),
               projectionStatus: "available",
             }),
             { status: 200, headers: { "content-type": "application/json" } },
@@ -745,6 +745,47 @@ describe("Event Game Controller reconnect browser seam", () => {
       type: "resolve-penalty-expiration",
       scoreFactId: scoreAction.intent.factId,
     });
+  });
+  test("projects a natural Heat cue and sends the distinct Controller override-skip path", async () => {
+    refreshProjection = browserHeatProjection("pending");
+    await enterAndOpen();
+    expect(container.textContent).toContain("Pending cue at 15:00");
+    const override = container.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    await act(async () => {
+      override.click();
+      override.dispatchEvent(new testWindow.Event("input", { bubbles: true }) as unknown as Event);
+      override.dispatchEvent(new testWindow.Event("change", { bubbles: true }) as unknown as Event);
+      await Promise.resolve();
+    });
+    const skipButton = Array.from(container.getElementsByTagName("button")).find((button) =>
+      button.textContent?.includes("Skip (Official Override)"),
+    );
+    expect(skipButton).not.toBeNull();
+    expect((skipButton as HTMLButtonElement).disabled).toBe(false);
+    await act(async () => {
+      Array.from(container.getElementsByTagName("button"))
+        .find((button) => button.textContent?.includes("Skip (Official Override)"))
+        ?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const submittedHeat = [
+      ...intentBodies,
+      ...replayBodies.flatMap((body) => body.actions ?? []),
+    ].at(-1)?.intent;
+    expect(submittedHeat).toMatchObject({
+      trigger: "heat-stoppage",
+      heatAction: "skip",
+      heatTriggerId: "heat-trigger-900000",
+      override: { guardrail: "heat-stoppage-rule-deviation" },
+    });
+  });
+
+  test("projects the active Heat timer in the Controller browser seam", async () => {
+    refreshProjection = browserHeatProjection("started");
+    await enterAndOpen();
+    expect(container.textContent).toContain("Timer: 00:00 elapsed");
   });
 
   test("renders stable fact identity and sends a contextual Correction from the browser seam", async () => {
@@ -1595,6 +1636,51 @@ function projection(
       commencedAtMs: defaultProjection ? 10_000 : options.commenced === true ? 0 : null,
       provisionalRunningSinceMs: null,
       provisionalElapsedMs: 0,
+    },
+  };
+}
+
+function browserHeatProjection(kind: "pending" | "started"): ControllerProjection {
+  const base = projection();
+  const startFact = {
+    factId: "browser-heat-start",
+    factType: "heat-stoppage",
+    gameSideId: null,
+    gameTimeMs: 900_000,
+    sportingOrder: 900_000,
+    synchronizationOrder: 1,
+    trustedAtMs: 1_000,
+    effective: true,
+    data: {
+      heatAction: "start",
+      heatTriggerId: "heat-trigger-900000",
+      triggerGameTimeMs: 900_000,
+      heatSequence: 1,
+    },
+  };
+  return {
+    ...base,
+    phase: "in-progress",
+    scoreByGameSide: { "side-a": kind === "pending" ? 30 : 0, "side-b": 0 },
+    goalCount: kind === "pending" ? 3 : 0,
+    gameFacts: kind === "started" ? [startFact] : [],
+    clock: { ...base.clock, gameTimeMs: 900_000, projectedAtMs: 1_000 },
+    heat: {
+      status: "inactive",
+      factId: null,
+      startedAtGameTimeMs: null,
+      nominalDurationMs: null,
+      allowedDurationMs: null,
+      actualDurationMs: null,
+      mode: "enabled",
+      pendingTrigger: null,
+      pendingTriggerId: null,
+      pendingTriggerGameTimeMs: null,
+      nextTriggerGameTimeMs: 1_500_000,
+      trigger: null,
+      permittedExtensionTriggerId: null,
+      activeTriggerId: null,
+      triggerDecision: null,
     },
   };
 }

--- a/src/pages/event-game-controller-page.tsx
+++ b/src/pages/event-game-controller-page.tsx
@@ -13,11 +13,14 @@ import type {
   ControllerProjection,
   LiveEventGameControlResult,
   LiveEventControllerIntent,
+  LiveHeatAction,
 } from "@/lib/live-event-game-control";
-import type { OfficialOverrideMetadata } from "@/lib/event-game-actions";
+import {
+  LIVE_EVENT_CONTROL_INTENT_VERSION,
+  projectLiveHeatState,
+} from "@/lib/live-event-game-control";
 import {
   CLOSE_PLAY_ADJUDICATION_WINDOW_MS,
-  LIVE_EVENT_CONTROL_INTENT_VERSION,
   LIVE_SUSPENSION_SNAPSHOT_VERSION,
   suspensionPenaltyStateFromProjection,
 } from "@/lib/live-event-game-control";
@@ -28,6 +31,7 @@ import {
   type LivePenaltyReason,
 } from "@/lib/live-event-penalties";
 import { validateGameClockMs } from "@/lib/validation-policy";
+import type { ActionJsonValue, OfficialOverrideMetadata } from "@/lib/event-game-actions";
 import { readControllerDeviceContext } from "@/lib/controller-device-context";
 import {
   acknowledgeControllerProjection,
@@ -143,6 +147,7 @@ export function EventGameControllerPage() {
   const [dodgeballPossession, setDodgeballPossession] = useState<PossessionSelection>({});
   const [showSuspensionRecovery, setShowSuspensionRecovery] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
+  const [heatOverrideConfirmed, setHeatOverrideConfirmed] = useState(false);
   const [busy, setBusy] = useState(false);
   const [pendingClosePlayAdjudication, setPendingClosePlayAdjudication] =
     useState<PendingClosePlayAdjudication | null>(null);
@@ -179,6 +184,20 @@ export function EventGameControllerPage() {
       : projectClockSample(
           clockReceiptAnchor.projection,
           localMonotonicMs - clockReceiptAnchor.localMonotonicMs,
+        );
+
+  const displayedHeat =
+    projection?.heat === undefined
+      ? undefined
+      : projectLiveHeatState(
+          projection.gameFacts ?? [],
+          projection.heat.mode,
+          clockProjection?.gameTimeMs ?? projection.clock.gameTimeMs,
+          projection.clock.projectedAtMs +
+            Math.max(
+              0,
+              localMonotonicMs - (clockReceiptAnchor?.localMonotonicMs ?? localMonotonicMs),
+            ),
         );
 
   function projectClockImmediately() {
@@ -809,6 +828,106 @@ export function EventGameControllerPage() {
     });
   }
 
+  function submitHeatAction(heatAction: LiveHeatAction) {
+    const heat = displayedHeat;
+    if (projection === null || heat === undefined) return;
+    const decisionAction =
+      heatAction === "start" ||
+      heatAction === "end-of-drive" ||
+      heatAction === "dead-volleyball" ||
+      heatAction === "other-stoppage" ||
+      heatAction === "skip" ||
+      heatAction === "skip-required" ||
+      heatAction === "suppress";
+    const triggerId =
+      heatAction === "extend-permitted"
+        ? heat.permittedExtensionTriggerId
+        : heatAction === "end" || heatAction === "extend"
+          ? heat.activeTriggerId
+          : decisionAction
+            ? heat.pendingTriggerId
+            : null;
+    const gameTimeMs =
+      decisionAction && typeof heat.pendingTriggerGameTimeMs === "number"
+        ? heat.pendingTriggerGameTimeMs
+        : (clockProjection?.gameTimeMs ?? projection.clock.gameTimeMs);
+    const override = heatOverrideConfirmed
+      ? buildHeatOverride(heatAction, heat, gameTimeMs)
+      : undefined;
+    queueIntent({
+      version: LIVE_EVENT_CONTROL_INTENT_VERSION,
+      type: "substantive",
+      trigger: "heat-stoppage",
+      operationId: crypto.randomUUID(),
+      factId: crypto.randomUUID(),
+      gameTimeMs,
+      heatAction,
+      ...(triggerId === null || triggerId === undefined ? {} : { heatTriggerId: triggerId }),
+      ...(override === undefined ? {} : { override }),
+      occurrence: { clientOriginAtMs: Date.now() },
+    });
+  }
+
+  function buildHeatOverride(
+    heatAction: LiveHeatAction,
+    heat: NonNullable<ControllerProjection["heat"]>,
+    gameTimeMs: number,
+  ): OfficialOverrideMetadata {
+    const modeChange = heatAction === "enable" || heatAction === "disable";
+    const pendingTriggerGameTimeMs = heat.pendingTriggerGameTimeMs ?? null;
+    const nominalDurationMs = heat.nominalDurationMs ?? null;
+    const actualDurationMs = heat.actualDurationMs ?? 0;
+    const scores = Object.values(projection?.scoreByGameSide ?? {});
+    const scoreDifference = Math.abs((scores[0] ?? 0) - (scores[1] ?? 0));
+    const beforeValue: ActionJsonValue = (
+      modeChange
+        ? { heatMode: heat.mode === "enabled" }
+        : heatAction === "suppress"
+          ? { pendingTriggerGameTimeMs }
+          : heatAction === "start" ||
+              heatAction === "end-of-drive" ||
+              heatAction === "dead-volleyball" ||
+              heatAction === "other-stoppage"
+            ? { heat: "pending", requiredDecision: "skip" }
+            : heatAction === "skip" || heatAction === "skip-required"
+              ? { scoreDifference }
+              : heatAction === "end" || heatAction === "extend"
+                ? actualDurationMs >= (nominalDurationMs ?? 0)
+                  ? {
+                      heat: heat.status,
+                      nominalDurationMs,
+                      actualDurationMs,
+                    }
+                  : { heat: heat.status }
+                : { heat: heat.status }
+    ) as ActionJsonValue;
+    return {
+      guardrail: modeChange ? "heat-stoppage-mode-change" : "heat-stoppage-rule-deviation",
+      direction: modeChange
+        ? "head-referee-directed-heat-mode-change"
+        : "head-referee-directed-heat-stoppage",
+      confirmation: "head-referee-confirmed",
+      authorityReference: "head-referee",
+      gameTimeMs,
+      beforeValue,
+      afterValue: modeChange
+        ? { heatMode: heatAction === "enable" }
+        : heatAction === "suppress"
+          ? { trigger: "suppressed" }
+          : heatAction === "end"
+            ? { heat: "ended" }
+            : {
+                heat:
+                  heatAction === "skip" || heatAction === "skip-required"
+                    ? "skipped"
+                    : heatAction === "extend"
+                      ? "extended"
+                      : heatAction,
+              },
+      reason: "head-referee-direction",
+    };
+  }
+
   function queueIntent(
     candidate: LiveEventControllerIntent,
     options: { causalPredecessorIds?: readonly string[] } = {},
@@ -1379,6 +1498,140 @@ export function EventGameControllerPage() {
                       ? "SEEKER RELEASED at 20:00"
                       : "Seeker release pending at 20:00"}
                   </p>
+                </div>
+              )}
+              {displayedHeat === undefined ? null : (
+                <div className="space-y-3 rounded-lg border border-orange-500/50 bg-orange-50 p-3 text-sm text-orange-950">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <div>
+                      <p className="font-medium">Heat Stoppage Controller workflow</p>
+                      <p>
+                        Mode: {displayedHeat.mode ?? "disabled"} · status: {displayedHeat.status}
+                      </p>
+                    </div>
+                    <div className="flex gap-2">
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={() => submitHeatAction("enable")}
+                        disabled={busy || displayedHeat.mode === "enabled"}
+                      >
+                        Enable mode
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={() => submitHeatAction("disable")}
+                        disabled={busy || displayedHeat.mode !== "enabled"}
+                      >
+                        Disable mode
+                      </Button>
+                    </div>
+                  </div>
+                  <p>
+                    {displayedHeat.pendingTrigger === null ||
+                    displayedHeat.pendingTrigger === undefined
+                      ? "No Heat Stoppage cue is pending."
+                      : `Pending cue at ${formatClock(displayedHeat.pendingTrigger.gameTimeMs)} · the Game Clock remains running until a Controller decision.`}
+                  </p>
+                  {displayedHeat.status === "started" || displayedHeat.status === "extended" ? (
+                    <div className="rounded border bg-white/70 p-2">
+                      <p>
+                        Timer: {formatClock(displayedHeat.actualDurationMs ?? 0)} elapsed · nominal{" "}
+                        {formatClock(displayedHeat.nominalDurationMs ?? 0)} · allowed{" "}
+                        {formatClock(
+                          displayedHeat.allowedDurationMs ?? displayedHeat.nominalDurationMs ?? 0,
+                        )}
+                      </p>
+                      <p className="text-xs">
+                        Start game time: {formatClock(displayedHeat.startedAtGameTimeMs ?? 0)}
+                      </p>
+                    </div>
+                  ) : null}
+                  {displayedHeat.status === "ended" && displayedHeat.completedAtAllowed === true ? (
+                    <div className="rounded border bg-white/70 p-2">
+                      <p>
+                        Heat Stoppage complete at the allowed duration; the Game Clock remains
+                        stopped.
+                      </p>
+                      <Button size="sm" onClick={() => submitHeatAction("end")} disabled={busy}>
+                        Acknowledge completion
+                      </Button>
+                    </div>
+                  ) : null}
+                  <label className="flex items-center gap-2">
+                    <input
+                      type="checkbox"
+                      checked={heatOverrideConfirmed}
+                      onChange={(event) => setHeatOverrideConfirmed(event.target.checked)}
+                    />
+                    Head Referee Official Override confirmed
+                  </label>
+                  {displayedHeat.pendingTriggerId === null ? null : (
+                    <div className="flex flex-wrap gap-2">
+                      {(
+                        [
+                          ["end-of-drive", "End of drive"],
+                          ["dead-volleyball", "Dead volleyball"],
+                          ["other-stoppage", "Other stoppage"],
+                          ["skip-required", "Required skip"],
+                          ["start", "Start Heat Stoppage"],
+                        ] as const
+                      ).map(([action, label]) => (
+                        <Button
+                          key={action}
+                          size="sm"
+                          variant="outline"
+                          onClick={() => submitHeatAction(action)}
+                          disabled={busy}
+                        >
+                          {label}
+                        </Button>
+                      ))}
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={() => submitHeatAction("skip")}
+                        disabled={busy || !heatOverrideConfirmed}
+                      >
+                        Skip (Official Override)
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={() => submitHeatAction("suppress")}
+                        disabled={busy || !heatOverrideConfirmed}
+                      >
+                        Suppress cue (override)
+                      </Button>
+                    </div>
+                  )}
+                  {displayedHeat.status === "started" || displayedHeat.status === "extended" ? (
+                    <div className="flex flex-wrap gap-2">
+                      <Button size="sm" onClick={() => submitHeatAction("end")} disabled={busy}>
+                        End Heat Stoppage
+                      </Button>
+                      {displayedHeat.permittedExtensionTriggerId ===
+                      displayedHeat.activeTriggerId ? (
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() => submitHeatAction("extend-permitted")}
+                          disabled={busy}
+                        >
+                          Permitted extension
+                        </Button>
+                      ) : null}
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={() => submitHeatAction("extend")}
+                        disabled={busy || !heatOverrideConfirmed}
+                      >
+                        Extend (override)
+                      </Button>
+                    </div>
+                  ) : null}
                 </div>
               )}
               <div className="flex flex-wrap gap-2">


### PR DESCRIPTION
## What changed

- add durable Event Game heat-stoppage mode snapshots, trigger obligations, decisions, timers, and audit evidence
- consume the typed Game Day Heat Stoppage Configuration resolver at Game Commencement and freeze the accepted mode atomically
- add Controller workflows for pending cues, required skips, permitted extensions, and Head Referee Official Overrides
- preserve heat state through correction, replay, reconnect, and the narrow phone workflow

## Why

Live Event Games need an operator-safe heat-stoppage workflow that follows the configured Game Day mode, survives reconnects, and records exceptional Head Referee decisions without consulting mutable configuration after commencement.

## Impact

Controllers can run ordinary and exceptional heat stoppages with trusted timing and durable recovery. Existing Ad Hoc behavior and accepted Event Game scoring, penalties, suspension recovery, and finish-lock behavior remain separate and preserved.

## Validation

- focused composed suites: 220 passed
- focused 360x640 Controller browser workflow passed
- `bun run check`
- `bun run test`: 822 passed
- `bun run build`
- `git diff --check`

No qualification, load, soak, crash, recovery, or exact-production-artifact workloads were run.

Closes #93
