### PR TITLE
Qualify mobile Controller interactions

### DIFF
--- a/scripts/test-event-game-controller-browser.ts
+++ b/scripts/test-event-game-controller-browser.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env bun
-import { chromium, type BrowserContext, type Page } from "playwright";
+import { chromium, webkit, type BrowserContext, type Page } from "playwright";
 import { mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -64,19 +64,24 @@ try {
   });
   await waitForServer(`${origin}/internal/healthz`);
 
-  browser = await chromium.launch({ headless: true });
-  const context = await browser.newContext({ ignoreHTTPSErrors: true });
-  await installControllerApi(context);
-  const controller = await context.newPage();
-  await completeSuspendReviewResume(controller);
+  for (const browserType of [chromium, webkit]) {
+    currentProjection = createProjection();
+    browser = await browserType.launch({ headless: true });
+    const context = await browser.newContext({ ignoreHTTPSErrors: true });
+    await installControllerApi(context);
+    const controller = await context.newPage();
+    await completeSuspendReviewResume(controller);
 
-  const secondContext = await browser.newContext({ ignoreHTTPSErrors: true });
-  await installControllerApi(secondContext);
-  const reviewingController = await secondContext.newPage();
-  await reviewAndResume(reviewingController);
+    const secondContext = await browser.newContext({ ignoreHTTPSErrors: true });
+    await installControllerApi(secondContext);
+    const reviewingController = await secondContext.newPage();
+    await reviewAndResume(reviewingController);
+    await browser.close();
+    browser = null;
+  }
 
   console.log(
-    "Focused Integration Test passed: 360x640 suspend/review/resume with two known balls.",
+    "Focused Integration Test passed: Chromium/WebKit 360x640 Controller interactions and suspend/review/resume.",
   );
 } catch (error) {
   console.error(error instanceof Error ? error.message : String(error));
@@ -100,7 +105,30 @@ async function completeSuspendReviewResume(page: Page) {
   await page.setViewportSize({ width: 360, height: 640 });
   await page.goto(`${origin}/event-control`);
   await page.getByLabel("Active Pitch Slot Control Grant QR").fill("disposable-grant");
-  await page.getByRole("button", { name: "Open Controller Device" }).click();
+  await page.getByRole("button", { name: "Open Event Game Controller" }).click();
+  await assertControllerSurface(page);
+  await page.getByRole("button", { name: "Start game clock" }).click();
+  await page.getByRole("button", { name: "Adjust game clock by plus 10 seconds" }).click();
+  await page.getByLabel("Set game clock (milliseconds)").fill("123000");
+  await page.getByRole("button", { name: "Correct Event Game clock" }).click();
+  await page.locator("#penalty-game-side").selectOption("side-a");
+  await page
+    .getByRole("button", { name: "Accept penalty card for the selected Game Side" })
+    .click();
+  await page.getByRole("button", { name: "Timeout stoppage: side-a" }).click();
+  await page.getByRole("button", { name: "Record 10-point goal for Game Side side-a" }).click();
+  await page.getByRole("button", { name: "Flip Event Game physical ends" }).click();
+  await page.getByRole("button", { name: "Reveal active Grant QR" }).click();
+  await page.getByRole("dialog", { name: "Active Grant QR" }).waitFor();
+  await page.mouse.click(2, 2);
+  await page.getByRole("dialog", { name: "Active Grant QR" }).waitFor({ state: "hidden" });
+  await page.waitForTimeout(50);
+  assert(
+    (await page.evaluate(() => document.activeElement?.getAttribute("aria-label"))) ===
+      "Show active Grant QR",
+    "QR outside-pointer dismissal did not return focus",
+  );
+  await page.getByRole("button", { name: "Record final Event Game result" }).click();
   await page.getByRole("button", { name: "Review suspension recovery" }).click();
   await page.locator("#volleyball-possession").selectOption("side-a");
   await page.locator("#dodgeball-possession-ball-1").selectOption("side-b");
@@ -118,11 +146,27 @@ async function completeSuspendReviewResume(page: Page) {
   await assertNoDocumentScroll(page);
 }
 
+async function assertControllerSurface(page: Page) {
+  const controls = await page.locator("main button").evaluateAll((buttons) =>
+    buttons.map((button) => ({
+      name: button.getAttribute("aria-label") ?? button.textContent?.trim() ?? "",
+      minHeight: Number.parseFloat(getComputedStyle(button).minHeight),
+    })),
+  );
+  assert(controls.length > 15, "production Controller control inventory was unexpectedly small");
+  for (const control of controls) {
+    assert(control.name.length > 0, "production Controller control had no accessible name");
+    assert(control.minHeight >= 44, `Controller control was below 44px: ${control.name}`);
+  }
+  await page.getByRole("region", { name: "Event Game Clock" }).waitFor();
+  await assertNoDocumentScroll(page);
+}
+
 async function reviewAndResume(page: Page) {
   await page.setViewportSize({ width: 360, height: 640 });
   await page.goto(`${origin}/event-control`);
   await page.getByLabel("Active Pitch Slot Control Grant QR").fill("disposable-grant");
-  await page.getByRole("button", { name: "Open Controller Device" }).click();
+  await page.getByRole("button", { name: "Open Event Game Controller" }).click();
   await page.locator('[data-suspension-snapshot="effective"]').waitFor();
   const snapshotText = await page.locator('[data-suspension-snapshot="effective"]').innerText();
   assert(snapshotText.includes("Volleyball: side-a"), "volleyball recovery was not shown");
@@ -176,10 +220,18 @@ async function installControllerApi(context: BrowserContext) {
       });
       return;
     }
+    if (url.pathname.endsWith("/reveal-qr")) {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({ status: "revealed", qrCredential: "focused-revealed-qr" }),
+      });
+      return;
+    }
     if (url.pathname.endsWith("/replay")) {
       const actions = Array.isArray(body?.actions) ? body.actions.filter(isRecord) : [];
       for (const action of actions) {
         const intent = isRecord(action.intent) ? action.intent : undefined;
+        if (intent !== undefined) applyIntent(intent);
         if (intent?.suspensionAction === "start") {
           const snapshot = intent.suspensionSnapshot as LiveSuspensionSnapshot;
           currentProjection = {
@@ -221,6 +273,7 @@ async function installControllerApi(context: BrowserContext) {
     }
     if (url.pathname.endsWith("/intent")) {
       const intent = isRecord(body?.intent) ? body.intent : undefined;
+      if (intent !== undefined) applyIntent(intent);
       if (intent?.suspensionAction === "start") {
         const snapshot = intent.suspensionSnapshot as LiveSuspensionSnapshot;
         currentProjection = {
@@ -252,6 +305,34 @@ async function installControllerApi(context: BrowserContext) {
     }
     await route.fulfill({ status: 404, body: "not found" });
   });
+}
+
+function applyIntent(intent: Record<string, unknown>) {
+  if (intent.type === "record-goal" && typeof intent.gameSideId === "string") {
+    currentProjection = {
+      ...currentProjection,
+      goalCount: currentProjection.goalCount + 1,
+      scoreByGameSide: {
+        ...currentProjection.scoreByGameSide,
+        [intent.gameSideId]: (currentProjection.scoreByGameSide[intent.gameSideId] ?? 0) + 10,
+      },
+    };
+  }
+  if (intent.type === "set-pitch-orientation" && typeof intent.pitchOrientation === "string") {
+    currentProjection = {
+      ...currentProjection,
+      presentation: {
+        ...(currentProjection.presentation ?? {
+          gameSideIds: ["side-a", "side-b"],
+          displayedTeamColors: { "side-a": "#00afe8", "side-b": "#ef4444" },
+        }),
+        pitchOrientation: intent.pitchOrientation as "side-a-left" | "side-b-left",
+      },
+    };
+  }
+  if (intent.type === "substantive" && intent.trigger === "result") {
+    currentProjection = { ...currentProjection, phase: "finished" };
+  }
 }
 
 async function assertNoDocumentScroll(page: Page) {
@@ -309,6 +390,11 @@ function createProjection(): ControllerProjection {
       provisionalElapsedMs: 0,
     },
     clock: projectClockBaseline(baseline, 0),
+    presentation: {
+      gameSideIds: ["side-a", "side-b"],
+      pitchOrientation: "side-a-left",
+      displayedTeamColors: { "side-a": "#00afe8", "side-b": "#ef4444" },
+    },
   };
 }
 

--- a/src/pages/event-game-controller-page.test.tsx
+++ b/src/pages/event-game-controller-page.test.tsx
@@ -176,6 +176,12 @@ describe("Event Game Controller reconnect browser seam", () => {
             { status: 200, headers: { "content-type": "application/json" } },
           );
         }
+        if (url.endsWith("/api/event-control/reveal-qr")) {
+          return new Response(JSON.stringify({ status: "revealed", qrCredential: "revealed-qr" }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        }
         if (url.endsWith("/api/event-control/leave")) {
           return new Response(JSON.stringify({ status: "left" }), {
             status: 200,
@@ -252,6 +258,59 @@ describe("Event Game Controller reconnect browser seam", () => {
     input.dispatchEvent(new testWindow.Event("input", { bubbles: true }) as unknown as Event);
     input.dispatchEvent(new testWindow.Event("change", { bubbles: true }) as unknown as Event);
   }
+
+  test("inventories active production Controller controls with contextual names and touch targets", async () => {
+    await enterAndOpen();
+    const activeSurface = container.querySelector<HTMLElement>(
+      "[class*='min-h-0'][class*='overflow-y-auto']",
+    );
+    expect(activeSurface).not.toBeNull();
+    expect(activeSurface?.className).toContain("[&_button]:min-h-11");
+    const buttons = Array.from(activeSurface?.querySelectorAll<HTMLButtonElement>("button") ?? []);
+    expect(buttons.length).toBeGreaterThan(15);
+    for (const button of buttons) {
+      expect(button.getAttribute("aria-label") ?? button.textContent?.trim()).not.toBe("");
+    }
+    expect(
+      container.querySelector('[role="region"][aria-label="Event Game Clock"]'),
+    ).not.toBeNull();
+    const clockButton = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Start game clock"]',
+    );
+    expect(clockButton?.getAttribute("aria-pressed")).toBe("false");
+    await act(async () => {
+      clockButton?.focus();
+      clockButton?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(testWindow.document.activeElement?.getAttribute("aria-label")).toBe("Pause game clock");
+  });
+
+  test("production Grant QR dialog closes on an outside pointer and returns focus", async () => {
+    await enterAndOpen();
+    const revealButton = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Reveal active Grant QR"]',
+    );
+    expect(revealButton).not.toBeNull();
+    await act(async () => {
+      revealButton?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const dialog = container.querySelector('[role="dialog"][aria-label="Active Grant QR"]');
+    expect(dialog).not.toBeNull();
+    await act(async () => {
+      dialog?.parentElement?.dispatchEvent(
+        new testWindow.MouseEvent("click", { bubbles: true }) as unknown as Event,
+      );
+      await new Promise((resolve) => testWindow.setTimeout(resolve, 0));
+    });
+    expect(container.querySelector('[role="dialog"][aria-label="Active Grant QR"]')).toBeNull();
+    expect(testWindow.document.activeElement?.getAttribute("aria-label")).toBe(
+      "Show active Grant QR",
+    );
+  });
 
   afterEach(async () => {
     await act(async () => {

--- a/src/pages/event-game-controller-page.tsx
+++ b/src/pages/event-game-controller-page.tsx
@@ -33,6 +33,7 @@ import {
 import { validateGameClockMs } from "@/lib/validation-policy";
 import type { ActionJsonValue, OfficialOverrideMetadata } from "@/lib/event-game-actions";
 import { readControllerDeviceContext } from "@/lib/controller-device-context";
+import { createInitialGamePresentation } from "@/lib/game-presentation-projection";
 import {
   acknowledgeControllerProjection,
   controllerReplicaStorageKey,
@@ -128,6 +129,7 @@ export function EventGameControllerPage() {
     "unavailable",
   );
   const [revealedQr, setRevealedQr] = useState<string | null>(null);
+  const [qrDialogOpen, setQrDialogOpen] = useState(false);
   const [switchTarget, setSwitchTarget] = useState<string | null>(null);
   const [stayedOnAssignment, setStayedOnAssignment] = useState<string | null>(null);
   const [clockRunning, setClockRunning] = useState(false);
@@ -167,6 +169,8 @@ export function EventGameControllerPage() {
     persistedReplicaLoad.warning,
   );
   const [browserContext] = useState(() => readControllerDeviceContext());
+  const qrTriggerRef = useRef<HTMLButtonElement>(null);
+  const qrDialogRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const timer = window.setInterval(() => setLocalMonotonicMs(readMonotonicNow()), 250);
@@ -484,6 +488,7 @@ export function EventGameControllerPage() {
       );
       if (response.status !== "revealed") throw new Error("reveal failed");
       setRevealedQr(response.qrCredential);
+      setQrDialogOpen(true);
     } catch {
       setMessage("The active Control Grant QR is no longer revealable.");
     } finally {
@@ -704,6 +709,34 @@ export function EventGameControllerPage() {
         ? { foulBeforeScore: cardFoulBeforeScore }
         : {}),
       ...(cardSeekerPenaltyConfirmed ? { seekerPenalty: "head-referee-confirmed" as const } : {}),
+      gameTimeMs: controllerGameTimeMs(),
+      occurrence: { clientOriginAtMs: Date.now() },
+    });
+  }
+
+  function flipPitchOrientation() {
+    const current = projection?.presentation ?? createInitialGamePresentation([]);
+    queueIntent({
+      version: LIVE_EVENT_CONTROL_INTENT_VERSION,
+      type: "set-pitch-orientation",
+      pitchOrientation: current.pitchOrientation === "side-a-left" ? "side-b-left" : "side-a-left",
+      operationId: crypto.randomUUID(),
+      factId: crypto.randomUUID(),
+      presentationChangeId: crypto.randomUUID(),
+      gameTimeMs: controllerGameTimeMs(),
+      occurrence: { clientOriginAtMs: Date.now() },
+    });
+  }
+
+  function changeDisplayedTeamColor(gameSideId: string, color: string) {
+    queueIntent({
+      version: LIVE_EVENT_CONTROL_INTENT_VERSION,
+      type: "set-displayed-team-color",
+      gameSideId,
+      color,
+      operationId: crypto.randomUUID(),
+      factId: crypto.randomUUID(),
+      presentationChangeId: crypto.randomUUID(),
       gameTimeMs: controllerGameTimeMs(),
       occurrence: { clientOriginAtMs: Date.now() },
     });
@@ -1363,20 +1396,63 @@ export function EventGameControllerPage() {
     setClockReceiptAnchor(null);
     setClockCorrectionInput("");
     setRevealedQr(null);
+    setQrDialogOpen(false);
     setSwitchTarget(null);
     setStayedOnAssignment(null);
   }
 
+  useEffect(() => {
+    if (!qrDialogOpen) return;
+    const dialog = qrDialogRef.current;
+    const opener = qrTriggerRef.current;
+    const focusable = dialog?.querySelector<HTMLElement>(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+    );
+    focusable?.focus();
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        setQrDialogOpen(false);
+        window.setTimeout(() => opener?.focus(), 0);
+        return;
+      }
+      if (event.key !== "Tab" || dialog === null) return;
+      const elements = Array.from(
+        dialog.querySelectorAll<HTMLElement>(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+        ),
+      );
+      if (elements.length === 0) return;
+      const first = elements[0];
+      const last = elements[elements.length - 1];
+      if (first === undefined || last === undefined) return;
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [qrDialogOpen]);
+
+  function closeQrDialog() {
+    setQrDialogOpen(false);
+    window.setTimeout(() => qrTriggerRef.current?.focus(), 0);
+  }
+
   return (
-    <main className="mx-auto max-h-[calc(100vh-1rem)] w-full max-w-xl overflow-y-auto p-4 pb-12 sm:max-h-none sm:overflow-visible sm:p-6">
-      <Card>
-        <CardHeader>
+    <main className="h-[100dvh] w-full overflow-hidden bg-slate-100 p-2 sm:p-6">
+      <Card className="mx-auto flex h-full min-h-0 w-full max-w-xl flex-col">
+        <CardHeader className="shrink-0 px-4 py-3 sm:px-6">
           <CardTitle>Event Game Controller</CardTitle>
           <CardDescription>
             A Grant Session survives refresh and connectivity loss until you explicitly leave.
           </CardDescription>
         </CardHeader>
-        <CardContent className="space-y-4">
+        <CardContent className="flex min-h-0 flex-1 flex-col overflow-hidden px-3 pb-3 sm:px-6">
           {sessionBearer === null ? (
             <>
               <div className="space-y-2">
@@ -1406,12 +1482,17 @@ export function EventGameControllerPage() {
                   disabled={busy}
                 />
               </div>
-              <Button className="w-full" onClick={() => void openController()} disabled={busy}>
+              <Button
+                className="min-h-11 w-full"
+                aria-label="Open Event Game Controller"
+                onClick={() => void openController()}
+                disabled={busy}
+              >
                 Open Controller Device
               </Button>
             </>
           ) : (
-            <>
+            <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain [&_button]:min-h-11">
               <div className="rounded-lg border bg-muted/30 p-3 text-sm">
                 <p className="font-medium">Controller Device: {eventGameId}</p>
                 <p className="mt-1 text-muted-foreground">
@@ -1423,14 +1504,37 @@ export function EventGameControllerPage() {
                   <p className="mt-1 text-muted-foreground">Projection temporarily unavailable.</p>
                 ) : null}
               </div>
-              <div className="flex flex-wrap gap-2 max-[639px]:hidden">
-                <Button variant="outline" onClick={() => void revealQr()} disabled={busy}>
-                  Reveal active Grant QR
+              <div className="flex shrink-0 flex-wrap gap-2">
+                <Button
+                  ref={qrTriggerRef}
+                  variant="outline"
+                  aria-label={
+                    revealedQr === null ? "Reveal active Grant QR" : "Show active Grant QR"
+                  }
+                  aria-expanded={qrDialogOpen}
+                  aria-controls="active-grant-qr-dialog"
+                  onClick={() => {
+                    if (revealedQr === null) void revealQr();
+                    else setQrDialogOpen(true);
+                  }}
+                  disabled={busy}
+                >
+                  {revealedQr === null ? "Reveal active Grant QR" : "Show active Grant QR"}
                 </Button>
-                <Button variant="outline" onClick={() => void refreshController()} disabled={busy}>
+                <Button
+                  variant="outline"
+                  aria-label="Refresh Event Game assignment"
+                  onClick={() => void refreshController()}
+                  disabled={busy}
+                >
                   Refresh assignment
                 </Button>
-                <Button variant="outline" onClick={() => void leaveController()} disabled={busy}>
+                <Button
+                  variant="outline"
+                  aria-label="Leave Event Game Controller session"
+                  onClick={() => void leaveController()}
+                  disabled={busy}
+                >
                   Leave Controller Session
                 </Button>
               </div>
@@ -1440,40 +1544,58 @@ export function EventGameControllerPage() {
                   <p className="mt-1">
                     Switch to {switchTarget}, or stay on {eventGameId}.
                   </p>
-                  <div className="mt-3 flex gap-2">
-                    <Button onClick={() => void switchController()} disabled={busy}>
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    <Button
+                      aria-label={`Switch to Event Game ${switchTarget}`}
+                      onClick={() => void switchController()}
+                      disabled={busy}
+                    >
                       Switch Event Game
                     </Button>
-                    <Button variant="outline" onClick={stayOnCurrentAssignment} disabled={busy}>
+                    <Button
+                      variant="outline"
+                      aria-label={`Stay on Event Game ${eventGameId}`}
+                      onClick={stayOnCurrentAssignment}
+                      disabled={busy}
+                    >
                       Stay here
                     </Button>
                   </div>
                 </div>
               )}
-              {revealedQr === null ? null : (
-                <div className="rounded-lg border p-3 text-sm">
-                  <p className="font-medium">Share this active Pitch Slot QR</p>
-                  <code className="mt-2 block break-all text-xs">{revealedQr}</code>
+              <div
+                className="sticky top-0 z-10 flex shrink-0 items-center justify-between gap-2 rounded-lg border bg-slate-950 p-3 text-white"
+                role="region"
+                aria-label="Event Game Clock"
+                aria-live="polite"
+              >
+                <div className="min-w-0 text-center">
+                  <p className="text-xs uppercase tracking-[0.2em] text-slate-300">Game Clock</p>
+                  <p className="mt-1 text-4xl font-semibold tabular-nums">
+                    {clockProjection === null || clockProjection.synchronization === "unavailable"
+                      ? "--:--"
+                      : formatClock(clockProjection.gameTimeMs)}
+                  </p>
+                  <p className="mt-1 text-xs text-slate-300">
+                    {clockProjection?.running ? "Play" : "Paused"} · Controller projection
+                  </p>
+                  <p className="mt-2 text-xs text-slate-300" data-clock-freshness="true">
+                    {clockProjection === null
+                      ? "Unavailable · manual timing required"
+                      : `${clockProjection.synchronization} · last synchronization: ${formatSynchronizationTime(clockProjection.lastSynchronizedAtMs)}`}
+                  </p>
                 </div>
-              )}
-              <div className="rounded-lg border bg-slate-950 p-4 text-center text-white">
-                <p className="text-xs uppercase tracking-[0.2em] text-slate-300">Game Clock</p>
-                <p className="mt-1 text-5xl font-semibold tabular-nums">
-                  {clockProjection === null || clockProjection.synchronization === "unavailable"
-                    ? "--:--"
-                    : formatClock(clockProjection.gameTimeMs)}
-                </p>
-                <p className="mt-1 text-xs text-slate-300">
-                  {clockProjection?.running ? "Play" : "Paused"} · Controller projection
-                </p>
-                <p className="mt-2 text-xs text-slate-300" data-clock-freshness="true">
-                  {clockProjection === null
-                    ? "Unavailable · manual timing required"
-                    : `${clockProjection.synchronization} · last synchronization: ${formatSynchronizationTime(clockProjection.lastSynchronizedAtMs)}`}
-                </p>
+                <Button
+                  aria-label={clockRunning ? "Pause game clock" : "Start game clock"}
+                  aria-pressed={clockRunning}
+                  onClick={toggleClock}
+                  disabled={busy}
+                >
+                  {clockRunning ? "Pause clock" : "Start clock"}
+                </Button>
               </div>
               {clockProjection === null ? null : (
-                <div className="space-y-1 rounded-lg border border-amber-500/50 bg-amber-50 p-3 text-sm text-amber-950 max-[639px]:hidden">
+                <div className="space-y-1 rounded-lg border border-amber-500/50 bg-amber-50 p-3 text-sm text-amber-950">
                   <p data-clock-cue="flag-runner">
                     {clockProjection.cues.flagRunnerEntry === "pending"
                       ? "Flag-runner entry pending at 19:00"
@@ -1634,14 +1756,51 @@ export function EventGameControllerPage() {
                   ) : null}
                 </div>
               )}
+              {projection === null ? null : (
+                <div className="flex flex-wrap items-center gap-2 rounded-lg border p-3">
+                  <Button
+                    variant="outline"
+                    aria-label="Flip Event Game physical ends"
+                    onClick={flipPitchOrientation}
+                    disabled={busy}
+                  >
+                    Flip physical ends
+                  </Button>
+                  <span className="text-sm text-muted-foreground">
+                    Game Side{" "}
+                    {projection.presentation?.pitchOrientation === "side-b-left"
+                      ? "side-b"
+                      : "side-a"}{" "}
+                    left
+                  </span>
+                  {Object.keys(projection.scoreByGameSide).map((gameSideId) => (
+                    <label key={gameSideId} className="flex items-center gap-2 text-sm">
+                      <input
+                        type="color"
+                        aria-label={`Game Side ${gameSideId} displayed team color`}
+                        value={
+                          projection.presentation?.displayedTeamColors[gameSideId] ?? "#00afe8"
+                        }
+                        onInput={(event) =>
+                          changeDisplayedTeamColor(
+                            gameSideId,
+                            (event.target as HTMLInputElement).value,
+                          )
+                        }
+                        disabled={busy}
+                        className="h-11 w-11 cursor-pointer rounded border border-slate-300 bg-white p-1"
+                      />
+                      {gameSideId}
+                    </label>
+                  ))}
+                </div>
+              )}
               <div className="flex flex-wrap gap-2">
-                <Button onClick={toggleClock} disabled={busy}>
-                  {clockRunning ? "Pause clock" : "Start clock"}
-                </Button>
                 {[-60_000, -10_000, 10_000, 60_000].map((adjustmentMs) => (
                   <Button
                     key={adjustmentMs}
                     variant="outline"
+                    aria-label={`Adjust game clock by ${adjustmentMs < 0 ? "minus" : "plus"} ${Math.abs(adjustmentMs) / 1000} seconds`}
                     onClick={() => adjustClock(adjustmentMs)}
                     disabled={busy}
                   >
@@ -1649,7 +1808,7 @@ export function EventGameControllerPage() {
                     {Math.abs(adjustmentMs) / 1000}s
                   </Button>
                 ))}
-                <div className="flex w-full flex-wrap items-end gap-2 rounded border p-2 text-left max-[639px]:hidden">
+                <div className="flex w-full flex-wrap items-end gap-2 rounded border p-2 text-left">
                   <div className="min-w-48 flex-1 space-y-1">
                     <Label htmlFor="clock-correction">Set game clock (milliseconds)</Label>
                     <Input
@@ -1663,6 +1822,7 @@ export function EventGameControllerPage() {
                   </div>
                   <Button
                     variant="outline"
+                    aria-label="Correct Event Game clock"
                     data-clock-correction="true"
                     onClick={correctClock}
                     disabled={busy}
@@ -1670,7 +1830,7 @@ export function EventGameControllerPage() {
                     Correct clock
                   </Button>
                 </div>
-                <div className="flex w-full flex-wrap items-end gap-2 rounded border border-amber-500/50 p-2 text-left max-[639px]:hidden">
+                <div className="flex w-full flex-wrap items-end gap-2 rounded border border-amber-500/50 p-2 text-left">
                   <div className="min-w-48 flex-1 space-y-1">
                     <Label htmlFor="clock-takeover-adjustment">
                       Emergency takeover adjustment (ms)
@@ -1686,6 +1846,7 @@ export function EventGameControllerPage() {
                   </div>
                   <Button
                     variant="outline"
+                    aria-label="Apply emergency Event Game clock takeover"
                     data-clock-takeover="true"
                     onClick={emergencyClockTakeover}
                     disabled={busy}
@@ -1693,7 +1854,7 @@ export function EventGameControllerPage() {
                     Emergency clock takeover
                   </Button>
                 </div>
-                <div className="flex w-full flex-wrap items-end gap-2 rounded border p-2 text-left max-[639px]:hidden">
+                <div className="flex w-full flex-wrap items-end gap-2 rounded border p-2 text-left">
                   <div className="min-w-32 flex-1 space-y-1">
                     <Label htmlFor="penalty-game-side">Penalized Game Side</Label>
                     <select
@@ -1749,6 +1910,7 @@ export function EventGameControllerPage() {
                   </p>
                   <Button
                     variant="outline"
+                    aria-label="Accept penalty card for the selected Game Side"
                     onClick={recordCard}
                     disabled={busy || cardGameSideId === ""}
                   >
@@ -1906,12 +2068,17 @@ export function EventGameControllerPage() {
                     )}
                   </div>
                 ) : null}
-                <Button variant="outline" onClick={() => trigger("result")} disabled={busy}>
+                <Button
+                  variant="outline"
+                  aria-label="Record final Event Game result"
+                  onClick={() => trigger("result")}
+                  disabled={busy}
+                >
                   Record result
                 </Button>
               </div>
               {projection === null ? null : (
-                <div className="space-y-3 max-[639px]:hidden">
+                <div className="space-y-3">
                   <p className="text-sm text-muted-foreground">
                     Phase: {projection.phase} · Goals: {projection.goalCount}
                     {projection.overtime ? " · Overtime" : ""}
@@ -1976,6 +2143,7 @@ export function EventGameControllerPage() {
                       <div>
                         <Button
                           variant="ghost"
+                          aria-label="Cancel close-play adjudication"
                           onClick={() => setPendingClosePlayAdjudication(null)}
                           disabled={busy}
                         >
@@ -2000,6 +2168,7 @@ export function EventGameControllerPage() {
                         </Button>
                         <Button
                           variant="ghost"
+                          aria-label="Cancel flag-catch boundary override"
                           onClick={() => setPendingFlagCatchBoundaryOverride(null)}
                           disabled={busy}
                         >
@@ -2026,11 +2195,16 @@ export function EventGameControllerPage() {
                       <span className="font-medium">Game Side {gameSideId}</span>
                       <div className="flex items-center gap-3">
                         <span className="text-2xl font-semibold tabular-nums">{score}</span>
-                        <Button onClick={() => recordGoal(gameSideId)} disabled={busy}>
+                        <Button
+                          aria-label={`Record 10-point goal for Game Side ${gameSideId}`}
+                          onClick={() => recordGoal(gameSideId)}
+                          disabled={busy}
+                        >
                           Record 10-point goal
                         </Button>
                         <Button
                           variant="outline"
+                          aria-label={`Record flag catch for Game Side ${gameSideId}`}
                           onClick={() => recordFlagCatch(gameSideId)}
                           disabled={busy}
                         >
@@ -2041,6 +2215,7 @@ export function EventGameControllerPage() {
                         projection.winnerGameSideId === null ? (
                           <Button
                             variant="outline"
+                            aria-label={`Concede Event Game for Game Side ${gameSideId}`}
                             onClick={() => recordConcession(gameSideId)}
                             disabled={busy}
                           >
@@ -2049,6 +2224,7 @@ export function EventGameControllerPage() {
                         ) : null}
                         <Button
                           variant="outline"
+                          aria-label={`Record directed forfeit for Game Side ${gameSideId}`}
                           onClick={() => recordForfeit(gameSideId)}
                           disabled={busy}
                         >
@@ -2057,7 +2233,12 @@ export function EventGameControllerPage() {
                       </div>
                     </div>
                   ))}
-                  <Button variant="outline" onClick={recordDoubleForfeit} disabled={busy}>
+                  <Button
+                    variant="outline"
+                    aria-label="Record directed double-forfeit"
+                    onClick={recordDoubleForfeit}
+                    disabled={busy}
+                  >
                     Record double-forfeit
                   </Button>
                   <div className="space-y-3 rounded-lg border p-3">
@@ -2189,6 +2370,7 @@ export function EventGameControllerPage() {
                           <Button
                             size="sm"
                             variant="outline"
+                            aria-label={`${fact.effective ? "Correct" : "Reinstate"} Game Fact ${fact.factId}`}
                             onClick={() => correctFact(fact.factId, !fact.effective)}
                             disabled={busy}
                           >
@@ -2211,11 +2393,41 @@ export function EventGameControllerPage() {
                   {durabilityWarning}
                 </p>
               )}
-            </>
+            </div>
           )}
-          {message === null ? null : <p className="text-sm text-muted-foreground">{message}</p>}
+          {message === null ? null : (
+            <p className="shrink-0 text-sm text-muted-foreground" role="status" aria-live="polite">
+              {message}
+            </p>
+          )}
         </CardContent>
       </Card>
+      {qrDialogOpen && revealedQr !== null ? (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/50 p-4"
+          onClick={(event) => {
+            if (event.target === event.currentTarget) closeQrDialog();
+          }}
+        >
+          <div
+            id="active-grant-qr-dialog"
+            ref={qrDialogRef}
+            role="dialog"
+            aria-modal="true"
+            aria-label="Active Grant QR"
+            tabIndex={-1}
+            className="w-full max-w-sm rounded-lg bg-white p-4 text-slate-900 shadow-xl"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <p className="font-medium">Share this active Pitch Slot QR</p>
+              <Button variant="outline" aria-label="Close active Grant QR" onClick={closeQrDialog}>
+                Close
+              </Button>
+            </div>
+            <code className="mt-3 block break-all text-xs">{revealedQr}</code>
+          </div>
+        </div>
+      ) : null}
     </main>
   );
 }


### PR DESCRIPTION
## What changed

- makes the production Event Game Controller usable at 360 by 640 without document scrolling while keeping the Game Clock and play/pause control visible
- adds contextual accessible names, state semantics, focus behavior, and 44-pixel frequent controls across scoring, penalties, timeouts, suspension, heat, presentation, correction, finish, and reconnect workflows
- adds outside-pointer and Escape dismissal with focus return for the active Grant QR
- extends the focused browser harness to cover Chromium and WebKit at the supported narrow-phone viewport

## Why

Spec #83 requires a phone-first Controller surface that remains operable and honest across every active workflow. This completes issue #96 on the real Event Game Controller without changing the separate Ad Hoc experience.

## Impact

Controllers get a narrow-phone layout with accessible, touch-sized controls and deterministic browser coverage. Human device, VoiceOver, Firefox release-candidate, and Production checklist work remain outside this implementation and are not approval gates.

## Validation

- `bun run test:focused:event-game-controller-browser`
- `bun run check`
- `bun test --isolate` — 833 passed, 0 failed
- `bun run build`
- `git diff --check`

Closes #96
