### PR TITLE
Configure Game Day heat stoppages

### DIFF
--- a/scripts/test-technical-admin-browser.ts
+++ b/scripts/test-technical-admin-browser.ts
@@ -5,6 +5,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { openSqliteFoundationStorage } from "@/lib/foundation-storage-sqlite";
+import { createGrantKeyRingDocument, writeGrantKeyRingFile } from "@/lib/grant-key-ring-custody";
 import { readGrantAuthorityOptions } from "@/lib/grant-runtime";
 import {
   createSqliteTechnicalAdminAuthRepository,
@@ -16,6 +17,7 @@ const directory = mkdtempSync(join(tmpdir(), "quadball-timer-admin-browser-"));
 const certificatePath = join(directory, "localhost.crt");
 const keyPath = join(directory, "localhost.key");
 const databasePath = join(directory, "technical-admin.sqlite");
+const grantKeyRingPath = join(directory, "grant-key-ring.json");
 const port = 38_000 + Math.floor(Math.random() * 1_000);
 const origin = `https://localhost:${port}`;
 const environment = {
@@ -26,6 +28,7 @@ const environment = {
   WEBAUTHN_RP_ID: "localhost",
   TECHNICAL_ADMIN_DATABASE: databasePath,
   FOUNDATION_DATABASE: join(directory, "foundation.sqlite"),
+  GRANT_KEY_RING_FILE: grantKeyRingPath,
   TLS_CERT_FILE: certificatePath,
   TLS_KEY_FILE: keyPath,
   PORT: String(port),
@@ -57,6 +60,7 @@ try {
   ]);
   if (certificate.exitCode !== 0)
     throw new Error("openssl could not create a temporary certificate.");
+  writeGrantKeyRingFile(grantKeyRingPath, createGrantKeyRingDocument("test"));
 
   const grantOptions = readGrantAuthorityOptions("test", environment);
   const foundation = openSqliteFoundationStorage(join(directory, "foundation.sqlite"), {
@@ -376,7 +380,17 @@ try {
   );
   await page.getByRole("button", { name: "Open Event Hub" }).click();
   await page.getByText("Event Hub", { exact: true }).waitFor();
+  const technicalInitialHeatHubResponsePromise = page.waitForResponse(
+    (response) =>
+      response.url().includes(`/api/event-admin/hub?eventId=${eventId}`) &&
+      response.url().includes("gameDayId=") &&
+      response.request().method() === "GET",
+  );
   await page.getByLabel("Game Day", { exact: true }).selectOption({ index: 1 });
+  assert(
+    (await technicalInitialHeatHubResponsePromise).status() === 200,
+    "Technical Admin initial Game Day selection failed",
+  );
   const eventAdminContext = await browser.newContext({ ignoreHTTPSErrors: true });
   const eventAdminPage = await eventAdminContext.newPage();
   eventAdminPage.setDefaultTimeout(5_000);
@@ -387,6 +401,116 @@ try {
   await eventAdminPage.getByText("Administrative audit evidence", { exact: true }).waitFor();
   await eventAdminPage.getByText("Event Administration", { exact: true }).waitFor();
   await eventAdminPage.getByText("Grant Audit", { exact: true }).waitFor();
+  const eventAdminHeatGameDaySelector = eventAdminPage.getByLabel("Game Day", { exact: true });
+  const eventAdminInitialHeatHubResponsePromise = eventAdminPage.waitForResponse(
+    (response) =>
+      response.url().includes(`/api/event-admin/hub?eventId=${eventId}`) &&
+      response.url().includes("gameDayId=") &&
+      response.request().method() === "GET",
+  );
+  await eventAdminHeatGameDaySelector.selectOption({ index: 1 });
+  assert(
+    (await eventAdminInitialHeatHubResponsePromise).status() === 200,
+    "Event Admin initial Game Day selection failed",
+  );
+  const configuredHeatGameDayId = await eventAdminHeatGameDaySelector.inputValue();
+  await eventAdminPage.getByText("Currently disabled", { exact: true }).waitFor();
+  const eventAdminHeatPatchResponsePromise = eventAdminPage.waitForResponse(
+    (response) =>
+      response
+        .url()
+        .endsWith(
+          `/api/event-admin/events/${eventId}/game-days/${configuredHeatGameDayId}/heat-stoppage-configuration`,
+        ) && response.request().method() === "PATCH",
+  );
+  const eventAdminHeatHubResponsePromise = eventAdminPage.waitForResponse(
+    (response) =>
+      response.url().includes(`/api/event-admin/hub?eventId=${eventId}`) &&
+      response.url().includes(`gameDayId=${configuredHeatGameDayId}`) &&
+      response.request().method() === "GET",
+  );
+  await eventAdminPage.getByRole("button", { name: "Enable", exact: true }).click();
+  assert(
+    (await eventAdminHeatPatchResponsePromise).status() === 200,
+    "Event Admin Heat Stoppage Configuration PATCH failed",
+  );
+  assert(
+    (await eventAdminHeatHubResponsePromise).status() === 200,
+    "Event Admin Heat Stoppage Configuration refresh failed",
+  );
+  await eventAdminPage.getByText("Currently enabled", { exact: true }).waitFor();
+
+  const technicalHeatGameDaySelector = page.getByLabel("Game Day", { exact: true });
+  await page.getByText("Currently disabled", { exact: true }).waitFor();
+  const technicalHeatDayTransitionResponsePromise = page.waitForResponse(
+    (response) =>
+      response.url().includes(`/api/event-admin/hub?eventId=${eventId}`) &&
+      response.url().includes("gameDayId=") &&
+      response.request().method() === "GET",
+  );
+  await technicalHeatGameDaySelector.selectOption({ index: 2 });
+  assert(
+    (await technicalHeatDayTransitionResponsePromise).status() === 200,
+    "Technical Admin Event Hub Game Day transition failed",
+  );
+  const technicalHeatReturnResponsePromise = page.waitForResponse(
+    (response) =>
+      response.url().includes(`/api/event-admin/hub?eventId=${eventId}`) &&
+      response.url().includes(`gameDayId=${configuredHeatGameDayId}`) &&
+      response.request().method() === "GET",
+  );
+  await technicalHeatGameDaySelector.selectOption({ value: configuredHeatGameDayId });
+  assert(
+    (await technicalHeatReturnResponsePromise).status() === 200,
+    "Technical Admin Event Hub Game Day return failed",
+  );
+  await page.getByText("Currently enabled", { exact: true }).waitFor();
+  const technicalHeatPatchResponsePromise = page.waitForResponse(
+    (response) =>
+      response
+        .url()
+        .endsWith(
+          `/api/event-admin/events/${eventId}/game-days/${configuredHeatGameDayId}/heat-stoppage-configuration`,
+        ) && response.request().method() === "PATCH",
+  );
+  const technicalHeatHubResponsePromise = page.waitForResponse(
+    (response) =>
+      response.url().includes(`/api/event-admin/hub?eventId=${eventId}`) &&
+      response.url().includes(`gameDayId=${configuredHeatGameDayId}`) &&
+      response.request().method() === "GET",
+  );
+  await page.getByRole("button", { name: "Disable", exact: true }).click();
+  assert(
+    (await technicalHeatPatchResponsePromise).status() === 200,
+    "Technical Admin delegated Heat Stoppage Configuration PATCH failed",
+  );
+  assert(
+    (await technicalHeatHubResponsePromise).status() === 200,
+    "Technical Admin delegated Heat Stoppage Configuration refresh failed",
+  );
+  await page.getByText("Currently disabled", { exact: true }).waitFor();
+  const heatAuditResponse = await eventAdminContext.request.get(
+    `${origin}/api/event-admin/audit?eventId=${eventId}&projection=event-administration&action=game-day-heat-stoppage-configured&limit=10`,
+  );
+  const heatAuditPayload = (await heatAuditResponse.json()) as {
+    status?: string;
+    value?: {
+      entries?: Array<{
+        action: string;
+        scope?: { gameDayId?: string | null };
+      }>;
+    };
+  };
+  assert(
+    heatAuditResponse.status() === 200 &&
+      heatAuditPayload.status === "accepted" &&
+      heatAuditPayload.value?.entries?.filter(
+        (entry) =>
+          entry.action === "game-day-heat-stoppage-configured" &&
+          entry.scope?.gameDayId === configuredHeatGameDayId,
+      ).length === 2,
+    "Heat Stoppage Configuration history did not expose both bounded transitions",
+  );
   const eventAdminAuditResponse = await eventAdminContext.request.get(
     `${origin}/api/event-admin/audit?eventId=${eventId}&projection=grant&limit=1`,
   );
@@ -621,7 +745,10 @@ try {
       removalPreviewPayload.value.fingerprint?.startsWith("event-catalog-removal-v1:") === true,
     "Event Admin Game Day removal preview failed",
   );
-  const removalStatusText = await eventAdminPage.getByRole("status").innerText();
+  const removalStatusText = await eventAdminPage
+    .getByRole("status")
+    .filter({ hasText: "catalog descendants 0" })
+    .innerText();
   assert(
     removalStatusText.includes("catalog descendants 0") &&
       removalStatusText.includes("retained Event Game Records 0") &&
@@ -1101,6 +1228,35 @@ try {
     pitchManagerAuditResponse.status() === 401 &&
       pitchManagerAuditResponse.headers()["set-cookie"] === undefined,
     "admitted Pitch Manager was not generically denied administrative audit evidence",
+  );
+  const pitchManagerHeatMutation = await pitchManagerContext.request.patch(
+    `${origin}/api/event-admin/events/${eventId}/game-days/${configuredHeatGameDayId}/heat-stoppage-configuration`,
+    { data: { configuration: "enabled" } },
+  );
+  assert(
+    pitchManagerHeatMutation.status() === 401 &&
+      pitchManagerHeatMutation.headers()["set-cookie"] === undefined &&
+      (await pitchManagerHeatMutation.text()).includes("Authentication failed.") === true,
+    "admitted Pitch Manager was not generically denied Heat Stoppage Configuration mutation",
+  );
+  const postDenialHubResponse = await eventAdminContext.request.get(
+    `${origin}/api/event-admin/hub?eventId=${eventId}&gameDayId=${configuredHeatGameDayId}`,
+  );
+  const postDenialHubPayload = (await postDenialHubResponse.json()) as {
+    status?: string;
+    value?: {
+      event?: {
+        gameDays?: Array<{ gameDayId: string; heatStoppageConfiguration: string }>;
+      };
+    };
+  };
+  assert(
+    postDenialHubResponse.status() === 200 &&
+      postDenialHubPayload.status === "accepted" &&
+      postDenialHubPayload.value?.event?.gameDays?.find(
+        (day) => day.gameDayId === configuredHeatGameDayId,
+      )?.heatStoppageConfiguration === "disabled",
+    "Pitch Manager Heat Stoppage Configuration denial changed catalog projection",
   );
   await pitchManagerPage
     .getByText(/Control Grant:/u)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1756,6 +1756,24 @@ async function startServer() {
             );
           },
         },
+        "/api/event-admin/events/:eventId/game-days/:gameDayId/heat-stoppage-configuration": {
+          async PATCH(req: Request) {
+            if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
+            const authority = resolveEventAdministrationAuthority(req, technicalAdminAuth);
+            const body = await readJsonRecord(req);
+            const path = new URL(req.url).pathname.split("/");
+            if (authority === null || body === null) return sensitiveGenericAuthFailure(401);
+            return sensitiveEventAdministrationMutationResponse(
+              await eventAdministration.setGameDayHeatStoppageConfiguration(
+                path[4] ?? "",
+                path[6] ?? "",
+                { configuration: body.configuration },
+                authority,
+              ),
+              authority,
+            );
+          },
+        },
         "/api/event-admin/events/:eventId/game-days/:gameDayId/event-games": {
           async POST(req: Request) {
             if (eventAdministration === null) return sensitiveGenericAuthFailure(503);

--- a/src/lib/event-administration.test.ts
+++ b/src/lib/event-administration.test.ts
@@ -1549,6 +1549,172 @@ describe("Event Administration handoff", () => {
     });
   });
 
+  test("lets Event Admin authority configure a Game Day without forecast evidence", async () => {
+    const fixture = createFixture();
+    const event = await fixture.catalog.createEvent(
+      { name: "Heat Administration Event", timeZone: "UTC" },
+      fixture.technical,
+    );
+    if (event.status !== "accepted") throw new Error("Expected Event.");
+    const day = await fixture.catalog.addGameDay(
+      event.value.eventId,
+      { date: "2026-08-15" },
+      fixture.technical,
+    );
+    if (day.status !== "accepted") throw new Error("Expected Game Day.");
+    const grant = await fixture.administration.createEventAdminGrant(
+      event.value.eventId,
+      fixture.technical,
+    );
+    if (grant.status !== "accepted") throw new Error("Expected Event Admin Grant.");
+    const reveal = await fixture.grants.revealGrant(grant.value.grantId, fixture.technical);
+    if (reveal.status !== "revealed") throw new Error("Expected Grant reveal.");
+    const admission = await fixture.administration.admitEventAdmin({
+      qrCredential: reveal.qrCredential,
+      browserContext: "heat-admin-browser",
+    });
+    if (admission.status !== "admitted") throw new Error("Expected Event Admin session.");
+    const eventAdmin = { kind: "grant-session" as const, sessionBearer: admission.sessionBearer };
+
+    expect(
+      await fixture.administration.setGameDayHeatStoppageConfiguration(
+        event.value.eventId,
+        day.value.gameDayId,
+        { configuration: "enabled" },
+        eventAdmin,
+      ),
+    ).toMatchObject({
+      status: "accepted",
+      value: { heatStoppageConfiguration: "enabled" },
+    });
+    expect(
+      await fixture.administration.setGameDayHeatStoppageConfiguration(
+        event.value.eventId,
+        day.value.gameDayId,
+        { configuration: "disabled" },
+        { kind: "grant-session", sessionBearer: "wrong-session" },
+      ),
+    ).toMatchObject({ status: "rejected", reason: "unauthorized" });
+    const hub = await fixture.administration.openEventHub({
+      eventId: event.value.eventId,
+      gameDayId: day.value.gameDayId,
+      authority: eventAdmin,
+    });
+    expect(hub).toMatchObject({
+      status: "accepted",
+      value: { event: { gameDays: [{ heatStoppageConfiguration: "enabled" }] } },
+    });
+  });
+
+  test("denies real Pitch Manager and Controller authorities without mutation", async () => {
+    const fixture = createFixture(undefined, {
+      resolve: () => ({ status: "eligible", eventGameId: "heat-controller-game" }),
+    });
+    const event = await fixture.catalog.createEvent(
+      { name: "Heat Authority Boundary", timeZone: "UTC" },
+      fixture.technical,
+    );
+    if (event.status !== "accepted") throw new Error("Expected Event.");
+    const day = await fixture.catalog.addGameDay(
+      event.value.eventId,
+      { date: "2026-08-15" },
+      fixture.technical,
+    );
+    const pitch = await fixture.administration.createPitch(
+      event.value.eventId,
+      { name: "Heat Pitch" },
+      fixture.technical,
+    );
+    if (day.status !== "accepted" || pitch.status !== "accepted")
+      throw new Error("Expected schedule structure.");
+    const eventGrant = await fixture.administration.createEventAdminGrant(
+      event.value.eventId,
+      fixture.technical,
+    );
+    if (eventGrant.status !== "accepted") throw new Error("Expected Event Admin Grant.");
+    const eventQr = await fixture.grants.revealGrant(eventGrant.value.grantId, fixture.technical);
+    if (eventQr.status !== "revealed") throw new Error("Expected Event Admin QR.");
+    const eventAdmission = await fixture.administration.admitEventAdmin({
+      qrCredential: eventQr.qrCredential,
+      browserContext: "heat-boundary-event-admin",
+    });
+    if (eventAdmission.status !== "admitted") throw new Error("Expected Event Admin session.");
+    const eventAuthority = {
+      kind: "grant-session" as const,
+      sessionBearer: eventAdmission.sessionBearer,
+    };
+    const managerGrant = await fixture.administration.createPitchManagerGrant(
+      event.value.eventId,
+      day.value.gameDayId,
+      pitch.value.pitchId,
+      eventAuthority,
+    );
+    if (managerGrant.status !== "accepted") throw new Error("Expected Pitch Manager Grant.");
+    const managerQr = await fixture.grants.revealGrant(managerGrant.value.grantId, eventAuthority);
+    if (managerQr.status !== "revealed") throw new Error("Expected Pitch Manager QR.");
+    const managerAdmission = await fixture.administration.admitPitchManager({
+      qrCredential: managerQr.qrCredential,
+      browserContext: "heat-boundary-pitch-manager",
+    });
+    if (managerAdmission.status !== "admitted") throw new Error("Expected Pitch Manager session.");
+    const slot = await fixture.administration.createGameplaySlot(
+      event.value.eventId,
+      day.value.gameDayId,
+      { sequence: 1, scheduledStart: "2026-08-15T10:00" },
+      fixture.technical,
+    );
+    if (slot.status !== "accepted") throw new Error("Expected Gameplay Slot.");
+    const pitchSlot = await fixture.storage.transaction(
+      (transaction) => transaction.listPitchSlots(day.value.gameDayId, pitch.value.pitchId)[0],
+    );
+    if (pitchSlot === undefined) throw new Error("Expected Pitch Slot.");
+    const control = await fixture.grants.createControlGrant({
+      authority: { kind: "grant-session", sessionBearer: managerAdmission.sessionBearer },
+      scope: {
+        eventId: event.value.eventId,
+        gameDayId: day.value.gameDayId,
+        pitchId: pitch.value.pitchId,
+        pitchSlotId: pitchSlot.pitchSlotId,
+      },
+    });
+    if (control.status !== "created") throw new Error("Expected Control Grant.");
+    const controlQr = await fixture.grants.revealGrant(control.grantId, fixture.technical);
+    if (controlQr.status !== "revealed") throw new Error("Expected Control Grant QR.");
+    const controllerAdmission = await fixture.administration.admitControlGrant({
+      qrCredential: controlQr.qrCredential,
+      browserContext: "heat-boundary-controller",
+    });
+    if (controllerAdmission.status !== "admitted") throw new Error("Expected Controller session.");
+
+    const before = await fixture.storage.transaction((transaction) => ({
+      gameDays: transaction.listGameDays(event.value.eventId),
+      audit: transaction.listEventAuditTrail(event.value.eventId),
+    }));
+    for (const sessionBearer of [
+      managerAdmission.sessionBearer,
+      controllerAdmission.sessionBearer,
+    ]) {
+      expect(
+        await fixture.administration.setGameDayHeatStoppageConfiguration(
+          event.value.eventId,
+          day.value.gameDayId,
+          { configuration: "enabled" },
+          { kind: "grant-session", sessionBearer },
+        ),
+      ).toMatchObject({
+        status: "rejected",
+        reason: "unauthorized",
+        detail: "Unable to authorize Event Administration.",
+      });
+    }
+    expect(
+      await fixture.storage.transaction((transaction) => ({
+        gameDays: transaction.listGameDays(event.value.eventId),
+        audit: transaction.listEventAuditTrail(event.value.eventId),
+      })),
+    ).toEqual(before);
+  });
+
   test("configures ordered schedule projections and confirms one Gameplay Slot", async () => {
     const fixture = createFixture();
     const event = await fixture.catalog.createEvent(

--- a/src/lib/event-administration.ts
+++ b/src/lib/event-administration.ts
@@ -435,6 +435,12 @@ export type EventAdministration = {
     input: { name?: unknown; defaultColor?: unknown },
     authority: EventAdministrationAuthority,
   ): Promise<EventAdministrationMutationOutcome<EventTeamProjection>>;
+  setGameDayHeatStoppageConfiguration(
+    eventId: unknown,
+    gameDayId: unknown,
+    input: { configuration: unknown },
+    authority: EventAdministrationAuthority,
+  ): Promise<EventAdministrationMutationOutcome<import("@/lib/event-catalog").EventGameDay>>;
   upsertEventTeamRoster(
     eventId: unknown,
     eventTeamId: unknown,
@@ -1488,6 +1494,12 @@ export function createEventAdministration(
     async updateEventTeam(eventId, eventTeamId, input, authority) {
       return runCatalogMutation(catalog, options, eventId, authority, (operations) =>
         operations.updateEventTeam(eventId, eventTeamId, input),
+      );
+    },
+
+    async setGameDayHeatStoppageConfiguration(eventId, gameDayId, input, authority) {
+      return runCatalogMutation(catalog, options, eventId, authority, (operations) =>
+        operations.setGameDayHeatStoppageConfiguration(eventId, gameDayId, input),
       );
     },
 

--- a/src/lib/event-catalog.test.ts
+++ b/src/lib/event-catalog.test.ts
@@ -53,6 +53,196 @@ describe("Event operations catalog", () => {
     });
   });
 
+  test("lets the Technical Admin configure one Game Day and records before/after evidence", async () => {
+    const fixture = createFixture();
+    const event = await fixture.catalog.createEvent(
+      { name: "Heat configuration Event", timeZone: "UTC" },
+      authority,
+    );
+    if (event.status !== "accepted") throw new Error("Expected Event.");
+    const day = await fixture.catalog.addGameDay(
+      event.value.eventId,
+      { date: "2026-08-15" },
+      authority,
+    );
+    if (day.status !== "accepted") throw new Error("Expected Game Day.");
+
+    const enabled = await fixture.catalog.setGameDayHeatStoppageConfiguration(
+      event.value.eventId,
+      day.value.gameDayId,
+      { configuration: "enabled" },
+      authority,
+    );
+
+    expect(enabled).toMatchObject({
+      status: "accepted",
+      value: { heatStoppageConfiguration: "enabled" },
+    });
+    const inspected = await fixture.catalog.inspectEvent(event.value.eventId, authority);
+    expect(inspected.status).toBe("accepted");
+    if (inspected.status !== "accepted") throw new Error("Expected inspection.");
+    expect(inspected.value.gameDays[0]).toMatchObject({
+      heatStoppageConfiguration: "enabled",
+    });
+    expect(inspected.value.auditTrail.at(-1)).toMatchObject({
+      action: "game-day-heat-stoppage-configured",
+      before: { heatStoppageConfiguration: "disabled" },
+      after: { heatStoppageConfiguration: "enabled" },
+    });
+  });
+
+  test("rejects invalid or cross-Event heat configuration without mutation", async () => {
+    const fixture = createFixture();
+    const first = await fixture.catalog.createEvent({ name: "One", timeZone: "UTC" }, authority);
+    const second = await fixture.catalog.createEvent({ name: "Two", timeZone: "UTC" }, authority);
+    if (first.status !== "accepted" || second.status !== "accepted")
+      throw new Error("Expected Events.");
+    const day = await fixture.catalog.addGameDay(
+      first.value.eventId,
+      { date: "2026-08-15" },
+      authority,
+    );
+    if (day.status !== "accepted") throw new Error("Expected Game Day.");
+
+    expect(
+      await fixture.catalog.setGameDayHeatStoppageConfiguration(
+        first.value.eventId,
+        day.value.gameDayId,
+        { configuration: "maybe" },
+        authority,
+      ),
+    ).toMatchObject({ status: "rejected", reason: "invalid-input" });
+    expect(
+      await fixture.catalog.setGameDayHeatStoppageConfiguration(
+        second.value.eventId,
+        day.value.gameDayId,
+        { configuration: "enabled" },
+        authority,
+      ),
+    ).toMatchObject({ status: "rejected", reason: "cross-event" });
+  });
+
+  test("projects one current configuration for multiple uncommenced Event Games", async () => {
+    const fixture = createFixture();
+    const event = await fixture.catalog.createEvent(
+      { name: "Multiple Heat Games", timeZone: "UTC" },
+      authority,
+    );
+    if (event.status !== "accepted") throw new Error("Expected Event.");
+    const day = await fixture.catalog.addGameDay(
+      event.value.eventId,
+      { date: "2026-08-15" },
+      authority,
+    );
+    const pitch = await fixture.catalog.createPitch(
+      event.value.eventId,
+      { name: "Heat Pitch" },
+      authority,
+    );
+    if (day.status !== "accepted" || pitch.status !== "accepted")
+      throw new Error("Expected schedule structure.");
+    const firstSlot = await fixture.catalog.createGameplaySlot(
+      event.value.eventId,
+      day.value.gameDayId,
+      { sequence: 1, scheduledStart: "2026-08-15T10:00" },
+      authority,
+    );
+    const secondSlot = await fixture.catalog.createGameplaySlot(
+      event.value.eventId,
+      day.value.gameDayId,
+      { sequence: 2, scheduledStart: "2026-08-15T11:00" },
+      authority,
+    );
+    if (firstSlot.status !== "accepted" || secondSlot.status !== "accepted")
+      throw new Error("Expected Gameplay Slots.");
+    const pitchSlots = await fixture.storage
+      .snapshot()
+      .then((snapshot) => snapshot.listPitchSlots(day.value.gameDayId, pitch.value.pitchId));
+    const firstPitchSlot = pitchSlots.find(
+      (slot) => slot.gameplaySlotId === firstSlot.value.gameplaySlotId,
+    );
+    const secondPitchSlot = pitchSlots.find(
+      (slot) => slot.gameplaySlotId === secondSlot.value.gameplaySlotId,
+    );
+    if (firstPitchSlot === undefined || secondPitchSlot === undefined)
+      throw new Error("Expected one Pitch Slot per Gameplay Slot.");
+    const firstGame = await fixture.catalog.createEventGame(
+      event.value.eventId,
+      day.value.gameDayId,
+      {
+        gameplaySlotId: firstSlot.value.gameplaySlotId,
+        pitchSlotId: firstPitchSlot.pitchSlotId,
+        gameCode: "HEAT-A",
+        sideA: { sourceLabel: "A" },
+        sideB: { sourceLabel: "B" },
+      },
+      authority,
+    );
+    const secondGame = await fixture.catalog.createEventGame(
+      event.value.eventId,
+      day.value.gameDayId,
+      {
+        gameplaySlotId: secondSlot.value.gameplaySlotId,
+        pitchSlotId: secondPitchSlot.pitchSlotId,
+        gameCode: "HEAT-B",
+        sideA: { sourceLabel: "C" },
+        sideB: { sourceLabel: "D" },
+      },
+      authority,
+    );
+    if (firstGame.status !== "accepted" || secondGame.status !== "accepted")
+      throw new Error("Expected Event Games.");
+
+    const configured = await fixture.catalog.setGameDayHeatStoppageConfiguration(
+      event.value.eventId,
+      day.value.gameDayId,
+      { configuration: "enabled" },
+      authority,
+    );
+    expect(configured).toMatchObject({
+      status: "accepted",
+      value: { heatStoppageConfiguration: "enabled" },
+    });
+    const inspected = await fixture.catalog.inspectEvent(event.value.eventId, authority);
+    expect(inspected).toMatchObject({
+      status: "accepted",
+      value: {
+        gameDays: [{ gameDayId: day.value.gameDayId, heatStoppageConfiguration: "enabled" }],
+        eventGames: [
+          { eventGameId: firstGame.value.eventGameId, gameDayId: day.value.gameDayId },
+          { eventGameId: secondGame.value.eventGameId, gameDayId: day.value.gameDayId },
+        ],
+      },
+    });
+  });
+
+  test("rolls back Game Day configuration, audit, and projection on an atomic failure", async () => {
+    const fixture = createFixture();
+    const event = await fixture.catalog.createEvent(
+      { name: "Atomic Heat Failure", timeZone: "UTC" },
+      authority,
+    );
+    if (event.status !== "accepted") throw new Error("Expected Event.");
+    const day = await fixture.catalog.addGameDay(
+      event.value.eventId,
+      { date: "2026-08-15" },
+      authority,
+    );
+    if (day.status !== "accepted") throw new Error("Expected Game Day.");
+    const before = await fixture.catalog.inspectEvent(event.value.eventId, authority);
+    fixture.storage.failNextTransaction(new Error("injected heat configuration failure"));
+
+    expect(
+      await fixture.catalog.setGameDayHeatStoppageConfiguration(
+        event.value.eventId,
+        day.value.gameDayId,
+        { configuration: "enabled" },
+        authority,
+      ),
+    ).toMatchObject({ status: "retryable-failure" });
+    expect(await fixture.catalog.inspectEvent(event.value.eventId, authority)).toEqual(before);
+  });
+
   test("projects Expected Start from the greater Gameplay and Pitch Slot delay", () => {
     expect(
       projectExpectedStartMs(

--- a/src/lib/event-catalog.ts
+++ b/src/lib/event-catalog.ts
@@ -254,6 +254,11 @@ export type EventCatalogMutationOperations = {
     eventTeamId: unknown,
     input: { name?: unknown; defaultColor?: unknown },
   ): CatalogOutcome<EventTeamProjection>;
+  setGameDayHeatStoppageConfiguration(
+    eventId: unknown,
+    gameDayId: unknown,
+    input: { configuration: unknown },
+  ): CatalogOutcome<EventGameDay>;
   upsertEventTeamRoster(
     eventId: unknown,
     eventTeamId: unknown,
@@ -449,6 +454,12 @@ export type EventCatalog = {
     eventId: unknown,
     gameDayId: unknown,
     input: { date: unknown },
+    authority: TechnicalAdminAuthority,
+  ): Promise<CatalogOutcome<EventGameDay>>;
+  setGameDayHeatStoppageConfiguration(
+    eventId: unknown,
+    gameDayId: unknown,
+    input: { configuration: unknown },
     authority: TechnicalAdminAuthority,
   ): Promise<CatalogOutcome<EventGameDay>>;
   createEventTeam(
@@ -848,6 +859,24 @@ export function createEventCatalog(
         transaction.appendAudit(audit);
         return accepted(projectDay(updated, event.timeZone, nowMs));
       });
+    },
+
+    async setGameDayHeatStoppageConfiguration(eventIdInput, gameDayIdInput, input, authority) {
+      if (!isTechnicalAdminAuthority(authority)) return unauthorized();
+      const actor = authorityActor(authority);
+      const nowMs = validNow(clock);
+      if (nowMs === null) return invalid("Event clock returned an invalid timestamp.");
+      return commit(storage, (transaction) =>
+        setGameDayHeatStoppageConfigurationOperation(
+          transaction,
+          clock,
+          ids,
+          eventIdInput,
+          gameDayIdInput,
+          input,
+          actor,
+        ),
+      );
     },
 
     async createEventTeam(eventId, input, authority) {
@@ -1401,6 +1430,16 @@ function createMutationOperations(
         ids,
         eventId,
         eventTeamId,
+        input,
+        actorReference,
+      ),
+    setGameDayHeatStoppageConfiguration: (eventId, gameDayId, input) =>
+      setGameDayHeatStoppageConfigurationOperation(
+        transaction,
+        clock,
+        ids,
+        eventId,
+        gameDayId,
         input,
         actorReference,
       ),
@@ -3028,6 +3067,62 @@ function validateOptionalText(
   if (value === undefined || value === null || value === "") return { ok: true, value: null };
   const result = normalizeBoundedText(value, maxCodePoints, field);
   return result.ok ? { ok: true, value: result.value } : result;
+}
+
+function setGameDayHeatStoppageConfigurationOperation(
+  transaction: EventCatalogStorageTransaction,
+  clock: EventCatalogClock,
+  ids: EventCatalogIds,
+  eventIdInput: unknown,
+  gameDayIdInput: unknown,
+  input: { configuration: unknown },
+  actorReference: string,
+): CatalogOutcome<EventGameDay> {
+  const eventId = validateId(eventIdInput, "eventId");
+  const gameDayId = validateId(gameDayIdInput, "gameDayId");
+  if (!eventId.ok) return invalid(eventId.error);
+  if (!gameDayId.ok) return invalid(gameDayId.error);
+  if (input.configuration !== "enabled" && input.configuration !== "disabled")
+    return invalid("Heat Stoppage Configuration must be enabled or disabled.");
+  const nowMs = validNow(clock);
+  if (nowMs === null) return invalid("Event clock returned an invalid timestamp.");
+  const event = transaction.findEvent(eventId.value);
+  if (event === null) return notFound("Event was not found.");
+  const existing = transaction
+    .listGameDays(event.eventId)
+    .find((day) => day.gameDayId === gameDayId.value);
+  if (existing === undefined) {
+    const elsewhere = transaction
+      .listEvents()
+      .some((candidate) =>
+        transaction
+          .listGameDays(candidate.eventId)
+          .some((day) => day.gameDayId === gameDayId.value),
+      );
+    return elsewhere
+      ? crossEvent("Game Day belongs to another Event.")
+      : notFound("Game Day was not found.");
+  }
+  if (existing.heatStoppageConfiguration === input.configuration)
+    return noChange("The Game Day already has this Heat Stoppage Configuration.");
+  const updated: StoredGameDay = {
+    ...existing,
+    heatStoppageConfiguration: input.configuration,
+    updatedAtMs: nowMs,
+  };
+  const audit = createAudit(
+    ids,
+    "game-day-heat-stoppage-configured",
+    event.eventId,
+    existing.gameDayId,
+    actorReference,
+    nowMs,
+    { heatStoppageConfiguration: existing.heatStoppageConfiguration },
+    { heatStoppageConfiguration: updated.heatStoppageConfiguration },
+  );
+  transaction.updateGameDay(updated);
+  transaction.appendAudit(audit);
+  return accepted(projectDay(updated, event.timeZone, nowMs));
 }
 
 function updatePitchOperation(

--- a/src/lib/foundation-grant-erasure-migration.test.ts
+++ b/src/lib/foundation-grant-erasure-migration.test.ts
@@ -210,7 +210,7 @@ describe("Grant cryptographic erasure migration", () => {
 
       const current = openSqliteFoundationStorage(databasePath);
       await current.applyMigrations({ requireCandidate: false });
-      expect(await current.readiness()).toMatchObject({ ok: true, schemaVersion: "30" });
+      expect(await current.readiness()).toMatchObject({ ok: true, schemaVersion: "31" });
       current.close();
 
       const raw = new Database(databasePath);
@@ -330,7 +330,7 @@ describe("Grant cryptographic erasure migration", () => {
       raw.close();
 
       const reopened = openSqliteFoundationStorage(databasePath);
-      expect(await reopened.readiness()).toMatchObject({ ok: true, schemaVersion: "30" });
+      expect(await reopened.readiness()).toMatchObject({ ok: true, schemaVersion: "31" });
       const restartedAudit = await reopened.transaction((transaction) =>
         transaction.listGrantAudit("grant-expired"),
       );

--- a/src/lib/foundation-migrations.test.ts
+++ b/src/lib/foundation-migrations.test.ts
@@ -13,7 +13,7 @@ const migrations: readonly FoundationMigration[] = [
 ];
 
 describe("foundation migration ledger compatibility", () => {
-  test("keeps accepted migrations 001 through 029 byte-for-byte immutable and pins 030", () => {
+  test("keeps accepted migrations 001 through 030 byte-for-byte immutable and pins 031", () => {
     expect(FOUNDATION_MIGRATIONS.map(({ id, checksum }) => ({ id, checksum }))).toEqual([
       {
         id: "001-foundation-event-game-record-roots",
@@ -134,6 +134,10 @@ describe("foundation migration ledger compatibility", () => {
       {
         id: "030-heat-stoppage-configuration",
         checksum: "83f87206e902c3fd05a5d4f465b079d658ecd306d91254db6a676fe65206a789",
+      },
+      {
+        id: "031-heat-stoppage-audit-action",
+        checksum: "f11ca907b67bb8cefb1866314513166d0b993e44fa9ccd00bb146d76798d81c8",
       },
     ]);
   });

--- a/src/lib/foundation-migrations.ts
+++ b/src/lib/foundation-migrations.ts
@@ -2009,6 +2009,28 @@ export const FOUNDATION_HEAT_STOPPAGE_CONFIGURATION_MIGRATION_SQL = `
       CHECK (heat_stoppage_configuration IN ('enabled', 'disabled'));
 `;
 
+/** Schema-31 adds the Event Catalog audit action for Heat Stoppage Configuration changes. */
+export const FOUNDATION_HEAT_STOPPAGE_AUDIT_ACTION_MIGRATION_SQL = `
+  CREATE TABLE foundation_event_catalog_audit_v30 AS SELECT * FROM foundation_event_catalog_audit;
+  DROP TABLE foundation_event_catalog_audit;
+  ${FOUNDATION_EVENT_CATALOG_AUDIT_TABLE_V3_SQL.replace(
+    "CREATE TABLE foundation_event_catalog_audit",
+    "CREATE TABLE foundation_event_catalog_audit_rebuilt",
+  ).replace(
+    "'event-game-teams-confirmed'",
+    "'event-game-teams-confirmed', 'event-publication-changed', 'event-catalog-entry-removed', 'access-sheet-generated', 'game-day-heat-stoppage-configured'",
+  )};
+  INSERT INTO foundation_event_catalog_audit_rebuilt
+    (audit_id, operation_id, action, event_id, game_day_id, actor_reference,
+     occurred_at_ms, before_json, after_json)
+  SELECT audit_id, operation_id, action, event_id, game_day_id, actor_reference,
+         occurred_at_ms, before_json, after_json
+  FROM foundation_event_catalog_audit_v30;
+  DROP TABLE foundation_event_catalog_audit_v30;
+  ALTER TABLE foundation_event_catalog_audit_rebuilt RENAME TO foundation_event_catalog_audit;
+  ${FOUNDATION_EVENT_CATALOG_AUDIT_EVENT_INDEX_SQL};
+`;
+
 export const FOUNDATION_MIGRATIONS: readonly FoundationMigration[] = Object.freeze([
   createMigration({
     id: "001-foundation-event-game-record-roots",
@@ -2189,6 +2211,12 @@ export const FOUNDATION_MIGRATIONS: readonly FoundationMigration[] = Object.free
     ordinal: 30,
     schemaVersion: 30,
     sql: FOUNDATION_HEAT_STOPPAGE_CONFIGURATION_MIGRATION_SQL,
+  }),
+  createMigration({
+    id: "031-heat-stoppage-audit-action",
+    ordinal: 31,
+    schemaVersion: 31,
+    sql: FOUNDATION_HEAT_STOPPAGE_AUDIT_ACTION_MIGRATION_SQL,
   }),
 ]);
 

--- a/src/lib/foundation-storage-sqlite.test.ts
+++ b/src/lib/foundation-storage-sqlite.test.ts
@@ -564,7 +564,7 @@ describe("SQLite foundation storage", () => {
       expect(await reopenedRecord.registerRoot(root)).toMatchObject({ status: "idempotent" });
       expect(await reopened.readiness()).toMatchObject({
         ok: true,
-        schemaVersion: "30",
+        schemaVersion: "31",
         evidence: { replay: { result: "passed", rootCount: 1, durationMs: expect.any(Number) } },
       });
       reopened.close();
@@ -612,12 +612,12 @@ describe("SQLite foundation storage", () => {
       const storage = openSqliteFoundationStorage(databasePath);
       const candidate = await storage.validateCandidate();
       expect(candidate.ready).toBe(true);
-      expect(candidate.readiness).toMatchObject({ ok: true, schemaVersion: "30" });
+      expect(candidate.readiness).toMatchObject({ ok: true, schemaVersion: "31" });
       expect(existsSync(candidate.candidatePath)).toBe(false);
       expect(await storage.readiness()).toMatchObject({ ok: false, status: "pending" });
 
       const migration = await storage.applyMigrations({ requireCandidate: true });
-      expect(migration.schemaVersion).toBe(30);
+      expect(migration.schemaVersion).toBe(31);
       expect(await storage.readiness()).toMatchObject({ ok: true });
       storage.close();
     });
@@ -849,15 +849,16 @@ describe("SQLite foundation storage", () => {
         removalAuditMigration.id,
         "029-access-sheet-generated-audit-action",
         heatStoppageConfigurationMigration.id,
+        "031-heat-stoppage-audit-action",
       ]);
-      expect(await current.readiness()).toMatchObject({ ok: true, schemaVersion: "30" });
+      expect(await current.readiness()).toMatchObject({ ok: true, schemaVersion: "31" });
       current.close();
     });
   });
 
   test("adds the Access Sheet audit action while preserving prior audit rows and shape", async () => {
     await withDatabase(async (databasePath) => {
-      const priorMigrations = FOUNDATION_MIGRATIONS.slice(0, -2);
+      const priorMigrations = FOUNDATION_MIGRATIONS.slice(0, -3);
       const prior = openSqliteFoundationStorage(databasePath, { migrations: priorMigrations });
       await prior.applyMigrations({ requireCandidate: false });
       prior.close();
@@ -890,7 +891,7 @@ describe("SQLite foundation storage", () => {
       database.close();
 
       const current = openSqliteFoundationStorage(databasePath, {
-        migrations: FOUNDATION_MIGRATIONS.slice(0, -1),
+        migrations: FOUNDATION_MIGRATIONS.slice(0, -2),
       });
       expect(await current.applyMigrations({ requireCandidate: false })).toMatchObject({
         appliedMigrationIds: ["029-access-sheet-generated-audit-action"],
@@ -957,9 +958,9 @@ describe("SQLite foundation storage", () => {
     await withDatabase(async (databasePath) => {
       const baseMigrations = FOUNDATION_MIGRATIONS;
       const failingMigration = createMigration(
-        "031-failing-test-migration",
-        31,
-        31,
+        "032-failing-test-migration",
+        32,
+        32,
         "CREATE TABLE migration_failure_probe (id TEXT) STRICT; THIS IS NOT SQL;",
       );
       const store = openSqliteFoundationStorage(databasePath, {
@@ -979,7 +980,7 @@ describe("SQLite foundation storage", () => {
       });
       expect(await priorBinary.readiness()).toMatchObject({
         ok: true,
-        schemaVersion: "30",
+        schemaVersion: "31",
       });
       priorBinary.close();
 
@@ -1051,7 +1052,7 @@ describe("SQLite foundation storage", () => {
         .query(
           "INSERT INTO foundation_migration_ledger (migration_id, ordinal, schema_version, checksum, status, applied_at_ms) VALUES (?, ?, ?, ?, ?, ?)",
         )
-        .run("future-999", 31, 31, "future-checksum", "complete", 2_000);
+        .run("future-999", 32, 32, "future-checksum", "complete", 2_000);
       futureDatabase.close();
       const future = openSqliteFoundationStorage(databasePath);
       expect(await future.readiness()).toMatchObject({ ok: false });

--- a/src/lib/foundation-storage.ts
+++ b/src/lib/foundation-storage.ts
@@ -235,6 +235,7 @@ export type EventCatalogAuditEntry = {
     | "event-removed"
     | "game-day-added"
     | "game-day-updated"
+    | "game-day-heat-stoppage-configured"
     | "game-day-removed"
     | "event-team-created"
     | "event-team-updated"

--- a/src/lib/heat-stoppage-configuration.test.ts
+++ b/src/lib/heat-stoppage-configuration.test.ts
@@ -193,7 +193,7 @@ describe("Heat Stoppage Configuration SQLite persistence", () => {
     const directory = await mkdtemp(join(tmpdir(), "quadball-timer-heat-config-"));
     const databasePath = join(directory, "foundation.sqlite");
     const before = openSqliteFoundationStorage(databasePath, {
-      migrations: FOUNDATION_MIGRATIONS.slice(0, -1) as readonly FoundationMigration[],
+      migrations: FOUNDATION_MIGRATIONS.slice(0, -2) as readonly FoundationMigration[],
     });
     await before.applyMigrations();
     before.close();
@@ -217,7 +217,10 @@ describe("Heat Stoppage Configuration SQLite persistence", () => {
     const storage = openSqliteFoundationStorage(databasePath);
     try {
       const migration = await storage.applyMigrations();
-      expect(migration.appliedMigrationIds).toEqual(["030-heat-stoppage-configuration"]);
+      expect(migration.appliedMigrationIds).toEqual([
+        "030-heat-stoppage-configuration",
+        "031-heat-stoppage-audit-action",
+      ]);
       await storage.transaction((transaction) => {
         expect(transaction.listGameDays("legacy-event")).toMatchObject([
           { gameDayId: "legacy-day", heatStoppageConfiguration: "disabled" },
@@ -226,6 +229,22 @@ describe("Heat Stoppage Configuration SQLite persistence", () => {
       await seed(storage, "enabled");
       await storage.transaction((transaction) => {
         expect(resolveHeatStoppageConfiguration(transaction, scope)).toBe("enabled");
+        transaction.appendEventAudit({
+          auditId: "heat-audit-1",
+          operationId: "heat-operation-1",
+          action: "game-day-heat-stoppage-configured",
+          eventId: scope.eventId,
+          gameDayId: scope.gameDayId,
+          actorReference: "technical-admin:test",
+          occurredAtMs: 2,
+          before: { heatStoppageConfiguration: "disabled" },
+          after: { heatStoppageConfiguration: "enabled" },
+        });
+        expect(transaction.listEventAuditTrail(scope.eventId)).toContainEqual(
+          expect.objectContaining({
+            action: "game-day-heat-stoppage-configured",
+          }),
+        );
       });
       let failure: unknown;
       try {

--- a/src/lib/live-event-game-control.test.ts
+++ b/src/lib/live-event-game-control.test.ts
@@ -2,12 +2,14 @@ import { describe, expect, test } from "bun:test";
 import { applyGameCommand, createInitialGameState } from "@/lib/game-engine";
 import { createFoundationAcceptance, type AcceptanceLimits } from "@/lib/foundation-acceptance";
 import { createInMemoryFoundationStorage } from "@/lib/foundation-storage-memory";
+import { createEventCatalog, createFoundationEventCatalogStorage } from "@/lib/event-catalog";
 import { createEventGameRecord } from "@/lib/event-game-record";
 import { createGrantTestAuthorityVerifier } from "@/lib/grant-authority-test-support";
 import { createTypedGrantAuthority } from "@/lib/grant-management";
 import type { GrantAuthorityOptions } from "@/lib/grant-authority";
 import type { ControlGrantSessionResolution, GrantKeyRing } from "@/lib/grant-types";
 import type { EventGameRecordRoot } from "@/lib/foundation-record-types";
+import type { FoundationStorage } from "@/lib/foundation-storage";
 import {
   createLiveEventGameControl,
   createLiveEventGameIqaInterpreter,
@@ -24,6 +26,15 @@ import { createLiveEventGameControlTransport } from "@/lib/live-event-game-trans
 import { LIVE_SEEKER_RELEASE_MS } from "@/lib/live-event-penalties";
 import { createAdHocGamesService } from "@/lib/ad-hoc-games";
 import { createControlScopeResolver as createRuntimeControlScopeResolver } from "@/lib/live-event-game-runtime";
+import type {
+  HeatStoppageConfiguration,
+  HeatStoppageConfigurationScope,
+} from "@/lib/heat-stoppage-configuration";
+import { resolveHeatStoppageConfiguration } from "@/lib/heat-stoppage-configuration";
+import {
+  MemoryTechnicalAdminAuthRepository,
+  createTechnicalAdminAuth,
+} from "@/lib/technical-admin-auth";
 
 describe("Live Event Game control", () => {
   test("keeps Penalty Reason values fixed while skip remains a Controller-only absence", () => {
@@ -5026,9 +5037,11 @@ describe("Live Event Game control", () => {
   });
 
   test("atomically rolls back the action, mode snapshot, and commencement at the lifecycle boundary", async () => {
+    let configuration: HeatStoppageConfiguration = "enabled";
     const harness = await createHarness({
       failureBoundary: "after-lifecycle",
       heatStoppageConfiguration: true,
+      readHeatStoppageConfiguration: (_scope: HeatStoppageConfigurationScope) => configuration,
     });
     const opened = await harness.control.openController({
       qrCredential: harness.qrCredential,
@@ -5047,6 +5060,183 @@ describe("Live Event Game control", () => {
     expect((await harness.record.readRoot(harness.root.recordId))?.lifecycle).toMatchObject({
       phase: "scheduled",
       commencedAtMs: null,
+    });
+    harness.failureBoundary = undefined;
+    const committed = await harness.control.submitControllerIntent({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: harness.root.eventGameId,
+      intent: substantiveIntent("atomic-card-retry", "card"),
+    });
+    expect(committed).toMatchObject({
+      status: "accepted",
+      projection: {
+        commencement: { status: "commenced" },
+        heat: { mode: "enabled" },
+      },
+    });
+    configuration = "disabled";
+    expect(
+      await harness.control.refreshController({
+        sessionBearer: opened.session.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+      }),
+    ).toMatchObject({
+      status: "authorized",
+      projection: { commencement: { status: "commenced" }, heat: { mode: "enabled" } },
+    });
+  });
+
+  test("freezes one configuration when catalog mutation overlaps commencement", async () => {
+    const storage = createInMemoryFoundationStorage();
+    const root = createRoot("game-configuration-race");
+    await storage.transaction((transaction) => {
+      transaction.insertEvent({
+        eventId: root.eventId,
+        name: "Configuration Race Event",
+        timeZone: "UTC",
+        publicationStatus: "unpublished",
+        createdAtMs: 1,
+        updatedAtMs: 1,
+      });
+      transaction.insertGameDay({
+        gameDayId: root.externalScope.gameDayId,
+        eventId: root.eventId,
+        date: "2026-08-15",
+        heatStoppageConfiguration: "disabled",
+        createdAtMs: 1,
+        updatedAtMs: 1,
+      });
+      transaction.insertPitch({
+        pitchId: root.externalScope.pitchId,
+        eventId: root.eventId,
+        name: "Configuration Race Pitch",
+        createdAtMs: 1,
+        updatedAtMs: 1,
+      });
+      transaction.insertGameplaySlot({
+        gameplaySlotId: "gameplay-slot-configuration-race",
+        eventId: root.eventId,
+        gameDayId: root.externalScope.gameDayId,
+        sequence: 1,
+        scheduledStartMs: 1,
+        expectedDelayMs: 0,
+        createdAtMs: 1,
+        updatedAtMs: 1,
+      });
+      transaction.insertPitchSlot({
+        pitchSlotId: root.externalScope.pitchSlotId,
+        eventId: root.eventId,
+        gameDayId: root.externalScope.gameDayId,
+        pitchId: root.externalScope.pitchId,
+        gameplaySlotId: "gameplay-slot-configuration-race",
+        sequence: 1,
+        expectedDelayMs: 0,
+        createdAtMs: 1,
+        updatedAtMs: 1,
+      });
+      transaction.insertEventGame({
+        eventGameId: root.eventGameId,
+        eventId: root.eventId,
+        gameDayId: root.externalScope.gameDayId,
+        gameplaySlotId: "gameplay-slot-configuration-race",
+        pitchSlotId: root.externalScope.pitchSlotId,
+        gameCode: null,
+        gameDesignation: null,
+        sideA: {
+          sideId: "side-a",
+          eventTeamId: null,
+          eventTeamName: null,
+          sourceLabel: "A",
+          confirmedAtMs: null,
+        },
+        sideB: {
+          sideId: "side-b",
+          eventTeamId: null,
+          eventTeamName: null,
+          sourceLabel: "B",
+          confirmedAtMs: null,
+        },
+        createdAtMs: 1,
+        updatedAtMs: 1,
+      });
+    });
+
+    let nextCatalogId = 0;
+    const catalog = createEventCatalog(createFoundationEventCatalogStorage(storage), {
+      clock: { nowMs: () => 2 },
+      ids: { next: (kind) => `${kind}-configuration-race-${++nextCatalogId}` },
+    });
+    const technicalAdmin = createTechnicalAdminAuth(
+      { environment: "test", origin: "https://timer.example", rpId: "timer.example" },
+      new MemoryTechnicalAdminAuthRepository(),
+    ).resolveHostLocalAuthority();
+    let holdConfigurationRead = false;
+    const configurationReadStarted = Promise.withResolvers<void>();
+    const releaseConfigurationRead = Promise.withResolvers<void>();
+    const harness = await createHarness({
+      storage,
+      eventGameId: root.eventGameId,
+      readHeatStoppageConfiguration: async (scope) => {
+        if (holdConfigurationRead) {
+          configurationReadStarted.resolve();
+          await releaseConfigurationRead.promise;
+        }
+        return storage.transaction((transaction) =>
+          resolveHeatStoppageConfiguration(transaction, scope),
+        );
+      },
+    });
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "controller-configuration-race",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+    holdConfigurationRead = true;
+
+    const commencement = harness.control.submitControllerIntent({
+      sessionBearer: opened.session.sessionBearer,
+      eventGameId: root.eventGameId,
+      intent: substantiveIntent("configuration-race-commencement", "card"),
+    });
+    await configurationReadStarted.promise;
+
+    expect(
+      await catalog.setGameDayHeatStoppageConfiguration(
+        root.eventId,
+        root.externalScope.gameDayId,
+        { configuration: "enabled" },
+        technicalAdmin,
+      ),
+    ).toMatchObject({ status: "accepted", value: { heatStoppageConfiguration: "enabled" } });
+    releaseConfigurationRead.resolve();
+
+    const commencementResult = await commencement;
+    expect(commencementResult).toMatchObject({
+      status: "accepted",
+      projection: {
+        commencement: { status: "commenced" },
+        heat: { mode: "enabled" },
+      },
+    });
+    expect(
+      await catalog.setGameDayHeatStoppageConfiguration(
+        root.eventId,
+        root.externalScope.gameDayId,
+        { configuration: "disabled" },
+        technicalAdmin,
+      ),
+    ).toMatchObject({ status: "accepted", value: { heatStoppageConfiguration: "disabled" } });
+    expect(
+      await harness.control.refreshController({
+        sessionBearer: opened.session.sessionBearer,
+        eventGameId: root.eventGameId,
+      }),
+    ).toMatchObject({
+      status: "authorized",
+      projection: {
+        commencement: { status: "commenced" },
+        heat: { mode: "enabled" },
+      },
     });
   });
 
@@ -6456,14 +6646,18 @@ async function createHarness(
     scopeStatus?: "empty" | "conflict";
     controlClock?: () => number;
     knownDodgeballIds?: readonly string[];
+    storage?: FoundationStorage;
     sessionResolution?: ControlGrantSessionResolution;
     acceptanceLimits?: AcceptanceLimits;
     heatStoppageConfiguration?: boolean;
+    readHeatStoppageConfiguration?: (
+      scope: HeatStoppageConfigurationScope,
+    ) => HeatStoppageConfiguration | null | Promise<HeatStoppageConfiguration | null>;
   } = {},
 ) {
   const root = createRoot(overrides.eventGameId ?? "game-live-control");
   const reassignedRoot = createRoot("game-reassigned", "reassigned");
-  const storage = createInMemoryFoundationStorage();
+  const storage = overrides.storage ?? createInMemoryFoundationStorage();
   const grantOptions = createGrantOptions(overrides.grantEventGameId ?? root.eventGameId);
   const authority = createTypedGrantAuthority(storage, grantOptions);
   const created = await authority.createControlGrant({
@@ -6547,6 +6741,9 @@ async function createHarness(
     ...(overrides.heatStoppageConfiguration === undefined
       ? {}
       : { heatStoppageConfiguration: overrides.heatStoppageConfiguration }),
+    ...(overrides.readHeatStoppageConfiguration === undefined
+      ? {}
+      : { readHeatStoppageConfiguration: overrides.readHeatStoppageConfiguration }),
   });
   triggerLifecycleChange = () => {
     void control.reconcileActiveControllerSessions();

--- a/src/pages/event-admin-page.tsx
+++ b/src/pages/event-admin-page.tsx
@@ -16,7 +16,12 @@ type HubResponse = {
       timeZone: string;
       lifecycle: string;
       publicationStatus: "unpublished" | "published" | "cancelled";
-      gameDays: Array<{ gameDayId: string; date: string; classification: string }>;
+      gameDays: Array<{
+        gameDayId: string;
+        date: string;
+        classification: string;
+        heatStoppageConfiguration: "enabled" | "disabled";
+      }>;
       teams: Array<{
         eventTeamId: string;
         name: string;
@@ -328,6 +333,9 @@ export function EventAdminPage({
 
   const hubScopeKey = () => `event-admin-hub:${eventId}`;
 
+  const gameDayScopeKey = (nextEventId = eventId, nextGameDayId = selectedGameDayId) =>
+    `event-admin-game-day:${nextEventId}:${nextGameDayId ?? "none"}`;
+
   const clearGrantSecrets = () => {
     setCredential("");
     setGrantCode("");
@@ -346,6 +354,7 @@ export function EventAdminPage({
   const invalidateGrantSecrets = () => {
     accessSheetOwner.invalidate();
     secretOwner.invalidate(secretScopeKey());
+    secretOwner.invalidate(gameDayScopeKey());
     secretOwner.invalidate(hubScopeKey());
     clearGrantSecrets();
   };
@@ -973,6 +982,39 @@ export function EventAdminPage({
     await loadHub(selectedGameDayId);
   };
 
+  const setHeatStoppageConfiguration = async (configuration: "enabled" | "disabled") => {
+    const gameDayId = selectedGameDayId;
+    if (gameDayId === null) return;
+    const token = secretOwner.capture(gameDayScopeKey(eventId, gameDayId));
+    try {
+      const response = await fetch(
+        `/api/event-admin/events/${encodeURIComponent(eventId)}/game-days/${encodeURIComponent(gameDayId)}/heat-stoppage-configuration`,
+        {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ configuration }),
+        },
+      );
+      const payload = (await response.json()) as {
+        status: "accepted" | "rejected" | "retryable-failure";
+        detail?: string;
+      };
+      if (!response.ok || payload.status !== "accepted")
+        throw new Error(payload.detail ?? "Heat Stoppage Configuration update failed.");
+      if (
+        !secretOwner.commit(token, () =>
+          setMessage(
+            `Heat Stoppage Configuration ${configuration === "enabled" ? "enabled" : "disabled"}.`,
+          ),
+        )
+      )
+        return;
+      await loadHub(gameDayId, token);
+    } catch (error) {
+      if (secretOwner.current(token)) throw error;
+    }
+  };
+
   const generateAccessSheet = async () => {
     const attempt = accessSheetOwner.begin();
     const gameDayId = selectedGameDayId ?? "";
@@ -1490,6 +1532,44 @@ export function EventAdminPage({
                   ))}
                 </select>
               </div>
+              {selectedGameDayId !== null ? (
+                <div className="space-y-3 rounded-lg border p-3">
+                  <div>
+                    <p className="font-semibold">Heat Stoppage Configuration</p>
+                    <p className="text-sm text-muted-foreground">
+                      New and uncommenced Event Games follow this Game Day setting. Commenced Games
+                      keep their effective mode.
+                    </p>
+                  </div>
+                  {(() => {
+                    const selectedDay = hub.event.gameDays.find(
+                      (day) => day.gameDayId === selectedGameDayId,
+                    );
+                    if (selectedDay === undefined) return null;
+                    return (
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span className="text-sm" role="status">
+                          Currently {selectedDay.heatStoppageConfiguration}
+                        </span>
+                        {(["enabled", "disabled"] as const).map((configuration) => (
+                          <Button
+                            key={configuration}
+                            disabled={
+                              busy || selectedDay.heatStoppageConfiguration === configuration
+                            }
+                            onClick={() =>
+                              void run(() => setHeatStoppageConfiguration(configuration))
+                            }
+                            variant={configuration === "enabled" ? "default" : "outline"}
+                          >
+                            {configuration === "enabled" ? "Enable" : "Disable"}
+                          </Button>
+                        ))}
+                      </div>
+                    );
+                  })()}
+                </div>
+              ) : null}
               <div className="space-y-3 rounded-lg border p-3">
                 <p className="font-semibold">Event Teams</p>
                 {hub.event.teams.map((team) =>

--- a/src/pages/grant-secret-lifecycle.test.tsx
+++ b/src/pages/grant-secret-lifecycle.test.tsx
@@ -33,7 +33,14 @@ const eventHub = {
     timeZone: "UTC",
     lifecycle: "active",
     publicationStatus: "unpublished",
-    gameDays: [{ gameDayId: "day", date: "2026-08-15", classification: "scheduled" }],
+    gameDays: [
+      {
+        gameDayId: "day",
+        date: "2026-08-15",
+        classification: "scheduled",
+        heatStoppageConfiguration: "disabled" as const,
+      },
+    ],
     teams: [],
     pitches: [{ pitchId: "pitch", name: "Pitch Main" }],
     gameplaySlots: [
@@ -68,7 +75,38 @@ const twoDayEventHub = {
     ...eventHub.event,
     gameDays: [
       ...eventHub.event.gameDays,
-      { gameDayId: "day-two", date: "2026-08-16", classification: "scheduled" },
+      {
+        gameDayId: "day-two",
+        date: "2026-08-16",
+        classification: "scheduled",
+        heatStoppageConfiguration: "enabled" as const,
+      },
+    ],
+  },
+};
+
+const dayBEventHub = {
+  ...twoDayEventHub,
+  selectedGameDayId: "day-two",
+  event: {
+    ...twoDayEventHub.event,
+    gameDays: twoDayEventHub.event.gameDays,
+    gameplaySlots: [
+      {
+        ...eventHub.event.gameplaySlots[0]!,
+        gameplaySlotId: "gameplay-day-two",
+        gameDayId: "day-two",
+        sequence: 2,
+      },
+    ],
+    pitchSlots: [
+      {
+        ...eventHub.event.pitchSlots[0]!,
+        pitchSlotId: "slot-day-two",
+        gameplaySlotId: "gameplay-day-two",
+        gameDayId: "day-two",
+        sequence: 2,
+      },
     ],
   },
 };
@@ -113,6 +151,175 @@ describe("Grant secret UI lifecycle", () => {
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
+  });
+
+  test("Event Admin configures the selected Game Day heat setting", async () => {
+    let configuration: "enabled" | "disabled" = "disabled";
+    let configurationUpdates = 0;
+    let hubCalls = 0;
+    fetchHandler = async (input, init) => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      const method = init?.method ?? "GET";
+      if (url.endsWith("/api/event-admin/admit"))
+        return json({ status: "admitted", sessionExpiresAtMs: 123_000 });
+      if (url.includes("/api/event-admin/hub")) {
+        hubCalls += 1;
+        if (hubCalls === 1) return json({ status: "rejected" }, 401);
+        return json({
+          status: "accepted",
+          value: {
+            ...eventHub,
+            event: {
+              ...eventHub.event,
+              gameDays: [
+                { ...eventHub.event.gameDays[0]!, heatStoppageConfiguration: configuration },
+              ],
+            },
+          },
+        });
+      }
+      if (url.includes("/heat-stoppage-configuration") && method === "PATCH") {
+        configurationUpdates += 1;
+        const rawBody = typeof init?.body === "string" ? init.body : "";
+        const body = JSON.parse(rawBody) as { configuration: typeof configuration };
+        configuration = body.configuration;
+        return json({ status: "accepted", value: { heatStoppageConfiguration: configuration } });
+      }
+      throw new Error(`Unexpected request: ${method} ${url}`);
+    };
+
+    await render(<EventAdminPage />);
+    await admitEventAdmin();
+    expect(container.textContent).toContain("Currently disabled");
+    await clickButton("Enable");
+    expect(configurationUpdates).toBe(1);
+    expect(container.textContent).toContain("Currently enabled");
+  });
+
+  test("Event Admin ignores stale Day A heat success after selecting Day B", async () => {
+    const pendingMutation = deferred<Response>();
+    const hubGameDays: Array<string | null> = [];
+    fetchHandler = async (input, init) => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      const method = init?.method ?? "GET";
+      if (url.includes("/api/event-admin/hub")) {
+        const parsed = new URL(url, "http://timer.quadball.app");
+        const gameDayId = parsed.searchParams.get("gameDayId");
+        hubGameDays.push(gameDayId);
+        return json({
+          status: "accepted",
+          value: gameDayId === "day-two" ? dayBEventHub : twoDayEventHub,
+        });
+      }
+      if (url.includes("/heat-stoppage-configuration") && method === "PATCH")
+        return pendingMutation.promise;
+      throw new Error(`Unexpected request: ${method} ${url}`);
+    };
+
+    await render(<EventAdminPage />);
+    await clickButton("Enable");
+    const gameDaySelector = container.querySelector(
+      "select#game-day-selector",
+    ) as HTMLSelectElement;
+    await act(async () => {
+      setSelectValue(gameDaySelector, "day-two");
+      await flush();
+    });
+    pendingMutation.resolve(
+      json({ status: "accepted", value: { heatStoppageConfiguration: "enabled" } }),
+    );
+    await flushAct();
+
+    expect(gameDaySelector.value).toBe("day-two");
+    expect(container.textContent).toContain("Currently enabled");
+    expect(container.textContent).toContain("Slot 2");
+    expect(container.textContent).not.toContain("Slot 1 ·");
+    expect(container.textContent).not.toContain("Heat Stoppage Configuration enabled.");
+    expect(hubGameDays).toEqual([null, "day-two"]);
+  });
+
+  test("Event Admin ignores stale Day A heat rejection after selecting Day B", async () => {
+    const pendingMutation = deferred<Response>();
+    const hubGameDays: Array<string | null> = [];
+    fetchHandler = async (input, init) => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      const method = init?.method ?? "GET";
+      if (url.includes("/api/event-admin/hub")) {
+        const parsed = new URL(url, "http://timer.quadball.app");
+        const gameDayId = parsed.searchParams.get("gameDayId");
+        hubGameDays.push(gameDayId);
+        return json({
+          status: "accepted",
+          value: gameDayId === "day-two" ? dayBEventHub : twoDayEventHub,
+        });
+      }
+      if (url.includes("/heat-stoppage-configuration") && method === "PATCH")
+        return pendingMutation.promise;
+      throw new Error(`Unexpected request: ${method} ${url}`);
+    };
+
+    await render(<EventAdminPage />);
+    await clickButton("Enable");
+    const gameDaySelector = container.querySelector(
+      "select#game-day-selector",
+    ) as HTMLSelectElement;
+    await act(async () => {
+      setSelectValue(gameDaySelector, "day-two");
+      await flush();
+    });
+    pendingMutation.resolve(json({ status: "rejected", detail: "stale Day A rejection" }, 409));
+    await flushAct();
+
+    expect(gameDaySelector.value).toBe("day-two");
+    expect(container.textContent).toContain("Currently enabled");
+    expect(container.textContent).toContain("Slot 2");
+    expect(container.textContent).not.toContain("Slot 1 ·");
+    expect(container.textContent).not.toContain("stale Day A rejection");
+    expect(hubGameDays).toEqual([null, "day-two"]);
+  });
+
+  test("Event Admin ignores stale Day A heat network failure after selecting Day B", async () => {
+    const pendingMutation = deferred<Response>();
+    const hubGameDays: Array<string | null> = [];
+    fetchHandler = async (input, init) => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      const method = init?.method ?? "GET";
+      if (url.includes("/api/event-admin/hub")) {
+        const parsed = new URL(url, "http://timer.quadball.app");
+        const gameDayId = parsed.searchParams.get("gameDayId");
+        hubGameDays.push(gameDayId);
+        return json({
+          status: "accepted",
+          value: gameDayId === "day-two" ? dayBEventHub : twoDayEventHub,
+        });
+      }
+      if (url.includes("/heat-stoppage-configuration") && method === "PATCH")
+        return pendingMutation.promise;
+      throw new Error(`Unexpected request: ${method} ${url}`);
+    };
+
+    await render(<EventAdminPage />);
+    await clickButton("Enable");
+    const gameDaySelector = container.querySelector(
+      "select#game-day-selector",
+    ) as HTMLSelectElement;
+    await act(async () => {
+      setSelectValue(gameDaySelector, "day-two");
+      await flush();
+    });
+    pendingMutation.reject(new Error("stale Day A network failure"));
+    await flushAct();
+
+    expect(gameDaySelector.value).toBe("day-two");
+    expect(container.textContent).toContain("Currently enabled");
+    expect(container.textContent).toContain("Slot 2");
+    expect(container.textContent).not.toContain("Slot 1 ·");
+    expect(container.textContent).not.toContain("stale Day A network failure");
+    expect(hubGameDays).toEqual([null, "day-two"]);
   });
 
   afterEach(async () => {


### PR DESCRIPTION
## What changed

Event Administration can now configure Heat Stoppage behavior per Game Day through the existing Event Hub. The setting defaults to disabled, is visible before commencement, and is returned through the authoritative Event Administration projection.

## Why

SQM needs a clear Game Day control while preserving the Live Event Game contract. New and uncommenced Event Games resolve the current Game Day setting; a commenced Game freezes exactly one effective Heat mode and is not changed by later catalog edits.

## Authority and audit

- Event Admin may use the authenticated Event Administration PATCH route for the selected Game Day.
- Technical Admin retains the catalog mutation authority.
- Pitch Manager and Controller authorities receive the same generic denial and cannot mutate the catalog.
- Configuration and audit evidence commit atomically in the shared SQLite transaction.
- Existing live runtime ownership from #93 is consumed; this PR does not re-own runtime workflows.

## Browser and deterministic evidence

The canonical Technical Admin Playwright harness covers the rendered disabled default, Event Admin enablement, Technical Admin Game Day transition and disablement, bounded audit history, and admitted Pitch Manager PATCH denial with unchanged projection.

A shared-foundation deterministic test interleaves a real Event Catalog mutation with commencement, proving one atomic frozen configuration and proving a later Game Day change cannot alter the commenced Game.

## Checks

- `bun run check`
- `bun run test` — 842 pass, 0 fail
- `bun run build`
- `bun run test:focused:technical-admin-browser`
- `git diff --check`

No Qualification Tests were run.

## Scope exclusions

No unrelated runtime workflow, sibling ticket, deployment, merge, or issue beyond the requested #114 closure was included.
