### PR TITLE
Render the live spectator Game

### DIFF
--- a/scripts/test-public-event-browser.ts
+++ b/scripts/test-public-event-browser.ts
@@ -19,6 +19,7 @@ import {
   createTechnicalAdminAuth,
   type TechnicalAdminAuthority,
 } from "@/lib/technical-admin-auth";
+import type { PublicAudienceClockProjection } from "@/lib/audience-projection";
 
 const directory = mkdtempSync(join(tmpdir(), "quadball-timer-public-browser-"));
 const foundationDatabase = join(directory, "foundation.sqlite");
@@ -127,6 +128,102 @@ try {
       () => document.documentElement.scrollWidth <= document.documentElement.clientWidth,
     ),
     "phone-sized Event schedule overflows horizontally",
+  );
+
+  const spectatorGamePath = `/events/${encodeURIComponent(current.eventId)}/games/browser-fixture`;
+  let browserClockFreshness: PublicAudienceClockProjection["synchronization"] = "stale";
+  await page.route(
+    `${origin}/api/audience/events/${encodeURIComponent(current.eventId)}/games/browser-fixture`,
+    async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          status: "accepted",
+          value: publicGameFixture(current.eventId, browserClockFreshness),
+        }),
+      });
+    },
+  );
+  await page.goto(`${origin}${spectatorGamePath}`);
+  await page.getByRole("heading", { name: "Live Final" }).waitFor();
+  await page.locator("[data-scoreboard-expanded]").waitFor();
+  await page.getByText("Last synchronized:").waitFor();
+  await page.getByText("Target 40").waitFor();
+  await page.getByText("Suspended").first().waitFor();
+  await page.getByText("started · 0:30 remaining · decision pending").waitFor();
+  await page.getByText("Team Timeout").waitFor();
+  await page.getByText("Game Suspension").waitFor();
+  await page.getByText("Heat Stoppage").waitFor();
+  await page.getByText("Winner Side A · Locked").waitFor();
+  const expandedSides = page.locator("[data-scoreboard-expanded] [data-side-id]");
+  assert((await expandedSides.count()) === 2, "expanded scoreboard did not render two sides");
+  assert(
+    (await expandedSides.nth(0).getAttribute("data-side-id")) === "side-b" &&
+      (await expandedSides.nth(1).getAttribute("data-side-id")) === "side-a",
+    "expanded scoreboard reordered sides without stable IDs",
+  );
+  assert(
+    (await expandedSides.nth(0).innerText()).includes("FLAG CATCH") &&
+      !(await expandedSides.nth(1).innerText()).includes("FLAG CATCH"),
+    "expanded scoreboard marked the wrong catching side",
+  );
+  assert(
+    await page.evaluate(
+      () => document.documentElement.scrollWidth <= document.documentElement.clientWidth,
+    ),
+    "phone-sized spectator Game overflows horizontally",
+  );
+  assert(
+    !(await page.locator("[data-scoreboard-expanded]").getAttribute("class"))?.includes("sticky"),
+    "expanded spectator scoreboard remained sticky",
+  );
+  await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+  await page.locator("[data-scoreboard-compact]").waitFor();
+  const compactText = await page.locator("[data-scoreboard-compact]").innerText();
+  for (const value of [
+    "A Very Long Team Name That Must Wrap On A Phone",
+    "Another Very Long Team Name For A Narrow Phone",
+    "40",
+    "30",
+    "2:05",
+    "Stale clock",
+    "Game Phase: Overtime",
+    "Operational status: Suspended",
+    "Schedule: Past",
+    "FLAG CATCH",
+  ]) {
+    assert(compactText.includes(value), `compact scoreboard omitted ${value}`);
+  }
+  assert(
+    (await page.locator("[data-scoreboard-compact]").getAttribute("class"))?.includes("sticky") ===
+      true,
+    "compact spectator scoreboard did not become sticky after scrolling",
+  );
+  const compactSides = page.locator("[data-scoreboard-compact] [data-side-id]");
+  assert((await compactSides.count()) === 2, "compact scoreboard did not render two sides");
+  assert(
+    (await compactSides.nth(0).getAttribute("data-side-id")) === "side-b" &&
+      (await compactSides.nth(1).getAttribute("data-side-id")) === "side-a",
+    "compact scoreboard reordered sides without stable IDs",
+  );
+  assert(
+    (await compactSides.nth(0).innerText()).includes("FLAG CATCH") &&
+      !(await compactSides.nth(1).innerText()).includes("FLAG CATCH"),
+    "compact scoreboard marked the wrong catching side",
+  );
+  for (const [status, label] of [
+    ["synchronized", "Synchronized clock"],
+    ["estimated", "Estimated clock"],
+    ["stale", "Stale clock"],
+    ["unavailable", "Clock unavailable"],
+  ] as const) {
+    browserClockFreshness = status;
+    await page.reload();
+    await page.getByText(label).first().waitFor();
+  }
+  await page.unroute(
+    `${origin}/api/audience/events/${encodeURIComponent(current.eventId)}/games/browser-fixture`,
   );
   const canonicalResponse = await page.goto(`${origin}${current.canonicalPath}`);
   await page.getByRole("heading", { name: "Published Current" }).waitFor();
