### PR TITLE
Add spectator capacity guardrails

### DIFF
--- a/src/index-ad-hoc.test.ts
+++ b/src/index-ad-hoc.test.ts
@@ -48,26 +48,26 @@ describe("Ad Hoc HTTP and WebSocket authority boundaries", () => {
   test("caps pre-upgrade Ad Hoc capacity below the configured Event reserve", () => {
     expect(
       calculateAdHocUpgradeCapacity({
-        eventTotalConnections: 5,
-        eventReservedConnections: 2,
-        activeEventConnections: 0,
-        adHocSocketCeiling: 10,
+        totalConnections: 5,
+        reservedConnections: 2,
+        activeControllerSessions: 0,
+        maxConnectedSockets: 10,
       }),
     ).toBe(3);
     expect(
       calculateAdHocUpgradeCapacity({
-        eventTotalConnections: 5,
-        eventReservedConnections: 2,
-        activeEventConnections: 4,
-        adHocSocketCeiling: 10,
+        totalConnections: 5,
+        reservedConnections: 2,
+        activeControllerSessions: 4,
+        maxConnectedSockets: 10,
       }),
     ).toBe(1);
     expect(
       calculateAdHocUpgradeCapacity({
-        eventTotalConnections: 5,
-        eventReservedConnections: 8,
-        activeEventConnections: 0,
-        adHocSocketCeiling: 10,
+        totalConnections: 5,
+        reservedConnections: 8,
+        activeControllerSessions: 0,
+        maxConnectedSockets: 10,
       }),
     ).toBe(0);
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,6 +86,10 @@ import {
 } from "@/lib/ad-hoc-games";
 import { readBuiltRuntimeIdentity, readRunningReleaseIdentity } from "@/lib/release-identity";
 import {
+  availableNonControllerCapacity,
+  type ControllerCapacityInput,
+} from "@/lib/controller-capacity";
+import {
   AD_HOC_EVENT_RESERVED_CONNECTION_CAPACITY,
   AD_HOC_EVENT_TOTAL_CONNECTION_CAPACITY,
   AD_HOC_MAX_CONNECTED_CONTROLLERS,
@@ -229,7 +233,7 @@ async function startServer() {
           process.env.EVENT_RESERVED_CONNECTION_CAPACITY,
           AD_HOC_EVENT_RESERVED_CONNECTION_CAPACITY,
         ),
-        activeConnections: () => eventCapacitySource(),
+        activeControllerSessions: () => eventCapacitySource(),
       },
       store:
         environment === "test" && !process.env.AD_HOC_DATABASE?.trim()
@@ -592,16 +596,16 @@ async function startServer() {
 
           const socketId = crypto.randomUUID();
           const totalSocketCapacity = calculateAdHocUpgradeCapacity({
-            eventTotalConnections: readRuntimeCapacity(
+            totalConnections: readRuntimeCapacity(
               process.env.EVENT_TOTAL_CONNECTION_CAPACITY,
               AD_HOC_EVENT_TOTAL_CONNECTION_CAPACITY,
             ),
-            eventReservedConnections: readRuntimeCapacity(
+            reservedConnections: readRuntimeCapacity(
               process.env.EVENT_RESERVED_CONNECTION_CAPACITY,
               AD_HOC_EVENT_RESERVED_CONNECTION_CAPACITY,
             ),
-            activeEventConnections: eventCapacitySource(),
-            adHocSocketCeiling: readRuntimeCapacity(
+            activeControllerSessions: eventCapacitySource(),
+            maxConnectedSockets: readRuntimeCapacity(
               process.env.AD_HOC_MAX_CONNECTED_SOCKETS,
               AD_HOC_MAX_CONNECTED_CONTROLLERS,
             ),
@@ -3168,17 +3172,10 @@ function readRuntimeCapacity(value: string | undefined, fallback: number): numbe
   return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback;
 }
 
-export function calculateAdHocUpgradeCapacity(input: {
-  eventTotalConnections: number;
-  eventReservedConnections: number;
-  activeEventConnections: number;
-  adHocSocketCeiling: number;
-}): number {
-  const eventTotal = Math.max(0, input.eventTotalConnections);
-  const eventReserve = Math.max(0, input.eventReservedConnections);
-  const activeEvent = Math.max(0, input.activeEventConnections);
-  const adHocCeiling = Math.max(0, input.adHocSocketCeiling);
-  return Math.max(0, Math.min(adHocCeiling, eventTotal - Math.max(eventReserve, activeEvent)));
+export function calculateAdHocUpgradeCapacity(
+  input: ControllerCapacityInput & { maxConnectedSockets: number },
+): number {
+  return availableNonControllerCapacity(input, input.maxConnectedSockets);
 }
 
 function releasePendingSocketReservation(socketId: string) {

--- a/src/lib/ad-hoc-games.ts
+++ b/src/lib/ad-hoc-games.ts
@@ -16,6 +16,10 @@ import {
 } from "@/lib/controller-synchronization";
 import { parseHexColor, DEFAULT_AWAY_TEAM_COLOR, DEFAULT_HOME_TEAM_COLOR } from "@/lib/team-colors";
 import {
+  availableNonControllerCapacity,
+  type ControllerCapacityInput,
+} from "@/lib/controller-capacity";
+import {
   normalizeBoundedText,
   SHARED_LIMITS,
   validateOpaqueIdentifier,
@@ -439,7 +443,7 @@ export type AdHocGamesServiceOptions = {
   eventCapacity?: {
     totalConnections?: number;
     reservedConnections?: number;
-    activeConnections?: () => number;
+    activeControllerSessions?: () => number;
   };
   schedule?: (delayMs: number, task: () => void) => unknown;
 };
@@ -464,7 +468,7 @@ export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) 
       options.eventCapacity?.totalConnections ?? AD_HOC_EVENT_TOTAL_CONNECTION_CAPACITY,
     reservedConnections:
       options.eventCapacity?.reservedConnections ?? AD_HOC_EVENT_RESERVED_CONNECTION_CAPACITY,
-    activeConnections: options.eventCapacity?.activeConnections ?? (() => 0),
+    activeControllerSessions: options.eventCapacity?.activeControllerSessions ?? (() => 0),
   };
   const schedule =
     options.schedule ??
@@ -515,14 +519,15 @@ export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) 
         const session = game.sessions.find((candidate) => candidate.sessionHash === sessionKey);
         if (session === undefined) return false;
         if (input.connected && !connections.has(input.connectionId)) {
-          const activeEventConnections = Math.max(0, eventCapacity.activeConnections());
-          const availableForAdHoc = Math.max(
-            0,
-            Math.min(
-              maxConnectedSockets,
-              eventCapacity.totalConnections -
-                Math.max(eventCapacity.reservedConnections, activeEventConnections),
-            ),
+          const activeControllerSessions = Math.max(0, eventCapacity.activeControllerSessions());
+          const capacityInput: ControllerCapacityInput = {
+            totalConnections: eventCapacity.totalConnections,
+            reservedConnections: eventCapacity.reservedConnections,
+            activeControllerSessions,
+          };
+          const availableForAdHoc = availableNonControllerCapacity(
+            capacityInput,
+            maxConnectedSockets,
           );
           if (connections.size >= availableForAdHoc) {
             return { capacity: true, rollback: true } as const;
@@ -1290,18 +1295,16 @@ export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) 
     genericUnavailableMessage: GENERIC_UNAVAILABLE,
     getResourceMetrics(): AdHocResourceMetrics {
       metrics.connectedControllers = connections.size;
-      const activeEventConnections = Math.max(0, eventCapacity.activeConnections());
+      const activeControllerSessions = Math.max(0, eventCapacity.activeControllerSessions());
+      const capacityInput: ControllerCapacityInput = {
+        totalConnections: eventCapacity.totalConnections,
+        reservedConnections: eventCapacity.reservedConnections,
+        activeControllerSessions,
+      };
       metrics.eventReservedCapacity = {
         configured: eventCapacity.reservedConnections,
-        active: activeEventConnections,
-        availableForAdHoc: Math.max(
-          0,
-          Math.min(
-            maxConnectedSockets,
-            eventCapacity.totalConnections -
-              Math.max(eventCapacity.reservedConnections, activeEventConnections),
-          ),
-        ),
+        active: activeControllerSessions,
+        availableForAdHoc: availableNonControllerCapacity(capacityInput, maxConnectedSockets),
       };
       return { ...metrics };
     },

--- a/src/lib/ad-hoc-resource-budgets.test.ts
+++ b/src/lib/ad-hoc-resource-budgets.test.ts
@@ -607,14 +607,14 @@ describe("Ad Hoc resource budgets", () => {
   });
 
   test("counts socket instances before ownership and exposes Event reserve pressure", async () => {
-    let activeEventConnections = 0;
+    let activeControllerSessions = 0;
     const service = createAdHocGamesService({
       now: () => 1_000,
       maxConnectedSockets: 2,
       eventCapacity: {
         totalConnections: 3,
         reservedConnections: 1,
-        activeConnections: () => activeEventConnections,
+        activeControllerSessions: () => activeControllerSessions,
       },
     });
     const first = await service.create({ homeName: "One", awayName: "Away" });
@@ -658,7 +658,7 @@ describe("Ad Hoc resource budgets", () => {
       }),
     ).toBe(true);
     expect(service.getResourceMetrics().connectedControllers).toBe(1);
-    activeEventConnections = 1;
+    activeControllerSessions = 1;
     expect(service.getResourceMetrics().eventReservedCapacity).toMatchObject({
       active: 1,
       availableForAdHoc: 2,

--- a/src/lib/controller-capacity.ts
+++ b/src/lib/controller-capacity.ts
@@ -1,0 +1,29 @@
+export type ControllerCapacityInput = {
+  totalConnections: number;
+  reservedConnections: number;
+  activeControllerSessions: number;
+};
+
+/**
+ * Return non-Controller capacity after honoring the configured reserve,
+ * active authoritative Controller Sessions, and an optional workflow cap.
+ */
+export function availableNonControllerCapacity(
+  input: ControllerCapacityInput,
+  maximum = Number.POSITIVE_INFINITY,
+): number {
+  const totalConnections = Number.isFinite(input.totalConnections)
+    ? Math.max(0, Math.floor(input.totalConnections))
+    : 0;
+  const reservedConnections = Number.isFinite(input.reservedConnections)
+    ? Math.min(totalConnections, Math.max(0, Math.floor(input.reservedConnections)))
+    : 0;
+  const activeControllerSessions = Number.isFinite(input.activeControllerSessions)
+    ? Math.max(0, Math.floor(input.activeControllerSessions))
+    : 0;
+  const available = Math.max(
+    0,
+    totalConnections - Math.max(reservedConnections, activeControllerSessions),
+  );
+  return Math.min(available, Number.isFinite(maximum) ? Math.max(0, maximum) : available);
+}

--- a/src/lib/live-event-game-control.test.ts
+++ b/src/lib/live-event-game-control.test.ts
@@ -717,7 +717,11 @@ describe("Live Event Game control", () => {
     const adHoc = createAdHocGamesService({
       now: () => 1_000,
       maxConnectedSockets: 1,
-      eventCapacity: { totalConnections: 2, reservedConnections: 1, activeConnections: () => 0 },
+      eventCapacity: {
+        totalConnections: 2,
+        reservedConnections: 1,
+        activeControllerSessions: () => 0,
+      },
     });
     const created = await adHoc.create({
       homeName: "Ad Hoc",

--- a/src/lib/spectator-capacity.test.ts
+++ b/src/lib/spectator-capacity.test.ts
@@ -1,0 +1,580 @@
+import { describe, expect, test } from "bun:test";
+import {
+  createSpectatorCapacity,
+  type SpectatorCurrentVersion,
+  type SpectatorQueuedUpdate,
+  type SpectatorStreamAdapter,
+} from "@/lib/spectator-capacity";
+import { SHARED_LIMITS, utf8ByteLength } from "@/lib/validation-policy";
+
+type AudienceProjection = { score: number; privateToken?: string };
+
+function createHarness(
+  options: {
+    activeControllers?: number;
+    totalConnections?: number;
+    controllerReserve?: number;
+    maxSpectators?: number;
+    perClientQueueLimit?: number;
+    globalQueueLimit?: number;
+    perClientQueuedOutputBytes?: number;
+    measureQueuedOutputBytes?: (update: SpectatorQueuedUpdate<AudienceProjection>) => number;
+    current?: SpectatorCurrentVersion<AudienceProjection>;
+  } = {},
+) {
+  const closed: { clientId: string; reason: string }[] = [];
+  const writes = new Map<string, string[]>();
+  const replicaOutcomes: { clientId: string; version: string; replaceableKey: string | null }[] =
+    [];
+  let current = options.current ?? { version: "v1", payload: { score: 0 } };
+  let currentAvailable = true;
+  let controllerCapacityAvailable = true;
+  let activeControllers = options.activeControllers ?? 0;
+  let currentReadCount = 0;
+  let blockCurrentRead = false;
+  let releaseCurrentRead: (() => void) | null = null;
+  const adapter: SpectatorStreamAdapter<AudienceProjection> = {
+    async readCurrentVersion() {
+      currentReadCount += 1;
+      if (blockCurrentRead) {
+        await new Promise<void>((resolve) => {
+          releaseCurrentRead = resolve;
+        });
+      }
+      if (!currentAvailable) return { status: "unavailable" };
+      return { status: "available", current };
+    },
+    measureQueuedOutputBytes(update) {
+      return (
+        options.measureQueuedOutputBytes?.(update) ??
+        utf8ByteLength(
+          JSON.stringify({
+            type: "audience-projection",
+            eventId: update.eventId,
+            version: update.version,
+            replaceableKey: update.replaceableKey,
+            payload: update.payload,
+          }),
+        )
+      );
+    },
+    write(clientId, update) {
+      const clientWrites = writes.get(clientId) ?? [];
+      clientWrites.push(update.version);
+      writes.set(clientId, clientWrites);
+      replicaOutcomes.push({
+        clientId,
+        version: update.version,
+        replaceableKey: update.replaceableKey,
+      });
+      return true;
+    },
+    close(clientId, reason) {
+      closed.push({ clientId, reason });
+    },
+  };
+  const capacity = createSpectatorCapacity({
+    adapter,
+    maxSpectators: options.maxSpectators,
+    perClientQueueLimit: options.perClientQueueLimit,
+    globalQueueLimit: options.globalQueueLimit,
+    perClientQueuedOutputBytes: options.perClientQueuedOutputBytes,
+    controllerCapacity: {
+      totalConnections: options.totalConnections ?? 502,
+      reservedConnections: options.controllerReserve ?? 2,
+      activeControllerSessions: () => {
+        if (!controllerCapacityAvailable) throw new Error("capacity unavailable");
+        return activeControllers;
+      },
+    },
+  });
+  return {
+    capacity,
+    closed,
+    writes,
+    replicaOutcomes,
+    currentReadCount: () => currentReadCount,
+    blockCurrentVersionRead() {
+      blockCurrentRead = true;
+    },
+    releaseCurrentVersionRead() {
+      blockCurrentRead = false;
+      releaseCurrentRead?.();
+      releaseCurrentRead = null;
+    },
+    setCurrent(next: SpectatorCurrentVersion<AudienceProjection>) {
+      current = next;
+    },
+    setActiveControllers(next: number) {
+      activeControllers = next;
+    },
+    acceptControllerSession() {
+      activeControllers += 1;
+      return activeControllers;
+    },
+    setAdapterCurrentVersionUnavailable() {
+      currentAvailable = false;
+    },
+    setControllerCapacityUnavailable() {
+      controllerCapacityAvailable = false;
+    },
+  };
+}
+
+describe("Spectator capacity", () => {
+  test("admits 500 logical spectators while protecting the Controller reserve", async () => {
+    const harness = createHarness();
+
+    for (let index = 0; index < 500; index += 1) {
+      expect(
+        await harness.capacity.admit({ clientId: `spectator-${index}`, eventId: "event-1" }),
+      ).toMatchObject({
+        status: "admitted",
+        currentVersion: "v1",
+      });
+    }
+
+    expect(
+      await harness.capacity.admit({ clientId: "spectator-overflow", eventId: "event-1" }),
+    ).toEqual({
+      status: "rejected",
+      reason: "capacity",
+      message: "Spectator capacity is currently full; try again later.",
+    });
+    expect(harness.capacity.getMetrics()).toMatchObject({
+      activeSpectators: 500,
+      rejectedAdmission: 1,
+      controllerImpactGuardrail: {
+        reservedConnections: 2,
+        activeControllerSessions: 0,
+        protectedAdmissionRejects: 0,
+      },
+    });
+  });
+
+  test("uses the Controller reserve before active Controller Sessions consume spectator capacity", async () => {
+    const harness = createHarness({ totalConnections: 5, controllerReserve: 2, maxSpectators: 5 });
+    expect(harness.acceptControllerSession()).toBe(1);
+
+    for (let index = 0; index < 3; index += 1) {
+      expect(
+        await harness.capacity.admit({ clientId: `spectator-${index}`, eventId: "event-1" }),
+      ).toMatchObject({
+        status: "admitted",
+      });
+    }
+    expect(harness.capacity.getMetrics().controllerImpactGuardrail).toMatchObject({
+      activeControllerSessions: 1,
+      availableForSpectators: 3,
+    });
+
+    expect(harness.acceptControllerSession()).toBe(2);
+    expect(harness.capacity.reconcileControllerCapacity()).toMatchObject({
+      status: "reconciled",
+      disconnected: 0,
+      availableForSpectators: 3,
+    });
+    expect(harness.acceptControllerSession()).toBe(3);
+    expect(harness.capacity.reconcileControllerCapacity()).toMatchObject({
+      status: "reconciled",
+      disconnected: 1,
+      availableForSpectators: 2,
+    });
+    expect(
+      await harness.capacity.admit({ clientId: "spectator-3", eventId: "event-1" }),
+    ).toMatchObject({
+      status: "rejected",
+      reason: "capacity",
+    });
+    const metricsAfterReconciliation = harness.capacity.getMetrics();
+    expect(harness.capacity.getMetrics()).toEqual(metricsAfterReconciliation);
+    expect(metricsAfterReconciliation.controllerImpactGuardrail).toMatchObject({
+      activeControllerSessions: 3,
+      availableForSpectators: 2,
+      reserveBreachesObserved: 1,
+    });
+  });
+
+  test("preflights overflow before authoritative projection reads while Controller priority stays available", async () => {
+    const harness = createHarness({ totalConnections: 502, controllerReserve: 2 });
+    for (let index = 0; index < 500; index += 1) {
+      await harness.capacity.admit({ clientId: `spectator-${index}`, eventId: "event-1" });
+    }
+    expect(harness.currentReadCount()).toBe(500);
+
+    expect(harness.acceptControllerSession()).toBe(1);
+    expect(harness.capacity.reconcileControllerCapacity()).toMatchObject({ disconnected: 0 });
+    const readsBeforeOverflow = harness.currentReadCount();
+    expect(
+      await harness.capacity.admit({ clientId: "overflow", eventId: "event-1" }),
+    ).toMatchObject({ status: "rejected", reason: "capacity" });
+    expect(harness.currentReadCount()).toBe(readsBeforeOverflow);
+
+    expect(harness.acceptControllerSession()).toBe(2);
+    expect(harness.capacity.reconcileControllerCapacity()).toMatchObject({ disconnected: 0 });
+    expect(harness.acceptControllerSession()).toBe(3);
+    expect(harness.capacity.reconcileControllerCapacity()).toMatchObject({ disconnected: 1 });
+    expect(harness.capacity.getMetrics()).toMatchObject({
+      activeSpectators: 499,
+      controllerImpactGuardrail: {
+        activeControllerSessions: 3,
+        availableForSpectators: 499,
+      },
+    });
+  });
+
+  test("rechecks and releases a provisional admission when Controller capacity changes during the read", async () => {
+    const harness = createHarness({ totalConnections: 5, controllerReserve: 2, maxSpectators: 5 });
+    await harness.capacity.admit({ clientId: "spectator-1", eventId: "event-1" });
+    await harness.capacity.admit({ clientId: "spectator-2", eventId: "event-1" });
+
+    harness.blockCurrentVersionRead();
+    const pendingAdmission = harness.capacity.admit({
+      clientId: "provisional",
+      eventId: "event-1",
+    });
+    await Promise.resolve();
+    expect(harness.currentReadCount()).toBe(3);
+
+    harness.setActiveControllers(3);
+    expect(harness.capacity.reconcileControllerCapacity()).toMatchObject({ disconnected: 0 });
+    harness.releaseCurrentVersionRead();
+    expect(await pendingAdmission).toMatchObject({ status: "rejected", reason: "capacity" });
+    expect(harness.capacity.getMetrics()).toMatchObject({ activeSpectators: 2 });
+
+    harness.setActiveControllers(0);
+    expect(
+      await harness.capacity.admit({ clientId: "after-release", eventId: "event-1" }),
+    ).toMatchObject({ status: "admitted" });
+  });
+
+  test("reserves global queued-output slots before concurrent authoritative reads", async () => {
+    const harness = createHarness({
+      totalConnections: 10,
+      controllerReserve: 0,
+      maxSpectators: 10,
+      globalQueueLimit: 2,
+    });
+    await harness.capacity.admit({ clientId: "first", eventId: "event-1" });
+    harness.blockCurrentVersionRead();
+    const pendingAdmission = harness.capacity.admit({ clientId: "second", eventId: "event-1" });
+    await Promise.resolve();
+    expect(harness.currentReadCount()).toBe(2);
+
+    expect(
+      await harness.capacity.admit({ clientId: "overflow", eventId: "event-1" }),
+    ).toMatchObject({ status: "rejected", reason: "capacity" });
+    expect(harness.currentReadCount()).toBe(2);
+    harness.releaseCurrentVersionRead();
+    expect(await pendingAdmission).toMatchObject({ status: "admitted" });
+    expect(harness.capacity.getMetrics()).toMatchObject({ queuedUpdates: 2 });
+
+    const reconnectHarness = createHarness({
+      totalConnections: 10,
+      controllerReserve: 0,
+      maxSpectators: 10,
+      globalQueueLimit: 1,
+    });
+    await reconnectHarness.capacity.admit({ clientId: "reconnect", eventId: "event-1" });
+    await reconnectHarness.capacity.drain("reconnect");
+    reconnectHarness.blockCurrentVersionRead();
+    const reconnect = reconnectHarness.capacity.admit({
+      clientId: "reconnect",
+      eventId: "event-1",
+    });
+    await Promise.resolve();
+    expect(reconnectHarness.currentReadCount()).toBe(2);
+    reconnectHarness.releaseCurrentVersionRead();
+    expect(await reconnect).toMatchObject({ status: "admitted" });
+  });
+
+  test("coalesces only after the latest barrier and preserves replica order", async () => {
+    const harness = createHarness({ perClientQueueLimit: 3, globalQueueLimit: 4 });
+    const admitted = await harness.capacity.admit({ clientId: "spectator-1", eventId: "event-1" });
+    expect(admitted.status).toBe("admitted");
+    await harness.capacity.drain("spectator-1");
+
+    expect(
+      harness.capacity.publish({
+        eventId: "event-1",
+        version: "v2",
+        payload: { score: 10 },
+        replaceableKey: "projection",
+      }),
+    ).toMatchObject({ queued: 1 });
+    harness.capacity.publish({
+      eventId: "event-1",
+      version: "timeline-v3",
+      payload: { score: 20 },
+      replaceableKey: null,
+    });
+    expect(
+      harness.capacity.publish({
+        eventId: "event-1",
+        version: "projection-v4",
+        payload: { score: 30 },
+        replaceableKey: "projection",
+      }),
+    ).toMatchObject({ queued: 1, coalesced: 0 });
+    expect(
+      harness.capacity.publish({
+        eventId: "event-1",
+        version: "projection-v5",
+        payload: { score: 40 },
+        replaceableKey: "projection",
+      }),
+    ).toMatchObject({ queued: 1, coalesced: 1 });
+
+    expect(harness.capacity.getQueueState("spectator-1")).toMatchObject({
+      queuedUpdates: 3,
+      queuedVersions: ["v2", "timeline-v3", "projection-v5"],
+    });
+    await harness.capacity.drain("spectator-1");
+    expect(harness.writes.get("spectator-1")).toEqual(["v1", "v2", "timeline-v3", "projection-v5"]);
+    expect(harness.replicaOutcomes).toEqual([
+      { clientId: "spectator-1", version: "v1", replaceableKey: "projection" },
+      { clientId: "spectator-1", version: "v2", replaceableKey: "projection" },
+      { clientId: "spectator-1", version: "timeline-v3", replaceableKey: null },
+      { clientId: "spectator-1", version: "projection-v5", replaceableKey: "projection" },
+    ]);
+    expect(harness.capacity.getMetrics().coalescedUpdates).toBe(1);
+  });
+
+  test("disconnects a slow reader at the per-client and global queue boundary", async () => {
+    const harness = createHarness({ perClientQueueLimit: 2, globalQueueLimit: 2 });
+    await harness.capacity.admit({ clientId: "slow", eventId: "event-1" });
+    await harness.capacity.drain("slow");
+    harness.capacity.publish({
+      eventId: "event-1",
+      version: "v2",
+      payload: { score: 1 },
+      replaceableKey: null,
+    });
+    harness.capacity.publish({
+      eventId: "event-1",
+      version: "v3",
+      payload: { score: 2 },
+      replaceableKey: null,
+    });
+    harness.capacity.publish({
+      eventId: "event-1",
+      version: "v4",
+      payload: { score: 3 },
+      replaceableKey: null,
+    });
+
+    expect(harness.closed).toEqual([{ clientId: "slow", reason: "slow-reader" }]);
+    expect(harness.capacity.getMetrics()).toMatchObject({ slowReaderDisconnects: 1 });
+    expect(harness.capacity.getQueueState("slow")).toBeNull();
+  });
+
+  test("rejects oversized or Infinity-sized Audience Projections before buffering them", async () => {
+    const initialTooLarge = createHarness({
+      current: { version: "v1", payload: { score: 1 } },
+      perClientQueuedOutputBytes: SHARED_LIMITS.transport.websocketTextFrameBytes,
+      measureQueuedOutputBytes: () => Number.POSITIVE_INFINITY,
+    });
+    expect(
+      await initialTooLarge.capacity.admit({ clientId: "too-large", eventId: "event-1" }),
+    ).toEqual({
+      status: "rejected",
+      reason: "output-limit",
+      message: "Spectator output is currently unavailable.",
+    });
+    expect(initialTooLarge.closed).toEqual([{ clientId: "too-large", reason: "slow-reader" }]);
+    expect(initialTooLarge.capacity.getMetrics()).toMatchObject({
+      activeSpectators: 0,
+      queuedUpdates: 0,
+    });
+
+    let large = false;
+    const coalescedTooLarge = createHarness({
+      perClientQueuedOutputBytes: SHARED_LIMITS.transport.websocketTextFrameBytes,
+      measureQueuedOutputBytes: (update) =>
+        large
+          ? Number.POSITIVE_INFINITY
+          : utf8ByteLength(
+              JSON.stringify({
+                type: "audience-projection",
+                eventId: update.eventId,
+                version: update.version,
+                replaceableKey: update.replaceableKey,
+                payload: update.payload,
+              }),
+            ),
+    });
+    expect(
+      await coalescedTooLarge.capacity.admit({
+        clientId: "coalesced-too-large",
+        eventId: "event-1",
+      }),
+    ).toMatchObject({ status: "admitted" });
+    await coalescedTooLarge.capacity.drain("coalesced-too-large");
+    coalescedTooLarge.capacity.publish({
+      eventId: "event-1",
+      version: "v2",
+      payload: { score: 2 },
+      replaceableKey: "projection",
+    });
+    large = true;
+    expect(
+      coalescedTooLarge.capacity.publish({
+        eventId: "event-1",
+        version: "v3",
+        payload: { score: 3 },
+        replaceableKey: "projection",
+      }),
+    ).toMatchObject({ queued: 0, disconnected: 1 });
+    expect(coalescedTooLarge.capacity.getQueueState("coalesced-too-large")).toBeNull();
+  });
+
+  test("enforces the exact serialized envelope boundary, including escaped fields", async () => {
+    const eventId = 'event-"quoted"';
+    const current = { version: "v1", payload: { score: 1 } } as const;
+    const exactEnvelope = JSON.stringify({
+      type: "audience-projection",
+      eventId,
+      version: current.version,
+      replaceableKey: "projection",
+      payload: current.payload,
+    });
+    const harness = createHarness({
+      current,
+      perClientQueuedOutputBytes: utf8ByteLength(exactEnvelope),
+    });
+
+    expect(await harness.capacity.admit({ clientId: "escaped", eventId })).toMatchObject({
+      status: "admitted",
+    });
+    await harness.capacity.drain("escaped");
+    harness.capacity.publish({
+      eventId,
+      version: "v2",
+      payload: { score: 123456789012345 },
+      replaceableKey: null,
+    });
+    expect(harness.closed).toEqual([{ clientId: "escaped", reason: "slow-reader" }]);
+  });
+
+  test("reconnects from the current authoritative version without replaying stale payloads", async () => {
+    const harness = createHarness({ current: { version: "v8", payload: { score: 80 } } });
+    await harness.capacity.admit({ clientId: "old", eventId: "event-1" });
+    await harness.capacity.drain("old");
+    harness.setCurrent({
+      version: "v9",
+      payload: { score: 90, privateToken: "must-not-be-measured" },
+    });
+    harness.capacity.publish({
+      eventId: "event-1",
+      version: "v9",
+      payload: { score: 90, privateToken: "must-not-be-measured" },
+      replaceableKey: "projection",
+    });
+    harness.capacity.disconnect("old", "client-reconnect");
+
+    const reconnected = await harness.capacity.admit({
+      clientId: "new",
+      eventId: "event-1",
+      lastSeenVersion: "v1",
+    });
+    expect(reconnected).toMatchObject({ status: "admitted", currentVersion: "v9" });
+    expect(harness.capacity.getQueueState("new")).toMatchObject({ queuedVersions: ["v9"] });
+    expect(JSON.stringify(harness.capacity.getMetrics())).not.toContain("privateToken");
+  });
+
+  test("returns a generic unavailable result when the authoritative current version cannot be read", async () => {
+    const harness = createHarness();
+    harness.setAdapterCurrentVersionUnavailable();
+
+    expect(await harness.capacity.admit({ clientId: "spectator-1", eventId: "event-1" })).toEqual({
+      status: "unavailable",
+      message: "Spectator experience is currently unavailable.",
+    });
+  });
+
+  test("does not turn an unavailable Controller capacity read into a public capacity detail", async () => {
+    const harness = createHarness();
+    harness.setControllerCapacityUnavailable();
+
+    expect(await harness.capacity.admit({ clientId: "spectator-1", eventId: "event-1" })).toEqual({
+      status: "unavailable",
+      message: "Spectator experience is currently unavailable.",
+    });
+  });
+
+  test("runs the deterministic 500-spectator harness with slow-reader, reconnect, and Controller churn", async () => {
+    const harness = createHarness({
+      perClientQueueLimit: 2,
+      totalConnections: 502,
+      controllerReserve: 2,
+    });
+    for (let index = 0; index < 500; index += 1) {
+      await harness.capacity.admit({ clientId: `logical-${index}`, eventId: "event-1" });
+      if (index < 499) await harness.capacity.drain(`logical-${index}`);
+      if (index === 99) {
+        expect(harness.acceptControllerSession()).toBe(1);
+        expect(harness.capacity.reconcileControllerCapacity()).toMatchObject({ disconnected: 0 });
+      }
+      if (index === 299) {
+        expect(harness.acceptControllerSession()).toBe(2);
+        expect(harness.capacity.reconcileControllerCapacity()).toMatchObject({ disconnected: 0 });
+      }
+    }
+
+    harness.capacity.publish({
+      eventId: "event-1",
+      version: "v2",
+      payload: { score: 1 },
+      replaceableKey: null,
+    });
+    harness.capacity.publish({
+      eventId: "event-1",
+      version: "v3",
+      payload: { score: 2 },
+      replaceableKey: null,
+    });
+    expect(harness.capacity.getQueueState("logical-499")).toBeNull();
+
+    for (let index = 0; index < 3; index += 1) {
+      harness.capacity.disconnect(`logical-${index}`, "client-reconnect");
+      expect(
+        await harness.capacity.admit({
+          clientId: `reconnected-${index}`,
+          eventId: "event-1",
+          lastSeenVersion: "v1",
+        }),
+      ).toMatchObject({ status: "admitted", currentVersion: "v1" });
+      await harness.capacity.drain(`reconnected-${index}`);
+    }
+
+    expect(harness.acceptControllerSession()).toBe(3);
+    expect(harness.capacity.reconcileControllerCapacity()).toMatchObject({
+      status: "reconciled",
+      disconnected: 0,
+    });
+    expect(harness.acceptControllerSession()).toBe(4);
+    expect(harness.capacity.reconcileControllerCapacity()).toMatchObject({
+      status: "reconciled",
+      disconnected: 1,
+    });
+    expect(harness.closed.at(-1)).toEqual({
+      clientId: "reconnected-2",
+      reason: "controller-priority",
+    });
+    expect(
+      await harness.capacity.admit({ clientId: "controller-pressure", eventId: "event-1" }),
+    ).toMatchObject({
+      status: "rejected",
+      reason: "capacity",
+    });
+    expect(harness.capacity.getMetrics()).toMatchObject({
+      activeSpectators: 498,
+      slowReaderDisconnects: 1,
+      controllerImpactGuardrail: {
+        activeControllerSessions: 4,
+        availableForSpectators: 498,
+        reserveBreachesObserved: 1,
+      },
+    });
+  });
+});

--- a/src/lib/spectator-capacity.ts
+++ b/src/lib/spectator-capacity.ts
@@ -1,0 +1,531 @@
+import {
+  availableNonControllerCapacity,
+  type ControllerCapacityInput,
+} from "@/lib/controller-capacity";
+import { SHARED_LIMITS } from "@/lib/validation-policy";
+
+/**
+ * The spectator path deliberately owns delivery pressure only. Controller
+ * admission and authority remain owned by the live-control runtime; this
+ * source is the read-only capacity signal supplied by that runtime.
+ */
+export type ControllerCapacitySignal = {
+  totalConnections: number;
+  reservedConnections: number;
+  /** Number of currently active authoritative Controller Grant Sessions. */
+  activeControllerSessions: () => number;
+};
+
+export type SpectatorCurrentVersion<TPayload> = {
+  version: string;
+  payload: TPayload;
+};
+
+export type SpectatorQueuedUpdate<TPayload> = SpectatorCurrentVersion<TPayload> & {
+  eventId: string;
+  replaceableKey: string | null;
+};
+
+export type SpectatorCurrentVersionResult<TPayload> =
+  | { status: "available"; current: SpectatorCurrentVersion<TPayload> }
+  | { status: "unavailable" };
+
+export type SpectatorStreamAdapter<TPayload> = {
+  readCurrentVersion(input: { eventId: string }): Promise<SpectatorCurrentVersionResult<TPayload>>;
+  /** Exact bytes of the serialized transport envelope, supplied by the transport seam. */
+  measureQueuedOutputBytes(update: SpectatorQueuedUpdate<TPayload>): number;
+  write(clientId: string, update: SpectatorQueuedUpdate<TPayload>): boolean | Promise<boolean>;
+  close(clientId: string, reason: SpectatorDisconnectReason): void;
+};
+
+export type SpectatorDisconnectReason =
+  | "slow-reader"
+  | "controller-priority"
+  | "client-reconnect"
+  | "client-closed";
+
+export type SpectatorCapacityOptions<TPayload> = {
+  adapter: SpectatorStreamAdapter<TPayload>;
+  controllerCapacity: ControllerCapacitySignal;
+  maxSpectators?: number;
+  /** Maximum number of queued updates retained for one spectator. */
+  perClientQueueLimit?: number;
+  /** Maximum number of queued updates retained across all spectators. */
+  globalQueueLimit?: number;
+  /** Reuses the shared WebSocket text-frame byte boundary by default. */
+  perClientQueuedOutputBytes?: number;
+};
+
+export type SpectatorAdmissionInput = {
+  clientId: string;
+  eventId: string;
+  /** Informational only: no historical replay is attempted. */
+  lastSeenVersion?: string;
+};
+
+export type SpectatorAdmissionResult =
+  | {
+      status: "admitted";
+      currentVersion: string;
+      currentVersionWasAlreadyKnown: boolean;
+    }
+  | {
+      status: "rejected";
+      reason: "capacity";
+      message: "Spectator capacity is currently full; try again later.";
+    }
+  | {
+      status: "rejected";
+      reason: "output-limit";
+      message: "Spectator output is currently unavailable.";
+    }
+  | {
+      status: "unavailable";
+      message: "Spectator experience is currently unavailable.";
+    };
+
+export type SpectatorPublishInput<TPayload> = SpectatorCurrentVersion<TPayload> & {
+  eventId: string;
+  replaceableKey: string | null;
+};
+
+export type SpectatorPublishResult = {
+  queued: number;
+  coalesced: number;
+  disconnected: number;
+};
+
+export type SpectatorQueueState = {
+  queuedUpdates: number;
+  queuedBytes: number;
+  queuedVersions: readonly string[];
+};
+
+export type SpectatorCapacityMetrics = {
+  activeSpectators: number;
+  rejectedAdmission: number;
+  coalescedUpdates: number;
+  slowReaderDisconnects: number;
+  queuedClients: number;
+  queuedUpdates: number;
+  queuedBytes: number;
+  controllerImpactGuardrail: {
+    totalConnections: number;
+    reservedConnections: number;
+    activeControllerSessions: number;
+    availableForSpectators: number;
+    protectedAdmissionRejects: number;
+    reserveBreachesObserved: number;
+  };
+};
+
+type SpectatorClient<TPayload> = {
+  eventId: string;
+  queue: SpectatorQueuedUpdate<TPayload>[];
+  queuedBytes: number;
+  admittedSequence: number;
+};
+
+const DEFAULT_MAX_SPECTATORS = SHARED_LIMITS.load.maxConnectedSpectators;
+const DEFAULT_PER_CLIENT_QUEUE_LIMIT = 8;
+const DEFAULT_GLOBAL_QUEUE_LIMIT = 2_000;
+const DEFAULT_PER_CLIENT_QUEUED_OUTPUT_BYTES = SHARED_LIMITS.transport.websocketTextFrameBytes;
+const GENERIC_UNAVAILABLE_MESSAGE = "Spectator experience is currently unavailable." as const;
+const OUTPUT_LIMIT_MESSAGE = "Spectator output is currently unavailable." as const;
+
+export function createSpectatorCapacity<TPayload>(
+  options: SpectatorCapacityOptions<TPayload>,
+): SpectatorCapacity<TPayload> {
+  const maxSpectators = positiveLimit(options.maxSpectators, DEFAULT_MAX_SPECTATORS);
+  const perClientQueueLimit = positiveLimit(
+    options.perClientQueueLimit,
+    DEFAULT_PER_CLIENT_QUEUE_LIMIT,
+  );
+  const globalQueueLimit = positiveLimit(options.globalQueueLimit, DEFAULT_GLOBAL_QUEUE_LIMIT);
+  const perClientQueuedOutputBytes = positiveLimit(
+    options.perClientQueuedOutputBytes,
+    DEFAULT_PER_CLIENT_QUEUED_OUTPUT_BYTES,
+  );
+  const clients = new Map<string, SpectatorClient<TPayload>>();
+  let queuedUpdates = 0;
+  let queuedBytes = 0;
+  let rejectedAdmission = 0;
+  let coalescedUpdates = 0;
+  let slowReaderDisconnects = 0;
+  let protectedAdmissionRejects = 0;
+  let reserveBreachesObserved = 0;
+  let admissionSequence = 0;
+  const provisionalAdmissions = new Set<string>();
+
+  function controllerSignal() {
+    const totalConnections = positiveLimit(options.controllerCapacity.totalConnections, 1);
+    const reservedConnections = boundedLimit(
+      options.controllerCapacity.reservedConnections,
+      0,
+      totalConnections,
+    );
+    let activeControllerSessions = 0;
+    try {
+      const observed = options.controllerCapacity.activeControllerSessions();
+      if (!Number.isFinite(observed)) return null;
+      activeControllerSessions = Math.max(0, Math.floor(observed));
+    } catch {
+      return null;
+    }
+    const capacityInput: ControllerCapacityInput = {
+      totalConnections,
+      reservedConnections,
+      activeControllerSessions,
+    };
+    const availableForSpectators = availableNonControllerCapacity(capacityInput);
+    return {
+      totalConnections,
+      reservedConnections,
+      activeControllerSessions,
+      availableForSpectators,
+    };
+  }
+
+  function allowedSpectators(signal: NonNullable<ReturnType<typeof controllerSignal>>): number {
+    return Math.min(maxSpectators, signal.availableForSpectators);
+  }
+
+  function reconcileControllerCapacityInternal(
+    signal: NonNullable<ReturnType<typeof controllerSignal>>,
+  ): number {
+    const excess = clients.size - allowedSpectators(signal);
+    if (excess <= 0) return 0;
+    const victims = [...clients.entries()]
+      .sort(
+        ([leftId, left], [rightId, right]) =>
+          right.admittedSequence - left.admittedSequence || rightId.localeCompare(leftId),
+      )
+      .slice(0, excess);
+    for (const [clientId] of victims) disconnect(clientId, "controller-priority");
+    reserveBreachesObserved += victims.length;
+    return victims.length;
+  }
+
+  function canAdmit(signal: NonNullable<ReturnType<typeof controllerSignal>>, clientId: string) {
+    const existing = clients.get(clientId);
+    const replacingCount = existing === undefined ? 0 : 1;
+    const alreadyProvisional = provisionalAdmissions.has(clientId);
+    const prospectiveSpectators =
+      clients.size - replacingCount + provisionalAdmissions.size + (alreadyProvisional ? 0 : 1);
+    const prospectiveQueuedUpdates =
+      queuedUpdates -
+      (existing?.queue.length ?? 0) +
+      (provisionalAdmissions.size - (alreadyProvisional ? 1 : 0)) +
+      1;
+    return (
+      prospectiveSpectators <= allowedSpectators(signal) &&
+      prospectiveQueuedUpdates <= globalQueueLimit
+    );
+  }
+
+  function recordCapacityRejection(signal: NonNullable<ReturnType<typeof controllerSignal>>) {
+    rejectedAdmission += 1;
+    protectedAdmissionRejects +=
+      signal.availableForSpectators < maxSpectators &&
+      allowedSpectators(signal) <= clients.size + provisionalAdmissions.size
+        ? 1
+        : 0;
+  }
+
+  function measureUpdateBytes(update: SpectatorQueuedUpdate<TPayload>): number {
+    try {
+      const measured = options.adapter.measureQueuedOutputBytes(update);
+      return Number.isFinite(measured) && measured >= 0 ? measured : Number.POSITIVE_INFINITY;
+    } catch {
+      return Number.POSITIVE_INFINITY;
+    }
+  }
+
+  function disconnect(clientId: string, reason: SpectatorDisconnectReason): boolean {
+    const client = clients.get(clientId);
+    if (client === undefined) return false;
+    clients.delete(clientId);
+    queuedUpdates -= client.queue.length;
+    queuedBytes -= client.queuedBytes;
+    if (reason === "slow-reader") slowReaderDisconnects += 1;
+    options.adapter.close(clientId, reason);
+    return true;
+  }
+
+  function enqueue(clientId: string, update: SpectatorQueuedUpdate<TPayload>): boolean {
+    const client = clients.get(clientId);
+    if (client === undefined) return false;
+    const updateBytes = measureUpdateBytes(update);
+    if (!Number.isFinite(updateBytes) || updateBytes < 0) {
+      disconnect(clientId, "slow-reader");
+      return false;
+    }
+    if (update.replaceableKey !== null) {
+      let latestBarrierIndex = -1;
+      for (let index = 0; index < client.queue.length; index += 1) {
+        if (client.queue[index]?.replaceableKey === null) latestBarrierIndex = index;
+      }
+      const existingIndex = client.queue.findIndex(
+        (queued, index) =>
+          index > latestBarrierIndex && queued.replaceableKey === update.replaceableKey,
+      );
+      if (existingIndex >= 0) {
+        const previous = client.queue[existingIndex];
+        if (previous === undefined) return false;
+        const previousBytes = measureUpdateBytes(previous);
+        const nextQueuedBytes = client.queuedBytes - previousBytes + updateBytes;
+        if (!Number.isFinite(previousBytes) || nextQueuedBytes > perClientQueuedOutputBytes) {
+          disconnect(clientId, "slow-reader");
+          return false;
+        }
+        client.queue[existingIndex] = update;
+        queuedBytes += nextQueuedBytes - client.queuedBytes;
+        client.queuedBytes = nextQueuedBytes;
+        coalescedUpdates += 1;
+        if (client.queue.length > perClientQueueLimit || queuedUpdates > globalQueueLimit) {
+          disconnect(clientId, "slow-reader");
+          return false;
+        }
+        return true;
+      }
+    }
+
+    if (
+      client.queue.length >= perClientQueueLimit ||
+      queuedUpdates >= globalQueueLimit ||
+      client.queuedBytes + updateBytes > perClientQueuedOutputBytes
+    ) {
+      disconnect(clientId, "slow-reader");
+      return false;
+    }
+    client.queue.push(update);
+    client.queuedBytes += updateBytes;
+    queuedUpdates += 1;
+    queuedBytes += updateBytes;
+    return true;
+  }
+
+  async function drain(clientId: string, limit = Number.POSITIVE_INFINITY): Promise<number> {
+    const client = clients.get(clientId);
+    if (client === undefined) return 0;
+    let written = 0;
+    while (written < limit) {
+      const update = client.queue[0];
+      if (update === undefined) break;
+      let accepted = false;
+      try {
+        accepted = await options.adapter.write(clientId, update);
+      } catch {
+        accepted = false;
+      }
+      if (!accepted) {
+        disconnect(clientId, "slow-reader");
+        break;
+      }
+      client.queue.shift();
+      queuedUpdates -= 1;
+      const updateBytes = measureUpdateBytes(update);
+      client.queuedBytes -= updateBytes;
+      queuedBytes -= updateBytes;
+      written += 1;
+    }
+    return written;
+  }
+
+  return {
+    async admit(input): Promise<SpectatorAdmissionResult> {
+      const initialSignal = controllerSignal();
+      if (initialSignal === null) {
+        return { status: "unavailable", message: GENERIC_UNAVAILABLE_MESSAGE };
+      }
+      reconcileControllerCapacityInternal(initialSignal);
+      if (!canAdmit(initialSignal, input.clientId)) {
+        recordCapacityRejection(initialSignal);
+        return {
+          status: "rejected",
+          reason: "capacity",
+          message: "Spectator capacity is currently full; try again later.",
+        };
+      }
+
+      if (provisionalAdmissions.has(input.clientId)) {
+        recordCapacityRejection(initialSignal);
+        return {
+          status: "rejected",
+          reason: "capacity",
+          message: "Spectator capacity is currently full; try again later.",
+        };
+      }
+      const provisional = !clients.has(input.clientId);
+      if (provisional) provisionalAdmissions.add(input.clientId);
+      try {
+        const result = await options.adapter.readCurrentVersion({ eventId: input.eventId });
+        if (result.status !== "available")
+          return { status: "unavailable", message: GENERIC_UNAVAILABLE_MESSAGE };
+        const current = result.current;
+
+        const finalSignal = controllerSignal();
+        if (finalSignal === null) {
+          return { status: "unavailable", message: GENERIC_UNAVAILABLE_MESSAGE };
+        }
+        reconcileControllerCapacityInternal(finalSignal);
+        if (!clients.has(input.clientId) && !provisionalAdmissions.has(input.clientId)) {
+          if (!canAdmit(finalSignal, input.clientId)) {
+            recordCapacityRejection(finalSignal);
+            return {
+              status: "rejected",
+              reason: "capacity",
+              message: "Spectator capacity is currently full; try again later.",
+            };
+          }
+          provisionalAdmissions.add(input.clientId);
+        }
+        if (!canAdmit(finalSignal, input.clientId)) {
+          recordCapacityRejection(finalSignal);
+          return {
+            status: "rejected",
+            reason: "capacity",
+            message: "Spectator capacity is currently full; try again later.",
+          };
+        }
+
+        if (clients.has(input.clientId)) disconnect(input.clientId, "client-reconnect");
+        clients.set(input.clientId, {
+          eventId: input.eventId,
+          queue: [],
+          queuedBytes: 0,
+          admittedSequence: admissionSequence++,
+        });
+        provisionalAdmissions.delete(input.clientId);
+        const queued = enqueue(input.clientId, {
+          eventId: input.eventId,
+          version: current.version,
+          payload: current.payload,
+          replaceableKey: "projection",
+        });
+        if (!queued) {
+          return {
+            status: "rejected",
+            reason: "output-limit",
+            message: OUTPUT_LIMIT_MESSAGE,
+          };
+        }
+        return {
+          status: "admitted",
+          currentVersion: current.version,
+          currentVersionWasAlreadyKnown: input.lastSeenVersion === current.version,
+        };
+      } catch {
+        return { status: "unavailable", message: GENERIC_UNAVAILABLE_MESSAGE };
+      } finally {
+        provisionalAdmissions.delete(input.clientId);
+      }
+    },
+    publish(input): SpectatorPublishResult {
+      const signal = controllerSignal();
+      if (signal === null) return { queued: 0, coalesced: 0, disconnected: 0 };
+      reconcileControllerCapacityInternal(signal);
+      let queued = 0;
+      let coalesced = 0;
+      let disconnected = 0;
+      for (const clientId of clients.keys()) {
+        const client = clients.get(clientId);
+        if (client?.eventId !== input.eventId) continue;
+        const before = coalescedUpdates;
+        if (
+          enqueue(clientId, {
+            eventId: input.eventId,
+            version: input.version,
+            payload: input.payload,
+            replaceableKey: input.replaceableKey,
+          })
+        ) {
+          queued += 1;
+          coalesced += coalescedUpdates - before;
+        } else {
+          disconnected += 1;
+        }
+      }
+      return { queued, coalesced, disconnected };
+    },
+    /** Call after authoritative Controller admission or session reconciliation. */
+    reconcileControllerCapacity() {
+      const signal = controllerSignal();
+      if (signal === null) {
+        return { status: "unavailable", message: GENERIC_UNAVAILABLE_MESSAGE };
+      }
+      return {
+        status: "reconciled",
+        activeControllerSessions: signal.activeControllerSessions,
+        availableForSpectators: signal.availableForSpectators,
+        disconnected: reconcileControllerCapacityInternal(signal),
+      };
+    },
+    drain,
+    disconnect(clientId, reason = "client-closed") {
+      return disconnect(clientId, reason);
+    },
+    getQueueState(clientId): SpectatorQueueState | null {
+      const client = clients.get(clientId);
+      if (client === undefined) return null;
+      return {
+        queuedUpdates: client.queue.length,
+        queuedBytes: client.queuedBytes,
+        queuedVersions: client.queue.map((update) => update.version),
+      };
+    },
+    getMetrics(): SpectatorCapacityMetrics {
+      const signal = controllerSignal();
+      const safeSignal = signal ?? {
+        totalConnections: positiveLimit(options.controllerCapacity.totalConnections, 1),
+        reservedConnections: boundedLimit(
+          options.controllerCapacity.reservedConnections,
+          0,
+          positiveLimit(options.controllerCapacity.totalConnections, 1),
+        ),
+        activeControllerSessions: 0,
+        availableForSpectators: 0,
+      };
+      return {
+        activeSpectators: clients.size,
+        rejectedAdmission,
+        coalescedUpdates,
+        slowReaderDisconnects,
+        queuedClients: [...clients.values()].filter((client) => client.queue.length > 0).length,
+        queuedUpdates,
+        queuedBytes,
+        controllerImpactGuardrail: {
+          ...safeSignal,
+          protectedAdmissionRejects,
+          reserveBreachesObserved,
+        },
+      };
+    },
+  };
+}
+
+export type SpectatorCapacity<TPayload> = {
+  admit(input: SpectatorAdmissionInput): Promise<SpectatorAdmissionResult>;
+  publish(input: SpectatorPublishInput<TPayload>): SpectatorPublishResult;
+  reconcileControllerCapacity():
+    | {
+        status: "reconciled";
+        activeControllerSessions: number;
+        availableForSpectators: number;
+        disconnected: number;
+      }
+    | { status: "unavailable"; message: "Spectator experience is currently unavailable." };
+  drain(clientId: string, limit?: number): Promise<number>;
+  disconnect(clientId: string, reason?: SpectatorDisconnectReason): boolean;
+  getQueueState(clientId: string): SpectatorQueueState | null;
+  getMetrics(): SpectatorCapacityMetrics;
+};
+
+function positiveLimit(value: number | undefined, fallback: number): number {
+  return Number.isSafeInteger(value) && value !== undefined && value > 0 ? value : fallback;
+}
+
+function boundedLimit(value: number, minimum: number, maximum: number): number {
+  if (!Number.isSafeInteger(value)) return minimum;
+  return Math.min(maximum, Math.max(minimum, value));
+}


### PR DESCRIPTION
## What changed

- adds a bounded spectator-capacity module with Controller-reserve-aware admission and deterministic spectator shedding
- centralizes the shared `totalConnections - max(reservedConnections, activeControllerSessions)` policy across Event and Ad Hoc paths
- reserves spectator and global queued-output capacity before authoritative reads, rechecks after the read, and releases provisional reservations on every outcome
- enforces exact serialized per-socket output bytes, barrier-safe projection coalescing, slow-reader disconnection, current-version reconnect, and payload-free metrics
- leaves the #137 WebSocket adapter as the explicit production composition seam

## Why

Public spectator traffic must not consume the connection or projection capacity needed by active Controllers during the Event. This establishes the minimum reliable admission and backpressure policy without adding empirical load or production-acceptance ceremony.

## Impact

Controller Sessions retain priority under spectator admission, reconnect, slow-reader, and queue churn. Public failures remain generic and recoverable, and private payloads do not enter operational metrics.

Closes #138.

## Validation

- focused capacity tests: 33 passed
- post-rebase `bun test --isolate`: 875 passed, 0 failed, 20,009 expectations
- `bun run check` (existing unrelated warnings only)
- `bun run build`
- `git diff --check`

No Qualification, load, soak, crash, recovery, or exact-production-artifact workload was run.
