### PR TITLE
Add public health endpoint for UptimeRobot

### DIFF
--- a/deploy/uptimerobot-monitoring.md
+++ b/deploy/uptimerobot-monitoring.md
@@ -1,0 +1,42 @@
+# Production UptimeRobot monitoring
+
+Quadball Timer exposes one deliberately minimal public readiness route at
+`/healthz`. It returns HTTP `200` and the fixed body `healthy` only when the
+Technical Admin store, Foundation database, migration/readiness checks, and
+authoritative write boundary are ready. Every unavailable or unsafe state
+returns HTTP `503` and the fixed body `unhealthy`. The response is
+`Cache-Control: no-store`; it never includes release, commit, runtime, schema,
+database, credential, object-count, dependency, or diagnostic information.
+
+The existing `/internal/healthz` endpoint remains a loopback-only process
+liveness check for activation. It is not a public monitor and must continue to
+return `404` through the public Production host. The separate loopback-only
+`/internal/release` endpoint remains the non-public release identity check.
+
+The Test deployment may expose the same `/healthz` route for deterministic
+verification, but it has no UptimeRobot monitor obligation.
+
+## Operator-owned UptimeRobot setup
+
+Create these two monitors in the operator-owned UptimeRobot account:
+
+| Monitor | URL | Expected result | Interval |
+| --- | --- | --- | --- |
+| Production Home | `https://timer.quadball.app/` | HTTP `200` | 5 minutes |
+| Production health | `https://timer.quadball.app/healthz` | HTTP `200` and body containing `healthy` | 5 minutes |
+
+Use UptimeRobot's free five-minute HTTP monitors. Do not configure a paid
+one-minute plan or a continuous WebSocket monitor for this SQM slice. Route
+both monitors to the operator's existing Production availability contact
+group. Monitor ownership, contact routing, and alert mute/escalation choices
+are external account settings; do not add account IDs, API keys, webhook
+secrets, or copied private diagnostics to this repository, release artifact,
+server environment, or deployment workflow.
+
+## Bounded human verification
+
+After the Production route is deployed, the operator records only the monitor
+names, URLs, interval, and observed HTTP outcome in the deployment handoff.
+Do not export monitor credentials, response captures, or private UptimeRobot
+diagnostics. The external check is a human setup/verification step and is not
+run by the application test suite or deployment workflow.

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,6 +109,7 @@ import {
   serializeBrowserMonitoringConfig,
 } from "@/lib/monitoring-redaction";
 import { runProductionActivationCli } from "@/lib/production-activation-cli";
+import { createPublicHealthRoute } from "@/lib/public-health";
 
 type SessionSubscription =
   | {
@@ -2110,6 +2111,14 @@ async function startServer() {
             ]);
           },
         },