@@ -245,6 +342,9 @@ try {
       oneCurrentAutoOpen: true,
       multipleCurrentDiscovery: true,
       busyPhoneSchedule: true,
+      spectatorGamePhone: true,
+      spectatorScoreboardCompaction: true,
+      spectatorSportingProjection: true,
       canonicalNavigation: true,
       unavailableHiddenUnknown: true,
       unavailableDatabaseFailure: true,
@@ -279,6 +379,65 @@ type PublicEventFixture = {
   gameDays: string[];
   canonicalPath: string;
 };
+
+function publicGameFixture(
+  eventId: string,
+  synchronization: PublicAudienceClockProjection["synchronization"] = "stale",
+) {
+  return {
+    eventId,
+    gameCode: "BROWSER-1",
+    gameDesignation: "Live Final",
+    scheduledStartMs: Date.now() - 20 * 60_000,
+    expectedStartMs: Date.now() - 18 * 60_000,
+    scheduleStatus: "past",
+    phase: "overtime",
+    operationalStatus: "suspended",
+    pitch: "Pitch 1",
+    sideA: {
+      name: "A Very Long Team Name That Must Wrap On A Phone",
+      color: "#112233",
+      score: 40,
+    },
+    sideB: {
+      name: "Another Very Long Team Name For A Narrow Phone",
+      color: "#445566",
+      score: 30,
+    },
+    overtimeTarget: 40,
+    clock: {
+      gameTimeMs: 125_000,
+      activePenaltyTimeMs: 0,
+      running: false,
+      projectedAtMs: Date.now(),
+      synchronization,
+      lastSynchronizedAtMs: synchronization === "unavailable" ? null : Date.now() - 30_000,
+      cues: {
+        flagRunnerEntry: "passed",
+        seekerWarning: "passed",
+        seekerCountdownMs: null,
+        seekerRelease: "released",
+      },
+    },
+    teamTimeout: { status: "started", side: "side-a", remainingMs: 30_000 },
+    gameSuspension: "suspended",
+    heatStoppage: {
+      status: "started",
+      mode: "enabled",
+      pending: true,
+      allowedDurationMs: 120_000,
+      actualDurationMs: 90_000,
+      remainingMs: 30_000,
+    },
+    flagState: { catchingSide: "side-b" },
+    result: { status: "finished", winner: "side-a", locked: true },
+    presentation: {
+      pitchOrientation: "side-b-left",
+      displayedTeamColors: { sideA: "#112233", sideB: "#445566" },
+    },
+    canonicalPath: `/events/${encodeURIComponent(eventId)}/games/browser-fixture`,
+  };
+}
 
 async function seedDatabase() {
   const foundation = openSqliteFoundationStorage(foundationDatabase, {

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -145,6 +145,11 @@ describe("App", () => {
       eventId: "event-123",
     });
     expect(parseRoute("/events", "?view=all")).toEqual({ type: "home", showAll: true });
+    expect(parseRoute("/events/event-123/games/game-456", "")).toEqual({
+      type: "event-game",
+      eventId: "event-123",
+      eventGameId: "game-456",
+    });
   });
 
   beforeEach(() => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,11 @@ import {
   parseAdHocHandoffHash,
   type AdHocHandoff,
 } from "@/lib/ad-hoc-handoff";
-import { PublicEventHomePage, PublicEventPage } from "@/pages/public-event-page";
+import {
+  PublicEventGamePage,
+  PublicEventHomePage,
+  PublicEventPage,
+} from "@/pages/public-event-page";
 import { TechnicalAdminPage } from "@/pages/technical-admin-page";
 import "./index.css";
 
@@ -25,6 +29,11 @@ type Route =
   | {
       type: "event";
       eventId: string;
+    }
+  | {
+      type: "event-game";
+      eventId: string;
+      eventGameId: string;
     }
   | {
       type: "color-test";
@@ -73,6 +82,10 @@ export function App({
 
   if (route.type === "event") {
     return <PublicEventPage eventId={route.eventId} />;
+  }
+
+  if (route.type === "event-game") {
+    return <PublicEventGamePage eventId={route.eventId} eventGameId={route.eventGameId} />;
   }
 
   if (route.type === "color-test") {
@@ -202,6 +215,19 @@ export function parseRoute(pathname: string, search: string, hash = ""): Route {
       type: "home",
       ...(new URLSearchParams(search).get("view") === "all" ? { showAll: true } : {}),
     };
+  }
+
+  const eventGameMatch = pathname.match(/^\/events\/([^/]+)\/games\/([^/]+)$/);
+  if (eventGameMatch !== null) {
+    try {
+      return {
+        type: "event-game",
+        eventId: decodeURIComponent(eventGameMatch[1] ?? ""),
+        eventGameId: decodeURIComponent(eventGameMatch[2] ?? ""),
+      };
+    } catch {
+      return { type: "home" };
+    }
   }
 
   const eventMatch = pathname.match(/^\/events\/([^/]+)$/);

--- a/src/index.ts
+++ b/src/index.ts
@@ -310,7 +310,16 @@ async function startServer() {
     }
 
     const eventCatalog = createEventCatalog(eventCatalogStorage, {});
-    const audienceProjection = createAudienceProjection(eventCatalogStorage);
+    let liveEventRuntime: LiveEventGameRuntime | null = null;
+    const audienceProjection = createAudienceProjection(eventCatalogStorage, {
+      gameInput: {
+        async read(eventGameId) {
+          return liveEventRuntime === null
+            ? { status: "unavailable" as const }
+            : await liveEventRuntime.readAudienceProjectionGameInput(eventGameId);
+        },
+      },
+    });
     let eventAdministration: EventAdministration | null = null;
     let administrativeAuditProjection: AdministrativeAuditProjection | null = null;
     if (foundationStorage !== undefined) {
@@ -336,7 +345,6 @@ async function startServer() {
         eventAdministration = null;
       }
     }
-    let liveEventRuntime: LiveEventGameRuntime | null = null;
     const liveEventDatabasePath = storagePaths.eventGameDatabase;
     const liveEventKeyRing = readLiveEventGrantKeyRing();
     if (liveEventKeyRing !== null) {
@@ -648,6 +656,11 @@ async function startServer() {
         "/api/audience/events/:eventId": {
           GET(req: Request) {
             return readAudienceEvent(req, audienceProjection);
+          },
+        },
+        "/api/audience/events/:eventId/games/:eventGameId": {
+          GET(req: Request) {
+            return readAudienceGame(req, audienceProjection);
           },
         },
         "/api/audience/events": {
@@ -2527,6 +2540,18 @@ export async function readAudienceEvent(
   return publicAudienceUnavailableResponse();
 }
 
+export async function readAudienceGame(
+  req: Request,
+  projection: Pick<AudienceProjectionReader, "readGame">,
+): Promise<Response> {
+  const segments = new URL(req.url).pathname.split("/");
+  const eventId = decodePathSegment(segments.at(-3));
+  const eventGameId = decodePathSegment(segments.at(-1));
+  const result = await projection.readGame(eventId, eventGameId);
+  if (result.status === "accepted") return sensitiveJson(result);
+  return publicAudienceUnavailableResponse();
+}
+
 export async function readPublicAudienceEventPage(
   req: Request,
   projection: Pick<AudienceProjectionReader, "read">,
@@ -2758,8 +2783,12 @@ function isPublicEventPath(pathname: string): boolean {
 
 function readPathSegment(url: string): string {
   const segment = new URL(url).pathname.split("/").at(-1) ?? "";
+  return decodePathSegment(segment);
+}
+
+function decodePathSegment(segment: string | undefined): string {
   try {
-    return decodeURIComponent(segment);
+    return decodeURIComponent(segment ?? "");
   } catch {
     return "";
   }

--- a/src/lib/audience-projection.test.ts
+++ b/src/lib/audience-projection.test.ts
@@ -19,11 +19,21 @@ import {
 } from "@/lib/event-catalog";
 import type { EventGameRecordRoot } from "@/lib/foundation-record-types";
 import { createInMemoryFoundationStorage } from "@/lib/foundation-storage-memory";
+import type { ControllerProjection } from "@/lib/live-event-game-control";
+import { readAudienceProjectionGameInput } from "@/lib/live-event-game-runtime";
 import {
   MemoryTechnicalAdminAuthRepository,
   createTechnicalAdminAuth,
 } from "@/lib/technical-admin-auth";
-import { readAudienceEvent, readAudienceEvents, readAudienceSitemap } from "@/index";
+import {
+  readAudienceEvent,
+  readAudienceEvents,
+  readAudienceGame,
+  readAudienceSitemap,
+} from "@/index";
+import { createInitialClockBaseline, projectClockBaseline } from "@/lib/clock-authority";
+import type { ClockProjection } from "@/lib/clock-authority";
+import { createInitialGamePresentation } from "@/lib/game-presentation-projection";
 
 const authority = createTechnicalAdminAuth(
   { environment: "test", origin: "https://timer.example", rpId: "timer.example" },
@@ -78,6 +88,10 @@ describe("Audience Publication Projection", () => {
       "future",
       "future",
     ]);
+    expect(schedule.scheduleGames.find((game) => game.gameCode === "awaiting")).toMatchObject({
+      scheduleStatus: "awaiting-start",
+      operationalStatus: "scheduled",
+    });
     expect(schedule.focusIndex).toBe(1);
     expect(schedule.runningGames[0]?.pitch).toBe("Pitch 1");
     expect(schedule.runningGames[1]?.pitch).toBe("Pitch 2");
@@ -185,7 +199,7 @@ describe("Audience Publication Projection", () => {
     });
   });
 
-  test("regenerates committed Game State and Pitch reassignment", async () => {
+  test("regenerates committed sporting input and Pitch reassignment", async () => {
     let includeGoal = false;
     let reassigned = false;
     const game = createScheduleGame("mutable", "2026-08-14T10:30:00.000Z", "Pitch 1");
@@ -507,7 +521,503 @@ describe("Audience Publication Projection", () => {
     expect(failureBody).toBe(await absenceResponse.text());
     expect(failureBody).not.toContain("private storage detail");
   });
+
+  test("projects one Published Event Game through the strict public allowlist", async () => {
+    const event = {
+      eventId: "event-public",
+      name: "Public Event",
+      timeZone: "UTC",
+      publicationStatus: "published" as const,
+      createdAtMs: 1,
+      updatedAtMs: 1,
+    };
+    const game = {
+      eventGameId: "event-game-public",
+      eventId: event.eventId,
+      gameDayId: "day-public",
+      gameplaySlotId: "slot-public",
+      pitchSlotId: "pitch-slot-public",
+      gameCode: "A1",
+      gameDesignation: "Semi-final",
+      sideA: {
+        sideId: "catalog-side-a",
+        eventTeamId: "team-a",
+        eventTeamName: "Very Long Home Team Name",
+        sourceLabel: null,
+        confirmedAtMs: 1,
+      },
+      sideB: {
+        sideId: "catalog-side-b",
+        eventTeamId: "team-b",
+        eventTeamName: "Very Long Away Team Name",
+        sourceLabel: null,
+        confirmedAtMs: 1,
+      },
+      createdAtMs: 1,
+      updatedAtMs: 1,
+    };
+    const snapshot = {
+      findEvent: (eventId: string) => (eventId === event.eventId ? event : null),
+      findEventGame: (eventGameId: string) => (eventGameId === game.eventGameId ? game : null),
+      findGameplaySlot: () => ({
+        gameplaySlotId: "slot-public",
+        eventId: event.eventId,
+        gameDayId: "day-public",
+        sequence: 1,
+        scheduledStartMs: 10_000,
+        expectedDelayMs: 2_000,
+        createdAtMs: 1,
+        updatedAtMs: 1,
+      }),
+      findPitchSlot: () => ({
+        pitchSlotId: "pitch-slot-public",
+        eventId: event.eventId,
+        gameDayId: "day-public",
+        pitchId: "pitch-public",
+        gameplaySlotId: "slot-public",
+        sequence: 1,
+        expectedDelayMs: 5_000,
+        createdAtMs: 1,
+        updatedAtMs: 1,
+      }),
+      findPitch: () => ({
+        pitchId: "pitch-public",
+        eventId: event.eventId,
+        name: "Pitch A",
+        createdAtMs: 1,
+        updatedAtMs: 1,
+      }),
+      listPitches: () => [
+        {
+          pitchId: "pitch-public",
+          eventId: event.eventId,
+          name: "Pitch A",
+          createdAtMs: 1,
+          updatedAtMs: 1,
+        },
+        {
+          pitchId: "pitch-public-b",
+          eventId: event.eventId,
+          name: "Pitch B",
+          createdAtMs: 1,
+          updatedAtMs: 1,
+        },
+      ],
+      findEventTeam: (eventTeamId: string) => ({
+        eventTeamId,
+        eventId: event.eventId,
+        name: eventTeamId === "team-a" ? "Very Long Home Team Name" : "Very Long Away Team Name",
+        defaultColor: eventTeamId === "team-a" ? "#112233" : "#445566",
+        createdAtMs: 1,
+        updatedAtMs: 1,
+      }),
+    } as unknown as EventCatalogStorageSnapshot;
+    const clock = projectClockBaseline(
+      { ...createInitialClockBaseline(), gameTimeMs: 12_000, lastAcceptedAtMs: 12_000 },
+      12_000,
+    );
+    const audience = createAudienceProjection(
+      { snapshot: async () => snapshot } as unknown as EventCatalogFoundationStorage,
+      {
+        now: () => 12_000,
+        gameInput: {
+          read: async () => ({
+            status: "accepted" as const,
+            value: {
+              gameSideIds: ["stable-side-a", "stable-side-b"] as const,
+              phase: "seekers-released" as const,
+              operationalStatus: "paused" as const,
+              scoreByGameSide: { "stable-side-a": 10, "stable-side-b": 20 },
+              clock,
+              presentation: {
+                ...createInitialGamePresentation(["stable-side-a", "stable-side-b"], {
+                  "stable-side-a": "#abcdef",
+                  "stable-side-b": "#fedcba",
+                }),
+                pitchOrientation: "side-b-left" as const,
+              },
+              overtimeTarget: null,
+              teamTimeout: { status: "inactive" as const, gameSideId: null, remainingMs: null },
+              heatStoppage: {
+                status: "started" as const,
+                mode: "enabled" as const,
+                pending: true,
+                allowedDurationMs: 120_000,
+                actualDurationMs: 90_000,
+                remainingMs: 30_000,
+              },
+              winnerGameSideId: null,
+              catchingGameSideId: null,
+              locked: false,
+            },
+          }),
+        },
+      },
+    );
+
+    const result = await audience.readGame(event.eventId, game.eventGameId);
+    expect(result).toMatchObject({
+      status: "accepted",
+      value: {
+        eventId: event.eventId,
+        gameCode: "A1",
+        operationalStatus: "paused",
+        phase: "seekers-released",
+        scheduledStartMs: 10_000,
+        expectedStartMs: 15_000,
+        pitch: "Pitch A",
+        sideA: { name: "Very Long Home Team Name", color: "#abcdef", score: 10 },
+        sideB: { name: "Very Long Away Team Name", color: "#fedcba", score: 20 },
+        presentation: {
+          pitchOrientation: "side-b-left",
+          displayedTeamColors: { sideA: "#abcdef", sideB: "#fedcba" },
+        },
+        teamTimeout: { status: "inactive", side: null, remainingMs: null },
+        heatStoppage: {
+          status: "started",
+          mode: "enabled",
+          pending: true,
+          allowedDurationMs: 120_000,
+          actualDurationMs: 90_000,
+          remainingMs: 30_000,
+        },
+        flagState: { catchingSide: null },
+        result: { status: "unfinished", winner: null, locked: false },
+      },
+    });
+    if (result.status !== "accepted") return;
+    const serialized = JSON.stringify(result.value);
+    expect(Object.keys(result.value)).not.toContain("timeout");
+    expect(Object.keys(result.value)).not.toContain("suspension");
+    expect(Object.keys(result.value)).not.toContain("stoppage");
+    expect(Object.keys(result.value)).not.toContain("heat");
+    expect(Object.keys(result.value)).not.toContain("winner");
+    expect(serialized).not.toContain('"caught"');
+    expect(serialized).not.toContain('"flagCatch"');
+    expect(serialized).not.toContain("grant");
+    expect(serialized).not.toContain("session");
+    expect(serialized).not.toContain("action");
+    expect(serialized).not.toContain("audit");
+    expect(serialized).not.toContain("correction");
+    expect(serialized).not.toContain("provenance");
+    expect(serialized).not.toContain("authority");
+    const httpResponse = await readAudienceGame(
+      new Request(
+        `https://timer.example/api/audience/events/${event.eventId}/games/${game.eventGameId}`,
+      ),
+      audience,
+    );
+    expect(httpResponse.status).toBe(200);
+    expect(httpResponse.headers.get("cache-control")).toBe("no-store");
+    expect(await httpResponse.text()).toContain('"status":"accepted"');
+  });
+
+  test("keeps hidden and unknown Event Game routes anonymously absent", async () => {
+    const projection = {
+      readGame: async () => ({ status: "unavailable" as const }),
+    };
+    const responses = await Promise.all(
+      ["hidden", "unknown"].map((eventId) =>
+        readAudienceGame(
+          new Request(`https://timer.example/api/audience/events/${eventId}/games/game-1`),
+          projection,
+        ),
+      ),
+    );
+    expect(responses.map((response) => response.status)).toEqual([404, 404]);
+    const bodies = await Promise.all(responses.map((response) => response.text()));
+    expect(bodies[0]).toBe(bodies[1]);
+    expect(bodies[0]).toBe('{"status":"unavailable"}');
+  });
+
+  test("table-drives the runtime adapter through the one public projector", async () => {
+    const nowMs = Date.parse("2026-08-14T10:00:00.000Z");
+    const game = createScheduleGame("adapter", "2026-08-14T09:30:00.000Z", "Pitch 1");
+    const baseRoot = createScheduleRoot("adapter", "in-progress");
+    const baseSnapshot = createScheduleSnapshot({
+      pitches: ["Pitch 1"],
+      games: [game],
+      roots: new Map([["adapter", baseRoot]]),
+    });
+    const sentinel = {
+      grant: "PRIVATE_GRANT_SENTINEL_135",
+      session: "PRIVATE_SESSION_SENTINEL_135",
+      action: "PRIVATE_ACTION_SENTINEL_135",
+      audit: "PRIVATE_AUDIT_SENTINEL_135",
+      correction: "PRIVATE_CORRECTION_SENTINEL_135",
+      authority: "PRIVATE_AUTHORITY_SENTINEL_135",
+      provenance: "PRIVATE_PROVENANCE_SENTINEL_135",
+    } as const;
+    const cases: readonly {
+      name: string;
+      root?: EventGameRecordRoot;
+      projection: ControllerProjection;
+      expected: Record<string, unknown>;
+      sentinels?: readonly string[];
+    }[] = [
+      {
+        name: "awaiting-start",
+        root: { ...baseRoot, lifecycle: { ...baseRoot.lifecycle, phase: "scheduled" } },
+        projection: createAudienceControllerProjection({ phase: "scheduled" }),
+        expected: { scheduleStatus: "awaiting-start", operationalStatus: "scheduled" },
+      },
+      {
+        name: "running",
+        projection: createAudienceControllerProjection({
+          clock: createAudienceClock({ running: true, synchronization: "synchronized" }),
+        }),
+        expected: { scheduleStatus: "running", operationalStatus: "running" },
+      },
+      {
+        name: "paused-stale",
+        projection: createAudienceControllerProjection({
+          clock: createAudienceClock({ synchronization: "stale" }),
+        }),
+        expected: { operationalStatus: "paused", clock: { synchronization: "stale" } },
+      },
+      {
+        name: "paused-estimated",
+        projection: createAudienceControllerProjection({
+          clock: createAudienceClock({ synchronization: "estimated" }),
+        }),
+        expected: { operationalStatus: "paused", clock: { synchronization: "estimated" } },
+      },
+      {
+        name: "disconnected-clock",
+        projection: createAudienceControllerProjection({
+          clock: createAudienceClock({
+            synchronization: "unavailable",
+            lastSynchronizedAtMs: null,
+          }),
+        }),
+        expected: {
+          operationalStatus: "paused",
+          clock: { synchronization: "unavailable", lastSynchronizedAtMs: null },
+        },
+      },
+      {
+        name: "overtime-target",
+        projection: createAudienceControllerProjection({
+          overtime: true,
+          overtimeTarget: 60,
+        }),
+        expected: { phase: "overtime", overtimeTarget: 60 },
+      },
+      {
+        name: "flag-catch",
+        projection: createAudienceControllerProjection({
+          scoreByGameSide: { "adapter-a": 30, "adapter-b": 20 },
+          winnerGameSideId: "adapter-a",
+          catch: {
+            factId: "catch-fact",
+            catchingGameSideId: "adapter-a",
+            nonCatchingGameSideId: "adapter-b",
+            gameTimeMs: 20 * 60 * 1000,
+            targetScore: 40,
+          },
+        }),
+        expected: {
+          sideA: { score: 30 },
+          sideB: { score: 20 },
+          flagState: { catchingSide: "side-a" },
+          result: { winner: "side-a" },
+        },
+      },
+      {
+        name: "team-timeout",
+        projection: createAudienceControllerProjection({
+          timeout: {
+            status: "started",
+            factId: "timeout-fact",
+            gameSideId: "adapter-b",
+            remainingMs: 15_000,
+          },
+        }),
+        expected: { teamTimeout: { status: "started", side: "side-b", remainingMs: 15_000 } },
+      },
+      {
+        name: "game-suspension",
+        projection: createAudienceControllerProjection({ phase: "suspended" }),
+        expected: {
+          operationalStatus: "suspended",
+          gameSuspension: "suspended",
+        },
+      },
+      {
+        name: "heat-stoppage",
+        projection: createAudienceControllerProjection({
+          heat: {
+            status: "started",
+            factId: "heat-fact",
+            startedAtGameTimeMs: 90_000,
+            nominalDurationMs: 120_000,
+            allowedDurationMs: 120_000,
+            actualDurationMs: 90_000,
+            completionAtTrustedAtMs: nowMs + 30_000,
+            mode: "enabled",
+            pendingTriggerGameTimeMs: null,
+          },
+        }),
+        expected: {
+          heatStoppage: { status: "started", remainingMs: 30_000 },
+        },
+      },
+      {
+        name: "finished-locked",
+        root: {
+          ...baseRoot,
+          lifecycle: { ...baseRoot.lifecycle, phase: "finished", lockedAtMs: nowMs },
+        },
+        projection: createAudienceControllerProjection({
+          phase: "finished",
+          winnerGameSideId: "adapter-b",
+          result: {
+            factId: "result-fact",
+            data: { resultKind: "concession", private: sentinel.correction },
+          },
+        }),
+        expected: {
+          operationalStatus: "finished",
+          result: { status: "finished", winner: "side-b", locked: true },
+        },
+      },
+      {
+        name: "private-source-sentinels",
+        projection: createAudienceControllerProjection({
+          clock: createAudienceClock({
+            baseline: {
+              ...createInitialClockBaseline(),
+              holderGrantSessionId: sentinel.session,
+              lastTransitionOperationId: sentinel.action,
+              staleGenerationOperationIds: [sentinel.authority],
+            },
+          }),
+          timeout: {
+            status: "started",
+            factId: sentinel.grant,
+            gameSideId: "adapter-a",
+            remainingMs: 10_000,
+          },
+          suspension: { status: "suspended", factId: sentinel.correction, snapshot: null },
+          stoppage: { status: "suspension", factId: sentinel.provenance },
+          heat: {
+            status: "started",
+            factId: sentinel.action,
+            startedAtGameTimeMs: 1,
+            nominalDurationMs: 120_000,
+            allowedDurationMs: 120_000,
+            actualDurationMs: 90_000,
+            completionAtTrustedAtMs: nowMs + 30_000,
+            mode: "enabled",
+            pendingTriggerGameTimeMs: null,
+          },
+          result: { factId: sentinel.audit, data: { private: sentinel.authority } },
+          catch: {
+            factId: sentinel.action,
+            catchingGameSideId: "adapter-a",
+            nonCatchingGameSideId: "adapter-b",
+            gameTimeMs: 1,
+            targetScore: 40,
+          },
+          gameFacts: [
+            {
+              factId: sentinel.audit,
+              factType: "private",
+              gameSideId: null,
+              gameTimeMs: null,
+              sportingOrder: 0,
+              synchronizationOrder: 0,
+              effective: true,
+              data: { private: sentinel.session },
+            },
+          ],
+        }),
+        expected: {
+          operationalStatus: "paused",
+          heatStoppage: { remainingMs: 30_000 },
+        },
+        sentinels: Object.values(sentinel),
+      },
+    ];
+
+    for (const scenario of cases) {
+      const input = readAudienceProjectionGameInput(scenario.root ?? baseRoot, scenario.projection);
+      expect(input.status, scenario.name).toBe("accepted");
+      if (input.status !== "accepted") continue;
+      const audience = createAudienceProjection(
+        { snapshot: async () => baseSnapshot } as unknown as EventCatalogFoundationStorage,
+        {
+          now: () => nowMs,
+          gameInput: { read: async () => input },
+        },
+      );
+      const result = await audience.readGame("event-schedule", "adapter");
+      expect(result.status, scenario.name).toBe("accepted");
+      if (result.status !== "accepted") continue;
+      expect(result.value, scenario.name).toMatchObject(scenario.expected);
+      for (const privateSentinel of scenario.sentinels ?? []) {
+        expect(JSON.stringify(scenario.projection)).toContain(privateSentinel);
+        expect(JSON.stringify(result.value)).not.toContain(privateSentinel);
+      }
+    }
+  });
 });
+
+function createAudienceClock(overrides: Partial<ClockProjection> = {}): ClockProjection {
+  const baseline = createInitialClockBaseline();
+  const projection = projectClockBaseline(baseline, 12_000);
+  return {
+    ...projection,
+    ...overrides,
+    baseline: { ...projection.baseline, ...overrides.baseline },
+    cues: { ...projection.cues, ...overrides.cues },
+  };
+}
+
+function createAudienceControllerProjection(
+  overrides: Partial<ControllerProjection> = {},
+): ControllerProjection {
+  return {
+    eventGameId: "adapter",
+    phase: "in-progress",
+    scoreByGameSide: { "adapter-a": 0, "adapter-b": 0 },
+    goalCount: 0,
+    timeout: {
+      status: "inactive",
+      factId: null,
+      gameSideId: null,
+      remainingMs: null,
+    },
+    suspension: { status: "none", factId: null, snapshot: null },
+    stoppage: { status: "none", factId: null },
+    heat: {
+      status: "inactive",
+      factId: null,
+      startedAtGameTimeMs: null,
+      nominalDurationMs: null,
+      mode: "enabled",
+      pendingTriggerGameTimeMs: null,
+    },
+    result: null,
+    overtime: false,
+    overtimeTarget: null,
+    winnerGameSideId: null,
+    catch: null,
+    commencement: {
+      status: "commenced",
+      commencedAtMs: 1,
+      provisionalRunningSinceMs: null,
+      provisionalElapsedMs: 0,
+    },
+    clock: createAudienceClock(),
+    presentation: {
+      gameSideIds: ["adapter-a", "adapter-b"],
+      pitchOrientation: "side-a-left",
+      displayedTeamColors: { "adapter-a": "#112233", "adapter-b": "#445566" },
+    },
+    ...overrides,
+  };
+}
 
 function createScheduleSnapshot(input: {
   pitches: string[];

--- a/src/lib/audience-projection.ts
+++ b/src/lib/audience-projection.ts
@@ -11,6 +11,8 @@ import {
   projectLiveEventGameDerivedState,
   type LiveEventGameDerivedState,
 } from "@/lib/live-event-game-control";
+import type { ClockProjection } from "@/lib/clock-authority";
+import type { GamePresentation } from "@/lib/game-presentation";
 
 export type PublicAudienceEventLifecycle = "unscheduled" | "current" | "future" | "past";
 
@@ -38,8 +40,47 @@ export type PublicAudienceGameSide = {
   name: string | null;
   color: string | null;
   score: number | null;
-  flagCatch: boolean;
 };
+
+export type PublicAudienceTeamTimeout = {
+  status: "inactive" | "stoppage" | "started" | "completed";
+  side: "side-a" | "side-b" | null;
+  remainingMs: number | null;
+};
+
+export type PublicAudienceGameSuspension = "none" | "suspended";
+
+export type PublicAudienceHeatStoppage = {
+  status:
+    | "inactive"
+    | "started"
+    | "ended"
+    | "skipped"
+    | "required-skip"
+    | "suppressed"
+    | "extended";
+  mode: "enabled" | "disabled" | null;
+  pending: boolean;
+  allowedDurationMs: number | null;
+  actualDurationMs: number | null;
+  remainingMs: number | null;
+};
+
+export type PublicAudienceResult = {
+  status: "unfinished" | "finished";
+  winner: "side-a" | "side-b" | null;
+  locked: boolean;
+};
+
+type PublicAudienceGameOperationalProjection =
+  | {
+      operationalStatus: Exclude<PublicAudienceGameOperationalStatus, "suspended">;
+      gameSuspension: "none";
+    }
+  | {
+      operationalStatus: "suspended";
+      gameSuspension: "suspended";
+    };
 
 export type PublicAudienceClockProjection = {
   gameTimeMs: number;
@@ -51,20 +92,57 @@ export type PublicAudienceClockProjection = {
   cues: LiveEventGameDerivedState["clock"]["cues"];
 };
 
-export type PublicAudienceGameProjection = {
+export type PublicAudienceGameProjection = PublicAudienceGameOperationalProjection & {
+  eventId: string;
   gameCode: string | null;
   gameDesignation: string | null;
   scheduledStartMs: number;
   expectedStartMs: number;
   scheduleStatus: PublicAudienceGameScheduleStatus;
   phase: PublicAudienceGamePhase;
-  operationalStatus: PublicAudienceGameOperationalStatus;
   pitch: string | null;
   sideA: PublicAudienceGameSide;
   sideB: PublicAudienceGameSide;
-  winner: "side-a" | "side-b" | null;
   overtimeTarget: number | null;
   clock: PublicAudienceClockProjection | null;
+  teamTimeout: PublicAudienceTeamTimeout;
+  heatStoppage: PublicAudienceHeatStoppage;
+  flagState: { catchingSide: "side-a" | "side-b" | null };
+  result: PublicAudienceResult;
+  presentation: {
+    pitchOrientation: "side-a-left" | "side-b-left";
+    displayedTeamColors: { sideA: string | null; sideB: string | null };
+  };
+  canonicalPath: string;
+};
+
+/** Allowlisted, server-side input for one public Audience Projection. */
+export type AudienceProjectionGameInput = {
+  gameSideIds: readonly [string, string];
+  phase: PublicAudienceGamePhase;
+  operationalStatus: PublicAudienceGameOperationalStatus;
+  scoreByGameSide: Readonly<Record<string, number>>;
+  clock: ClockProjection | null;
+  presentation: GamePresentation | null;
+  overtimeTarget: number | null;
+  teamTimeout: {
+    status: PublicAudienceTeamTimeout["status"];
+    gameSideId: string | null;
+    remainingMs: number | null;
+  };
+  heatStoppage: PublicAudienceHeatStoppage;
+  winnerGameSideId: string | null;
+  catchingGameSideId: string | null;
+  locked: boolean;
+};
+
+export type AudienceProjectionGameInputOutcome =
+  | { status: "accepted"; value: AudienceProjectionGameInput }
+  | { status: "unavailable" }
+  | { status: "retryable-failure" };
+
+export type AudienceProjectionGameInputReader = {
+  read(eventGameId: string): Promise<AudienceProjectionGameInputOutcome>;
 };
 
 export type PublicAudienceScheduleProjection = {
@@ -104,10 +182,19 @@ export type AudienceProjectionListOutcome =
 
 export type AudienceProjectionOptions = {
   now?: () => number;
+  gameInput?: AudienceProjectionGameInputReader;
 };
 
 export type AudienceProjectionReader = {
   read(eventId: unknown): Promise<AudienceProjectionOutcome>;
+  readGame(
+    eventId: unknown,
+    eventGameId: unknown,
+  ): Promise<
+    | { status: "accepted"; value: PublicAudienceGameProjection }
+    | { status: "unavailable" }
+    | { status: "retryable-failure" }
+  >;
   list(): Promise<AudienceProjectionListOutcome>;
 };
 
@@ -134,6 +221,38 @@ export function createAudienceProjection(
         if (event === null || event.publicationStatus !== "published")
           return { status: "unavailable" };
         return { status: "accepted", value: projectPublicEvent(snapshot, event, now()) };
+      } catch {
+        return { status: "retryable-failure" };
+      }
+    },
+    async readGame(eventId: unknown, eventGameId: unknown) {
+      if (
+        typeof eventId !== "string" ||
+        eventId.trim().length === 0 ||
+        typeof eventGameId !== "string" ||
+        eventGameId.trim().length === 0 ||
+        options.gameInput === undefined
+      )
+        return { status: "unavailable" };
+      try {
+        const snapshot = await storage.snapshot();
+        const event = snapshot.findEvent(eventId);
+        const game = snapshot.findEventGame(eventGameId);
+        if (
+          event === null ||
+          event.publicationStatus !== "published" ||
+          game === null ||
+          game.eventId !== eventId
+        )
+          return { status: "unavailable" };
+        const input = await options.gameInput.read(eventGameId);
+        if (input.status !== "accepted") return input;
+        const projected = projectScheduleGames(snapshot, [game]).at(0);
+        if (projected === undefined) return { status: "unavailable" };
+        return {
+          status: "accepted",
+          value: projectAudienceGameFromInput(snapshot, event, projected, input.value, now()),
+        };
       } catch {
         return { status: "retryable-failure" };
       }
@@ -179,15 +298,104 @@ function projectPublicEvent(
       color: defaultColor,
     })),
     pitches: snapshot.listPitches(event.eventId).map(({ name }) => ({ name })),
-    schedule: projectSchedule(snapshot, event.eventId, nowMs),
+    schedule: projectSchedule(snapshot, event, nowMs),
   };
+}
+
+function projectAudienceGameFromInput(
+  snapshot: EventCatalogStorageSnapshot,
+  event: StoredEvent,
+  game: ProjectedEventGame,
+  input: AudienceProjectionGameInput,
+  nowMs: number,
+): PublicAudienceGameProjection {
+  const sideA = projectAudienceGameSideFromInput(snapshot, game.sideA, input, "a");
+  const sideB = projectAudienceGameSideFromInput(snapshot, game.sideB, input, "b");
+  const winner = sideForGameSideId(input.winnerGameSideId, input.gameSideIds);
+  const pitchSlot = snapshot.findPitchSlot(game.pitchSlotId);
+  const pitch = pitchSlot === null ? null : (snapshot.findPitch(pitchSlot.pitchId)?.name ?? null);
+  const multiplePitches = snapshot.listPitches(event.eventId).length > 1;
+  return {
+    eventId: event.eventId,
+    gameCode: game.gameCode,
+    gameDesignation: game.gameDesignation,
+    scheduledStartMs: scheduledStartForGame(snapshot, game),
+    expectedStartMs: game.expectedStartMs,
+    scheduleStatus: classifyScheduleStatus(
+      input.operationalStatus === "finished"
+        ? "finished"
+        : input.operationalStatus === "suspended"
+          ? "suspended"
+          : input.operationalStatus === "scheduled"
+            ? "scheduled"
+            : "in-progress",
+      game.expectedStartMs,
+      nowMs,
+    ),
+    phase: input.phase,
+    ...publicOperationalProjection(input.operationalStatus),
+    pitch: multiplePitches ? pitch : null,
+    sideA,
+    sideB,
+    overtimeTarget: input.overtimeTarget,
+    clock: projectClock(input.clock),
+    teamTimeout: {
+      status: input.teamTimeout.status,
+      side: sideForGameSideId(input.teamTimeout.gameSideId, input.gameSideIds),
+      remainingMs: input.teamTimeout.remainingMs,
+    },
+    heatStoppage: structuredClone(input.heatStoppage),
+    flagState: {
+      catchingSide: sideForGameSideId(input.catchingGameSideId, input.gameSideIds),
+    },
+    result: {
+      status: input.operationalStatus === "finished" ? "finished" : "unfinished",
+      winner,
+      locked: input.locked,
+    },
+    presentation: {
+      pitchOrientation: input.presentation?.pitchOrientation ?? "side-a-left",
+      displayedTeamColors: {
+        sideA: sideA.color,
+        sideB: sideB.color,
+      },
+    },
+    canonicalPath: `/events/${encodeURIComponent(event.eventId)}/games/${encodeURIComponent(game.eventGameId)}`,
+  };
+}
+
+function projectAudienceGameSideFromInput(
+  snapshot: EventCatalogStorageSnapshot,
+  side: EventGame["sideA"],
+  input: AudienceProjectionGameInput,
+  sideLabel: "a" | "b",
+): PublicAudienceGameSide {
+  const eventColor =
+    side.eventTeamId === null
+      ? null
+      : (snapshot.findEventTeam(side.eventTeamId)?.defaultColor ?? null);
+  const gameSideId = input.gameSideIds[sideLabel === "a" ? 0 : 1]!;
+  return {
+    name: side.eventTeamName ?? side.sourceLabel,
+    color: input.presentation?.displayedTeamColors[gameSideId] ?? eventColor,
+    score: input.scoreByGameSide[gameSideId] ?? null,
+  };
+}
+
+function sideForGameSideId(
+  gameSideId: string | null,
+  gameSideIds: readonly [string, string] | undefined,
+): "side-a" | "side-b" | null {
+  if (gameSideIds === undefined) return null;
+  return gameSideId === gameSideIds[0] ? "side-a" : gameSideId === gameSideIds[1] ? "side-b" : null;
 }
 
 function projectSchedule(
   snapshot: EventCatalogStorageSnapshot,
-  eventId: string,
+  event: StoredEvent,
   nowMs: number,
 ): PublicAudienceScheduleProjection {
+  const eventId = event.eventId;
   const gamesById = new Map<string, EventGame>();
   for (const gameDay of snapshot.listGameDays(eventId)) {
     for (const game of snapshot.listEventGames(gameDay.gameDayId)) {
@@ -196,9 +404,16 @@ function projectSchedule(
     }
   }
 
-  const multiplePitches = snapshot.listPitches(eventId).length > 1;
   const projected = projectScheduleGames(snapshot, [...gamesById.values()])
-    .map((game) => projectAudienceGame(snapshot, game, nowMs, multiplePitches))
+    .map((game) =>
+      projectAudienceGameFromInput(
+        snapshot,
+        event,
+        game,
+        readAudienceProjectionGameInputFromCatalog(snapshot, game, nowMs),
+        nowMs,
+      ),
+    )
     .sort(compareAudienceGames);
   const runningGames = projected.filter((game) => game.scheduleStatus === "running");
   const upcomingGames = projected.filter(
@@ -218,39 +433,59 @@ function projectSchedule(
   };
 }
 
-function projectAudienceGame(
+function readAudienceProjectionGameInputFromCatalog(
   snapshot: EventCatalogStorageSnapshot,
   game: ProjectedEventGame,
   nowMs: number,
-  multiplePitches: boolean,
-): PublicAudienceGameProjection {
+): AudienceProjectionGameInput {
   const root = snapshot.findRootByEventGameId(game.eventGameId);
   const derived = root === null ? null : readDerivedState(snapshot, root);
   const lifecyclePhase = derived?.phase ?? root?.lifecycle.phase ?? "scheduled";
-  const phase = projectGamePhase(derived);
-  const pitchSlot = snapshot.findPitchSlot(game.pitchSlotId);
-  const pitch = pitchSlot === null ? null : (snapshot.findPitch(pitchSlot.pitchId)?.name ?? null);
-  const sideA = projectAudienceGameSide(snapshot, game.sideA, derived, root, "a");
-  const sideB = projectAudienceGameSide(snapshot, game.sideB, derived, root, "b");
-  const winner = winnerSide(derived, root);
-
+  const gameSideIds = [
+    root?.gameSides[0]?.id ?? game.sideA.sideId,
+    root?.gameSides[1]?.id ?? game.sideB.sideId,
+  ] as const;
+  const clock = derived === null ? null : projectClockBaseline(derived.clock.baseline, nowMs);
   return {
-    gameCode: game.gameCode,
-    gameDesignation: game.gameDesignation,
-    scheduledStartMs: scheduledStartForGame(snapshot, game),
-    expectedStartMs: game.expectedStartMs,
-    scheduleStatus: classifyScheduleStatus(lifecyclePhase, game.expectedStartMs, nowMs),
-    phase,
+    gameSideIds,
+    phase: projectGamePhase(derived),
     operationalStatus: operationalStatus(lifecyclePhase, derived),
-    pitch: multiplePitches ? pitch : null,
-    sideA,
-    sideB,
-    winner,
+    scoreByGameSide: structuredClone(derived?.scoreByGameSide ?? {}),
+    clock,
+    presentation:
+      derived?.presentation === undefined ? null : structuredClone(derived.presentation),
     overtimeTarget: derived?.overtimeTarget ?? null,
-    clock: projectClock(
-      derived === null ? null : projectClockBaseline(derived.clock.baseline, nowMs),
-    ),
+    teamTimeout: {
+      status: derived?.timeout.status ?? "inactive",
+      gameSideId: derived?.timeout.gameSideId ?? null,
+      remainingMs: derived?.timeout.remainingMs ?? null,
+    },
+    heatStoppage: {
+      status: derived?.heat.status ?? "inactive",
+      mode: derived?.heat.mode ?? null,
+      pending: (derived?.heat.pendingTriggerGameTimeMs ?? null) !== null,
+      allowedDurationMs: derived?.heat.allowedDurationMs ?? null,
+      actualDurationMs: derived?.heat.actualDurationMs ?? null,
+      remainingMs: heatRemainingMs(derived?.heat.allowedDurationMs, derived?.heat.actualDurationMs),
+    },
+    winnerGameSideId: derived?.winnerGameSideId ?? null,
+    catchingGameSideId: derived?.catch?.catchingGameSideId ?? null,
+    locked: root?.lifecycle.lockedAtMs !== null && root?.lifecycle.lockedAtMs !== undefined,
   };
+}
+
+function heatRemainingMs(
+  allowedDurationMs: number | null | undefined,
+  actualDurationMs: number | null | undefined,
+) {
+  if (
+    allowedDurationMs === null ||
+    allowedDurationMs === undefined ||
+    actualDurationMs === null ||
+    actualDurationMs === undefined
+  )
+    return null;
+  return Math.max(0, allowedDurationMs - actualDurationMs);
 }
 
 function readDerivedState(
@@ -262,35 +497,6 @@ function readDerivedState(
     throw new Error("Committed Event Game state cannot be rebuilt.");
   }
   return derived;
-}
-
-function projectAudienceGameSide(
-  snapshot: EventCatalogStorageSnapshot,
-  side: EventGame["sideA"],
-  derived: LiveEventGameDerivedState | null,
-  root: ReturnType<EventCatalogStorageSnapshot["findRootByEventGameId"]>,
-  sideLabel: "a" | "b",
-): PublicAudienceGameSide {
-  const color =
-    side.eventTeamId === null
-      ? null
-      : (snapshot.findEventTeam(side.eventTeamId)?.defaultColor ?? null);
-  const rootSide = root?.gameSides[sideLabel === "a" ? 0 : 1];
-  const score =
-    derived === null || rootSide === undefined
-      ? null
-      : (derived.scoreByGameSide[rootSide.id] ?? null);
-  const flagCatch =
-    derived?.catch !== null &&
-    derived?.catch !== undefined &&
-    rootSide !== undefined &&
-    derived.catch.catchingGameSideId === rootSide.id;
-  return {
-    name: side.eventTeamName ?? side.sourceLabel,
-    color,
-    score,
-    flagCatch,
-  };
 }
 
 function scheduledStartForGame(snapshot: EventCatalogStorageSnapshot, game: ProjectedEventGame) {
@@ -327,24 +533,15 @@ function operationalStatus(
         : "scheduled";
 }
 
-function winnerSide(
-  derived: LiveEventGameDerivedState | null,
-  root: ReturnType<EventCatalogStorageSnapshot["findRootByEventGameId"]>,
-): "side-a" | "side-b" | null {
-  if (
-    derived?.winnerGameSideId === null ||
-    derived?.winnerGameSideId === undefined ||
-    root === null
-  )
-    return null;
-  if (root.gameSides[0]?.id === derived.winnerGameSideId) return "side-a";
-  if (root.gameSides[1]?.id === derived.winnerGameSideId) return "side-b";
-  return null;
+function publicOperationalProjection(
+  operationalStatus: PublicAudienceGameOperationalStatus,
+): PublicAudienceGameOperationalProjection {
+  return operationalStatus === "suspended"
+    ? { operationalStatus, gameSuspension: "suspended" }
+    : { operationalStatus, gameSuspension: "none" };
 }
 
-function projectClock(
-  clock: LiveEventGameDerivedState["clock"] | null,
-): PublicAudienceClockProjection | null {
+function projectClock(clock: ClockProjection | null): PublicAudienceClockProjection | null {
   if (clock === null) return null;
   return {
     gameTimeMs: clock.gameTimeMs,

--- a/src/lib/live-event-game-control.ts
+++ b/src/lib/live-event-game-control.ts
@@ -3330,6 +3330,21 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
     };
   }
 
+  async function readControllerProjection(
+    eventGameId: string,
+  ): Promise<ControllerProjection | null> {
+    try {
+      const owner = await options.resolveEventGameRecord(eventGameId);
+      if (owner === null) return null;
+      const root = await owner.record.readRoot(owner.recordId);
+      return root === null || root.eventGameId !== eventGameId
+        ? null
+        : await readProjection(owner.record, root);
+    } catch {
+      return null;
+    }
+  }
+
   return {
     openController,
     refreshController,
@@ -3361,6 +3376,7 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
     replayControlActions: replayControllerActions,
     submitGamePresentationChange,
     replayGamePresentationChanges,
+    readControllerProjection,
   };
 }
 

--- a/src/lib/live-event-game-runtime.ts
+++ b/src/lib/live-event-game-runtime.ts
@@ -1,4 +1,10 @@
 import { randomBytes } from "node:crypto";
+import type {
+  AudienceProjectionGameInput,
+  AudienceProjectionGameInputOutcome,
+  PublicAudienceGamePhase,
+  PublicAudienceGameOperationalStatus,
+} from "@/lib/audience-projection";
 import { createFoundationAcceptance } from "@/lib/foundation-acceptance";
 import { createEventGameRecord, type ExternalScopeResolver } from "@/lib/event-game-record";
 import type { EventGameRecord } from "@/lib/event-game-record";
@@ -9,6 +15,7 @@ import {
 import {
   createLiveEventGameControl,
   createLiveEventGameIqaInterpreter,
+  type ControllerProjection,
   validateLiveEventGameActionInTransaction,
 } from "@/lib/live-event-game-control";
 import { createTypedGrantAuthority } from "@/lib/grant-management";
@@ -29,8 +36,83 @@ import type { FoundationStorage } from "@/lib/foundation-storage";
 
 export type LiveEventGameRuntime = {
   control: ReturnType<typeof createLiveEventGameControl>;
+  readAudienceProjectionGameInput(eventGameId: string): Promise<AudienceProjectionGameInputOutcome>;
   close(): void;
 };
+
+export function readAudienceProjectionGameInput(
+  root: EventGameRecordRoot | null,
+  projection: ControllerProjection | null,
+): AudienceProjectionGameInputOutcome {
+  if (root === null || projection === null || projection.presentation === undefined) {
+    return { status: "unavailable" };
+  }
+  const gameSideIds = root.gameSides.map((side) => side.id);
+  if (gameSideIds.length !== 2) return { status: "unavailable" };
+  const phase: PublicAudienceGamePhase =
+    projection.overtime === true
+      ? "overtime"
+      : projection.clock.cues.seekerRelease === "released"
+        ? "seekers-released"
+        : "seeker-floor";
+  const operationalStatus: PublicAudienceGameOperationalStatus =
+    projection.phase === "finished"
+      ? "finished"
+      : projection.phase === "suspended"
+        ? "suspended"
+        : projection.phase === "scheduled"
+          ? "scheduled"
+          : projection.clock.running
+            ? "running"
+            : "paused";
+  const timeout = projection.timeout ?? {
+    status: "inactive" as const,
+    gameSideId: null,
+    remainingMs: null,
+  };
+  const heat = projection.heat ?? {
+    status: "inactive" as const,
+    mode: null,
+    pendingTriggerGameTimeMs: null,
+    allowedDurationMs: null,
+    actualDurationMs: null,
+    completionAtTrustedAtMs: null,
+  };
+  const allowedDurationMs = heat.allowedDurationMs ?? null;
+  const actualDurationMs = heat.actualDurationMs ?? null;
+  const remainingMs =
+    allowedDurationMs !== null && actualDurationMs !== null
+      ? Math.max(0, allowedDurationMs - actualDurationMs)
+      : heat.completionAtTrustedAtMs === null || heat.completionAtTrustedAtMs === undefined
+        ? null
+        : Math.max(0, heat.completionAtTrustedAtMs - projection.clock.projectedAtMs);
+  const value: AudienceProjectionGameInput = {
+    gameSideIds: [gameSideIds[0]!, gameSideIds[1]!] as const,
+    phase,
+    operationalStatus,
+    scoreByGameSide: structuredClone(projection.scoreByGameSide),
+    clock: structuredClone(projection.clock),
+    presentation: structuredClone(projection.presentation),
+    overtimeTarget: projection.overtimeTarget ?? null,
+    teamTimeout: {
+      status: timeout.status,
+      gameSideId: timeout.gameSideId ?? null,
+      remainingMs: timeout.remainingMs ?? null,
+    },
+    heatStoppage: {
+      status: heat.status,
+      mode: heat.mode ?? null,
+      pending: (heat.pendingTriggerGameTimeMs ?? null) !== null,
+      allowedDurationMs,
+      actualDurationMs,
+      remainingMs,
+    },
+    winnerGameSideId: projection.winnerGameSideId ?? null,
+    catchingGameSideId: projection.catch?.catchingGameSideId ?? null,
+    locked: root.lifecycle.lockedAtMs !== null,
+  };
+  return { status: "accepted", value };
+}
 
 export async function openLiveEventGameRuntime(input: {
   databasePath: string;
@@ -232,6 +314,13 @@ export async function openLiveEventGameRuntime(input: {
     };
     return {
       control,
+      async readAudienceProjectionGameInput(eventGameId) {
+        const root = await storage.transaction((transaction) =>
+          transaction.findRootByEventGameId(eventGameId),
+        );
+        const projection = await control.readControllerProjection(eventGameId);
+        return readAudienceProjectionGameInput(root, projection);
+      },
       close() {
         clearInterval(lockTimer);
         control.close();

--- a/src/pages/public-event-game-page.test.tsx
+++ b/src/pages/public-event-game-page.test.tsx
@@ -1,0 +1,175 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { Window } from "happy-dom";
+import { PublicEventGamePage } from "@/pages/public-event-page";
+import type { PublicAudienceGameProjection } from "@/lib/audience-projection";
+
+describe("public spectator Game page", () => {
+  const originalWindow = globalThis.window;
+  const originalDocument = globalThis.document;
+  const originalNavigator = globalThis.navigator;
+  const originalLocation = globalThis.location;
+  const originalHistory = globalThis.history;
+  const originalFetch = globalThis.fetch;
+  const originalActEnvironment = (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean })
+    .IS_REACT_ACT_ENVIRONMENT;
+  let testWindow: Window;
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    testWindow = new Window({ url: "http://timer.quadball.app/events/event-1/games/game-1" });
+    Object.assign(globalThis, {
+      window: testWindow,
+      document: testWindow.document,
+      navigator: testWindow.navigator,
+      location: testWindow.location,
+      history: testWindow.history,
+      fetch: async () =>
+        new Response(JSON.stringify({ status: "accepted", value: projection() }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    });
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+      await Promise.resolve();
+    });
+    container.remove();
+    testWindow.close();
+    Object.assign(globalThis, {
+      window: originalWindow,
+      document: originalDocument,
+      navigator: originalNavigator,
+      location: originalLocation,
+      history: originalHistory,
+      fetch: originalFetch,
+    });
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+      originalActEnvironment;
+  });
+
+  test("keeps the expanded score readable and exposes sporting freshness", async () => {
+    await act(async () => {
+      root.render(<PublicEventGamePage eventId="event-1" eventGameId="game-1" />);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const scoreboard = container.querySelector('[aria-label="Live scoreboard"]');
+    expect(scoreboard?.className).not.toContain("sticky");
+    expect(container.querySelector("[data-scoreboard-expanded]")).not.toBeNull();
+    expect(container.textContent).toContain("Winner Side A · Locked");
+    expect(container.textContent).toContain("Game Phase");
+    expect(container.textContent).toContain("Operational status");
+    expect(container.textContent).toContain("Team Timeout");
+    expect(container.textContent).toContain("Game Suspension");
+    expect(container.textContent).toContain("Heat Stoppage");
+    expect(container.textContent).toContain("Stale clock");
+    expect(container.textContent).toContain("Last synchronized:");
+    expect(container.textContent).toContain("started · 0:30 remaining");
+    expect(container.textContent).toContain("Suspended");
+    expect(container.textContent).toContain("Locked");
+    expect(container.textContent).toContain("Flag catch");
+    expect(container.textContent).toContain("A Very Long Team Name That Must Wrap");
+    expect(container.textContent).toContain("Another Long Team Name For A Narrow Screen");
+    expect(container.textContent).toContain("2:05");
+    expect(container.querySelectorAll(".break-words").length).toBe(2);
+    const expandedSides = Array.from(
+      container.querySelectorAll("[data-scoreboard-expanded] [data-side-id]"),
+    );
+    expect(expandedSides.map((side) => side.getAttribute("data-side-id"))).toEqual([
+      "side-b",
+      "side-a",
+    ]);
+    expect(expandedSides[0]?.textContent).toContain("Flag catch");
+    expect(expandedSides[1]?.textContent).not.toContain("Flag catch");
+
+    Object.defineProperty(testWindow, "scrollY", { configurable: true, value: 500 });
+    await act(async () => {
+      testWindow.dispatchEvent(new testWindow.Event("scroll"));
+      await Promise.resolve();
+    });
+    const compact = container.querySelector("[data-scoreboard-compact]");
+    expect(compact?.textContent).toContain("A Very Long Team Name That Must Wrap");
+    expect(compact?.textContent).toContain("Another Long Team Name For A Narrow Screen");
+    expect(compact?.textContent).toContain("30");
+    expect(compact?.textContent).toContain("20");
+    expect(compact?.textContent).toContain("2:05");
+    expect(compact?.textContent).toContain("Stale clock");
+    expect(compact?.textContent).toContain("Overtime");
+    expect(compact?.textContent).toContain("Operational status: Suspended");
+    expect(compact?.textContent).toContain("Flag catch");
+    const compactSides = Array.from(compact?.querySelectorAll("[data-side-id]") ?? []);
+    expect(compactSides.map((side) => side.getAttribute("data-side-id"))).toEqual([
+      "side-b",
+      "side-a",
+    ]);
+    expect(compactSides[0]?.textContent).toContain("Flag catch");
+    expect(compactSides[1]?.textContent).not.toContain("Flag catch");
+  });
+});
+
+function projection(): PublicAudienceGameProjection {
+  return {
+    eventId: "event-1",
+    gameCode: "A1",
+    gameDesignation: "Final",
+    scheduledStartMs: 1_000,
+    expectedStartMs: 2_000,
+    scheduleStatus: "past",
+    operationalStatus: "suspended",
+    phase: "overtime",
+    pitch: "Pitch A",
+    sideA: {
+      name: "A Very Long Team Name That Must Wrap",
+      color: "#112233",
+      score: 30,
+    },
+    sideB: {
+      name: "Another Long Team Name For A Narrow Screen",
+      color: "#445566",
+      score: 20,
+    },
+    overtimeTarget: 40,
+    clock: {
+      gameTimeMs: 125_000,
+      activePenaltyTimeMs: 0,
+      running: false,
+      projectedAtMs: 125_000,
+      synchronization: "stale",
+      lastSynchronizedAtMs: 120_000,
+      cues: {
+        flagRunnerEntry: "passed",
+        seekerWarning: "passed",
+        seekerCountdownMs: null,
+        seekerRelease: "released",
+      },
+    },
+    presentation: {
+      pitchOrientation: "side-b-left",
+      displayedTeamColors: { sideA: "#112233", sideB: "#445566" },
+    },
+    teamTimeout: { status: "completed", side: "side-a", remainingMs: 0 },
+    gameSuspension: "suspended",
+    heatStoppage: {
+      status: "started",
+      mode: "enabled",
+      pending: false,
+      allowedDurationMs: 120_000,
+      actualDurationMs: 90_000,
+      remainingMs: 30_000,
+    },
+    flagState: { catchingSide: "side-b" },
+    result: { status: "finished", winner: "side-a", locked: true },
+    canonicalPath: "/events/event-1/games/game-1",
+  };
+}

--- a/src/pages/public-event-page.tsx
+++ b/src/pages/public-event-page.tsx
@@ -167,6 +167,309 @@ export function PublicEventPage({ eventId }: { eventId: string }) {
   );
 }
 
+export function PublicEventGamePage({
+  eventId,
+  eventGameId,
+}: {
+  eventId: string;
+  eventGameId: string;
+}) {
+  const [game, setGame] = useState<PublicAudienceGameProjection | null>(null);
+  const [unavailable, setUnavailable] = useState(false);
+  const [compactScoreboard, setCompactScoreboard] = useState(false);
+  const scoreboardSentinelRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    setGame(null);
+    setUnavailable(false);
+    void fetch(
+      `/api/audience/events/${encodeURIComponent(eventId)}/games/${encodeURIComponent(eventGameId)}`,
+    )
+      .then(async (response) => {
+        if (!response.ok) throw new Error("Game unavailable");
+        const payload = (await response.json()) as AudienceGameResponse;
+        if (payload.status !== "accepted") throw new Error("Game unavailable");
+        return payload.value;
+      })
+      .then((nextGame) => {
+        if (active) setGame(nextGame);
+      })
+      .catch(() => {
+        if (active) setUnavailable(true);
+      });
+    return () => {
+      active = false;
+    };
+  }, [eventGameId, eventId]);
+
+  useEffect(() => {
+    const sentinel = scoreboardSentinelRef.current;
+    if (sentinel === null) return;
+    if (typeof IntersectionObserver === "function") {
+      const observer = new IntersectionObserver(([entry]) => {
+        setCompactScoreboard(entry?.isIntersecting === false);
+      });
+      observer.observe(sentinel);
+      return () => observer.disconnect();
+    }
+    const update = () => setCompactScoreboard(window.scrollY > 120);
+    update();
+    window.addEventListener("scroll", update, { passive: true });
+    return () => window.removeEventListener("scroll", update);
+  }, [game]);
+
+  if (unavailable) return <GameUnavailablePanel eventId={eventId} />;
+  if (game === null) {
+    return (
+      <PublicShell title="Live spectator Game" description="Loading public Game information…">
+        <p className="rounded-2xl border bg-card/80 p-5 text-sm text-muted-foreground">Loading…</p>
+      </PublicShell>
+    );
+  }
+
+  const sides =
+    game.presentation.pitchOrientation === "side-b-left"
+      ? [
+          { sideId: "side-b" as const, side: game.sideB, label: "Side B" },
+          { sideId: "side-a" as const, side: game.sideA, label: "Side A" },
+        ]
+      : [
+          { sideId: "side-a" as const, side: game.sideA, label: "Side A" },
+          { sideId: "side-b" as const, side: game.sideB, label: "Side B" },
+        ];
+  const title = game.gameDesignation ?? game.gameCode ?? "Live spectator Game";
+
+  return (
+    <PublicShell title={title} description="Public Audience Projection · no sign-in required">
+      <div className="space-y-4">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <Button
+            variant="outline"
+            onClick={() => navigateTo(`/events/${encodeURIComponent(eventId)}`)}
+          >
+            Back to Event
+          </Button>
+          <p className="text-sm text-muted-foreground">{game.pitch ?? "Event Game"}</p>
+        </div>
+        <div
+          ref={scoreboardSentinelRef}
+          aria-hidden="true"
+          className="h-px"
+          data-scoreboard-sentinel
+        />
+        {compactScoreboard ? (
+          <section
+            aria-label="Compact live scoreboard"
+            className="sticky top-2 z-10 rounded-2xl border bg-background/95 p-2 shadow-lg backdrop-blur"
+            data-scoreboard-compact
+          >
+            <div className="mb-1 flex flex-wrap items-center justify-center gap-x-2 gap-y-0.5 text-[0.65rem] text-muted-foreground">
+              <span>Game Phase: {gamePhaseLabel(game.phase)}</span>
+              <span>Operational status: {operationalStatusLabel(game.operationalStatus)}</span>
+              <span>Schedule: {scheduleStatusLabel(game.scheduleStatus)}</span>
+            </div>
+            <div className="grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center gap-2">
+              <CompactScoreSide
+                side={sides[0]!.side}
+                label={sides[0]!.label}
+                sideId={sides[0]!.sideId}
+                isCatching={game.flagState.catchingSide === sides[0]!.sideId}
+              />
+              <div className="flex flex-col items-center">
+                <span className="font-mono text-lg font-bold tabular-nums">
+                  {formatClock(game.clock?.gameTimeMs ?? 0)}
+                </span>
+                <span className="text-[0.65rem] text-muted-foreground">
+                  {clockFreshnessLabel(game.clock?.synchronization ?? "unavailable")}
+                </span>
+              </div>
+              <CompactScoreSide
+                side={sides[1]!.side}
+                label={sides[1]!.label}
+                align="right"
+                sideId={sides[1]!.sideId}
+                isCatching={game.flagState.catchingSide === sides[1]!.sideId}
+              />
+            </div>
+          </section>
+        ) : null}
+        <section
+          aria-label="Live scoreboard"
+          className="rounded-3xl border bg-background/95 p-3 shadow-lg sm:p-5"
+          data-scoreboard-expanded
+        >
+          <div className="mb-3 flex flex-wrap items-center justify-between gap-2 text-sm">
+            <span className="font-semibold">{scheduleStatusLabel(game.scheduleStatus)}</span>
+            <span className="text-muted-foreground">
+              Game Phase: {gamePhaseLabel(game.phase)} · Operational status:{" "}
+              {operationalStatusLabel(game.operationalStatus)}
+            </span>
+          </div>
+          <div className="grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-stretch gap-2 sm:gap-4">
+            <PublicScoreSide
+              side={sides[0]!.side}
+              label={sides[0]!.label}
+              sideId={sides[0]!.sideId}
+              isCatching={game.flagState.catchingSide === sides[0]!.sideId}
+            />
+            <div className="flex min-w-20 flex-col items-center justify-center rounded-2xl bg-muted/60 px-2 py-3">
+              <span className="font-mono text-3xl font-bold tabular-nums sm:text-4xl">
+                {formatClock(game.clock?.gameTimeMs ?? 0)}
+              </span>
+              <span className="mt-1 text-center text-xs text-muted-foreground">
+                {clockFreshnessLabel(game.clock?.synchronization ?? "unavailable")}
+              </span>
+            </div>
+            <PublicScoreSide
+              side={sides[1]!.side}
+              label={sides[1]!.label}
+              align="right"
+              sideId={sides[1]!.sideId}
+              isCatching={game.flagState.catchingSide === sides[1]!.sideId}
+            />
+          </div>
+          <div className="mt-3 flex flex-wrap justify-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
+            <span>
+              Last synchronized:{" "}
+              {formatLastSynchronization(game.clock?.lastSynchronizedAtMs ?? null)}
+            </span>
+            <span>Expected start: {formatDateTime(game.expectedStartMs)}</span>
+          </div>
+        </section>
+        <Card>
+          <CardHeader>
+            <CardTitle>Game Phase and operational status</CardTitle>
+            <CardDescription>
+              Committed public information from the Event Game&apos;s Audience Projection.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3 text-sm">
+            <dl className="grid gap-3 sm:grid-cols-2">
+              <StatusValue label="Game Phase" value={gamePhaseLabel(game.phase)} />
+              <StatusValue
+                label="Operational status"
+                value={operationalStatusLabel(game.operationalStatus)}
+              />
+              <StatusValue
+                label="Overtime target"
+                value={game.phase === "overtime" ? `Target ${game.overtimeTarget ?? "—"}` : "No"}
+              />
+              <StatusValue
+                label="Flag"
+                value={
+                  game.flagState.catchingSide !== null
+                    ? `Caught by ${game.flagState.catchingSide}`
+                    : "Not caught"
+                }
+              />
+              <StatusValue label="Team Timeout" value={timeoutLabel(game.teamTimeout)} />
+              <StatusValue
+                label="Game Suspension"
+                value={game.gameSuspension === "suspended" ? "Suspended" : "None"}
+              />
+              <StatusValue label="Heat Stoppage" value={heatLabel(game.heatStoppage)} />
+              <StatusValue label="Result" value={resultLabel(game.result)} />
+            </dl>
+            <p className="rounded-xl border border-dashed p-3 text-muted-foreground">
+              Public play history will be added by the Timeline work; this page shows the committed
+              scoreboard projection.
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    </PublicShell>
+  );
+}
+
+function PublicScoreSide({
+  side,
+  label,
+  sideId,
+  isCatching,
+  align = "left",
+}: {
+  side: PublicAudienceGameProjection["sideA"];
+  label: string;
+  sideId: "side-a" | "side-b";
+  isCatching: boolean;
+  align?: "left" | "right";
+}) {
+  return (
+    <div
+      className={`min-w-0 rounded-2xl border-2 bg-card p-3 ${align === "right" ? "text-right" : "text-left"}`}
+      style={{ borderColor: side.color ?? "hsl(var(--border))" }}
+      data-side-id={sideId}
+    >
+      <p className="text-xs font-semibold tracking-wide text-muted-foreground uppercase">{label}</p>
+      <p className="mt-1 break-words text-base font-semibold leading-tight sm:text-xl">
+        {side.name ?? "Unassigned Team"}
+      </p>
+      <p className="mt-2 text-4xl font-bold tabular-nums sm:text-5xl">
+        {side.score ?? "—"}
+        {isCatching ? (
+          <span className="mt-1 block text-xs font-semibold tracking-wide text-foreground uppercase">
+            Flag catch
+          </span>
+        ) : null}
+      </p>
+    </div>
+  );
+}
+
+function CompactScoreSide({
+  side,
+  label,
+  sideId,
+  isCatching,
+  align = "left",
+}: {
+  side: PublicAudienceGameProjection["sideA"];
+  label: string;
+  sideId: "side-a" | "side-b";
+  isCatching: boolean;
+  align?: "left" | "right";
+}) {
+  return (
+    <div
+      className={`min-w-0 ${align === "right" ? "text-right" : "text-left"}`}
+      data-side-id={sideId}
+    >
+      <p className="truncate text-xs font-semibold">{side.name ?? "Unassigned Team"}</p>
+      <p className="truncate text-sm font-semibold">
+        <span aria-label={`${label} score`}>{side.score ?? "—"}</span>
+        {isCatching ? <span className="ml-1 text-[0.65rem] uppercase">Flag catch</span> : null}
+      </p>
+    </div>
+  );
+}
+
+function StatusValue({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-xl border p-3">
+      <dt className="text-muted-foreground">{label}</dt>
+      <dd className="mt-1 font-medium">{value}</dd>
+    </div>
+  );
+}
+
+function GameUnavailablePanel({ eventId }: { eventId: string }) {
+  return (
+    <PublicShell title="Game unavailable" description="This public Game is not available.">
+      <Card>
+        <CardContent className="space-y-4 pt-6">
+          <p className="text-sm text-muted-foreground">
+            The Game may be hidden, unknown, or temporarily unavailable.
+          </p>
+          <Button onClick={() => navigateTo(`/events/${encodeURIComponent(eventId)}`)}>
+            Back to Event
+          </Button>
+        </CardContent>
+      </Card>
+    </PublicShell>
+  );
+}
+
 function ScheduleBoard({
   schedule,
   timeZone,
@@ -326,7 +629,11 @@ function GameCard({
   compact?: boolean;
 }) {
   const winnerName =
-    game.winner === "side-a" ? game.sideA.name : game.winner === "side-b" ? game.sideB.name : null;
+    game.result.winner === "side-a"
+      ? game.sideA.name
+      : game.result.winner === "side-b"
+        ? game.sideB.name
+        : null;
   return (
     <Card className={compact ? "bg-card/70" : "border-primary/40 bg-card shadow-md"}>
       <CardHeader className={compact ? "pb-3" : undefined}>
@@ -348,8 +655,16 @@ function GameCard({
       </CardHeader>
       <CardContent className="space-y-3">
         <div className="grid grid-cols-[1fr_auto] items-center gap-x-3 gap-y-2">
-          <GameSideRow side={game.sideA} label="Side A" />
-          <GameSideRow side={game.sideB} label="Side B" />
+          <GameSideRow
+            side={game.sideA}
+            label="Side A"
+            isCatching={game.flagState.catchingSide === "side-a"}
+          />
+          <GameSideRow
+            side={game.sideB}
+            label="Side B"
+            isCatching={game.flagState.catchingSide === "side-b"}
+          />
         </div>
         <div className="flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted-foreground">
           <span>Scheduled Start {formatScheduleTime(game.scheduledStartMs, timeZone)}</span>
@@ -384,9 +699,11 @@ function GameCard({
 function GameSideRow({
   side,
   label,
+  isCatching,
 }: {
   side: PublicAudienceGameProjection["sideA"];
   label: string;
+  isCatching: boolean;
 }) {
   return (
     <>
@@ -400,7 +717,7 @@ function GameSideRow({
       >
         <span className="sr-only">{label}: </span>
         {side.name ?? "TBD"}
-        {side.flagCatch ? <span className="ml-2 text-xs font-semibold">Flag catch</span> : null}
+        {isCatching ? <span className="ml-2 text-xs font-semibold">Flag catch</span> : null}
       </span>
       <span
         className="text-right text-2xl font-semibold tabular-nums"
@@ -482,6 +799,53 @@ function formatClock(milliseconds: number) {
   const minutes = Math.floor(milliseconds / 60_000);
   const seconds = Math.floor((milliseconds % 60_000) / 1_000);
   return `${minutes}:${String(seconds).padStart(2, "0")}`;
+}
+
+function formatDateTime(milliseconds: number) {
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(milliseconds));
+}
+
+function clockFreshnessLabel(
+  status: NonNullable<PublicAudienceGameProjection["clock"]>["synchronization"],
+) {
+  return status === "synchronized"
+    ? "Synchronized clock"
+    : status === "estimated"
+      ? "Estimated clock"
+      : status === "stale"
+        ? "Stale clock"
+        : "Clock unavailable";
+}
+
+function formatLastSynchronization(milliseconds: number | null) {
+  return milliseconds === null ? "unavailable" : formatDateTime(milliseconds);
+}
+
+function timeoutLabel(timeout: PublicAudienceGameProjection["teamTimeout"]) {
+  return timeout.status === "inactive"
+    ? "None"
+    : timeout.status === "started"
+      ? `Started${timeout.remainingMs === null ? "" : ` · ${Math.ceil(timeout.remainingMs / 1_000)}s`}`
+      : timeout.status[0]!.toUpperCase() + timeout.status.slice(1);
+}
+
+function heatLabel(heat: PublicAudienceGameProjection["heatStoppage"]) {
+  return heat.status === "inactive"
+    ? "Inactive"
+    : `${heat.status}${heat.remainingMs === null ? "" : ` · ${formatDuration(heat.remainingMs)} remaining`}${heat.pending ? " · decision pending" : ""}`;
+}
+
+function formatDuration(milliseconds: number) {
+  const seconds = Math.ceil(Math.max(0, milliseconds) / 1_000);
+  return `${Math.floor(seconds / 60)}:${String(seconds % 60).padStart(2, "0")}`;
+}
+
+function resultLabel(result: PublicAudienceGameProjection["result"]) {
+  if (result.status === "unfinished") return "In progress";
+  return `${result.winner === null ? "Finished" : `Winner ${result.winner === "side-a" ? "Side A" : "Side B"}`}${result.locked ? " · Locked" : ""}`;
 }
 
 function clockStatusLabel(
@@ -788,6 +1152,9 @@ function lifecycleLabel(lifecycle: PublicAudienceEventProjection["lifecycle"]): 
 
 type AudienceEventResponse =
   | { status: "accepted"; value: PublicAudienceEventProjection }
+  | { status: "unavailable" };
+type AudienceGameResponse =
+  | { status: "accepted"; value: PublicAudienceGameProjection }
   | { status: "unavailable" };
 type AudienceEventsResponse =
   | { status: "accepted"; value: { events: readonly PublicAudienceEventProjection[] } }


### PR DESCRIPTION
## What changed

- adds the public spectator Game route backed by the allowlisted Audience Projection
- renders a phone-first expanded and sticky compact scoreboard with stable team identity, score, Game Clock value and freshness, Game Phase, schedule and operational status, Flag Catch, Team Timeout, Game Suspension, Heat Stoppage, overtime, finish, and lock presentation
- normalizes catalog and runtime inputs through one public projector and keeps Grants, sessions, Controller actions, audit evidence, correction provenance, and authority internals private
- preserves Pitch Orientation and current Game Presentation without changing the stable public Game URL

## Why

Spectators need a useful, readable Game view beside the pitch even before live streaming is connected. This establishes the authoritative HTTP projection and public UI that the later Timeline and WebSocket layers extend.

## Impact

Published Event Games now have a useful anonymous phone experience with explicit freshness and unavailable behavior. The browser does not recreate Clock Authority or infer sporting outcomes.

Closes #135.

## Validation

- post-rebase full stack `bun test --isolate`: 875 passed, 0 failed, 20,009 expectations
- post-rebase focused projection, runtime, component, and capacity tests: 59 passed, 0 failed, 929 expectations
- `bun run test:focused:public-event-browser`
- `bun run check` (existing unrelated warnings only)
- `bun run build`
- `git diff --check`

No Qualification, load, soak, crash, recovery, or exact-production-artifact workload was run.
