### PR TITLE
Make immutable release pruning Linux-safe

### DIFF
--- a/deploy/activate-release.sh
+++ b/deploy/activate-release.sh
@@ -171,42 +171,60 @@ fi
 realpath_command="${QBT_FOCUSED_TEST_REALPATH:-realpath}"
 
 remove_validated_release() {
-  local release_path="$1" release_root resolved_release_path trash_root detached_path
+  local release_path="$1" release_root resolved_release_path quarantine_path
   release_root="$("$realpath_command" -e -- "${base_dir}/releases")" || return 1
   [[ -d "$release_root" && ! -L "$release_root" ]] || return 1
   [[ "$release_path" == "$release_root"/* && "$release_path" != *..* && "$release_path" != *//* ]] || return 1
   [[ -d "$release_path" && ! -L "$release_path" ]] || return 1
   resolved_release_path="$("$realpath_command" -e -- "$release_path")" || return 1
   [[ "$resolved_release_path" == "$release_path" && "$(dirname -- "$resolved_release_path")" == "$release_root" ]] || return 1
-  [[ -d "${base_dir}/.staging" && ! -L "${base_dir}/.staging" ]] || return 1
-  trash_root="$(mktemp -d "${base_dir}/.staging/.prune-XXXXXX")" || {
-    echo "Release prune cleanup could not allocate bounded trash: ${release_path}" >&2
+  quarantine_path="${release_root}/.prune-$(basename -- "$resolved_release_path")"
+  if [[ -e "$quarantine_path" || -L "$quarantine_path" ]]; then
+    echo "Release prune cleanup found existing quarantine evidence: ${quarantine_path}" >&2
     return 1
-  }
-  detached_path="${trash_root}/$(basename -- "$resolved_release_path")"
-  if ! mv -- "$resolved_release_path" "$detached_path"; then
-    rmdir -- "$trash_root" 2>/dev/null || true
+  fi
+  if ! mv -- "$resolved_release_path" "$quarantine_path"; then
     echo "Release prune cleanup could not detach validated release: ${release_path}" >&2
     return 1
   fi
   if [[ "${QBT_FOCUSED_TEST_PRUNE_FAILURE:-}" == after-rename ]]; then
-    echo "Release prune cleanup deferred after detach: ${detached_path}" >&2
+    echo "Release prune cleanup deferred after detach: ${quarantine_path}" >&2
     return 1
   fi
-  if ! chmod -R u+w "$detached_path"; then
-    echo "Release prune cleanup left detached evidence after write-enable failure: ${detached_path}" >&2
+  if ! chmod -R u+w "$quarantine_path"; then
+    echo "Release prune cleanup left detached evidence after write-enable failure: ${quarantine_path}" >&2
     return 1
   fi
-  if ! rm -rf -- "$detached_path"; then
-    echo "Release prune cleanup left detached evidence after removal failure: ${detached_path}" >&2
+  if ! rm -rf -- "$quarantine_path"; then
+    echo "Release prune cleanup left detached evidence after removal failure: ${quarantine_path}" >&2
     return 1
   fi
-  rmdir -- "$trash_root" 2>/dev/null || true
+}
+
+list_selectable_releases() {
+  local release_root="$1"
+  local release_path
+  local -a selectable_releases=()
+  shopt -s nullglob
+  for release_path in "$release_root"/*; do
+    [[ -d "$release_path" && ! -L "$release_path" ]] && selectable_releases+=("$release_path")
+  done
+  shopt -u nullglob
+  if ((${#selectable_releases[@]} > 0)); then
+    ls -1dt -- "${selectable_releases[@]}"
+  fi
 }
 
 if [[ "${QBT_FOCUSED_TEST_PRUNE_PROBE:-}" == 1 ]]; then
   [[ "${QBT_FOCUSED_TEST_MODE:-}" == 1 ]] || exit 1
   remove_validated_release "${QBT_FOCUSED_TEST_PRUNE_TARGET:-}"
+  exit $?
+fi
+
+if [[ "${QBT_FOCUSED_TEST_PRUNE_LIST:-}" == 1 ]]; then
+  [[ "${QBT_FOCUSED_TEST_MODE:-}" == 1 ]] || exit 1
+  release_root="$("$realpath_command" -e -- "${base_dir}/releases")" || exit 1
+  list_selectable_releases "$release_root"
   exit $?
 fi
 
@@ -515,9 +533,10 @@ prune_releases() {
   local -a all_releases
   if [[ "${QBT_FOCUSED_TEST_MODE:-}" == 1 ]]; then return 0; fi
   release_root="$("$realpath_command" -e -- "${base_dir}/releases")" || return 1
+  find "$release_root" -mindepth 1 -maxdepth 1 -type d -name '.prune-*' -print >&2
   all_releases=()
   while IFS= read -r release_path; do all_releases+=("$release_path"); done < <(
-    find "$release_root" -mindepth 1 -maxdepth 1 -type d -printf '%T@ %p\n' | sort -rn | cut -d' ' -f2-
+    list_selectable_releases "$release_root"
   )
   local release_count=0
   if ((${#all_releases[@]} > 0)); then

--- a/deploy/activate-test-release.sh
+++ b/deploy/activate-test-release.sh
@@ -91,42 +91,60 @@ fi
 realpath_command="${QBT_FOCUSED_TEST_REALPATH:-realpath}"
 
 remove_validated_release() {
-  local release_path="$1" release_root resolved_release_path trash_root detached_path
+  local release_path="$1" release_root resolved_release_path quarantine_path
   release_root="$("$realpath_command" -e -- "${base_dir}/releases")" || return 1
   [[ -d "$release_root" && ! -L "$release_root" ]] || return 1
   [[ "$release_path" == "$release_root"/* && "$release_path" != *..* && "$release_path" != *//* ]] || return 1
   [[ -d "$release_path" && ! -L "$release_path" ]] || return 1
   resolved_release_path="$("$realpath_command" -e -- "$release_path")" || return 1
   [[ "$resolved_release_path" == "$release_path" && "$(dirname -- "$resolved_release_path")" == "$release_root" ]] || return 1
-  [[ -d "${base_dir}/.staging" && ! -L "${base_dir}/.staging" ]] || return 1
-  trash_root="$(mktemp -d "${base_dir}/.staging/.prune-XXXXXX")" || {
-    echo "Release prune cleanup could not allocate bounded trash: ${release_path}" >&2
+  quarantine_path="${release_root}/.prune-$(basename -- "$resolved_release_path")"
+  if [[ -e "$quarantine_path" || -L "$quarantine_path" ]]; then
+    echo "Release prune cleanup found existing quarantine evidence: ${quarantine_path}" >&2
     return 1
-  }
-  detached_path="${trash_root}/$(basename -- "$resolved_release_path")"
-  if ! mv -- "$resolved_release_path" "$detached_path"; then
-    rmdir -- "$trash_root" 2>/dev/null || true
+  fi
+  if ! mv -- "$resolved_release_path" "$quarantine_path"; then
     echo "Release prune cleanup could not detach validated release: ${release_path}" >&2
     return 1
   fi
   if [[ "${QBT_FOCUSED_TEST_PRUNE_FAILURE:-}" == after-rename ]]; then
-    echo "Release prune cleanup deferred after detach: ${detached_path}" >&2
+    echo "Release prune cleanup deferred after detach: ${quarantine_path}" >&2
     return 1
   fi
-  if ! chmod -R u+w "$detached_path"; then
-    echo "Release prune cleanup left detached evidence after write-enable failure: ${detached_path}" >&2
+  if ! chmod -R u+w "$quarantine_path"; then
+    echo "Release prune cleanup left detached evidence after write-enable failure: ${quarantine_path}" >&2
     return 1
   fi
-  if ! rm -rf -- "$detached_path"; then
-    echo "Release prune cleanup left detached evidence after removal failure: ${detached_path}" >&2
+  if ! rm -rf -- "$quarantine_path"; then
+    echo "Release prune cleanup left detached evidence after removal failure: ${quarantine_path}" >&2
     return 1
   fi
-  rmdir -- "$trash_root" 2>/dev/null || true
+}
+
+list_selectable_releases() {
+  local release_root="$1"
+  local release_path
+  local -a selectable_releases=()
+  shopt -s nullglob
+  for release_path in "$release_root"/*; do
+    [[ -d "$release_path" && ! -L "$release_path" ]] && selectable_releases+=("$release_path")
+  done
+  shopt -u nullglob
+  if ((${#selectable_releases[@]} > 0)); then
+    ls -1dt -- "${selectable_releases[@]}"
+  fi
 }
 
 if [[ "${QBT_FOCUSED_TEST_PRUNE_PROBE:-}" == 1 ]]; then
   [[ "${QBT_FOCUSED_TEST_MODE:-}" == 1 ]] || exit 1
   remove_validated_release "${QBT_FOCUSED_TEST_PRUNE_TARGET:-}"
+  exit $?
+fi
+
+if [[ "${QBT_FOCUSED_TEST_PRUNE_LIST:-}" == 1 ]]; then
+  [[ "${QBT_FOCUSED_TEST_MODE:-}" == 1 ]] || exit 1
+  release_root="$("$realpath_command" -e -- "${base_dir}/releases")" || exit 1
+  list_selectable_releases "$release_root"
   exit $?
 fi
 
@@ -387,9 +405,10 @@ prune_releases() {
   local current_release="$1" rollback_release="$2" release_path release_root
   local -a all_releases
   release_root="$("$realpath_command" -e -- "${base_dir}/releases")" || return 1
+  find "$release_root" -mindepth 1 -maxdepth 1 -type d -name '.prune-*' -print >&2
   all_releases=()
   while IFS= read -r release_path; do all_releases+=("$release_path"); done < <(
-    find "$release_root" -mindepth 1 -maxdepth 1 -type d -printf '%T@ %p\n' | sort -rn | cut -d' ' -f2-
+    list_selectable_releases "$release_root"
   )
   local release_count=0
   if ((${#all_releases[@]} > 0)); then

--- a/src/production-activation-fast.test.ts
+++ b/src/production-activation-fast.test.ts
@@ -13,7 +13,7 @@ import {
   writeFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 
 const repositoryRoot = process.cwd();
 const roots: string[] = [];
@@ -461,8 +461,13 @@ describe("Production activation Fast phase matrix", () => {
       });
       expect(failedPrune.exitCode, failedPrune.output).not.toBe(0);
       expect(await pathExists(fixture.stale), failedPrune.output).toBe(false);
-      const trashEntries = await readdir(join(fixture.base, ".staging"));
-      expect(trashEntries.some((entry) => entry.startsWith(".prune-"))).toBe(true);
+      const quarantineEntries = await readdir(fixture.releaseRoot);
+      expect(quarantineEntries).toContain(`.prune-${basename(fixture.stale)}`);
+      const selectable = runPruneList(script, fixture);
+      expect(selectable.exitCode, selectable.output).toBe(0);
+      expect(selectable.output).not.toContain(`.prune-${basename(fixture.stale)}`);
+      expect(selectable.output).toContain(fixture.current);
+      expect(selectable.output).toContain(fixture.rollback);
       expect((await lstat(fixture.current)).mode & 0o200).toBe(0);
       expect((await lstat(fixture.rollback)).mode & 0o200).toBe(0);
 
@@ -480,7 +485,7 @@ describe("Production activation Fast phase matrix", () => {
         valid.noncanonical,
       ]) {
         const invalidRun = runPruneProbe(script, valid, invalidTarget);
-        expect(invalidRun.exitCode).not.toBe(0);
+        expect(invalidRun.exitCode, `${invalidTarget}\n${invalidRun.output}`).not.toBe(0);
       }
       expect(await pathExists(valid.symlink)).toBe(true);
       expect(await pathExists(valid.nested)).toBe(true);
@@ -712,9 +717,7 @@ async function createPruneHarness(): Promise<{
   await chmod(join(outside, "marker"), 0o444);
   await chmod(current, 0o555);
   await chmod(rollback, 0o555);
-  // macOS rejects renaming a non-writable directory; keep its payload immutable
-  // while allowing the cross-directory rename that the Linux deployment uses.
-  await chmod(stale, process.platform === "darwin" ? 0o755 : 0o555);
+  await chmod(stale, 0o555);
   await chmod(nested, 0o555);
   await chmod(outside, 0o555);
   await symlink(outside, symlinkPath);
@@ -731,7 +734,7 @@ exec /bin/realpath "$@"
     base,
     current,
     nested,
-    noncanonical: join(releaseRoot, "..", "releases", "current-release"),
+    noncanonical: `${releaseRoot}/../releases/current-release`,
     outside,
     releaseRoot,
     rollback,
@@ -765,6 +768,26 @@ function runPruneProbe(
   return {
     exitCode: result.exitCode,
     output: `${new TextDecoder().decode(result.stdout)}${new TextDecoder().decode(result.stderr)}`,
+  };
+}
+
+function runPruneList(script: string, fixture: Awaited<ReturnType<typeof createPruneHarness>>) {
+  const result = Bun.spawnSync({
+    cmd: ["bash", script, "--base-dir", fixture.base, "--release", releaseId],
+    env: {
+      ...process.env,
+      QBT_FOCUSED_TEST_MAINTENANCE_WRAPPER: join(fixture.root, "maintenance"),
+      QBT_FOCUSED_TEST_MODE: "1",
+      QBT_FOCUSED_TEST_PRUNE_LIST: "1",
+      QBT_FOCUSED_TEST_REALPATH: join(fixture.root, "bin", "realpath"),
+      QBT_FOCUSED_TEST_ROOT: fixture.root,
+    },
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  return {
+    exitCode: result.exitCode,
+    output: `${result.stdout.toString()}${result.stderr.toString()}`,
   };
 }
 


### PR DESCRIPTION
## Summary

- quarantine stale immutable releases with an atomic rename inside the release directory before enabling owner writes and deleting them
- exclude interrupted `.prune-*` quarantine evidence from selectable-release retention while surfacing it in deployment output
- exercise the observed Linux `0555` release condition and the subsequent retention pass for both Production and Test

This repairs the cleanup failure seen in deployment run `31906467386` after #251 landed. Production and Test deployment logic remain otherwise unchanged.

## Verification

- `bun test --isolate src/production-activation-fast.test.ts` — 3 passed, 263 assertions
- `bun run test:focused:activation` — 3 passed, 89 assertions
- `bun run check`
- Bash syntax and ShellCheck for both activation scripts
- `git diff --check`

No Qualification tests were run. Live deployment verification remains required before #251 is closed.

Issue: #251
Spec: #158
