### PR TITLE
test: remove SQLite probe await-thenable warnings

### DIFF
--- a/src/lib/sqlite-foundation-probe-docker.test.ts
+++ b/src/lib/sqlite-foundation-probe-docker.test.ts
@@ -406,20 +406,20 @@ describe("Docker SQLite qualification boundary", () => {
     };
 
     const success = await makeExecution(0);
-    await expect(success.execution.run()).resolves.toMatchObject({ exitCode: 0 });
+    expect(success.execution.run()).resolves.toMatchObject({ exitCode: 0 });
     expect(success.commands.find((value) => value[0] === "logs")).toEqual(["logs", containerId]);
 
     const failure = await makeExecution(1);
-    await expect(failure.execution.run()).rejects.toMatchObject({ result: { exitCode: 1 } });
+    expect(failure.execution.run()).rejects.toMatchObject({ result: { exitCode: 1 } });
     expect(failure.commands.find((value) => value[0] === "logs")).toEqual(["logs", containerId]);
 
     const logFailure = await makeExecution(0, 1, "logs unavailable");
-    await expect(logFailure.execution.run()).rejects.toMatchObject({
+    expect(logFailure.execution.run()).rejects.toMatchObject({
       result: { stderr: "logs unavailable", stderrBytes: 16 },
     });
 
     const enospc = await makeExecution(0, 1, "ENOSPC");
-    await expect(enospc.execution.run()).rejects.toMatchObject({
+    expect(enospc.execution.run()).rejects.toMatchObject({
       measurement: { diskBytes: null, resourceViolations: ["disk-lower-bound"] },
       result: { stderr: "ENOSPC", stderrBytes: 6 },
     });
@@ -447,7 +447,7 @@ describe("Docker SQLite qualification boundary", () => {
     });
     expect(identity.serverArchitecture).toBe("amd64");
     expect(calls.map((value) => value[0])).toEqual(["info", "version"]);
-    await expect(
+    expect(
       admitDockerEngine({
         platform: "linux",
         architecture: "x64",
@@ -461,7 +461,7 @@ describe("Docker SQLite qualification boundary", () => {
         }),
       }),
     ).rejects.toBeInstanceOf(DockerAdmissionError);
-    await expect(
+    expect(
       admitDockerEngine({
         platform: "linux",
         architecture: "x64",
@@ -489,7 +489,7 @@ describe("Docker SQLite qualification boundary", () => {
     expect(new TextEncoder().encode(boundedInfo).byteLength).toBeLessThan(4 * 1024);
     expect(new TextEncoder().encode(boundedVersion).byteLength).toBeLessThan(4 * 1024);
 
-    await expect(
+    expect(
       admitDockerEngine({
         platform: "linux",
         architecture: "x64",
@@ -505,7 +505,7 @@ describe("Docker SQLite qualification boundary", () => {
     ).rejects.toBeInstanceOf(DockerAdmissionError);
 
     const calls: string[][] = [];
-    await expect(
+    expect(
       admitDockerEngine({
         platform: "linux",
         architecture: "x64",

--- a/src/lib/sqlite-foundation-probe-runner.test.ts
+++ b/src/lib/sqlite-foundation-probe-runner.test.ts
@@ -85,7 +85,7 @@ describe("Docker qualification orchestration", () => {
   test("never creates or starts a Docker workload when admission rejects", async () => {
     let created = false;
     const emitted: Array<{ outcome: string }> = [];
-    await expect(
+    expect(
       runCompiledSqliteFoundationProbe("/owned/artifact", {
         createExecution: async () => {
           created = true;
@@ -102,7 +102,7 @@ describe("Docker qualification orchestration", () => {
 
   test("awaits late admission cleanup before final evidence", async () => {
     const events: string[] = [];
-    await expect(
+    expect(
       runCompiledSqliteFoundationProbe("/owned/artifact", {
         timeoutMs: 160,
         createExecution: async (_path, { workSignal }) =>
@@ -154,7 +154,7 @@ describe("Docker qualification orchestration", () => {
         failures: string[];
       };
     }> = [];
-    await expect(
+    expect(
       runCompiledSqliteFoundationProbe("/owned/artifact", {
         timeoutMs: 160,
         createExecution: async (_path, { admissionSignal }) =>
@@ -181,7 +181,7 @@ describe("Docker qualification orchestration", () => {
   test("fails closed at the admission boundary without claiming removal", async () => {
     const events: string[] = [];
     const emitted: Array<{ cleanup: { status: string; containerRemoved: boolean | null } }> = [];
-    await expect(
+    expect(
       runCompiledSqliteFoundationProbe("/owned/artifact", {
         timeoutMs: 1_000,
         createExecution: async (_path, { cleanupSignal, admissionSignal }) =>
@@ -216,7 +216,7 @@ describe("Docker qualification orchestration", () => {
       cleanup: { status: string; temporaryDataRemoved: boolean };
       evidence: { emission: string };
     }> = [];
-    await expect(
+    expect(
       runCompiledSqliteFoundationProbe("/owned/artifact", {
         createExecution: async () =>
           (() => {
@@ -242,7 +242,7 @@ describe("Docker qualification orchestration", () => {
         failures: string[];
       };
     }> = [];
-    await expect(
+    expect(
       runCompiledSqliteFoundationProbe("/owned/artifact", {
         createExecution: async () => {
           throw new DockerAdmissionError("native platform unavailable");
@@ -264,7 +264,7 @@ describe("Docker qualification orchestration", () => {
   test("bounds a stalled evidence sink by the hard deadline", async () => {
     const fallback: Array<{ cleanup: { status: string } }> = [];
     const started = Date.now();
-    await expect(
+    expect(
       runCompiledSqliteFoundationProbe("/owned/artifact", {
         timeoutMs: 40,
         commit: "abcdef1",
@@ -298,7 +298,7 @@ describe("Docker qualification orchestration", () => {
   test("propagates interruption through bounded cleanup", async () => {
     const interruption = new AbortController();
     const emitted: Array<{ outcome: string }> = [];
-    await expect(
+    expect(
       runCompiledSqliteFoundationProbe("/owned/artifact", {
         commit: "abcdef1",
         signal: interruption.signal,


### PR DESCRIPTION
Closes #232

## Summary

- remove the redundant outer `await` from Bun `.resolves` and `.rejects` assertions in the two SQLite probe Fast-Test files
- include the same warning introduced by the newly merged #179 work, leaving the complete probe-test cluster warning-free
- preserve every asynchronous assertion, timeout, admission, cleanup, and evidence expectation

## Why

Bun tracks `.resolves` and `.rejects` assertions internally, while their matcher return type is not thenable. The outer `await` therefore produced `typescript(await-thenable)` warnings without contributing synchronization.

## Verification

- `bun install --frozen-lockfile`
- `bun run check` (no warnings in either affected SQLite probe test file)
- `bun test --isolate src/lib/sqlite-foundation-probe-docker.test.ts src/lib/sqlite-foundation-probe-runner.test.ts` — 35 passed, 147 expectations
- full ordinary Fast suite on the reviewed implementation — 810 passed
- Standards review — 0 findings
- Spec review — 0 findings
- `git diff --check`

No Qualification Test, `check:sqlite-runtime`, load, soak, crash, or recovery workload was run.
