### PR TITLE
Fix late Docker create cleanup

### DIFF
--- a/scripts/test-focused-admission.ts
+++ b/scripts/test-focused-admission.ts
@@ -2,6 +2,7 @@ import { performance } from "node:perf_hooks";
 import {
   admitDockerEngine,
   buildFocusedDockerCommand,
+  cleanupLateCreatedDockerContainer,
   cleanupMalformedCreateOutput,
   cleanupOwnedDockerContainer,
   parseContainerId,
@@ -154,9 +155,9 @@ async function createHarmlessExecution(
   lifecycle: DockerProbeLifecycle,
 ) {
   const name = command[command.indexOf("--name") + 1] ?? `quadball-timer-focused-${capability}`;
-  // Allow only the short admission grace after the work deadline; cleanup keeps
-  // the remaining reserve for exact ownership and absence proof.
-  const create = await runDockerCommand(command, { signal: lifecycle.admissionSignal }).catch(
+  // Keep the daemon-side create request alive through the cleanup reserve so a
+  // late-created container is reconciled before final evidence is emitted.
+  const create = await runDockerCommand(command, { signal: lifecycle.cleanupSignal }).catch(
     () => null,
   );
   if (create === null || create.exitCode !== 0 || create.outputExceeded) {
@@ -182,6 +183,17 @@ async function createHarmlessExecution(
     throw new FocusedAdmissionError(
       "Docker returned an invalid focused container identity",
       cleanupDisposition,
+    );
+  }
+  if (lifecycle.admissionSignal.aborted) {
+    const disposition = await cleanupLateCreatedDockerContainer(
+      runDockerCommand,
+      { id, name, capability },
+      lifecycle.cleanupSignal,
+    );
+    throw new FocusedAdmissionError(
+      "Docker focused admission completed after its work deadline",
+      disposition,
     );
   }
   const admitted = await verifyDockerContainerConfiguration(

--- a/src/lib/sqlite-foundation-probe-docker.test.ts
+++ b/src/lib/sqlite-foundation-probe-docker.test.ts
@@ -302,7 +302,7 @@ describe("Docker SQLite qualification boundary", () => {
     ]);
     expect(calls[2]).toContain(`type=bind,src=${artifactPath},dst=/opt/quadball-timer,readonly`);
     expect(calls.map((value) => value[0])).not.toContain("start");
-    expect(createSignal).toBe(admissionSignal);
+    expect(createSignal).toBe(cleanupSignal);
   });
 
   test("uses production stop, kill, wait, removal, and exact absence in order", async () => {
@@ -782,6 +782,69 @@ describe("Docker SQLite qualification boundary", () => {
     );
     expect(cleanup).toBe("removed");
     expect(calls).toEqual(["ps", "ps", "ps", "ps", "ps", "ps", "inspect", "rm", "ps"]);
+  });
+
+  test("waits for daemon-side create completion before final late-create cleanup", async () => {
+    const artifactPath = await realpath("/bin/sh");
+    const admission = new AbortController();
+    const reconciliation = new AbortController();
+    const cleanup = new AbortController();
+    const calls: string[] = [];
+    let daemonCreated = false;
+    let createSignal: AbortSignal | undefined;
+    let resolveCreateDaemonResult!: () => void;
+    const createDaemonResult = new Promise<void>((resolve) => {
+      resolveCreateDaemonResult = () => {
+        daemonCreated = true;
+        resolve();
+      };
+    });
+    let markCreateStarted!: () => void;
+    const createStarted = new Promise<void>((resolve) => {
+      markCreateStarted = resolve;
+    });
+
+    const pending = createDockerProbeExecution(artifactPath, {
+      platform: "linux",
+      architecture: "x64",
+      invocationId: capability,
+      admissionSignal: admission.signal,
+      reconciliationSignal: reconciliation.signal,
+      cleanupSignal: cleanup.signal,
+      runCommand: async (arguments_, options) => {
+        const command = arguments_[0] ?? "";
+        calls.push(command);
+        if (command === "info")
+          return dockerResult(JSON.stringify({ OSType: "linux", Architecture: "x86_64" }));
+        if (command === "version")
+          return dockerResult(JSON.stringify({ Os: "linux", Arch: "amd64" }));
+        if (command === "create") {
+          createSignal = options?.signal;
+          markCreateStarted();
+          const aborted = new Promise<never>((_, reject) => {
+            options?.signal?.addEventListener("abort", () => reject(new Error("client aborted")), {
+              once: true,
+            });
+          });
+          await Promise.race([createDaemonResult, aborted]);
+          return dockerResult(`${containerId}\n`);
+        }
+        if (command === "inspect") return dockerResult(ownedContainerInspection());
+        if (command === "rm") return dockerResult();
+        if (command === "ps") return dockerResult();
+        throw new Error(`unexpected Docker command: ${arguments_.join(" ")}`);
+      },
+    }).catch((value) => value);
+    await createStarted;
+    admission.abort();
+    reconciliation.abort();
+    resolveCreateDaemonResult();
+    const error = await pending;
+    expect(daemonCreated).toBe(true);
+    expect(createSignal).toBe(cleanup.signal);
+    expect(error).toBeInstanceOf(DockerAdmissionError);
+    expect((error as DockerAdmissionError).disposition).toBe("removed");
+    expect(calls).toEqual(["info", "version", "create", "inspect", "rm", "ps"]);
   });
 
   test("classifies explicit pre-create empty observations as not-created", async () => {

--- a/src/lib/sqlite-foundation-probe-docker.ts
+++ b/src/lib/sqlite-foundation-probe-docker.ts
@@ -251,9 +251,9 @@ export async function createDockerProbeExecution(
       image: dependencies.image,
     }),
     // A work-timeout may race the daemon-side create request. Keep the Docker
-    // client alive only through the short admission grace; cleanup owns the
-    // remaining reserve for exact identity and absence proof.
-    { signal: admissionSignal },
+    // client alive through the cleanup reserve so the daemon's create result is
+    // reconciled before final evidence is emitted.
+    { signal: cleanupSignal },
   ).catch(() => null);
   if (create === null || create.exitCode !== 0 || create.outputExceeded) {
     const cleanupDisposition = await cleanupMalformedCreateOutput(runCommand, name, capability, {
@@ -283,6 +283,17 @@ export async function createDockerProbeExecution(
     artifactPath,
     identityVerified: false,
   };
+  if (admissionSignal?.aborted) {
+    const disposition = await cleanupLateCreatedDockerContainer(
+      runCommand,
+      container,
+      cleanupSignal,
+    );
+    throw new DockerAdmissionError(
+      "Docker admission completed after its work deadline.",
+      disposition,
+    );
+  }
   const admitted = await verifyDockerContainerConfiguration(
     runCommand,
     container,
@@ -538,6 +549,15 @@ export async function cleanupOwnedDockerContainer(
     identityVerified: true,
     removed: await verifyOwnedDockerContainerAbsence(runCommand, container.id, signal),
   };
+}
+
+export async function cleanupLateCreatedDockerContainer(
+  runCommand: DockerCommandRunner,
+  container: Pick<DockerProbeContainer, "id" | "name" | "capability">,
+  signal?: AbortSignal,
+): Promise<DockerAdmissionDisposition> {
+  const cleanup = await cleanupOwnedDockerContainer(runCommand, container, signal);
+  return cleanup.identityVerified && cleanup.removed ? "removed" : "unverified";
 }
 
 async function verifyOwnedContainer(


### PR DESCRIPTION
Closes #179

## Summary

- keep the daemon-side Docker `create` request alive through the registered cleanup reserve
- when creation finishes after the admission deadline, revalidate the exact full container ID, generated name, and capability label before removal
- prove exact absence before returning final admission evidence in both the Qualification and harmless focused-admission entrypoints
- add deterministic deferred-promise and injected-signal coverage for the native VPS timing order

## Why

The native #82 preflight demonstrated that Docker could finish creating the owned container after the admission deadline while the harness had already returned failed evidence. That left a test-owned container in `Created` state and blocked the exact-artifact Qualification Test.

This correction keeps the same deadline, containment, ownership, unrelated-container safety, bounded evidence, and no-retry contracts. It changes only how the already-owned late daemon result is reconciled during the reserved cleanup phase.

## Verification

- `bun install --frozen-lockfile`
- `bun run check`
- affected Docker/runner/focused Fast tests — 40 passed
- coordinator Docker/runner/evidence tests after current-main rebase — 38 passed, 156 expectations
- complete ordinary Fast suite — 859 passed, 19,333 assertions
- `bun run build`
- `bun run build:executable`
- harmless Darwin focused admission blocked before workload launch with `qualificationWorkloadRan:false` and `workloadLaunched:false`
- Standards review — no hard findings
- Spec review — no findings
- `git diff --check`

No Qualification Test, `check:sqlite-runtime`, VPS/SSH access, Production access, load, soak, crash, or recovery workload was run during implementation or review.
