### PR TITLE
Correct Event Game identity and presentation

### DIFF
--- a/src/index-event-admin.test.ts
+++ b/src/index-event-admin.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+import { readEventAdminIdentityRoute, readEventAdminPresentationRoute } from "./index";
+
+describe("Event Admin presentation HTTP route", () => {
+  test("passes the event segment and Event Game segment to both presentation changes", () => {
+    const path = "/api/event-admin/events/event-a/event-games/game-17/presentation".split("/");
+
+    expect(readEventAdminPresentationRoute(path)).toEqual({
+      eventId: "event-a",
+      eventGameId: "game-17",
+    });
+  });
+});
+
+test("passes the Event, Game Day, and Event Game segments to identity correction", () => {
+  const path = "/api/event-admin/events/event-a/game-days/day-2/event-games/game-17/identity".split(
+    "/",
+  );
+
+  expect(readEventAdminIdentityRoute(path)).toEqual({
+    eventId: "event-a",
+    gameDayId: "day-2",
+    eventGameId: "game-17",
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,10 +17,12 @@ import { createLiveEventGameControlTransport } from "@/lib/live-event-game-trans
 import {
   openLiveEventGameRuntime,
   createControlScopeResolver,
+  createExternalScopeResolver,
   readLiveEventDodgeballIdsByEventGame,
   readLiveEventGrantKeyRing,
   type LiveEventGameRuntime,
 } from "@/lib/live-event-game-runtime";
+import { createEventGameRecordTransactionSeam } from "@/lib/event-game-record";
 import {
   clearTechnicalAdminCookie,
   clearTechnicalAdminCsrfCookie,
@@ -349,6 +351,11 @@ async function startServer() {
           grants: grantAuthority,
           controlScopeResolver: grantOptions.controlScopeResolver,
           environmentId: environment,
+          eventGameRecordTransaction: (transaction) =>
+            createEventGameRecordTransactionSeam(transaction, {
+              externalScopeResolver: createExternalScopeResolver(),
+              interpreter: createLiveEventGameIqaInterpreter(),
+            }),
         });
         administrativeAuditProjection = createAdministrativeAuditProjection({
           storage: foundationStorage,
@@ -2012,6 +2019,54 @@ async function startServer() {
             );
           },
         },
+        "/api/event-admin/events/:eventId/game-days/:gameDayId/event-games/:eventGameId/identity": {
+          async POST(req: Request) {
+            if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
+            const authority = resolveEventAdministrationAuthority(req, technicalAdminAuth);
+            const body = await readJsonRecord(req);
+            const path = new URL(req.url).pathname.split("/");
+            if (authority === null || body === null) return sensitiveGenericAuthFailure(401);
+            return sensitiveEventAdministrationMutationResponse(
+              await eventAdministration.correctEventGameIdentity(
+                readEventAdminIdentityRoute(path).eventId,
+                readEventAdminIdentityRoute(path).gameDayId,
+                readEventAdminIdentityRoute(path).eventGameId,
+                {
+                  gameSideId: body.gameSideId,
+                  eventTeamId: body.eventTeamId,
+                  operationId: body.operationId,
+                  confirmation: body.confirmation,
+                  reason: body.reason,
+                },
+                authority,
+              ),
+              authority,
+            );
+          },
+        },
+        "/api/event-admin/events/:eventId/event-games/:eventGameId/presentation": {
+          async POST(req: Request) {
+            if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
+            const authority = resolveEventAdministrationAuthority(req, technicalAdminAuth);
+            const body = await readJsonRecord(req);
+            const path = new URL(req.url).pathname.split("/");
+            if (authority === null || body === null) return sensitiveGenericAuthFailure(401);
+            return sensitiveEventAdministrationMutationResponse(
+              await eventAdministration.changeEventGamePresentation(
+                readEventAdminPresentationRoute(path).eventId,
+                readEventAdminPresentationRoute(path).eventGameId,
+                {
+                  operationId: body.operationId,
+                  presentationChangeId: body.presentationChangeId,
+                  causalPredecessorIds: body.causalPredecessorIds,
+                  change: body.change,
+                },
+                authority,
+              ),
+              authority,
+            );
+          },
+        },
         "/api/event-admin/slot-setup": {
           async GET(req: Request) {
             if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
@@ -3187,6 +3242,25 @@ export function calculateAdHocUpgradeCapacity(
   input: ControllerCapacityInput & { maxConnectedSockets: number },
 ): number {
   return availableNonControllerCapacity(input, input.maxConnectedSockets);
+}
+
+export function readEventAdminPresentationRoute(path: readonly string[]): {
+  eventId: string;
+  eventGameId: string;
+} {
+  return { eventId: path.at(-4) ?? "", eventGameId: path.at(-2) ?? "" };
+}
+
+export function readEventAdminIdentityRoute(path: readonly string[]): {
+  eventId: string;
+  gameDayId: string;
+  eventGameId: string;
+} {
+  return {
+    eventId: path.at(-6) ?? "",
+    gameDayId: path.at(-4) ?? "",
+    eventGameId: path.at(-2) ?? "",
+  };
 }
 
 function releasePendingSocketReservation(socketId: string) {

--- a/src/lib/audience-projection.test.ts
+++ b/src/lib/audience-projection.test.ts
@@ -41,6 +41,76 @@ const authority = createTechnicalAdminAuth(
 ).resolveHostLocalAuthority();
 
 describe("Audience Publication Projection", () => {
+  test("keeps correction-time Event Game identity names while exposing neutral allowlisted state", async () => {
+    const event: StoredEvent = {
+      eventId: "event-identity",
+      name: "Identity Event",
+      timeZone: "UTC",
+      publicationStatus: "published",
+      createdAtMs: 1,
+      updatedAtMs: 1,
+    };
+    const game = createScheduleGame("identity-game", "2026-08-14T10:00:00.000Z", "Pitch 1");
+    game.sideA = {
+      ...game.sideA,
+      eventTeamId: "team-correction",
+      eventTeamName: "Correction-time Team",
+    };
+    game.sideB = { ...game.sideB, eventTeamId: "team-other", eventTeamName: "Other Team" };
+    const snapshot = {
+      listEvents: () => [event],
+      findEvent: () => event,
+      listGameDays: () => [
+        { gameDayId: "day-identity", eventId: event.eventId, date: "2026-08-14" },
+      ],
+      listEventGames: () => [game],
+      listEventTeams: () => [
+        {
+          eventTeamId: "team-correction",
+          eventId: event.eventId,
+          name: "Renamed Later",
+          defaultColor: "#123456",
+        },
+        {
+          eventTeamId: "team-other",
+          eventId: event.eventId,
+          name: "Other Team",
+          defaultColor: "#654321",
+        },
+      ],
+      listPitches: () => [{ pitchId: "pitch-identity", eventId: event.eventId, name: "Pitch 1" }],
+      listPitchSlots: () => [],
+      listGameplaySlots: () => [],
+      findEventGame: () => game,
+      findEventTeam: () => null,
+      listEventAuditTrail: () => [],
+    } as unknown as EventCatalogStorageSnapshot;
+    const audience = createAudienceProjection(
+      { snapshot: async () => snapshot } as unknown as EventCatalogFoundationStorage,
+      { now: () => Date.parse("2026-08-14T10:00:00.000Z") },
+    );
+
+    const result = await audience.read(event.eventId);
+    expect(result).toMatchObject({
+      status: "accepted",
+      value: {
+        identityNotice: "event-team-identities-current",
+        eventGames: [
+          {
+            eventGameId: game.eventGameId,
+            sides: [
+              { eventTeamId: "team-correction", eventTeamName: "Correction-time Team" },
+              { eventTeamId: "team-other", eventTeamName: "Other Team" },
+            ],
+          },
+        ],
+      },
+    });
+    if (result.status !== "accepted") return;
+    expect(result.value).not.toHaveProperty("auditTrail");
+    expect(result.value).not.toHaveProperty("reason");
+  });
+
   test("groups every running Game, uses a half-open one-hour horizon, and orders the schedule", async () => {
     const now = Date.parse("2026-08-14T10:00:00.000Z");
     const snapshot = createScheduleSnapshot({

--- a/src/lib/audience-projection.ts
+++ b/src/lib/audience-projection.ts
@@ -25,6 +25,14 @@ export type PublicAudiencePitch = {
   name: string;
 };
 
+export type PublicAudienceEventGameInput = {
+  eventGameId: string;
+  sides: readonly [
+    { gameSideId: string; eventTeamId: string | null; eventTeamName: string | null },
+    { gameSideId: string; eventTeamId: string | null; eventTeamName: string | null },
+  ];
+};
+
 export type PublicAudienceGameScheduleStatus = "past" | "running" | "awaiting-start" | "future";
 
 export type PublicAudienceGamePhase = "seeker-floor" | "seekers-released" | "overtime";
@@ -164,6 +172,10 @@ export type PublicAudienceEventProjection = {
   canonicalPath: string;
   teams: readonly PublicAudienceEventTeam[];
   pitches: readonly PublicAudiencePitch[];
+  /** Neutral public state; correction reasons, audit rows, and provenance stay private. */
+  identityNotice?: "event-team-identities-current";
+  /** Allowlisted identity input for downstream roster and public Timeline composition. */
+  eventGames?: readonly PublicAudienceEventGameInput[];
   schedule: PublicAudienceScheduleProjection;
 };
 
@@ -298,6 +310,25 @@ function projectPublicEvent(
       color: defaultColor,
     })),
     pitches: snapshot.listPitches(event.eventId).map(({ name }) => ({ name })),
+    identityNotice: "event-team-identities-current",
+    eventGames: snapshot
+      .listGameDays(event.eventId)
+      .flatMap((day) => snapshot.listEventGames(day.gameDayId))
+      .map((game) => ({
+        eventGameId: game.eventGameId,
+        sides: [
+          {
+            gameSideId: game.sideA.sideId,
+            eventTeamId: game.sideA.eventTeamId,
+            eventTeamName: game.sideA.eventTeamName,
+          },
+          {
+            gameSideId: game.sideB.sideId,
+            eventTeamId: game.sideB.eventTeamId,
+            eventTeamName: game.sideB.eventTeamName,
+          },
+        ],
+      })) as PublicAudienceEventGameInput[],
     schedule: projectSchedule(snapshot, event, nowMs),
   };
 }

--- a/src/lib/controller-intent-retry.ts
+++ b/src/lib/controller-intent-retry.ts
@@ -32,6 +32,8 @@ export function controllerIntentRetryKey(intent: LiveEventControllerIntent): str
         intent.sportingOrderOverride ?? null,
         intent.override ?? null,
       ]);
+    case "acknowledge-team-assignment":
+      return JSON.stringify([intent.type, intent.gameSideId, intent.correctionOperationId]);
     case "record-flag-catch":
     case "record-concession":
     case "record-forfeit":

--- a/src/lib/controller-reconnect.ts
+++ b/src/lib/controller-reconnect.ts
@@ -393,7 +393,7 @@ export function reconcileControllerReplay(
             action.status === "causally-blocked" ||
             action.status === "held-for-correction",
         )
-        .map((action) => action.intent.factId),
+        .flatMap((action) => ("factId" in action.intent ? [action.intent.factId] : [])),
     );
     authoritativeProjection.gameFacts = authoritativeProjection.gameFacts.filter(
       (fact) => !retainedPendingFactIds.has(fact.factId),

--- a/src/lib/event-administration.test.ts
+++ b/src/lib/event-administration.test.ts
@@ -2,7 +2,16 @@ import { describe, expect, test } from "bun:test";
 import { createAudienceProjection } from "@/lib/audience-projection";
 import { createEventAdministration } from "@/lib/event-administration";
 import { createEventCatalog, createFoundationEventCatalogStorage } from "@/lib/event-catalog";
-import type { FoundationStorage } from "@/lib/foundation-storage";
+import {
+  createEventGameRecord,
+  createEventGameRecordTransactionSeam,
+} from "@/lib/event-game-record";
+import { createLiveEventGameIqaInterpreter } from "@/lib/live-event-game-control";
+import {
+  canonicalizeEventGameRecordRoot,
+  type EventGameRecordRoot,
+} from "@/lib/foundation-record-types";
+import type { FoundationStorage, FoundationStorageSnapshot } from "@/lib/foundation-storage";
 import { createInMemoryFoundationStorage } from "@/lib/foundation-storage-memory";
 import { createGrantAuthority, createGrantAuthorityVerifier } from "@/lib/grant-authority";
 import type { GrantKeyRing } from "@/lib/grant-types";
@@ -2392,6 +2401,411 @@ describe("Event Administration handoff", () => {
       browserContext: "right-type",
     });
     expect(accepted).toMatchObject({ status: "admitted", grantType: "event-admin" });
+  });
+
+  test("composes identity retry, current winner, and transaction rollback through Event Admin", async () => {
+    const fixture = createFixture();
+    const event = await fixture.catalog.createEvent(
+      { name: "Composed identity", timeZone: "UTC" },
+      fixture.technical,
+    );
+    if (event.status !== "accepted") throw new Error("Expected Event.");
+    const day = await fixture.catalog.addGameDay(
+      event.value.eventId,
+      { date: "2026-08-14" },
+      fixture.technical,
+    );
+    const home = await fixture.catalog.createEventTeam(
+      event.value.eventId,
+      { name: "Home" },
+      fixture.technical,
+    );
+    const replacement = await fixture.catalog.createEventTeam(
+      event.value.eventId,
+      { name: "Replacement" },
+      fixture.technical,
+    );
+    const later = await fixture.catalog.createEventTeam(
+      event.value.eventId,
+      { name: "Later" },
+      fixture.technical,
+    );
+    const other = await fixture.catalog.createEventTeam(
+      event.value.eventId,
+      { name: "Other" },
+      fixture.technical,
+    );
+    const pitch = await fixture.catalog.createPitch(
+      event.value.eventId,
+      { name: "Composed Pitch" },
+      fixture.technical,
+    );
+    if (
+      day.status !== "accepted" ||
+      home.status !== "accepted" ||
+      replacement.status !== "accepted" ||
+      later.status !== "accepted" ||
+      other.status !== "accepted" ||
+      pitch.status !== "accepted"
+    )
+      throw new Error("Expected catalog structure.");
+    const slot = await fixture.catalog.createGameplaySlot(
+      event.value.eventId,
+      day.value.gameDayId,
+      { sequence: 1, scheduledStart: "2026-08-14T10:00" },
+      fixture.technical,
+    );
+    if (slot.status !== "accepted") throw new Error("Expected Gameplay Slot.");
+    const pitchSlot = (
+      await fixture.storage.transaction((transaction) =>
+        transaction.listPitchSlots(day.value.gameDayId, pitch.value.pitchId),
+      )
+    )[0];
+    if (pitchSlot === undefined) throw new Error("Expected Pitch Slot.");
+    const game = await fixture.catalog.createEventGame(
+      event.value.eventId,
+      day.value.gameDayId,
+      {
+        gameplaySlotId: slot.value.gameplaySlotId,
+        pitchSlotId: pitchSlot.pitchSlotId,
+        sideA: { sourceLabel: "Home" },
+        sideB: { sourceLabel: "Other" },
+      },
+      fixture.technical,
+    );
+    if (game.status !== "accepted") throw new Error("Expected Event Game.");
+    const confirmed = await fixture.catalog.confirmGameplaySlotTeams(
+      event.value.eventId,
+      day.value.gameDayId,
+      slot.value.gameplaySlotId,
+      {
+        games: [
+          {
+            eventGameId: game.value.eventGameId,
+            sideAEventTeamId: home.value.eventTeamId,
+            sideBEventTeamId: other.value.eventTeamId,
+          },
+        ],
+      },
+      fixture.technical,
+    );
+    if (confirmed.status !== "accepted") throw new Error("Expected confirmed Game.");
+    const assigned = confirmed.value[0];
+    if (assigned === undefined) throw new Error("Expected assigned Game.");
+    const root: EventGameRecordRoot = {
+      recordId: `record-${game.value.eventGameId}`,
+      eventId: event.value.eventId,
+      eventGameId: game.value.eventGameId,
+      ownership: { eventId: event.value.eventId, eventGameId: game.value.eventGameId },
+      externalScope: {
+        eventId: event.value.eventId,
+        gameDayId: day.value.gameDayId,
+        pitchId: pitch.value.pitchId,
+        pitchSlotId: pitchSlot.pitchSlotId,
+      },
+      gameSides: [
+        {
+          id: assigned.sideA.sideId,
+          eventTeamId: home.value.eventTeamId,
+          teamInterpretationRef: `event-team:${home.value.eventTeamId}`,
+        },
+        {
+          id: assigned.sideB.sideId,
+          eventTeamId: other.value.eventTeamId,
+          teamInterpretationRef: `event-team:${other.value.eventTeamId}`,
+        },
+      ],
+      lifecycle: {
+        phase: "scheduled",
+        commencedAtMs: null,
+        finishedAtMs: null,
+        lockedAtMs: null,
+        lockReason: null,
+      },
+      compatibility: {
+        recordVersion: "record-v1",
+        schemaVersion: "schema-v1",
+        interpreterVersion: "live-event-iqa-v1",
+      },
+      creationEvidence: {
+        operationId: "record-registration",
+        actorReference: "technical-admin",
+        source: "event-game-registration",
+        createdAtMs: Date.parse("2026-08-14T12:00:00Z"),
+      },
+    };
+    const externalScopeResolver = {
+      resolve(scope: EventGameRecordRoot["externalScope"], snapshot: FoundationStorageSnapshot) {
+        const pitchSlot = snapshot.findPitchSlot?.(scope.pitchSlotId);
+        return pitchSlot === null || pitchSlot === undefined
+          ? { status: "mismatch" as const, detail: "scope mismatch" }
+          : pitchSlot.eventId === scope.eventId &&
+              pitchSlot.gameDayId === scope.gameDayId &&
+              pitchSlot.pitchId === scope.pitchId
+            ? { status: "resolved" as const, scope: structuredClone(scope) }
+            : { status: "mismatch" as const, detail: "scope mismatch" };
+      },
+      resolveEventTeam(eventId: string, eventTeamId: string, snapshot: FoundationStorageSnapshot) {
+        const team = snapshot.findEventTeam(eventTeamId);
+        return team === null || team.eventId !== eventId
+          ? { status: "missing" as const, detail: "Event Team is unavailable." }
+          : { status: "resolved" as const };
+      },
+    };
+    const record = createEventGameRecord(fixture.storage, {
+      externalScopeResolver,
+      interpreter: createLiveEventGameIqaInterpreter(),
+      clock: () => Date.parse("2026-08-14T12:00:00Z"),
+    });
+    expect(await record.registerRoot(root)).toMatchObject({ status: "registered" });
+    const administration = createEventAdministration({
+      storage: fixture.storage,
+      grants: fixture.grants,
+      nowMs: () => Date.parse("2026-08-14T12:00:00Z"),
+      eventGameRecordTransaction: (transaction) =>
+        createEventGameRecordTransactionSeam(transaction, {
+          externalScopeResolver,
+          interpreter: createLiveEventGameIqaInterpreter(),
+          clock: () => Date.parse("2026-08-14T12:00:00Z"),
+        }),
+    });
+    const grant = await administration.createEventAdminGrant(
+      event.value.eventId,
+      fixture.technical,
+    );
+    if (grant.status !== "accepted") throw new Error("Expected Event Admin Grant.");
+    const revealed = await fixture.grants.revealGrant(grant.value.grantId, fixture.technical);
+    if (revealed.status !== "revealed") throw new Error("Expected Event Admin QR.");
+    const admission = await administration.admitEventAdmin({
+      qrCredential: revealed.qrCredential,
+      browserContext: "composed-identity-admin",
+    });
+    if (admission.status !== "admitted") throw new Error("Expected Event Admin session.");
+    const eventAdmin = { kind: "grant-session" as const, sessionBearer: admission.sessionBearer };
+    const identityInput = {
+      gameSideId: assigned.sideA.sideId,
+      eventTeamId: replacement.value.eventTeamId,
+      operationId: "composed-auth-check",
+    };
+    expect(
+      await administration.correctEventGameIdentity(
+        "wrong-event",
+        day.value.gameDayId,
+        game.value.eventGameId,
+        identityInput,
+        eventAdmin,
+      ),
+    ).toMatchObject({ status: "rejected", reason: "unauthorized" });
+    expect(
+      await administration.correctEventGameIdentity(
+        event.value.eventId,
+        "wrong-day",
+        game.value.eventGameId,
+        identityInput,
+        eventAdmin,
+      ),
+    ).toMatchObject({ status: "rejected" });
+    expect(
+      await administration.correctEventGameIdentity(
+        event.value.eventId,
+        day.value.gameDayId,
+        game.value.eventGameId,
+        identityInput,
+        { kind: "grant-session", sessionBearer: "wrong-session" },
+      ),
+    ).toMatchObject({ status: "rejected", reason: "unauthorized" });
+    expect(
+      await administration.changePublicationStatus(
+        event.value.eventId,
+        { status: "published" },
+        eventAdmin,
+      ),
+    ).toMatchObject({ status: "accepted" });
+
+    const first = await administration.correctEventGameIdentity(
+      event.value.eventId,
+      day.value.gameDayId,
+      game.value.eventGameId,
+      {
+        gameSideId: assigned.sideA.sideId,
+        eventTeamId: replacement.value.eventTeamId,
+        operationId: "composed-op-a",
+      },
+      fixture.technical,
+    );
+    expect(first).toMatchObject({
+      status: "accepted",
+      value: {
+        operationId: "composed-op-a",
+        eventTeamId: replacement.value.eventTeamId,
+        eventTeamName: "Replacement",
+      },
+    });
+    const second = await administration.correctEventGameIdentity(
+      event.value.eventId,
+      day.value.gameDayId,
+      game.value.eventGameId,
+      {
+        gameSideId: assigned.sideA.sideId,
+        eventTeamId: later.value.eventTeamId,
+        operationId: "composed-op-b",
+      },
+      eventAdmin,
+    );
+    expect(second).toMatchObject({
+      status: "accepted",
+      value: { eventTeamId: later.value.eventTeamId },
+    });
+    const beforeRetry = await fixture.storage.transaction((transaction) => ({
+      actions: transaction.listActions(root.recordId),
+      recordAudit: transaction.listAuditEntries(root.recordId),
+      eventAudit: transaction.listEventAuditTrail(event.value.eventId),
+    }));
+    const retry = await administration.correctEventGameIdentity(
+      event.value.eventId,
+      day.value.gameDayId,
+      game.value.eventGameId,
+      {
+        gameSideId: assigned.sideA.sideId,
+        eventTeamId: replacement.value.eventTeamId,
+        operationId: "composed-op-a",
+      },
+      fixture.technical,
+    );
+    expect(retry).toMatchObject({
+      status: "accepted",
+      value: {
+        operationId: "composed-op-a",
+        eventTeamId: replacement.value.eventTeamId,
+        eventTeamName: "Replacement",
+      },
+    });
+    const afterRetry = await fixture.storage.transaction((transaction) => ({
+      actions: transaction.listActions(root.recordId),
+      recordAudit: transaction.listAuditEntries(root.recordId),
+      eventAudit: transaction.listEventAuditTrail(event.value.eventId),
+    }));
+    expect(afterRetry).toEqual(beforeRetry);
+    expect(
+      await fixture.catalog.inspectEvent(event.value.eventId, fixture.technical),
+    ).toMatchObject({
+      value: {
+        eventGames: [{ sideA: { eventTeamId: later.value.eventTeamId, eventTeamName: "Later" } }],
+      },
+    });
+
+    await fixture.storage.transaction((transaction) => {
+      const storedRoot = transaction.findRootByEventGameId(game.value.eventGameId);
+      if (storedRoot === null) throw new Error("Expected stored root.");
+      const nextRoot: EventGameRecordRoot = structuredClone(storedRoot);
+      nextRoot.lifecycle = {
+        ...nextRoot.lifecycle,
+        phase: "in-progress",
+        commencedAtMs: 1,
+      };
+      transaction.updateRoot({
+        root: nextRoot,
+        canonicalContent: canonicalizeEventGameRecordRoot(nextRoot),
+      });
+    });
+    expect(
+      await administration.correctEventGameIdentity(
+        event.value.eventId,
+        day.value.gameDayId,
+        game.value.eventGameId,
+        {
+          gameSideId: assigned.sideA.sideId,
+          eventTeamId: later.value.eventTeamId,
+          operationId: "composed-post-no-confirmation",
+        },
+        eventAdmin,
+      ),
+    ).toMatchObject({ status: "rejected" });
+    expect(
+      await administration.correctEventGameIdentity(
+        event.value.eventId,
+        day.value.gameDayId,
+        game.value.eventGameId,
+        {
+          gameSideId: assigned.sideA.sideId,
+          eventTeamId: replacement.value.eventTeamId,
+          operationId: "composed-post-no-reason",
+          confirmation: true,
+        },
+        eventAdmin,
+      ),
+    ).toMatchObject({ status: "rejected" });
+    expect(
+      await administration.correctEventGameIdentity(
+        event.value.eventId,
+        day.value.gameDayId,
+        game.value.eventGameId,
+        {
+          gameSideId: assigned.sideA.sideId,
+          eventTeamId: replacement.value.eventTeamId,
+          operationId: "composed-post-accepted",
+          confirmation: true,
+          reason: "Corrected after commencement",
+        },
+        eventAdmin,
+      ),
+    ).toMatchObject({
+      status: "accepted",
+      value: {
+        eventTeamId: replacement.value.eventTeamId,
+        eventTeamName: "Replacement",
+        commenced: true,
+        controllerAcknowledgementRequired: true,
+      },
+    });
+    const beforeFailure = await fixture.storage.transaction((transaction) => ({
+      actions: transaction.listActions(root.recordId),
+      recordAudit: transaction.listAuditEntries(root.recordId),
+      eventAudit: transaction.listEventAuditTrail(event.value.eventId),
+    }));
+    const audience = createAudienceProjection(
+      createFoundationEventCatalogStorage(fixture.storage),
+      { now: () => Date.parse("2026-08-14T12:00:00Z") },
+    );
+    const publicBeforeFailure = await audience.read(event.value.eventId);
+    const failing = createEventAdministration({
+      storage: fixture.storage,
+      grants: fixture.grants,
+      nowMs: () => Date.parse("2026-08-14T12:00:00Z"),
+      eventGameRecordTransaction: () => {
+        throw new Error("injected Record failure");
+      },
+    });
+    expect(
+      await failing.correctEventGameIdentity(
+        event.value.eventId,
+        day.value.gameDayId,
+        game.value.eventGameId,
+        {
+          gameSideId: assigned.sideA.sideId,
+          eventTeamId: later.value.eventTeamId,
+          operationId: "composed-op-failure",
+          confirmation: true,
+          reason: "Injected failure rollback",
+        },
+        eventAdmin,
+      ),
+    ).toMatchObject({ status: "retryable-failure" });
+    expect(
+      await fixture.storage.transaction((transaction) => transaction.listActions(root.recordId)),
+    ).toEqual(beforeFailure.actions);
+    expect(
+      await fixture.storage.transaction((transaction) =>
+        transaction.listAuditEntries(root.recordId),
+      ),
+    ).toEqual(beforeFailure.recordAudit);
+    expect(
+      await fixture.storage.transaction((transaction) =>
+        transaction.listEventAuditTrail(event.value.eventId),
+      ),
+    ).toEqual(beforeFailure.eventAudit);
+    const publicAfterFailure = await audience.read(event.value.eventId);
+    expect(publicAfterFailure).toEqual(publicBeforeFailure);
   });
 });
 

--- a/src/lib/event-administration.ts
+++ b/src/lib/event-administration.ts
@@ -1,4 +1,6 @@
 import type { FoundationStorage, FoundationStorageTransaction } from "@/lib/foundation-storage";
+import type { EventGameRecordTransactionSeam } from "@/lib/event-game-record";
+import type { GamePresentation } from "@/lib/game-presentation";
 import {
   createEventCatalog,
   createFoundationEventCatalogStorage,
@@ -21,6 +23,10 @@ import {
   type ProjectedEventGame,
   type ScheduleDelayPreview,
   type PitchReassignmentResult,
+  type EventGameIdentityCorrection,
+  type EventGameIdentityCorrectionInput,
+  correctEventGameIdentityInTransaction,
+  reconcileEventGameIdentityInTransaction,
   projectScheduleGames,
 } from "@/lib/event-catalog";
 import type { TechnicalAdminAuthority } from "@/lib/technical-admin-auth";
@@ -171,6 +177,13 @@ export type EventAdministrationOutcome<T> =
     }
   | { status: "retryable-failure"; detail: string };
 
+export type EventGamePresentationChangeInput = {
+  operationId?: unknown;
+  presentationChangeId?: unknown;
+  causalPredecessorIds?: unknown;
+  change: unknown;
+};
+
 export type EventAdministrationMutationOutcome<T> = EventAdministrationOutcome<T> & {
   sessionExpiresAtMs?: number | null;
 };
@@ -186,7 +199,24 @@ export type EventAdministrationOptions = {
   environmentId?: string;
   accessSheetRenderer?: AccessSheetRenderer;
   accessSheetIds?: AccessSheetIds;
+  eventGameRecordTransaction?: (
+    transaction: FoundationStorageTransaction,
+  ) => EventGameRecordTransactionSeam;
 };
+
+class EventAdministrationTransactionRejection extends Error {
+  constructor(
+    readonly outcome:
+      | {
+          status: "rejected";
+          reason: "invalid-input" | "unauthorized" | "not-found";
+          detail: string;
+        }
+      | { status: "retryable-failure"; detail: string },
+  ) {
+    super(outcome.detail);
+  }
+}
 
 export type EventAdministration = {
   previewEventCatalogRemoval(
@@ -519,6 +549,19 @@ export type EventAdministration = {
     input: { targetPitchSlotId: unknown; mode?: unknown },
     authority: EventAdministrationAuthority,
   ): Promise<EventAdministrationMutationOutcome<PitchReassignmentResult>>;
+  correctEventGameIdentity(
+    eventId: unknown,
+    gameDayId: unknown,
+    eventGameId: unknown,
+    input: EventGameIdentityCorrectionInput,
+    authority: EventAdministrationAuthority,
+  ): Promise<EventAdministrationMutationOutcome<EventGameIdentityCorrection>>;
+  changeEventGamePresentation(
+    eventId: unknown,
+    eventGameId: unknown,
+    input: EventGamePresentationChangeInput,
+    authority: EventAdministrationAuthority,
+  ): Promise<EventAdministrationMutationOutcome<GamePresentation>>;
   openSlotSetup(
     eventId: unknown,
     gameDayId: unknown,
@@ -1567,6 +1610,174 @@ export function createEventAdministration(
       return runCatalogMutation(catalog, options, eventId, authority, (operations) =>
         operations.reassignEventGame(eventId, gameDayId, eventGameId, input),
       );
+    },
+
+    async correctEventGameIdentity(eventId, gameDayId, eventGameId, input, authority) {
+      if (options.eventGameRecordTransaction === undefined) return unavailable();
+      const eventIdResult = validateEventId(eventId);
+      const gameDayIdResult = validateEventId(gameDayId);
+      const eventGameIdResult = validateEventId(eventGameId);
+      if (!eventIdResult.ok || !gameDayIdResult.ok || !eventGameIdResult.ok)
+        return invalid("Event Game identity correction identifier is invalid.");
+      try {
+        return await options.storage.transaction((transaction) => {
+          const authorized = authorizeEventScopeInTransaction(
+            options,
+            transaction,
+            eventIdResult.value,
+            authority,
+          );
+          if (authorized === null) return unauthorized();
+          const event = transaction.findEvent(eventIdResult.value);
+          const game = transaction.findEventGame(eventGameIdResult.value);
+          const root = transaction.findRootByEventGameId(eventGameIdResult.value);
+          if (event === null || game === null || root === null)
+            return notFound("Event Game was not found.");
+          if (root.eventId !== event.eventId || game.eventId !== event.eventId)
+            return unauthorized();
+          const catalogResult = correctEventGameIdentityInTransaction(
+            transaction,
+            { nowMs },
+            { next: (kind) => `${kind}-${crypto.randomUUID()}` },
+            eventIdResult.value,
+            gameDayIdResult.value,
+            eventGameIdResult.value,
+            input,
+            authorized.actorReference,
+          );
+          if (catalogResult.status !== "accepted") return mapCatalogOutcome(catalogResult);
+          const record = options.eventGameRecordTransaction!(transaction);
+          const correction = record.correctTeamAssignment({
+            recordId: root.recordId,
+            eventGameId: root.eventGameId,
+            operationId: catalogResult.value.operationId,
+            gameSideId: catalogResult.value.gameSideId,
+            eventTeamId: catalogResult.value.eventTeamId,
+            teamInterpretationRef: `event-team:${catalogResult.value.eventTeamId}`,
+            eventTeamName: catalogResult.value.eventTeamName,
+            trustedAtMs: nowMs(),
+            grant: {
+              sessionId: authorized.sessionId ?? authorized.actorReference,
+              versionId: "event-admin",
+            },
+          });
+          if (correction.status === "rejected")
+            throw new EventAdministrationTransactionRejection({
+              status: "rejected",
+              reason: "invalid-input",
+              detail: correction.detail,
+            });
+          const duplicate = correction.status === "duplicate-accepted";
+          const effective = correction.effectiveTeamAssignments?.find(
+            (assignment) => assignment.gameSideId === catalogResult.value.gameSideId,
+          );
+          if (effective === undefined)
+            throw new EventAdministrationTransactionRejection({
+              status: "retryable-failure",
+              detail: "The Event Game Record did not return the corrected Game Side.",
+            });
+          const reconciled = reconcileEventGameIdentityInTransaction(
+            transaction,
+            { next: (kind) => `${kind}-${crypto.randomUUID()}` },
+            eventIdResult.value,
+            gameDayIdResult.value,
+            eventGameIdResult.value,
+            effective.gameSideId,
+            effective.eventTeamId,
+            authorized.actorReference,
+          );
+          if (reconciled.status !== "accepted")
+            throw new EventAdministrationTransactionRejection(
+              reconciled.status === "retryable-failure"
+                ? reconciled
+                : {
+                    status: "rejected",
+                    reason: reconciled.reason === "cross-event" ? "unauthorized" : "invalid-input",
+                    detail: reconciled.detail,
+                  },
+            );
+          const currentSide =
+            reconciled.value.sideA.sideId === catalogResult.value.gameSideId
+              ? reconciled.value.sideA
+              : reconciled.value.sideB;
+          return {
+            ...accepted({
+              ...catalogResult.value,
+              ...(duplicate
+                ? {}
+                : {
+                    eventTeamId: currentSide.eventTeamId ?? catalogResult.value.eventTeamId,
+                    eventTeamName: currentSide.eventTeamName ?? catalogResult.value.eventTeamName,
+                  }),
+              commenced: root.lifecycle.commencedAtMs !== null,
+              controllerAcknowledgementRequired: root.lifecycle.commencedAtMs !== null,
+            }),
+            sessionExpiresAtMs: authorized.sessionExpiresAtMs,
+          };
+        });
+      } catch (error) {
+        if (error instanceof EventAdministrationTransactionRejection) return error.outcome;
+        return unavailable();
+      }
+    },
+
+    async changeEventGamePresentation(eventIdInput, eventGameIdInput, input, authority) {
+      if (options.eventGameRecordTransaction === undefined) return unavailable();
+      const eventId = validateEventId(eventIdInput);
+      const eventGameId = validateEventId(eventGameIdInput);
+      if (!eventId.ok || !eventGameId.ok)
+        return invalid("Event Game presentation identifier is invalid.");
+      try {
+        return await options.storage.transaction((transaction) => {
+          const authorized = authorizeEventScopeInTransaction(
+            options,
+            transaction,
+            eventId.value,
+            authority,
+          );
+          if (authorized === null) return unauthorized();
+          const event = transaction.findEvent(eventId.value);
+          const game = transaction.findEventGame(eventGameId.value);
+          const root = transaction.findRootByEventGameId(eventGameId.value);
+          if (event === null || game === null || root === null)
+            return notFound("Event Game was not found.");
+          if (game.eventId !== event.eventId || root.eventId !== event.eventId)
+            return unauthorized();
+          const operationId = validateEventId(
+            input.operationId ?? `event-admin-presentation-${crypto.randomUUID()}`,
+          );
+          const presentationChangeId = validateEventId(
+            input.presentationChangeId ?? `presentation-${crypto.randomUUID()}`,
+          );
+          if (!operationId.ok || !presentationChangeId.ok)
+            return invalid("Presentation identity is invalid.");
+          const record = options.eventGameRecordTransaction!(transaction);
+          const result = record.acceptPresentationChange({
+            recordId: root.recordId,
+            eventGameId: root.eventGameId,
+            operationId: operationId.value,
+            presentationChangeId: presentationChangeId.value,
+            change: input.change,
+            causalPredecessorIds: Array.isArray(input.causalPredecessorIds)
+              ? input.causalPredecessorIds
+              : [],
+            occurrence: { trustedAtMs: nowMs(), clientOriginAtMs: null, source: "online" },
+            grant: {
+              sessionId: authorized.sessionId ?? authorized.actorReference,
+              versionId: "event-admin",
+            },
+            acceptedAtMs: nowMs(),
+          });
+          if (result.status === "rejected")
+            return result.reason === "storage-not-ready" ? unavailable() : invalid(result.detail);
+          return {
+            ...accepted(record.readPresentation(root.recordId)),
+            sessionExpiresAtMs: authorized.sessionExpiresAtMs,
+          };
+        });
+      } catch {
+        return unavailable();
+      }
     },
 
     async openSlotSetup(eventIdInput, gameDayIdInput, authority) {
@@ -2762,6 +2973,16 @@ function accepted<T>(value: T): EventAdministrationOutcome<T> {
 
 function invalid(detail: string): EventAdministrationOutcome<never> {
   return { status: "rejected", reason: "invalid-input", detail };
+}
+
+function mapCatalogOutcome<T>(result: CatalogOutcome<T>): EventAdministrationOutcome<T> {
+  if (result.status === "accepted") return result;
+  if (result.status === "retryable-failure") return result;
+  return {
+    status: "rejected",
+    reason: result.reason === "not-found" ? "not-found" : "invalid-input",
+    detail: result.detail,
+  };
 }
 
 function unauthorized(): EventAdministrationOutcome<never> {

--- a/src/lib/event-catalog.test.ts
+++ b/src/lib/event-catalog.test.ts
@@ -2141,4 +2141,244 @@ describe("Event operations catalog", () => {
         auditBeforeFailedReassignment.value.length,
       );
   });
+  test("corrects one stable Game Side before commencement and preserves its stable identity", async () => {
+    const fixture = createFixture();
+    const event = await fixture.catalog.createEvent(
+      { name: "Identity", timeZone: "UTC" },
+      authority,
+    );
+    if (event.status !== "accepted") throw new Error("Expected Event.");
+    const day = await fixture.catalog.addGameDay(
+      event.value.eventId,
+      { date: "2026-08-14" },
+      authority,
+    );
+    const home = await fixture.catalog.createEventTeam(
+      event.value.eventId,
+      { name: "Old" },
+      authority,
+    );
+    const replacement = await fixture.catalog.createEventTeam(
+      event.value.eventId,
+      { name: "Replacement" },
+      authority,
+    );
+    const other = await fixture.catalog.createEventTeam(
+      event.value.eventId,
+      { name: "Other" },
+      authority,
+    );
+    const later = await fixture.catalog.createEventTeam(
+      event.value.eventId,
+      { name: "Later" },
+      authority,
+    );
+    const pitch = await fixture.catalog.createPitch(
+      event.value.eventId,
+      { name: "Pitch A" },
+      authority,
+    );
+    if (
+      day.status !== "accepted" ||
+      home.status !== "accepted" ||
+      replacement.status !== "accepted" ||
+      other.status !== "accepted" ||
+      later.status !== "accepted" ||
+      pitch.status !== "accepted"
+    )
+      throw new Error("Expected setup.");
+    const slot = await fixture.catalog.createGameplaySlot(
+      event.value.eventId,
+      day.value.gameDayId,
+      { sequence: 1, scheduledStart: "2026-08-14T10:00" },
+      authority,
+    );
+    if (slot.status !== "accepted") throw new Error("Expected slot.");
+    const pitchSlot = (await fixture.storage.snapshot()).listPitchSlots(
+      day.value.gameDayId,
+      pitch.value.pitchId,
+    )[0];
+    if (pitchSlot === undefined) throw new Error("Expected Pitch Slot.");
+    const game = await fixture.catalog.createEventGame(
+      event.value.eventId,
+      day.value.gameDayId,
+      {
+        gameplaySlotId: slot.value.gameplaySlotId,
+        pitchSlotId: pitchSlot.pitchSlotId,
+        sideA: { sourceLabel: "Old" },
+        sideB: { sourceLabel: "Other" },
+      },
+      authority,
+    );
+    if (game.status !== "accepted") throw new Error(`Expected Game: ${JSON.stringify(game)}`);
+    const confirmed = await fixture.catalog.confirmGameplaySlotTeams(
+      event.value.eventId,
+      day.value.gameDayId,
+      slot.value.gameplaySlotId,
+      {
+        games: [
+          {
+            eventGameId: game.value.eventGameId,
+            sideAEventTeamId: home.value.eventTeamId,
+            sideBEventTeamId: other.value.eventTeamId,
+          },
+        ],
+      },
+      authority,
+    );
+    if (confirmed.status !== "accepted")
+      throw new Error(`Expected confirmed Game: ${JSON.stringify(confirmed)}`);
+    const assignedGame = confirmed.value[0];
+    if (assignedGame === undefined) throw new Error("Expected assigned Game.");
+
+    expect(
+      await fixture.catalog.correctEventGameIdentity(
+        event.value.eventId,
+        day.value.gameDayId,
+        game.value.eventGameId,
+        {
+          gameSideId: assignedGame.sideA.sideId,
+          eventTeamId: replacement.value.eventTeamId,
+          operationId: "identity-op-a",
+        },
+        authority,
+      ),
+    ).toMatchObject({
+      status: "accepted",
+      value: {
+        gameSideId: assignedGame.sideA.sideId,
+        eventTeamName: "Replacement",
+        commenced: false,
+      },
+    });
+    const changed = await fixture.catalog.inspectEvent(event.value.eventId, authority);
+    expect(changed).toMatchObject({
+      value: {
+        eventGames: [
+          { sideA: { eventTeamId: replacement.value.eventTeamId, eventTeamName: "Replacement" } },
+        ],
+      },
+    });
+
+    expect(
+      await fixture.catalog.updateEventTeam(
+        event.value.eventId,
+        replacement.value.eventTeamId,
+        { name: "Replacement Renamed Later" },
+        authority,
+      ),
+    ).toMatchObject({ status: "accepted" });
+    expect(await fixture.catalog.inspectEvent(event.value.eventId, authority)).toMatchObject({
+      value: {
+        eventGames: [
+          { sideA: { eventTeamId: replacement.value.eventTeamId, eventTeamName: "Replacement" } },
+        ],
+      },
+    });
+
+    const beforeRetryAudit = await fixture.catalog.listAuditTrail(event.value.eventId, authority);
+    expect(
+      await fixture.catalog.correctEventGameIdentity(
+        event.value.eventId,
+        day.value.gameDayId,
+        game.value.eventGameId,
+        {
+          gameSideId: assignedGame.sideA.sideId,
+          eventTeamId: later.value.eventTeamId,
+          operationId: "identity-op-b",
+        },
+        authority,
+      ),
+    ).toMatchObject({ status: "accepted", value: { eventTeamId: later.value.eventTeamId } });
+    const afterLaterCorrectionAudit = await fixture.catalog.listAuditTrail(
+      event.value.eventId,
+      authority,
+    );
+    if (afterLaterCorrectionAudit.status !== "accepted")
+      throw new Error("Expected the later correction audit.");
+    const retried = await fixture.catalog.correctEventGameIdentity(
+      event.value.eventId,
+      day.value.gameDayId,
+      game.value.eventGameId,
+      {
+        gameSideId: assignedGame.sideA.sideId,
+        eventTeamId: replacement.value.eventTeamId,
+        operationId: "identity-op-a",
+      },
+      authority,
+    );
+    expect(retried).toMatchObject({
+      status: "accepted",
+      value: {
+        operationId: "identity-op-a",
+        eventTeamId: replacement.value.eventTeamId,
+        eventTeamName: "Replacement",
+      },
+    });
+    const retryAudit = await fixture.catalog.listAuditTrail(event.value.eventId, authority);
+    if (retryAudit.status !== "accepted") throw new Error("Expected the retry audit.");
+    expect(retryAudit.value).toHaveLength(afterLaterCorrectionAudit.value.length);
+    expect(await fixture.catalog.inspectEvent(event.value.eventId, authority)).toMatchObject({
+      value: {
+        eventGames: [{ sideA: { eventTeamId: later.value.eventTeamId, eventTeamName: "Later" } }],
+      },
+    });
+    const concurrentRetries = await Promise.all([
+      fixture.catalog.correctEventGameIdentity(
+        event.value.eventId,
+        day.value.gameDayId,
+        game.value.eventGameId,
+        {
+          gameSideId: assignedGame.sideA.sideId,
+          eventTeamId: replacement.value.eventTeamId,
+          operationId: "identity-op-a",
+        },
+        authority,
+      ),
+      fixture.catalog.correctEventGameIdentity(
+        event.value.eventId,
+        day.value.gameDayId,
+        game.value.eventGameId,
+        {
+          gameSideId: assignedGame.sideA.sideId,
+          eventTeamId: replacement.value.eventTeamId,
+          operationId: "identity-op-a",
+        },
+        authority,
+      ),
+    ]);
+    expect(concurrentRetries).toHaveLength(2);
+    expect(concurrentRetries[0]).toMatchObject({
+      status: "accepted",
+      value: { eventTeamId: replacement.value.eventTeamId, eventTeamName: "Replacement" },
+    });
+    expect(concurrentRetries[1]).toMatchObject({
+      status: "accepted",
+      value: { eventTeamId: replacement.value.eventTeamId, eventTeamName: "Replacement" },
+    });
+    const afterConcurrentRetriesAudit = await fixture.catalog.listAuditTrail(
+      event.value.eventId,
+      authority,
+    );
+    if (afterConcurrentRetriesAudit.status !== "accepted")
+      throw new Error("Expected the concurrent retry audit.");
+    expect(afterConcurrentRetriesAudit.value).toHaveLength(afterLaterCorrectionAudit.value.length);
+    expect(
+      await fixture.catalog.correctEventGameIdentity(
+        event.value.eventId,
+        day.value.gameDayId,
+        game.value.eventGameId,
+        {
+          gameSideId: assignedGame.sideA.sideId,
+          eventTeamId: home.value.eventTeamId,
+          operationId: "identity-op-a",
+        },
+        authority,
+      ),
+    ).toMatchObject({ status: "rejected", reason: "duplicate" });
+    expect(beforeRetryAudit.status).toBe("accepted");
+
+    const root = (await fixture.storage.snapshot()).findRootByEventGameId(game.value.eventGameId);
+    if (root !== null) throw new Error("This catalog fixture has no commenced root.");
+  });
 });

--- a/src/lib/event-catalog.ts
+++ b/src/lib/event-catalog.ts
@@ -232,6 +232,99 @@ export type EventCatalogOptions = {
   ids?: EventCatalogIds;
 };
 
+/** Trusted transaction-local catalog seam used when a record and catalog mutation must commit together. */
+export function correctEventGameIdentityInTransaction(
+  transaction: FoundationStorageTransaction,
+  clock: EventCatalogClock,
+  ids: EventCatalogIds,
+  eventId: unknown,
+  gameDayId: unknown,
+  eventGameId: unknown,
+  input: EventGameIdentityCorrectionInput,
+  actorReference: string,
+): CatalogOutcome<EventGameIdentityCorrection> {
+  return correctEventGameIdentityOperation(
+    eventCatalogTransaction(transaction),
+    clock,
+    ids,
+    eventId,
+    gameDayId,
+    eventGameId,
+    input,
+    actorReference,
+  );
+}
+
+/**
+ * Reconciles the catalog projection with the already-canonical Record winner.
+ * The Record decides lifecycle, ordering, and conflicts; the catalog only keeps
+ * its public Event Team identity in step and records the resulting catalog edit.
+ */
+export function reconcileEventGameIdentityInTransaction(
+  transaction: FoundationStorageTransaction,
+  ids: EventCatalogIds,
+  eventIdInput: unknown,
+  gameDayIdInput: unknown,
+  eventGameIdInput: unknown,
+  gameSideIdInput: unknown,
+  eventTeamIdInput: unknown,
+  actorReference: string,
+): CatalogOutcome<EventGame> {
+  const eventId = validateId(eventIdInput, "eventId");
+  const gameDayId = validateId(gameDayIdInput, "gameDayId");
+  const eventGameId = validateId(eventGameIdInput, "eventGameId");
+  const gameSideId = validateId(gameSideIdInput, "gameSideId");
+  const eventTeamId = validateId(eventTeamIdInput, "eventTeamId");
+  if (!eventId.ok || !gameDayId.ok || !eventGameId.ok || !gameSideId.ok || !eventTeamId.ok)
+    return invalid("Event Game identity reconciliation identifier is invalid.");
+  const event = transaction.findEvent(eventId.value);
+  const game = transaction.findEventGame(eventGameId.value);
+  const team = transaction.findEventTeam(eventTeamId.value);
+  if (event === null || game === null || team === null)
+    return notFound("Event Game was not found.");
+  if (game.eventId !== event.eventId || game.gameDayId !== gameDayId.value)
+    return crossEvent("Event Game does not belong to the selected Event and Game Day.");
+  const side =
+    game.sideA.sideId === gameSideId.value
+      ? "sideA"
+      : game.sideB.sideId === gameSideId.value
+        ? "sideB"
+        : null;
+  if (side === null)
+    return invalid("Event Game identity reconciliation references an unknown Game Side.");
+  if (team.eventId !== event.eventId) return crossEvent("Event Team belongs to another Event.");
+  const otherSide = side === "sideA" ? game.sideB : game.sideA;
+  if (otherSide.eventTeamId === team.eventTeamId)
+    return invalid("Event Game sides must use distinct Event Teams.");
+  const previous = side === "sideA" ? game.sideA : game.sideB;
+  if (previous.eventTeamId === team.eventTeamId) return accepted(game);
+  const nextSide = {
+    ...previous,
+    eventTeamId: team.eventTeamId,
+    eventTeamName: team.name,
+    sourceLabel: null,
+    confirmedAtMs: game.updatedAtMs,
+  };
+  const next: EventGame = {
+    ...game,
+    ...(side === "sideA" ? { sideA: nextSide } : { sideB: nextSide }),
+  };
+  transaction.updateEventGame(next);
+  transaction.appendEventAudit(
+    createAudit(
+      ids,
+      "event-game-teams-confirmed",
+      event.eventId,
+      gameDayId.value,
+      actorReference,
+      next.updatedAtMs,
+      { eventGame: game, correction: { gameSideId: gameSideId.value, reason: null } },
+      { eventGame: next, correction: { gameSideId: gameSideId.value, reason: null } },
+    ),
+  );
+  return accepted(next);
+}
+
 export type EventCatalogMutationOperations = {
   previewEventCatalogRemoval(
     target: EventCatalogRemovalTargetInput,
@@ -325,6 +418,12 @@ export type EventCatalogMutationOperations = {
     eventGameId: unknown,
     input: { targetPitchSlotId: unknown; mode?: unknown },
   ): CatalogOutcome<PitchReassignmentResult>;
+  correctEventGameIdentity(
+    eventId: unknown,
+    gameDayId: unknown,
+    eventGameId: unknown,
+    input: EventGameIdentityCorrectionInput,
+  ): CatalogOutcome<EventGameIdentityCorrection>;
 };
 
 export type ScheduleDelayChange = {
@@ -355,6 +454,27 @@ export type PitchReassignmentResult = {
   swappedEventGame: EventGame | null;
   scheduleConflict: boolean;
   teamScheduleConflicts: readonly string[];
+};
+
+export type EventGameIdentityCorrectionInput = {
+  gameSideId: unknown;
+  eventTeamId: unknown;
+  operationId?: unknown;
+  confirmation?: unknown;
+  reason?: unknown;
+};
+
+export type EventGameIdentityCorrection = {
+  operationId: string;
+  eventGameId: string;
+  gameSideId: string;
+  previousEventTeamId: string;
+  previousEventTeamName: string;
+  eventTeamId: string;
+  eventTeamName: string;
+  commenced: boolean;
+  reason: string | null;
+  controllerAcknowledgementRequired: boolean;
 };
 
 export type EventCatalogStorageSnapshot = {
@@ -551,6 +671,13 @@ export type EventCatalog = {
     input: { targetPitchSlotId: unknown; mode?: unknown },
     authority: TechnicalAdminAuthority,
   ): Promise<CatalogOutcome<PitchReassignmentResult>>;
+  correctEventGameIdentity(
+    eventId: unknown,
+    gameDayId: unknown,
+    eventGameId: unknown,
+    input: EventGameIdentityCorrectionInput,
+    authority: TechnicalAdminAuthority,
+  ): Promise<CatalogOutcome<EventGameIdentityCorrection>>;
   lookupAudienceRoster(
     eventId: unknown,
     eventTeamId: unknown,
@@ -1059,6 +1186,22 @@ export function createEventCatalog(
       );
     },
 
+    async correctEventGameIdentity(eventId, gameDayId, eventGameId, input, authority) {
+      if (!isTechnicalAdminAuthority(authority)) return unauthorized();
+      return commit(storage, (transaction) =>
+        correctEventGameIdentityOperation(
+          transaction,
+          clock,
+          ids,
+          eventId,
+          gameDayId,
+          eventGameId,
+          input,
+          authorityActor(authority),
+        ),
+      );
+    },
+
     async lookupAudienceRoster(eventIdInput, eventTeamIdInput, playerNumberInput) {
       const eventId = validateId(eventIdInput, "eventId");
       const eventTeamId = validateId(eventTeamIdInput, "eventTeamId");
@@ -1244,10 +1387,11 @@ function createAudit(
   occurredAtMs: number,
   before: unknown,
   after: unknown,
+  operationId?: string,
 ): EventAdministrationAuditEntry {
   return {
     auditId: ids.next("audit"),
-    operationId: ids.next("operation"),
+    operationId: operationId ?? ids.next("operation"),
     action,
     eventId,
     gameDayId,
@@ -1506,6 +1650,17 @@ function createMutationOperations(
       ),
     reassignEventGame: (eventId, gameDayId, eventGameId, input) =>
       reassignEventGameOperation(
+        transaction,
+        clock,
+        ids,
+        eventId,
+        gameDayId,
+        eventGameId,
+        input,
+        actorReference,
+      ),
+    correctEventGameIdentity: (eventId, gameDayId, eventGameId, input) =>
+      correctEventGameIdentityOperation(
         transaction,
         clock,
         ids,
@@ -2660,6 +2815,164 @@ function previewPitchSlotExpectedDelayOperation(
   return accepted(
     createDelayPreview(transaction, "pitch-slot", slot.pitchSlotId, slots, delay.value, cascade),
   );
+}
+
+function correctEventGameIdentityOperation(
+  transaction: EventCatalogStorageTransaction,
+  clock: EventCatalogClock,
+  ids: EventCatalogIds,
+  eventIdInput: unknown,
+  gameDayIdInput: unknown,
+  eventGameIdInput: unknown,
+  input: EventGameIdentityCorrectionInput,
+  actorReference: string,
+): CatalogOutcome<EventGameIdentityCorrection> {
+  const eventId = validateId(eventIdInput, "eventId");
+  const gameDayId = validateId(gameDayIdInput, "gameDayId");
+  const eventGameId = validateId(eventGameIdInput, "eventGameId");
+  const gameSideId = validateId(input.gameSideId, "gameSideId");
+  const targetEventTeamId = validateId(input.eventTeamId, "eventTeamId");
+  const operationId =
+    input.operationId === undefined
+      ? { ok: true as const, value: ids.next("operation") }
+      : validateId(input.operationId, "operationId");
+  if (
+    !eventId.ok ||
+    !gameDayId.ok ||
+    !eventGameId.ok ||
+    !gameSideId.ok ||
+    !targetEventTeamId.ok ||
+    !operationId.ok
+  )
+    return invalid("Event Game identity correction identifier is invalid.");
+  if (input.confirmation !== undefined && typeof input.confirmation !== "boolean")
+    return invalid("Event Game identity correction confirmation must be a boolean.");
+  const reasonResult =
+    input.reason === undefined || input.reason === null
+      ? { ok: true as const, value: null }
+      : normalizeBoundedText(
+          input.reason,
+          SHARED_LIMITS.names.operatorNoteMaxCodePoints,
+          "Event Game identity correction reason",
+        );
+  if (!reasonResult.ok) return invalid(reasonResult.error);
+  const reason = reasonResult.value;
+  if (reason !== null && reason.length === 0)
+    return invalid("Event Game identity correction reason must not be empty.");
+  const nowMs = validNow(clock);
+  if (nowMs === null) return invalid("Event clock returned an invalid timestamp.");
+  const event = transaction.findEvent(eventId.value);
+  const game = transaction.findEventGame(eventGameId.value);
+  if (event === null || game === null) return notFound("Event Game was not found.");
+  const priorRoot = transaction.findRootByEventGameId(game.eventGameId);
+  const commenced =
+    priorRoot?.lifecycle.commencedAtMs !== null && priorRoot?.lifecycle.commencedAtMs !== undefined;
+  const previousAttempt = transaction
+    .listAuditTrail(event.eventId)
+    .find(
+      (entry) =>
+        entry.operationId === operationId.value && entry.action === "event-game-teams-confirmed",
+    );
+  if (previousAttempt !== undefined) {
+    const before = isRecord(previousAttempt.before) ? previousAttempt.before : null;
+    const beforeGame = before !== null && isRecord(before.eventGame) ? before.eventGame : null;
+    const beforeSideCandidate = beforeGame?.[sideKey(game, gameSideId.value)];
+    const beforeSide = isRecord(beforeSideCandidate) ? beforeSideCandidate : null;
+    const after = isRecord(previousAttempt.after) ? previousAttempt.after : null;
+    const afterGame = after !== null && isRecord(after.eventGame) ? after.eventGame : null;
+    const afterSideCandidate = afterGame?.[sideKey(game, gameSideId.value)];
+    const afterSide = isRecord(afterSideCandidate) ? afterSideCandidate : null;
+    const originalCorrection =
+      after !== null && isRecord(after.correction) ? after.correction : null;
+    if (afterSide !== null && afterSide.eventTeamId === targetEventTeamId.value) {
+      return accepted({
+        operationId: operationId.value,
+        eventGameId: game.eventGameId,
+        gameSideId: gameSideId.value,
+        previousEventTeamId:
+          typeof beforeSide?.eventTeamId === "string" ? beforeSide.eventTeamId : "",
+        previousEventTeamName:
+          typeof beforeSide?.eventTeamName === "string" ? beforeSide.eventTeamName : "",
+        eventTeamId: afterSide.eventTeamId,
+        eventTeamName: typeof afterSide.eventTeamName === "string" ? afterSide.eventTeamName : "",
+        commenced,
+        reason: typeof originalCorrection?.reason === "string" ? originalCorrection.reason : null,
+        controllerAcknowledgementRequired: commenced,
+      });
+    }
+    return {
+      status: "rejected",
+      reason: "duplicate",
+      detail: "The identity correction operation is already bound to another Event Team.",
+    };
+  }
+  if (game.eventId !== event.eventId || game.gameDayId !== gameDayId.value)
+    return crossEvent("Event Game does not belong to the selected Event and Game Day.");
+  const side =
+    game.sideA.sideId === gameSideId.value
+      ? "sideA"
+      : game.sideB.sideId === gameSideId.value
+        ? "sideB"
+        : null;
+  if (side === null)
+    return invalid("Event Game identity correction references an unknown Game Side.");
+  const target = transaction.findEventTeam(targetEventTeamId.value);
+  if (target === null) return notFound("Event Team was not found.");
+  if (target.eventId !== event.eventId) return crossEvent("Event Team belongs to another Event.");
+  const otherSide = side === "sideA" ? game.sideB : game.sideA;
+  if (otherSide.eventTeamId === target.eventTeamId)
+    return invalid("Event Game sides must use distinct Event Teams.");
+  if (commenced && input.confirmation !== true)
+    return invalid("Post-commencement Event Game identity correction requires confirmation.");
+  if (commenced && reason === null)
+    return invalid("Post-commencement Event Game identity correction requires a reason.");
+  const previous = side === "sideA" ? game.sideA : game.sideB;
+  if (previous.eventTeamId === null || previous.eventTeamName === null)
+    return invalid("Only an assigned Event Team identity can be corrected.");
+  if (previous.eventTeamId === target.eventTeamId)
+    return noChange("Event Game identity is unchanged.");
+  const nextSide = {
+    ...previous,
+    eventTeamId: target.eventTeamId,
+    eventTeamName: target.name,
+    sourceLabel: null,
+    confirmedAtMs: nowMs,
+  };
+  const next: EventGame = {
+    ...game,
+    ...(side === "sideA" ? { sideA: nextSide } : { sideB: nextSide }),
+    updatedAtMs: nowMs,
+  };
+  transaction.updateEventGame(next);
+  transaction.appendAudit(
+    createAudit(
+      ids,
+      "event-game-teams-confirmed",
+      event.eventId,
+      gameDayId.value,
+      actorReference,
+      nowMs,
+      { eventGame: game, correction: { gameSideId: gameSideId.value, reason } },
+      { eventGame: next, correction: { gameSideId: gameSideId.value, reason } },
+      operationId.value,
+    ),
+  );
+  return accepted({
+    operationId: operationId.value,
+    eventGameId: game.eventGameId,
+    gameSideId: gameSideId.value,
+    previousEventTeamId: previous.eventTeamId ?? "",
+    previousEventTeamName: previous.eventTeamName ?? "",
+    eventTeamId: target.eventTeamId,
+    eventTeamName: target.name,
+    commenced,
+    reason,
+    controllerAcknowledgementRequired: commenced,
+  });
+}
+
+function sideKey(game: EventGame, gameSideId: string): "sideA" | "sideB" {
+  return game.sideA.sideId === gameSideId ? "sideA" : "sideB";
 }
 
 function reassignEventGameOperation(

--- a/src/lib/event-game-action-codecs.ts
+++ b/src/lib/event-game-action-codecs.ts
@@ -85,6 +85,7 @@ type TeamAssignmentCorrectionPayload = {
   gameSideId: string;
   eventTeamId: string;
   teamInterpretationRef: string;
+  eventTeamName?: string;
 };
 
 function createGameFactCodec(): ControlActionCodec<GameFactPayload> {
@@ -202,11 +203,17 @@ function createTeamAssignmentCorrectionCodec(): ControlActionCodec<TeamAssignmen
       if (!gameSideId.ok) return gameSideId;
       if (!eventTeamId.ok) return eventTeamId;
       if (!teamInterpretationRef.ok) return teamInterpretationRef;
+      const eventTeamName =
+        payload.eventTeamName === undefined
+          ? valid(undefined)
+          : validateId(payload.eventTeamName, "payload.eventTeamName");
+      if (!eventTeamName.ok) return eventTeamName;
       return valid({
         correctionId: correctionId.value,
         gameSideId: gameSideId.value,
         eventTeamId: eventTeamId.value,
         teamInterpretationRef: teamInterpretationRef.value,
+        ...(eventTeamName.value === undefined ? {} : { eventTeamName: eventTeamName.value }),
       });
     },
     canonicalize(payload) {
@@ -222,6 +229,7 @@ function createTeamAssignmentCorrectionCodec(): ControlActionCodec<TeamAssignmen
         gameSideId: payload.gameSideId,
         eventTeamId: payload.eventTeamId,
         teamInterpretationRef: payload.teamInterpretationRef,
+        ...(payload.eventTeamName === undefined ? {} : { eventTeamName: payload.eventTeamName }),
       };
     },
   };
@@ -505,16 +513,22 @@ export function validateInterpretation(
       value.teamInterpretationRef,
       "interpretation.teamInterpretationRef",
     );
+    const eventTeamName =
+      value.eventTeamName === undefined
+        ? valid(undefined)
+        : validateId(value.eventTeamName, "interpretation.eventTeamName");
     if (!correctionId.ok) return correctionId;
     if (!gameSideId.ok) return gameSideId;
     if (!eventTeamId.ok) return eventTeamId;
     if (!teamInterpretationRef.ok) return teamInterpretationRef;
+    if (!eventTeamName.ok) return eventTeamName;
     return valid({
       type: "team-assignment-correction",
       correctionId: correctionId.value,
       gameSideId: gameSideId.value,
       eventTeamId: eventTeamId.value,
       teamInterpretationRef: teamInterpretationRef.value,
+      ...(eventTeamName.value === undefined ? {} : { eventTeamName: eventTeamName.value }),
     });
   }
   if (value.type === "non-fact") {

--- a/src/lib/event-game-actions.ts
+++ b/src/lib/event-game-actions.ts
@@ -131,6 +131,7 @@ export type TeamAssignmentCorrectionInterpretation = {
   gameSideId: string;
   eventTeamId: string;
   teamInterpretationRef: string;
+  eventTeamName?: string;
 };
 
 export type NonFactInterpretation = {
@@ -254,6 +255,7 @@ export type EffectiveGameSideAssignment = {
   gameSideId: string;
   eventTeamId: string;
   teamInterpretationRef: string;
+  eventTeamName?: string;
 };
 
 export type ControlActionConflict = {
@@ -687,7 +689,7 @@ export function rebuildControlActionHistory(
   }
 
   const effectiveByFactId = new Map([...factsById.keys()].map((factId) => [factId, true]));
-  const effectiveTeamAssignments = new Map(
+  const effectiveTeamAssignments = new Map<string, EffectiveGameSideAssignment>(
     root.gameSides.map((side) => [
       side.id,
       {
@@ -716,7 +718,7 @@ export function rebuildControlActionHistory(
   }
   for (const action of ordered.actions) {
     if (action.interpretation.type !== "team-assignment-correction") continue;
-    const { gameSideId, eventTeamId, teamInterpretationRef } = action.interpretation;
+    const { gameSideId, eventTeamId, teamInterpretationRef, eventTeamName } = action.interpretation;
     const current = effectiveTeamAssignments.get(gameSideId);
     if (current === undefined) {
       return {
@@ -745,6 +747,7 @@ export function rebuildControlActionHistory(
       ...current,
       eventTeamId,
       teamInterpretationRef,
+      eventTeamName,
     });
   }
 

--- a/src/lib/event-game-record.test.ts
+++ b/src/lib/event-game-record.test.ts
@@ -4,7 +4,11 @@ import {
   type EventGameRecordRoot,
 } from "@/lib/foundation-record-types";
 import { createDeterministicTestIqaInterpreter } from "@/lib/event-game-actions";
-import { createEventGameRecord, type ExternalScopeResolver } from "@/lib/event-game-record";
+import {
+  createEventGameRecord,
+  createEventGameRecordTransactionSeam,
+  type ExternalScopeResolver,
+} from "@/lib/event-game-record";
 import { createInMemoryFoundationStorage } from "@/lib/foundation-storage-memory";
 
 function createRoot(overrides: Partial<EventGameRecordRoot> = {}): EventGameRecordRoot {
@@ -128,6 +132,63 @@ describe("Event Game Record contract", () => {
     }
 
     expect(await storage.readRoot(root.recordId)).toBeNull();
+  });
+
+  test("uses the transaction-local Record seam for equal-time identity corrections", async () => {
+    const root = createRoot();
+    const storage = createInMemoryFoundationStorage();
+    const record = createEventGameRecord(storage, {
+      externalScopeResolver: createScopeResolver(root),
+      interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
+      clock: () => 2_000,
+    });
+    expect(await record.registerRoot(root)).toMatchObject({ status: "registered" });
+
+    const outcomes = await storage.transaction((transaction) => {
+      const seam = createEventGameRecordTransactionSeam(transaction, {
+        externalScopeResolver: createScopeResolver(root),
+        interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
+        clock: () => 2_000,
+      });
+      const base = {
+        recordId: root.recordId,
+        eventGameId: root.eventGameId,
+        gameSideId: "side-1",
+        teamInterpretationRef: "team-3-v1",
+        eventTeamName: "Correction-time Team Three",
+        trustedAtMs: 2_000,
+        grant: { sessionId: "event-admin", versionId: "event-admin" },
+      };
+      const first = seam.correctTeamAssignment({
+        ...base,
+        operationId: "identity-a",
+        eventTeamId: "team-3",
+      });
+      const second = seam.correctTeamAssignment({
+        ...base,
+        operationId: "identity-b",
+        eventTeamId: "team-4",
+        teamInterpretationRef: "team-4-v1",
+        eventTeamName: "Correction-time Team Four",
+      });
+      return { first, second };
+    });
+
+    expect(outcomes.first.status).toBe("accepted");
+    expect(outcomes.second.status).toBe("accepted");
+    const rebuilt = await record.rebuild();
+    expect(rebuilt).toMatchObject({
+      status: "ready",
+      effectiveTeamAssignments: [
+        {
+          gameSideId: "side-1",
+          eventTeamId: "team-4",
+          teamInterpretationRef: "team-4-v1",
+          eventTeamName: "Correction-time Team Four",
+        },
+        { gameSideId: "side-2", eventTeamId: "team-2" },
+      ],
+    });
   });
 });
 

--- a/src/lib/event-game-record.ts
+++ b/src/lib/event-game-record.ts
@@ -28,6 +28,7 @@ import {
   validateDependencies,
   validateIdempotencyHistory,
 } from "@/lib/event-game-record-helpers";
+import { validateId } from "@/lib/event-game-action-codecs";
 import {
   CONTROL_ACTION_ORDERING_VERSION,
   createControlActionCodecRegistry,
@@ -38,11 +39,13 @@ import {
   rebuildControlActionHistory,
   type ActionRebuildResult,
   type ControlAction,
+  type ControlActionInput,
   type ControlActionCodec,
   type ControlActionCodecRegistry,
   type ControlActionRecoveryProvenance,
   type ControlAuditEntry,
   type EventGameRecordMetadata,
+  type EffectiveGameSideAssignment,
   type IqaGameRulesInterpreter,
   sha256,
 } from "@/lib/event-game-actions";
@@ -236,6 +239,28 @@ export type GamePresentationAcceptanceOutcome =
       detail: string;
     };
 
+export type EventGameRecordTeamAssignmentCorrectionRequest = {
+  recordId: string;
+  eventGameId: string;
+  operationId: string;
+  gameSideId: string;
+  eventTeamId: string;
+  teamInterpretationRef: string;
+  eventTeamName?: string;
+  trustedAtMs: number;
+  grant: { sessionId: string; versionId: string };
+};
+
+export type EventGameRecordTransactionSeam = {
+  correctTeamAssignment(
+    input: EventGameRecordTeamAssignmentCorrectionRequest,
+  ): ControlActionAcceptanceOutcome & {
+    effectiveTeamAssignments?: readonly EffectiveGameSideAssignment[];
+  };
+  acceptPresentationChange(input: unknown): GamePresentationAcceptanceOutcome;
+  readPresentation(recordId: string): GamePresentation;
+};
+
 export type EventGameRecordReadiness =
   | {
       ok: true;
@@ -332,10 +357,18 @@ function presentationDefaultColors(
   root: EventGameRecordRoot,
   snapshot: FoundationStorageSnapshot,
   resolver: ExternalScopeResolver,
+  effectiveTeamAssignments: readonly EffectiveGameSideAssignment[] = [],
 ): Record<string, string> {
   const defaults: Record<string, string> = {};
+  const effectiveBySide = new Map(
+    effectiveTeamAssignments.map((assignment) => [assignment.gameSideId, assignment.eventTeamId]),
+  );
   for (const side of root.gameSides) {
-    const color = resolver.resolveEventTeamDefaultColor?.(root.eventId, side.eventTeamId, snapshot);
+    const color = resolver.resolveEventTeamDefaultColor?.(
+      root.eventId,
+      effectiveBySide.get(side.id) ?? side.eventTeamId,
+      snapshot,
+    );
     if (color !== null && color !== undefined && isValidHexColor(color)) {
       defaults[side.id] = `#${color.trim().replace(/^#/, "").toLowerCase()}`;
     }
@@ -496,6 +529,19 @@ export function createEventGameRecord(
       throw new Error("Event Game Record has not been registered.");
     }
     return activeRecordId;
+  }
+
+  function presentationDefaults(
+    root: EventGameRecordRoot,
+    transaction: FoundationStorageSnapshot,
+  ): Record<string, string> {
+    const rebuilt = rebuildRecordSnapshot(root, transaction, codecRegistry, options.interpreter);
+    return presentationDefaultColors(
+      root,
+      transaction,
+      options.externalScopeResolver,
+      rebuilt.status === "ready" ? rebuilt.effectiveTeamAssignments : [],
+    );
   }
 
   async function rebuildActiveRecord(): Promise<ActionRebuildResult> {
@@ -1062,7 +1108,7 @@ export function createEventGameRecord(
           root,
           transaction.listPresentationChanges?.(root.recordId) ?? [],
           transaction.listPresentationAuditEntries?.(root.recordId) ?? [],
-          presentationDefaultColors(root, transaction, options.externalScopeResolver),
+          presentationDefaults(root, transaction),
         );
       });
       const presentationRanks = await storage.transaction((transaction) => {
@@ -1086,22 +1132,7 @@ export function createEventGameRecord(
         } satisfies GamePresentationAcceptanceOutcome;
       }
       try {
-        const outcome = await storage.transaction((transaction) => {
-          if (
-            transaction.findPresentationChangeByOperationId === undefined ||
-            transaction.listPresentationChanges === undefined ||
-            transaction.listPresentationAuditEntries === undefined ||
-            transaction.insertPresentationChange === undefined ||
-            transaction.appendPresentationAuditEntry === undefined ||
-            transaction.appendPresentationAuditRevision === undefined ||
-            transaction.sealPresentationEvidence === undefined
-          ) {
-            return {
-              status: "rejected",
-              reason: "storage-not-ready",
-              detail: "The presentation record seam is not durably available.",
-            } satisfies GamePresentationAcceptanceOutcome;
-          }
+        return await storage.transaction((transaction) => {
           const root = transaction.findRootByRecordId(parsed.recordId);
           if (root === null || root.eventGameId !== parsed.eventGameId) {
             return {
@@ -1117,198 +1148,11 @@ export function createEventGameRecord(
               detail: "The Event Game Record is not active.",
             } satisfies GamePresentationAcceptanceOutcome;
           }
-          if (parsed.change.type === "displayed-team-color") {
-            const gameSideId = parsed.change.gameSideId;
-            if (!root.gameSides.some((side) => side.id === gameSideId)) {
-              return {
-                status: "rejected",
-                reason: "invalid-change",
-                detail: "Game Presentation Change references an unknown stable Game Side.",
-              } satisfies GamePresentationAcceptanceOutcome;
-            }
-          }
-          const retainedPresentationChanges = transaction.listPresentationChanges(root.recordId);
-          const predecessorIds = new Set(parsed.causalPredecessorIds);
-          const retainedOperationIds = new Set([
-            ...transaction.listActions(root.recordId).map((stored) => stored.action.operationId),
-            ...retainedPresentationChanges.map((change) => change.operationId),
-          ]);
-          if (
-            predecessorIds.size !== parsed.causalPredecessorIds.length ||
-            predecessorIds.has(parsed.operationId) ||
-            parsed.causalPredecessorIds.some(
-              (predecessor) => !retainedOperationIds.has(predecessor),
-            )
-          ) {
-            return {
-              status: "rejected",
-              reason: "invalid-change",
-              detail: "Game Presentation Change causal predecessors are not retained.",
-            } satisfies GamePresentationAcceptanceOutcome;
-          }
-          const previousPresentation = deriveGamePresentation(
-            root.gameSides.map((side) => side.id),
-            retainedPresentationChanges,
-            presentationDefaultColors(root, transaction, options.externalScopeResolver),
-          );
-          const existing = transaction.findPresentationChangeByOperationId?.(
-            root.recordId,
-            parsed.operationId,
-          );
-          const fingerprint = fingerprintGamePresentationChange(parsed);
-          if (existing !== null && existing !== undefined) {
-            if (existing.contentFingerprint === fingerprint) {
-              const audit: StoredGamePresentationAuditEntry = {
-                auditVersion: "control-audit-v1",
-                auditId: presentationAuditId(
-                  root,
-                  "presentation-duplicate",
-                  parsed.operationId,
-                  "",
-                ),
-                recordId: root.recordId,
-                eventGameId: root.eventGameId,
-                operationId: parsed.operationId,
-                presentationChangeId: parsed.presentationChangeId,
-                kind: "presentation-duplicate",
-                classification: "game-presentation-change",
-                outcome: "duplicate-accepted",
-                createdAtMs: parsed.acceptedAtMs,
-                redactedDetail: "Duplicate Game Presentation Change acknowledged idempotently.",
-                previousPresentation: structuredClone(previousPresentation),
-                resultingPresentation: structuredClone(previousPresentation),
-                change: parsed.change,
-                grant: parsed.grant,
-              };
-              if (
-                !transaction
-                  .listPresentationAuditEntries?.(root.recordId)
-                  .some((entry) => entry.auditId === audit.auditId)
-              ) {
-                transaction.appendPresentationAuditEntry?.(audit);
-                transaction.sealPresentationEvidence(root.recordId);
-              }
-              return {
-                status: "duplicate-accepted",
-                change: structuredClone(existing),
-                auditId: audit.auditId,
-              } satisfies GamePresentationAcceptanceOutcome;
-            }
-            const audit: StoredGamePresentationAuditEntry = {
-              auditVersion: "control-audit-v1",
-              auditId: presentationAuditId(
-                root,
-                "presentation-conflict",
-                parsed.operationId,
-                fingerprint,
-              ),
-              recordId: root.recordId,
-              eventGameId: root.eventGameId,
-              operationId: parsed.operationId,
-              presentationChangeId: parsed.presentationChangeId,
-              kind: "presentation-conflict",
-              classification: "game-presentation-change",
-              outcome: "rejected",
-              createdAtMs: parsed.acceptedAtMs,
-              redactedDetail:
-                "operation identity is already bound to different presentation content",
-              previousPresentation: structuredClone(previousPresentation),
-              resultingPresentation: structuredClone(previousPresentation),
-              change: parsed.change,
-              grant: parsed.grant,
-            };
-            transaction.appendPresentationAuditEntry?.(audit);
-            transaction.sealPresentationEvidence(root.recordId);
-            return {
-              status: "rejected",
-              reason: "operation-conflict",
-              detail: "The presentation operation identity is already bound to different content.",
-            } satisfies GamePresentationAcceptanceOutcome;
-          }
-          const sameChange = transaction
-            .listPresentationChanges?.(root.recordId)
-            .find((change) => change.presentationChangeId === parsed.presentationChangeId);
-          if (sameChange !== undefined) {
-            return {
-              status: "rejected",
-              reason: "operation-conflict",
-              detail: "The presentation change identity is already retained.",
-            } satisfies GamePresentationAcceptanceOutcome;
-          }
-          const stored: StoredGamePresentationChange = {
-            ...parsed,
-            causalPredecessorIds: [...parsed.causalPredecessorIds],
-            canonicalContent: canonicalizeGamePresentationChange(parsed),
-            contentFingerprint: fingerprint,
-          };
-          transaction.insertPresentationChange?.(stored);
-          const orderedChanges = orderGamePresentationChanges(
-            transaction.listPresentationChanges(root.recordId),
-          );
-          const storedIndex = orderedChanges.findIndex(
-            (change) => change.operationId === stored.operationId,
-          );
-          const canonicalPreviousPresentation = deriveGamePresentation(
-            root.gameSides.map((side) => side.id),
-            orderedChanges.slice(0, storedIndex),
-            presentationDefaultColors(root, transaction, options.externalScopeResolver),
-          );
-          const resultingPresentation = deriveGamePresentation(
-            root.gameSides.map((side) => side.id),
-            orderedChanges.slice(0, storedIndex + 1),
-            presentationDefaultColors(root, transaction, options.externalScopeResolver),
-          );
-          const audit: StoredGamePresentationAuditEntry = {
-            auditVersion: "control-audit-v1",
-            auditId: presentationAuditId(root, "presentation-accepted", parsed.operationId, ""),
-            recordId: root.recordId,
-            eventGameId: root.eventGameId,
-            operationId: parsed.operationId,
-            presentationChangeId: parsed.presentationChangeId,
-            kind: "presentation-accepted",
-            classification: "game-presentation-change",
-            outcome: "accepted",
-            createdAtMs: parsed.acceptedAtMs,
-            redactedDetail: "Game Presentation Change accepted and synchronized.",
-            previousPresentation: structuredClone(canonicalPreviousPresentation),
-            resultingPresentation: structuredClone(resultingPresentation),
-            change: parsed.change,
-            grant: parsed.grant,
-          };
-          transaction.appendPresentationAuditEntry?.(audit);
-          const allAudits = transaction.listPresentationAuditEntries(root.recordId);
-          const canonicalAudits = materializePresentationAuditSnapshots(
-            root,
-            orderedChanges,
-            allAudits,
-            presentationDefaultColors(root, transaction, options.externalScopeResolver),
-          );
-          const effectiveAudits = collapseGamePresentationAuditEntries(allAudits);
-          for (const canonicalAudit of canonicalAudits) {
-            if (canonicalAudit.kind !== "presentation-accepted") continue;
-            const currentAudit = effectiveAudits.find(
-              (entry) => entry.auditId === canonicalAudit.auditId,
-            );
-            if (
-              currentAudit !== undefined &&
-              (JSON.stringify(currentAudit.previousPresentation) !==
-                JSON.stringify(canonicalAudit.previousPresentation) ||
-                JSON.stringify(currentAudit.resultingPresentation) !==
-                  JSON.stringify(canonicalAudit.resultingPresentation))
-            ) {
-              transaction.appendPresentationAuditRevision(
-                revisionGamePresentationAuditEntry(canonicalAudit),
-              );
-            }
-          }
-          transaction.sealPresentationEvidence(root.recordId);
-          return {
-            status: "accepted",
-            change: stored,
-            auditId: audit.auditId,
-          } satisfies GamePresentationAcceptanceOutcome;
+          return createEventGameRecordTransactionSeam(
+            transaction,
+            options,
+          ).acceptPresentationChange(parsed);
         });
-        return outcome;
       } catch (error) {
         if (error instanceof FoundationStorageNotReadyError) {
           return {
@@ -1333,7 +1177,7 @@ export function createEventGameRecord(
         return deriveGamePresentation(
           root.gameSides.map((side) => side.id),
           changes,
-          presentationDefaultColors(root, transaction, options.externalScopeResolver),
+          presentationDefaults(root, transaction),
         );
       });
     },
@@ -1369,7 +1213,7 @@ export function createEventGameRecord(
           root,
           changes,
           transaction.listPresentationAuditEntries?.(root.recordId) ?? [],
-          presentationDefaultColors(root, transaction, options.externalScopeResolver),
+          presentationDefaults(root, transaction),
         ).sort((left, right) => compareAuditEntries(left, right, presentationRanks));
       });
     },
@@ -1434,6 +1278,379 @@ export function createEventGameRecord(
       } satisfies EventGameRecordReadiness;
     },
   };
+}
+
+export function createEventGameRecordTransactionSeam(
+  transaction: FoundationStorageTransaction,
+  options: EventGameRecordOptions,
+): EventGameRecordTransactionSeam {
+  const clock = options.clock ?? (() => Date.now());
+  const registry =
+    options.actionCodecRegistry ?? createControlActionCodecRegistry(options.actionCodecs);
+
+  function readReadyHistory(root: EventGameRecordRoot): ActionRebuildResult {
+    return rebuildRecordSnapshot(root, transaction, registry, options.interpreter);
+  }
+
+  function presentationDefaults(
+    root: EventGameRecordRoot,
+    snapshot: FoundationStorageSnapshot,
+  ): Record<string, string> {
+    const rebuilt = readReadyHistory(root);
+    return presentationDefaultColors(
+      root,
+      snapshot,
+      options.externalScopeResolver,
+      rebuilt.status === "ready" ? rebuilt.effectiveTeamAssignments : [],
+    );
+  }
+
+  function correctTeamAssignment(
+    input: EventGameRecordTeamAssignmentCorrectionRequest,
+  ): ControlActionAcceptanceOutcome & {
+    effectiveTeamAssignments?: readonly EffectiveGameSideAssignment[];
+  } {
+    const recordId = validateId(input.recordId, "recordId");
+    const eventGameId = validateId(input.eventGameId, "eventGameId");
+    const operationId = validateId(input.operationId, "operationId");
+    const gameSideId = validateId(input.gameSideId, "gameSideId");
+    const eventTeamId = validateId(input.eventTeamId, "eventTeamId");
+    const teamInterpretationRef = validateId(input.teamInterpretationRef, "teamInterpretationRef");
+    const eventTeamName =
+      input.eventTeamName === undefined
+        ? { ok: true as const, value: undefined }
+        : validateId(input.eventTeamName, "eventTeamName");
+    if (
+      !recordId.ok ||
+      !eventGameId.ok ||
+      !operationId.ok ||
+      !gameSideId.ok ||
+      !eventTeamId.ok ||
+      !teamInterpretationRef.ok ||
+      !eventTeamName.ok
+    )
+      return {
+        status: "rejected",
+        reason: "invalid-action",
+        detail: "Event Team Assignment Correction identity is invalid.",
+      };
+    const root = transaction.findRootByRecordId(recordId.value);
+    if (root === null || root.eventGameId !== eventGameId.value)
+      return {
+        status: "rejected",
+        reason: "record-not-found",
+        detail: "The Event Game Record is not registered for this Event Game.",
+      };
+    if (!root.gameSides.some((side) => side.id === gameSideId.value))
+      return {
+        status: "rejected",
+        reason: "invalid-action",
+        detail: "Team Assignment Correction references an unknown stable Game Side.",
+      };
+    const scope = options.externalScopeResolver.resolve(root.externalScope, transaction);
+    if (scope.status !== "resolved")
+      return { status: "rejected", reason: "storage-not-ready", detail: scope.detail };
+    const team = options.externalScopeResolver.resolveEventTeam(
+      root.eventId,
+      eventTeamId.value,
+      transaction,
+    );
+    if (team.status !== "resolved")
+      return { status: "rejected", reason: "invalid-action", detail: team.detail };
+    const before = readReadyHistory(root);
+    if (before.status !== "ready")
+      return { status: "rejected", reason: "storage-not-ready", detail: before.detail };
+    const actionInput: ControlActionInput = {
+      recordId: recordId.value,
+      eventGameId: eventGameId.value,
+      operationId: operationId.value,
+      kind: { id: "team-assignment-correction", version: "1" },
+      payload: {
+        correctionId: operationId.value,
+        gameSideId: gameSideId.value,
+        eventTeamId: eventTeamId.value,
+        teamInterpretationRef: teamInterpretationRef.value,
+        ...(eventTeamName.value === undefined ? {} : { eventTeamName: eventTeamName.value }),
+      },
+      causalPredecessorIds: [],
+      occurrence: { trustedAtMs: input.trustedAtMs, clientOriginAtMs: null, source: "online" },
+      grant: input.grant,
+      lifecycle: structuredClone(root.lifecycle),
+    };
+    const prepared = prepareControlAction(actionInput, root, registry, clock(), {
+      allowConcurrentTeamAssignment: true,
+    });
+    if (!prepared.ok)
+      return { status: "rejected", reason: "invalid-action", detail: prepared.error };
+    const existing = transaction.findActionByOperationId(root.recordId, operationId.value);
+    if (existing !== null) {
+      if (existing.contentFingerprint === prepared.value.contentFingerprint) {
+        return {
+          status: "duplicate-accepted",
+          action: structuredClone(existing.action),
+          auditId: acceptedAuditId(existing.action),
+          effectiveTeamAssignments: structuredClone(before.effectiveTeamAssignments),
+        };
+      }
+      transaction.appendAuditEntry(
+        createAuditEntry(
+          prepared.value.input,
+          "action-conflict",
+          "operation identity is already bound to different content",
+          clock(),
+          {
+            interpretation: prepared.value.interpretation,
+            collision: {
+              acceptedAction: existing.action,
+              acceptedContentFingerprint: existing.contentFingerprint,
+              rejectedAttempt: prepared.value,
+            },
+          },
+        ),
+      );
+      return {
+        status: "rejected",
+        reason: "operation-conflict",
+        detail: "The operation identity is already bound to different content.",
+      };
+    }
+    const action = materializeControlAction(prepared.value, clock());
+    const candidate = rebuildControlActionHistory(
+      root,
+      [
+        ...transaction.listActions(root.recordId),
+        {
+          action,
+          canonicalContent: prepared.value.canonicalContent,
+          contentFingerprint: prepared.value.contentFingerprint,
+        },
+      ],
+      registry,
+      options.interpreter!,
+    );
+    if (candidate.status !== "ready")
+      return { status: "rejected", reason: "storage-not-ready", detail: candidate.detail };
+    transaction.insertAction({
+      action,
+      canonicalContent: prepared.value.canonicalContent,
+      contentFingerprint: prepared.value.contentFingerprint,
+    });
+    const metadata = transaction.readRecordMetadata(root.recordId);
+    const acceptedAtMs = action.acceptedAtMs;
+    transaction.upsertRecordMetadata({
+      recordId: root.recordId,
+      actionCount: (metadata?.actionCount ?? 0) + 1,
+      orderingVersion: CONTROL_ACTION_ORDERING_VERSION,
+      lastAcceptedAtMs: Math.max(metadata?.lastAcceptedAtMs ?? 0, acceptedAtMs),
+      updatedAtMs: Math.max(
+        metadata?.updatedAtMs ?? root.creationEvidence.createdAtMs,
+        acceptedAtMs,
+      ),
+    });
+    const audit = createAuditEntry(
+      prepared.value.input,
+      "action-accepted",
+      ACCEPTED_AUDIT_DETAIL,
+      acceptedAtMs,
+      { interpretation: prepared.value.interpretation },
+    );
+    transaction.appendAuditEntry(audit);
+    appendConcurrentCorrectionAudits(transaction, root.recordId, acceptedAtMs);
+    const after = readReadyHistory(root);
+    if (after.status !== "ready")
+      return { status: "rejected", reason: "storage-not-ready", detail: after.detail };
+    return {
+      status: "accepted",
+      action,
+      auditId: audit.auditId,
+      effectiveTeamAssignments: structuredClone(after.effectiveTeamAssignments),
+    };
+  }
+
+  function acceptPresentationChange(input: unknown): GamePresentationAcceptanceOutcome {
+    const parsed = readPresentationAcceptanceInput(input);
+    if (parsed === null)
+      return {
+        status: "rejected",
+        reason: "invalid-change",
+        detail: "Game Presentation Change is malformed.",
+      };
+    if (
+      transaction.findPresentationChangeByOperationId === undefined ||
+      transaction.listPresentationChanges === undefined ||
+      transaction.listPresentationAuditEntries === undefined ||
+      transaction.insertPresentationChange === undefined ||
+      transaction.appendPresentationAuditEntry === undefined ||
+      transaction.appendPresentationAuditRevision === undefined ||
+      transaction.sealPresentationEvidence === undefined
+    )
+      return {
+        status: "rejected",
+        reason: "storage-not-ready",
+        detail: "The presentation record seam is not durably available.",
+      };
+    const root = transaction.findRootByRecordId(parsed.recordId);
+    if (root === null || root.eventGameId !== parsed.eventGameId)
+      return {
+        status: "rejected",
+        reason: "record-not-found",
+        detail: "The Event Game Record is not registered for this Event Game.",
+      };
+    if (parsed.change.type === "displayed-team-color") {
+      const gameSideId = parsed.change.gameSideId;
+      if (!root.gameSides.some((side) => side.id === gameSideId))
+        return {
+          status: "rejected",
+          reason: "invalid-change",
+          detail: "Game Presentation Change references an unknown stable Game Side.",
+        };
+    }
+    const retained = transaction.listPresentationChanges(root.recordId);
+    const predecessorIds = new Set(parsed.causalPredecessorIds);
+    const retainedOperationIds = new Set([
+      ...transaction.listActions(root.recordId).map((stored) => stored.action.operationId),
+      ...retained.map((change) => change.operationId),
+    ]);
+    if (
+      predecessorIds.size !== parsed.causalPredecessorIds.length ||
+      predecessorIds.has(parsed.operationId) ||
+      parsed.causalPredecessorIds.some((predecessor) => !retainedOperationIds.has(predecessor))
+    )
+      return {
+        status: "rejected",
+        reason: "invalid-change",
+        detail: "Game Presentation Change causal predecessors are not retained.",
+      };
+    const existing = transaction.findPresentationChangeByOperationId(
+      root.recordId,
+      parsed.operationId,
+    );
+    const fingerprint = fingerprintGamePresentationChange(parsed);
+    const defaults = presentationDefaults(root, transaction);
+    const previous = deriveGamePresentation(
+      root.gameSides.map((side) => side.id),
+      retained,
+      defaults,
+    );
+    if (existing !== null) {
+      if (existing.contentFingerprint === fingerprint) {
+        const audit: StoredGamePresentationAuditEntry = {
+          auditVersion: "control-audit-v1",
+          auditId: presentationAuditId(root, "presentation-duplicate", parsed.operationId, ""),
+          recordId: root.recordId,
+          eventGameId: root.eventGameId,
+          operationId: parsed.operationId,
+          presentationChangeId: parsed.presentationChangeId,
+          kind: "presentation-duplicate",
+          classification: "game-presentation-change",
+          outcome: "duplicate-accepted",
+          createdAtMs: parsed.acceptedAtMs,
+          redactedDetail: "Duplicate Game Presentation Change acknowledged idempotently.",
+          previousPresentation: structuredClone(previous),
+          resultingPresentation: structuredClone(previous),
+          change: parsed.change,
+          grant: parsed.grant,
+        };
+        if (
+          !transaction
+            .listPresentationAuditEntries(root.recordId)
+            .some((entry) => entry.auditId === audit.auditId)
+        )
+          transaction.appendPresentationAuditEntry(audit);
+        transaction.sealPresentationEvidence(root.recordId);
+        return {
+          status: "duplicate-accepted",
+          change: structuredClone(existing),
+          auditId: audit.auditId,
+        };
+      }
+      return {
+        status: "rejected",
+        reason: "operation-conflict",
+        detail: "The presentation operation identity is already bound to different content.",
+      };
+    }
+    if (retained.some((change) => change.presentationChangeId === parsed.presentationChangeId))
+      return {
+        status: "rejected",
+        reason: "operation-conflict",
+        detail: "The presentation change identity is already retained.",
+      };
+    const stored: StoredGamePresentationChange = {
+      ...parsed,
+      causalPredecessorIds: [...parsed.causalPredecessorIds],
+      canonicalContent: canonicalizeGamePresentationChange(parsed),
+      contentFingerprint: fingerprint,
+    };
+    transaction.insertPresentationChange(stored);
+    const ordered = orderGamePresentationChanges([...retained, stored]);
+    const index = ordered.findIndex((change) => change.operationId === stored.operationId);
+    const canonicalPrevious = deriveGamePresentation(
+      root.gameSides.map((side) => side.id),
+      ordered.slice(0, index),
+      defaults,
+    );
+    const resulting = deriveGamePresentation(
+      root.gameSides.map((side) => side.id),
+      ordered.slice(0, index + 1),
+      defaults,
+    );
+    const audit: StoredGamePresentationAuditEntry = {
+      auditVersion: "control-audit-v1",
+      auditId: presentationAuditId(root, "presentation-accepted", parsed.operationId, ""),
+      recordId: root.recordId,
+      eventGameId: root.eventGameId,
+      operationId: parsed.operationId,
+      presentationChangeId: parsed.presentationChangeId,
+      kind: "presentation-accepted",
+      classification: "game-presentation-change",
+      outcome: "accepted",
+      createdAtMs: parsed.acceptedAtMs,
+      redactedDetail: "Game Presentation Change accepted and synchronized.",
+      previousPresentation: structuredClone(canonicalPrevious),
+      resultingPresentation: structuredClone(resulting),
+      change: parsed.change,
+      grant: parsed.grant,
+    };
+    transaction.appendPresentationAuditEntry(audit);
+    const audits = transaction.listPresentationAuditEntries(root.recordId);
+    const effectiveAudits = collapseGamePresentationAuditEntries(audits);
+    for (const canonicalAudit of materializePresentationAuditSnapshots(
+      root,
+      ordered,
+      audits,
+      defaults,
+    )) {
+      if (canonicalAudit.kind !== "presentation-accepted") continue;
+      const currentAudit = effectiveAudits.find(
+        (entry) => entry.auditId === canonicalAudit.auditId,
+      );
+      if (
+        currentAudit !== undefined &&
+        (JSON.stringify(currentAudit.previousPresentation) !==
+          JSON.stringify(canonicalAudit.previousPresentation) ||
+          JSON.stringify(currentAudit.resultingPresentation) !==
+            JSON.stringify(canonicalAudit.resultingPresentation))
+      )
+        transaction.appendPresentationAuditRevision(
+          revisionGamePresentationAuditEntry(canonicalAudit),
+        );
+    }
+    transaction.sealPresentationEvidence(root.recordId);
+    return { status: "accepted", change: stored, auditId: audit.auditId };
+  }
+
+  function readPresentation(recordId: string): GamePresentation {
+    const root = transaction.findRootByRecordId(recordId);
+    if (root === null) throw new Error("The Event Game Record is not registered.");
+    return deriveGamePresentation(
+      root.gameSides.map((side) => side.id),
+      transaction.listPresentationChanges?.(root.recordId) ?? [],
+      presentationDefaults(root, transaction),
+    );
+  }
+
+  return { correctTeamAssignment, acceptPresentationChange, readPresentation };
 }
 
 export function appendConcurrentCorrectionAudits(

--- a/src/lib/live-event-game-control.test.ts
+++ b/src/lib/live-event-game-control.test.ts
@@ -3,7 +3,10 @@ import { applyGameCommand, createInitialGameState } from "@/lib/game-engine";
 import { createFoundationAcceptance, type AcceptanceLimits } from "@/lib/foundation-acceptance";
 import { createInMemoryFoundationStorage } from "@/lib/foundation-storage-memory";
 import { createEventCatalog, createFoundationEventCatalogStorage } from "@/lib/event-catalog";
-import { createEventGameRecord } from "@/lib/event-game-record";
+import {
+  createEventGameRecord,
+  createEventGameRecordTransactionSeam,
+} from "@/lib/event-game-record";
 import { createGrantTestAuthorityVerifier } from "@/lib/grant-authority-test-support";
 import { createTypedGrantAuthority } from "@/lib/grant-management";
 import type { GrantAuthorityOptions } from "@/lib/grant-authority";
@@ -37,6 +40,116 @@ import {
 } from "@/lib/technical-admin-auth";
 
 describe("Live Event Game control", () => {
+  test("projects only the current correction with its correction-time name and gates acknowledgement", async () => {
+    let liveName = "Renamed Later";
+    const harness = await createHarness({
+      eventTeamNameResolver: (eventTeamId) =>
+        eventTeamId === "team-c" || eventTeamId === "team-d" ? liveName : null,
+    });
+    const commenced = await harness.record.transitionLifecycle({
+      ...harness.root.lifecycle,
+      phase: "in-progress",
+      commencedAtMs: 1_000,
+    });
+    expect(commenced.status).toBe("updated");
+
+    const correct = (operationId: string, eventTeamId: string, eventTeamName: string) =>
+      harness.storage.transaction((transaction) =>
+        createEventGameRecordTransactionSeam(transaction, {
+          externalScopeResolver: createScopeResolver(harness.root),
+          interpreter: createLiveEventGameIqaInterpreter(),
+          clock: () => harness.grantOptions.clock.nowMs(),
+        }).correctTeamAssignment({
+          recordId: harness.root.recordId,
+          eventGameId: harness.root.eventGameId,
+          operationId,
+          gameSideId: "side-a",
+          eventTeamId,
+          teamInterpretationRef: `${eventTeamId}-v1`,
+          eventTeamName,
+          trustedAtMs: 2_000,
+          grant: { sessionId: "event-admin", versionId: "event-admin" },
+        }),
+      );
+    expect(
+      await correct("identity-correction-1", "team-c", "Correction-time Team C"),
+    ).toMatchObject({ status: "accepted" });
+
+    const opened = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "identity-current-controller",
+    });
+    if (opened.status !== "opened") throw new Error("Expected the Controller to open.");
+    expect(opened.projection?.teamAssignmentCorrections).toEqual([
+      {
+        operationId: "identity-correction-1",
+        gameSideId: "side-a",
+        eventTeamId: "team-c",
+        eventTeamName: "Correction-time Team C",
+        teamInterpretationRef: "team-c-v1",
+      },
+    ]);
+    expect(
+      await harness.control.submitControllerIntent({
+        sessionBearer: opened.session.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+        intent: goalIntent({ operationId: "blocked-unacknowledged-goal", gameSideId: "side-a" }),
+      }),
+    ).toMatchObject({ status: "rejected" });
+
+    const acknowledgement = (operationId: string, correctionOperationId: string) => ({
+      version: LIVE_EVENT_CONTROL_INTENT_VERSION,
+      type: "acknowledge-team-assignment" as const,
+      operationId,
+      factId: `${operationId}-fact`,
+      gameSideId: "side-a",
+      correctionOperationId,
+      gameTimeMs: 0,
+      occurrence: { clientOriginAtMs: null },
+    });
+    expect(
+      await harness.control.submitControllerIntent({
+        sessionBearer: opened.session.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+        intent: acknowledgement("acknowledge-correction-1", "identity-correction-1"),
+      }),
+    ).toMatchObject({ status: "accepted" });
+
+    expect(
+      await correct("identity-correction-2", "team-d", "Correction-time Team D"),
+    ).toMatchObject({ status: "accepted" });
+    liveName = "Renamed Again";
+    const refreshed = await harness.control.openController({
+      qrCredential: harness.qrCredential,
+      browserContext: "identity-current-controller-2",
+    });
+    if (refreshed.status !== "opened")
+      throw new Error("Expected the refreshed Controller to open.");
+    expect(refreshed.projection?.teamAssignmentCorrections).toEqual([
+      {
+        operationId: "identity-correction-2",
+        gameSideId: "side-a",
+        eventTeamId: "team-d",
+        eventTeamName: "Correction-time Team D",
+        teamInterpretationRef: "team-d-v1",
+      },
+    ]);
+    expect(
+      await harness.control.submitControllerIntent({
+        sessionBearer: opened.session.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+        intent: acknowledgement("stale-acknowledgement", "identity-correction-1"),
+      }),
+    ).toMatchObject({ status: "rejected" });
+    expect(
+      await harness.control.submitControllerIntent({
+        sessionBearer: opened.session.sessionBearer,
+        eventGameId: harness.root.eventGameId,
+        intent: acknowledgement("acknowledge-correction-2", "identity-correction-2"),
+      }),
+    ).toMatchObject({ status: "accepted" });
+  });
+
   test("keeps Penalty Reason values fixed while skip remains a Controller-only absence", () => {
     expect(
       parseLiveEventControllerIntent({
@@ -6657,6 +6770,7 @@ async function createHarness(
     readHeatStoppageConfiguration?: (
       scope: HeatStoppageConfigurationScope,
     ) => HeatStoppageConfiguration | null | Promise<HeatStoppageConfiguration | null>;
+    eventTeamNameResolver?: (eventTeamId: string) => string | null;
   } = {},
 ) {
   const root = createRoot(overrides.eventGameId ?? "game-live-control");
@@ -6742,6 +6856,8 @@ async function createHarness(
     knownDodgeballIdsForEventGame:
       overrides.knownDodgeballIds === undefined ? undefined : () => overrides.knownDodgeballIds!,
     projectionFailure: overrides.projectionFailure,
+    resolveEventTeamName: async (_eventId, eventTeamId) =>
+      overrides.eventTeamNameResolver?.(eventTeamId) ?? null,
     ...(overrides.heatStoppageConfiguration === undefined
       ? {}
       : { heatStoppageConfiguration: overrides.heatStoppageConfiguration }),

--- a/src/lib/live-event-game-control.ts
+++ b/src/lib/live-event-game-control.ts
@@ -1,6 +1,8 @@
 import type {
   ActionJsonValue,
+  ActionRebuildResult,
   EffectiveGameFact,
+  EffectiveGameSideAssignment,
   IqaGameRulesInterpreter,
   OfficialOverrideMetadata,
 } from "@/lib/event-game-actions";
@@ -115,6 +117,11 @@ type ControllerPresentationIntentBase = Omit<ControllerIntentBase, "factId"> & {
 };
 
 export type LiveEventControllerIntent =
+  | (ControllerIntentBase & {
+      type: "acknowledge-team-assignment";
+      gameSideId: string;
+      correctionOperationId: string;
+    })
   | (ControllerIntentBase & {
       type: "record-goal";
       gameSideId: string;
@@ -440,6 +447,14 @@ export type ControllerProjection = {
   commencement: ControllerCommencement;
   clock: ClockProjection;
   presentation?: GamePresentation;
+  teamAssignments?: readonly EffectiveGameSideAssignment[];
+  teamAssignmentCorrections?: readonly {
+    operationId: string;
+    gameSideId: string;
+    eventTeamId: string;
+    eventTeamName: string;
+    teamInterpretationRef: string;
+  }[];
 };
 
 type LiveMaterializationAuthority = {
@@ -548,6 +563,10 @@ export type LiveEventGameControlOptions = {
   knownDodgeballIdsForEventGame?: (eventGameId: string) => readonly string[] | undefined;
   /** Test-only seam for proving the post-commit projection response. */
   projectionFailure?: () => boolean;
+  resolveEventTeamName?: (
+    eventId: string,
+    eventTeamId: string,
+  ) => string | null | Promise<string | null>;
   /** Production composition seam backed by the Event Admin catalog snapshot. */
   readHeatStoppageConfiguration?: (
     scope: HeatStoppageConfigurationScope,
@@ -606,6 +625,7 @@ export function parseLiveEventControllerIntent(
   }
   if (
     value.type !== "record-goal" &&
+    value.type !== "acknowledge-team-assignment" &&
     value.type !== "record-flag-catch" &&
     value.type !== "record-concession" &&
     value.type !== "record-forfeit" &&
@@ -649,6 +669,48 @@ export function parseLiveEventControllerIntent(
   );
   if (!operationId.ok) return invalid(operationId.error);
   if (!gameTimeMs.ok) return invalid(gameTimeMs.error);
+
+  if (value.type === "acknowledge-team-assignment") {
+    const factId = validateOpaqueIdentifier(value.factId, "factId");
+    const gameSideId = validateOpaqueIdentifier(value.gameSideId, "gameSideId");
+    const correctionOperationId = validateOpaqueIdentifier(
+      value.correctionOperationId,
+      "correctionOperationId",
+    );
+    if (!factId.ok) return invalid(factId.error);
+    if (!gameSideId.ok) return invalid(gameSideId.error);
+    if (!correctionOperationId.ok) return invalid(correctionOperationId.error);
+    if (!isRecord(value.occurrence)) return invalid("occurrence must be an object.");
+    const clientOrigin =
+      value.occurrence.clientOriginAtMs === null || value.occurrence.clientOriginAtMs === undefined
+        ? null
+        : validateIntegerInRange(
+            value.occurrence.clientOriginAtMs,
+            0,
+            Number.MAX_SAFE_INTEGER,
+            "occurrence.clientOriginAtMs",
+          );
+    if (clientOrigin !== null && !clientOrigin.ok) return invalid(clientOrigin.error);
+    const source = value.occurrence.source;
+    if (source !== undefined && source !== "online" && source !== "offline")
+      return invalid("occurrence.source is unsupported.");
+    return {
+      ok: true,
+      value: {
+        version: LIVE_EVENT_CONTROL_INTENT_VERSION,
+        type: value.type,
+        operationId: operationId.value,
+        factId: factId.value,
+        gameSideId: gameSideId.value,
+        correctionOperationId: correctionOperationId.value,
+        gameTimeMs: gameTimeMs.value,
+        occurrence: {
+          clientOriginAtMs: clientOrigin === null ? null : clientOrigin.value,
+          ...(source === undefined ? {} : { source }),
+        },
+      },
+    } as { ok: true; value: LiveEventControllerIntent };
+  }
 
   if (value.type === "set-pitch-orientation" || value.type === "set-displayed-team-color") {
     const presentationChangeId = validateOpaqueIdentifier(
@@ -1391,11 +1453,42 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
     string,
     { eventGameId: string; expiresAtMs: number | null }
   >();
+  const teamAssignmentAcknowledgements = new Map<string, Set<string>>();
   let reconcilingActiveControllerSessions = false;
   let reconciliationDirty = false;
   let reconciliationGeneration = 0;
   let reconciliationCompletion: Promise<number> | null = null;
   let closed = false;
+
+  function currentTeamAssignmentCorrection(
+    rebuild: Extract<ActionRebuildResult, { status: "ready" }>,
+    gameSideId: string,
+  ) {
+    const assignment = rebuild.effectiveTeamAssignments.find(
+      (candidate) => candidate.gameSideId === gameSideId,
+    );
+    if (assignment === undefined) return undefined;
+    const action = [...rebuild.canonicalActions].reverse().find((candidate) => {
+      const interpretation = candidate.interpretation;
+      return (
+        interpretation.type === "team-assignment-correction" &&
+        interpretation.gameSideId === gameSideId &&
+        interpretation.eventTeamId === assignment.eventTeamId &&
+        interpretation.teamInterpretationRef === assignment.teamInterpretationRef &&
+        candidate.lifecycle.commencedAtMs !== null
+      );
+    });
+    if (action === undefined || action.interpretation.type !== "team-assignment-correction") {
+      return undefined;
+    }
+    return {
+      operationId: action.operationId,
+      gameSideId,
+      eventTeamId: assignment.eventTeamId,
+      eventTeamName: action.interpretation.eventTeamName ?? assignment.eventTeamName,
+      teamInterpretationRef: assignment.teamInterpretationRef,
+    };
+  }
 
   async function lockEventGameIfDue(eventGameId: string): Promise<boolean> {
     try {
@@ -2035,6 +2128,40 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
     }
 
     const actionsBefore = await owner.record.readActions();
+    const correctionSideId = controllerGameSideId(parsed.value);
+    const currentRebuild = correctionSideId === null ? undefined : await owner.record.rebuild();
+    if (currentRebuild?.status === "failed") return retryableAction(parsed.value.operationId);
+    const latestTeamCorrection =
+      correctionSideId === null || currentRebuild === undefined
+        ? undefined
+        : currentTeamAssignmentCorrection(currentRebuild, correctionSideId);
+    if (parsed.value.type === "acknowledge-team-assignment") {
+      if (
+        latestTeamCorrection === undefined ||
+        latestTeamCorrection.operationId !== parsed.value.correctionOperationId
+      )
+        return rejectedAction(parsed.value.operationId);
+      const acknowledged =
+        teamAssignmentAcknowledgements.get(authorized.grantSessionId) ?? new Set();
+      acknowledged.add(parsed.value.correctionOperationId);
+      teamAssignmentAcknowledgements.set(authorized.grantSessionId, acknowledged);
+      const currentRoot = await owner.record.readRoot(owner.recordId);
+      const projection =
+        currentRoot === null ? null : await readProjection(owner.record, currentRoot);
+      return {
+        status: "accepted",
+        acknowledgement: { status: "acknowledged", operationId: parsed.value.operationId },
+        projection,
+        projectionStatus: projection === null ? "unavailable" : "available",
+        synchronization: synchronized(),
+        auditReference: { kind: "control", id: parsed.value.correctionOperationId },
+      };
+    }
+    if (correctionSideId !== null && latestTeamCorrection !== undefined) {
+      const acknowledged = teamAssignmentAcknowledgements.get(authorized.grantSessionId);
+      if (!acknowledged?.has(latestTeamCorrection.operationId))
+        return rejectedAction(parsed.value.operationId);
+    }
     const existingAction = actionsBefore.find(
       (stored) => stored.action.operationId === parsed.value.operationId,
     );
@@ -3043,6 +3170,19 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
             ? { status: "heat-stoppage", factId: projectedHeat.factId }
             : { status: "none", factId: null };
       const presentation = await record.readPresentation();
+      const teamAssignmentCorrections = await Promise.all(
+        rebuild.effectiveTeamAssignments.map(async (assignment) => {
+          const correction = currentTeamAssignmentCorrection(rebuild, assignment.gameSideId);
+          if (correction === undefined) return null;
+          return {
+            ...correction,
+            eventTeamName:
+              correction.eventTeamName ??
+              (await options.resolveEventTeamName?.(root.eventId, correction.eventTeamId)) ??
+              `Event Team ${correction.eventTeamId}`,
+          };
+        }),
+      ).then((corrections) => corrections.filter((correction) => correction !== null));
       const runningSinceMs =
         root.lifecycle.commencedAtMs === null ? latestRunningClockStart(derived.gameFacts) : null;
       const controllerProjection: ControllerProjection = {
@@ -3081,6 +3221,8 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
           provisionalElapsedMs: runningSinceMs === null ? 0 : Math.max(0, clock() - runningSinceMs),
         },
         presentation: structuredClone(presentation),
+        teamAssignments: structuredClone(rebuild.effectiveTeamAssignments),
+        teamAssignmentCorrections: structuredClone(teamAssignmentCorrections),
       };
       return controllerProjection;
     } catch {
@@ -3369,6 +3511,7 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
       reconciliationGeneration += 1;
       reconciliationDirty = false;
       activeControllerSessions.clear();
+      teamAssignmentAcknowledgements.clear();
     },
     submitControllerIntent,
     replayControllerActions,
@@ -4438,30 +4581,6 @@ function buildMissingAutomaticPenaltyConsequence(
       sportingOrder: sourceFact?.sportingOrder ?? release.releasedMs,
     },
   };
-}
-
-async function ensureClockCommencement(
-  owner: { recordId: string; record: EventGameRecord },
-  root: EventGameRecordRoot,
-  nowMs: number,
-): Promise<{ status: "ready"; root: EventGameRecordRoot } | { status: "rejected" }> {
-  if (root.lifecycle.commencedAtMs !== null || root.lifecycle.phase !== "scheduled") {
-    return { status: "ready", root };
-  }
-  const actions = await owner.record.readActions();
-  const rebuilt = rebuildLiveDerivedState(root, actions);
-  if (rebuilt === null) return { status: "rejected" };
-  const runningSinceMs = latestRunningClockStart(rebuilt.gameFacts);
-  if (runningSinceMs === null || nowMs - runningSinceMs < 10_000) {
-    return { status: "ready", root };
-  }
-  const transition = await owner.record.transitionLifecycle({
-    ...root.lifecycle,
-    phase: "in-progress",
-    commencedAtMs: runningSinceMs + 10_000,
-  });
-  if (transition.status === "rejected") return { status: "rejected" };
-  return { status: "ready", root: transition.root };
 }
 
 function createHeatModeSnapshotAction(input: {

--- a/src/lib/live-event-game-runtime.ts
+++ b/src/lib/live-event-game-runtime.ts
@@ -259,6 +259,11 @@ export async function openLiveEventGameRuntime(input: {
     };
     const control = createLiveEventGameControl({
       resolveEventGameRecord,
+      resolveEventTeamName: async (eventId, eventTeamId) =>
+        storage.transaction((transaction) => {
+          const team = transaction.findEventTeam(eventTeamId);
+          return team?.eventId === eventId ? team.name : null;
+        }),
       acceptance,
       grantAuthority: authority,
       clock,
@@ -625,7 +630,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function createExternalScopeResolver(): ExternalScopeResolver {
+export function createExternalScopeResolver(): ExternalScopeResolver {
   return {
     resolve(scope, snapshot) {
       const root = snapshot.findRootByPitchSlotId(scope.pitchSlotId);
@@ -633,10 +638,15 @@ function createExternalScopeResolver(): ExternalScopeResolver {
         ? { status: "resolved", scope: structuredClone(scope) }
         : { status: "mismatch", detail: "Event Game Pitch Slot is unavailable." };
     },
-    resolveEventTeam(eventId, eventTeamId, _snapshot) {
-      return eventId.length > 0 && eventTeamId.length > 0
+    resolveEventTeam(eventId, eventTeamId, snapshot) {
+      const team = snapshot.findEventTeam(eventTeamId);
+      return eventId.length > 0 && team !== null && team.eventId === eventId
         ? { status: "resolved" }
         : { status: "missing", detail: "Event Team is unavailable." };
+    },
+    resolveEventTeamDefaultColor(eventId, eventTeamId, snapshot) {
+      const team = snapshot.findEventTeam(eventTeamId);
+      return team?.eventId === eventId ? team.defaultColor : null;
     },
   };
 }

--- a/src/pages/event-admin-page.tsx
+++ b/src/pages/event-admin-page.tsx
@@ -51,8 +51,18 @@ type HubResponse = {
         pitchSlotId: string;
         gameCode: string | null;
         gameDesignation: string | null;
-        sideA: { eventTeamId: string | null; sourceLabel: string | null };
-        sideB: { eventTeamId: string | null; sourceLabel: string | null };
+        sideA: {
+          sideId: string;
+          eventTeamId: string | null;
+          eventTeamName: string | null;
+          sourceLabel: string | null;
+        };
+        sideB: {
+          sideId: string;
+          eventTeamId: string | null;
+          eventTeamName: string | null;
+          sourceLabel: string | null;
+        };
         expectedStartMs: number;
         expectedPlayingPeriod: { startMs: number; endMs: number };
         scheduleConflict: boolean;
@@ -66,6 +76,12 @@ type HubResponse = {
 
 type TeamDraft = { name: string; defaultColor: string };
 type ConfirmationDraft = { sideA: string; sideB: string };
+type IdentityDraft = { eventTeamId: string; confirmation: boolean; reason: string };
+type PresentationDraft = {
+  pitchOrientation: "side-a-left" | "side-b-left";
+  sideAColor: string;
+  sideBColor: string;
+};
 type ScheduleResponse = {
   status: "accepted";
   value: {
@@ -281,6 +297,10 @@ export function EventAdminPage({
   const [confirmationDrafts, setConfirmationDrafts] = useState<Record<string, ConfirmationDraft>>(
     {},
   );
+  const [identityDrafts, setIdentityDrafts] = useState<Record<string, IdentityDraft>>({});
+  const [presentationDrafts, setPresentationDrafts] = useState<Record<string, PresentationDraft>>(
+    {},
+  );
   const [schedule, setSchedule] = useState<ScheduleResponse["value"] | null>(null);
   const [delayDrafts, setDelayDrafts] = useState<Record<string, string>>({});
   const [cascadeDrafts, setCascadeDrafts] = useState<Record<string, boolean>>({});
@@ -367,6 +387,8 @@ export function EventAdminPage({
     setTeamDrafts({});
     setPitchDrafts({});
     setConfirmationDrafts({});
+    setIdentityDrafts({});
+    setPresentationDrafts({});
     setSchedule(null);
     setDelayDrafts({});
     setCascadeDrafts({});
@@ -493,6 +515,45 @@ export function EventAdminPage({
               current[game.eventGameId] ?? {
                 sideA: game.sideA.eventTeamId ?? "",
                 sideB: game.sideB.eventTeamId ?? "",
+              },
+            ]),
+          ),
+        );
+        setIdentityDrafts((current) =>
+          Object.fromEntries(
+            payload.value.event.eventGames.flatMap((game) =>
+              [
+                [game.eventGameId, game.sideA],
+                [game.eventGameId, game.sideB],
+              ].map(([, value]) => {
+                const sideValue = value as typeof game.sideA;
+                const key = `${game.eventGameId}:${sideValue.sideId}`;
+                return [
+                  key,
+                  current[key] ?? {
+                    eventTeamId: sideValue.eventTeamId ?? "",
+                    confirmation: false,
+                    reason: "",
+                  },
+                ];
+              }),
+            ),
+          ),
+        );
+        setPresentationDrafts((current) =>
+          Object.fromEntries(
+            payload.value.event.eventGames.map((game) => [
+              game.eventGameId,
+              current[game.eventGameId] ?? {
+                pitchOrientation: "side-a-left",
+                sideAColor:
+                  payload.value.event.teams.find(
+                    (team) => team.eventTeamId === game.sideA.eventTeamId,
+                  )?.defaultColor ?? "#112233",
+                sideBColor:
+                  payload.value.event.teams.find(
+                    (team) => team.eventTeamId === game.sideB.eventTeamId,
+                  )?.defaultColor ?? "#445566",
               },
             ]),
           ),
@@ -1254,16 +1315,87 @@ export function EventAdminPage({
     await loadHub(selectedGameDayId);
   };
 
+  const correctEventGameIdentity = async (
+    game: HubResponse["value"]["event"]["eventGames"][number],
+    side: "sideA" | "sideB",
+    token: GrantSecretToken,
+  ) => {
+    if (selectedGameDayId === null) return;
+    if (!secretOwner.current(token)) return;
+    const sideValue = game[side];
+    const key = `${game.eventGameId}:${sideValue.sideId}`;
+    const draft = identityDrafts[key] ?? {
+      eventTeamId: sideValue.eventTeamId ?? "",
+      confirmation: false,
+      reason: "",
+    };
+    const response = await fetch(
+      `/api/event-admin/events/${eventId}/game-days/${selectedGameDayId}/event-games/${game.eventGameId}/identity`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          operationId: crypto.randomUUID(),
+          gameSideId: sideValue.sideId,
+          eventTeamId: draft.eventTeamId,
+          confirmation: draft.confirmation,
+          reason: draft.reason.trim() || undefined,
+        }),
+      },
+    );
+    if (!secretOwner.current(token)) return;
+    if (!response.ok) {
+      const detail = await responseError(response, "Event Team correction failed.");
+      if (secretOwner.current(token)) throw new Error(detail);
+      return;
+    }
+    await loadHub(selectedGameDayId, token);
+  };
+
+  const changeEventGamePresentation = async (
+    eventGameId: string,
+    change:
+      | { type: "pitch-orientation"; pitchOrientation: "side-a-left" | "side-b-left" }
+      | {
+          type: "displayed-team-color";
+          gameSideId: string;
+          color: string;
+        },
+    token: GrantSecretToken,
+  ) => {
+    if (!secretOwner.current(token)) return;
+    const response = await fetch(
+      `/api/event-admin/events/${eventId}/event-games/${eventGameId}/presentation`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          operationId: crypto.randomUUID(),
+          presentationChangeId: crypto.randomUUID(),
+          change,
+        }),
+      },
+    );
+    if (!secretOwner.current(token)) return;
+    if (!response.ok) {
+      const detail = await responseError(response, "Game Presentation Change failed.");
+      if (secretOwner.current(token)) throw new Error(detail);
+      return;
+    }
+    await loadHub(selectedGameDayId, token);
+  };
+
   useEffect(() => {
     if (eventId.length > 0) void loadHub().catch(() => undefined);
   }, []);
 
-  const run = async (action: () => Promise<void>) => {
+  const run = async (action: () => Promise<void>, ownerToken?: GrantSecretToken) => {
     setBusy(true);
     setMessage(null);
     try {
       await action();
     } catch (error) {
+      if (ownerToken !== undefined && !secretOwner.current(ownerToken)) return;
       setMessage(
         error instanceof EventPublicationValidationError
           ? error.message
@@ -1272,7 +1404,7 @@ export function EventAdminPage({
             : "Unable to authorize the Event Hub.",
       );
     } finally {
-      setBusy(false);
+      if (ownerToken === undefined || secretOwner.current(ownerToken)) setBusy(false);
     }
   };
 
@@ -1994,6 +2126,194 @@ export function EventAdminPage({
                                           </option>
                                         ))}
                                       </select>
+                                    </div>
+                                    <div className="mt-2 space-y-2 border-t pt-2">
+                                      {(["sideA", "sideB"] as const).map((side) => {
+                                        const sideValue = game[side];
+                                        const key = `${game.eventGameId}:${sideValue.sideId}`;
+                                        const identity = identityDrafts[key] ?? {
+                                          eventTeamId: sideValue.eventTeamId ?? "",
+                                          confirmation: false,
+                                          reason: "",
+                                        };
+                                        return (
+                                          <div
+                                            className="grid gap-1 sm:grid-cols-[auto_1fr_auto]"
+                                            key={sideValue.sideId}
+                                          >
+                                            <span className="text-xs text-muted-foreground">
+                                              {side === "sideA" ? "Side A" : "Side B"} ·{" "}
+                                              {sideValue.sideId}
+                                            </span>
+                                            <select
+                                              aria-label={`Correct ${game.eventGameId} ${side} Event Team`}
+                                              className="h-9 rounded-md border bg-background px-2 text-sm"
+                                              value={identity.eventTeamId}
+                                              onChange={(event) =>
+                                                setIdentityDrafts((current) => ({
+                                                  ...current,
+                                                  [key]: {
+                                                    ...identity,
+                                                    eventTeamId: event.target.value,
+                                                  },
+                                                }))
+                                              }
+                                            >
+                                              <option value="">Corrected Event Team</option>
+                                              {hub.event.teams.map((team) => (
+                                                <option
+                                                  key={team.eventTeamId}
+                                                  value={team.eventTeamId}
+                                                >
+                                                  {team.name}
+                                                </option>
+                                              ))}
+                                            </select>
+                                            <Button
+                                              variant="outline"
+                                              disabled={busy || identity.eventTeamId.length === 0}
+                                              onClick={() => {
+                                                const token = secretOwner.capture(secretScopeKey());
+                                                void run(
+                                                  () => correctEventGameIdentity(game, side, token),
+                                                  token,
+                                                );
+                                              }}
+                                            >
+                                              Correct identity
+                                            </Button>
+                                            <label className="flex items-center gap-2 text-xs sm:col-start-2">
+                                              <input
+                                                type="checkbox"
+                                                checked={identity.confirmation}
+                                                onChange={(event) =>
+                                                  setIdentityDrafts((current) => ({
+                                                    ...current,
+                                                    [key]: {
+                                                      ...identity,
+                                                      confirmation: event.target.checked,
+                                                    },
+                                                  }))
+                                                }
+                                              />
+                                              Confirm if Game has commenced
+                                            </label>
+                                            <Input
+                                              aria-label={`${game.eventGameId} ${side} correction reason`}
+                                              placeholder="Reason when commenced"
+                                              value={identity.reason}
+                                              onChange={(event) =>
+                                                setIdentityDrafts((current) => ({
+                                                  ...current,
+                                                  [key]: {
+                                                    ...identity,
+                                                    reason: event.target.value,
+                                                  },
+                                                }))
+                                              }
+                                            />
+                                          </div>
+                                        );
+                                      })}
+                                      {(() => {
+                                        const presentation = presentationDrafts[
+                                          game.eventGameId
+                                        ] ?? {
+                                          pitchOrientation: "side-a-left" as const,
+                                          sideAColor: "#112233",
+                                          sideBColor: "#445566",
+                                        };
+                                        return (
+                                          <div className="grid gap-2 border-t pt-2 text-xs sm:grid-cols-3">
+                                            <select
+                                              aria-label={`${game.eventGameId} pitch orientation`}
+                                              className="h-9 rounded-md border bg-background px-2 text-sm"
+                                              value={presentation.pitchOrientation}
+                                              onChange={(event) => {
+                                                const pitchOrientation = event.target
+                                                  .value as PresentationDraft["pitchOrientation"];
+                                                setPresentationDrafts((current) => ({
+                                                  ...current,
+                                                  [game.eventGameId]: {
+                                                    ...presentation,
+                                                    pitchOrientation,
+                                                  },
+                                                }));
+                                                const token = secretOwner.capture(secretScopeKey());
+                                                void run(
+                                                  () =>
+                                                    changeEventGamePresentation(
+                                                      game.eventGameId,
+                                                      {
+                                                        type: "pitch-orientation",
+                                                        pitchOrientation,
+                                                      },
+                                                      token,
+                                                    ),
+                                                  token,
+                                                );
+                                              }}
+                                            >
+                                              <option value="side-a-left">Side A left</option>
+                                              <option value="side-b-left">Side B left</option>
+                                            </select>
+                                            {(["sideA", "sideB"] as const).map((side) => {
+                                              const colorKey =
+                                                side === "sideA" ? "sideAColor" : "sideBColor";
+                                              const color = presentation[colorKey];
+                                              return (
+                                                <label
+                                                  className="flex items-center gap-2"
+                                                  key={side}
+                                                >
+                                                  {side === "sideA" ? "Side A" : "Side B"} color
+                                                  <input
+                                                    type="color"
+                                                    aria-label={`${game.eventGameId} ${side} displayed color`}
+                                                    value={color}
+                                                    onInput={(event) => {
+                                                      const nextColor = (
+                                                        event.target as HTMLInputElement
+                                                      ).value;
+                                                      setPresentationDrafts((current) => ({
+                                                        ...current,
+                                                        [game.eventGameId]: {
+                                                          ...presentation,
+                                                          [colorKey]: nextColor,
+                                                        },
+                                                      }));
+                                                    }}
+                                                  />
+                                                  <Button
+                                                    variant="outline"
+                                                    size="sm"
+                                                    disabled={busy}
+                                                    onClick={() => {
+                                                      const token =
+                                                        secretOwner.capture(secretScopeKey());
+                                                      void run(
+                                                        () =>
+                                                          changeEventGamePresentation(
+                                                            game.eventGameId,
+                                                            {
+                                                              type: "displayed-team-color",
+                                                              gameSideId: game[side].sideId,
+                                                              color,
+                                                            },
+                                                            token,
+                                                          ),
+                                                        token,
+                                                      );
+                                                    }}
+                                                  >
+                                                    Apply
+                                                  </Button>
+                                                </label>
+                                              );
+                                            })}
+                                          </div>
+                                        );
+                                      })()}
                                     </div>
                                   </div>
                                 );

--- a/src/pages/event-game-controller-page.test.tsx
+++ b/src/pages/event-game-controller-page.test.tsx
@@ -287,6 +287,47 @@ describe("Event Game Controller reconnect browser seam", () => {
     expect(testWindow.document.activeElement?.getAttribute("aria-label")).toBe("Pause game clock");
   });
 
+  test("acknowledges only the current corrected Event Team identity before team actions", async () => {
+    replayMode = "success";
+    openProjection = {
+      ...projection(),
+      teamAssignmentCorrections: [
+        {
+          operationId: "identity-op-current",
+          gameSideId: "side-a",
+          eventTeamId: "team-corrected",
+          eventTeamName: "Correction-time Team",
+          teamInterpretationRef: "event-team:team-corrected",
+        },
+      ],
+    };
+    await enterAndOpen();
+
+    expect(container.textContent).toContain("Correction-time Team");
+    expect(container.textContent).toContain("Acknowledge the corrected identity");
+    expect(container.textContent).not.toContain("Old historical Team");
+    const acknowledge = Array.from(container.getElementsByTagName("button")).find((button) =>
+      button.textContent?.includes("Acknowledge identity"),
+    );
+    expect(acknowledge).not.toBeNull();
+    await act(async () => {
+      acknowledge?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const acknowledgement = replayBodies.flatMap((body) => body.actions ?? []).at(-1);
+    expect(acknowledgement?.intent).toMatchObject({
+      type: "acknowledge-team-assignment",
+      gameSideId: "side-a",
+      correctionOperationId: "identity-op-current",
+    });
+    expect(container.textContent).not.toContain("Acknowledge the corrected identity");
+    expect(container.querySelector('button[aria-label="Start game clock"]')).not.toBeNull();
+  });
+
   test("production Grant QR dialog closes on an outside pointer and returns focus", async () => {
     await enterAndOpen();
     const revealButton = container.querySelector<HTMLButtonElement>(

--- a/src/pages/event-game-controller-page.tsx
+++ b/src/pages/event-game-controller-page.tsx
@@ -132,6 +132,9 @@ export function EventGameControllerPage() {
   const [qrDialogOpen, setQrDialogOpen] = useState(false);
   const [switchTarget, setSwitchTarget] = useState<string | null>(null);
   const [stayedOnAssignment, setStayedOnAssignment] = useState<string | null>(null);
+  const [acknowledgedTeamCorrections, setAcknowledgedTeamCorrections] = useState<
+    Readonly<Record<string, string>>
+  >({});
   const [clockRunning, setClockRunning] = useState(false);
   const [clockReceiptAnchor, setClockReceiptAnchor] = useState<ClockReceiptAnchor | null>(null);
   const [localMonotonicMs, setLocalMonotonicMs] = useState(readMonotonicNow);
@@ -972,8 +975,9 @@ export function EventGameControllerPage() {
       const relatedPendingOperationId =
         relatedFactId === undefined
           ? undefined
-          : current.pendingActions.find((action) => action.intent.factId === relatedFactId)?.intent
-              .operationId;
+          : current.pendingActions.find(
+              (action) => "factId" in action.intent && action.intent.factId === relatedFactId,
+            )?.intent.operationId;
       const dispatched = dispatchControllerAction(
         current,
         {
@@ -1000,6 +1004,21 @@ export function EventGameControllerPage() {
     } catch {
       setMessage("The Controller action could not be retained safely.");
     }
+  }
+
+  function acknowledgeTeamAssignment(
+    correction: NonNullable<ControllerProjection["teamAssignmentCorrections"]>[number],
+  ) {
+    queueIntent({
+      version: LIVE_EVENT_CONTROL_INTENT_VERSION,
+      type: "acknowledge-team-assignment",
+      operationId: crypto.randomUUID(),
+      factId: crypto.randomUUID(),
+      gameSideId: correction.gameSideId,
+      correctionOperationId: correction.operationId,
+      gameTimeMs: 0,
+      occurrence: { clientOriginAtMs: Date.now() },
+    });
   }
 
   function currentSportingTimeMs(): number | null {
@@ -1375,6 +1394,12 @@ export function EventGameControllerPage() {
         if (intent.type === "clock" || intent.type === "set-running") {
           setClockRunning(intent.running);
         }
+      }
+      if (intent.type === "acknowledge-team-assignment") {
+        setAcknowledgedTeamCorrections((current) => ({
+          ...current,
+          [intent.gameSideId]: intent.correctionOperationId,
+        }));
       }
     } catch {
       setMessage("The online Controller action could not be submitted.");
@@ -1794,6 +1819,28 @@ export function EventGameControllerPage() {
                     </label>
                   ))}
                 </div>
+              )}
+              {projection?.teamAssignmentCorrections?.map((correction) =>
+                acknowledgedTeamCorrections[correction.gameSideId] ===
+                correction.operationId ? null : (
+                  <div
+                    key={correction.operationId}
+                    className="flex items-center justify-between gap-3 rounded border border-amber-300 bg-amber-50 p-2 text-sm"
+                  >
+                    <span>
+                      Game Side {correction.gameSideId} now uses {correction.eventTeamName} (Event
+                      Team {correction.eventTeamId}). Acknowledge the corrected identity before
+                      recording another team action.
+                    </span>
+                    <Button
+                      variant="outline"
+                      onClick={() => acknowledgeTeamAssignment(correction)}
+                      disabled={busy}
+                    >
+                      Acknowledge identity
+                    </Button>
+                  </div>
+                ),
               )}
               <div className="flex flex-wrap gap-2">
                 {[-60_000, -10_000, 10_000, 60_000].map((adjustmentMs) => (

--- a/src/pages/grant-secret-lifecycle.test.tsx
+++ b/src/pages/grant-secret-lifecycle.test.tsx
@@ -68,6 +68,43 @@ const eventHub = {
   authority: "event-admin",
 };
 
+const identityEventHub = {
+  ...eventHub,
+  event: {
+    ...eventHub.event,
+    teams: [
+      { eventTeamId: "team-a", name: "Original Team", defaultColor: "#112233", roster: [] },
+      { eventTeamId: "team-b", name: "Corrected Team", defaultColor: "#445566", roster: [] },
+    ],
+    eventGames: [
+      {
+        eventGameId: "game-identity",
+        gameDayId: "day",
+        gameplaySlotId: "gameplay",
+        pitchSlotId: "slot",
+        gameCode: "G-1",
+        gameDesignation: "Pool A",
+        sideA: {
+          sideId: "side-a",
+          eventTeamId: "team-a",
+          eventTeamName: "Original Team",
+          sourceLabel: null,
+        },
+        sideB: {
+          sideId: "side-b",
+          eventTeamId: "team-b",
+          eventTeamName: "Corrected Team",
+          sourceLabel: null,
+        },
+        expectedStartMs: Date.UTC(2026, 7, 15, 10),
+        expectedPlayingPeriod: { startMs: 0, endMs: 1 },
+        scheduleConflict: false,
+        teamScheduleConflict: false,
+      },
+    ],
+  },
+};
+
 const twoDayEventHub = {
   ...eventHub,
   selectedGameDayId: "day",
@@ -195,6 +232,93 @@ describe("Grant secret UI lifecycle", () => {
     await clickButton("Enable");
     expect(configurationUpdates).toBe(1);
     expect(container.textContent).toContain("Currently enabled");
+  });
+
+  test("Event Admin operates public identity and presentation controls", async () => {
+    const requests: { url: string; body: Record<string, unknown> }[] = [];
+    let hubCalls = 0;
+    fetchHandler = async (input, init) => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      const method = init?.method ?? "GET";
+      if (url.endsWith("/api/event-admin/admit"))
+        return json({ status: "admitted", sessionExpiresAtMs: 123_000 });
+      if (url.includes("/api/event-admin/hub")) {
+        hubCalls += 1;
+        if (hubCalls === 1) return json({ status: "rejected" }, 401);
+        return json({ status: "accepted", value: identityEventHub });
+      }
+      if (method === "POST" && (url.endsWith("/identity") || url.endsWith("/presentation"))) {
+        requests.push({
+          url,
+          body: JSON.parse(typeof init?.body === "string" ? init.body : "{}") as Record<
+            string,
+            unknown
+          >,
+        });
+        return json({ status: "accepted", value: identityEventHub });
+      }
+      throw new Error(`Unexpected request: ${method} ${url}`);
+    };
+
+    await render(<EventAdminPage />);
+    await admitEventAdmin();
+    const identitySelect = container.querySelector(
+      'select[aria-label="Correct game-identity sideA Event Team"]',
+    ) as HTMLSelectElement | null;
+    expect(identitySelect).not.toBeNull();
+    await act(async () => {
+      setSelectValue(identitySelect as HTMLSelectElement, "team-b");
+      await flush();
+    });
+    const identityButton = Array.from(container.querySelectorAll("button")).find(
+      (button) =>
+        button.textContent?.trim() === "Correct identity" &&
+        button.parentElement?.querySelector(
+          'select[aria-label="Correct game-identity sideA Event Team"]',
+        ) !== null,
+    );
+    expect(identityButton).not.toBeNull();
+    await act(async () => {
+      identityButton?.click();
+      await flush();
+    });
+    expect(requests[0]).toMatchObject({
+      url: "/api/event-admin/events/event/game-days/day/event-games/game-identity/identity",
+      body: { gameSideId: "side-a", eventTeamId: "team-b", confirmation: false },
+    });
+
+    const orientation = container.querySelector(
+      'select[aria-label="game-identity pitch orientation"]',
+    ) as HTMLSelectElement;
+    await act(async () => {
+      setSelectValue(orientation, "side-b-left");
+      await flush();
+    });
+    expect(requests.at(-1)).toMatchObject({
+      url: "/api/event-admin/events/event/event-games/game-identity/presentation",
+      body: { change: { type: "pitch-orientation", pitchOrientation: "side-b-left" } },
+    });
+
+    const color = container.querySelector(
+      'input[aria-label="game-identity sideA displayed color"]',
+    ) as HTMLInputElement;
+    await act(async () => {
+      setInputValue(color, "#abcdef");
+      await flush();
+    });
+    const colorButton = color.parentElement?.querySelector("button") as HTMLButtonElement | null;
+    expect(colorButton).not.toBeNull();
+    await act(async () => {
+      colorButton?.click();
+      await flush();
+    });
+    expect(requests.at(-1)).toMatchObject({
+      url: "/api/event-admin/events/event/event-games/game-identity/presentation",
+      body: {
+        change: { type: "displayed-team-color", gameSideId: "side-a", color: "#abcdef" },
+      },
+    });
   });
 
   test("Event Admin ignores stale Day A heat success after selecting Day B", async () => {


### PR DESCRIPTION
## Summary

Implements the Event Team identity correction and shared Event Game presentation boundary from #105/#121.

- Preserves stable Game Side sporting history while correcting the current Event Team assignment, including fixed correction-time names and idempotent/concurrent retries.
- Adds scoped Technical/Event Admin HTTP and page controls for identity correction, Pitch Orientation, and displayed-color overrides, with pre/post-commencement authority and confirmation/reason rules.
- Keeps Catalog, transaction-local Event Game Record, Control, Event Administration audit, and public projection changes atomic and reconciled.
- Requires explicit server-owned Controller acknowledgement before another team-targeted action, while clock controls remain usable.
- Exposes only allowlisted current identity data and a neutral public notice; roster lookup, public Timeline relabelling, #114, #122, and #123 remain out of scope.

## Checks

- `bun run check`
- `bun run test` — 888 tests across 78 files, 20,233 expectations
- Focused route/composed/browser suite — 128/128
- `bun run build`
- `git diff --check`
