### PR TITLE
Synchronize durable Game Presentation Changes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -620,12 +620,22 @@ async function startServer() {
         },
         "/api/event-control/intent": {
           POST(req: Request) {
-            return liveEventControlTransport.submitControllerIntent(req);
+            return liveEventControlTransport.submitControlAction(req);
           },
         },
         "/api/event-control/replay": {
           POST(req: Request) {
-            return liveEventControlTransport.replayControllerActions(req);
+            return liveEventControlTransport.replayControlActions(req);
+          },
+        },
+        "/api/event-control/presentation-change": {
+          POST(req: Request) {
+            return liveEventControlTransport.submitGamePresentationChange(req);
+          },
+        },
+        "/api/event-control/presentation-replay": {
+          POST(req: Request) {
+            return liveEventControlTransport.replayGamePresentationChanges(req);
           },
         },
         "/api/event-control/refresh": {

--- a/src/lib/controller-intent-retry.ts
+++ b/src/lib/controller-intent-retry.ts
@@ -133,6 +133,15 @@ export function controllerIntentRetryKey(intent: LiveEventControllerIntent): str
     case "reset":
     case "undo":
       return JSON.stringify([intent.type, intent.gameTimeMs]);
+    case "set-pitch-orientation":
+      return JSON.stringify([intent.type, intent.pitchOrientation, intent.presentationChangeId]);
+    case "set-displayed-team-color":
+      return JSON.stringify([
+        intent.type,
+        intent.gameSideId,
+        intent.color,
+        intent.presentationChangeId,
+      ]);
   }
 }
 

--- a/src/lib/event-game-corrections.support.ts
+++ b/src/lib/event-game-corrections.support.ts
@@ -5,6 +5,7 @@ import {
   LEGACY_CONTROL_ACTION_VERSION,
   LEGACY_CONTROL_AUDIT_VERSION,
   type ControlActionInput,
+  type ControlAuditEntry,
 } from "@/lib/event-game-actions";
 import { createEventGameRecord } from "@/lib/event-game-record";
 import { DURABLE_EVIDENCE_PROVENANCE } from "@/lib/foundation-storage";
@@ -36,7 +37,7 @@ export async function snapshot(record: Awaited<ReturnType<typeof createRecord>>)
       derivedGameState: projectedRebuild.derivedGameState,
       conflicts: projectedRebuild.conflicts,
     },
-    audit: audit.map(projectControlAuditEntryForConvergence),
+    audit: audit.filter(isControlAuditEntry).map(projectControlAuditEntryForConvergence),
   };
 }
 
@@ -478,8 +479,14 @@ async function snapshotFromRebuild(
       derivedGameState: projectedRebuild.derivedGameState,
       conflicts: projectedRebuild.conflicts,
     },
-    audit: audit.map(projectControlAuditEntryForConvergence),
+    audit: audit.filter(isControlAuditEntry).map(projectControlAuditEntryForConvergence),
   };
