### PR TITLE
Repair Production backup and Test activation

### DIFF
--- a/deploy/activate-release.sh
+++ b/deploy/activate-release.sh
@@ -168,6 +168,48 @@ if [[ "${QBT_FOCUSED_TEST_MODE:-}" == 1 ]]; then
   expected_staged_dir="${base_dir}/.staging/${release_id}"
 fi
 
+realpath_command="${QBT_FOCUSED_TEST_REALPATH:-realpath}"
+
+remove_validated_release() {
+  local release_path="$1" release_root resolved_release_path trash_root detached_path
+  release_root="$("$realpath_command" -e -- "${base_dir}/releases")" || return 1
+  [[ -d "$release_root" && ! -L "$release_root" ]] || return 1
+  [[ "$release_path" == "$release_root"/* && "$release_path" != *..* && "$release_path" != *//* ]] || return 1
+  [[ -d "$release_path" && ! -L "$release_path" ]] || return 1
+  resolved_release_path="$("$realpath_command" -e -- "$release_path")" || return 1
+  [[ "$resolved_release_path" == "$release_path" && "$(dirname -- "$resolved_release_path")" == "$release_root" ]] || return 1
+  [[ -d "${base_dir}/.staging" && ! -L "${base_dir}/.staging" ]] || return 1
+  trash_root="$(mktemp -d "${base_dir}/.staging/.prune-XXXXXX")" || {
+    echo "Release prune cleanup could not allocate bounded trash: ${release_path}" >&2
+    return 1
+  }
+  detached_path="${trash_root}/$(basename -- "$resolved_release_path")"
+  if ! mv -- "$resolved_release_path" "$detached_path"; then
+    rmdir -- "$trash_root" 2>/dev/null || true
+    echo "Release prune cleanup could not detach validated release: ${release_path}" >&2
+    return 1
+  fi
+  if [[ "${QBT_FOCUSED_TEST_PRUNE_FAILURE:-}" == after-rename ]]; then
+    echo "Release prune cleanup deferred after detach: ${detached_path}" >&2
+    return 1
+  fi
+  if ! chmod -R u+w "$detached_path"; then
+    echo "Release prune cleanup left detached evidence after write-enable failure: ${detached_path}" >&2
+    return 1
+  fi
+  if ! rm -rf -- "$detached_path"; then
+    echo "Release prune cleanup left detached evidence after removal failure: ${detached_path}" >&2
+    return 1
+  fi
+  rmdir -- "$trash_root" 2>/dev/null || true
+}
+
+if [[ "${QBT_FOCUSED_TEST_PRUNE_PROBE:-}" == 1 ]]; then
+  [[ "${QBT_FOCUSED_TEST_MODE:-}" == 1 ]] || exit 1
+  remove_validated_release "${QBT_FOCUSED_TEST_PRUNE_TARGET:-}"
+  exit $?
+fi
+
 inject_focused_failure() {
   if [[ "${QBT_FOCUSED_TEST_MODE:-}" == 1 && "$EUID" -ne 0 && -n "${QBT_FOCUSED_TEST_ROOT:-}" && "$focused_failure_phase" == "$1" ]]; then
     echo "Focused activation failure at $1." >&2
@@ -469,16 +511,22 @@ compatible_previous_release() {
 }
 
 prune_releases() {
-  local current_release="$1" rollback_release="$2" release_path
+  local current_release="$1" rollback_release="$2" release_path release_root
   local -a all_releases
   if [[ "${QBT_FOCUSED_TEST_MODE:-}" == 1 ]]; then return 0; fi
-  mapfile -t all_releases < <(find "${base_dir}/releases" -mindepth 1 -maxdepth 1 -type d -printf '%T@ %p\n' | sort -rn | cut -d' ' -f2-)
+  release_root="$("$realpath_command" -e -- "${base_dir}/releases")" || return 1
+  all_releases=()
+  while IFS= read -r release_path; do all_releases+=("$release_path"); done < <(
+    find "$release_root" -mindepth 1 -maxdepth 1 -type d -printf '%T@ %p\n' | sort -rn | cut -d' ' -f2-
+  )
   local release_count=0
-  for release_path in "${all_releases[@]}"; do
-    [[ "$release_path" == "$current_release" || "$release_path" == "$rollback_release" ]] && continue
-    release_count=$((release_count + 1))
-    if (( release_count > keep_releases - 2 )); then rm -rf -- "$release_path"; fi
-  done
+  if ((${#all_releases[@]} > 0)); then
+    for release_path in "${all_releases[@]}"; do
+      [[ "$release_path" == "$current_release" || "$release_path" == "$rollback_release" ]] && continue
+      release_count=$((release_count + 1))
+      if (( release_count > keep_releases - 2 )); then remove_validated_release "$release_path"; fi
+    done
+  fi
 }
 
 if restart_service && check_health "$release_id" "$release_dir" && check_representative_behavior; then

--- a/deploy/activate-test-release.sh
+++ b/deploy/activate-test-release.sh
@@ -87,6 +87,116 @@ if [[ "${QBT_FOCUSED_TEST_MODE:-}" == 1 ]]; then
   current_link="${base_dir}/current"
   expected_staged_dir="${base_dir}/.staging/${release_id}"
 fi
+
+realpath_command="${QBT_FOCUSED_TEST_REALPATH:-realpath}"
+
+remove_validated_release() {
+  local release_path="$1" release_root resolved_release_path trash_root detached_path
+  release_root="$("$realpath_command" -e -- "${base_dir}/releases")" || return 1
+  [[ -d "$release_root" && ! -L "$release_root" ]] || return 1
+  [[ "$release_path" == "$release_root"/* && "$release_path" != *..* && "$release_path" != *//* ]] || return 1
+  [[ -d "$release_path" && ! -L "$release_path" ]] || return 1
+  resolved_release_path="$("$realpath_command" -e -- "$release_path")" || return 1
+  [[ "$resolved_release_path" == "$release_path" && "$(dirname -- "$resolved_release_path")" == "$release_root" ]] || return 1
+  [[ -d "${base_dir}/.staging" && ! -L "${base_dir}/.staging" ]] || return 1
+  trash_root="$(mktemp -d "${base_dir}/.staging/.prune-XXXXXX")" || {
+    echo "Release prune cleanup could not allocate bounded trash: ${release_path}" >&2
+    return 1
+  }
+  detached_path="${trash_root}/$(basename -- "$resolved_release_path")"
+  if ! mv -- "$resolved_release_path" "$detached_path"; then
+    rmdir -- "$trash_root" 2>/dev/null || true
+    echo "Release prune cleanup could not detach validated release: ${release_path}" >&2
+    return 1
+  fi
+  if [[ "${QBT_FOCUSED_TEST_PRUNE_FAILURE:-}" == after-rename ]]; then
+    echo "Release prune cleanup deferred after detach: ${detached_path}" >&2
+    return 1
+  fi
+  if ! chmod -R u+w "$detached_path"; then
+    echo "Release prune cleanup left detached evidence after write-enable failure: ${detached_path}" >&2
+    return 1
+  fi
+  if ! rm -rf -- "$detached_path"; then
+    echo "Release prune cleanup left detached evidence after removal failure: ${detached_path}" >&2
+    return 1
+  fi
+  rmdir -- "$trash_root" 2>/dev/null || true
+}
+
+if [[ "${QBT_FOCUSED_TEST_PRUNE_PROBE:-}" == 1 ]]; then
+  [[ "${QBT_FOCUSED_TEST_MODE:-}" == 1 ]] || exit 1
+  remove_validated_release "${QBT_FOCUSED_TEST_PRUNE_TARGET:-}"
+  exit $?
+fi
+
+readiness_window_seconds=60
+focused_activation_elapsed_seconds=0
+focused_activation_clock_file="${QBT_FOCUSED_TEST_CLOCK_FILE:-}"
+activation_now_seconds() {
+  if [[ "${QBT_FOCUSED_TEST_CLOCK:-}" == logical ]]; then
+    if [[ -n "$focused_activation_clock_file" ]]; then
+      cat "$focused_activation_clock_file"
+    else
+      printf '%s\n' "$focused_activation_elapsed_seconds"
+    fi
+  else
+    date +%s
+  fi
+}
+activation_consume_probe_duration() {
+  if [[ "${QBT_FOCUSED_TEST_CLOCK:-}" != logical ]]; then return 0; fi
+  local duration="${QBT_FOCUSED_TEST_PROBE_SECONDS:-0}" now remaining
+  [[ "$duration" =~ ^[0-9]+$ ]] || return 1
+  now="$(activation_now_seconds)" || return 1
+  remaining=$((readiness_deadline - now))
+  (( remaining > 0 )) || return 0
+  (( duration > remaining )) && duration="$remaining"
+  if [[ -n "$focused_activation_clock_file" ]]; then
+    printf '%s\n' "$((now + duration))" >"$focused_activation_clock_file"
+  else
+    focused_activation_elapsed_seconds=$((now + duration))
+  fi
+}
+activation_probe_timeout() {
+  local now remaining
+  now="$(activation_now_seconds)" || return 1
+  remaining=$((readiness_deadline - now))
+  (( remaining > 0 )) || return 1
+  printf '%s\n' "$remaining"
+}
+activation_record_probe() {
+  local probe_name="$1" phase="$2" status="$3" now
+  [[ -n "${QBT_FOCUSED_TEST_PROBE_LOG:-}" ]] || return 0
+  now="$(activation_now_seconds)" || return 1
+  printf '%s %s %s %s\n' "$now" "$phase" "$probe_name" "$status" >>"$QBT_FOCUSED_TEST_PROBE_LOG"
+}
+activation_curl() {
+  local probe_name="$1" request_timeout status
+  shift
+  request_timeout="$(activation_probe_timeout)" || return 1
+  activation_record_probe "$probe_name" start pending || return 1
+  curl --silent --show-error --max-time "$request_timeout" "$@"
+  status=$?
+  activation_consume_probe_duration || return 1
+  activation_record_probe "$probe_name" end "$status" || return 1
+  return "$status"
+}
+activation_wait_seconds() {
+  local seconds="$1"
+  if [[ "${QBT_FOCUSED_TEST_CLOCK:-}" == logical ]]; then
+    local now
+    now="$(activation_now_seconds)" || return 1
+    if [[ -n "$focused_activation_clock_file" ]]; then
+      printf '%s\n' "$((now + seconds))" >"$focused_activation_clock_file"
+    else
+      focused_activation_elapsed_seconds=$((now + seconds))
+    fi
+  else
+    sleep "$seconds"
+  fi
+}
+
 if [[ -n "$staged_dir" ]]; then
   [[ "$staged_dir" == "$expected_staged_dir" ]] || { echo "Invalid Test staging directory." >&2; exit 1; }
   cleanup_staged=1
@@ -225,7 +335,7 @@ check_release_identity() {
   local selected_release_id="$1"
   local selected_release_dir="$2"
   local identity expected_digest candidate_schema
-  identity="$(curl --fail --silent --show-error --max-time 2 "http://127.0.0.1:${port}/internal/release")" || return 1
+  identity="$(activation_curl release --fail "http://127.0.0.1:${port}/internal/release")" || return 1
   expected_digest="$(sed -n 's/.*"executableSha256":"\([0-9a-f]\{64\}\)".*/\1/p' "${selected_release_dir}/release-manifest.json")"
   candidate_schema="$(sed -n 's/.*"schemaCompatibility":"\([^"]*\)\".*/\1/p' "${selected_release_dir}/release-manifest.json")"
   grep -Fq "\"releaseAttemptId\":\"${selected_release_id}\"" <<<"$identity" || return 1
@@ -236,20 +346,25 @@ check_release_identity() {
 check_health() {
   local selected_release_id="$1"
   local selected_release_dir="$2"
+  local readiness_now
   inject_focused_failure readiness || return 1
-  for ((attempt = 1; attempt <= 20; attempt++)); do
-    if curl --fail --silent --show-error --max-time 2 "http://127.0.0.1:${port}/internal/healthz" >/dev/null &&
-      curl --fail --silent --show-error --max-time 2 "http://127.0.0.1:${port}/" | grep -Fq "Test environment — not for live games" &&
-      check_release_identity "$selected_release_id" "$selected_release_dir"; then return 0; fi
-    sleep 1
+  readiness_now="$(activation_now_seconds)" || return 1
+  readiness_deadline=$((readiness_now + readiness_window_seconds))
+  while (( readiness_now < readiness_deadline )); do
+    if activation_curl health --fail "http://127.0.0.1:${port}/internal/healthz" >/dev/null &&
+      activation_curl home --fail "http://127.0.0.1:${port}/" | grep -Fq "Test environment — not for live games" &&
+      check_release_identity "$selected_release_id" "$selected_release_dir" &&
+      check_representative_behavior; then return 0; fi
+    activation_wait_seconds 1 || return 1
+    readiness_now="$(activation_now_seconds)" || return 1
   done
   return 1
 }
 
 check_representative_behavior() {
-  curl --fail --silent --show-error --max-time 2 "http://127.0.0.1:${port}/api/audience/events" >/dev/null || return 1
   local websocket_headers
-  websocket_headers="$(curl --silent --show-error --max-time 2 \
+  activation_curl events --fail "http://127.0.0.1:${port}/api/audience/events" >/dev/null || return 1
+  websocket_headers="$(activation_curl websocket \
     -H "Origin: http://127.0.0.1:${port}" \
     -H "Connection: Upgrade" \
     -H "Upgrade: websocket" \
@@ -269,18 +384,24 @@ compatible_previous_release() {
 }
 
 prune_releases() {
-  local current_release="$1" rollback_release="$2" release_path
+  local current_release="$1" rollback_release="$2" release_path release_root
   local -a all_releases
-  mapfile -t all_releases < <(find "${base_dir}/releases" -mindepth 1 -maxdepth 1 -type d -printf '%T@ %p\n' | sort -rn | cut -d' ' -f2-)
+  release_root="$("$realpath_command" -e -- "${base_dir}/releases")" || return 1
+  all_releases=()
+  while IFS= read -r release_path; do all_releases+=("$release_path"); done < <(
+    find "$release_root" -mindepth 1 -maxdepth 1 -type d -printf '%T@ %p\n' | sort -rn | cut -d' ' -f2-
+  )
   local release_count=0
-  for release_path in "${all_releases[@]}"; do
-    [[ "$release_path" == "$current_release" || "$release_path" == "$rollback_release" ]] && continue
-    release_count=$((release_count + 1))
-    if (( release_count > keep_releases - 2 )); then rm -rf -- "$release_path"; fi
-  done
+  if ((${#all_releases[@]} > 0)); then
+    for release_path in "${all_releases[@]}"; do
+      [[ "$release_path" == "$current_release" || "$release_path" == "$rollback_release" ]] && continue
+      release_count=$((release_count + 1))
+      if (( release_count > keep_releases - 2 )); then remove_validated_release "$release_path"; fi
+    done
+  fi
 }
 
-if restart_service && check_health "$release_id" "$release_dir" && check_representative_behavior; then
+if restart_service && check_health "$release_id" "$release_dir"; then
   prune_releases "$release_dir" "$previous_release"
   if ! inject_focused_failure final-report; then exit 1; fi
   echo "Activated immutable Test release attempt ${release_id}."
@@ -290,8 +411,17 @@ echo "Test deployment failed; attempting compatible binary rollback without rest
 if [[ -n "$previous_release" && -d "$previous_release" ]] && compatible_previous_release; then
   previous_release_id="${previous_release##*/}"
   ln -sfn -- "$previous_release" "$current_link"
-  if restart_service && check_health "$previous_release_id" "$previous_release"; then echo "Rolled back Test to ${previous_release}." >&2; else echo "Test rollback failed health checks." >&2; fi
+  if restart_service && check_health "$previous_release_id" "$previous_release"; then
+    echo "Rolled back Test to ${previous_release}." >&2
+    exit 1
+  fi
+  echo "Test rollback failed health checks; stopping Test service fail-closed." >&2
 else
   echo "No compatible previous Test release available for rollback." >&2
+fi
+if ! sudo systemctl stop "$service_name"; then
+  echo "Test fail-closed stop failed; service state is not trusted." >&2
+else
+  echo "Test service stopped after failed activation." >&2
 fi
 exit 1

--- a/src/lib/foundation-recovery-sqlite.ts
+++ b/src/lib/foundation-recovery-sqlite.ts
@@ -98,7 +98,7 @@ export function inspectRecoveryDatabase(
       logicalDigest.update("\n");
     }
   }
-  const actionCount = included.has("foundation_event_game_record_actions")
+  const actionCount = relations.includes("foundation_event_game_record_actions")
     ? countRows(database, "foundation_event_game_record_actions")
     : 0;
   const grantVersions = relations.includes("foundation_grant_roots")

--- a/src/lib/foundation-recovery.test.ts
+++ b/src/lib/foundation-recovery.test.ts
@@ -161,6 +161,51 @@ describe("Event foundation recovery", () => {
     });
   });
 
+  test("backs up an older Foundation schema before migration without inventing relations", async () => {
+    await withRecoveryPaths(async ({ livePath, backupDirectory }) => {
+      const harness = await createHarness(livePath, backupDirectory);
+      harness.storage.close();
+
+      const legacyPath = join(dirname(livePath), "legacy.sqlite");
+      const legacy = openSqliteFoundationStorage(legacyPath, {
+        migrations: FOUNDATION_MIGRATIONS.slice(0, 2),
+        grantKeyRing: harness.keyRing,
+        grantValidationContext: { environmentId: "test", keyRing: harness.keyRing },
+      });
+      await legacy.applyMigrations({ requireCandidate: false });
+      const recovery = createFoundationRecovery(legacy, {
+        ...harness.options,
+        createId: () => "legacy-backup",
+      });
+
+      const manifest = await recovery.createPreDeploymentBackup();
+      const source = new Database(legacyPath, { readonly: true });
+      expect(
+        source
+          .query(
+            "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'foundation_event_game_record_actions'",
+          )
+          .get(),
+      ).toBeNull();
+      source.close();
+      expect(manifest.actionCount).toBe(0);
+
+      const manifestPath = join(backupDirectory, `${manifest.snapshotId}.manifest.json`);
+      await expect(recovery.verifyBackup(manifestPath)).resolves.toEqual(manifest);
+      legacy.close();
+
+      const migrated = openSqliteFoundationStorage(legacyPath, {
+        grantKeyRing: harness.keyRing,
+        grantValidationContext: { environmentId: "test", keyRing: harness.keyRing },
+      });
+      await migrated.applyMigrations({ requireCandidate: true });
+      expect((await migrated.migrationPreflight()).schemaVersion).toBe(
+        Number(CURRENT_SCHEMA_VERSION),
+      );
+      migrated.close();
+    });
+  });
+
   test("uses a private physical workspace and rejects unsafe existing paths", async () => {
     await withRecoveryPaths(async ({ livePath, backupDirectory }) => {
       let rawMode: number | null = null;

--- a/src/lib/production-activation.focused.ts
+++ b/src/lib/production-activation.focused.ts
@@ -74,7 +74,7 @@ describe("disposable activation SQLite integration", () => {
         requiredOwnerUid: process.getuid?.() ?? 0,
       });
       const legacy = openSqliteFoundationStorage(foundationPath, {
-        migrations: FOUNDATION_MIGRATIONS.slice(0, -1),
+        migrations: FOUNDATION_MIGRATIONS.slice(0, 2),
         grantKeyRing: keyRing,
         grantValidationContext: { environmentId: "production", keyRing },
       });

--- a/src/production-activation-fast.test.ts
+++ b/src/production-activation-fast.test.ts
@@ -3,6 +3,8 @@ import {
   chmod,
   mkdir,
   mkdtemp,
+  lstat,
+  readdir,
   access,
   readFile,
   realpath,
@@ -17,10 +19,16 @@ const repositoryRoot = process.cwd();
 const roots: string[] = [];
 const releaseId = "sha-fast-run-matrix-attempt-1";
 const previousReleaseId = "sha-prior-run-matrix-attempt-1";
+const testActivationReleaseId = "sha-fast-run-test-activation-attempt-1";
 const secretSentinel = "FAST_SECRET_MUST_NOT_LEAK";
 
 afterEach(async () => {
-  await Promise.all(roots.splice(0).map((root) => rm(root, { force: true, recursive: true })));
+  await Promise.all(
+    roots.splice(0).map(async (root) => {
+      Bun.spawnSync({ cmd: ["chmod", "-R", "u+w", root] });
+      await rm(root, { force: true, recursive: true });
+    }),
+  );
 });
 
 function digest(contents: string): string {
@@ -401,4 +409,415 @@ describe("Production activation Fast phase matrix", () => {
     }
     expect(await readFile(harness.probe, "utf8")).toBe("0 1 1\n");
   }, 30_000);
+
+  test("uses one bounded semantic Test readiness deadline for delayed and unhealthy services", async () => {
+    const script = join(repositoryRoot, "deploy/activate-test-release.sh");
+    const delayed = await createTestActivationHarness();
+    const delayedRun = runTestActivation(delayed, {
+      QBT_TEST_DELAY_CALLS: "3",
+    });
+    expect(delayedRun.exitCode, delayedRun.output).toBe(0);
+    expect(delayedRun.output).toContain("Activated immutable Test release attempt");
+    expect(await realpath(join(delayed.base, "current"))).toBe(delayed.release);
+    expect(await readFile(delayed.transitions, "utf8")).toBe("stop\nrestart\n");
+    expectProbeBudget(parseProbeLog(await readFile(delayed.probeLog, "utf8")), 0, 60);
+    expect(Number(await readFile(delayed.clock, "utf8"))).toBe(19);
+
+    const unhealthy = await createTestActivationHarness();
+    const unhealthyRun = runTestActivation(unhealthy, {
+      QBT_FOCUSED_TEST_PROBE_SECONDS: "19",
+      QBT_TEST_UNHEALTHY: "1",
+    });
+    expect(unhealthyRun.exitCode).not.toBe(0);
+    expect(unhealthyRun.output).toContain("Test deployment failed");
+    expect(await realpath(join(unhealthy.base, "current"))).toBe(unhealthy.previous);
+    expect(unhealthyRun.output).not.toContain("Activated immutable Test release attempt");
+    expect(unhealthyRun.output).toContain("stopping Test service fail-closed");
+    expect(unhealthyRun.output).toContain("Test service stopped after failed activation");
+    expect(await readFile(unhealthy.transitions, "utf8")).toBe("stop\nrestart\nrestart\nstop\n");
+    const unhealthyProbes = parseProbeLog(await readFile(unhealthy.probeLog, "utf8"));
+    expect(unhealthyProbes.some((probe) => probe.start >= 60)).toBe(true);
+    expectProbeBudget(
+      unhealthyProbes.filter((probe) => probe.start < 60),
+      0,
+      60,
+    );
+    expectProbeBudget(
+      unhealthyProbes.filter((probe) => probe.start >= 60),
+      60,
+      120,
+    );
+    expect(unhealthyProbes.every((probe) => probe.start < 120 && probe.end <= 120)).toBe(true);
+    expect(Number(await readFile(unhealthy.clock, "utf8"))).toBe(120);
+    expect(await readFile(script, "utf8")).toContain("readiness_window_seconds=60");
+  }, 10_000);
+
+  test("detaches only validated stale releases before cleanup in Production and Test", async () => {
+    for (const scriptName of ["activate-release.sh", "activate-test-release.sh"]) {
+      const script = join(repositoryRoot, "deploy", scriptName);
+      const fixture = await createPruneHarness();
+      const failedPrune = runPruneProbe(script, fixture, fixture.stale, {
+        QBT_FOCUSED_TEST_PRUNE_FAILURE: "after-rename",
+      });
+      expect(failedPrune.exitCode, failedPrune.output).not.toBe(0);
+      expect(await pathExists(fixture.stale), failedPrune.output).toBe(false);
+      const trashEntries = await readdir(join(fixture.base, ".staging"));
+      expect(trashEntries.some((entry) => entry.startsWith(".prune-"))).toBe(true);
+      expect((await lstat(fixture.current)).mode & 0o200).toBe(0);
+      expect((await lstat(fixture.rollback)).mode & 0o200).toBe(0);
+
+      const valid = await createPruneHarness();
+      const validRun = runPruneProbe(script, valid, valid.stale);
+      expect(validRun.exitCode, validRun.output).toBe(0);
+      expect(await pathExists(valid.stale)).toBe(false);
+      expect(await pathExists(valid.current)).toBe(true);
+      expect(await pathExists(valid.rollback)).toBe(true);
+
+      for (const invalidTarget of [
+        valid.symlink,
+        valid.nested,
+        valid.outside,
+        valid.noncanonical,
+      ]) {
+        const invalidRun = runPruneProbe(script, valid, invalidTarget);
+        expect(invalidRun.exitCode).not.toBe(0);
+      }
+      expect(await pathExists(valid.symlink)).toBe(true);
+      expect(await pathExists(valid.nested)).toBe(true);
+      expect(await pathExists(valid.outside)).toBe(true);
+      expect(await pathExists(valid.stale)).toBe(false);
+      expect((await lstat(valid.current)).mode & 0o200).toBe(0);
+      expect((await lstat(valid.rollback)).mode & 0o200).toBe(0);
+    }
+  }, 10_000);
 });
+
+async function createTestActivationHarness(): Promise<{
+  base: string;
+  bin: string;
+  clock: string;
+  count: string;
+  maintenance: string;
+  previous: string;
+  probeLog: string;
+  release: string;
+  root: string;
+  transitions: string;
+}> {
+  const root = await realpath(await mkdtemp(join(tmpdir(), "quadball-test-activation-fast-")));
+  roots.push(root);
+  const base = join(root, "srv", "quadball-timer-test");
+  const bin = join(root, "bin");
+  const count = join(root, "curl-count");
+  const clock = join(root, "logical-clock");
+  const probeLog = join(root, "probe-log");
+  const transitions = join(root, "service-transitions");
+  const previous = join(base, "releases", "sha-prior-test-activation-attempt-1");
+  const release = join(base, "releases", testActivationReleaseId);
+  const maintenance = join(root, "maintenance");
+  await mkdir(join(release, "deploy/systemd"), { recursive: true });
+  await mkdir(previous, { recursive: true });
+  await mkdir(join(base, ".staging"), { recursive: true });
+  await mkdir(bin, { recursive: true });
+  await writeFile(join(release, "deploy/systemd/quadball-timer-test.service"), "[Unit]\n");
+  await writeFile(join(release, "quadball-timer"), "test executable\n");
+  await chmod(join(release, "quadball-timer"), 0o555);
+  const executableDigest = digest("test executable\n");
+  await writeFile(
+    join(release, "release-manifest.json"),
+    JSON.stringify({
+      releaseAttemptId: testActivationReleaseId,
+      executableSha256: executableDigest,
+      schemaCompatibility: "31",
+    }),
+  );
+  await writeFile(
+    join(previous, "release-manifest.json"),
+    '{"supportedFoundationSchemaVersions":["31"]}',
+  );
+  await symlink(previous, join(base, "current"));
+  await writeFile(count, "0\n");
+  await writeFile(clock, "0\n");
+  await writeFile(probeLog, "");
+  await writeFile(transitions, "");
+  await executable(
+    join(bin, "systemctl"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == stop || "$1" == restart ]]; then
+  printf '%s\\n' "$1" >>"$QBT_TEST_SERVICE_TRANSITIONS"
+  exit 0
+fi
+if [[ "$1" == show ]]; then
+  property=""
+  for argument in "$@"; do [[ "$argument" == --property=* ]] && property="\${argument#--property=}"; done
+  case "$property" in
+    Environment) echo "QUADBALL_ENVIRONMENT=test PUBLIC_ORIGIN=https://test.timer.quadball.app FOUNDATION_DATABASE=/var/lib/quadball-timer-test/foundation.sqlite TECHNICAL_ADMIN_DATABASE=/var/lib/quadball-timer-test/technical-admin.sqlite EVENT_GAME_DATABASE=/var/lib/quadball-timer-test/event-game.sqlite GRANT_KEY_RING_FILE=/etc/quadball-timer/test-grant-key-ring.json" ;;
+    ExecStart) echo "$QBT_TEST_BASE/current/quadball-timer" ;;
+    StateDirectory) echo "quadball-timer-test" ;;
+    StateDirectoryMode) echo "0750" ;;
+  esac
+fi
+`,
+  );
+  await executable(join(bin, "sudo"), '#!/usr/bin/env bash\nexec "$@"\n');
+  await executable(join(bin, "flock"), "#!/usr/bin/env bash\nexit 0\n");
+  await executable(
+    join(bin, "df"),
+    "#!/usr/bin/env bash\nprintf 'Filesystem 1024-blocks Used Available Capacity Mounted on\\nfast 999999 1 999998 1%% /fast\\n'\n",
+  );
+  await executable(
+    join(bin, "grep"),
+    `#!/usr/bin/env bash
+if [[ "$*" == *"/proc/cpuinfo"* ]]; then exit 0; fi
+exec /usr/bin/grep "$@"
+`,
+  );
+  await executable(
+    join(bin, "realpath"),
+    `#!/usr/bin/env bash
+if [[ "$1" == -e ]]; then shift; fi
+if [[ "$1" == -- ]]; then shift; fi
+exec /bin/realpath "$@"
+`,
+  );
+  await executable(
+    join(bin, "find"),
+    `#!/usr/bin/env bash
+if [[ "$*" == *"-printf"* ]]; then
+  for path in "$QBT_TEST_BASE/releases"/*; do
+    [[ -d "$path" ]] && printf '1.0 %s\\n' "$path"
+  done
+  exit 0
+fi
+exec /usr/bin/find "$@"
+`,
+  );
+  await executable(
+    join(bin, "curl"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+count="$(cat "$QBT_TEST_CURL_COUNT")"
+count=$((count + 1))
+printf '%s\\n' "$count" >"$QBT_TEST_CURL_COUNT"
+url="\${!#}"
+if [[ "\${QBT_TEST_UNHEALTHY:-}" == 1 || "$count" -le \${QBT_TEST_DELAY_CALLS:-0} ]]; then exit 7; fi
+case "$url" in
+  */internal/release) printf '{"releaseAttemptId":"%s","executableSha256":"%s","runningExecutableSha256":"%s","schemaCompatibility":"31"}\\n' "$QBT_TEST_RELEASE" "$QBT_TEST_DIGEST" "$QBT_TEST_DIGEST" ;;
+  */ws) printf 'HTTP/1.1 101 Switching Protocols\\r\\n\\r\\n' ;;
+  */api/audience/events|*/internal/healthz) printf '{}\\n' ;;
+  */) printf 'Test environment — not for live games\\n' ;;
+esac
+`,
+  );
+  await executable(
+    maintenance,
+    `#!/usr/bin/env bash
+set -euo pipefail
+case "$3" in
+  preflight) printf '{"schemaVersion":31}\\n' ;;
+  validate-migration) printf '{"ready":true}\\n' ;;
+  apply-migrations) printf '{"schemaVersion":31}\\n' ;;
+  *) : ;;
+esac
+`,
+  );
+  return { base, bin, clock, count, maintenance, previous, probeLog, release, root, transitions };
+}
+
+function runTestActivation(
+  fixture: Awaited<ReturnType<typeof createTestActivationHarness>>,
+  extra: Record<string, string>,
+) {
+  const result = Bun.spawnSync({
+    cmd: [
+      "bash",
+      join(repositoryRoot, "deploy/activate-test-release.sh"),
+      "--base-dir",
+      fixture.base,
+      "--release",
+      testActivationReleaseId,
+    ],
+    env: {
+      ...process.env,
+      ...extra,
+      PATH: `${fixture.bin}:${process.env.PATH ?? ""}`,
+      QBT_FOCUSED_TEST_CLOCK: "logical",
+      QBT_FOCUSED_TEST_CLOCK_FILE: fixture.clock,
+      QBT_FOCUSED_TEST_MAINTENANCE_WRAPPER: fixture.maintenance,
+      QBT_FOCUSED_TEST_MODE: "1",
+      QBT_FOCUSED_TEST_PROBE_LOG: fixture.probeLog,
+      QBT_FOCUSED_TEST_PROBE_SECONDS: extra.QBT_FOCUSED_TEST_PROBE_SECONDS ?? "2",
+      QBT_FOCUSED_TEST_RELEASE_VERIFIED: "1",
+      QBT_FOCUSED_TEST_REALPATH: join(fixture.root, "bin", "realpath"),
+      QBT_FOCUSED_TEST_ROOT: fixture.root,
+      QBT_TEST_BASE: fixture.base,
+      QBT_TEST_CURL_COUNT: fixture.count,
+      QBT_TEST_DIGEST: digest("test executable\n"),
+      QBT_TEST_RELEASE: testActivationReleaseId,
+      QBT_TEST_SERVICE_TRANSITIONS: fixture.transitions,
+    },
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  return {
+    exitCode: result.exitCode,
+    output: `${new TextDecoder().decode(result.stdout)}${new TextDecoder().decode(result.stderr)}`,
+  };
+}
+
+async function createPruneHarness(): Promise<{
+  base: string;
+  current: string;
+  nested: string;
+  noncanonical: string;
+  outside: string;
+  releaseRoot: string;
+  rollback: string;
+  root: string;
+  stale: string;
+  symlink: string;
+}> {
+  const root = await realpath(await mkdtemp(join(tmpdir(), "quadball-prune-fast-")));
+  roots.push(root);
+  const base = join(root, "srv", "quadball-timer");
+  const releaseRoot = join(base, "releases");
+  const staging = join(base, ".staging");
+  const bin = join(root, "bin");
+  const maintenance = join(root, "maintenance");
+  const current = join(releaseRoot, "current-release");
+  const rollback = join(releaseRoot, "rollback-release");
+  const stale = join(releaseRoot, "stale-release");
+  const nested = join(releaseRoot, "nested", "victim");
+  const outside = join(root, "outside-release");
+  const symlinkPath = join(releaseRoot, "symlink-victim");
+  await mkdir(current, { recursive: true });
+  await mkdir(rollback, { recursive: true });
+  await mkdir(stale, { recursive: true });
+  await mkdir(nested, { recursive: true });
+  await mkdir(outside, { recursive: true });
+  await mkdir(staging, { recursive: true });
+  await mkdir(bin, { recursive: true });
+  await chmod(releaseRoot, 0o755);
+  await chmod(staging, 0o755);
+  await writeFile(join(current, "marker"), "current\n");
+  await writeFile(join(rollback, "marker"), "rollback\n");
+  await writeFile(join(stale, "marker"), "stale\n");
+  await writeFile(join(nested, "marker"), "nested\n");
+  await writeFile(join(outside, "marker"), "outside\n");
+  await chmod(join(current, "marker"), 0o444);
+  await chmod(join(rollback, "marker"), 0o444);
+  await chmod(join(stale, "marker"), 0o444);
+  await chmod(join(nested, "marker"), 0o444);
+  await chmod(join(outside, "marker"), 0o444);
+  await chmod(current, 0o555);
+  await chmod(rollback, 0o555);
+  // macOS rejects renaming a non-writable directory; keep its payload immutable
+  // while allowing the cross-directory rename that the Linux deployment uses.
+  await chmod(stale, process.platform === "darwin" ? 0o755 : 0o555);
+  await chmod(nested, 0o555);
+  await chmod(outside, 0o555);
+  await symlink(outside, symlinkPath);
+  await executable(maintenance, "#!/usr/bin/env bash\nexit 0\n");
+  await executable(
+    join(bin, "realpath"),
+    `#!/usr/bin/env bash
+if [[ "$1" == -e ]]; then shift; fi
+if [[ "$1" == -- ]]; then shift; fi
+exec /bin/realpath "$@"
+`,
+  );
+  return {
+    base,
+    current,
+    nested,
+    noncanonical: join(releaseRoot, "..", "releases", "current-release"),
+    outside,
+    releaseRoot,
+    rollback,
+    root,
+    stale,
+    symlink: symlinkPath,
+  };
+}
+
+function runPruneProbe(
+  script: string,
+  fixture: Awaited<ReturnType<typeof createPruneHarness>>,
+  target: string,
+  extra: Record<string, string> = {},
+) {
+  const result = Bun.spawnSync({
+    cmd: ["bash", script, "--base-dir", fixture.base, "--release", releaseId],
+    env: {
+      ...process.env,
+      ...extra,
+      QBT_FOCUSED_TEST_MAINTENANCE_WRAPPER: join(fixture.root, "maintenance"),
+      QBT_FOCUSED_TEST_MODE: "1",
+      QBT_FOCUSED_TEST_PRUNE_PROBE: "1",
+      QBT_FOCUSED_TEST_PRUNE_TARGET: target,
+      QBT_FOCUSED_TEST_REALPATH: join(fixture.root, "bin", "realpath"),
+      QBT_FOCUSED_TEST_ROOT: fixture.root,
+    },
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  return {
+    exitCode: result.exitCode,
+    output: `${new TextDecoder().decode(result.stdout)}${new TextDecoder().decode(result.stderr)}`,
+  };
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function parseProbeLog(contents: string): Array<{
+  end: number;
+  phase: string;
+  probe: string;
+  start: number;
+}> {
+  const records = contents
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => {
+      const [time, phase, probe, status] = line.split(" ");
+      if (
+        time === undefined ||
+        phase === undefined ||
+        probe === undefined ||
+        status === undefined
+      ) {
+        throw new Error(`Malformed probe log record: ${line}`);
+      }
+      return { end: Number(time), phase, probe, start: Number(time), status };
+    });
+  const probes: Array<{ end: number; phase: string; probe: string; start: number }> = [];
+  for (let index = 0; index < records.length; index += 2) {
+    const start = records[index];
+    const end = records[index + 1];
+    if (start === undefined || end === undefined) throw new Error("Unpaired probe log record");
+    expect(start?.phase).toBe("start");
+    expect(end?.phase).toBe("end");
+    expect(start?.probe).toBe(end?.probe);
+    probes.push({ end: end.end, phase: end.status, probe: end.probe, start: start.start });
+  }
+  return probes;
+}
+
+function expectProbeBudget(
+  probes: Array<{ end: number; start: number }>,
+  minimum: number,
+  deadline: number,
+) {
+  expect(probes.length).toBeGreaterThan(0);
+  expect(probes.every((probe) => probe.start >= minimum && probe.start < deadline)).toBe(true);
+  expect(probes.every((probe) => probe.end >= probe.start && probe.end <= deadline)).toBe(true);
+}


### PR DESCRIPTION
## What changed

- allow verified Production backup inspection of an older Foundation schema when an allowlisted relation does not exist yet, without weakening unknown-relation rejection
- enforce one shared bounded Test readiness budget across health, Home, release identity, representative Event HTTP, and WebSocket probes
- stop Test fail-closed when both the candidate and compatible rollback release fail readiness
- atomically detach validated stale releases before enabling write permission for cleanup
- add shipped-script Fast coverage for older-schema backup, delayed and unhealthy Test activation, bounded probe timing, rollback stop behavior, and safe pruning

## Why

The first schema-aware deployment built successfully but Production backup failed on the pre-migration schema with `no such table: foundation_event_game_record_actions`. Test activated successfully but its immediate representative check reported a false failure; cleanup then could not remove immutable old releases.

## Impact

Production can take its required verified pre-migration backup before applying the current migrations. Test activation tolerates bounded startup delay while still failing closed when neither release becomes healthy. Production and Test outcomes remain independent.

## Validation

- full ordinary suite: 892 passed, 0 failed
- `bun run check`
- `bun run build:executable`
- activation Fast matrix: 3 passed
- activation Focused Integration: 3 passed
- `bash -n` and ShellCheck for deployment scripts
- `git diff --check`
- final Standards and Spec reviews: no findings

No Qualification tests were run.

Parent specification: #158  
Implementation ticket: #251