+        "/healthz": createPublicHealthRoute({
+          foundationStorage,
+          technicalAdminAuth,
+          authoritativeServices: {
+            eventAdministration: eventAdministration !== null,
+            liveEventRuntime,
+          },
+        }),
         "/internal/healthz": {
           GET(req: Request) {
             if (!isInternalHealthHost(req.headers.get("host"))) {

--- a/src/lib/live-event-game-runtime.test.ts
+++ b/src/lib/live-event-game-runtime.test.ts
@@ -265,6 +265,11 @@ describe("Live Event Game SQLite runtime", () => {
       clock: () => 10_000,
     });
     try {
+      expect(await runtime.readiness()).toMatchObject({
+        ok: true,
+        storage: "sqlite",
+        evidence: { transaction: { writePressure: "normal" } },
+      });
       const opened = await runtime.control.openController({
         qrCredential,
         browserContext: "runtime-test-device",

--- a/src/lib/live-event-game-runtime.ts
+++ b/src/lib/live-event-game-runtime.ts
@@ -28,6 +28,7 @@ import {
 } from "@/lib/foundation-record-types";
 import { lockControlGrantEventGame } from "@/lib/grant-management-sessions";
 import type {
+  FoundationStorageReadiness,
   FoundationStorageSnapshot,
   FoundationStorageTransaction,
 } from "@/lib/foundation-storage";
@@ -37,6 +38,7 @@ import type { FoundationStorage } from "@/lib/foundation-storage";
 export type LiveEventGameRuntime = {
   control: ReturnType<typeof createLiveEventGameControl>;
   readAudienceProjectionGameInput(eventGameId: string): Promise<AudienceProjectionGameInputOutcome>;
+  readiness(): Promise<FoundationStorageReadiness>;
   close(): void;
 };
 
@@ -326,6 +328,7 @@ export async function openLiveEventGameRuntime(input: {
         const projection = await control.readControllerProjection(eventGameId);
         return readAudienceProjectionGameInput(root, projection);
       },
+      readiness: () => storage.readiness(),
       close() {
         clearInterval(lockTimer);
         control.close();

--- a/src/lib/public-health.test.ts
+++ b/src/lib/public-health.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, test } from "bun:test";
+import type { FoundationStorage, FoundationStorageReadiness } from "@/lib/foundation-storage";
+import { createPublicHealthRoute, isPubliclyHealthy, readPublicHealth } from "@/lib/public-health";
+
+const readyTechnicalAdmin = {
+  storageStatus: () => ({
+    state: "ready" as const,
+    credentialPresent: true,
+    activeSessionCount: 0,
+    generation: 1,
+  }),
+};
+
+const readyLiveEventRuntime = {
+  readiness: async () => sqliteReadiness("normal"),
+};
+
+const readyAuthoritativeServices = {
+  eventAdministration: true,
+  liveEventRuntime: readyLiveEventRuntime,
+};
+
+function sqliteReadiness(
+  writePressure: "unknown" | "normal" | "unsafe",
+): FoundationStorageReadiness {
+  return {
+    ok: true as const,
+    schemaVersion: "26",
+    storage: "sqlite" as const,
+    evidence: {
+      runtime: { engine: "bun", version: "test", sqliteVersion: "3" },
+      transaction: {
+        lastLatencyMs: null,
+        rejectionCount: 0,
+        rejectionCategories: {
+          busy: 0,
+          readonly: 0,
+          full: 0,
+          "io-error": 0,
+          "commit-failure": 0,
+          corruption: 0,
+        },
+        writePressure,
+      },
+      sqlite: {
+        journalMode: "wal",
+        synchronous: 2,
+        foreignKeys: true,
+        walBytes: 0,
+        checkpoint: "ok",
+        diskBytes: 0,
+        diskFreeBytes: 1,
+        failureCategory: null,
+      },
+      migration: { state: "ready", schemaVersion: "26", appliedCount: 26 },
+      keys: {
+        requiredCount: 0,
+        availableCount: 0,
+        missingCount: 0,
+        requiredCategories: { encryption: 0, lookup: 0, audit: 0 },
+        availableCategories: { encryption: 0, lookup: 0, audit: 0 },
+        missingCategories: { encryption: 0, lookup: 0, audit: 0 },
+      },
+      replay: { result: "not-configured", rootCount: 0, actionCount: 0, durationMs: null },
+    },
+  };
+}
+
+const readyFoundation: Pick<FoundationStorage, "readiness"> = {
+  readiness: async () => sqliteReadiness("normal"),
+};
+
+const sensitiveReadinessFailure: Pick<FoundationStorage, "readiness"> = {
+  readiness: async () => ({
+    ok: false as const,
+    status: "integrity-failure" as const,
+    detail:
+      "database path, schema version, release identity, credential detail, object counts, and stack diagnostics stay private",
+    storage: "sqlite" as const,
+  }),
+};
+
+describe("public health contract", () => {
+  test("mounts the literal /healthz route and serves its HTTP contract", async () => {
+    const server = Bun.serve({
+      port: 0,
+      routes: {
+        "/healthz": createPublicHealthRoute({
+          foundationStorage: readyFoundation,
+          technicalAdminAuth: readyTechnicalAdmin,
+          authoritativeServices: readyAuthoritativeServices,
+        }),
+      },
+    });
+
+    try {
+      const response = await fetch(new URL("/healthz", server.url));
+      expect(response.status).toBe(200);
+      expect(await response.text()).toBe("healthy\n");
+      expect(response.headers.get("cache-control")).toBe("no-store");
+      expect(response.headers.get("content-type")).toBe("text/plain; charset=utf-8");
+      expect(response.headers.get("referrer-policy")).toBe("no-referrer");
+      expect(response.headers.get("x-content-type-options")).toBe("nosniff");
+      expect((await fetch(new URL("/not-healthz", server.url))).status).toBe(404);
+    } finally {
+      await server.stop(true);
+    }
+  });
+
+  test("returns only unhealthy when any authoritative boundary is unavailable", async () => {
+    const unavailableTechnicalAdmin = {
+      storageStatus: () => ({
+        ...readyTechnicalAdmin.storageStatus(),
+        state: "unavailable" as const,
+      }),
+    };
+    const throwingTechnicalAdmin = {
+      storageStatus: () => {
+        throw new Error("credential database stack diagnostic");
+      },
+    };
+    const throwingFoundation: Pick<FoundationStorage, "readiness"> = {
+      readiness: async () => {
+        throw new Error("database schema release object diagnostic");
+      },
+    };
+
+    for (const dependencies of [
+      {
+        foundationStorage: undefined,
+        technicalAdminAuth: readyTechnicalAdmin,
+        authoritativeServices: readyAuthoritativeServices,
+      },
+      {
+        foundationStorage: sensitiveReadinessFailure,
+        technicalAdminAuth: readyTechnicalAdmin,
+        authoritativeServices: readyAuthoritativeServices,
+      },
+      {
+        foundationStorage: readyFoundation,
+        technicalAdminAuth: unavailableTechnicalAdmin,
+        authoritativeServices: readyAuthoritativeServices,
+      },
+      {
+        foundationStorage: readyFoundation,
+        technicalAdminAuth: throwingTechnicalAdmin,
+        authoritativeServices: readyAuthoritativeServices,
+      },
+      {
+        foundationStorage: throwingFoundation,
+        technicalAdminAuth: readyTechnicalAdmin,
+        authoritativeServices: readyAuthoritativeServices,
+      },
+      {
+        foundationStorage: readyFoundation,
+        technicalAdminAuth: readyTechnicalAdmin,
+        authoritativeServices: {
+          eventAdministration: false,
+          liveEventRuntime: readyLiveEventRuntime,
+        },
+      },
+      {
+        foundationStorage: readyFoundation,
+        technicalAdminAuth: readyTechnicalAdmin,
+        authoritativeServices: { eventAdministration: true, liveEventRuntime: null },
+      },
+      {
+        foundationStorage: readyFoundation,
+        technicalAdminAuth: readyTechnicalAdmin,
+        authoritativeServices: {
+          eventAdministration: true,
+          liveEventRuntime: { readiness: async () => sqliteReadiness("unsafe") },
+        },
+      },
+      {
+        foundationStorage: readyFoundation,
+        technicalAdminAuth: readyTechnicalAdmin,
+        authoritativeServices: {
+          eventAdministration: true,
+          liveEventRuntime: {
+            readiness: async () => {
+              throw new Error("live runtime database diagnostic");
+            },
+          },
+        },
+      },
+    ]) {
+      const response = await readPublicHealth(dependencies);
+      expect(response.status).toBe(503);
+      const body = await response.text();
+      expect(body).toBe("unhealthy\n");
+      expect(body).toMatch(/^(healthy|unhealthy)\n$/);
+      expect(response.headers.get("cache-control")).toBe("no-store");
+      expect(response.headers.get("content-type")).toBe("text/plain; charset=utf-8");
+      expect(`${body}\n${JSON.stringify([...response.headers])}`).not.toMatch(
+        /release|commit|source|workflow|sha|digest|hash|bun|runtime|schema|migration|database|sqlite|credential|secret|object|count|dependency|host|port|diagnostic|detail|stack|token|password/i,
+      );
+    }
+  });
+
+  test("does not treat unsafe authoritative write pressure as healthy", async () => {
+    expect(
+      await isPubliclyHealthy({
+        foundationStorage: {
+          readiness: async () => sqliteReadiness("unsafe"),
+        },
+        technicalAdminAuth: readyTechnicalAdmin,
+        authoritativeServices: readyAuthoritativeServices,
+      }),
+    ).toBe(false);
+  });
+
+  test("fails closed when SQLite write pressure is unknown or absent", async () => {
+    const readinessResults: FoundationStorageReadiness[] = [
+      sqliteReadiness("unknown"),
+      { ok: true, schemaVersion: "26", storage: "sqlite" },
+    ];
+    for (const readiness of readinessResults) {
+      expect(
+        await isPubliclyHealthy({
+          foundationStorage: {
+            readiness: async () => readiness,
+          },
+          technicalAdminAuth: readyTechnicalAdmin,
+          authoritativeServices: readyAuthoritativeServices,
+        }),
+      ).toBe(false);
+    }
+  });
+});

--- a/src/lib/public-health.ts
+++ b/src/lib/public-health.ts
@@ -1,0 +1,78 @@
+import type { FoundationStorage } from "@/lib/foundation-storage";
+import type { LiveEventGameRuntime } from "@/lib/live-event-game-runtime";
+import type { TechnicalAdminAuth, TechnicalAdminStorageStatus } from "@/lib/technical-admin-auth";
+
+/** The intentionally small dependency surface of the public health contract. */
+export type PublicHealthDependencies = {
+  foundationStorage: Pick<FoundationStorage, "readiness"> | undefined;
+  technicalAdminAuth: Pick<TechnicalAdminAuth, "storageStatus">;
+  /** The SQM-critical authoritative services that must remain available. */
+  authoritativeServices: {
+    eventAdministration: boolean;
+    liveEventRuntime: Pick<LiveEventGameRuntime, "readiness"> | null;
+  };
+};
+
+const PUBLIC_HEALTH_HEADERS = {
+  "cache-control": "no-store",
+  "content-type": "text/plain; charset=utf-8",
+  "referrer-policy": "no-referrer",
+  "x-content-type-options": "nosniff",
+};
+
+/**
+ * Render the sole public readiness signal. The body is deliberately a fixed two-value
+ * representation, so readiness evidence and failure details cannot become a public oracle.
+ */
+export async function readPublicHealth(dependencies: PublicHealthDependencies): Promise<Response> {
+  const healthy = await isPubliclyHealthy(dependencies);
+  return new Response(healthy ? "healthy\n" : "unhealthy\n", {
+    status: healthy ? 200 : 503,
+    headers: PUBLIC_HEALTH_HEADERS,
+  });
+}
+
+export function createPublicHealthRoute(dependencies: PublicHealthDependencies) {
+  return {
+    GET(_request: Request) {
+      return readPublicHealth(dependencies);
+    },
+  };
+}
+
+export async function isPubliclyHealthy(dependencies: PublicHealthDependencies): Promise<boolean> {
+  if (
+    !dependencies.authoritativeServices.eventAdministration ||
+    dependencies.authoritativeServices.liveEventRuntime === null
+  ) {
+    return false;
+  }
+
+  if (!(await isFoundationStorageHealthy(dependencies.authoritativeServices.liveEventRuntime))) {
+    return false;
+  }
+
+  let technicalAdminStatus: TechnicalAdminStorageStatus;
+  try {
+    technicalAdminStatus = dependencies.technicalAdminAuth.storageStatus();
+  } catch {
+    return false;
+  }
+  if (technicalAdminStatus.state !== "ready") return false;
+
+  if (dependencies.foundationStorage === undefined) return false;
+  return isFoundationStorageHealthy(dependencies.foundationStorage);
+}
+
+async function isFoundationStorageHealthy(
+  storage: Pick<FoundationStorage, "readiness">,
+): Promise<boolean> {
+  try {
+    const readiness = await storage.readiness();
+    if (!readiness.ok) return false;
+    if (readiness.storage === "memory") return true;
+    return readiness.evidence?.transaction.writePressure === "normal";
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## What changed

- add a literal public `/healthz` endpoint with fixed healthy and unavailable responses
- evaluate Foundation, Live Event, Technical Admin, and Event Administration readiness on every request
- fail closed when an authoritative service is missing, throws, or reports unsafe write pressure
- prevent caching and exclude private diagnostic, identity, credential, and operational data
- document the bounded UptimeRobot configuration and post-deployment verification

## Why

Production Operations #158 needs a stable public signal for external uptime monitoring. This implements the code and operator contract from #167 without exposing the internal readiness evidence used to make the decision.

## Impact

UptimeRobot can monitor `/healthz` without authentication. Healthy responses are fixed `200` output; degraded authoritative readiness returns a fixed `503`. No public diagnostic details or administrative controls are added.

The remaining live step is to configure and verify the UptimeRobot monitor after deployment. That step is intentionally not performed by this PR.

## Validation

- targeted public-health, Live Event runtime, startup, and deployment tests: 36 passed
- full ordinary Fast suite: 865 passed across 76 files
- `bun run check`
- `git diff --check`
- accepted patch identity preserved across the rebase onto merged `main`

Base: `main`

Parent specification: #158  
Implementation ticket: #167