+}
+
+function isControlAuditEntry(
+  entry: Awaited<ReturnType<Awaited<ReturnType<typeof createRecord>>["readAudit"]>>[number],
+): entry is ControlAuditEntry {
+  return !("classification" in entry && entry.classification === "game-presentation-change");
 }
 
 function mismatchFailure(

--- a/src/lib/event-game-record-helpers.ts
+++ b/src/lib/event-game-record-helpers.ts
@@ -66,7 +66,7 @@ export function validateAuditHistory(
   const contentFingerprintsByOperationId = new Map(
     actions.map((stored) => [stored.action.operationId, stored.contentFingerprint]),
   );
-  const actionOperationIds = new Set(actionsByOperationId.keys());
+  const submissionOperationIds = new Set(actionsByOperationId.keys());
   const acceptedOperationIds = new Set<string>();
   for (const entry of entries) {
     if (entry.recordId !== root.recordId || entry.eventGameId !== root.eventGameId) {
@@ -150,7 +150,7 @@ export function validateAuditHistory(
         entry.operationId === null ? undefined : actionsByOperationId.get(entry.operationId);
       if (
         entry.operationId === null ||
-        !actionOperationIds.has(entry.operationId) ||
+        !submissionOperationIds.has(entry.operationId) ||
         action === undefined ||
         entry.auditId !== acceptedAuditId(action) ||
         entry.createdAtMs !== action.acceptedAtMs ||

--- a/src/lib/event-game-record.ts
+++ b/src/lib/event-game-record.ts
@@ -44,7 +44,26 @@ import {
   type ControlAuditEntry,
   type EventGameRecordMetadata,
   type IqaGameRulesInterpreter,
+  sha256,
 } from "@/lib/event-game-actions";
+import {
+  canonicalizeGamePresentationChange,
+  fingerprintGamePresentationChange,
+  isValidHexColor,
+  orderGamePresentationChanges,
+  type GamePresentation,
+  type GamePresentationAuditKind,
+  type GamePresentationChange,
+  type StoredGamePresentationAuditEntry,
+  type StoredGamePresentationChange,
+} from "@/lib/game-presentation";
+import {
+  collapseGamePresentationAuditEntries,
+  deriveGamePresentation,
+  type GamePresentationAcceptanceInput,
+  revisionGamePresentationAuditEntry,
+} from "@/lib/game-presentation-projection";
+import { validateIntegerInRange, validateOpaqueIdentifier } from "@/lib/validation-policy";
 
 /**
  * Trusted composition boundary for Control Audit Trail access.
@@ -72,6 +91,14 @@ export type ExternalEventTeamResolution =
   | { status: "resolved" }
   | { status: "missing" | "mismatch"; detail: string };
 
+export type ExternalEventTeamColorResolver = {
+  resolveDefaultColor(
+    eventId: string,
+    eventTeamId: string,
+    snapshot: FoundationStorageSnapshot,
+  ): string | null;
+};
+
 /**
  * Resolves the external Event hierarchy without exposing external storage rows.
  * The transaction capability is the same synchronous snapshot used to accept the owned root.
@@ -86,6 +113,7 @@ export type ExternalScopeResolver = {
     eventTeamId: string,
     snapshot: FoundationStorageSnapshot,
   ): ExternalEventTeamResolution;
+  resolveEventTeamDefaultColor?: ExternalEventTeamColorResolver["resolveDefaultColor"];
 };
 
 function sameLifecycleContext(
@@ -160,11 +188,17 @@ export type EventGameRecord = {
   acceptAction(input: unknown): Promise<ControlActionAcceptanceOutcome>;
   readActions(): Promise<StoredControlAction[]>;
   readRecoveryProvenance(): Promise<ControlActionRecoveryProvenance[]>;
-  readAudit(credential: unknown): Promise<ControlAuditEntry[]>;
+  readAudit(credential: unknown): Promise<ControlAuditTrailEntry[]>;
+  acceptPresentationChange(input: unknown): Promise<GamePresentationAcceptanceOutcome>;
+  readPresentationHistory(): Promise<StoredGamePresentationChange[]>;
+  readPresentation(): Promise<GamePresentation>;
+  readPresentationAudit(credential: unknown): Promise<StoredGamePresentationAuditEntry[]>;
   readMetadata(): Promise<EventGameRecordMetadata | null>;
   rebuild(): Promise<ActionRebuildResult>;
   readiness(): Promise<EventGameRecordReadiness>;
 };
+
+export type ControlAuditTrailEntry = ControlAuditEntry | StoredGamePresentationAuditEntry;
 
 export type LifecycleTransitionOutcome =
   | { status: "updated" | "idempotent"; root: EventGameRecordRoot }
@@ -187,6 +221,18 @@ export type ControlActionAcceptanceOutcome =
         | "cyclic-dependency"
         | "fact-target-missing"
         | "storage-not-ready";
+      detail: string;
+    };
+
+export type GamePresentationAcceptanceOutcome =
+  | {
+      status: "accepted" | "duplicate-accepted";
+      change: StoredGamePresentationChange;
+      auditId: string;
+    }
+  | {
+      status: "rejected";
+      reason: "invalid-change" | "record-not-found" | "operation-conflict" | "storage-not-ready";
       detail: string;
     };
 
@@ -282,6 +328,150 @@ function hasCompatibleReplayContext(
   );
 }
 
+function presentationDefaultColors(
+  root: EventGameRecordRoot,
+  snapshot: FoundationStorageSnapshot,
+  resolver: ExternalScopeResolver,
+): Record<string, string> {
+  const defaults: Record<string, string> = {};
+  for (const side of root.gameSides) {
+    const color = resolver.resolveEventTeamDefaultColor?.(root.eventId, side.eventTeamId, snapshot);
+    if (color !== null && color !== undefined && isValidHexColor(color)) {
+      defaults[side.id] = `#${color.trim().replace(/^#/, "").toLowerCase()}`;
+    }
+  }
+  return defaults;
+}
+
+function isRecord(value: unknown): value is Record<string, any> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function presentationAuditId(
+  root: EventGameRecordRoot,
+  kind: GamePresentationAuditKind,
+  operationId: string | null,
+  detail: string,
+): string {
+  return `presentation:${kind}:${root.recordId}:${operationId ?? sha256(detail)}`;
+}
+
+function materializePresentationAuditSnapshots(
+  root: EventGameRecordRoot,
+  changes: readonly StoredGamePresentationChange[],
+  audits: readonly StoredGamePresentationAuditEntry[],
+  defaultColors: Readonly<Record<string, string>>,
+): StoredGamePresentationAuditEntry[] {
+  const ordered = orderGamePresentationChanges(changes);
+  const indexByOperationId = new Map(
+    ordered.map((change, index) => [change.operationId, index] as const),
+  );
+  const gameSideIds = root.gameSides.map((side) => side.id);
+  return collapseGamePresentationAuditEntries(audits).map((audit) => {
+    if (audit.kind !== "presentation-accepted" || audit.operationId === null) {
+      return structuredClone(audit);
+    }
+    const index = indexByOperationId.get(audit.operationId);
+    if (index === undefined) return structuredClone(audit);
+    return {
+      ...structuredClone(audit),
+      previousPresentation: deriveGamePresentation(
+        gameSideIds,
+        ordered.slice(0, index),
+        defaultColors,
+      ),
+      resultingPresentation: deriveGamePresentation(
+        gameSideIds,
+        ordered.slice(0, index + 1),
+        defaultColors,
+      ),
+    };
+  });
+}
+
+function readPresentationAcceptanceInput(value: unknown): GamePresentationAcceptanceInput | null {
+  if (!isRecord(value)) return null;
+  const change = value.change;
+  if (
+    !isRecord(change) ||
+    typeof value.recordId !== "string" ||
+    typeof value.eventGameId !== "string"
+  ) {
+    return null;
+  }
+  if (
+    !validateOpaqueIdentifier(value.recordId, "recordId").ok ||
+    !validateOpaqueIdentifier(value.eventGameId, "eventGameId").ok ||
+    !validateOpaqueIdentifier(value.operationId, "operationId").ok ||
+    !validateOpaqueIdentifier(value.presentationChangeId, "presentationChangeId").ok ||
+    typeof value.operationId !== "string" ||
+    typeof value.presentationChangeId !== "string" ||
+    !Array.isArray(value.causalPredecessorIds) ||
+    !isRecord(value.occurrence) ||
+    !isRecord(value.grant) ||
+    typeof value.acceptedAtMs !== "number"
+  )
+    return null;
+  let normalizedChange: GamePresentationChange;
+  if (
+    change.type === "pitch-orientation" &&
+    (change.pitchOrientation === "side-a-left" || change.pitchOrientation === "side-b-left")
+  ) {
+    normalizedChange = { type: "pitch-orientation", pitchOrientation: change.pitchOrientation };
+  } else if (
+    change.type === "displayed-team-color" &&
+    validateOpaqueIdentifier(change.gameSideId, "gameSideId").ok &&
+    typeof change.color === "string" &&
+    isValidHexColor(change.color)
+  ) {
+    normalizedChange = {
+      type: "displayed-team-color",
+      gameSideId: change.gameSideId,
+      color: `#${change.color.trim().replace(/^#/, "").toLowerCase()}`,
+    };
+  } else return null;
+  if (
+    !value.causalPredecessorIds.every(
+      (id): id is string => validateOpaqueIdentifier(id, "causalPredecessorId").ok,
+    ) ||
+    new Set(value.causalPredecessorIds).size !== value.causalPredecessorIds.length ||
+    value.causalPredecessorIds.includes(value.operationId) ||
+    !validateIntegerInRange(
+      value.occurrence.trustedAtMs,
+      0,
+      Number.MAX_SAFE_INTEGER,
+      "occurrence.trustedAtMs",
+    ).ok ||
+    (value.occurrence.clientOriginAtMs !== null &&
+      !validateIntegerInRange(
+        value.occurrence.clientOriginAtMs,
+        0,
+        Number.MAX_SAFE_INTEGER,
+        "occurrence.clientOriginAtMs",
+      ).ok) ||
+    (value.occurrence.source !== "online" && value.occurrence.source !== "offline") ||
+    !validateOpaqueIdentifier(value.grant.sessionId, "grant.sessionId").ok ||
+    !validateOpaqueIdentifier(value.grant.versionId, "grant.versionId").ok ||
+    !validateIntegerInRange(value.acceptedAtMs, 0, Number.MAX_SAFE_INTEGER, "acceptedAtMs").ok
+  )
+    return null;
+  return {
+    recordId: value.recordId,
+    eventGameId: value.eventGameId,
+    operationId: value.operationId,
+    presentationChangeId: value.presentationChangeId,
+    change: normalizedChange,
+    causalPredecessorIds: value.causalPredecessorIds,
+    occurrence: {
+      trustedAtMs: value.occurrence.trustedAtMs,
+      clientOriginAtMs: value.occurrence.clientOriginAtMs,
+      source: value.occurrence.source,
+    },
+    grant: { sessionId: value.grant.sessionId, versionId: value.grant.versionId },
+    acceptedAtMs: value.acceptedAtMs,
+  };
+}
+
 export function createEventGameRecord(
   storage: FoundationStorage,
   options: EventGameRecordOptions,
@@ -324,13 +514,13 @@ export function createEventGameRecord(
         storage.readAuditEntries(root.recordId),
         storage.readRecordMetadata(root.recordId),
       ]);
-      const snapshot: FoundationStorageSnapshot = {
+      const snapshot = {
         revision: 0,
         findRootByRecordId: () => root,
         findRootByEventGameId: () => root,
         findRootByPitchSlotId: () => root,
         findRootByGameSideId: () => root,
-        findActionByOperationId: (_recordId, operationId) =>
+        findActionByOperationId: (_recordId: string, operationId: string) =>
           storedActions.find((stored) => stored.action.operationId === operationId) ?? null,
         listActions: () => storedActions,
         listIdempotencyEntries: () => idempotencyEntries,
@@ -339,12 +529,6 @@ export function createEventGameRecord(
         findEvent: () => null,
         listEvents: () => [],
         listGameDays: () => [],
-        findEventTeam: () => null,
-        listEventTeams: () => [],
-        listRoster: () => [],
-        findRosterEntry: () => null,
-        findPitch: () => null,
-        listPitches: () => [],
         listEventAuditTrail: () => [],
         findGrantById: () => null,
         listGrants: () => [],
@@ -361,7 +545,7 @@ export function createEventGameRecord(
         findReplayReceiptByDigest: () => null,
         findReplayReceiptByReservationId: () => null,
         listAcceptanceIntegrityAnchors: () => [],
-      };
+      } as unknown as FoundationStorageSnapshot;
       return rebuildRecordSnapshot(root, snapshot, codecRegistry, options.interpreter);
     } catch (error) {
       if (error instanceof FoundationStorageNotReadyError) {
@@ -871,7 +1055,323 @@ export function createEventGameRecord(
         throw new Error("A trusted Event Admin or Technical Admin audit authority is required.");
       }
       const entries = await storage.readAuditEntries(currentRecordId());
-      return entries.sort(compareAuditEntries);
+      const presentationEntries = await storage.transaction((transaction) => {
+        const root = transaction.findRootByRecordId(currentRecordId());
+        if (root === null) return [];
+        return materializePresentationAuditSnapshots(
+          root,
+          transaction.listPresentationChanges?.(root.recordId) ?? [],
+          transaction.listPresentationAuditEntries?.(root.recordId) ?? [],
+          presentationDefaultColors(root, transaction, options.externalScopeResolver),
+        );
+      });
+      const presentationRanks = await storage.transaction((transaction) => {
+        const changes = transaction.listPresentationChanges?.(currentRecordId()) ?? [];
+        return new Map(
+          orderGamePresentationChanges(changes).map((change, index) => [change.operationId, index]),
+        );
+      });
+      return [...entries, ...presentationEntries].sort((left, right) =>
+        compareAuditEntries(left, right, presentationRanks),
+      );
+    },
+
+    async acceptPresentationChange(input) {
+      const parsed = readPresentationAcceptanceInput(input);
+      if (parsed === null) {
+        return {
+          status: "rejected",
+          reason: "invalid-change",
+          detail: "Game Presentation Change is malformed.",
+        } satisfies GamePresentationAcceptanceOutcome;
+      }
+      try {
+        const outcome = await storage.transaction((transaction) => {
+          if (
+            transaction.findPresentationChangeByOperationId === undefined ||
+            transaction.listPresentationChanges === undefined ||
+            transaction.listPresentationAuditEntries === undefined ||
+            transaction.insertPresentationChange === undefined ||
+            transaction.appendPresentationAuditEntry === undefined ||
+            transaction.appendPresentationAuditRevision === undefined ||
+            transaction.sealPresentationEvidence === undefined
+          ) {
+            return {
+              status: "rejected",
+              reason: "storage-not-ready",
+              detail: "The presentation record seam is not durably available.",
+            } satisfies GamePresentationAcceptanceOutcome;
+          }
+          const root = transaction.findRootByRecordId(parsed.recordId);
+          if (root === null || root.eventGameId !== parsed.eventGameId) {
+            return {
+              status: "rejected",
+              reason: "record-not-found",
+              detail: "The Event Game Record is not registered for this Event Game.",
+            } satisfies GamePresentationAcceptanceOutcome;
+          }
+          if (parsed.recordId !== currentRecordId()) {
+            return {
+              status: "rejected",
+              reason: "record-not-found",
+              detail: "The Event Game Record is not active.",
+            } satisfies GamePresentationAcceptanceOutcome;
+          }
+          if (parsed.change.type === "displayed-team-color") {
+            const gameSideId = parsed.change.gameSideId;
+            if (!root.gameSides.some((side) => side.id === gameSideId)) {
+              return {
+                status: "rejected",
+                reason: "invalid-change",
+                detail: "Game Presentation Change references an unknown stable Game Side.",
+              } satisfies GamePresentationAcceptanceOutcome;
+            }
+          }
+          const retainedPresentationChanges = transaction.listPresentationChanges(root.recordId);
+          const predecessorIds = new Set(parsed.causalPredecessorIds);
+          const retainedOperationIds = new Set([
+            ...transaction.listActions(root.recordId).map((stored) => stored.action.operationId),
+            ...retainedPresentationChanges.map((change) => change.operationId),
+          ]);
+          if (
+            predecessorIds.size !== parsed.causalPredecessorIds.length ||
+            predecessorIds.has(parsed.operationId) ||
+            parsed.causalPredecessorIds.some(
+              (predecessor) => !retainedOperationIds.has(predecessor),
+            )
+          ) {
+            return {
+              status: "rejected",
+              reason: "invalid-change",
+              detail: "Game Presentation Change causal predecessors are not retained.",
+            } satisfies GamePresentationAcceptanceOutcome;
+          }
+          const previousPresentation = deriveGamePresentation(
+            root.gameSides.map((side) => side.id),
+            retainedPresentationChanges,
+            presentationDefaultColors(root, transaction, options.externalScopeResolver),
+          );
+          const existing = transaction.findPresentationChangeByOperationId?.(
+            root.recordId,
+            parsed.operationId,
+          );
+          const fingerprint = fingerprintGamePresentationChange(parsed);
+          if (existing !== null && existing !== undefined) {
+            if (existing.contentFingerprint === fingerprint) {
+              const audit: StoredGamePresentationAuditEntry = {
+                auditVersion: "control-audit-v1",
+                auditId: presentationAuditId(
+                  root,
+                  "presentation-duplicate",
+                  parsed.operationId,
+                  "",
+                ),
+                recordId: root.recordId,
+                eventGameId: root.eventGameId,
+                operationId: parsed.operationId,
+                presentationChangeId: parsed.presentationChangeId,
+                kind: "presentation-duplicate",
+                classification: "game-presentation-change",
+                outcome: "duplicate-accepted",
+                createdAtMs: parsed.acceptedAtMs,
+                redactedDetail: "Duplicate Game Presentation Change acknowledged idempotently.",
+                previousPresentation: structuredClone(previousPresentation),
+                resultingPresentation: structuredClone(previousPresentation),
+                change: parsed.change,
+                grant: parsed.grant,
+              };
+              if (
+                !transaction
+                  .listPresentationAuditEntries?.(root.recordId)
+                  .some((entry) => entry.auditId === audit.auditId)
+              ) {
+                transaction.appendPresentationAuditEntry?.(audit);
+                transaction.sealPresentationEvidence(root.recordId);
+              }
+              return {
+                status: "duplicate-accepted",
+                change: structuredClone(existing),
+                auditId: audit.auditId,
+              } satisfies GamePresentationAcceptanceOutcome;
+            }
+            const audit: StoredGamePresentationAuditEntry = {
+              auditVersion: "control-audit-v1",
+              auditId: presentationAuditId(
+                root,
+                "presentation-conflict",
+                parsed.operationId,
+                fingerprint,
+              ),
+              recordId: root.recordId,
+              eventGameId: root.eventGameId,
+              operationId: parsed.operationId,
+              presentationChangeId: parsed.presentationChangeId,
+              kind: "presentation-conflict",
+              classification: "game-presentation-change",
+              outcome: "rejected",
+              createdAtMs: parsed.acceptedAtMs,
+              redactedDetail:
+                "operation identity is already bound to different presentation content",
+              previousPresentation: structuredClone(previousPresentation),
+              resultingPresentation: structuredClone(previousPresentation),
+              change: parsed.change,
+              grant: parsed.grant,
+            };
+            transaction.appendPresentationAuditEntry?.(audit);
+            transaction.sealPresentationEvidence(root.recordId);
+            return {
+              status: "rejected",
+              reason: "operation-conflict",
+              detail: "The presentation operation identity is already bound to different content.",
+            } satisfies GamePresentationAcceptanceOutcome;
+          }
+          const sameChange = transaction
+            .listPresentationChanges?.(root.recordId)
+            .find((change) => change.presentationChangeId === parsed.presentationChangeId);
+          if (sameChange !== undefined) {
+            return {
+              status: "rejected",
+              reason: "operation-conflict",
+              detail: "The presentation change identity is already retained.",
+            } satisfies GamePresentationAcceptanceOutcome;
+          }
+          const stored: StoredGamePresentationChange = {
+            ...parsed,
+            causalPredecessorIds: [...parsed.causalPredecessorIds],
+            canonicalContent: canonicalizeGamePresentationChange(parsed),
+            contentFingerprint: fingerprint,
+          };
+          transaction.insertPresentationChange?.(stored);
+          const orderedChanges = orderGamePresentationChanges(
+            transaction.listPresentationChanges(root.recordId),
+          );
+          const storedIndex = orderedChanges.findIndex(
+            (change) => change.operationId === stored.operationId,
+          );
+          const canonicalPreviousPresentation = deriveGamePresentation(
+            root.gameSides.map((side) => side.id),
+            orderedChanges.slice(0, storedIndex),
+            presentationDefaultColors(root, transaction, options.externalScopeResolver),
+          );
+          const resultingPresentation = deriveGamePresentation(
+            root.gameSides.map((side) => side.id),
+            orderedChanges.slice(0, storedIndex + 1),
+            presentationDefaultColors(root, transaction, options.externalScopeResolver),
+          );
+          const audit: StoredGamePresentationAuditEntry = {
+            auditVersion: "control-audit-v1",
+            auditId: presentationAuditId(root, "presentation-accepted", parsed.operationId, ""),
+            recordId: root.recordId,
+            eventGameId: root.eventGameId,
+            operationId: parsed.operationId,
+            presentationChangeId: parsed.presentationChangeId,
+            kind: "presentation-accepted",
+            classification: "game-presentation-change",
+            outcome: "accepted",
+            createdAtMs: parsed.acceptedAtMs,
+            redactedDetail: "Game Presentation Change accepted and synchronized.",
+            previousPresentation: structuredClone(canonicalPreviousPresentation),
+            resultingPresentation: structuredClone(resultingPresentation),
+            change: parsed.change,
+            grant: parsed.grant,
+          };
+          transaction.appendPresentationAuditEntry?.(audit);
+          const allAudits = transaction.listPresentationAuditEntries(root.recordId);
+          const canonicalAudits = materializePresentationAuditSnapshots(
+            root,
+            orderedChanges,
+            allAudits,
+            presentationDefaultColors(root, transaction, options.externalScopeResolver),
+          );
+          const effectiveAudits = collapseGamePresentationAuditEntries(allAudits);
+          for (const canonicalAudit of canonicalAudits) {
+            if (canonicalAudit.kind !== "presentation-accepted") continue;
+            const currentAudit = effectiveAudits.find(
+              (entry) => entry.auditId === canonicalAudit.auditId,
+            );
+            if (
+              currentAudit !== undefined &&
+              (JSON.stringify(currentAudit.previousPresentation) !==
+                JSON.stringify(canonicalAudit.previousPresentation) ||
+                JSON.stringify(currentAudit.resultingPresentation) !==
+                  JSON.stringify(canonicalAudit.resultingPresentation))
+            ) {
+              transaction.appendPresentationAuditRevision(
+                revisionGamePresentationAuditEntry(canonicalAudit),
+              );
+            }
+          }
+          transaction.sealPresentationEvidence(root.recordId);
+          return {
+            status: "accepted",
+            change: stored,
+            auditId: audit.auditId,
+          } satisfies GamePresentationAcceptanceOutcome;
+        });
+        return outcome;
+      } catch (error) {
+        if (error instanceof FoundationStorageNotReadyError) {
+          return {
+            status: "rejected",
+            reason: "storage-not-ready",
+            detail: "Presentation records are not durably available.",
+          } satisfies GamePresentationAcceptanceOutcome;
+        }
+        return {
+          status: "rejected",
+          reason: "storage-not-ready",
+          detail: "The Game Presentation Change could not be durably committed.",
+        } satisfies GamePresentationAcceptanceOutcome;
+      }
+    },
+
+    async readPresentation() {
+      return storage.transaction((transaction) => {
+        const root = transaction.findRootByRecordId(currentRecordId());
+        if (root === null) throw new Error("The Event Game Record is not registered.");
+        const changes = transaction.listPresentationChanges?.(root.recordId) ?? [];
+        return deriveGamePresentation(
+          root.gameSides.map((side) => side.id),
+          changes,
+          presentationDefaultColors(root, transaction, options.externalScopeResolver),
+        );
+      });
+    },
+
+    async readPresentationHistory() {
+      return storage.transaction((transaction) => {
+        const root = transaction.findRootByRecordId(currentRecordId());
+        if (root === null) throw new Error("The Event Game Record is not registered.");
+        return orderGamePresentationChanges(
+          transaction.listPresentationChanges?.(root.recordId) ?? [],
+        ).map((change) => structuredClone(change));
+      });
+    },
+
+    async readPresentationAudit(credential) {
+      let verified = false;
+      try {
+        verified = options.auditAuthorityVerifier?.verify(credential) === true;
+      } catch {
+        verified = false;
+      }
+      if (!verified) {
+        throw new Error("A trusted Event Admin or Technical Admin audit authority is required.");
+      }
+      return storage.transaction((transaction) => {
+        const root = transaction.findRootByRecordId(currentRecordId());
+        if (root === null) throw new Error("The Event Game Record is not registered.");
+        const changes = transaction.listPresentationChanges?.(root.recordId) ?? [];
+        const presentationRanks = new Map(
+          orderGamePresentationChanges(changes).map((change, index) => [change.operationId, index]),
+        );
+        return materializePresentationAuditSnapshots(
+          root,
+          changes,
+          transaction.listPresentationAuditEntries?.(root.recordId) ?? [],
+          presentationDefaultColors(root, transaction, options.externalScopeResolver),
+        ).sort((left, right) => compareAuditEntries(left, right, presentationRanks));
+      });
     },
 
     readMetadata() {
@@ -978,17 +1478,44 @@ export function appendConcurrentCorrectionAudits(
   }
 }
 
-function compareAuditEntries(left: ControlAuditEntry, right: ControlAuditEntry): number {
-  const leftOccurrence = left.provenance?.occurrence?.trustedAtMs ?? Number.MAX_SAFE_INTEGER;
-  const rightOccurrence = right.provenance?.occurrence?.trustedAtMs ?? Number.MAX_SAFE_INTEGER;
-  const leftOperation = left.operationId ?? left.links?.relatedOperationIds.join(":") ?? "";
-  const rightOperation = right.operationId ?? right.links?.relatedOperationIds.join(":") ?? "";
+function compareAuditEntries(
+  left: ControlAuditTrailEntry,
+  right: ControlAuditTrailEntry,
+  presentationRanks: ReadonlyMap<string, number> = new Map(),
+): number {
+  if (
+    isPresentationAuditEntry(left) &&
+    isPresentationAuditEntry(right) &&
+    left.operationId !== null &&
+    right.operationId !== null
+  ) {
+    const leftRank = presentationRanks.get(left.operationId);
+    const rightRank = presentationRanks.get(right.operationId);
+    if (leftRank !== undefined && rightRank !== undefined && leftRank !== rightRank) {
+      return leftRank - rightRank;
+    }
+  }
+  const leftControl = left as ControlAuditEntry;
+  const rightControl = right as ControlAuditEntry;
+  const leftOccurrence = leftControl.provenance?.occurrence?.trustedAtMs ?? leftControl.createdAtMs;
+  const rightOccurrence =
+    rightControl.provenance?.occurrence?.trustedAtMs ?? rightControl.createdAtMs;
+  const leftOperation =
+    leftControl.operationId ?? leftControl.links?.relatedOperationIds.join(":") ?? "";
+  const rightOperation =
+    rightControl.operationId ?? rightControl.links?.relatedOperationIds.join(":") ?? "";
   return (
     (leftOccurrence === rightOccurrence ? 0 : leftOccurrence < rightOccurrence ? -1 : 1) ||
     compareOpaqueIdentifiers(leftOperation, rightOperation) ||
     compareOpaqueIdentifiers(left.kind, right.kind) ||
     compareOpaqueIdentifiers(left.auditId, right.auditId)
   );
+}
+
+function isPresentationAuditEntry(
+  entry: ControlAuditTrailEntry,
+): entry is ControlAuditTrailEntry & { classification: "game-presentation-change" } {
+  return "classification" in entry && entry.classification === "game-presentation-change";
 }
 
 function compareOpaqueIdentifiers(left: string, right: string): number {

--- a/src/lib/game-presentation-projection.ts
+++ b/src/lib/game-presentation-projection.ts
@@ -1,0 +1,93 @@
+import {
+  DEFAULT_AWAY_TEAM_COLOR,
+  DEFAULT_HOME_TEAM_COLOR,
+  normalizeTeamColor,
+} from "@/lib/team-colors";
+import { canonicalizeJson, sha256 } from "@/lib/event-game-action-json";
+import {
+  applyGamePresentationChange,
+  orderGamePresentationChanges,
+  type GamePresentation,
+  type StoredGamePresentationAuditEntry,
+  type StoredGamePresentationAuditRevision,
+  type StoredGamePresentationChange,
+} from "@/lib/game-presentation";
+
+export type GamePresentationAcceptanceInput = Pick<
+  StoredGamePresentationChange,
+  | "recordId"
+  | "eventGameId"
+  | "operationId"
+  | "presentationChangeId"
+  | "change"
+  | "causalPredecessorIds"
+  | "occurrence"
+  | "grant"
+  | "acceptedAtMs"
+>;
+
+export function createInitialGamePresentation(
+  gameSideIds: readonly string[],
+  defaultColors: Readonly<Record<string, string>> = {},
+): GamePresentation {
+  return {
+    gameSideIds: [...gameSideIds],
+    pitchOrientation: "side-a-left",
+    displayedTeamColors: Object.fromEntries(
+      gameSideIds.map((gameSideId, index) => [
+        gameSideId,
+        normalizeTeamColor(
+          defaultColors[gameSideId],
+          index === 0 ? DEFAULT_HOME_TEAM_COLOR : DEFAULT_AWAY_TEAM_COLOR,
+        ),
+      ]),
+    ),
+  };
+}
+
+export function deriveGamePresentation(
+  gameSideIds: readonly string[],
+  changes: readonly StoredGamePresentationChange[],
+  defaultColors: Readonly<Record<string, string>> = {},
+): GamePresentation {
+  return orderGamePresentationChanges(changes).reduce(
+    (presentation, storedChange) => applyGamePresentationChange(presentation, storedChange.change),
+    createInitialGamePresentation(gameSideIds, defaultColors),
+  );
+}
+
+export function collapseGamePresentationAuditEntries(
+  entries: readonly StoredGamePresentationAuditEntry[],
+): StoredGamePresentationAuditEntry[] {
+  const superseded = new Set(
+    entries.flatMap((entry) =>
+      entry.supersedesAuditId === undefined ? [] : [entry.supersedesAuditId],
+    ),
+  );
+  return [...entries]
+    .filter((entry) => !superseded.has(entry.auditId))
+    .map((entry) => structuredClone(entry))
+    .sort((left, right) =>
+      left.createdAtMs === right.createdAtMs
+        ? left.auditId.localeCompare(right.auditId)
+        : left.createdAtMs - right.createdAtMs,
+    );
+}
+
+export function revisionGamePresentationAuditEntry(
+  entry: StoredGamePresentationAuditEntry,
+): StoredGamePresentationAuditRevision {
+  const revision = sha256(
+    canonicalizeJson({
+      supersedesAuditId: entry.auditId,
+      previousPresentation: entry.previousPresentation,
+      resultingPresentation: entry.resultingPresentation,
+    }),
+  ).slice(0, 16);
+  const baseAuditId = entry.auditId.split(":revision:")[0] ?? entry.auditId;
+  return {
+    ...structuredClone(entry),
+    auditId: `${baseAuditId}:revision:${revision}`,
+    supersedesAuditId: entry.auditId,
+  };
+}

--- a/src/lib/game-presentation.ts
+++ b/src/lib/game-presentation.ts
@@ -61,6 +61,7 @@ export type StoredGamePresentationAuditEntry = {
   grant: GamePresentationGrantProvenance | null;
   /** Append-only revision linkage for repaired canonical snapshots. */
   supersedesAuditId?: string;
+  links?: { targetFactId?: string; grantAuditId?: string };
 };
 
 export type StoredGamePresentationAuditRevision = StoredGamePresentationAuditEntry & {

--- a/src/lib/live-event-game-control.ts
+++ b/src/lib/live-event-game-control.ts
@@ -14,6 +14,13 @@ import {
   SYSTEM_TIMEOUT_COMPLETION_GRANT,
 } from "@/lib/event-game-actions";
 import { parseJsonValue, validateOverride } from "@/lib/event-game-action-codecs";
+import {
+  isValidHexColor,
+  type GamePresentation,
+  type GamePresentationGrantProvenance,
+  type PitchOrientation,
+} from "@/lib/game-presentation";
+import { createInitialGamePresentation } from "@/lib/game-presentation-projection";
 import { DEFAULT_IQA_SPORTING_RULES } from "@/lib/iqa-game-rules";
 import {
   CLOCK_AUTHORITY_VERSION,
@@ -102,6 +109,11 @@ type ControllerIntentBase = {
   override?: OfficialOverrideMetadata;
 };
 
+type ControllerPresentationIntentBase = Omit<ControllerIntentBase, "factId"> & {
+  factId: string;
+  presentationChangeId: string;
+};
+
 export type LiveEventControllerIntent =
   | (ControllerIntentBase & {
       type: "record-goal";
@@ -181,7 +193,34 @@ export type LiveEventControllerIntent =
     })
   | (ControllerIntentBase & {
       type: "reset" | "undo";
+    })
+  | (ControllerPresentationIntentBase & {
+      type: "set-pitch-orientation";
+      pitchOrientation: PitchOrientation;
+    })
+  | (ControllerPresentationIntentBase & {
+      type: "set-displayed-team-color";
+      gameSideId: string;
+      color: string;
     });
+
+export type LiveEventControllerSubmission = LiveEventControllerIntent;
+export type GamePresentationChangeIntent = Extract<
+  LiveEventControllerIntent,
+  { type: "set-pitch-orientation" | "set-displayed-team-color" }
+>;
+export type LiveEventControlActionIntent = Exclude<
+  LiveEventControllerIntent,
+  GamePresentationChangeIntent
+>;
+export type GamePresentationChangeResult =
+  | {
+      status: "accepted" | "duplicate-accepted";
+      operationId: string;
+      presentation: GamePresentation;
+      auditId: string;
+    }
+  | { status: "retryable" | "rejected"; operationId: string | null; message: string };
 
 export type ControllerCommencement = {
   status: "provisional" | "commenced";
@@ -194,6 +233,9 @@ export type ControllerSessionAttachment = {
   eventGameId: string;
   grantSessionId: string;
   grantVersion: string;
+};
+export type ControllerSessionWithReplayProof = ControllerSessionAttachment & {
+  replayProvenanceProof: string;
 };
 
 export type ControllerSwitchRequired = {
@@ -242,6 +284,7 @@ export type LiveEventGameDerivedState = {
   catch: LiveCatchState | null;
   gameFacts: readonly ControllerGameFact[];
   penalties: LivePenaltyProjection;
+  presentation?: GamePresentation;
 };
 
 /**
@@ -396,6 +439,7 @@ export type ControllerProjection = {
   guardrails?: readonly LiveEventGuardrailExplanation[];
   commencement: ControllerCommencement;
   clock: ClockProjection;
+  presentation?: GamePresentation;
 };
 
 type LiveMaterializationAuthority = {
@@ -582,7 +626,9 @@ export function parseLiveEventControllerIntent(
     value.type !== "set-game-clock" &&
     value.type !== "substantive" &&
     value.type !== "reset" &&
-    value.type !== "undo"
+    value.type !== "undo" &&
+    value.type !== "set-pitch-orientation" &&
+    value.type !== "set-displayed-team-color"
   )
     return invalid("Controller intent type is unsupported.");
   const normalizedType =
@@ -595,7 +641,6 @@ export function parseLiveEventControllerIntent(
           : value.type;
 
   const operationId = validateOpaqueIdentifier(value.operationId, "operationId");
-  const factId = validateOpaqueIdentifier(value.factId, "factId");
   const gameTimeMs = validateIntegerInRange(
     value.gameTimeMs,
     0,
@@ -603,8 +648,75 @@ export function parseLiveEventControllerIntent(
     "gameTimeMs",
   );
   if (!operationId.ok) return invalid(operationId.error);
-  if (!factId.ok) return invalid(factId.error);
   if (!gameTimeMs.ok) return invalid(gameTimeMs.error);
+
+  if (value.type === "set-pitch-orientation" || value.type === "set-displayed-team-color") {
+    const presentationChangeId = validateOpaqueIdentifier(
+      value.presentationChangeId,
+      "presentationChangeId",
+    );
+    if (!presentationChangeId.ok) return invalid(presentationChangeId.error);
+    if (!isRecord(value.occurrence)) return invalid("occurrence must be an object.");
+    const clientOrigin =
+      value.occurrence.clientOriginAtMs === null || value.occurrence.clientOriginAtMs === undefined
+        ? null
+        : validateIntegerInRange(
+            value.occurrence.clientOriginAtMs,
+            0,
+            Number.MAX_SAFE_INTEGER,
+            "occurrence.clientOriginAtMs",
+          );
+    if (clientOrigin !== null && !clientOrigin.ok) return invalid(clientOrigin.error);
+    const source = value.occurrence.source;
+    if (source !== undefined && source !== "online" && source !== "offline") {
+      return invalid("occurrence.source is unsupported.");
+    }
+    if (value.type === "set-pitch-orientation") {
+      if (value.pitchOrientation !== "side-a-left" && value.pitchOrientation !== "side-b-left") {
+        return invalid("pitchOrientation is unsupported.");
+      }
+      return {
+        ok: true,
+        value: {
+          version: LIVE_EVENT_CONTROL_INTENT_VERSION,
+          type: value.type,
+          operationId: operationId.value,
+          factId: presentationChangeId.value,
+          presentationChangeId: presentationChangeId.value,
+          gameTimeMs: gameTimeMs.value,
+          pitchOrientation: value.pitchOrientation,
+          occurrence: {
+            clientOriginAtMs: clientOrigin === null ? null : clientOrigin.value,
+            ...(source === undefined ? {} : { source }),
+          },
+        },
+      } as { ok: true; value: LiveEventControllerIntent };
+    }
+    const gameSideId = validateOpaqueIdentifier(value.gameSideId, "gameSideId");
+    if (!gameSideId.ok) return invalid(gameSideId.error);
+    if (!isValidHexColor(value.color)) return invalid("color is invalid.");
+    return {
+      ok: true,
+      value: {
+        version: LIVE_EVENT_CONTROL_INTENT_VERSION,
+        type: value.type,
+        operationId: operationId.value,
+        factId: presentationChangeId.value,
+        presentationChangeId: presentationChangeId.value,
+        gameTimeMs: gameTimeMs.value,
+        gameSideId: gameSideId.value,
+        color: value.color.trim().startsWith("#")
+          ? value.color.trim().toUpperCase()
+          : `#${value.color.trim().toUpperCase()}`,
+        occurrence: {
+          clientOriginAtMs: clientOrigin === null ? null : clientOrigin.value,
+          ...(source === undefined ? {} : { source }),
+        },
+      },
+    } as { ok: true; value: LiveEventControllerIntent };
+  }
+  const factId = validateOpaqueIdentifier(value.factId, "factId");
+  if (!factId.ok) return invalid(factId.error);
 
   let sportingOrder: number | undefined;
   if (value.sportingOrder !== undefined) {
@@ -967,6 +1079,8 @@ export function parseLiveEventControllerIntent(
     } as LiveEventControllerIntent,
   };
 }
+
+export const parseLiveEventControllerSubmission = parseLiveEventControllerIntent;
 
 export function explainLiveEventGuardrail(intent: {
   type: LiveEventControllerIntent["type"];
@@ -1792,6 +1906,8 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
       return null;
     const actions = parsed.map((candidate) => {
       if (!candidate.ok) throw new Error("Locked replay intent is invalid.");
+      if (!("factId" in candidate.value))
+        throw new Error("Presentation changes are not locked actions.");
       return {
         recordId: root.recordId,
         eventGameId: root.eventGameId,
@@ -1877,6 +1993,8 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
     const operationId = readOperationId(input.intent);
     const parsed = parseLiveEventControllerIntent(input.intent);
     if (!parsed.ok) return rejectedAction(operationId);
+    if (isGamePresentationIntentValue(parsed.value))
+      return rejectedAction(parsed.value.operationId);
 
     const owner = await options.resolveEventGameRecord(authorized.eventGameId);
     const root = owner === null ? null : await owner.record.readRoot(owner.recordId);
@@ -2323,6 +2441,7 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
         storedAction.interpretation.factType === "penalty-release-consequence" &&
         isRecord(storedAction.interpretation.payload) &&
         isRecord(storedAction.interpretation.payload.data) &&
+        "factId" in parsed.value &&
         storedAction.interpretation.payload.data.sourceFactId === parsed.value.factId,
     );
     const automaticPenaltyConsequence =
@@ -2923,6 +3042,7 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
           : projectedHeat.status === "started" || projectedHeat.status === "extended"
             ? { status: "heat-stoppage", factId: projectedHeat.factId }
             : { status: "none", factId: null };
+      const presentation = await record.readPresentation();
       const runningSinceMs =
         root.lifecycle.commencedAtMs === null ? latestRunningClockStart(derived.gameFacts) : null;
       const controllerProjection: ControllerProjection = {
@@ -2960,6 +3080,7 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
           provisionalRunningSinceMs: runningSinceMs,
           provisionalElapsedMs: runningSinceMs === null ? 0 : Math.max(0, clock() - runningSinceMs),
         },
+        presentation: structuredClone(presentation),
       };
       return controllerProjection;
     } catch {
@@ -3058,6 +3179,157 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
     );
   }
 
+  async function submitGamePresentationChange(input: {
+    sessionBearer: string;
+    eventGameId: string;
+    change: unknown;
+    causalPredecessorIds?: readonly string[];
+    originatingGrant?: GamePresentationGrantProvenance;
+  }): Promise<GamePresentationChangeResult> {
+    const authorized = await options.grantAuthority.authorizeGrant({
+      sessionBearer: input.sessionBearer,
+      eventGameId: input.eventGameId,
+      readOnly: true,
+    });
+    if (
+      authorized.status !== "authorized" ||
+      authorized.grantType !== "control" ||
+      authorized.eventGameId === null
+    ) {
+      return {
+        status: "rejected",
+        operationId: null,
+        message: "Unable to perform that Game Presentation Change.",
+      };
+    }
+    const parsed = parseLiveEventControllerIntent(input.change);
+    if (!parsed.ok || !isGamePresentationIntentValue(parsed.value)) {
+      return {
+        status: "rejected",
+        operationId: readOperationId(input.change),
+        message: "Unable to perform that Game Presentation Change.",
+      };
+    }
+    const owner = await options.resolveEventGameRecord(authorized.eventGameId);
+    const root = owner === null ? null : await owner.record.readRoot(owner.recordId);
+    if (owner === null || root === null) {
+      return {
+        status: "rejected",
+        operationId: parsed.value.operationId,
+        message: "Unable to perform that Game Presentation Change.",
+      };
+    }
+    const grant: GamePresentationGrantProvenance = input.originatingGrant ?? {
+      sessionId: authorized.grantSessionId,
+      versionId: authorized.grantVersion,
+    };
+    const outcome = await owner.record.acceptPresentationChange({
+      recordId: root.recordId,
+      eventGameId: root.eventGameId,
+      operationId: parsed.value.operationId,
+      presentationChangeId: parsed.value.presentationChangeId,
+      change:
+        parsed.value.type === "set-pitch-orientation"
+          ? { type: "pitch-orientation", pitchOrientation: parsed.value.pitchOrientation }
+          : {
+              type: "displayed-team-color",
+              gameSideId: parsed.value.gameSideId,
+              color: parsed.value.color,
+            },
+      causalPredecessorIds: [...(input.causalPredecessorIds ?? [])],
+      occurrence: {
+        trustedAtMs: clock(),
+        clientOriginAtMs: parsed.value.occurrence.clientOriginAtMs,
+        source: parsed.value.occurrence.source ?? "online",
+      },
+      grant,
+      acceptedAtMs: clock(),
+    });
+    if (outcome.status === "rejected") {
+      return {
+        status: outcome.reason === "storage-not-ready" ? "retryable" : "rejected",
+        operationId: parsed.value.operationId,
+        message: outcome.detail,
+      };
+    }
+    const projection = await readProjection(owner.record, root);
+    return {
+      status: outcome.status,
+      operationId: parsed.value.operationId,
+      presentation:
+        projection?.presentation ??
+        createInitialGamePresentation(root.gameSides.map((side) => side.id)),
+      auditId: outcome.auditId,
+    };
+  }
+
+  async function replayGamePresentationChanges(input: {
+    sessionBearer: string;
+    eventGameId: string;
+    batchId: string;
+    replicaGeneration: string;
+    expectedGrantSessionId: string;
+    expectedGrantVersion: string;
+    changes: readonly {
+      eventGameId: string;
+      change: unknown;
+      causalPredecessorIds?: readonly unknown[];
+      originatingGrant?: unknown;
+    }[];
+  }): Promise<ControllerReplayResult> {
+    const outcomes: ControllerReplayOutcome[] = [];
+    for (const candidate of input.changes) {
+      const parsed = parseLiveEventControllerIntent(candidate.change);
+      const operationId = parsed.ok
+        ? parsed.value.operationId
+        : (readOperationId(candidate.change) ?? "");
+      if (!parsed.ok || candidate.eventGameId !== input.eventGameId) {
+        outcomes.push({ operationId, status: "terminally-rejected" });
+        continue;
+      }
+      const result = await submitGamePresentationChange({
+        sessionBearer: input.sessionBearer,
+        eventGameId: input.eventGameId,
+        change: candidate.change,
+        causalPredecessorIds: Array.isArray(candidate.causalPredecessorIds)
+          ? candidate.causalPredecessorIds.filter(
+              (value): value is string => typeof value === "string",
+            )
+          : [],
+      });
+      outcomes.push({
+        operationId,
+        status:
+          result.status === "accepted"
+            ? "accepted"
+            : result.status === "duplicate-accepted"
+              ? "idempotent"
+              : result.status === "retryable"
+                ? "retryable"
+                : "terminally-rejected",
+      });
+    }
+    const owner = await options.resolveEventGameRecord(input.eventGameId);
+    const root = owner === null ? null : await owner.record.readRoot(owner.recordId);
+    const projection =
+      owner === null || root === null ? null : await readProjection(owner.record, root);
+    return {
+      batchId: input.batchId,
+      replicaGeneration: input.replicaGeneration,
+      session: {
+        eventGameId: input.eventGameId,
+        grantSessionId: input.expectedGrantSessionId,
+        grantVersion: input.expectedGrantVersion,
+      },
+      eventGameId: input.eventGameId,
+      status: outcomes.some((outcome) => outcome.status === "retryable")
+        ? "retryable"
+        : "synchronized",
+      outcomes,
+      projection,
+    };
+  }
+
   return {
     openController,
     refreshController,
@@ -3085,7 +3357,17 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
     },
     submitControllerIntent,
     replayControllerActions,
+    submitControlAction: submitControllerIntent,
+    replayControlActions: replayControllerActions,
+    submitGamePresentationChange,
+    replayGamePresentationChanges,
   };
+}
+
+function isGamePresentationIntentValue(
+  value: LiveEventControllerIntent,
+): value is GamePresentationChangeIntent {
+  return value.type === "set-pitch-orientation" || value.type === "set-displayed-team-color";
 }
 
 function projectLiveTimeout(timeout: LiveTimeoutState, nowMs: number): LiveTimeoutState {

--- a/src/lib/live-event-game-transport.ts
+++ b/src/lib/live-event-game-transport.ts
@@ -4,6 +4,7 @@ import type {
   ControllerQrResult,
   ControllerRefreshResult,
   ControllerReplayResult,
+  GamePresentationChangeResult,
   LiveEventGameControlResult,
   OpenControllerResult,
 } from "@/lib/live-event-game-control";
@@ -16,8 +17,12 @@ export type LiveEventGameControlTransport = {
   stayController(request: Request): Promise<Response>;
   revealControllerQr(request: Request): Promise<Response>;
   leaveController(request: Request): Promise<Response>;
+  submitControlAction(request: Request): Promise<Response>;
   submitControllerIntent(request: Request): Promise<Response>;
+  replayControlActions(request: Request): Promise<Response>;
   replayControllerActions(request: Request): Promise<Response>;
+  submitGamePresentationChange(request: Request): Promise<Response>;
+  replayGamePresentationChanges(request: Request): Promise<Response>;
 };
 
 export type LiveEventGameControlTransportTarget = {
@@ -41,12 +46,12 @@ export type LiveEventGameControlTransportTarget = {
     eventGameId: string;
   }): Promise<ControllerQrResult>;
   leaveController(input: { sessionBearer: string }): Promise<ControllerLeaveResult>;
-  submitControllerIntent(input: {
+  submitControlAction(input: {
     sessionBearer: string;
     eventGameId: string;
     intent: unknown;
   }): Promise<LiveEventGameControlResult>;
-  replayControllerActions(input: {
+  replayControlActions(input: {
     sessionBearer: string;
     eventGameId: string;
     batchId: string;
@@ -57,6 +62,25 @@ export type LiveEventGameControlTransportTarget = {
       eventGameId: string;
       intent: unknown;
       causalPredecessorIds?: readonly unknown[];
+    }[];
+  }): Promise<ControllerReplayResult>;
+  submitGamePresentationChange(input: {
+    sessionBearer: string;
+    eventGameId: string;
+    change: unknown;
+  }): Promise<GamePresentationChangeResult>;
+  replayGamePresentationChanges(input: {
+    sessionBearer: string;
+    eventGameId: string;
+    batchId: string;
+    replicaGeneration: string;
+    expectedGrantSessionId: string;
+    expectedGrantVersion: string;
+    changes: readonly {
+      eventGameId: string;
+      change: unknown;
+      causalPredecessorIds?: readonly unknown[];
+      originatingGrant: unknown;
     }[];
   }): Promise<ControllerReplayResult>;
 };
@@ -89,7 +113,7 @@ export function createLiveEventGameControlTransport(
       return result.status === "opened" ? noStoreJson(result) : unavailable();
     },
 
-    async submitControllerIntent(request) {
+    async submitControlAction(request) {
       if (!isAllowedRequest(request)) return unavailable();
       const control = resolve();
       if (control === null) return unavailable();
@@ -107,14 +131,41 @@ export function createLiveEventGameControlTransport(
         return unavailable();
       }
 
-      const result = await control.submitControllerIntent({
+      const result = await control.submitControlAction({
         sessionBearer: body.body.sessionBearer,
         eventGameId: body.body.eventGameId,
         intent: body.body.intent,
       });
       return noStoreJson(result, resultStatus(result));
     },
-    async replayControllerActions(request) {
+    async submitControllerIntent(request) {
+      return this.submitControlAction(request);
+    },
+    async submitGamePresentationChange(request) {
+      if (!isAllowedRequest(request)) return unavailable();
+      const control = resolve();
+      if (control === null) return unavailable();
+      const body = await readJsonBodyWithinLimit(
+        request,
+        SHARED_LIMITS.transport.httpJsonBodyBytes,
+      );
+      if (
+        !body.ok ||
+        !isRecord(body.body) ||
+        typeof body.body.sessionBearer !== "string" ||
+        typeof body.body.eventGameId !== "string" ||
+        body.body.change === undefined
+      ) {
+        return unavailable();
+      }
+      const result = await control.submitGamePresentationChange({
+        sessionBearer: body.body.sessionBearer,
+        eventGameId: body.body.eventGameId,
+        change: body.body.change,
+      });
+      return noStoreJson(result, resultStatus(result));
+    },
+    async replayControlActions(request) {
       if (!isAllowedRequest(request)) return unavailable();
       const control = resolve();
       if (control === null) return unavailable();
@@ -140,7 +191,7 @@ export function createLiveEventGameControlTransport(
       ) {
         return unavailable();
       }
-      const result = await control.replayControllerActions({
+      const result = await control.replayControlActions({
         sessionBearer: body.body.sessionBearer,
         eventGameId: body.body.eventGameId,
         batchId: body.body.batchId,
@@ -156,6 +207,60 @@ export function createLiveEventGameControlTransport(
             causalPredecessorIds: Array.isArray(action.causalPredecessorIds)
               ? action.causalPredecessorIds
               : [null],
+          };
+        }),
+      });
+      return noStoreJson(result, resultStatus(result));
+    },
+    async replayControllerActions(request) {
+      return this.replayControlActions(request);
+    },
+    async replayGamePresentationChanges(request) {
+      if (!isAllowedRequest(request)) return unavailable();
+      const control = resolve();
+      if (control === null) return unavailable();
+      const body = await readJsonBodyWithinLimit(
+        request,
+        SHARED_LIMITS.transport.httpJsonBodyBytes,
+      );
+      if (
+        !body.ok ||
+        !isRecord(body.body) ||
+        typeof body.body.sessionBearer !== "string" ||
+        typeof body.body.eventGameId !== "string" ||
+        typeof body.body.batchId !== "string" ||
+        typeof body.body.replicaGeneration !== "string" ||
+        typeof body.body.grantSessionId !== "string" ||
+        typeof body.body.grantVersion !== "string" ||
+        !Array.isArray(body.body.changes) ||
+        body.body.changes.length === 0 ||
+        body.body.changes.length > SHARED_LIMITS.replay.maxControlActions
+      ) {
+        return unavailable();
+      }
+      const result = await control.replayGamePresentationChanges({
+        sessionBearer: body.body.sessionBearer,
+        eventGameId: body.body.eventGameId,
+        batchId: body.body.batchId,
+        replicaGeneration: body.body.replicaGeneration,
+        expectedGrantSessionId: body.body.grantSessionId,
+        expectedGrantVersion: body.body.grantVersion,
+        changes: body.body.changes.map((change) => {
+          if (!isRecord(change)) {
+            return {
+              eventGameId: "",
+              change: null,
+              causalPredecessorIds: [null],
+              originatingGrant: null,
+            };
+          }
+          return {
+            eventGameId: typeof change.eventGameId === "string" ? change.eventGameId : "",
+            change: change.change,
+            causalPredecessorIds: Array.isArray(change.causalPredecessorIds)
+              ? change.causalPredecessorIds
+              : [null],
+            originatingGrant: change.originatingGrant,
           };
         }),
       });
@@ -243,7 +348,9 @@ async function readSessionInput(
   return { sessionBearer: body.body.sessionBearer };
 }
 
-function resultStatus(result: LiveEventGameControlResult | ControllerReplayResult): number {
+function resultStatus(
+  result: LiveEventGameControlResult | GamePresentationChangeResult | ControllerReplayResult,
+): number {
   if (result.status === "retryable") return 503;
   if (result.status === "rejected") return 403;
   return 200;


### PR DESCRIPTION
## What changed

- add durable Game Presentation Change acceptance, history, projection, and canonical audit ordering to Event Game Records
- synchronize both Displayed Team Colors and Pitch Orientation across multiple Controllers
- route presentation submissions through the shared Controller transport, offline queue, replay, and reconciliation paths
- preserve stable Game Side identities and presentation state through reconnect and restart

## Why

Presentation updates are durable operator decisions but are not Control Actions or Game Facts. They need their own ordered record and audit path while still sharing the Controller transport and recovery machinery.

## Impact

Multiple Controllers now converge on the same presentation state without changing sporting score, penalty, Game Fact, or Game Side identity. The implementation consumes the published Foundation integrity interfaces and does not duplicate Grant, schema, key, or readiness ownership.

## Validation

- focused Controller, runtime, reconnect, and Event Game Record suites: 119 passed
- `bun run check`
- full `bun run test`: 822 passed
- `bun run build`
- `git diff --check`

No qualification, load, soak, crash, recovery, or exact-production-artifact workloads were run.

Closes #94
