### PR TITLE
Allow Test Environment WebSocket connections

### DIFF
--- a/scripts/test-ad-hoc-browser.ts
+++ b/scripts/test-ad-hoc-browser.ts
@@ -30,12 +30,12 @@ const lifecycleTimer = setTimeout(() => lifecycleController.abort(), 52_000);
 
 async function run() {
   directory = mkdtempSync(join(tmpdir(), "quadball-timer-adhoc-browser-"));
-  certificatePath = join(directory, "localhost.crt");
-  keyPath = join(directory, "localhost.key");
+  certificatePath = join(directory, "test.timer.quadball.app.crt");
+  keyPath = join(directory, "test.timer.quadball.app.key");
   databasePath = join(directory, "ad-hoc.sqlite");
   grantKeyRingPath = join(directory, "grant-key-ring.json");
   port = 39_000 + Math.floor(Math.random() * 1_000);
-  origin = `https://localhost:${port}`;
+  origin = `https://test.timer.quadball.app:${port}`;
   environment = {
     ...process.env,
     NODE_ENV: "test",
@@ -63,9 +63,9 @@ async function run() {
         "rsa:2048",
         "-nodes",
         "-subj",
-        "/CN=localhost",
+        "/CN=test.timer.quadball.app",
         "-addext",
-        "subjectAltName=DNS:localhost",
+        "subjectAltName=DNS:test.timer.quadball.app",
         "-days",
         "1",
         "-keyout",
@@ -82,7 +82,10 @@ async function run() {
 
     await raceWithDeadline(startServer(), lifecycleController.signal);
     browser = await raceWithDeadline(
-      chromium.launch({ headless: true }),
+      chromium.launch({
+        headless: true,
+        args: ["--host-resolver-rules=MAP test.timer.quadball.app 127.0.0.1"],
+      }),
       lifecycleController.signal,
     );
     await raceWithDeadline(
@@ -94,9 +97,53 @@ async function run() {
         first.setDefaultTimeout(15_000);
         second.setDefaultTimeout(15_000);
 
+        await first.addInitScript(() => {
+          const evidence = { sawBusy: false, sawOffline: false };
+          const inspect = () => {
+            const text = document.body?.textContent ?? "";
+            evidence.sawBusy ||= /Ad Hoc connection busy/u.test(text);
+            evidence.sawOffline ||= /\bOffline(?:\s+\d+)?\b/u.test(text);
+          };
+          const install = () => {
+            const observer = new MutationObserver(inspect);
+            observer.observe(document.body, {
+              childList: true,
+              characterData: true,
+              subtree: true,
+            });
+            inspect();
+          };
+          if (document.body === null) {
+            document.addEventListener("DOMContentLoaded", install, { once: true });
+          } else {
+            install();
+          }
+          (
+            window as typeof window & {
+              __quadballTimerInitialAdHocConnectionEvidence?: typeof evidence;
+            }
+          ).__quadballTimerInitialAdHocConnectionEvidence = evidence;
+        });
         await first.goto(origin);
         await first.getByRole("button", { name: /Start an Ad Hoc Game/ }).click();
         await first.waitForURL(/\/game\/adhoc-/u);
+        await first.getByText("Live", { exact: true }).waitFor();
+        const initialConnectionEvidence = await first.evaluate(() => {
+          const evidence = (
+            window as typeof window & {
+              __quadballTimerInitialAdHocConnectionEvidence?: {
+                sawBusy: boolean;
+                sawOffline: boolean;
+              };
+            }
+          ).__quadballTimerInitialAdHocConnectionEvidence;
+          if (evidence === undefined)
+            throw new Error("Initial connection evidence was unavailable.");
+          return evidence;
+        });
+        if (initialConnectionEvidence.sawBusy || initialConnectionEvidence.sawOffline) {
+          throw new Error("Newly created Test-shaped Ad Hoc Game did not reach Live cleanly.");
+        }
         await assertAccessibleQr(first, "creator");
 
         const gameId = new URL(first.url()).pathname.split("/").at(-1);
@@ -517,7 +564,7 @@ async function waitForServer() {
       "-sSf",
       "-H",
       `host: localhost:${port}`,
-      `${origin}/internal/healthz`,
+      `https://127.0.0.1:${port}/internal/healthz`,
     ]);
     if (response.exitCode === 0) return;
     await Bun.sleep(50);

--- a/src/lib/ws-origin.test.ts
+++ b/src/lib/ws-origin.test.ts
@@ -6,6 +6,24 @@ describe("ws-origin", () => {
     expect(isAllowedWebSocketOrigin("https://timer.quadball.app", "timer.quadball.app")).toBe(true);
   });
 
+  test("accepts the canonical Test origin for the Test host", () => {
+    expect(
+      isAllowedWebSocketOrigin("https://test.timer.quadball.app", "test.timer.quadball.app"),
+    ).toBe(true);
+    expect(
+      isAllowedWebSocketOrigin(
+        "https://test.timer.quadball.app:443",
+        "test.timer.quadball.app:443",
+      ),
+    ).toBe(true);
+    expect(
+      isAllowedWebSocketOrigin(
+        "https://test.timer.quadball.app:39421",
+        "test.timer.quadball.app:39421",
+      ),
+    ).toBe(true);
+  });
+
   test("accepts explicit local development origins", () => {
     expect(isAllowedWebSocketOrigin("http://localhost:3000", "localhost:3000")).toBe(true);
     expect(isAllowedWebSocketOrigin("http://127.0.0.1:3000", "127.0.0.1:3000")).toBe(true);
@@ -14,8 +32,31 @@ describe("ws-origin", () => {
 
   test("rejects cross-site websocket origins", () => {
     expect(isAllowedWebSocketOrigin("https://evil.example", "timer.quadball.app")).toBe(false);
+    expect(isAllowedWebSocketOrigin("https://test.timer.quadball.app", "timer.quadball.app")).toBe(
+      false,
+    );
+    expect(isAllowedWebSocketOrigin("https://timer.quadball.app", "test.timer.quadball.app")).toBe(
+      false,
+    );
     expect(isAllowedWebSocketOrigin("http://localhost:3001", "localhost:3000")).toBe(false);
     expect(isAllowedWebSocketOrigin("http://timer.quadball.app", "timer.quadball.app")).toBe(false);
     expect(isAllowedWebSocketOrigin(null, "timer.quadball.app")).toBe(false);
+    expect(isAllowedWebSocketOrigin("https://test.timer.quadball.app", null)).toBe(false);
+    expect(
+      isAllowedWebSocketOrigin("https://test.timer.quadball.app", "test.timer.quadball.app:8443"),
+    ).toBe(false);
+    expect(
+      isAllowedWebSocketOrigin(
+        "https://test.timer.quadball.app:8443",
+        "test.timer.quadball.app:8444",
+      ),
+    ).toBe(false);
+    expect(
+      isAllowedWebSocketOrigin("http://test.timer.quadball.app", "test.timer.quadball.app"),
+    ).toBe(false);
+    expect(
+      isAllowedWebSocketOrigin("ws://test.timer.quadball.app", "test.timer.quadball.app"),
+    ).toBe(false);
+    expect(isAllowedWebSocketOrigin("not-an-origin", "test.timer.quadball.app")).toBe(false);
   });
 });

--- a/src/lib/ws-origin.ts
+++ b/src/lib/ws-origin.ts
@@ -1,4 +1,5 @@
 const PRODUCTION_ORIGIN = "https://timer.quadball.app";
+const TEST_HOSTNAME = "test.timer.quadball.app";
 const LOCAL_HOSTNAMES = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
 
 export function isAllowedWebSocketOrigin(originHeader: string | null, hostHeader: string | null) {
@@ -15,6 +16,10 @@ export function isAllowedWebSocketOrigin(originHeader: string | null, hostHeader
 
   if (origin.origin === PRODUCTION_ORIGIN) {
     return host.hostname === "timer.quadball.app";
+  }
+
+  if (origin.protocol === "https:" && origin.hostname === TEST_HOSTNAME) {
+    return host.hostname === TEST_HOSTNAME && hasMatchingPort(origin, host);
   }
 
   if (!LOCAL_HOSTNAMES.has(origin.hostname) || !LOCAL_HOSTNAMES.has(host.hostname)) {
@@ -38,4 +43,9 @@ function parseUrl(value: string) {
 
 function parseHost(value: string) {
   return parseUrl(`http://${value}`);
+}
+
+function hasMatchingPort(origin: URL, host: URL) {
+  const defaultPort = origin.protocol === "https:" ? "443" : "80";
+  return (origin.port || defaultPort) === (host.port || defaultPort);
 }


### PR DESCRIPTION
## What changed

- Admit the canonical Test Environment HTTPS origin only when the effective Origin and Host ports match.
- Cover canonical, same-port, mismatched-port, missing-header, malformed-origin, and invalid-protocol cases at the origin-policy boundary.
- Run the Ad Hoc browser path under the canonical Test hostname with disposable local TLS and resolver seams, and prove the initial Game reaches Live without showing busy or offline status.

## Why

The Test Environment hostname was missing from the WebSocket origin allowlist. Same-origin upgrades were rejected with HTTP 403, so newly created Ad Hoc Games immediately appeared offline and queued local changes behind a misleading connection-busy message.

## Impact

New Ad Hoc Games on the Test Environment can establish their online Controller connection immediately. Production and loopback admission remain unchanged, while foreign origins, host mismatches, and invalid protocols remain rejected.

## Validation

- `bun run check`
- `bun run test` — 890 passed
- `bun run test:focused:ad-hoc` — 11 passed
- `bun run test:focused:adhoc-browser`
- `bun run build`
- `git diff --check`

Closes #252.