### PR TITLE
Correct and reopen locked Event Games

### DIFF
--- a/scripts/test-technical-admin-browser.ts
+++ b/scripts/test-technical-admin-browser.ts
@@ -5,6 +5,15 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { openSqliteFoundationStorage } from "@/lib/foundation-storage-sqlite";
+import { createEventGameRecord, type ExternalScopeResolver } from "@/lib/event-game-record";
+import {
+  canonicalizeEventGameRecordRoot,
+  type EventGameRecordRoot,
+} from "@/lib/foundation-record-types";
+import type { FoundationStorageTransaction } from "@/lib/foundation-storage";
+import { createLiveEventGameIqaInterpreter } from "@/lib/live-event-game-control";
+import { createControlScopeResolver } from "@/lib/live-event-game-runtime";
+import { lockControlGrantEventGame } from "@/lib/grant-management-sessions";
 import { createGrantKeyRingDocument, writeGrantKeyRingFile } from "@/lib/grant-key-ring-custody";
 import { readGrantAuthorityOptions } from "@/lib/grant-runtime";
 import {
@@ -20,6 +29,24 @@ const databasePath = join(directory, "technical-admin.sqlite");
 const grantKeyRingPath = join(directory, "grant-key-ring.json");
 const port = 38_000 + Math.floor(Math.random() * 1_000);
 const origin = `https://localhost:${port}`;
+const baseGrantKeyRingDocument = createGrantKeyRingDocument("test");
+const grantKeyRingDocument = {
+  ...baseGrantKeyRingDocument,
+  encryption: {
+    currentVersion: "encryption-v1",
+    keys: { "encryption-v1": baseGrantKeyRingDocument.encryption.keys.v1! },
+  },
+  lookup: {
+    currentVersion: "lookup-v1",
+    keys: { "lookup-v1": baseGrantKeyRingDocument.lookup.keys.v1! },
+  },
+  audit: {
+    currentVersion: "audit-v1",
+    keys: { "audit-v1": baseGrantKeyRingDocument.audit.keys.v1! },
+  },
+};
+const currentGrantKey = (set: { currentVersion: string; keys: Record<string, string> }) =>
+  set.keys[set.currentVersion]!;
 const environment = {
   ...process.env,
   NODE_ENV: "test",
@@ -28,7 +55,11 @@ const environment = {
   WEBAUTHN_RP_ID: "localhost",
   TECHNICAL_ADMIN_DATABASE: databasePath,
   FOUNDATION_DATABASE: join(directory, "foundation.sqlite"),
+  EVENT_GAME_DATABASE: join(directory, "foundation.sqlite"),
   GRANT_KEY_RING_FILE: grantKeyRingPath,
+  EVENT_GAME_ENCRYPTION_KEY: currentGrantKey(grantKeyRingDocument.encryption),
+  EVENT_GAME_LOOKUP_KEY: currentGrantKey(grantKeyRingDocument.lookup),
+  EVENT_GAME_AUDIT_KEY: currentGrantKey(grantKeyRingDocument.audit),
   TLS_CERT_FILE: certificatePath,
   TLS_KEY_FILE: keyPath,
   PORT: String(port),
@@ -60,7 +91,7 @@ try {
   ]);
   if (certificate.exitCode !== 0)
     throw new Error("openssl could not create a temporary certificate.");
-  writeGrantKeyRingFile(grantKeyRingPath, createGrantKeyRingDocument("test"));
+  writeGrantKeyRingFile(grantKeyRingPath, grantKeyRingDocument);
 
   const grantOptions = readGrantAuthorityOptions("test", environment);
   const foundation = openSqliteFoundationStorage(join(directory, "foundation.sqlite"), {
@@ -1073,7 +1104,9 @@ try {
   await eventAdminPage.getByRole("button", { name: "Add unresolved Event Game" }).click();
   assert((await secondGameResponsePromise).status() === 201, "second Event Game creation failed");
   await eventAdminPage.getByRole("button", { name: "Refresh Slot setup" }).click();
-  await eventAdminPage.getByText("Opening", { exact: true }).waitFor();
+  await eventAdminPage
+    .getByRole("option", { name: "Opening", exact: true })
+    .waitFor({ state: "attached" });
   await eventAdminPage.getByRole("button", { name: "Published Event", exact: true }).click();
   const publicationWarning = eventAdminPage.getByText(/Published with incomplete schedule:/u);
   await publicationWarning.waitFor();
@@ -1957,7 +1990,9 @@ try {
   await eventAdminPage.getByRole("button", { name: "Add unresolved Event Game" }).click();
   assert((await thirdGameResponsePromise).status() === 201, "third Event Game creation failed");
   await eventAdminPage.getByRole("button", { name: "Refresh Slot setup" }).click();
-  await eventAdminPage.getByText("Third", { exact: true }).waitFor();
+  await eventAdminPage
+    .getByRole("option", { name: "Third", exact: true })
+    .waitFor({ state: "attached" });
   await eventAdminPage.getByRole("button", { name: "Pitch Main", exact: true }).click();
   await eventAdminPage.getByLabel("Pitch Slot 1 Expected Delay minutes").waitFor();
   const lastTargetSelector = eventAdminPage
@@ -1973,9 +2008,6 @@ try {
   assert(
     multiOccupantSwapResponse.status() === 400,
     `multi-occupant swap returned ${multiOccupantSwapResponse.status()}`,
-  );
-  const sessionCookieBeforeRefresh = (await eventAdminContext.cookies()).find(
-    (cookie) => cookie.name === "__Host-event-admin-session",
   );
   const projectionResponse = await eventAdminContext.request.get(
     `${origin}/api/event-admin/hub?eventId=${eventId}`,
@@ -2037,14 +2069,308 @@ try {
   );
   await eventAdminPage.getByLabel("Audit action filter").fill("event-created");
   assert((await eventFilterResponsePromise).status() === 200, "Event Admin filter change failed");
+
+  const lockedSlotResponse = await postJsonValueFromPage(
+    eventAdminPage,
+    `${origin}/api/event-admin/events/${eventId}/game-days/${pitchManagerGameDayId}/gameplay-slots`,
+    { sequence: 4, scheduledStart: "2026-08-15T12:00" },
+  );
+  const lockedSlotPayload = JSON.parse(lockedSlotResponse.body) as {
+    value?: { gameplaySlotId?: string };
+  };
+  const lockedGameplaySlotId = lockedSlotPayload.value?.gameplaySlotId;
+  assert(
+    lockedSlotResponse.status === 201 && lockedGameplaySlotId !== undefined,
+    "browser locked-game Gameplay Slot creation failed",
+  );
+  const lockedTeamAResponse = await postJsonValueFromPage(
+    eventAdminPage,
+    `${origin}/api/event-admin/events/${eventId}/teams`,
+    { name: "Browser Blue", defaultColor: "#112233" },
+  );
+  const lockedTeamAPayload = JSON.parse(lockedTeamAResponse.body) as {
+    value?: { eventTeamId?: string };
+  };
+  const lockedTeamAId = lockedTeamAPayload.value?.eventTeamId;
+  const lockedTeamBResponse = await postJsonValueFromPage(
+    eventAdminPage,
+    `${origin}/api/event-admin/events/${eventId}/teams`,
+    { name: "Browser Red", defaultColor: "#445566" },
+  );
+  const lockedTeamBPayload = JSON.parse(lockedTeamBResponse.body) as {
+    value?: { eventTeamId?: string };
+  };
+  const lockedTeamBId = lockedTeamBPayload.value?.eventTeamId;
+  assert(
+    lockedTeamAResponse.status === 201 &&
+      lockedTeamBResponse.status === 201 &&
+      lockedTeamAId !== undefined &&
+      lockedTeamBId !== undefined,
+    "browser locked-game Event Team creation failed",
+  );
+  const lockedSetupResponse = await eventAdminContext.request.get(
+    `${origin}/api/event-admin/slot-setup?eventId=${eventId}&gameDayId=${pitchManagerGameDayId}`,
+  );
+  const lockedSetupPayload = (await lockedSetupResponse.json()) as {
+    value?: {
+      pitchSlots?: Array<{ pitchSlotId: string; pitchId: string; gameplaySlotId: string }>;
+    };
+  };
+  const lockedPitchSlot = lockedSetupPayload.value?.pitchSlots?.find(
+    (slot) => slot.pitchId === pitchManagerPitchId && slot.gameplaySlotId === lockedGameplaySlotId,
+  );
+  assert(lockedPitchSlot !== undefined, "browser locked-game Pitch Slot was not created");
+  const lockedGameResponse = await postJsonValueFromPage(
+    eventAdminPage,
+    `${origin}/api/event-admin/events/${eventId}/game-days/${pitchManagerGameDayId}/event-games`,
+    {
+      gameplaySlotId: lockedGameplaySlotId,
+      pitchSlotId: lockedPitchSlot.pitchSlotId,
+      gameCode: "LOCKED-01",
+      gameDesignation: "Locked Opening",
+      sideA: { sourceLabel: "Blue" },
+      sideB: { sourceLabel: "Red" },
+    },
+  );
+  const lockedGamePayload = JSON.parse(lockedGameResponse.body) as {
+    value?: { eventGameId?: string };
+  };
+  const lockedEventGameId = lockedGamePayload.value?.eventGameId;
+  assert(
+    lockedGameResponse.status === 201 && lockedEventGameId !== undefined,
+    "browser locked Event Game creation failed",
+  );
+  const lockedConfirmTeamsResponse = await postJsonValueFromPage(
+    eventAdminPage,
+    `${origin}/api/event-admin/events/${eventId}/game-days/${pitchManagerGameDayId}/gameplay-slots/${lockedGameplaySlotId}/confirm-teams`,
+    {
+      games: [
+        {
+          eventGameId: lockedEventGameId,
+          sideAEventTeamId: lockedTeamAId,
+          sideBEventTeamId: lockedTeamBId,
+        },
+      ],
+    },
+  );
+  assert(
+    lockedConfirmTeamsResponse.status === 200,
+    `browser locked-game team confirmation failed: ${lockedConfirmTeamsResponse.body}`,
+  );
+  const lockedGameSides = await seedLockedBrowserGame({
+    eventId,
+    gameDayId: pitchManagerGameDayId,
+    eventGameId: lockedEventGameId,
+    pitchId: pitchManagerPitchId,
+    pitchSlotId: lockedPitchSlot.pitchSlotId,
+  });
+  const lockedControlGrantPath = `/api/event-admin/events/${eventId}/game-days/${pitchManagerGameDayId}/pitches/${pitchManagerPitchId}/pitch-slots/${lockedPitchSlot.pitchSlotId}/control-grant`;
+  const lockedControlCreate = await postJsonBodyFromPage(
+    eventAdminPage,
+    `${origin}${lockedControlGrantPath}`,
+    {},
+  );
+  assert(lockedControlCreate.status === 201, "browser locked-game Control Grant creation failed");
+  const lockedControlReveal = await postJsonBodyFromPage(
+    eventAdminPage,
+    `${origin}${lockedControlGrantPath}/reveal`,
+    {},
+  );
+  const lockedControlRevealPayload = JSON.parse(lockedControlReveal.body) as {
+    value?: { qrCredential?: string };
+  };
+  const lockedQrCredential = lockedControlRevealPayload.value?.qrCredential;
+  assert(
+    lockedControlReveal.status === 200 && lockedQrCredential !== undefined,
+    "browser locked-game QR reveal failed",
+  );
+  const lockedCodeCreate = await postJsonBodyFromPage(
+    eventAdminPage,
+    `${origin}${lockedControlGrantPath}/code`,
+    {},
+  );
+  const lockedCodePayload = JSON.parse(lockedCodeCreate.body) as { value?: { code?: string } };
+  const lockedOldCode = lockedCodePayload.value?.code;
+  assert(
+    lockedCodeCreate.status === 200 && lockedOldCode !== undefined,
+    `browser locked-game Grant Code creation failed (${lockedCodeCreate.status}): ${lockedCodeCreate.body}`,
+  );
+  const lockedControlPage = await eventAdminContext.newPage();
+  lockedControlPage.setDefaultTimeout(5_000);
+  await lockedControlPage.goto(`${origin}/event-control`);
+  const oldQrOpen = JSON.parse(
+    (
+      await postJsonBodyFromPage(lockedControlPage, `${origin}/api/event-control/open`, {
+        qrCredential: lockedQrCredential,
+        browserContext: "browser-locked-old-qr",
+      })
+    ).body,
+  ) as { session?: { sessionBearer?: string } };
+  const oldQrSessionBearer = oldQrOpen.session?.sessionBearer;
+  assert(
+    oldQrSessionBearer !== undefined,
+    `browser locked-game old QR admission failed: ${JSON.stringify(oldQrOpen)}`,
+  );
+  const oldCodeContext = await browser.newContext({ ignoreHTTPSErrors: true });
+  const oldCodePage = await oldCodeContext.newPage();
+  await oldCodePage.goto(`${origin}/event-control`);
+  const oldCodeOpen = await postJsonBodyFromPage(oldCodePage, `${origin}/api/event-control/open`, {
+    grantCode: lockedOldCode,
+    browserContext: "browser-locked-old-code",
+  });
+  assert(oldCodeOpen.status === 200, "browser locked-game old code admission failed");
+  await lockSeededBrowserGame({ eventGameId: lockedEventGameId, lockedAtMs: Date.now() });
+  const oldCodeAfterLock = await postJsonBodyFromPage(
+    oldCodePage,
+    `${origin}/api/event-control/open`,
+    {
+      grantCode: lockedOldCode,
+      browserContext: "browser-locked-old-code-after-lock",
+    },
+  );
+  assert(oldCodeAfterLock.status !== 200, "locked-game old Grant Code was revived");
+  const oldSessionAfterLock = await oldCodePage.evaluate(
+    async ({ bearer, eventGameId }) => {
+      const response = await fetch("/api/event-control/refresh", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ sessionBearer: bearer, eventGameId }),
+      });
+      return response.status;
+    },
+    { bearer: oldQrSessionBearer, eventGameId: lockedEventGameId },
+  );
+  assert(oldSessionAfterLock !== 200, "locked-game old session was revived");
+
+  const lockedDaySelector = eventAdminPage.getByLabel("Game Day", { exact: true });
+  const lockedFirstDayHub = eventAdminPage.waitForResponse(
+    (response) =>
+      response.url().includes("/api/event-admin/hub?") && response.request().method() === "GET",
+  );
+  await lockedDaySelector.selectOption({ value: firstSelectedGameDay });
+  await lockedFirstDayHub;
+  const lockedCurrentDayHub = eventAdminPage.waitForResponse(
+    (response) =>
+      response.url().includes("/api/event-admin/hub?") && response.request().method() === "GET",
+  );
+  await lockedDaySelector.selectOption({ value: pitchManagerGameDayId });
+  await lockedCurrentDayHub;
+  await eventAdminPage.locator("#locked-game-id").selectOption(lockedEventGameId);
+  await eventAdminPage.locator("#locked-operation-id").fill("browser-correction-1");
+  await eventAdminPage.locator("#locked-end-state").fill(
+    JSON.stringify({
+      scoreByGameSide: {
+        [lockedGameSides.sideAId]: 1,
+        [lockedGameSides.sideBId]: 0,
+      },
+      winnerGameSideId: lockedGameSides.sideAId,
+      flagCatchingGameSideId: null,
+      catchTimeMs: null,
+      endTimeMs: 1_000,
+      gameTimeMs: 0,
+    }),
+  );
+  const lockedCorrectionPreviewResponse = eventAdminPage.waitForResponse(
+    (response) =>
+      response.url().endsWith("/locked-correction/preview") &&
+      response.request().method() === "POST",
+  );
+  await eventAdminPage.getByRole("button", { name: "Preview Locked Game Correction" }).click();
+  assert(
+    (await lockedCorrectionPreviewResponse).status() === 200,
+    "browser locked correction preview failed",
+  );
+  await eventAdminPage.getByText(/Preview ready/u).waitFor();
+  const lockedCorrectionResponse = eventAdminPage.waitForResponse(
+    (response) =>
+      response.url().endsWith("/locked-correction") && response.request().method() === "POST",
+  );
+  await eventAdminPage.getByRole("button", { name: "Confirm Official Override" }).click();
+  const lockedCorrectionResponseValue = await lockedCorrectionResponse;
+  assert(
+    lockedCorrectionResponseValue.status() === 200,
+    `browser locked correction confirmation failed: ${await lockedCorrectionResponseValue.text()}`,
+  );
+  await eventAdminPage.locator("#locked-operation-id").fill("browser-reopen-1");
+  const lockedReopenPreviewResponse = eventAdminPage.waitForResponse(
+    (response) =>
+      response.url().endsWith("/reopen/preview") && response.request().method() === "POST",
+  );
+  await eventAdminPage.getByRole("button", { name: "Preview Game Reopening" }).click();
+  const lockedReopenPreviewResponseValue = await lockedReopenPreviewResponse;
+  assert(
+    lockedReopenPreviewResponseValue.status() === 200,
+    `browser Game Reopening preview failed: ${await lockedReopenPreviewResponseValue.text()}`,
+  );
+  await eventAdminPage.getByText(/Preview ready/u).waitFor();
+  const lockedReopenResponse = eventAdminPage.waitForResponse(
+    (response) => response.url().endsWith("/reopen") && response.request().method() === "POST",
+  );
+  await eventAdminPage.getByRole("button", { name: "Confirm Game Reopening" }).click();
+  const lockedReopenResponseValue = await lockedReopenResponse;
+  assert(
+    lockedReopenResponseValue.status() === 200,
+    `browser Game Reopening confirmation failed: ${await lockedReopenResponseValue.text()}`,
+  );
+  const freshQrOpen = await postJsonBodyFromPage(
+    lockedControlPage,
+    `${origin}/api/event-control/open`,
+    {
+      qrCredential: lockedQrCredential,
+      browserContext: "browser-locked-fresh-qr",
+    },
+  );
+  assert(freshQrOpen.status === 200, "reopened browser Game did not admit through existing QR");
+  const freshCodeCreate = await postJsonBodyFromPage(
+    eventAdminPage,
+    `${origin}${lockedControlGrantPath}/code`,
+    {},
+  );
+  const freshCodePayload = JSON.parse(freshCodeCreate.body) as { value?: { code?: string } };
+  assert(
+    freshCodeCreate.status === 200 && freshCodePayload.value?.code !== undefined,
+    "reopened browser Game did not create a fresh code",
+  );
+  const freshCodeOpen = await postJsonBodyFromPage(
+    lockedControlPage,
+    `${origin}/api/event-control/open`,
+    {
+      grantCode: freshCodePayload.value?.code ?? "",
+      browserContext: "browser-locked-fresh-code",
+    },
+  );
+  assert(freshCodeOpen.status === 200, "reopened browser Game fresh code admission failed");
+  const sessionCookieBeforeAuditRead = (await eventAdminContext.cookies()).find(
+    (cookie) => cookie.name === "__Host-event-admin-session",
+  );
+  const linkedEventAudit = await eventAdminContext.request.get(
+    `${origin}/api/event-admin/audit?eventId=${eventId}&projection=event-administration&limit=100`,
+  );
+  const linkedGrantAudit = await eventAdminContext.request.get(
+    `${origin}/api/event-admin/audit?eventId=${eventId}&projection=grant&limit=100`,
+  );
+  const linkedEventAuditText = await linkedEventAudit.text();
+  const linkedGrantAuditText = await linkedGrantAudit.text();
+  assert(
+    linkedEventAudit.status() === 200 &&
+      linkedEventAuditText.includes("locked-game-corrected") &&
+      linkedEventAuditText.includes("game-reopened") &&
+      !linkedEventAuditText.includes("beforeValue") &&
+      linkedGrantAudit.status() === 200 &&
+      linkedGrantAuditText.includes("control-action-accepted") &&
+      !linkedGrantAuditText.includes("beforeValue"),
+    "browser locked-game linked audit evidence was not redacted",
+  );
+  await oldCodeContext.close();
+  await lockedControlPage.close();
   const sessionCookieAfterRefresh = (await eventAdminContext.cookies()).find(
     (cookie) => cookie.name === "__Host-event-admin-session",
   );
   assert(
-    sessionCookieBeforeRefresh !== undefined &&
+    sessionCookieBeforeAuditRead !== undefined &&
       sessionCookieAfterRefresh !== undefined &&
-      sessionCookieAfterRefresh.expires === sessionCookieBeforeRefresh.expires &&
-      sessionCookieAfterRefresh.value === sessionCookieBeforeRefresh.value,
+      sessionCookieAfterRefresh.expires === sessionCookieBeforeAuditRead.expires &&
+      sessionCookieAfterRefresh.value === sessionCookieBeforeAuditRead.value,
     "Event Admin projection changed the rolling session cookie",
   );
   const wrongEventResponse = await fetchFromPage(
@@ -2545,6 +2871,213 @@ async function postJsonBodyFromPage(page: Page, url: string, body: Record<string
     },
     { requestUrl: url, requestBody: body },
   );
+}
+
+async function postJsonValueFromPage(page: Page, url: string, body: unknown) {
+  return page.evaluate(
+    async ({ requestUrl, requestBody }) => {
+      const response = await fetch(requestUrl, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(requestBody),
+      });
+      return { status: response.status, body: await response.text() };
+    },
+    { requestUrl: url, requestBody: body },
+  );
+}
+
+async function seedLockedBrowserGame(input: {
+  eventId: string;
+  gameDayId: string;
+  eventGameId: string;
+  pitchId: string;
+  pitchSlotId: string;
+}) {
+  const storage = openSqliteFoundationStorage(environment.FOUNDATION_DATABASE!, {
+    grantKeyRing: readGrantAuthorityOptions("test", environment).keyRing,
+  });
+  createEventGameRecord(storage, {
+    externalScopeResolver: {
+      resolve(scope, snapshot) {
+        const root = snapshot.findRootByPitchSlotId(scope.pitchSlotId);
+        return root === null
+          ? { status: "mismatch", detail: "Browser locked Event Game scope is unavailable." }
+          : { status: "resolved", scope };
+      },
+      resolveEventTeam() {
+        return { status: "resolved" };
+      },
+    },
+    interpreter: createLiveEventGameIqaInterpreter(),
+  });
+  const catalogGame = await storage.transaction((transaction) =>
+    transaction.findEventGame(input.eventGameId),
+  );
+  if (
+    catalogGame === null ||
+    catalogGame.sideA.eventTeamId === null ||
+    catalogGame.sideB.eventTeamId === null
+  )
+    throw new Error("Browser locked Event Game team confirmation was not durable.");
+  const createdAtMs = Date.now() - 60_000;
+  const root: EventGameRecordRoot = {
+    recordId: `browser-locked-record-${input.eventGameId}`,
+    eventId: input.eventId,
+    eventGameId: input.eventGameId,
+    ownership: { eventId: input.eventId, eventGameId: input.eventGameId },
+    externalScope: {
+      eventId: input.eventId,
+      gameDayId: input.gameDayId,
+      pitchId: input.pitchId,
+      pitchSlotId: input.pitchSlotId,
+    },
+    gameSides: [
+      {
+        id: catalogGame.sideA.sideId,
+        eventTeamId: catalogGame.sideA.eventTeamId,
+        teamInterpretationRef: catalogGame.sideA.eventTeamId,
+      },
+      {
+        id: catalogGame.sideB.sideId,
+        eventTeamId: catalogGame.sideB.eventTeamId,
+        teamInterpretationRef: catalogGame.sideB.eventTeamId,
+      },
+    ],
+    lifecycle: {
+      phase: "in-progress",
+      commencedAtMs: createdAtMs,
+      finishedAtMs: null,
+      lockedAtMs: null,
+      lockReason: null,
+    },
+    compatibility: {
+      recordVersion: "event-game-record-v1",
+      schemaVersion: "event-game-record-v1",
+      interpreterVersion: "live-event-iqa-v1",
+    },
+    creationEvidence: {
+      operationId: `browser-locked-create-${input.eventGameId}`,
+      actorReference: "technical-admin-browser",
+      source: "event-game-registration",
+      createdAtMs,
+    },
+  };
+  const resolver: ExternalScopeResolver = {
+    resolve(scope, snapshot) {
+      const pitchSlot = snapshot.findPitchSlot?.(scope.pitchSlotId);
+      return pitchSlot?.eventId === scope.eventId &&
+        pitchSlot.gameDayId === scope.gameDayId &&
+        pitchSlot.pitchId === scope.pitchId
+        ? { status: "resolved", scope }
+        : { status: "mismatch", detail: "Browser locked Event Game scope is unavailable." };
+    },
+    resolveEventTeam() {
+      return { status: "resolved" };
+    },
+  };
+  try {
+    const record = createEventGameRecord(storage, {
+      externalScopeResolver: resolver,
+      interpreter: createLiveEventGameIqaInterpreter(),
+      clock: () => Date.now(),
+    });
+    const registered = await record.registerRoot(root);
+    if (registered.status !== "registered")
+      throw new Error("Browser locked root registration failed.");
+    const forfeit = await record.acceptAction({
+      recordId: root.recordId,
+      eventGameId: root.eventGameId,
+      operationId: `browser-locked-forfeit-${input.eventGameId}`,
+      kind: { id: "game-fact", version: "1" },
+      payload: {
+        factId: `browser-locked-forfeit-${input.eventGameId}`,
+        factType: "forfeit",
+        gameSideId: catalogGame.sideB.sideId,
+        gameTimeMs: 0,
+        data: { resultKind: "forfeit", sportingOrder: 0 },
+      },
+      causalPredecessorIds: [],
+      occurrence: {
+        trustedAtMs: createdAtMs + 1_000,
+        clientOriginAtMs: createdAtMs + 1_000,
+        source: "online",
+      },
+      grant: { sessionId: "browser-seed", versionId: "browser-seed-v1" },
+      lifecycle: root.lifecycle,
+    });
+    if (forfeit.status !== "accepted") throw new Error("Browser locked forfeit seed failed.");
+    const finished = await record.transitionLifecycle({
+      ...root.lifecycle,
+      phase: "finished",
+      finishedAtMs: createdAtMs + 1_000,
+    });
+    if (finished.status !== "updated") throw new Error("Browser locked finish seed failed.");
+  } finally {
+    storage.close();
+  }
+  return { sideAId: catalogGame.sideA.sideId, sideBId: catalogGame.sideB.sideId };
+}
+
+async function lockSeededBrowserGame(input: { eventGameId: string; lockedAtMs: number }) {
+  const grantOptions = readGrantAuthorityOptions("test", environment);
+  const storage = openSqliteFoundationStorage(environment.FOUNDATION_DATABASE!, {
+    grantKeyRing: grantOptions.keyRing,
+    grantValidationContext: { environmentId: "test", keyRing: grantOptions.keyRing },
+  });
+  createEventGameRecord(storage, {
+    externalScopeResolver: {
+      resolve(scope) {
+        return { status: "resolved", scope };
+      },
+      resolveEventTeam() {
+        return { status: "resolved" };
+      },
+    },
+    interpreter: createLiveEventGameIqaInterpreter(),
+  });
+  const options = {
+    ...grantOptions,
+    controlScopeResolver: createControlScopeResolver(() => input.lockedAtMs, false),
+    controlGrantLifecycle: {
+      resolveEventGameLock(evidence: unknown) {
+        if (
+          typeof evidence !== "object" ||
+          evidence === null ||
+          (evidence as { kind?: unknown }).kind !== "event-game-lock" ||
+          (evidence as { eventGameId?: unknown }).eventGameId !== input.eventGameId
+        )
+          return null;
+        return {
+          eventGameId: input.eventGameId,
+          apply(transaction: FoundationStorageTransaction) {
+            const current = transaction.findRootByEventGameId(input.eventGameId);
+            if (current === null) throw new Error("Browser locked root disappeared.");
+            const lockedRoot: EventGameRecordRoot = {
+              ...current,
+              lifecycle: {
+                ...current.lifecycle,
+                lockedAtMs: input.lockedAtMs,
+                lockReason: "finished-inactivity",
+              },
+            };
+            transaction.updateRoot({
+              root: lockedRoot,
+              canonicalContent: canonicalizeEventGameRecordRoot(lockedRoot),
+            });
+          },
+        };
+      },
+    },
+  };
+  const result = await lockControlGrantEventGame(storage, options, {
+    kind: "event-game-lock",
+    eventGameId: input.eventGameId,
+    lockedAtMs: input.lockedAtMs,
+  });
+  if (result.status !== "locked")
+    throw new Error(`Browser locked Event Game transition failed: ${JSON.stringify(result)}`);
+  storage.close();
 }
 
 async function postJsonWithHeadersFromPage(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1294,6 +1294,86 @@ async function startServer() {
             );
           },
         },
+        "/api/event-admin/events/:eventId/game-days/:gameDayId/event-games/:eventGameId/locked-correction":
+          {
+            async POST(req: Request) {
+              if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
+              const authority = resolveEventAdministrationAuthority(req, technicalAdminAuth);
+              if (authority === null) return sensitiveGenericAuthFailure(401);
+              const body = await readJsonRecord(req);
+              if (body === null) return sensitiveEventAdministrationResponse(invalidEventBody());
+              const path = new URL(req.url).pathname.split("/");
+              const result = await eventAdministration.correctLockedEventGame(
+                path[4] ?? "",
+                path[8] ?? "",
+                {
+                  operationId: body.operationId,
+                  endState: body.endState,
+                  overrideConfirmed: body.overrideConfirmed,
+                  previewFingerprint: body.previewFingerprint,
+                },
+                authority,
+              );
+              await liveEventRuntime?.control.reconcileActiveControllerSessions();
+              return sensitiveEventAdministrationMutationResponse(result, authority);
+            },
+          },
+        "/api/event-admin/events/:eventId/game-days/:gameDayId/event-games/:eventGameId/locked-correction/preview":
+          {
+            async POST(req: Request) {
+              if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
+              const authority = resolveEventAdministrationAuthority(req, technicalAdminAuth);
+              if (authority === null) return sensitiveGenericAuthFailure(401);
+              const body = await readJsonRecord(req);
+              if (body === null) return sensitiveEventAdministrationResponse(invalidEventBody());
+              const path = new URL(req.url).pathname.split("/");
+              return sensitiveEventAdministrationResponse(
+                await eventAdministration.previewLockedEventGameCorrection(
+                  path[4] ?? "",
+                  path[8] ?? "",
+                  { operationId: body.operationId, endState: body.endState },
+                  authority,
+                ),
+              );
+            },
+          },
+        "/api/event-admin/events/:eventId/game-days/:gameDayId/event-games/:eventGameId/reopen": {
+          async POST(req: Request) {
+            if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
+            const authority = resolveEventAdministrationAuthority(req, technicalAdminAuth);
+            if (authority === null) return sensitiveGenericAuthFailure(401);
+            const body = await readJsonRecord(req);
+            if (body === null) return sensitiveEventAdministrationResponse(invalidEventBody());
+            const path = new URL(req.url).pathname.split("/");
+            const result = await eventAdministration.reopenEventGame(
+              path[4] ?? "",
+              path[8] ?? "",
+              { operationId: body.operationId, previewFingerprint: body.previewFingerprint },
+              authority,
+            );
+            await liveEventRuntime?.control.reconcileActiveControllerSessions();
+            return sensitiveEventAdministrationMutationResponse(result, authority);
+          },
+        },
+        "/api/event-admin/events/:eventId/game-days/:gameDayId/event-games/:eventGameId/reopen/preview":
+          {
+            async POST(req: Request) {
+              if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
+              const authority = resolveEventAdministrationAuthority(req, technicalAdminAuth);
+              if (authority === null) return sensitiveGenericAuthFailure(401);
+              const body = await readJsonRecord(req);
+              if (body === null) return sensitiveEventAdministrationResponse(invalidEventBody());
+              const path = new URL(req.url).pathname.split("/");
+              return sensitiveEventAdministrationResponse(
+                await eventAdministration.previewEventGameReopening(
+                  path[4] ?? "",
+                  path[8] ?? "",
+                  { operationId: body.operationId },
+                  authority,
+                ),
+              );
+            },
+          },
         "/api/event-admin/events/:eventId/game-days/:gameDayId/pitches/:pitchId/pitch-manager-grant":
           {
             async GET(req: Request) {

--- a/src/lib/administrative-audit.ts
+++ b/src/lib/administrative-audit.ts
@@ -495,6 +495,17 @@ function redactCatalogSnapshot(value: unknown): Record<string, unknown> | null {
     "eventTeamName",
     "sourceLabel",
     "confirmedAtMs",
+    "scoreByGameSide",
+    "winnerGameSideId",
+    "flagCatchingGameSideId",
+    "catchTimeMs",
+    "endTimeMs",
+    "lockRetained",
+    "lockRemoved",
+    "overrideApplied",
+    "phase",
+    "lockedAtMs",
+    "lockReason",
   ]);
   const result: Record<string, unknown> = {};
   for (const key of allowed) {
@@ -502,6 +513,17 @@ function redactCatalogSnapshot(value: unknown): Record<string, unknown> | null {
     const current = value[key];
     if (key === "sideA" || key === "sideB") {
       result[key] = redactCatalogSnapshot(current);
+    } else if (key === "scoreByGameSide" && isRecord(current)) {
+      const scores = Object.entries(current);
+      if (
+        scores.every(
+          ([sideId, score]) =>
+            validateOpaqueIdentifier(sideId, "gameSideId").ok &&
+            typeof score === "number" &&
+            Number.isSafeInteger(score),
+        )
+      )
+        result[key] = Object.fromEntries(scores);
     } else if (
       current === null ||
       typeof current === "string" ||

--- a/src/lib/event-administration.ts
+++ b/src/lib/event-administration.ts
@@ -62,6 +62,15 @@ import {
   type AccessSheetRequest,
   type AccessSheetIds,
 } from "@/lib/access-sheet";
+import {
+  createLockedEventGameAdministration,
+  type GameReopeningInput,
+  type GameReopeningResult,
+  type GameReopeningPreviewInput,
+  type LockedGamePreview,
+  type LockedGameCorrectionInput,
+  type LockedGameCorrectionResult,
+} from "@/lib/locked-event-game-administration";
 
 export const GENERIC_EVENT_HUB_AUTHORIZATION_FAILURE = Object.freeze({
   status: "rejected",
@@ -196,6 +205,8 @@ export type EventAdministrationOptions = {
   controlScopeResolver?: ControlGrantScopeResolver;
   /** Test-only composition seam for proving rollback after typed retirement. */
   removalFailureInjector?: () => void;
+  /** Test-only composition seam for proving locked-game audit rollback. */
+  lockedGameFailureInjector?: () => void;
   environmentId?: string;
   accessSheetRenderer?: AccessSheetRenderer;
   accessSheetIds?: AccessSheetIds;
@@ -582,6 +593,30 @@ export type EventAdministration = {
   openPitchManagerCurrentView(input: {
     authority: EventAdministrationAuthority;
   }): Promise<EventAdministrationOutcome<PitchManagerViewProjection>>;
+  correctLockedEventGame(
+    eventId: unknown,
+    eventGameId: unknown,
+    input: LockedGameCorrectionInput,
+    authority: EventAdministrationAuthority,
+  ): Promise<EventAdministrationOutcome<LockedGameCorrectionResult>>;
+  previewLockedEventGameCorrection(
+    eventId: unknown,
+    eventGameId: unknown,
+    input: LockedGameCorrectionInput,
+    authority: EventAdministrationAuthority,
+  ): Promise<EventAdministrationOutcome<LockedGamePreview>>;
+  reopenEventGame(
+    eventId: unknown,
+    eventGameId: unknown,
+    input: GameReopeningInput,
+    authority: EventAdministrationAuthority,
+  ): Promise<EventAdministrationOutcome<GameReopeningResult>>;
+  previewEventGameReopening(
+    eventId: unknown,
+    eventGameId: unknown,
+    input: GameReopeningPreviewInput,
+    authority: EventAdministrationAuthority,
+  ): Promise<EventAdministrationOutcome<LockedGamePreview>>;
 };
 
 export function createEventAdministration(
@@ -593,6 +628,13 @@ export function createEventAdministration(
     createEventCatalog(createFoundationEventCatalogStorage(options.storage), {
       clock: { nowMs },
     });
+  const lockedEventGames = createLockedEventGameAdministration({
+    storage: options.storage,
+    failureInjector: options.lockedGameFailureInjector,
+    nowMs,
+    authorize: (transaction, eventId, authority, readOnly) =>
+      authorizeEventScopeInTransaction(options, transaction, eventId, authority, readOnly),
+  });
 
   return {
     async previewEventCatalogRemoval(target, authority) {
@@ -1808,6 +1850,27 @@ export function createEventAdministration(
     async openPitchManagerCurrentView(input) {
       return openPitchManagerCurrentProjection(options, input.authority);
     },
+
+    async correctLockedEventGame(eventId, eventGameId, input, authority) {
+      return lockedEventGames.correctLockedEventGame(eventId, eventGameId, input, authority);
+    },
+
+    async previewLockedEventGameCorrection(eventId, eventGameId, input, authority) {
+      return lockedEventGames.previewLockedEventGameCorrection(
+        eventId,
+        eventGameId,
+        input,
+        authority,
+      );
+    },
+
+    async reopenEventGame(eventId, eventGameId, input, authority) {
+      return lockedEventGames.reopenEventGame(eventId, eventGameId, input, authority);
+    },
+
+    async previewEventGameReopening(eventId, eventGameId, input, authority) {
+      return lockedEventGames.previewEventGameReopening(eventId, eventGameId, input, authority);
+    },
   };
 }
 
@@ -1821,6 +1884,7 @@ function authorizeEventScopeInTransaction(
   kind: "technical-admin" | "event-admin";
   sessionId: string | null;
   sessionExpiresAtMs: number | null;
+  grantVersion: string | null;
   actorReference: string;
 } | null {
   if (isTechnicalAdminAuthority(authority))
@@ -1828,6 +1892,7 @@ function authorizeEventScopeInTransaction(
       kind: "technical-admin",
       sessionId: null,
       sessionExpiresAtMs: null,
+      grantVersion: null,
       actorReference: `technical-admin:${authority.environment}:${authority.sessionId}`,
     };
   if (
@@ -1851,6 +1916,7 @@ function authorizeEventScopeInTransaction(
     kind: "event-admin",
     sessionId: result.grantSessionId,
     sessionExpiresAtMs: result.sessionExpiresAtMs ?? null,
+    grantVersion: result.grantVersion,
     actorReference: `event-admin:${result.grantSessionId}`,
   };
 }

--- a/src/lib/event-game-action-codecs.ts
+++ b/src/lib/event-game-action-codecs.ts
@@ -596,11 +596,14 @@ export function validateStoredInput(
   const origin: ValidationResult<ControlActionOrigin | undefined> =
     value.origin === undefined
       ? valid(undefined)
-      : value.origin === "controller" || value.origin === "system-heat-stoppage"
+      : value.origin === "controller" ||
+          value.origin === "system-heat-stoppage" ||
+          value.origin === "event-admin"
         ? valid(value.origin)
         : invalid("origin is unsupported.");
   const grant =
-    value.origin === "system-heat-stoppage" && value.grant === null
+    (value.origin === "system-heat-stoppage" || value.origin === "event-admin") &&
+    value.grant === null
       ? valid(null)
       : validateGrant(value.grant);
   const lifecycle = validateLifecycle(value.lifecycle);

--- a/src/lib/event-game-actions.ts
+++ b/src/lib/event-game-actions.ts
@@ -62,7 +62,7 @@ export const SYSTEM_TIMEOUT_COMPLETION_GRANT: Readonly<{
   versionId: "system-v1",
 });
 
-export type ControlActionOrigin = "controller" | "system-heat-stoppage";
+export type ControlActionOrigin = "controller" | "system-heat-stoppage" | "event-admin";
 
 export type ControlActionLifecycleContext = {
   phase: EventGameLifecyclePhase;
@@ -169,6 +169,7 @@ export type ControlAuditLinkage = {
     operationId: string;
   } | null;
   grantAuditId?: string | null;
+  valueChange?: { before: ActionJsonValue; after: ActionJsonValue };
   acceptanceId?: string | null;
   /** Acceptance-owned candidate identity, paired independently from Grant evidence. */
   contentFingerprint?: string;
@@ -350,11 +351,14 @@ export function validateControlActionEnvelope(
   const originResult: ValidationResult<ControlActionOrigin | undefined> =
     input.origin === undefined
       ? valid(undefined)
-      : input.origin === "controller" || input.origin === "system-heat-stoppage"
+      : input.origin === "controller" ||
+          input.origin === "system-heat-stoppage" ||
+          input.origin === "event-admin"
         ? valid(input.origin)
         : invalid("origin is unsupported.");
   const grant =
-    input.origin === "system-heat-stoppage" && input.grant === null
+    (input.origin === "system-heat-stoppage" || input.origin === "event-admin") &&
+    input.grant === null
       ? valid(null)
       : validateGrant(input.grant);
   const lifecycle = validateLifecycle(input.lifecycle);
@@ -492,12 +496,15 @@ export function prepareControlAction(
   const originResult: ValidationResult<ControlActionOrigin | undefined> =
     input.origin === undefined
       ? valid(undefined)
-      : input.origin === "controller" || input.origin === "system-heat-stoppage"
+      : input.origin === "controller" ||
+          input.origin === "system-heat-stoppage" ||
+          input.origin === "event-admin"
         ? valid(input.origin)
         : invalid("origin is unsupported.");
   if (!originResult.ok) return originResult;
   const grantResult =
-    input.origin === "system-heat-stoppage" && input.grant === null
+    (input.origin === "system-heat-stoppage" || input.origin === "event-admin") &&
+    input.grant === null
       ? valid(null)
       : validateGrant(input.grant);
   if (!grantResult.ok) return grantResult;

--- a/src/lib/event-game-record-helpers.ts
+++ b/src/lib/event-game-record-helpers.ts
@@ -14,6 +14,7 @@ import {
   type ControlActionCodecRegistry,
   type ControlActionInput,
   type ControlActionInterpretation,
+  type ActionJsonValue,
   type ControlAuditEntry,
   type PreparedControlAction,
 } from "@/lib/event-game-actions";
@@ -642,6 +643,7 @@ export function createAuditEntry(
   context: {
     interpretation?: ControlActionInterpretation;
     relatedOperationIds?: readonly string[];
+    valueChange?: { before: ActionJsonValue; after: ActionJsonValue };
     collision?: {
       acceptedAction: ControlAction;
       acceptedContentFingerprint: string;
@@ -689,6 +691,9 @@ export function createAuditEntry(
       relatedOperationIds: [
         ...(context.collision !== undefined ? [] : (context.relatedOperationIds ?? [])),
       ],
+      ...(context.valueChange === undefined
+        ? {}
+        : { valueChange: structuredClone(context.valueChange) }),
       ordering: {
         trustedAtMs: (acceptedAction ?? input).occurrence.trustedAtMs,
         operationId: (acceptedAction ?? input).operationId,

--- a/src/lib/event-game-record.ts
+++ b/src/lib/event-game-record.ts
@@ -10,8 +10,10 @@ import {
   type FoundationStorage,
   type FoundationStorageSnapshot,
   type FoundationStorageTransaction,
+  type EventCatalogAuditEntry,
   type StoredControlAction,
 } from "@/lib/foundation-storage";
+import type { StoredGrantAuditEntry } from "@/lib/grant-types";
 import {
   ACCEPTED_AUDIT_DETAIL,
   acceptedAuditId,
@@ -48,6 +50,7 @@ import {
   type EffectiveGameSideAssignment,
   type IqaGameRulesInterpreter,
   sha256,
+  type PreparedControlAction,
 } from "@/lib/event-game-actions";
 import {
   canonicalizeGamePresentationChange,
@@ -163,6 +166,45 @@ export type EventGameRecordOptions = {
   actionCodecRegistry?: ControlActionCodecRegistry;
   interpreter?: IqaGameRulesInterpreter;
   auditAuthorityVerifier?: ControlAuditAuthorityVerifier;
+  actionAcceptanceGuard?: (
+    transaction: FoundationStorageTransaction,
+    root: EventGameRecordRoot,
+    input: unknown,
+  ) =>
+    | { status: "accepted" }
+    | {
+        status: "rejected";
+        reason: Extract<ControlActionAcceptanceOutcome, { status: "rejected" }>["reason"];
+        detail: string;
+      };
+  acceptedLifecycleTransition?: (input: {
+    transaction: FoundationStorageTransaction;
+    root: EventGameRecordRoot;
+    action: ControlAction;
+    audit: ControlAuditEntry;
+  }) =>
+    | {
+        status: "updated";
+        root: EventGameRecordRoot;
+        applyAfterRootUpdate?: (transaction: FoundationStorageTransaction) => void;
+        eventAudit?: EventCatalogAuditEntry;
+        eventAuditId?: string;
+        grantAudits?: readonly StoredGrantAuditEntry[];
+      }
+    | { status: "rejected"; detail: string };
+  acceptedDuplicateActionResolver?: (
+    transaction: FoundationStorageTransaction,
+    root: EventGameRecordRoot,
+    input: unknown,
+    prepared: PreparedControlAction | null,
+  ) => ControlActionAcceptanceOutcome | null;
+  acceptedActionAuditContext?: (input: { root: EventGameRecordRoot; action: ControlAction }) => {
+    linkAcceptance?: boolean;
+    valueChange?: {
+      before: import("@/lib/event-game-actions").ActionJsonValue;
+      after: import("@/lib/event-game-actions").ActionJsonValue;
+    };
+  };
 };
 
 export type RootRegistrationOutcome =
@@ -212,6 +254,7 @@ export type ControlActionAcceptanceOutcome =
       status: "accepted" | "duplicate-accepted";
       action: ControlAction;
       auditId: string;
+      eventAuditId?: string;
     }
   | {
       status: "rejected";
@@ -810,6 +853,20 @@ export function createEventGameRecord(
             } satisfies ControlActionAcceptanceOutcome;
           }
 
+          const earlyPreparation = prepareControlAction(input, root, codecRegistry, nowMs, {
+            allowConcurrentTeamAssignment: true,
+          });
+          const earlyDuplicate = options.acceptedDuplicateActionResolver?.(
+            transaction,
+            root,
+            input,
+            earlyPreparation.ok ? earlyPreparation.value : null,
+          );
+          if (earlyDuplicate !== null && earlyDuplicate !== undefined) return earlyDuplicate;
+
+          const guard = options.actionAcceptanceGuard?.(transaction, root, input);
+          if (guard?.status === "rejected") return guard;
+
           const historyReady =
             verifiedRevision === transaction.revision ||
             rebuildRecordSnapshot(root, transaction, codecRegistry, options.interpreter).status ===
@@ -988,6 +1045,60 @@ export function createEventGameRecord(
               } satisfies ControlActionAcceptanceOutcome;
             }
           }
+          const acceptedAuditContext = options.acceptedActionAuditContext?.({ root, action });
+          const audit = createAuditEntry(
+            prepared.value.input,
+            "action-accepted",
+            ACCEPTED_AUDIT_DETAIL,
+            nowMs,
+            {
+              interpretation: prepared.value.interpretation,
+              relatedOperationIds:
+                correctionTarget === null ? [] : [correctionTarget.action.operationId],
+              valueChange: acceptedAuditContext?.valueChange,
+            },
+          );
+          if (acceptedAuditContext?.linkAcceptance === true) {
+            audit.links ??= {
+              actionId: null,
+              targetFactId: null,
+              causalPredecessorIds: [],
+              relatedOperationIds: [],
+              ordering: null,
+            };
+            audit.links.acceptanceId = `accept-${audit.auditId}`;
+            audit.links.contentFingerprint = prepared.value.contentFingerprint;
+          }
+          const lifecycle = options.acceptedLifecycleTransition?.({
+            transaction,
+            root,
+            action,
+            audit,
+          });
+          if (lifecycle?.status === "rejected") {
+            return {
+              status: "rejected",
+              reason: "invalid-action",
+              detail: lifecycle.detail,
+            } satisfies ControlActionAcceptanceOutcome;
+          }
+          if (lifecycle !== undefined) {
+            const validatedRoot = validateEventGameRecordRoot(lifecycle.root);
+            if (!validatedRoot.ok) {
+              return {
+                status: "rejected",
+                reason: "invalid-action",
+                detail: validatedRoot.error,
+              } satisfies ControlActionAcceptanceOutcome;
+            }
+            if (!sameLifecycleContext(root.lifecycle, validatedRoot.value.lifecycle)) {
+              transaction.updateRoot({
+                root: validatedRoot.value,
+                canonicalContent: canonicalizeEventGameRecordRoot(validatedRoot.value),
+              });
+            }
+            lifecycle.applyAfterRootUpdate?.(transaction);
+          }
           transaction.insertAction({
             action,
             canonicalContent: prepared.value.canonicalContent,
@@ -1006,18 +1117,13 @@ export function createEventGameRecord(
             lastAcceptedAtMs,
             updatedAtMs: lastAcceptedAtMs,
           });
-          const audit = createAuditEntry(
-            prepared.value.input,
-            "action-accepted",
-            ACCEPTED_AUDIT_DETAIL,
-            nowMs,
-            {
-              interpretation: prepared.value.interpretation,
-              relatedOperationIds:
-                correctionTarget === null ? [] : [correctionTarget.action.operationId],
-            },
-          );
           transaction.appendAuditEntry(audit);
+          if (lifecycle?.eventAudit !== undefined) {
+            transaction.appendEventAudit(lifecycle.eventAudit);
+          }
+          for (const grantAudit of lifecycle?.grantAudits ?? []) {
+            transaction.appendGrantAudit(grantAudit);
+          }
           if (
             action.interpretation.type === "correction" ||
             action.interpretation.type === "team-assignment-correction"
@@ -1029,6 +1135,7 @@ export function createEventGameRecord(
             status: "accepted",
             action,
             auditId: audit.auditId,
+            eventAuditId: lifecycle?.eventAuditId,
           } satisfies ControlActionAcceptanceOutcome;
         });
         if (outcome.status === "accepted" && nextVerifiedRevision !== undefined) {

--- a/src/lib/foundation-grant-erasure-migration.test.ts
+++ b/src/lib/foundation-grant-erasure-migration.test.ts
@@ -210,7 +210,7 @@ describe("Grant cryptographic erasure migration", () => {
 
       const current = openSqliteFoundationStorage(databasePath);
       await current.applyMigrations({ requireCandidate: false });
-      expect(await current.readiness()).toMatchObject({ ok: true, schemaVersion: "31" });
+      expect(await current.readiness()).toMatchObject({ ok: true, schemaVersion: "32" });
       current.close();
 
       const raw = new Database(databasePath);
@@ -330,7 +330,7 @@ describe("Grant cryptographic erasure migration", () => {
       raw.close();
 
       const reopened = openSqliteFoundationStorage(databasePath);
-      expect(await reopened.readiness()).toMatchObject({ ok: true, schemaVersion: "31" });
+      expect(await reopened.readiness()).toMatchObject({ ok: true, schemaVersion: "32" });
       const restartedAudit = await reopened.transaction((transaction) =>
         transaction.listGrantAudit("grant-expired"),
       );

--- a/src/lib/foundation-migrations.test.ts
+++ b/src/lib/foundation-migrations.test.ts
@@ -139,6 +139,10 @@ describe("foundation migration ledger compatibility", () => {
         id: "031-heat-stoppage-audit-action",
         checksum: "f11ca907b67bb8cefb1866314513166d0b993e44fa9ccd00bb146d76798d81c8",
       },
+      {
+        id: "032-locked-event-game-administration-audit",
+        checksum: "74a854e145a707a19289ffad838d8428cd0771836f693813fd74a559ad4a4f1e",
+      },
     ]);
   });
 

--- a/src/lib/foundation-migrations.ts
+++ b/src/lib/foundation-migrations.ts
@@ -2031,6 +2031,28 @@ export const FOUNDATION_HEAT_STOPPAGE_AUDIT_ACTION_MIGRATION_SQL = `
   ${FOUNDATION_EVENT_CATALOG_AUDIT_EVENT_INDEX_SQL};
 `;
 
+/** Schema-32 adds immutable Event Admin Locked Game correction and reopening audit actions. */
+export const FOUNDATION_LOCKED_GAME_ADMINISTRATION_AUDIT_MIGRATION_SQL = `
+  CREATE TABLE foundation_event_catalog_audit_v31 AS SELECT * FROM foundation_event_catalog_audit;
+  DROP TABLE foundation_event_catalog_audit;
+  ${FOUNDATION_EVENT_CATALOG_AUDIT_TABLE_V3_SQL.replace(
+    "CREATE TABLE foundation_event_catalog_audit",
+    "CREATE TABLE foundation_event_catalog_audit_rebuilt",
+  ).replace(
+    "'event-game-teams-confirmed'",
+    "'event-game-teams-confirmed', 'event-publication-changed', 'event-catalog-entry-removed', 'access-sheet-generated', 'game-day-heat-stoppage-configured', 'locked-game-corrected', 'game-reopened'",
+  )};
+  INSERT INTO foundation_event_catalog_audit_rebuilt
+    (audit_id, operation_id, action, event_id, game_day_id, actor_reference,
+     occurred_at_ms, before_json, after_json)
+  SELECT audit_id, operation_id, action, event_id, game_day_id, actor_reference,
+         occurred_at_ms, before_json, after_json
+  FROM foundation_event_catalog_audit_v31;
+  DROP TABLE foundation_event_catalog_audit_v31;
+  ALTER TABLE foundation_event_catalog_audit_rebuilt RENAME TO foundation_event_catalog_audit;
+  ${FOUNDATION_EVENT_CATALOG_AUDIT_EVENT_INDEX_SQL};
+`;
+
 export const FOUNDATION_MIGRATIONS: readonly FoundationMigration[] = Object.freeze([
   createMigration({
     id: "001-foundation-event-game-record-roots",
@@ -2217,6 +2239,12 @@ export const FOUNDATION_MIGRATIONS: readonly FoundationMigration[] = Object.free
     ordinal: 31,
     schemaVersion: 31,
     sql: FOUNDATION_HEAT_STOPPAGE_AUDIT_ACTION_MIGRATION_SQL,
+  }),
+  createMigration({
+    id: "032-locked-event-game-administration-audit",
+    ordinal: 32,
+    schemaVersion: 32,
+    sql: FOUNDATION_LOCKED_GAME_ADMINISTRATION_AUDIT_MIGRATION_SQL,
   }),
 ]);
 

--- a/src/lib/foundation-storage-sqlite-helpers.ts
+++ b/src/lib/foundation-storage-sqlite-helpers.ts
@@ -19,6 +19,7 @@ import {
   validateTimestamp,
   validateInterpretation,
   validateStoredInput,
+  parseJsonValue,
 } from "@/lib/event-game-action-codecs";
 import {
   FoundationStorageConstraintError,
@@ -240,6 +241,8 @@ function readAuditLinks(value: unknown): ControlAuditLinkage {
     value.rejectedCandidate === undefined
       ? undefined
       : readRejectedCandidate(value.rejectedCandidate);
+  const valueChange =
+    value.valueChange === undefined ? undefined : readAuditValueChange(value.valueChange);
   return {
     actionId,
     targetFactId,
@@ -255,10 +258,21 @@ function readAuditLinks(value: unknown): ControlAuditLinkage {
     ...(value.contentFingerprint === undefined
       ? {}
       : { contentFingerprint: readFingerprint(value.contentFingerprint, "contentFingerprint") }),
+    ...(valueChange === undefined ? {} : { valueChange }),
     ...(value.reason === undefined ? {} : { reason: readNonEmptyText(value.reason, "reason") }),
     ...(rejectedCandidate === undefined ? {} : { rejectedCandidate }),
     ...(collision === undefined ? {} : { collision }),
   };
+}
+
+function readAuditValueChange(value: unknown): NonNullable<ControlAuditLinkage["valueChange"]> {
+  if (!isObject(value)) throw new Error("Stored Control Audit value change is invalid.");
+  const before = parseJsonValue(value.before, "valueChange.before");
+  const after = parseJsonValue(value.after, "valueChange.after");
+  if (!before.ok || !after.ok) {
+    throw new Error("Stored Control Audit value change is invalid.");
+  }
+  return { before: before.value, after: after.value };
 }
 
 function readRejectedCandidate(
@@ -367,7 +381,9 @@ function readAuditProvenance(value: unknown): ControlAuditProvenance {
   const origin =
     value.origin === undefined
       ? ({ ok: true, value: undefined } as const)
-      : value.origin === "controller" || value.origin === "system-heat-stoppage"
+      : value.origin === "controller" ||
+          value.origin === "system-heat-stoppage" ||
+          value.origin === "event-admin"
         ? ({ ok: true, value: value.origin } as const)
         : ({ ok: false, error: "Stored Control Audit origin is invalid." } as const);
   const lifecycle = validateLifecycle(value.lifecycle);

--- a/src/lib/foundation-storage-sqlite.test.ts
+++ b/src/lib/foundation-storage-sqlite.test.ts
@@ -10,7 +10,11 @@ import {
   type FoundationMigration,
 } from "@/lib/foundation-migrations";
 import type { EventGameRecordRoot } from "@/lib/foundation-record-types";
-import { createDeterministicTestIqaInterpreter } from "@/lib/event-game-actions";
+import type { StoredControlAuditEntry } from "@/lib/foundation-storage";
+import {
+  CONTROL_AUDIT_VERSION,
+  createDeterministicTestIqaInterpreter,
+} from "@/lib/event-game-actions";
 import { createFoundationAcceptance } from "@/lib/foundation-acceptance";
 import type { ControlActionInput } from "@/lib/event-game-actions";
 import { createEventGameRecord, type ExternalScopeResolver } from "@/lib/event-game-record";
@@ -36,6 +40,69 @@ async function withDatabase<T>(work: (databasePath: string) => Promise<T>): Prom
 }
 
 describe("SQLite foundation storage", () => {
+  test("round-trips locked correction value-change links through SQLite reopen", async () => {
+    await withDatabase(async (databasePath) => {
+      const entry: StoredControlAuditEntry = {
+        auditVersion: CONTROL_AUDIT_VERSION,
+        auditId: "audit-locked-correction",
+        recordId: "record-locked-correction",
+        eventGameId: "game-locked-correction",
+        operationId: "operation-locked-correction",
+        kind: "action-accepted",
+        outcome: "accepted",
+        createdAtMs: 42,
+        redactedDetail: "",
+        links: {
+          actionId: "action-locked-correction",
+          targetFactId: null,
+          causalPredecessorIds: [],
+          relatedOperationIds: ["operation-locked-correction"],
+          ordering: { trustedAtMs: 42, operationId: "operation-locked-correction" },
+          grantAuditId: "grant-audit-locked-correction",
+          valueChange: {
+            before: { scoreByGameSide: { "side-a": 20, "side-b": 10 }, endTimeMs: 1_000 },
+            after: { scoreByGameSide: { "side-a": 30, "side-b": 10 }, endTimeMs: 1_000 },
+          },
+        },
+        provenance: {
+          occurrence: { trustedAtMs: 42, clientOriginAtMs: 42, source: "online" },
+          grant: null,
+          origin: "event-admin",
+          lifecycle: {
+            phase: "scheduled",
+            commencedAtMs: null,
+            finishedAtMs: null,
+            lockedAtMs: null,
+            lockReason: null,
+          },
+          override: null,
+          recoveryProvenance: null,
+        },
+      };
+      const storage = openSqliteFoundationStorage(databasePath);
+      await storage.applyMigrations({ requireCandidate: false });
+      const root = createRoot(entry.recordId);
+      const record = createEventGameRecord(storage, {
+        externalScopeResolver: createScopeResolver(root),
+        interpreter: createDeterministicTestIqaInterpreter("rules-v1"),
+      });
+      expect(await record.registerRoot(root)).toMatchObject({ status: "registered" });
+      await storage.transaction((transaction) => transaction.appendAuditEntry(entry));
+      expect((await storage.readAuditEntries(entry.recordId))[0]).toMatchObject({
+        auditId: entry.auditId,
+        links: entry.links,
+      });
+      storage.close();
+
+      const reopened = openSqliteFoundationStorage(databasePath, { requireReplayContext: false });
+      expect((await reopened.readAuditEntries(entry.recordId))[0]).toMatchObject({
+        auditId: entry.auditId,
+        links: entry.links,
+      });
+      reopened.close();
+    });
+  });
+
   test("latches an after-COMMIT boundary failure without claiming readiness", async () => {
     await withDatabase(async (databasePath) => {
       let injected = true;
@@ -564,7 +631,7 @@ describe("SQLite foundation storage", () => {
       expect(await reopenedRecord.registerRoot(root)).toMatchObject({ status: "idempotent" });
       expect(await reopened.readiness()).toMatchObject({
         ok: true,
-        schemaVersion: "31",
+        schemaVersion: "32",
         evidence: { replay: { result: "passed", rootCount: 1, durationMs: expect.any(Number) } },
       });
       reopened.close();
@@ -612,21 +679,21 @@ describe("SQLite foundation storage", () => {
       const storage = openSqliteFoundationStorage(databasePath);
       const candidate = await storage.validateCandidate();
       expect(candidate.ready).toBe(true);
-      expect(candidate.readiness).toMatchObject({ ok: true, schemaVersion: "31" });
+      expect(candidate.readiness).toMatchObject({ ok: true, schemaVersion: "32" });
       expect(existsSync(candidate.candidatePath)).toBe(false);
       expect(await storage.readiness()).toMatchObject({ ok: false, status: "pending" });
 
       const migration = await storage.applyMigrations({ requireCandidate: true });
-      expect(migration.schemaVersion).toBe(31);
+      expect(migration.schemaVersion).toBe(32);
       expect(await storage.readiness()).toMatchObject({ ok: true });
       storage.close();
     });
   });
 
-  test("preserves prior Event Catalog audit rows, shape, ordering, index, and FK behavior through Access Sheet migration", async () => {
+  test("preserves prior Event Catalog audit rows, shape, ordering, index, and FK behavior through appended audit migrations", async () => {
     await withDatabase(async (databasePath) => {
       const prior = openSqliteFoundationStorage(databasePath, {
-        migrations: FOUNDATION_MIGRATIONS.slice(0, 27),
+        migrations: FOUNDATION_MIGRATIONS.slice(0, 30),
       });
       await prior.applyMigrations({ requireCandidate: false });
       prior.close();
@@ -723,20 +790,53 @@ describe("SQLite foundation storage", () => {
           JSON.stringify({ kind: "event", eventId: "event-missing-parent-is-allowed" }),
           JSON.stringify(null),
         );
+      const insertNewActions = after.query(
+        `INSERT INTO foundation_event_catalog_audit
+           (audit_id, operation_id, action, event_id, game_day_id, actor_reference,
+            occurred_at_ms, before_json, after_json)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      );
+      for (const [auditId, action] of [
+        ["audit-locked-correction", "locked-game-corrected"],
+        ["audit-game-reopened", "game-reopened"],
+      ] as const) {
+        insertNewActions.run(
+          auditId,
+          `operation-${auditId}`,
+          action,
+          "event-prior",
+          null,
+          "actor-redacted",
+          10_002,
+          JSON.stringify({ controlAuditId: `control-${auditId}` }),
+          JSON.stringify({ controlAuditId: `control-${auditId}` }),
+        );
+      }
+      const newActions = after
+        .query(
+          `SELECT action FROM foundation_event_catalog_audit
+            WHERE audit_id IN (?, ?)
+            ORDER BY audit_id`,
+        )
+        .all("audit-game-reopened", "audit-locked-correction");
       const rows = after
         .query(
           `SELECT audit_id AS auditId, action, event_id AS eventId, occurred_at_ms AS occurredAtMs
              FROM foundation_event_catalog_audit
-            WHERE event_id = ?
+            WHERE event_id = ? AND audit_id IN (?, ?)
             ORDER BY occurred_at_ms, audit_id`,
         )
-        .all("event-prior");
+        .all("event-prior", "audit-a", "audit-b");
       after.close();
 
       expect(currentColumns).toEqual(priorColumns);
       expect(currentForeignKeys).toEqual(priorForeignKeys);
       expect(currentIndexes.map((row) => row.name)).toEqual(priorIndexes.map((row) => row.name));
       expect(indexColumns).toEqual(["event_id", "occurred_at_ms", "audit_id"]);
+      expect(newActions).toEqual([
+        { action: "game-reopened" },
+        { action: "locked-game-corrected" },
+      ]);
       expect(rows).toEqual([
         {
           auditId: "audit-a",
@@ -850,15 +950,16 @@ describe("SQLite foundation storage", () => {
         "029-access-sheet-generated-audit-action",
         heatStoppageConfigurationMigration.id,
         "031-heat-stoppage-audit-action",
+        "032-locked-event-game-administration-audit",
       ]);
-      expect(await current.readiness()).toMatchObject({ ok: true, schemaVersion: "31" });
+      expect(await current.readiness()).toMatchObject({ ok: true, schemaVersion: "32" });
       current.close();
     });
   });
 
   test("adds the Access Sheet audit action while preserving prior audit rows and shape", async () => {
     await withDatabase(async (databasePath) => {
-      const priorMigrations = FOUNDATION_MIGRATIONS.slice(0, -3);
+      const priorMigrations = FOUNDATION_MIGRATIONS.slice(0, -4);
       const prior = openSqliteFoundationStorage(databasePath, { migrations: priorMigrations });
       await prior.applyMigrations({ requireCandidate: false });
       prior.close();
@@ -891,7 +992,7 @@ describe("SQLite foundation storage", () => {
       database.close();
 
       const current = openSqliteFoundationStorage(databasePath, {
-        migrations: FOUNDATION_MIGRATIONS.slice(0, -2),
+        migrations: FOUNDATION_MIGRATIONS.slice(0, -3),
       });
       expect(await current.applyMigrations({ requireCandidate: false })).toMatchObject({
         appliedMigrationIds: ["029-access-sheet-generated-audit-action"],
@@ -980,7 +1081,7 @@ describe("SQLite foundation storage", () => {
       });
       expect(await priorBinary.readiness()).toMatchObject({
         ok: true,
-        schemaVersion: "31",
+        schemaVersion: "32",
       });
       priorBinary.close();
 
@@ -1052,7 +1153,7 @@ describe("SQLite foundation storage", () => {
         .query(
           "INSERT INTO foundation_migration_ledger (migration_id, ordinal, schema_version, checksum, status, applied_at_ms) VALUES (?, ?, ?, ?, ?, ?)",
         )
-        .run("future-999", 32, 32, "future-checksum", "complete", 2_000);
+        .run("future-999", 33, 33, "future-checksum", "complete", 2_000);
       futureDatabase.close();
       const future = openSqliteFoundationStorage(databasePath);
       expect(await future.readiness()).toMatchObject({ ok: false });

--- a/src/lib/foundation-storage.ts
+++ b/src/lib/foundation-storage.ts
@@ -248,7 +248,9 @@ export type EventCatalogAuditEntry = {
     | "event-game-teams-confirmed"
     | "event-publication-changed"
     | "event-catalog-entry-removed"
-    | "access-sheet-generated";
+    | "access-sheet-generated"
+    | "locked-game-corrected"
+    | "game-reopened";
   eventId: string;
   gameDayId: string | null;
   actorReference: string;

--- a/src/lib/grant-management-code.ts
+++ b/src/lib/grant-management-code.ts
@@ -83,7 +83,7 @@ export async function createGrantCode(
       )
         return unauthorizedGrant();
       if (grant.status !== "active") return unauthorizedGrant();
-      if (!hasCurrentAdmissionEligibility(options, grant))
+      if (!hasCurrentAdmissionEligibility(options, grant, transaction))
         return {
           status: "rejected",
           reason: "invalid-state",

--- a/src/lib/heat-stoppage-configuration.test.ts
+++ b/src/lib/heat-stoppage-configuration.test.ts
@@ -193,7 +193,7 @@ describe("Heat Stoppage Configuration SQLite persistence", () => {
     const directory = await mkdtemp(join(tmpdir(), "quadball-timer-heat-config-"));
     const databasePath = join(directory, "foundation.sqlite");
     const before = openSqliteFoundationStorage(databasePath, {
-      migrations: FOUNDATION_MIGRATIONS.slice(0, -2) as readonly FoundationMigration[],
+      migrations: FOUNDATION_MIGRATIONS.slice(0, -3) as readonly FoundationMigration[],
     });
     await before.applyMigrations();
     before.close();
@@ -220,6 +220,7 @@ describe("Heat Stoppage Configuration SQLite persistence", () => {
       expect(migration.appliedMigrationIds).toEqual([
         "030-heat-stoppage-configuration",
         "031-heat-stoppage-audit-action",
+        "032-locked-event-game-administration-audit",
       ]);
       await storage.transaction((transaction) => {
         expect(transaction.listGameDays("legacy-event")).toMatchObject([

--- a/src/lib/live-event-game-control.ts
+++ b/src/lib/live-event-game-control.ts
@@ -309,6 +309,70 @@ export function projectLiveEventGameDerivedState(
   return rebuildLiveDerivedState(root, storedActions);
 }
 
+export type LockedGameEndStateRuleInput = {
+  scoreByGameSide: Readonly<Record<string, number>>;
+  winnerGameSideId: string | null;
+  flagCatchingGameSideId: string | null;
+  catchTimeMs: number | null;
+  endTimeMs: number | null;
+};
+
+/**
+ * Validate an externally reconciled end state against the same durable Game Side and scoring
+ * relationships used by the live projection. Event administration calls this seam instead of
+ * maintaining a second end-state heuristic.
+ */
+export function validateLockedGameEndStateAgainstRules(
+  root: EventGameRecordRoot,
+  state: LockedGameEndStateRuleInput,
+): { status: "accepted" } | { status: "rejected"; detail: string } {
+  const sideIds = root.gameSides.map((side) => side.id);
+  const suppliedSideIds = Object.keys(state.scoreByGameSide);
+  if (
+    suppliedSideIds.length !== sideIds.length ||
+    sideIds.some((sideId) => !Object.hasOwn(state.scoreByGameSide, sideId))
+  ) {
+    return { status: "rejected", detail: "The corrected scores must name every Game Side." };
+  }
+  if (
+    Object.values(state.scoreByGameSide).some(
+      (score) =>
+        !Number.isSafeInteger(score) ||
+        score < 0 ||
+        score > SHARED_LIMITS.score.max ||
+        score % 10 !== 0,
+    )
+  ) {
+    return { status: "rejected", detail: "The corrected scores do not follow IQA scoring rules." };
+  }
+  if (state.winnerGameSideId !== null && !sideIds.includes(state.winnerGameSideId)) {
+    return { status: "rejected", detail: "The corrected winner is not a Game Side." };
+  }
+  if (state.flagCatchingGameSideId !== null && !sideIds.includes(state.flagCatchingGameSideId)) {
+    return { status: "rejected", detail: "The corrected catcher is not a Game Side." };
+  }
+  if (
+    (state.flagCatchingGameSideId === null) !== (state.catchTimeMs === null) ||
+    (state.catchTimeMs !== null && state.endTimeMs !== null && state.catchTimeMs > state.endTimeMs)
+  ) {
+    return { status: "rejected", detail: "The corrected catch and end times are inconsistent." };
+  }
+  if (state.endTimeMs === null && state.winnerGameSideId !== null) {
+    return { status: "rejected", detail: "An unfinished result cannot declare a winner." };
+  }
+  if (state.winnerGameSideId !== null) {
+    const winningScore = state.scoreByGameSide[state.winnerGameSideId];
+    const highestScore = Math.max(...Object.values(state.scoreByGameSide));
+    if (
+      winningScore !== highestScore ||
+      Object.values(state.scoreByGameSide).filter((score) => score === highestScore).length !== 1
+    ) {
+      return { status: "rejected", detail: "The corrected winner does not match the result." };
+    }
+  }
+  return { status: "accepted" };
+}
+
 export type LiveTimeoutState = {
   status: "inactive" | "stoppage" | "started" | "completed";
   factId: string | null;
@@ -3153,10 +3217,15 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
       if (derived === null) return null;
       const configuredHeatMode = await readConfiguredHeatMode(root, derived.gameFacts);
       const projectedClock = projectClockBaseline(derived.clock.baseline, clock());
-      const projectedFacts = derived.gameFacts.map((fact) => ({
-        ...fact,
-        data: structuredClone(fact.data),
-      }));
+      const projectedFacts = derived.gameFacts
+        .filter(
+          (fact) =>
+            fact.factType !== "locked-game-correction" && fact.factType !== "game-reopening",
+        )
+        .map((fact) => ({
+          ...fact,
+          data: structuredClone(fact.data),
+        }));
       const projectedHeat = deriveHeatStoppageState(
         derived.gameFacts,
         projectedClock.gameTimeMs,
@@ -3686,6 +3755,47 @@ function sameNumberRecord(
   );
 }
 
+function readLockedGameCorrectionData(value: unknown): {
+  scoreByGameSide: Readonly<Record<string, number>>;
+  winnerGameSideId: string | null;
+  flagCatchingGameSideId: string | null;
+  catchTimeMs: number | null;
+  endTimeMs: number | null;
+} | null {
+  if (!isRecord(value) || !isRecord(value.correction)) return null;
+  const correction = value.correction;
+  if (!isRecord(correction) || !isRecord(correction.scoreByGameSide)) return null;
+  const scores: Record<string, number> = {};
+  for (const [sideId, score] of Object.entries(correction.scoreByGameSide)) {
+    if (typeof score !== "number" || !Number.isFinite(score)) return null;
+    scores[sideId] = score;
+  }
+  const nullableString = (candidate: unknown): string | null | undefined =>
+    candidate === null || typeof candidate === "string" ? candidate : undefined;
+  const nullableNumber = (candidate: unknown): number | null | undefined =>
+    candidate === null || (typeof candidate === "number" && Number.isFinite(candidate))
+      ? candidate
+      : undefined;
+  const winnerGameSideId = nullableString(correction.winnerGameSideId);
+  const flagCatchingGameSideId = nullableString(correction.flagCatchingGameSideId);
+  const catchTimeMs = nullableNumber(correction.catchTimeMs);
+  const endTimeMs = nullableNumber(correction.endTimeMs);
+  if (
+    winnerGameSideId === undefined ||
+    flagCatchingGameSideId === undefined ||
+    catchTimeMs === undefined ||
+    endTimeMs === undefined
+  )
+    return null;
+  return {
+    scoreByGameSide: scores,
+    winnerGameSideId,
+    flagCatchingGameSideId,
+    catchTimeMs,
+    endTimeMs,
+  };
+}
+
 function deriveLiveEventGameState(
   root: EventGameRecordRoot,
   canonicalActions: readonly { action: import("@/lib/event-game-actions").ControlAction }[],
@@ -3942,6 +4052,45 @@ function deriveLiveEventGameState(
   if (suspension.status === "suspended" && clock.running) {
     throw new Error("Effective suspension cannot coexist with a running Game Clock.");
   }
+  const lockedCorrectionFact = [...orderedEffectiveFacts]
+    .reverse()
+    .find((fact) => fact.factType === "locked-game-correction");
+  if (lockedCorrectionFact !== undefined) {
+    const correction = readLockedGameCorrectionData(lockedCorrectionFact.data);
+    if (correction !== null) {
+      for (const sideId of sideIds)
+        scoreByGameSide[sideId] = correction.scoreByGameSide[sideId] ?? 0;
+      winnerGameSideId = correction.winnerGameSideId;
+      winnerFactId = correction.winnerGameSideId === null ? null : lockedCorrectionFact.factId;
+      goalCount = Object.values(scoreByGameSide).reduce(
+        (total, score) => total + Math.floor(score / 10),
+        0,
+      );
+      const nonCatchingGameSideId =
+        correction.flagCatchingGameSideId === null
+          ? null
+          : (sideIds.find((sideId) => sideId !== correction.flagCatchingGameSideId) ?? null);
+      catchState =
+        correction.flagCatchingGameSideId === null || nonCatchingGameSideId === null
+          ? null
+          : {
+              factId: lockedCorrectionFact.factId,
+              catchingGameSideId: correction.flagCatchingGameSideId,
+              nonCatchingGameSideId,
+              gameTimeMs: correction.catchTimeMs ?? lockedCorrectionFact.gameTimeMs ?? 0,
+              targetScore: null,
+            };
+      if (correction.endTimeMs !== null) {
+        resultFact = {
+          ...lockedCorrectionFact,
+          data: {
+            winnerGameSideId: correction.winnerGameSideId,
+            endTimeMs: correction.endTimeMs,
+          },
+        };
+      }
+    }
+  }
   const stoppage: LiveStoppageState =
     suspension.status === "suspended"
       ? { status: "suspension", factId: suspension.factId }
@@ -3960,6 +4109,12 @@ function deriveLiveEventGameState(
             },
           ),
         };
+  const publicGameFacts = gameFacts.flatMap((fact) => {
+    if (fact.factType === "game-reopening") return [];
+    if (fact.factType !== "locked-game-correction") return [fact];
+    if (resultFact === null || resultFact.factId !== fact.factId) return [];
+    return [{ ...resultFact, factType: "result", data: resultFact.data }];
+  });
   const effectiveResult = result !== null || winnerGameSideId !== null;
   const effectiveSuspension = suspension.status === "suspended";
   const phase = effectiveResult
@@ -3983,7 +4138,7 @@ function deriveLiveEventGameState(
     overtimeTarget,
     winnerGameSideId,
     catch: catchState,
-    gameFacts,
+    gameFacts: publicGameFacts,
     penalties: deriveLivePenaltyProjection(gameFacts, clock.gameTimeMs),
     clock,
   };

--- a/src/lib/locked-event-game-administration.test.ts
+++ b/src/lib/locked-event-game-administration.test.ts
@@ -1,0 +1,1356 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createFoundationAcceptance } from "@/lib/foundation-acceptance";
+import { createEventAdministration } from "@/lib/event-administration";
+import { createEventCatalog, createFoundationEventCatalogStorage } from "@/lib/event-catalog";
+import { createEventGameRecord } from "@/lib/event-game-record";
+import {
+  canonicalizeEventGameRecordRoot,
+  validateEventGameRecordRoot,
+  type EventGameRecordRoot,
+} from "@/lib/foundation-record-types";
+import { createInMemoryFoundationStorage } from "@/lib/foundation-storage-memory";
+import type { FoundationStorage } from "@/lib/foundation-storage";
+import { openSqliteFoundationStorage } from "@/lib/foundation-storage-sqlite";
+import { createGrantAuthorityVerifier } from "@/lib/grant-authority";
+import type { GrantAuthorityOptions } from "@/lib/grant-authority";
+import { createTypedGrantAuthority } from "@/lib/grant-management";
+import {
+  createLiveEventGameIqaInterpreter,
+  createLiveEventGameControl,
+  EVENT_GAME_LOCK_DELAY_MS,
+  projectLiveEventGameDerivedState,
+  validateLiveEventGameActionInTransaction,
+} from "@/lib/live-event-game-control";
+import type { GrantKeyRing } from "@/lib/grant-types";
+import {
+  MemoryTechnicalAdminAuthRepository,
+  createTechnicalAdminAuth,
+  isTechnicalAdminAuthority,
+} from "@/lib/technical-admin-auth";
+
+const keyRing: GrantKeyRing = {
+  encryption: { currentVersion: "v1", keys: new Map([["v1", bytes(32)]]) },
+  lookup: { currentVersion: "v1", keys: new Map([["v1", bytes(32)]]) },
+  audit: { currentVersion: "v1", keys: new Map([["v1", bytes(32)]]) },
+};
+
+describe("locked Event Game administration", () => {
+  test("preserves locked correction value-change links in memory and SQLite after reopen", async () => {
+    const memoryFixture = await createFixture();
+    const memoryResult = await memoryFixture.administration.correctLockedEventGame(
+      memoryFixture.eventId,
+      memoryFixture.eventGameId,
+      {
+        operationId: "locked-correction-audit-parity",
+        endState: { scoreByGameSide: { "side-a": 30, "side-b": 20 } },
+      },
+      memoryFixture.technical,
+    );
+    expect(memoryResult).toMatchObject({ status: "accepted" });
+    const memoryAudit = await memoryFixture.storage.transaction((transaction) =>
+      transaction.listAuditEntries(memoryFixture.recordId),
+    );
+
+    const directory = await mkdtemp(join(tmpdir(), "quadball-locked-audit-parity-"));
+    const databasePath = join(directory, "foundation.sqlite");
+    const sqliteStorage = openSqliteFoundationStorage(databasePath, {
+      grantKeyRing: keyRing,
+      grantValidationContext: { environmentId: "test", keyRing },
+    });
+    try {
+      await sqliteStorage.applyMigrations({ requireCandidate: false });
+      const sqliteFixture = await createFixture(sqliteStorage);
+      const sqliteResult = await sqliteFixture.administration.correctLockedEventGame(
+        sqliteFixture.eventId,
+        sqliteFixture.eventGameId,
+        {
+          operationId: "locked-correction-audit-parity",
+          endState: { scoreByGameSide: { "side-a": 30, "side-b": 20 } },
+        },
+        sqliteFixture.technical,
+      );
+      expect(sqliteResult).toMatchObject({ status: "accepted" });
+      const sqliteAudit = await sqliteStorage.transaction((transaction) =>
+        transaction.listAuditEntries(sqliteFixture.recordId),
+      );
+      const memoryLinks = memoryAudit.find(
+        (audit) => audit.operationId === "locked-correction-audit-parity",
+      )?.links;
+      const sqliteLinks = sqliteAudit.find(
+        (audit) => audit.operationId === "locked-correction-audit-parity",
+      )?.links;
+      expect(sqliteLinks).toMatchObject({
+        actionId: memoryLinks?.actionId,
+        valueChange: memoryLinks?.valueChange,
+      });
+
+      sqliteStorage.close();
+      const reopened = openSqliteFoundationStorage(databasePath, {
+        requireReplayContext: false,
+        grantKeyRing: keyRing,
+      });
+      try {
+        const reopenedAudit = await reopened.readAuditEntries(sqliteFixture.recordId);
+        expect(
+          reopenedAudit.find((audit) => audit.operationId === "locked-correction-audit-parity")
+            ?.links,
+        ).toMatchObject({
+          actionId: memoryLinks?.actionId,
+          valueChange: memoryLinks?.valueChange,
+        });
+      } finally {
+        reopened.close();
+      }
+    } finally {
+      try {
+        sqliteStorage.close();
+      } catch {
+        // The SQLite storage is already closed after the reopen transition.
+      }
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("previews bounded correction and reopening impact before requiring confirmation", async () => {
+    const fixture = await createFixture();
+    const correctionInput = {
+      operationId: "preview-correction",
+      endState: { scoreByGameSide: { "side-a": 30, "side-b": 20 } },
+    };
+    const correctionPreview = await fixture.administration.previewLockedEventGameCorrection(
+      fixture.eventId,
+      fixture.eventGameId,
+      correctionInput,
+      fixture.technical,
+    );
+    expect(correctionPreview).toMatchObject({
+      status: "accepted",
+      value: {
+        operation: "locked-game-correction",
+        eventGameId: fixture.eventGameId,
+        impact: {
+          facts: "corrected",
+          lifecycle: { lock: "retained" },
+          authority: { controlGrant: "preserved" },
+          queuedDiscard: { category: "locked-replay", count: 0 },
+        },
+      },
+    });
+    if (correctionPreview.status !== "accepted") throw new Error("Expected correction preview.");
+    expect(JSON.stringify(correctionPreview.value)).not.toContain(fixture.oldQrCredential);
+    expect(JSON.stringify(correctionPreview.value)).not.toContain(fixture.oldGrantCode);
+    expect(
+      await fixture.rawAdministration.correctLockedEventGame(
+        fixture.eventId,
+        fixture.eventGameId,
+        correctionInput,
+        fixture.technical,
+      ),
+    ).toMatchObject({ status: "rejected", reason: "invalid-input" });
+    const acceptedCorrection = await fixture.rawAdministration.correctLockedEventGame(
+      fixture.eventId,
+      fixture.eventGameId,
+      { ...correctionInput, previewFingerprint: correctionPreview.value.fingerprint },
+      fixture.technical,
+    );
+    expect(acceptedCorrection).toMatchObject({ status: "accepted" });
+
+    const reopenPreview = await fixture.administration.previewEventGameReopening(
+      fixture.eventId,
+      fixture.eventGameId,
+      { operationId: "preview-reopen" },
+      fixture.technical,
+    );
+    expect(reopenPreview).toMatchObject({
+      status: "accepted",
+      value: {
+        operation: "game-reopening",
+        impact: {
+          facts: "preserved",
+          lifecycle: { lock: "removed" },
+          timer: "restarted",
+          authority: { controlGrant: "preserved" },
+        },
+      },
+    });
+  });
+
+  test("applies an authorized locked correction atomically and retains Game Lock", async () => {
+    const fixture = await createFixture();
+    const result = await fixture.administration.correctLockedEventGame(
+      fixture.eventId,
+      fixture.eventGameId,
+      {
+        operationId: "locked-correction-1",
+        endState: {
+          scoreByGameSide: { "side-a": 30, "side-b": 20 },
+          winnerGameSideId: "side-a",
+          flagCatchingGameSideId: "side-a",
+          catchTimeMs: 1_500,
+          endTimeMs: 2_000,
+        },
+      },
+      fixture.technical,
+    );
+
+    expect(result).toMatchObject({
+      status: "accepted",
+      value: {
+        eventGameId: fixture.eventGameId,
+        lockRetained: true,
+        overrideApplied: false,
+        after: {
+          scoreByGameSide: { "side-a": 30, "side-b": 20 },
+          winnerGameSideId: "side-a",
+        },
+      },
+    });
+
+    const state = await fixture.storage.transaction((transaction) => ({
+      root: transaction.findRootByEventGameId(fixture.eventGameId),
+      actions: transaction.listActions(fixture.recordId),
+      controlAudit: transaction.listAuditEntries(fixture.recordId),
+      eventAudit: transaction.listEventAuditTrail(fixture.eventId),
+    }));
+    expect(state.root?.lifecycle).toMatchObject({
+      phase: "finished",
+      lockedAtMs: 3_000,
+      lockReason: "finished-inactivity",
+    });
+    expect(state.actions).toHaveLength(1);
+    expect(state.actions[0]?.action.origin).toBe("event-admin");
+    expect(state.controlAudit).toHaveLength(1);
+    expect(state.eventAudit).toEqual(
+      expect.arrayContaining([expect.objectContaining({ action: "locked-game-corrected" })]),
+    );
+    const duplicate = await fixture.administration.correctLockedEventGame(
+      fixture.eventId,
+      fixture.eventGameId,
+      {
+        operationId: "locked-correction-1",
+        endState: { scoreByGameSide: { "side-a": 31 } },
+      },
+      fixture.technical,
+    );
+    expect(duplicate).toMatchObject({ status: "rejected", reason: "invalid-input" });
+    const projection = projectLiveEventGameDerivedState(
+      state.root!,
+      state.actions.map((stored) => ({
+        action: stored.action,
+        canonicalContent: stored.canonicalContent,
+        contentFingerprint: stored.contentFingerprint,
+      })),
+    );
+    expect(projection).toMatchObject({
+      scoreByGameSide: { "side-a": 30, "side-b": 20 },
+      winnerGameSideId: "side-a",
+      catch: { catchingGameSideId: "side-a", gameTimeMs: 1_500 },
+      result: { data: { endTimeMs: 2_000 } },
+    });
+    if (projection === null) throw new Error("Expected a public Event Game projection.");
+    expect(projection.gameFacts).toEqual(
+      expect.arrayContaining([expect.objectContaining({ factType: "result" })]),
+    );
+    expect(projection.gameFacts).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ factType: "locked-game-correction" })]),
+    );
+    expect(JSON.stringify(projection)).not.toContain("locked-game-correction");
+  });
+
+  test("requires one confirmation for an inconsistent correction and records Official Override", async () => {
+    const fixture = await createFixture();
+    const input = {
+      operationId: "locked-correction-inconsistent",
+      endState: { scoreByGameSide: { "side-a": 25, "side-b": 20 } },
+    };
+    expect(
+      await fixture.administration.correctLockedEventGame(
+        fixture.eventId,
+        fixture.eventGameId,
+        input,
+        fixture.technical,
+      ),
+    ).toMatchObject({ status: "rejected", reason: "invalid-input" });
+    const result = await fixture.administration.correctLockedEventGame(
+      fixture.eventId,
+      fixture.eventGameId,
+      { ...input, overrideConfirmed: true },
+      fixture.technical,
+    );
+    expect(result).toMatchObject({ status: "accepted", value: { overrideApplied: true } });
+    const action = await fixture.storage.transaction((transaction) =>
+      transaction.listActions(fixture.recordId),
+    );
+    expect(action[0]?.action.override).toMatchObject({
+      guardrail: "locked-game-end-state-consistency",
+      confirmation: "event-admin-confirmed",
+    });
+  });
+
+  test("uses canonical result relationships for the single override confirmation", async () => {
+    const fixture = await createFixture();
+    const input = {
+      operationId: "locked-correction-result-relationship",
+      endState: {
+        scoreByGameSide: { "side-a": 30, "side-b": 20 },
+        winnerGameSideId: "side-b",
+        flagCatchingGameSideId: "side-a",
+        catchTimeMs: 2_500,
+        endTimeMs: 2_000,
+      },
+    };
+    expect(
+      await fixture.administration.correctLockedEventGame(
+        fixture.eventId,
+        fixture.eventGameId,
+        input,
+        fixture.technical,
+      ),
+    ).toMatchObject({ status: "rejected", reason: "invalid-input" });
+    expect(
+      await fixture.administration.correctLockedEventGame(
+        fixture.eventId,
+        fixture.eventGameId,
+        { ...input, overrideConfirmed: true },
+        fixture.technical,
+      ),
+    ).toMatchObject({ status: "accepted", value: { overrideApplied: true } });
+  });
+
+  test("rejects a stale concurrent correction without overwriting the accepted one", async () => {
+    const fixture = await createFixture();
+    const results = await Promise.all([
+      fixture.administration.correctLockedEventGame(
+        fixture.eventId,
+        fixture.eventGameId,
+        { operationId: "concurrent-correction-a", endState: { scoreByGameSide: { "side-a": 30 } } },
+        fixture.technical,
+      ),
+      fixture.administration.correctLockedEventGame(
+        fixture.eventId,
+        fixture.eventGameId,
+        { operationId: "concurrent-correction-b", endState: { scoreByGameSide: { "side-a": 40 } } },
+        fixture.technical,
+      ),
+    ]);
+    expect(results.filter((result) => result.status === "accepted")).toHaveLength(1);
+    expect(results.filter((result) => result.status === "rejected")).toHaveLength(1);
+    const actions = await fixture.storage.transaction((transaction) =>
+      transaction.listActions(fixture.recordId),
+    );
+    expect(actions).toHaveLength(1);
+  });
+
+  test("rejects an acceptance submitted with a stale preview fingerprint", async () => {
+    const fixture = await createFixture();
+    const preview = await fixture.rawAdministration.previewLockedEventGameCorrection(
+      fixture.eventId,
+      fixture.eventGameId,
+      { operationId: "stale-preview", endState: { scoreByGameSide: { "side-a": 30 } } },
+      fixture.technical,
+    );
+    if (preview.status !== "accepted") throw new Error("Expected stale preview.");
+    expect(
+      await fixture.administration.correctLockedEventGame(
+        fixture.eventId,
+        fixture.eventGameId,
+        { operationId: "fresh-correction", endState: { scoreByGameSide: { "side-a": 40 } } },
+        fixture.technical,
+      ),
+    ).toMatchObject({ status: "accepted" });
+    expect(
+      await fixture.rawAdministration.correctLockedEventGame(
+        fixture.eventId,
+        fixture.eventGameId,
+        {
+          operationId: "stale-preview",
+          endState: { scoreByGameSide: { "side-a": 30 } },
+          previewFingerprint: preview.value.fingerprint,
+        },
+        fixture.technical,
+      ),
+    ).toMatchObject({ status: "rejected", reason: "invalid-input" });
+  });
+
+  test("reopens a locked game without changing facts", async () => {
+    const fixture = await createFixture();
+    const correction = await fixture.administration.correctLockedEventGame(
+      fixture.eventId,
+      fixture.eventGameId,
+      {
+        operationId: "locked-correction-before-reopen",
+        endState: { scoreByGameSide: { "side-a": 30, "side-b": 20 } },
+      },
+      fixture.technical,
+    );
+    expect(correction.status).toBe("accepted");
+    const result = await fixture.administration.reopenEventGame(
+      fixture.eventId,
+      fixture.eventGameId,
+      { operationId: "reopen-1" },
+      fixture.technical,
+    );
+    expect(result).toMatchObject({
+      status: "accepted",
+      value: {
+        eventGameId: fixture.eventGameId,
+        lockRemoved: true,
+        lifecycle: { lockedAtMs: null },
+      },
+    });
+    const state = await fixture.storage.transaction((transaction) => ({
+      root: transaction.findRootByEventGameId(fixture.eventGameId),
+      actions: transaction.listActions(fixture.recordId),
+      audit: transaction.listEventAuditTrail(fixture.eventId),
+    }));
+    expect(state.root?.lifecycle).toMatchObject({
+      phase: "finished",
+      lockedAtMs: null,
+      lockReason: null,
+    });
+    expect(state.actions).toHaveLength(2);
+    expect(state.audit).toEqual(
+      expect.arrayContaining([expect.objectContaining({ action: "game-reopened" })]),
+    );
+  });
+
+  test("reopening is idempotent for sequential and concurrent identical retries", async () => {
+    const fixture = await createFixture();
+    const preview = await fixture.rawAdministration.previewEventGameReopening(
+      fixture.eventId,
+      fixture.eventGameId,
+      { operationId: "reopen-idempotent" },
+      fixture.technical,
+    );
+    if (preview.status !== "accepted") throw new Error("Expected reopening preview.");
+    const input = {
+      operationId: "reopen-idempotent",
+      previewFingerprint: preview.value.fingerprint,
+    };
+    const first = await fixture.rawAdministration.reopenEventGame(
+      fixture.eventId,
+      fixture.eventGameId,
+      input,
+      fixture.technical,
+    );
+    const firstState = await fixture.storage.transaction((transaction) => ({
+      root: transaction.findRootByEventGameId(fixture.eventGameId),
+      action: transaction.findActionByOperationId(fixture.recordId, "reopen-idempotent"),
+    }));
+    expect(firstState.root?.lifecycle.lockedAtMs).toBe(null);
+    expect(firstState.action?.action.interpretation).toMatchObject({
+      type: "fact",
+      factType: "game-reopening",
+    });
+    const retry = await fixture.rawAdministration.reopenEventGame(
+      fixture.eventId,
+      fixture.eventGameId,
+      input,
+      fixture.technical,
+    );
+    expect(first).toMatchObject({ status: "accepted" });
+    expect(retry).toEqual(first);
+
+    const concurrentFixture = await createFixture();
+    const concurrentPreview = await concurrentFixture.rawAdministration.previewEventGameReopening(
+      concurrentFixture.eventId,
+      concurrentFixture.eventGameId,
+      { operationId: "reopen-concurrent-idempotent" },
+      concurrentFixture.technical,
+    );
+    if (concurrentPreview.status !== "accepted") throw new Error("Expected concurrent preview.");
+    const concurrentInput = {
+      operationId: "reopen-concurrent-idempotent",
+      previewFingerprint: concurrentPreview.value.fingerprint,
+    };
+    const concurrent = await Promise.all([
+      concurrentFixture.rawAdministration.reopenEventGame(
+        concurrentFixture.eventId,
+        concurrentFixture.eventGameId,
+        concurrentInput,
+        concurrentFixture.technical,
+      ),
+      concurrentFixture.rawAdministration.reopenEventGame(
+        concurrentFixture.eventId,
+        concurrentFixture.eventGameId,
+        concurrentInput,
+        concurrentFixture.technical,
+      ),
+    ]);
+    expect(concurrent[0]).toEqual(concurrent[1]);
+    const state = await concurrentFixture.storage.transaction((transaction) => ({
+      actions: transaction.listActions(concurrentFixture.recordId),
+      audits: transaction.listEventAuditTrail(concurrentFixture.eventId),
+    }));
+    expect(state.actions).toHaveLength(1);
+    expect(state.audits.filter((audit) => audit.action === "game-reopened")).toHaveLength(1);
+  });
+
+  test("stops the closing timer when reopening a corrected unfinished state", async () => {
+    const fixture = await createFixture();
+    const correction = await fixture.administration.correctLockedEventGame(
+      fixture.eventId,
+      fixture.eventGameId,
+      {
+        operationId: "locked-correction-unfinished",
+        endState: {
+          winnerGameSideId: null,
+          flagCatchingGameSideId: null,
+          catchTimeMs: null,
+          endTimeMs: null,
+        },
+      },
+      fixture.technical,
+    );
+    expect(correction).toMatchObject({ status: "accepted", value: { lockRetained: true } });
+    const reopened = await fixture.administration.reopenEventGame(
+      fixture.eventId,
+      fixture.eventGameId,
+      { operationId: "reopen-unfinished" },
+      fixture.technical,
+    );
+    expect(reopened).toMatchObject({
+      status: "accepted",
+      value: { lifecycle: { phase: "in-progress", finishedAtMs: null, lockedAtMs: null } },
+    });
+  });
+
+  test("reopens from the fresh deadline and restarts ordinary finish timing", async () => {
+    const fixture = await createFixture();
+    const firstReopenAt = 3_000;
+    fixture.setNow(firstReopenAt);
+    fixture.setGrantEligible(true);
+    expect(
+      await fixture.administration.reopenEventGame(
+        fixture.eventId,
+        fixture.eventGameId,
+        { operationId: "reopen-fresh-deadline" },
+        fixture.technical,
+      ),
+    ).toMatchObject({ status: "accepted", value: { lifecycle: { lockedAtMs: null } } });
+    const firstReopenMetadata = await fixture.storage.readRecordMetadata(fixture.recordId);
+    expect(firstReopenMetadata?.lastAcceptedAtMs).toBe(firstReopenAt);
+    const firstQr = await fixture.grants.revealGrant(fixture.controlGrantId, {
+      kind: "technical-admin",
+      id: "fixture-technical",
+    });
+    const firstSession = await fixture.grants.admitGrant({
+      qrCredential: firstQr.status === "revealed" ? firstQr.qrCredential : "invalid",
+      browserContext: "fresh-deadline-controller",
+    });
+    if (firstSession.status !== "admitted") throw new Error("Expected fresh Controller admission.");
+    const control = fixture.createControl();
+
+    fixture.setNow(firstReopenAt + EVENT_GAME_LOCK_DELAY_MS - 1);
+    expect(
+      await control.refreshController({
+        sessionBearer: firstSession.sessionBearer,
+        eventGameId: fixture.eventGameId,
+      }),
+    ).toMatchObject({ status: "authorized" });
+    expect((await fixture.storage.readRoot(fixture.recordId))?.lifecycle.lockedAtMs).toBe(null);
+
+    fixture.setNow(firstReopenAt + EVENT_GAME_LOCK_DELAY_MS);
+    expect(
+      await control.refreshController({
+        sessionBearer: firstSession.sessionBearer,
+        eventGameId: fixture.eventGameId,
+      }),
+    ).toMatchObject({ status: "rejected" });
+    expect((await fixture.storage.readRoot(fixture.recordId))?.lifecycle).toMatchObject({
+      phase: "finished",
+      lockedAtMs: firstReopenAt + EVENT_GAME_LOCK_DELAY_MS,
+    });
+
+    const correction = await fixture.administration.correctLockedEventGame(
+      fixture.eventId,
+      fixture.eventGameId,
+      {
+        operationId: "correct-to-unfinished-for-deadline",
+        endState: {
+          winnerGameSideId: null,
+          flagCatchingGameSideId: null,
+          catchTimeMs: null,
+          endTimeMs: null,
+        },
+      },
+      fixture.technical,
+    );
+    expect(correction).toMatchObject({ status: "accepted", value: { lockRetained: true } });
+    const unfinishedReopenAt = firstReopenAt + EVENT_GAME_LOCK_DELAY_MS + 1_000;
+    fixture.setNow(unfinishedReopenAt);
+    expect(
+      await fixture.administration.reopenEventGame(
+        fixture.eventId,
+        fixture.eventGameId,
+        { operationId: "reopen-unfinished-deadline" },
+        fixture.technical,
+      ),
+    ).toMatchObject({
+      status: "accepted",
+      value: { lifecycle: { phase: "in-progress", finishedAtMs: null, lockedAtMs: null } },
+    });
+    fixture.setNow(unfinishedReopenAt + EVENT_GAME_LOCK_DELAY_MS + 1);
+    const unfinishedSession = await fixture.grants.admitGrant({
+      qrCredential: fixture.oldQrCredential,
+      browserContext: "unfinished-controller",
+    });
+    if (unfinishedSession.status !== "admitted")
+      throw new Error("Expected unfinished Controller admission.");
+    expect(
+      await control.refreshController({
+        sessionBearer: unfinishedSession.sessionBearer,
+        eventGameId: fixture.eventGameId,
+      }),
+    ).toMatchObject({ status: "authorized" });
+    expect((await fixture.storage.readRoot(fixture.recordId))?.lifecycle).toMatchObject({
+      phase: "in-progress",
+      finishedAtMs: null,
+      lockedAtMs: null,
+    });
+
+    const ordinaryFinishAt = unfinishedReopenAt + EVENT_GAME_LOCK_DELAY_MS + 2_000;
+    fixture.setNow(ordinaryFinishAt);
+    expect(
+      await control.submitControllerIntent({
+        sessionBearer: unfinishedSession.sessionBearer,
+        eventGameId: fixture.eventGameId,
+        intent: {
+          version: "live-event-control-intent-v1",
+          type: "record-forfeit",
+          operationId: "ordinary-refinish-after-reopen",
+          factId: "ordinary-refinish-after-reopen-fact",
+          gameSideId: "side-a",
+          gameTimeMs: 0,
+          occurrence: { clientOriginAtMs: 0 },
+        },
+      }),
+    ).toMatchObject({ status: "accepted" });
+    const finishMetadata = await fixture.storage.readRecordMetadata(fixture.recordId);
+    expect(finishMetadata?.lastAcceptedAtMs).toBe(ordinaryFinishAt);
+    fixture.setNow(ordinaryFinishAt + EVENT_GAME_LOCK_DELAY_MS - 1);
+    expect((await fixture.storage.readRoot(fixture.recordId))?.lifecycle.lockedAtMs).toBe(null);
+    fixture.setNow(ordinaryFinishAt + EVENT_GAME_LOCK_DELAY_MS);
+    expect(
+      await control.refreshController({
+        sessionBearer: unfinishedSession.sessionBearer,
+        eventGameId: fixture.eventGameId,
+      }),
+    ).toMatchObject({ status: "rejected" });
+    expect((await fixture.storage.readRoot(fixture.recordId))?.lifecycle.lockedAtMs).toBe(
+      ordinaryFinishAt + EVENT_GAME_LOCK_DELAY_MS,
+    );
+  });
+
+  test("keeps locked queued work as bounded discard evidence after fresh reopen replay", async () => {
+    const fixture = await createFixture();
+    fixture.setGrantEligible(true);
+    fixture.setNow(3_000);
+    expect(
+      await fixture.administration.correctLockedEventGame(
+        fixture.eventId,
+        fixture.eventGameId,
+        {
+          operationId: "correction-before-queued-discard",
+          endState: {
+            scoreByGameSide: { "side-a": 30, "side-b": 20 },
+            winnerGameSideId: "side-a",
+            endTimeMs: 2_000,
+          },
+        },
+        fixture.technical,
+      ),
+    ).toMatchObject({ status: "accepted" });
+    expect(
+      await fixture.administration.reopenEventGame(
+        fixture.eventId,
+        fixture.eventGameId,
+        { operationId: "reopen-before-queued-discard" },
+        fixture.technical,
+      ),
+    ).toMatchObject({ status: "accepted" });
+    const queuedQr = await fixture.grants.revealGrant(fixture.controlGrantId, {
+      kind: "technical-admin",
+      id: "fixture-technical",
+    });
+    const admitted = await fixture.grants.admitGrant({
+      qrCredential: queuedQr.status === "revealed" ? queuedQr.qrCredential : "invalid",
+      browserContext: "queued-discard-controller",
+    });
+    if (admitted.status !== "admitted") throw new Error("Expected queued-work admission.");
+    const control = fixture.createControl();
+    const replayInput = {
+      sessionBearer: admitted.sessionBearer,
+      eventGameId: fixture.eventGameId,
+      batchId: "queued-discard-batch",
+      replicaGeneration: "queued-discard-generation",
+      expectedGrantSessionId: admitted.grantSessionId,
+      expectedGrantVersion: admitted.grantVersion,
+      actions: [
+        {
+          eventGameId: fixture.eventGameId,
+          intent: {
+            version: "live-event-control-intent-v1" as const,
+            type: "record-goal" as const,
+            operationId: "queued-discard-goal",
+            factId: "queued-discard-goal-fact",
+            gameSideId: "side-a",
+            gameTimeMs: 0,
+            occurrence: { clientOriginAtMs: 0 },
+          },
+          causalPredecessorIds: [],
+        },
+      ],
+    };
+    fixture.setNow(3_000 + EVENT_GAME_LOCK_DELAY_MS - 1);
+    expect(await control.replayControllerActions(replayInput)).toMatchObject({
+      status: "synchronized",
+      outcomes: [{ operationId: "queued-discard-goal", status: "held-for-correction" }],
+    });
+    const rejectedAtMs = 3_000 + EVENT_GAME_LOCK_DELAY_MS;
+    fixture.setNow(rejectedAtMs);
+    expect(await control.replayControllerActions(replayInput)).toMatchObject({
+      status: "synchronized",
+      discardedCount: 1,
+      outcomes: [{ operationId: "queued-discard-goal", status: "locked-discarded" }],
+    });
+    expect(await fixture.storage.readActions(fixture.recordId)).toHaveLength(2);
+    const discardEvidence = await fixture.storage.transaction((transaction) =>
+      transaction.listAuditEntries(fixture.recordId),
+    );
+    expect(discardEvidence.filter((audit) => audit.lockedReplay !== undefined)).toEqual([
+      expect.objectContaining({
+        lockedReplay: {
+          count: 1,
+          eventGameId: fixture.eventGameId,
+          originatingSessionId: admitted.grantSessionId,
+          rejectedAtMs,
+        },
+      }),
+    ]);
+
+    fixture.setNow(rejectedAtMs + 1_000);
+    expect(
+      await fixture.administration.reopenEventGame(
+        fixture.eventId,
+        fixture.eventGameId,
+        { operationId: "reopen-after-queued-discard" },
+        fixture.technical,
+      ),
+    ).toMatchObject({ status: "accepted" });
+    const fresh = await fixture.grants.admitGrant({
+      qrCredential: fixture.oldQrCredential,
+      browserContext: "queued-discard-fresh-controller",
+    });
+    if (fresh.status !== "admitted") throw new Error("Expected fresh replay admission.");
+    fixture.setNow(rejectedAtMs + 2_000);
+    const freshReplay = await control.replayControllerActions({
+      ...replayInput,
+      sessionBearer: fresh.sessionBearer,
+      expectedGrantSessionId: fresh.grantSessionId,
+    });
+    expect(freshReplay).toMatchObject({ status: "synchronized" });
+    expect(await fixture.storage.readActions(fixture.recordId)).toHaveLength(3);
+    expect(
+      (await fixture.storage.readActions(fixture.recordId)).some(
+        (stored) => stored.action.operationId === "queued-discard-goal",
+      ),
+    ).toBe(false);
+    expect(
+      (
+        await fixture.storage.transaction((transaction) =>
+          transaction.listAuditEntries(fixture.recordId),
+        )
+      ).filter((audit) => audit.lockedReplay !== undefined),
+    ).toHaveLength(1);
+  });
+
+  test("preserves the existing QR while old sessions and code stay invalid after reopening", async () => {
+    const fixture = await createFixture();
+    const result = await fixture.administration.reopenEventGame(
+      fixture.eventId,
+      fixture.eventGameId,
+      { operationId: "reopen-rotate-authority" },
+      fixture.technical,
+    );
+    expect(result).toMatchObject({ status: "accepted", value: { lockRemoved: true } });
+    if (result.status !== "accepted") throw new Error("Expected reopening acceptance.");
+    const preservedQr = await fixture.grants.revealGrant(fixture.controlGrantId, {
+      kind: "technical-admin",
+      id: "fixture-technical",
+    });
+    expect(preservedQr).toMatchObject({
+      status: "revealed",
+      qrCredential: fixture.oldQrCredential,
+    });
+
+    expect(
+      await fixture.grants.admitGrant({
+        qrCredential: preservedQr.status === "revealed" ? preservedQr.qrCredential : "invalid",
+        browserContext: "fresh-qr-after-reopen",
+      }),
+    ).toMatchObject({ status: "admitted", eventGameId: fixture.eventGameId });
+    expect(
+      await fixture.grants.admitGrantCode({
+        grantCode: fixture.oldGrantCode,
+        browserContext: "old-code-after-reopen",
+      }),
+    ).toMatchObject({ status: "rejected" });
+    expect(
+      await fixture.grants.authorizeGrant({
+        sessionBearer: fixture.oldSessionBearer,
+        eventGameId: fixture.eventGameId,
+      }),
+    ).toMatchObject({ status: "rejected" });
+
+    fixture.setGrantEligible(true);
+    const freshCode = await fixture.grants.createGrantCode(fixture.controlGrantId, {
+      kind: "technical-admin",
+      id: "fixture-technical",
+    });
+    expect(freshCode).toMatchObject({ status: "created" });
+    expect(result.value.controlGrantVersion).toBe(fixture.oldGrantVersion);
+  });
+
+  test("denies a Control session generically without refreshing its authority", async () => {
+    const fixture = await createFixture();
+    const before = await fixture.storage.transaction((transaction) => ({
+      sessions: transaction.listGrantSessions(fixture.controlGrantId),
+      audits: transaction.listGrantAudit(fixture.controlGrantId),
+    }));
+    const denied = await fixture.administration.reopenEventGame(
+      fixture.eventId,
+      fixture.eventGameId,
+      { operationId: "reopen-control-denied" },
+      { kind: "grant-session", sessionBearer: fixture.oldSessionBearer },
+    );
+    expect(denied).toMatchObject({ status: "rejected", reason: "unauthorized" });
+    const after = await fixture.storage.transaction((transaction) => ({
+      sessions: transaction.listGrantSessions(fixture.controlGrantId),
+      audits: transaction.listGrantAudit(fixture.controlGrantId),
+    }));
+    expect(after).toEqual(before);
+  });
+
+  test("allows a delegated Event Admin to reopen through its scoped session", async () => {
+    const fixture = await createFixture();
+    const adminGrant = await fixture.grants.createEventAdminGrant({
+      scope: {
+        eventId: fixture.eventId,
+        eventTimeZone: "UTC",
+        finalGameDayDate: "2026-08-15",
+      },
+      authority: { kind: "technical-admin", id: "fixture-technical" },
+    });
+    expect(adminGrant.status).toBe("created");
+    if (adminGrant.status !== "created") throw new Error("Expected Event Admin Grant.");
+    const adminSession = await fixture.grants.admitGrant({
+      qrCredential: adminGrant.qrCredential,
+      browserContext: "event-admin-browser",
+    });
+    expect(adminSession.status).toBe("admitted");
+    if (adminSession.status !== "admitted") throw new Error("Expected Event Admin Session.");
+    expect(
+      await fixture.administration.reopenEventGame(
+        fixture.eventId,
+        fixture.eventGameId,
+        { operationId: "reopen-event-admin" },
+        { kind: "grant-session", sessionBearer: adminSession.sessionBearer },
+      ),
+    ).toMatchObject({ status: "accepted", value: { lockRemoved: true } });
+    const linked = await fixture.storage.transaction((transaction) => ({
+      control: transaction
+        .listAuditEntries(fixture.recordId)
+        .filter((audit) => audit.outcome === "accepted"),
+      grant: transaction
+        .listGrantAudit(adminGrant.grantId)
+        .filter((audit) => audit.action === "control-action-accepted"),
+    }));
+    expect(linked.grant).toHaveLength(1);
+    expect(linked.control).toHaveLength(1);
+    expect(linked.control[0]?.links?.grantAuditId).toBe(linked.grant[0]?.auditId);
+    expect(linked.grant[0]?.controlAuditId).toBe(linked.control[0]?.auditId);
+  });
+
+  test("links delegated Event Admin correction authority use to its Control audit", async () => {
+    const fixture = await createFixture();
+    const adminGrant = await fixture.grants.createEventAdminGrant({
+      scope: {
+        eventId: fixture.eventId,
+        eventTimeZone: "UTC",
+        finalGameDayDate: "2026-08-15",
+      },
+      authority: { kind: "technical-admin", id: "fixture-technical" },
+    });
+    if (adminGrant.status !== "created") throw new Error("Expected Event Admin Grant.");
+    const adminSession = await fixture.grants.admitGrant({
+      qrCredential: adminGrant.qrCredential,
+      browserContext: "event-admin-correction-browser",
+    });
+    if (adminSession.status !== "admitted") throw new Error("Expected Event Admin Session.");
+    expect(
+      await fixture.administration.correctLockedEventGame(
+        fixture.eventId,
+        fixture.eventGameId,
+        { operationId: "correct-event-admin", endState: { scoreByGameSide: { "side-a": 30 } } },
+        { kind: "grant-session", sessionBearer: adminSession.sessionBearer },
+      ),
+    ).toMatchObject({ status: "accepted" });
+    const linked = await fixture.storage.transaction((transaction) => ({
+      control: transaction
+        .listAuditEntries(fixture.recordId)
+        .filter((audit) => audit.outcome === "accepted"),
+      grant: transaction
+        .listGrantAudit(adminGrant.grantId)
+        .filter((audit) => audit.action === "control-action-accepted"),
+    }));
+    expect(linked.grant).toHaveLength(1);
+    expect(linked.control).toHaveLength(1);
+    expect(linked.control[0]?.links?.grantAuditId).toBe(linked.grant[0]?.auditId);
+    expect(linked.grant[0]?.controlAuditId).toBe(linked.control[0]?.auditId);
+  });
+
+  test("rolls back the root, action, linked audits, and Grant state on injected failure", async () => {
+    const fixture = await createFixture();
+    const failingAdministration = createEventAdministration({
+      storage: fixture.storage,
+      grants: {
+        ...fixture.grants,
+      },
+      nowMs: () => 3_000,
+      lockedGameFailureInjector: () => {
+        throw new Error("injected-grant-audit-failure");
+      },
+    });
+    const preview = await failingAdministration.previewEventGameReopening(
+      fixture.eventId,
+      fixture.eventGameId,
+      { operationId: "reopen-injected-failure" },
+      fixture.technical,
+    );
+    if (preview.status !== "accepted") throw new Error("Expected reopening preview.");
+    const result = await failingAdministration.reopenEventGame(
+      fixture.eventId,
+      fixture.eventGameId,
+      {
+        operationId: "reopen-injected-failure",
+        previewFingerprint: preview.value.fingerprint,
+      },
+      fixture.technical,
+    );
+    expect(result).toMatchObject({ status: "retryable-failure" });
+    const state = await fixture.storage.transaction((transaction) => ({
+      root: transaction.findRootByEventGameId(fixture.eventGameId),
+      actions: transaction.listActions(fixture.recordId),
+      controlAudits: transaction.listAuditEntries(fixture.recordId),
+      eventAudits: transaction.listEventAuditTrail(fixture.eventId),
+      grant: transaction.findGrantById(fixture.controlGrantId),
+      grantAudits: transaction.listGrantAudit(fixture.controlGrantId),
+    }));
+    expect(state.root?.lifecycle).toMatchObject({ lockedAtMs: 3_000 });
+    expect(state.actions).toHaveLength(0);
+    expect(state.controlAudits).toHaveLength(0);
+    expect(
+      state.eventAudits.filter((audit) => audit.operationId === "reopen-injected-failure"),
+    ).toHaveLength(0);
+    expect(state.grant?.grantVersion).toBe(fixture.oldGrantVersion);
+    expect(state.grantAudits).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ action: "control-action-accepted" })]),
+    );
+  });
+});
+
+async function createFixture(storage: FoundationStorage = createInMemoryFoundationStorage()) {
+  let nowMs = 3_000;
+  let grantRandomCounter = 0;
+  const technical = createTechnicalAdminAuth(
+    { environment: "test", origin: "https://timer.example", rpId: "timer.example" },
+    new MemoryTechnicalAdminAuthRepository(),
+  ).resolveHostLocalAuthority();
+  const catalog = createEventCatalog(createFoundationEventCatalogStorage(storage), {
+    clock: { nowMs: () => nowMs },
+  });
+  const event = await catalog.createEvent({ name: "Locked Game", timeZone: "UTC" }, technical);
+  if (event.status !== "accepted") throw new Error("Expected Event.");
+  const day = await catalog.addGameDay(event.value.eventId, { date: "2026-08-15" }, technical);
+  if (day.status !== "accepted") throw new Error("Expected Game Day.");
+  const pitch = await catalog.createPitch(event.value.eventId, { name: "Pitch 1" }, technical);
+  if (pitch.status !== "accepted") throw new Error("Expected Pitch.");
+  const slot = await catalog.createGameplaySlot(
+    event.value.eventId,
+    day.value.gameDayId,
+    { sequence: 1, scheduledStart: "2026-08-15T10:00" },
+    technical,
+  );
+  if (slot.status !== "accepted")
+    throw new Error(`Expected Gameplay Slot: ${JSON.stringify(slot)}`);
+  const pitchSlot = (
+    await storage.transaction((transaction) =>
+      transaction.listPitchSlots(day.value.gameDayId, pitch.value.pitchId),
+    )
+  )[0];
+  if (pitchSlot === undefined) throw new Error("Expected Pitch Slot.");
+  const game = await catalog.createEventGame(
+    event.value.eventId,
+    day.value.gameDayId,
+    {
+      gameplaySlotId: slot.value.gameplaySlotId,
+      pitchSlotId: pitchSlot.pitchSlotId,
+      sideA: { sourceLabel: "A" },
+      sideB: { sourceLabel: "B" },
+    },
+    technical,
+  );
+  if (game.status !== "accepted") throw new Error(`Expected Event Game: ${JSON.stringify(game)}`);
+
+  const root: EventGameRecordRoot = {
+    recordId: "record-122",
+    eventId: event.value.eventId,
+    eventGameId: game.value.eventGameId,
+    ownership: { eventId: event.value.eventId, eventGameId: game.value.eventGameId },
+    externalScope: {
+      eventId: event.value.eventId,
+      gameDayId: day.value.gameDayId,
+      pitchId: pitch.value.pitchId,
+      pitchSlotId: pitchSlot.pitchSlotId,
+    },
+    gameSides: [
+      { id: "side-a", eventTeamId: "team-a", teamInterpretationRef: "team-a" },
+      { id: "side-b", eventTeamId: "team-b", teamInterpretationRef: "team-b" },
+    ],
+    lifecycle: {
+      phase: "finished",
+      commencedAtMs: 1_000,
+      finishedAtMs: 2_000,
+      lockedAtMs: 3_000,
+      lockReason: "finished-inactivity",
+    },
+    compatibility: {
+      recordVersion: "event-game-record-v1",
+      schemaVersion: "event-game-record-v1",
+      interpreterVersion: "live-event-iqa-v1",
+    },
+    creationEvidence: {
+      operationId: "register-122",
+      actorReference: "event-admin:test",
+      source: "event-game-registration",
+      createdAtMs: 500,
+    },
+  };
+  const grantableRoot = {
+    ...root,
+    lifecycle: { ...root.lifecycle, lockedAtMs: null, lockReason: null },
+  } satisfies EventGameRecordRoot;
+  await storage.transaction((transaction) => {
+    transaction.insertRoot({
+      root: grantableRoot,
+      canonicalContent: canonicalizeEventGameRecordRoot(grantableRoot),
+    });
+    transaction.upsertRecordMetadata({
+      recordId: root.recordId,
+      actionCount: 0,
+      orderingVersion: "causal-occurrence-operation-v1",
+      lastAcceptedAtMs: null,
+      updatedAtMs: root.creationEvidence.createdAtMs,
+    });
+  });
+
+  const record = createEventGameRecord(storage, {
+    externalScopeResolver: {
+      resolve: (scope) => ({ status: "resolved" as const, scope }),
+      resolveEventTeam: () => ({ status: "resolved" as const }),
+    },
+    interpreter: createLiveEventGameIqaInterpreter(),
+    clock: () => nowMs,
+    auditAuthorityVerifier: { verify: () => true },
+  });
+  if ((await record.registerRoot(grantableRoot)).status !== "idempotent")
+    throw new Error("Expected the fixture Event Game Record root to be present.");
+
+  let grantEligible = true;
+  const grantOptions: GrantAuthorityOptions = {
+    environmentId: "test",
+    clock: { nowMs: () => nowMs },
+    randomness: {
+      bytes: (length: number) => {
+        const result = new Uint8Array(length);
+        for (let index = 0; index < length; index += 1)
+          result[index] = (grantRandomCounter + index) % 256;
+        grantRandomCounter += length;
+        return result;
+      },
+    },
+    keyRing,
+    controlScopeResolver: {
+      resolve: (scope, snapshot) => {
+        const current = snapshot?.findRootByPitchSlotId(scope.pitchSlotId);
+        if (snapshot === undefined) {
+          return grantEligible
+            ? { status: "eligible" as const, eventGameId: root.eventGameId }
+            : {
+                status: "terminal" as const,
+                reason: "game-locked" as const,
+                eventGameId: root.eventGameId,
+              };
+        }
+        if (current === null || current === undefined) return { status: "empty" as const };
+        return current.lifecycle.lockedAtMs === null
+          ? { status: "eligible" as const, eventGameId: current.eventGameId }
+          : {
+              status: "terminal" as const,
+              reason: "game-locked" as const,
+              eventGameId: current.eventGameId,
+            };
+      },
+    },
+    privilegedAuthorityVerifier: createGrantAuthorityVerifier((input) =>
+      isTechnicalAdminAuthority(input)
+        ? { kind: "technical-admin", id: input.sessionId }
+        : isRecord(input) && input.kind === "technical-admin" && typeof input.id === "string"
+          ? { kind: "technical-admin", id: input.id }
+          : isRecord(input) &&
+              input.kind === "grant-session" &&
+              typeof input.sessionBearer === "string"
+            ? {
+                kind: "grant-session",
+                sessionBearer: input.sessionBearer,
+                sessionId: "fixture-session",
+              }
+            : null,
+    ),
+  };
+  const grants = createTypedGrantAuthority(storage, grantOptions);
+  const controlGrant = await grants.createControlGrant({
+    scope: root.externalScope,
+    authority: { kind: "technical-admin", id: "fixture-technical" },
+  });
+  if (controlGrant.status !== "created")
+    throw new Error(`Expected Control Grant: ${JSON.stringify(controlGrant)}`);
+  const oldCode = await grants.createGrantCode(controlGrant.grantId, {
+    kind: "technical-admin",
+    id: "fixture-technical",
+  });
+  if (oldCode.status !== "created")
+    throw new Error(`Expected Grant Code: ${JSON.stringify(oldCode)}`);
+  const oldSession = await grants.admitGrant({
+    qrCredential: controlGrant.qrCredential,
+    browserContext: "old-qr-before-reopen",
+  });
+  if (oldSession.status !== "admitted")
+    throw new Error(`Expected Grant Session: ${JSON.stringify(oldSession)}`);
+  const oldCodeSession = await grants.admitGrantCode({
+    grantCode: oldCode.code,
+    browserContext: "old-code-before-reopen",
+  });
+  if (oldCodeSession.status !== "admitted")
+    throw new Error(`Expected Grant Code Session: ${JSON.stringify(oldCodeSession)}`);
+  await grants.disableGrantCode(controlGrant.grantId, technical);
+  await grants.leaveGrantSession(oldSession.sessionBearer);
+  await grants.leaveGrantSession(oldCodeSession.sessionBearer);
+  grantEligible = false;
+  await storage.transaction((transaction) => {
+    transaction.updateRoot({
+      root,
+      canonicalContent: canonicalizeEventGameRecordRoot(root),
+    });
+  });
+  const rawAdministration = createEventAdministration({ storage, grants, nowMs: () => nowMs });
+  const administration = {
+    ...rawAdministration,
+    async correctLockedEventGame(
+      eventIdInput: unknown,
+      eventGameIdInput: unknown,
+      input: Parameters<typeof rawAdministration.correctLockedEventGame>[2],
+      authority: Parameters<typeof rawAdministration.correctLockedEventGame>[3],
+    ) {
+      const preview = await rawAdministration.previewLockedEventGameCorrection(
+        eventIdInput,
+        eventGameIdInput,
+        input,
+        authority,
+      );
+      if (preview.status !== "accepted") return preview;
+      return rawAdministration.correctLockedEventGame(
+        eventIdInput,
+        eventGameIdInput,
+        { ...input, previewFingerprint: preview.value.fingerprint },
+        authority,
+      );
+    },
+    async reopenEventGame(
+      eventIdInput: unknown,
+      eventGameIdInput: unknown,
+      input: Parameters<typeof rawAdministration.reopenEventGame>[2],
+      authority: Parameters<typeof rawAdministration.reopenEventGame>[3],
+    ) {
+      const preview = await rawAdministration.previewEventGameReopening(
+        eventIdInput,
+        eventGameIdInput,
+        input,
+        authority,
+      );
+      if (preview.status !== "accepted") return preview;
+      return rawAdministration.reopenEventGame(
+        eventIdInput,
+        eventGameIdInput,
+        { ...input, previewFingerprint: preview.value.fingerprint },
+        authority,
+      );
+    },
+  };
+  const createControl = () => {
+    const replayCapabilities = new Map<
+      string,
+      { replayDigest: string; reservationId: string | null; authorized: boolean }
+    >();
+    const lockedReplayCapability = {
+      issue(replayDigest: string) {
+        const evidence = `replay-evidence-${replayCapabilities.size + 1}`;
+        replayCapabilities.set(evidence, { replayDigest, reservationId: null, authorized: false });
+        return evidence;
+      },
+      remember(input: { evidence: string; replayDigest: string; reservationId: string }) {
+        const current = replayCapabilities.get(input.evidence);
+        if (current?.replayDigest === input.replayDigest)
+          replayCapabilities.set(input.evidence, {
+            ...current,
+            reservationId: input.reservationId,
+          });
+      },
+      find(replayDigest: string) {
+        for (const [evidence, current] of replayCapabilities) {
+          if (current.replayDigest === replayDigest && current.reservationId !== null)
+            return evidence;
+        }
+        return null;
+      },
+      authorize(replayDigest: string) {
+        for (const [evidence, current] of replayCapabilities) {
+          if (current.replayDigest === replayDigest)
+            replayCapabilities.set(evidence, { ...current, authorized: true });
+        }
+      },
+      authorized(evidence: string) {
+        return replayCapabilities.get(evidence)?.authorized === true;
+      },
+      reservationId(evidence: string) {
+        return replayCapabilities.get(evidence)?.reservationId ?? null;
+      },
+    };
+    const acceptance = createFoundationAcceptance(storage, {
+      grant: grantOptions,
+      externalScopeResolver: {
+        resolve: (scope) => ({ status: "resolved" as const, scope }),
+        resolveEventTeam: () => ({ status: "resolved" as const }),
+      },
+      clock: () => nowMs,
+      interpreter: createLiveEventGameIqaInterpreter(),
+      verifyLockedReplay: ({ evidence }) =>
+        typeof evidence === "string" &&
+        lockedReplayCapability.reservationId(evidence) !== null &&
+        lockedReplayCapability.authorized(evidence),
+      authorizeLockedReplay: ({ evidence }) => lockedReplayCapability.authorized(evidence),
+      lockedReplayReservationId: (evidence) =>
+        typeof evidence === "string" ? lockedReplayCapability.reservationId(evidence) : null,
+      replayEligibility: ({ replayEvidenceId }) =>
+        lockedReplayCapability.reservationId(replayEvidenceId) !== null
+          ? { status: "eligible" as const }
+          : { status: "ineligible" as const },
+      validateActionInTransaction: ({ transaction, root: currentRoot, action }) =>
+        validateLiveEventGameActionInTransaction(
+          transaction.listActions(currentRoot.recordId),
+          currentRoot,
+          action,
+          null,
+        ),
+    });
+    return createLiveEventGameControl({
+      resolveEventGameRecord: async (eventGameId) =>
+        eventGameId === root.eventGameId ? { recordId: root.recordId, record } : null,
+      acceptance,
+      lockedReplayCapability,
+      grantAuthority: grants,
+      clock: () => nowMs,
+      listEventGameRoots: async () =>
+        storage.transaction((transaction) => transaction.listRoots?.() ?? []),
+      authorizeLockedReplay: async ({
+        sessionBearer,
+        eventGameId,
+        grantSessionId,
+        grantVersion,
+      }) => {
+        const authorized = await grants.authorizeGrant({
+          sessionBearer,
+          eventGameId,
+          readOnly: true,
+        });
+        return (
+          authorized.status === "authorized" &&
+          authorized.grantType === "control" &&
+          authorized.grantSessionId === grantSessionId &&
+          authorized.grantVersion === grantVersion
+        );
+      },
+      lockEventGame: (eventGameId, lockedAtMs) =>
+        storage.transaction((transaction) => {
+          const current = transaction.findRootByEventGameId(eventGameId);
+          if (
+            current === null ||
+            current.lifecycle.phase !== "finished" ||
+            current.lifecycle.finishedAtMs === null ||
+            current.lifecycle.lockedAtMs !== null
+          )
+            return { status: "rejected" as const, reason: "invalid-state" };
+          const locked = validateEventGameRecordRoot({
+            ...current,
+            lifecycle: { ...current.lifecycle, lockedAtMs, lockReason: "finished-inactivity" },
+          });
+          if (!locked.ok) return { status: "rejected" as const, reason: "invalid-state" };
+          transaction.updateRoot({
+            root: locked.value,
+            canonicalContent: canonicalizeEventGameRecordRoot(locked.value),
+          });
+          return {
+            status: "locked" as const,
+            eventGameId,
+            terminatedSessionCount: 0,
+          };
+        }),
+    });
+  };
+  return {
+    storage,
+    technical,
+    eventId: event.value.eventId,
+    eventGameId: game.value.eventGameId,
+    recordId: root.recordId,
+    record,
+    grants,
+    grantOptions,
+    createControl,
+    setNow: (value: number) => {
+      nowMs = value;
+    },
+    setGrantEligible: (eligible: boolean) => {
+      grantEligible = eligible;
+    },
+    controlGrantId: controlGrant.grantId,
+    oldGrantVersion: controlGrant.grantVersion,
+    oldQrCredential: controlGrant.qrCredential,
+    oldGrantCode: oldCode.code,
+    oldSessionBearer: oldSession.sessionBearer,
+    administration,
+    rawAdministration,
+  };
+}
+
+function bytes(length: number): Uint8Array {
+  return new Uint8Array(length).fill(7);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/lib/locked-event-game-administration.ts
+++ b/src/lib/locked-event-game-administration.ts
@@ -1,0 +1,1162 @@
+import type {
+  EventAdministrationAuthority,
+  EventAdministrationOutcome,
+} from "@/lib/event-administration";
+import {
+  actionIdentity,
+  type ControlAction,
+  type ControlActionInput,
+  type ControlAuditEntry,
+} from "@/lib/event-game-actions";
+import {
+  createEventGameRecord,
+  type ControlActionAcceptanceOutcome,
+  type ExternalScopeResolver,
+} from "@/lib/event-game-record";
+import { ACCEPTED_AUDIT_DETAIL, acceptedAuditId } from "@/lib/event-game-record-helpers";
+import {
+  canonicalizeEventGameRecordRoot,
+  type EventGameRecordRoot,
+} from "@/lib/foundation-record-types";
+import type {
+  EventCatalogAuditEntry,
+  FoundationStorage,
+  FoundationStorageTransaction,
+  StoredControlAction,
+} from "@/lib/foundation-storage";
+import {
+  GRANT_CREDENTIAL_KIND,
+  GRANT_TYPE,
+  type StoredGrant,
+  type StoredGrantAuditEntry,
+  validateControlGrantScope,
+} from "@/lib/grant-types";
+import {
+  createLiveEventGameIqaInterpreter,
+  projectLiveEventGameDerivedState,
+  validateLockedGameEndStateAgainstRules,
+} from "@/lib/live-event-game-control";
+import { canonicalizeJson, sha256 } from "@/lib/event-game-action-json";
+import { SHARED_LIMITS, validateOpaqueIdentifier } from "@/lib/validation-policy";
+
+export type LockedGameEndState = {
+  scoreByGameSide: Readonly<Record<string, number>>;
+  winnerGameSideId: string | null;
+  flagCatchingGameSideId: string | null;
+  catchTimeMs: number | null;
+  endTimeMs: number | null;
+};
+export type LockedGameCorrectionInput = {
+  operationId: unknown;
+  endState: unknown;
+  overrideConfirmed?: unknown;
+  previewFingerprint?: unknown;
+};
+export type GameReopeningPreviewInput = { operationId: unknown };
+export type LockedGamePreviewImpact = {
+  facts: "preserved" | "corrected";
+  lifecycle: { from: string; to: string; lock: "retained" | "removed" };
+  timer: "restarted" | "stopped" | "unchanged";
+  authority: { controlGrant: "preserved"; qr: "preserved"; grantVersion: "preserved" };
+  sessions: { category: "terminated"; count: number };
+  code: { category: "expired" | "create-after-reopen"; count: number };
+  queuedDiscard: { category: "locked-replay"; count: number };
+};
+export type LockedGamePreview = {
+  eventGameId: string;
+  recordId: string;
+  operation: "locked-game-correction" | "game-reopening";
+  operationId: string;
+  impact: LockedGamePreviewImpact;
+  fingerprint: string;
+};
+export type LockedGameCorrectionResult = {
+  eventGameId: string;
+  recordId: string;
+  actionId: string;
+  controlAuditId: string;
+  eventAuditId: string;
+  before: LockedGameEndState;
+  after: LockedGameEndState;
+  lockRetained: true;
+  overrideApplied: boolean;
+};
+export type GameReopeningInput = { operationId: unknown; previewFingerprint?: unknown };
+export type GameReopeningResult = {
+  eventGameId: string;
+  recordId: string;
+  actionId: string;
+  controlAuditId: string;
+  eventAuditId: string;
+  controlGrantVersion: string;
+  lockRemoved: true;
+  lifecycle: EventGameRecordRoot["lifecycle"];
+};
+
+type AuthorizedActor = {
+  actorReference: string;
+  sessionId: string | null;
+  grantVersion: string | null;
+};
+type Dependencies = {
+  storage: FoundationStorage;
+  failureInjector?: () => void;
+  nowMs: () => number;
+  authorize(
+    transaction: FoundationStorageTransaction,
+    eventId: string,
+    authority: EventAdministrationAuthority,
+    readOnly?: boolean,
+  ): AuthorizedActor | null;
+};
+
+type GrantLifecycleSnapshot = {
+  grantId: string;
+  grantVersion: string;
+  codeState: "absent" | "present" | "disabled" | "erased";
+  terminatedSessionCount: number;
+  activeSessionCount: number;
+  codeFingerprint: string | null;
+};
+
+type LockedGameContext = {
+  root: EventGameRecordRoot;
+  before: LockedGameEndState;
+  actor: AuthorizedActor;
+  grant: GrantLifecycleSnapshot;
+  queuedDiscardCount: number;
+  rootRevision: {
+    metadata: ReturnType<FoundationStorageTransaction["readRecordMetadata"]>;
+  };
+  duplicateAction?: ControlActionInput;
+};
+
+const externalScopeResolver: ExternalScopeResolver = {
+  resolve(scope, snapshot) {
+    const event = snapshot.findEvent(scope.eventId);
+    const day = snapshot
+      .listGameDays(scope.eventId)
+      .find((candidate) => candidate.gameDayId === scope.gameDayId);
+    const pitch = snapshot.findPitch(scope.pitchId);
+    const pitchSlot = snapshot.findPitchSlot?.(scope.pitchSlotId);
+    const gameplaySlot = snapshot.findGameplaySlot?.(pitchSlot?.gameplaySlotId ?? "");
+    return event !== null &&
+      day !== undefined &&
+      pitch?.eventId === scope.eventId &&
+      pitchSlot?.gameDayId === scope.gameDayId &&
+      pitchSlot.pitchId === scope.pitchId &&
+      gameplaySlot?.gameDayId === scope.gameDayId
+      ? { status: "resolved", scope }
+      : { status: "mismatch", detail: "Event Game external scope is unavailable." };
+  },
+  resolveEventTeam(eventId, eventTeamId, snapshot) {
+    return snapshot.findEventTeam(eventTeamId)?.eventId === eventId
+      ? { status: "resolved" }
+      : { status: "mismatch", detail: "Event Team is unavailable." };
+  },
+};
+
+export function createLockedEventGameAdministration(dependencies: Dependencies) {
+  return {
+    previewLockedEventGameCorrection(
+      eventId: unknown,
+      eventGameId: unknown,
+      input: LockedGameCorrectionInput,
+      authority: EventAdministrationAuthority,
+    ) {
+      return runCorrectionPreview(dependencies, eventId, eventGameId, input, authority);
+    },
+    correctLockedEventGame(
+      eventId: unknown,
+      eventGameId: unknown,
+      input: LockedGameCorrectionInput,
+      authority: EventAdministrationAuthority,
+    ) {
+      return runCorrection(dependencies, eventId, eventGameId, input, authority);
+    },
+    reopenEventGame(
+      eventId: unknown,
+      eventGameId: unknown,
+      input: GameReopeningInput,
+      authority: EventAdministrationAuthority,
+    ) {
+      return runReopening(dependencies, eventId, eventGameId, input, authority);
+    },
+    previewEventGameReopening(
+      eventId: unknown,
+      eventGameId: unknown,
+      input: GameReopeningPreviewInput,
+      authority: EventAdministrationAuthority,
+    ) {
+      return runReopeningPreview(dependencies, eventId, eventGameId, input, authority);
+    },
+  };
+}
+
+async function runCorrectionPreview(
+  dependencies: Dependencies,
+  eventIdInput: unknown,
+  eventGameIdInput: unknown,
+  input: LockedGameCorrectionInput,
+  authority: EventAdministrationAuthority,
+): Promise<EventAdministrationOutcome<LockedGamePreview>> {
+  const ids = parseIds(eventIdInput, eventGameIdInput, input.operationId, "Locked Game Correction");
+  if (!ids.ok) return invalid(ids.error);
+  const parsed = parseEndState(input.endState);
+  if (!parsed.ok) return invalid(parsed.error);
+  const context = await readLockedContext(dependencies, ids.eventId, ids.eventGameId, authority);
+  if (context.status !== "accepted") return context;
+  const after = mergeEndState(context.value.before, parsed.value);
+  return accepted(
+    makePreview(
+      context.value,
+      "locked-game-correction",
+      ids.operationId,
+      after,
+      context.value.root.lifecycle,
+    ),
+  );
+}
+
+async function runReopeningPreview(
+  dependencies: Dependencies,
+  eventIdInput: unknown,
+  eventGameIdInput: unknown,
+  input: GameReopeningPreviewInput,
+  authority: EventAdministrationAuthority,
+): Promise<EventAdministrationOutcome<LockedGamePreview>> {
+  const ids = parseIds(eventIdInput, eventGameIdInput, input.operationId, "Game Reopening");
+  if (!ids.ok) return invalid(ids.error);
+  const context = await readLockedContext(dependencies, ids.eventId, ids.eventGameId, authority);
+  if (context.status !== "accepted") return context;
+  const reopenedRoot = reopeningRoot(context.value.root, context.value.before);
+  return accepted(
+    makePreview(
+      context.value,
+      "game-reopening",
+      ids.operationId,
+      context.value.before,
+      reopenedRoot.lifecycle,
+    ),
+  );
+}
+
+async function runCorrection(
+  dependencies: Dependencies,
+  eventIdInput: unknown,
+  eventGameIdInput: unknown,
+  input: LockedGameCorrectionInput,
+  authority: EventAdministrationAuthority,
+): Promise<EventAdministrationOutcome<LockedGameCorrectionResult>> {
+  const ids = parseIds(eventIdInput, eventGameIdInput, input.operationId, "Locked Game Correction");
+  if (!ids.ok) return invalid(ids.error);
+  const parsed = parseEndState(input.endState);
+  if (!parsed.ok) return invalid(parsed.error);
+  const context = await readLockedContext(dependencies, ids.eventId, ids.eventGameId, authority);
+  if (context.status !== "accepted") return context;
+  const after = mergeEndState(context.value.before, parsed.value);
+  const preview = makePreview(
+    context.value,
+    "locked-game-correction",
+    ids.operationId,
+    after,
+    context.value.root.lifecycle,
+  );
+  if (input.previewFingerprint !== preview.fingerprint)
+    return invalid("A fresh Locked Game Correction preview is required.");
+  const inconsistent =
+    validateLockedGameEndStateAgainstRules(context.value.root, after).status === "rejected";
+  if (inconsistent && input.overrideConfirmed !== true)
+    return invalid("This Locked Game Correction requires one confirmation.");
+  const nowMs = readNow(dependencies.nowMs);
+  if (nowMs === null) return invalid("Event clock returned an invalid timestamp.");
+  const actionInput = createAdminFactAction(
+    context.value.root,
+    ids.operationId,
+    nowMs,
+    context.value.actor,
+    "locked-game-correction",
+    { correction: after },
+    inconsistent,
+    context.value.before,
+    after,
+  );
+  const eventAudit = createEventAuditWriter(
+    "locked-game-corrected",
+    ids.eventId,
+    ids.operationId,
+    context.value.root,
+    context.value.actor.actorReference,
+    nowMs,
+  );
+  const eventAuditId = eventAudit.id;
+  const record = createRecord(dependencies, ids.eventId, authority, {
+    requireLocked: true,
+    actionInput,
+    expectedBefore: context.value.before,
+    previewGuard: (transaction, root, actor, input) =>
+      previewFingerprintForInput(transaction, root, actor, input) === preview.fingerprint,
+    auditContext: () => ({
+      linkAcceptance: context.value.actor.sessionId !== null,
+      valueChange: { before: context.value.before, after },
+    }),
+    lifecycleTransition: ({ transaction, root, action, audit }) => ({
+      status: "updated",
+      root,
+      eventAudit: eventAudit(audit.auditId),
+      eventAuditId,
+      grantAudits: (() => {
+        const audits = linkedGrantAudits(transaction, context.value, audit, action, nowMs);
+        dependencies.failureInjector?.();
+        return audits;
+      })(),
+    }),
+  });
+  const registration = await record.registerRoot(context.value.root);
+  if (registration.status === "rejected")
+    return registration.reason === "storage-not-ready"
+      ? unavailable()
+      : invalid(registration.detail);
+  const outcome = await record.acceptAction(actionInput);
+  if (outcome.status === "accepted" || outcome.status === "duplicate-accepted") {
+    return accepted({
+      eventGameId: ids.eventGameId,
+      recordId: context.value.root.recordId,
+      actionId: actionIdentity(context.value.root.recordId, outcome.action.operationId),
+      controlAuditId: outcome.auditId,
+      eventAuditId: outcome.eventAuditId ?? eventAuditId,
+      before: context.value.before,
+      after,
+      lockRetained: true,
+      overrideApplied: outcome.action.override !== undefined,
+    });
+  }
+  return mapRecordOutcome(outcome);
+}
+
+async function runReopening(
+  dependencies: Dependencies,
+  eventIdInput: unknown,
+  eventGameIdInput: unknown,
+  input: GameReopeningInput,
+  authority: EventAdministrationAuthority,
+): Promise<EventAdministrationOutcome<GameReopeningResult>> {
+  const ids = parseIds(eventIdInput, eventGameIdInput, input.operationId, "Game Reopening");
+  if (!ids.ok) return invalid(ids.error);
+  const context = await readLockedContext(
+    dependencies,
+    ids.eventId,
+    ids.eventGameId,
+    authority,
+    ids.operationId,
+  );
+  if (context.status !== "accepted") return context;
+  const reopenedRoot = reopeningRoot(context.value.root, context.value.before);
+  const preview = makePreview(
+    context.value,
+    "game-reopening",
+    ids.operationId,
+    context.value.before,
+    reopenedRoot.lifecycle,
+  );
+  const duplicateRetry = context.value.duplicateAction !== undefined;
+  if (!duplicateRetry && input.previewFingerprint !== preview.fingerprint)
+    return invalid("A fresh Game Reopening preview is required.");
+  const nowMs = readNow(dependencies.nowMs);
+  if (nowMs === null) return invalid("Event clock returned an invalid timestamp.");
+  const actionInput =
+    context.value.duplicateAction ??
+    createAdminFactAction(
+      context.value.root,
+      ids.operationId,
+      nowMs,
+      context.value.actor,
+      "game-reopening",
+      { reopening: true },
+      false,
+    );
+  const eventAudit = createEventAuditWriter(
+    "game-reopened",
+    ids.eventId,
+    ids.operationId,
+    context.value.root,
+    context.value.actor.actorReference,
+    nowMs,
+  );
+  const record = createRecord(dependencies, ids.eventId, authority, {
+    requireLocked: true,
+    actionInput,
+    previewGuard: (transaction, root, actor, input) =>
+      previewFingerprintForInput(transaction, root, actor, input) === preview.fingerprint,
+    duplicateResolver: (transaction, root, input, prepared) =>
+      resolveReopeningDuplicate(dependencies, transaction, root, input, prepared, authority),
+    auditContext: () => ({ linkAcceptance: context.value.actor.sessionId !== null }),
+    lifecycleTransition: ({ transaction, action, audit }) => {
+      transaction.updateRoot({
+        root: reopenedRoot,
+        canonicalContent: canonicalizeEventGameRecordRoot(reopenedRoot),
+      });
+      return {
+        status: "updated",
+        root: reopenedRoot,
+        eventAudit: eventAudit(audit.auditId),
+        eventAuditId: eventAudit.id,
+        grantAudits: (() => {
+          const audits = linkedGrantAudits(transaction, context.value, audit, action, nowMs);
+          dependencies.failureInjector?.();
+          return audits;
+        })(),
+      };
+    },
+  });
+  const registration = await record.registerRoot(context.value.root);
+  if (registration.status === "rejected")
+    return registration.reason === "storage-not-ready"
+      ? unavailable()
+      : invalid(registration.detail);
+  const outcome = await record.acceptAction(actionInput);
+  if (outcome.status === "accepted" || outcome.status === "duplicate-accepted") {
+    return accepted({
+      eventGameId: ids.eventGameId,
+      recordId: context.value.root.recordId,
+      actionId: actionIdentity(context.value.root.recordId, outcome.action.operationId),
+      controlAuditId: outcome.auditId,
+      eventAuditId: outcome.eventAuditId ?? eventAudit.id,
+      controlGrantVersion: context.value.grant.grantVersion,
+      lockRemoved: true,
+      lifecycle: reopenedRoot.lifecycle,
+    });
+  }
+  return mapRecordOutcome(outcome);
+}
+
+function createRecord(
+  dependencies: Dependencies,
+  eventId: string,
+  authority: EventAdministrationAuthority,
+  options: {
+    requireLocked: boolean;
+    actionInput: ControlActionInput;
+    expectedBefore?: LockedGameEndState;
+    previewGuard?: (
+      transaction: FoundationStorageTransaction,
+      root: EventGameRecordRoot,
+      actor: AuthorizedActor,
+      input: unknown,
+    ) => boolean;
+    duplicateResolver?: (
+      transaction: FoundationStorageTransaction,
+      root: EventGameRecordRoot,
+      input: unknown,
+      prepared: import("@/lib/event-game-actions").PreparedControlAction | null,
+    ) => ControlActionAcceptanceOutcome | null;
+    auditContext?: () => {
+      linkAcceptance?: boolean;
+      valueChange?: { before: LockedGameEndState; after: LockedGameEndState };
+    };
+    lifecycleTransition: (input: {
+      transaction: FoundationStorageTransaction;
+      root: EventGameRecordRoot;
+      action: ControlAction;
+      audit: ControlAuditEntry;
+    }) => {
+      status: "updated";
+      root: EventGameRecordRoot;
+      applyAfterRootUpdate?: (transaction: FoundationStorageTransaction) => void;
+      eventAudit?: EventCatalogAuditEntry;
+      eventAuditId?: string;
+      grantAudits?: readonly StoredGrantAuditEntry[];
+    };
+  },
+) {
+  return createEventGameRecord(dependencies.storage, {
+    externalScopeResolver,
+    clock: dependencies.nowMs,
+    interpreter: createLiveEventGameIqaInterpreter(),
+    actionAcceptanceGuard: (transaction, root, input) => {
+      const actor = dependencies.authorize(transaction, eventId, authority);
+      if (actor === null)
+        return { status: "rejected", reason: "invalid-action", detail: "event-admin-unauthorized" };
+      if (options.requireLocked && root.lifecycle.lockedAtMs === null)
+        return { status: "rejected", reason: "invalid-action", detail: "event-game-not-locked" };
+      if (
+        !isRecord(input) ||
+        input.eventGameId !== root.eventGameId ||
+        input.origin !== "event-admin"
+      )
+        return {
+          status: "rejected",
+          reason: "invalid-action",
+          detail: "event-admin-action-context-invalid",
+        };
+      if (actor.sessionId === null && input.grant !== null)
+        return {
+          status: "rejected",
+          reason: "invalid-action",
+          detail: "event-admin-grant-context-invalid",
+        };
+      if (
+        actor.sessionId !== null &&
+        (!isRecord(input.grant) || input.grant.sessionId !== actor.sessionId)
+      )
+        return {
+          status: "rejected",
+          reason: "invalid-action",
+          detail: "event-admin-grant-context-invalid",
+        };
+      if (
+        options.previewGuard !== undefined &&
+        !options.previewGuard(transaction, root, actor, input)
+      )
+        return {
+          status: "rejected",
+          reason: "invalid-action",
+          detail: "The Event Game operation preview is stale.",
+        };
+      if (options.expectedBefore !== undefined) {
+        const existing = transaction.findActionByOperationId(root.recordId, input.operationId);
+        if (existing === null) {
+          const current = projectEndState(root, transaction.listActions(root.recordId));
+          if (!sameEndState(current, options.expectedBefore))
+            return {
+              status: "rejected",
+              reason: "operation-conflict",
+              detail: "event-game-concurrency-conflict",
+            };
+        }
+      }
+      return { status: "accepted" };
+    },
+    acceptedActionAuditContext: options.auditContext,
+    acceptedDuplicateActionResolver: options.duplicateResolver,
+    acceptedLifecycleTransition: options.lifecycleTransition,
+  });
+}
+
+async function readLockedContext(
+  dependencies: Dependencies,
+  eventId: string,
+  eventGameId: string,
+  authority: EventAdministrationAuthority,
+  duplicateOperationId?: string,
+): Promise<
+  EventAdministrationOutcome<{
+    root: EventGameRecordRoot;
+    before: LockedGameEndState;
+    actor: AuthorizedActor;
+    grant: GrantLifecycleSnapshot;
+    queuedDiscardCount: number;
+    rootRevision: LockedGameContext["rootRevision"];
+    duplicateAction?: ControlActionInput;
+  }>
+> {
+  try {
+    return await dependencies.storage.transaction((transaction) => {
+      const actor = dependencies.authorize(transaction, eventId, authority, true);
+      if (actor === null) return unauthorized();
+      const root = transaction.findRootByEventGameId(eventGameId);
+      const game = transaction.findEventGame(eventGameId);
+      if (root === null || game === null || game.eventId !== eventId) return notFound();
+      const existing =
+        duplicateOperationId === undefined
+          ? null
+          : transaction.findActionByOperationId(root.recordId, duplicateOperationId);
+      const duplicateAction =
+        existing?.action.interpretation.type === "fact" &&
+        existing.action.interpretation.factType === "game-reopening"
+          ? structuredClone(existing.action)
+          : undefined;
+      if (root.lifecycle.lockedAtMs === null && duplicateAction === undefined)
+        return inUse("Event Game is not locked.");
+      const context = contextForTransaction(transaction, root, actor);
+      return accepted({
+        ...context,
+        ...(duplicateAction === undefined ? {} : { duplicateAction }),
+      });
+    });
+  } catch {
+    return unavailable();
+  }
+}
+
+function findControlGrant(
+  transaction: FoundationStorageTransaction,
+  root: EventGameRecordRoot,
+): StoredGrant | null {
+  return (
+    transaction
+      .listGrants()
+      .filter((candidate) => {
+        if (candidate.grantType !== GRANT_TYPE) return false;
+        const scope = validateControlGrantScope(candidate.scope);
+        return (
+          scope.ok &&
+          scope.value.eventId === root.externalScope.eventId &&
+          scope.value.gameDayId === root.externalScope.gameDayId &&
+          scope.value.pitchId === root.externalScope.pitchId &&
+          scope.value.pitchSlotId === root.externalScope.pitchSlotId
+        );
+      })
+      .sort((left, right) => right.createdAtMs - left.createdAtMs)[0] ?? null
+  );
+}
+
+function makePreview(
+  context: LockedGameContext,
+  operation: LockedGamePreview["operation"],
+  operationId: string,
+  after: LockedGameEndState,
+  lifecycle: EventGameRecordRoot["lifecycle"],
+): LockedGamePreview {
+  const reopening = operation === "game-reopening";
+  return {
+    eventGameId: context.root.eventGameId,
+    recordId: context.root.recordId,
+    operation,
+    operationId,
+    impact: {
+      facts: reopening ? "preserved" : "corrected",
+      lifecycle: {
+        from: context.root.lifecycle.phase,
+        to: lifecycle.phase,
+        lock: reopening ? "removed" : "retained",
+      },
+      timer: reopening
+        ? context.before.endTimeMs === null
+          ? "stopped"
+          : "restarted"
+        : "unchanged",
+      authority: { controlGrant: "preserved", qr: "preserved", grantVersion: "preserved" },
+      sessions: { category: "terminated", count: context.grant.terminatedSessionCount },
+      code: {
+        category: reopening ? "create-after-reopen" : "expired",
+        count: reopening && context.grant.codeState === "erased" ? 1 : 0,
+      },
+      queuedDiscard: { category: "locked-replay", count: context.queuedDiscardCount },
+    },
+    fingerprint: operationFingerprint(context, operation, operationId, after, lifecycle),
+  };
+}
+
+function operationFingerprint(
+  context: LockedGameContext,
+  operation: LockedGamePreview["operation"],
+  operationId: string,
+  after: LockedGameEndState,
+  lifecycle: EventGameRecordRoot["lifecycle"],
+): string {
+  return sha256(
+    canonicalizeJson({
+      version: "locked-event-game-preview-v1",
+      operation,
+      operationId,
+      eventId: context.root.eventId,
+      eventGameId: context.root.eventGameId,
+      recordId: context.root.recordId,
+      root: canonicalizeEventGameRecordRoot(context.root),
+      lifecycle,
+      currentEndState: context.before,
+      proposedEndState: after,
+      authority: context.actor,
+      grant: context.grant,
+      rootRevision: context.rootRevision,
+      queuedDiscardCount: context.queuedDiscardCount,
+    }),
+  );
+}
+
+function reopeningRoot(root: EventGameRecordRoot, before: LockedGameEndState): EventGameRecordRoot {
+  const finished = before.endTimeMs !== null;
+  return {
+    ...root,
+    lifecycle: {
+      ...root.lifecycle,
+      phase: finished ? "finished" : "in-progress",
+      finishedAtMs: finished ? root.lifecycle.finishedAtMs : null,
+      lockedAtMs: null,
+      lockReason: null,
+    },
+  };
+}
+
+function previewFingerprintForInput(
+  transaction: FoundationStorageTransaction,
+  root: EventGameRecordRoot,
+  actor: AuthorizedActor,
+  input: unknown,
+): string | null {
+  if (!isRecord(input) || typeof input.operationId !== "string") return null;
+  const context = contextForTransaction(transaction, root, actor);
+  const payload = input.payload;
+  if (!isRecord(payload) || !isRecord(payload.data)) return null;
+  if (payload.factType === "game-reopening" && payload.data.reopening === true) {
+    const reopened = reopeningRoot(
+      root,
+      projectEndState(root, transaction.listActions(root.recordId)),
+    );
+    return operationFingerprint(
+      context,
+      "game-reopening",
+      input.operationId,
+      context.before,
+      reopened.lifecycle,
+    );
+  }
+  if (payload.factType !== "locked-game-correction") return null;
+  const parsed = parseEndState(payload.data.correction);
+  if (!parsed.ok) return null;
+  const before = projectEndState(root, transaction.listActions(root.recordId));
+  return operationFingerprint(
+    context,
+    "locked-game-correction",
+    input.operationId,
+    mergeEndState(before, parsed.value),
+    root.lifecycle,
+  );
+}
+
+function contextForTransaction(
+  transaction: FoundationStorageTransaction,
+  root: EventGameRecordRoot,
+  actor: AuthorizedActor,
+): LockedGameContext {
+  const grant = findControlGrant(transaction, root);
+  if (grant === null) throw new Error("The Event Game Control Grant is unavailable.");
+  const sessions = transaction.listGrantSessions(grant.grantId);
+  return {
+    root,
+    before: projectEndState(root, transaction.listActions(root.recordId)),
+    actor,
+    grant: {
+      grantId: grant.grantId,
+      grantVersion: grant.grantVersion,
+      codeState: grant.code?.state ?? "absent",
+      terminatedSessionCount: sessions.filter((session) => session.status !== "active").length,
+      activeSessionCount: sessions.filter((session) => session.status === "active").length,
+      codeFingerprint: grant.code?.fingerprint ?? null,
+    },
+    rootRevision: {
+      metadata: transaction.readRecordMetadata(root.recordId),
+    },
+    queuedDiscardCount: Math.min(
+      1000,
+      transaction
+        .listAuditEntries(root.recordId)
+        .reduce((count, audit) => count + (audit.lockedReplay?.count ?? 0), 0),
+    ),
+  };
+}
+
+function sameActionInput(input: Record<string, unknown>, action: ControlAction): boolean {
+  const comparableInput = JSON.parse(
+    JSON.stringify({
+      recordId: input.recordId,
+      eventGameId: input.eventGameId,
+      operationId: input.operationId,
+      kind: input.kind,
+      payload: input.payload,
+      causalPredecessorIds: input.causalPredecessorIds,
+      occurrence: input.occurrence,
+      grant: input.grant,
+      origin: input.origin,
+      lifecycle: input.lifecycle,
+      override: input.override,
+      recoveryProvenance: input.recoveryProvenance,
+    }),
+  );
+  const comparableAction = JSON.parse(
+    JSON.stringify({
+      recordId: action.recordId,
+      eventGameId: action.eventGameId,
+      operationId: action.operationId,
+      kind: action.kind,
+      payload: action.payload,
+      causalPredecessorIds: action.causalPredecessorIds,
+      occurrence: action.occurrence,
+      grant: action.grant,
+      origin: action.origin,
+      lifecycle: action.lifecycle,
+      override: action.override,
+      recoveryProvenance: action.recoveryProvenance,
+    }),
+  );
+  return canonicalizeJson(comparableInput) === canonicalizeJson(comparableAction);
+}
+
+function resolveReopeningDuplicate(
+  dependencies: Dependencies,
+  transaction: FoundationStorageTransaction,
+  root: EventGameRecordRoot,
+  _input: unknown,
+  prepared: import("@/lib/event-game-actions").PreparedControlAction | null,
+  authority: EventAdministrationAuthority,
+): ControlActionAcceptanceOutcome | null {
+  const actor = dependencies.authorize(transaction, root.eventId, authority);
+  if (actor === null || !isRecord(_input) || typeof _input.operationId !== "string") return null;
+  const existing = transaction.findActionByOperationId(root.recordId, _input.operationId);
+  if (existing === null) return null;
+  const same =
+    ((prepared !== null && existing.contentFingerprint === prepared.contentFingerprint) ||
+      (prepared === null && sameActionInput(_input, existing.action))) &&
+    existing.action.interpretation.type === "fact" &&
+    existing.action.interpretation.factType === "game-reopening";
+  if (same) {
+    return {
+      status: "duplicate-accepted",
+      action: structuredClone(existing.action),
+      auditId: acceptedAuditId(existing.action),
+      eventAuditId: eventAuditIdFor(root.eventId, existing.action.operationId, "game-reopened"),
+    };
+  }
+  return {
+    status: "rejected",
+    reason: "operation-conflict",
+    detail: "The operation identity is already bound to different content.",
+  };
+}
+
+function linkedGrantAudits(
+  transaction: FoundationStorageTransaction,
+  context: LockedGameContext,
+  controlAudit: ControlAuditEntry,
+  action: ControlAction,
+  nowMs: number,
+): readonly StoredGrantAuditEntry[] {
+  if (context.actor.sessionId === null) return [];
+  for (const grant of transaction.listGrants()) {
+    const session = transaction
+      .listGrantSessions(grant.grantId)
+      .find((candidate) => candidate.sessionId === context.actor.sessionId);
+    if (session === undefined) continue;
+    const auditId = `grant-audit-${sha256(`${grant.grantId}:${action.operationId}:event-game`)}`;
+    const contentFingerprint = controlAudit.links?.contentFingerprint;
+    const acceptanceId = controlAudit.links?.acceptanceId;
+    if (contentFingerprint === undefined || acceptanceId === undefined) return [];
+    const actorReference = `actor-${sha256(`${grant.grantId}:${session.sessionId}`).slice(0, 32)}`;
+    controlAudit.links ??= {
+      actionId: null,
+      targetFactId: null,
+      causalPredecessorIds: [],
+      relatedOperationIds: [],
+      ordering: null,
+    };
+    controlAudit.links.grantAuditId = auditId;
+    return [
+      {
+        auditId,
+        action: "control-action-accepted",
+        outcome: "accepted",
+        actorReference,
+        grantId: grant.grantId,
+        grantType: grant.grantType,
+        grantVersion: grant.grantVersion,
+        scope: structuredClone(grant.scope),
+        sessionId: session.sessionId,
+        replacedSessionId: null,
+        eventGameId: context.root.eventGameId,
+        previousEventGameId: null,
+        replayEvidenceId: null,
+        credentialKind: GRANT_CREDENTIAL_KIND,
+        credentialFingerprint: null,
+        beforeStatus: grant.status,
+        afterStatus: grant.status,
+        beforeExpiresAtMs: grant.expiresAtMs,
+        afterExpiresAtMs: grant.expiresAtMs,
+        terminalReason: null,
+        acceptanceId,
+        controlAuditId: controlAudit.auditId,
+        controlActionId: actionIdentity(action.recordId, action.operationId),
+        contentFingerprint,
+        outcomeDetail: canonicalizeJson({
+          status: "accepted",
+          reason: null,
+          detail: ACCEPTED_AUDIT_DETAIL,
+        }),
+        createdAtMs: nowMs,
+      },
+    ];
+  }
+  return [];
+}
+
+function createEventAuditWriter(
+  action: "locked-game-corrected" | "game-reopened",
+  eventId: string,
+  operationId: string,
+  root: EventGameRecordRoot,
+  actorReference: string,
+  occurredAtMs: number,
+) {
+  const auditId = eventAuditIdFor(eventId, operationId, action);
+  const writer = (controlAuditId: string): EventCatalogAuditEntry => {
+    return {
+      auditId,
+      operationId,
+      action,
+      eventId,
+      gameDayId: root.externalScope.gameDayId,
+      actorReference,
+      occurredAtMs,
+      before: {
+        eventGameId: root.eventGameId,
+        controlAuditId,
+        valueReference: "control-audit",
+      },
+      after: {
+        eventGameId: root.eventGameId,
+        controlAuditId,
+        valueReference: "control-audit",
+      },
+    };
+  };
+  return Object.assign(writer, { id: auditId });
+}
+
+function eventAuditIdFor(
+  eventId: string,
+  operationId: string,
+  action: "locked-game-corrected" | "game-reopened",
+): string {
+  return `event-audit-${sha256(`${eventId}:${operationId}:${action}`)}`;
+}
+
+function mapRecordOutcome(
+  outcome: ControlActionAcceptanceOutcome,
+): EventAdministrationOutcome<never> {
+  if (outcome.status !== "rejected") return unavailable();
+  if (outcome.detail === "event-admin-unauthorized") return unauthorized();
+  if (outcome.detail === "event-game-not-locked") return inUse("Event Game is not locked.");
+  if (outcome.reason === "operation-conflict") return conflict();
+  if (outcome.reason === "storage-not-ready") return unavailable();
+  return invalid(outcome.detail);
+}
+
+function createAdminFactAction(
+  root: EventGameRecordRoot,
+  operationId: string,
+  nowMs: number,
+  actor: AuthorizedActor,
+  factType: "locked-game-correction" | "game-reopening",
+  data: Record<string, unknown>,
+  overrideApplied: boolean,
+  before?: LockedGameEndState,
+  after?: LockedGameEndState,
+): ControlActionInput {
+  return {
+    recordId: root.recordId,
+    eventGameId: root.eventGameId,
+    operationId,
+    kind: { id: "game-fact", version: "1" },
+    payload: {
+      factId: `${operationId}-fact`,
+      factType,
+      gameSideId: null,
+      gameTimeMs: after?.endTimeMs ?? before?.endTimeMs ?? 0,
+      data,
+    },
+    causalPredecessorIds: [],
+    occurrence: { trustedAtMs: nowMs, clientOriginAtMs: null, source: "online" },
+    grant:
+      actor.sessionId === null
+        ? null
+        : {
+            sessionId: actor.sessionId,
+            versionId: actor.grantVersion ?? "event-admin-current",
+            authorityReference: actor.actorReference,
+          },
+    origin: "event-admin",
+    lifecycle: root.lifecycle,
+    ...(overrideApplied && before !== undefined && after !== undefined
+      ? {
+          override: {
+            guardrail: "locked-game-end-state-consistency",
+            direction: "event-admin-directed-reconciliation",
+            confirmation: "event-admin-confirmed",
+            authorityReference: actor.actorReference,
+            gameTimeMs: after.endTimeMs ?? root.lifecycle.finishedAtMs ?? nowMs,
+            beforeValue: before,
+            afterValue: after,
+          },
+        }
+      : {}),
+  };
+}
+
+function parseEndState(
+  value: unknown,
+): { ok: true; value: Partial<LockedGameEndState> } | { ok: false; error: string } {
+  if (!isRecord(value)) return { ok: false, error: "Locked Game end state must be an object." };
+  const result: Partial<LockedGameEndState> = {};
+  if (value.scoreByGameSide !== undefined) {
+    if (!isRecord(value.scoreByGameSide)) return { ok: false, error: "Scores must be an object." };
+    const scores: Record<string, number> = {};
+    for (const [sideId, score] of Object.entries(value.scoreByGameSide)) {
+      if (!validateOpaqueIdentifier(sideId, "scoreByGameSide side").ok || !isSafeScore(score))
+        return { ok: false, error: "Scores are invalid." };
+      scores[sideId] = score;
+    }
+    result.scoreByGameSide = scores;
+  }
+  const winner = nullableId(value.winnerGameSideId, "winnerGameSideId");
+  const catcher = nullableId(value.flagCatchingGameSideId, "flagCatchingGameSideId");
+  const catchTime = nullableTime(value.catchTimeMs, "catchTimeMs");
+  const endTime = nullableTime(value.endTimeMs, "endTimeMs");
+  if (!winner.ok) return winner;
+  if (!catcher.ok) return catcher;
+  if (!catchTime.ok) return catchTime;
+  if (!endTime.ok) return endTime;
+  if (winner.present) result.winnerGameSideId = winner.value;
+  if (catcher.present) result.flagCatchingGameSideId = catcher.value;
+  if (catchTime.present) result.catchTimeMs = catchTime.value;
+  if (endTime.present) result.endTimeMs = endTime.value;
+  return Object.keys(result).length === 0
+    ? { ok: false, error: "End state must change a value." }
+    : { ok: true, value: result };
+}
+
+function projectEndState(
+  root: EventGameRecordRoot,
+  actions: readonly StoredControlAction[],
+): LockedGameEndState {
+  const derived = projectLiveEventGameDerivedState(root, actions);
+  const latest = actions
+    .map(lockedCorrectionData)
+    .filter((value): value is LockedGameEndState => value !== null)
+    .at(-1);
+  return (
+    latest ?? {
+      scoreByGameSide:
+        derived?.scoreByGameSide ?? Object.fromEntries(root.gameSides.map((side) => [side.id, 0])),
+      winnerGameSideId: derived?.winnerGameSideId ?? null,
+      flagCatchingGameSideId: derived?.catch?.catchingGameSideId ?? null,
+      catchTimeMs: derived?.catch?.gameTimeMs ?? null,
+      endTimeMs: root.lifecycle.finishedAtMs,
+    }
+  );
+}
+function sameEndState(left: LockedGameEndState, right: LockedGameEndState): boolean {
+  const leftScores = Object.entries(left.scoreByGameSide);
+  const rightScores = Object.entries(right.scoreByGameSide);
+  return (
+    left.winnerGameSideId === right.winnerGameSideId &&
+    left.flagCatchingGameSideId === right.flagCatchingGameSideId &&
+    left.catchTimeMs === right.catchTimeMs &&
+    left.endTimeMs === right.endTimeMs &&
+    leftScores.length === rightScores.length &&
+    leftScores.every(([sideId, score]) => right.scoreByGameSide[sideId] === score)
+  );
+}
+function mergeEndState(
+  before: LockedGameEndState,
+  patch: Partial<LockedGameEndState>,
+): LockedGameEndState {
+  return {
+    scoreByGameSide:
+      patch.scoreByGameSide !== undefined
+        ? { ...before.scoreByGameSide, ...patch.scoreByGameSide }
+        : before.scoreByGameSide,
+    winnerGameSideId:
+      patch.winnerGameSideId !== undefined ? patch.winnerGameSideId : before.winnerGameSideId,
+    flagCatchingGameSideId:
+      patch.flagCatchingGameSideId !== undefined
+        ? patch.flagCatchingGameSideId
+        : before.flagCatchingGameSideId,
+    catchTimeMs: patch.catchTimeMs !== undefined ? patch.catchTimeMs : before.catchTimeMs,
+    endTimeMs: patch.endTimeMs !== undefined ? patch.endTimeMs : before.endTimeMs,
+  };
+}
+function lockedCorrectionData(stored: StoredControlAction): LockedGameEndState | null {
+  const interpretation = stored.action.interpretation;
+  if (interpretation.type !== "fact" || interpretation.factType !== "locked-game-correction")
+    return null;
+  const payload = interpretation.payload;
+  if (!isRecord(payload) || Array.isArray(payload)) return null;
+  const data = payload.data;
+  if (data === null || typeof data !== "object" || Array.isArray(data)) return null;
+  const correction = (data as { correction?: unknown }).correction;
+  if (!isRecord(correction)) return null;
+  const parsed = parseEndState(correction);
+  return parsed.ok &&
+    parsed.value.scoreByGameSide !== undefined &&
+    parsed.value.winnerGameSideId !== undefined &&
+    parsed.value.flagCatchingGameSideId !== undefined &&
+    parsed.value.catchTimeMs !== undefined &&
+    parsed.value.endTimeMs !== undefined
+    ? (parsed.value as LockedGameEndState)
+    : null;
+}
+function parseIds(eventId: unknown, eventGameId: unknown, operationId: unknown, label: string) {
+  const parsedEvent = validateOpaqueIdentifier(eventId, "eventId");
+  const parsedGame = validateOpaqueIdentifier(eventGameId, "eventGameId");
+  const parsedOperation = validateOpaqueIdentifier(operationId, "operationId");
+  return parsedEvent.ok && parsedGame.ok && parsedOperation.ok
+    ? {
+        ok: true as const,
+        eventId: parsedEvent.value,
+        eventGameId: parsedGame.value,
+        operationId: parsedOperation.value,
+      }
+    : { ok: false as const, error: `${label} identifiers are invalid.` };
+}
+function isSafeScore(value: unknown): value is number {
+  return (
+    typeof value === "number" &&
+    Number.isSafeInteger(value) &&
+    value >= 0 &&
+    value <= SHARED_LIMITS.score.max
+  );
+}
+function nullableId(
+  value: unknown,
+  field: string,
+): { ok: true; present: boolean; value: string | null } | { ok: false; error: string } {
+  if (value === undefined) return { ok: true, present: false, value: null };
+  if (value === null) return { ok: true, present: true, value: null };
+  const parsed = validateOpaqueIdentifier(value, field);
+  return parsed.ok ? { ok: true, present: true, value: parsed.value } : parsed;
+}
+function nullableTime(
+  value: unknown,
+  field: string,
+): { ok: true; present: boolean; value: number | null } | { ok: false; error: string } {
+  if (value === undefined) return { ok: true, present: false, value: null };
+  if (value === null) return { ok: true, present: true, value: null };
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0)
+    return { ok: false, error: `${field} is invalid.` };
+  return { ok: true, present: true, value };
+}
+function readNow(clock: () => number): number | null {
+  const value = clock();
+  return Number.isSafeInteger(value) && value >= 0 ? value : null;
+}
+function isRecord(value: unknown): value is Record<string, any> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+function accepted<T>(value: T): EventAdministrationOutcome<T> {
+  return { status: "accepted", value };
+}
+function invalid(detail: string): EventAdministrationOutcome<never> {
+  return { status: "rejected", reason: "invalid-input", detail };
+}
+function unauthorized(): EventAdministrationOutcome<never> {
+  return {
+    status: "rejected",
+    reason: "unauthorized",
+    detail: "Unable to authorize Event administration.",
+  };
+}
+function notFound(): EventAdministrationOutcome<never> {
+  return { status: "rejected", reason: "not-found", detail: "Event Game was not found." };
+}
+function inUse(detail: string): EventAdministrationOutcome<never> {
+  return { status: "rejected", reason: "in-use", detail };
+}
+function conflict(): EventAdministrationOutcome<never> {
+  return invalid("Operation identity conflicts with committed content.");
+}
+function unavailable(): EventAdministrationOutcome<never> {
+  return {
+    status: "retryable-failure",
+    detail: "Locked Event Game administration is unavailable.",
+  };
+}

--- a/src/pages/event-admin-page.tsx
+++ b/src/pages/event-admin-page.tsx
@@ -190,6 +190,28 @@ type AccessSheetGenerationAttempt = {
   scopeKey: string;
 };
 
+type LockedGameRequestToken = {
+  eventId: string;
+  gameDayId: string;
+  authority: HubResponse["value"]["authority"] | "none";
+  generation: number;
+  grantToken: GrantSecretToken;
+};
+
+type LockedGamePreview = {
+  operation: "locked-game-correction" | "game-reopening";
+  fingerprint: string;
+  impact: {
+    facts: string;
+    lifecycle: { from: string; to: string; lock: string };
+    timer: string;
+    authority: { controlGrant: string; qr: string; grantVersion: string };
+    sessions: { category: string; count: number };
+    code: { category: string; count: number };
+    queuedDiscard: { category: string; count: number };
+  };
+};
+
 function useAccessSheetArtifactOwner(scope: AccessSheetArtifactScope) {
   const scopeKey = JSON.stringify(scope);
   const sequenceRef = useRef(0);
@@ -278,6 +300,12 @@ export function EventAdminPage({
   const [pitchManagerGameDayId, setPitchManagerGameDayId] = useState("");
   const [message, setMessage] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
+  const [lockedGameId, setLockedGameId] = useState("");
+  const [lockedOperationId, setLockedOperationId] = useState("");
+  const [lockedEndState, setLockedEndState] = useState(
+    '{\n  "scoreByGameSide": {},\n  "winnerGameSideId": null,\n  "flagCatchingGameSideId": null,\n  "catchTimeMs": null,\n  "endTimeMs": null\n}',
+  );
+  const [lockedGamePreview, setLockedGamePreview] = useState<LockedGamePreview | null>(null);
   const [teamName, setTeamName] = useState("");
   const [teamColor, setTeamColor] = useState("#00afe8");
   const [pitchName, setPitchName] = useState("");
@@ -344,6 +372,8 @@ export function EventAdminPage({
     type: accessSheetType,
   });
   const [secretOwner] = useState(createGrantSecretOwner);
+  const lockedGameRequestGeneration = useRef(0);
+  const lockedGameRequestToken = useRef<LockedGameRequestToken | null>(null);
 
   const secretScopeKey = (
     nextEventId = eventId,
@@ -355,6 +385,38 @@ export function EventAdminPage({
 
   const gameDayScopeKey = (nextEventId = eventId, nextGameDayId = selectedGameDayId) =>
     `event-admin-game-day:${nextEventId}:${nextGameDayId ?? "none"}`;
+
+  const invalidateLockedGameRequest = () => {
+    lockedGameRequestGeneration.current += 1;
+    const current = lockedGameRequestToken.current;
+    if (current !== null) secretOwner.invalidate(current.grantToken.scopeKey);
+    lockedGameRequestToken.current = null;
+    setLockedGamePreview(null);
+  };
+
+  const captureLockedGameRequest = (): LockedGameRequestToken | null => {
+    const currentEventId = eventId.trim();
+    if (currentEventId.length === 0 || selectedGameDayId === null) return null;
+    const existing = lockedGameRequestToken.current;
+    if (existing !== null && secretOwner.current(existing.grantToken)) return existing;
+    const grantToken = secretOwner.capture(hubScopeKey());
+    const next: LockedGameRequestToken = {
+      eventId: currentEventId,
+      gameDayId: selectedGameDayId,
+      authority: (hub?.authority ?? "none") as LockedGameRequestToken["authority"],
+      generation: lockedGameRequestGeneration.current,
+      grantToken,
+    };
+    lockedGameRequestToken.current = next;
+    return next;
+  };
+
+  const lockedGameRequestCurrent = (token: LockedGameRequestToken) =>
+    token.generation === lockedGameRequestGeneration.current &&
+    token.eventId === eventId.trim() &&
+    token.gameDayId === selectedGameDayId &&
+    token.authority === (hub?.authority ?? "none") &&
+    secretOwner.current(token.grantToken);
 
   const clearGrantSecrets = () => {
     setCredential("");
@@ -372,6 +434,7 @@ export function EventAdminPage({
   };
 
   const invalidateGrantSecrets = () => {
+    invalidateLockedGameRequest();
     accessSheetOwner.invalidate();
     secretOwner.invalidate(secretScopeKey());
     secretOwner.invalidate(gameDayScopeKey());
@@ -380,6 +443,7 @@ export function EventAdminPage({
   };
 
   const changeEventId = (nextEventId: string) => {
+    invalidateLockedGameRequest();
     invalidateGrantSecrets();
     setHub(null);
     setSelectedGameDayId(null);
@@ -417,6 +481,8 @@ export function EventAdminPage({
     setGameDesignation("");
     setSideASource("");
     setSideBSource("");
+    setLockedGameId("");
+    setLockedOperationId("");
     setPublicationImpactConfirmed(false);
     setEventId(nextEventId);
   };
@@ -461,6 +527,10 @@ export function EventAdminPage({
     },
     [secretOwner],
   );
+
+  useEffect(() => {
+    invalidateLockedGameRequest();
+  }, [eventId, selectedGameDayId, hub?.authority]);
 
   const loadHub = async (nextGameDayId = selectedGameDayId, providedToken?: GrantSecretToken) => {
     accessSheetOwner.invalidate();
@@ -1385,6 +1455,130 @@ export function EventAdminPage({
     await loadHub(selectedGameDayId, token);
   };
 
+  const previewLockedGame = async (operation: LockedGamePreview["operation"]) => {
+    if (lockedGameId.trim().length === 0) throw new Error("Choose an Event Game.");
+    if (lockedOperationId.trim().length === 0) throw new Error("Enter an operation ID.");
+    if (selectedGameDayId === null) throw new Error("Choose a Game Day.");
+    let endState: unknown = undefined;
+    if (operation === "locked-game-correction") {
+      try {
+        endState = JSON.parse(lockedEndState);
+      } catch {
+        throw new Error("End state must be valid JSON.");
+      }
+    }
+    const token = captureLockedGameRequest();
+    if (token === null) return;
+    try {
+      const previewPath =
+        operation === "locked-game-correction" ? "locked-correction/preview" : "reopen/preview";
+      const response = await fetch(
+        `/api/event-admin/events/${token.eventId}/game-days/${token.gameDayId}/event-games/${lockedGameId}/${previewPath}`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            operationId: lockedOperationId,
+            ...(operation === "locked-game-correction" ? { endState } : {}),
+          }),
+        },
+      );
+      const payload = (await response.json()) as {
+        status?: string;
+        value?: LockedGamePreview;
+        detail?: string;
+        message?: string;
+      };
+      if (!lockedGameRequestCurrent(token)) return;
+      if (!response.ok || payload.status !== "accepted" || payload.value === undefined)
+        throw new Error(payload.detail ?? payload.message ?? "Locked Game preview failed.");
+      setLockedGamePreview(payload.value);
+    } catch (error) {
+      if (lockedGameRequestCurrent(token)) throw error;
+    }
+  };
+
+  const correctLockedGame = async (overrideConfirmed: boolean) => {
+    if (lockedGamePreview?.operation !== "locked-game-correction")
+      throw new Error("Preview the Locked Game Correction before confirming it.");
+    if (lockedGameId.trim().length === 0) throw new Error("Choose an Event Game.");
+    if (lockedOperationId.trim().length === 0) throw new Error("Enter an operation ID.");
+    let endState: unknown;
+    try {
+      endState = JSON.parse(lockedEndState);
+    } catch {
+      throw new Error("End state must be valid JSON.");
+    }
+    const token = captureLockedGameRequest();
+    if (token === null) return;
+    try {
+      const response = await fetch(
+        `/api/event-admin/events/${token.eventId}/game-days/${token.gameDayId}/event-games/${lockedGameId}/locked-correction`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            operationId: lockedOperationId,
+            endState,
+            overrideConfirmed,
+            previewFingerprint: lockedGamePreview.fingerprint,
+          }),
+        },
+      );
+      const payload = (await response.json()) as {
+        status?: string;
+        detail?: string;
+        message?: string;
+      };
+      if (!lockedGameRequestCurrent(token)) return;
+      if (!response.ok || payload.status !== "accepted")
+        throw new Error(payload.detail ?? payload.message ?? "Locked Game correction failed.");
+      if (!lockedGameRequestCurrent(token)) return;
+      await loadHub(token.gameDayId, token.grantToken);
+      if (!lockedGameRequestCurrent(token)) return;
+      setLockedGamePreview(null);
+    } catch (error) {
+      if (lockedGameRequestCurrent(token)) throw error;
+    }
+  };
+
+  const reopenLockedGame = async () => {
+    if (lockedGamePreview?.operation !== "game-reopening")
+      throw new Error("Preview Game Reopening before confirming it.");
+    if (lockedGameId.trim().length === 0) throw new Error("Choose an Event Game.");
+    if (lockedOperationId.trim().length === 0) throw new Error("Enter an operation ID.");
+    if (selectedGameDayId === null) throw new Error("Choose a Game Day.");
+    const token = captureLockedGameRequest();
+    if (token === null) return;
+    try {
+      const response = await fetch(
+        `/api/event-admin/events/${token.eventId}/game-days/${token.gameDayId}/event-games/${lockedGameId}/reopen`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            operationId: lockedOperationId,
+            previewFingerprint: lockedGamePreview.fingerprint,
+          }),
+        },
+      );
+      const payload = (await response.json()) as {
+        status?: string;
+        detail?: string;
+        message?: string;
+      };
+      if (!lockedGameRequestCurrent(token)) return;
+      if (!response.ok || payload.status !== "accepted")
+        throw new Error(payload.detail ?? payload.message ?? "Game Reopening failed.");
+      if (!lockedGameRequestCurrent(token)) return;
+      await loadHub(token.gameDayId, token.grantToken);
+      if (!lockedGameRequestCurrent(token)) return;
+      setLockedGamePreview(null);
+    } catch (error) {
+      if (lockedGameRequestCurrent(token)) throw error;
+    }
+  };
+
   useEffect(() => {
     if (eventId.length > 0) void loadHub().catch(() => undefined);
   }, []);
@@ -1507,6 +1701,127 @@ export function EventAdminPage({
                 </p>
               </div>
               <AdministrativeAuditBrowser eventId={hub.event.eventId} route="event-admin" />
+              <div className="space-y-3 rounded-lg border p-3">
+                <div>
+                  <p className="font-semibold">Locked Event Game administration</p>
+                  <p className="text-xs text-muted-foreground">
+                    Correct settled facts while retaining the lock, or reopen the game for fresh
+                    control admission. One confirmation is required when the end state is
+                    inconsistent with ordinary scoring rules.
+                  </p>
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="locked-game-id">Event Game</Label>
+                  <select
+                    id="locked-game-id"
+                    className="border-input bg-background h-10 w-full rounded-md border px-3 text-sm"
+                    value={lockedGameId}
+                    onChange={(event) => {
+                      setLockedGameId(event.currentTarget.value);
+                      setLockedGamePreview(null);
+                    }}
+                  >
+                    <option value="">Choose an Event Game</option>
+                    {hub.event.eventGames.map((game) => (
+                      <option key={game.eventGameId} value={game.eventGameId}>
+                        {game.gameDesignation ?? game.gameCode ?? game.eventGameId}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="locked-operation-id">Operation ID</Label>
+                  <Input
+                    id="locked-operation-id"
+                    value={lockedOperationId}
+                    onChange={(event) => {
+                      setLockedOperationId(event.currentTarget.value);
+                      setLockedGamePreview(null);
+                    }}
+                    onInput={(event) => {
+                      setLockedOperationId(event.currentTarget.value);
+                      setLockedGamePreview(null);
+                    }}
+                    placeholder="unique correction or reopening ID"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="locked-end-state">Corrected end state (JSON)</Label>
+                  <textarea
+                    id="locked-end-state"
+                    className="border-input bg-background min-h-36 w-full rounded-md border p-3 font-mono text-xs"
+                    value={lockedEndState}
+                    onChange={(event) => {
+                      setLockedEndState(event.currentTarget.value);
+                      setLockedGamePreview(null);
+                    }}
+                    onInput={(event) => {
+                      setLockedEndState(event.currentTarget.value);
+                      setLockedGamePreview(null);
+                    }}
+                  />
+                </div>
+                {lockedGamePreview !== null ? (
+                  <div className="space-y-1 rounded-md bg-muted p-3 text-xs">
+                    <p className="font-semibold">
+                      Preview ready ·{" "}
+                      {lockedGamePreview.operation === "game-reopening" ? "reopen" : "correction"}
+                    </p>
+                    <p>
+                      Facts: {lockedGamePreview.impact.facts}; lifecycle:{" "}
+                      {lockedGamePreview.impact.lifecycle.from} →{" "}
+                      {lockedGamePreview.impact.lifecycle.to}; lock:{" "}
+                      {lockedGamePreview.impact.lifecycle.lock}.
+                    </p>
+                    <p>
+                      Timer: {lockedGamePreview.impact.timer}; terminated sessions:{" "}
+                      {lockedGamePreview.impact.sessions.count}; queued discard evidence:{" "}
+                      {lockedGamePreview.impact.queuedDiscard.count}.
+                    </p>
+                  </div>
+                ) : null}
+                <div className="flex flex-wrap gap-2">
+                  <Button
+                    type="button"
+                    disabled={busy}
+                    onClick={() => void run(() => previewLockedGame("locked-game-correction"))}
+                  >
+                    Preview Locked Game Correction
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    disabled={busy || lockedGamePreview?.operation !== "locked-game-correction"}
+                    onClick={() => void run(() => correctLockedGame(true))}
+                  >
+                    Confirm Official Override
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    disabled={busy || lockedGamePreview?.operation !== "locked-game-correction"}
+                    onClick={() => void run(() => correctLockedGame(false))}
+                  >
+                    Confirm Locked Game Correction
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    disabled={busy}
+                    onClick={() => void run(() => previewLockedGame("game-reopening"))}
+                  >
+                    Preview Game Reopening
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    disabled={busy || lockedGamePreview?.operation !== "game-reopening"}
+                    onClick={() => void run(reopenLockedGame)}
+                  >
+                    Confirm Game Reopening
+                  </Button>
+                </div>
+              </div>
               <div className="space-y-3 rounded-lg border p-3">
                 <div>
                   <p className="font-semibold">Unused catalog removal</p>
@@ -1649,6 +1964,7 @@ export function EventAdminPage({
                   value={selectedGameDayId ?? ""}
                   onChange={(event) => {
                     const next = event.target.value || null;
+                    invalidateLockedGameRequest();
                     invalidateGrantSecrets();
                     setSelectedGameDayId(next);
                     void run(async () => {

--- a/src/pages/grant-secret-lifecycle.test.tsx
+++ b/src/pages/grant-secret-lifecycle.test.tsx
@@ -157,6 +157,19 @@ const eventBHub = {
   },
 };
 
+const lockedGameHub = {
+  ...twoDayEventHub,
+  event: {
+    ...twoDayEventHub.event,
+    eventGames: [
+      {
+        ...identityEventHub.event.eventGames[0]!,
+        gameDesignation: "Opening",
+      },
+    ],
+  },
+};
+
 const eventPitchView = {
   pitch: { pitchId: "pitch", name: "Pitch Main" },
   gameplaySlots: eventHub.event.gameplaySlots,
@@ -444,6 +457,236 @@ describe("Grant secret UI lifecycle", () => {
     expect(container.textContent).not.toContain("Slot 1 ·");
     expect(container.textContent).not.toContain("stale Day A network failure");
     expect(hubGameDays).toEqual([null, "day-two"]);
+  });
+
+  test("Event Admin previews and confirms correction and reopening with separate override", async () => {
+    const requests: { url: string; body: Record<string, unknown> }[] = [];
+    let hubCalls = 0;
+    const correctionPreview = {
+      operation: "locked-game-correction",
+      fingerprint: "correction-preview-v1",
+      impact: {
+        facts: "corrected",
+        lifecycle: { from: "finished", to: "finished", lock: "retained" },
+        timer: "unchanged",
+        authority: { controlGrant: "preserved", qr: "preserved", grantVersion: "preserved" },
+        sessions: { category: "terminated", count: 1 },
+        code: { category: "expired", count: 1 },
+        queuedDiscard: { category: "locked-replay", count: 1 },
+      },
+    };
+    const reopeningPreview = {
+      ...correctionPreview,
+      operation: "game-reopening",
+      fingerprint: "reopening-preview-v1",
+      impact: { ...correctionPreview.impact, facts: "preserved", timer: "restarted" },
+    };
+    fetchHandler = async (input, init) => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      const method = init?.method ?? "GET";
+      if (url.endsWith("/api/event-admin/admit"))
+        return json({ status: "admitted", sessionExpiresAtMs: 123_000 });
+      if (url.includes("/api/event-admin/hub")) {
+        hubCalls += 1;
+        if (hubCalls === 1) return json({ status: "rejected" }, 401);
+        return json({ status: "accepted", value: { ...lockedGameHub, selectedGameDayId: "day" } });
+      }
+      if (method === "POST" && url.endsWith("/locked-correction/preview"))
+        return json({ status: "accepted", value: correctionPreview });
+      if (method === "POST" && url.endsWith("/locked-correction")) {
+        requests.push({
+          url,
+          body: JSON.parse(typeof init?.body === "string" ? init.body : "{}") as Record<
+            string,
+            unknown
+          >,
+        });
+        return json({ status: "accepted" });
+      }
+      if (method === "POST" && url.endsWith("/reopen/preview"))
+        return json({ status: "accepted", value: reopeningPreview });
+      if (method === "POST" && url.endsWith("/reopen")) {
+        requests.push({
+          url,
+          body: JSON.parse(typeof init?.body === "string" ? init.body : "{}") as Record<
+            string,
+            unknown
+          >,
+        });
+        return json({ status: "accepted" });
+      }
+      throw new Error(`Unexpected locked-game request: ${method} ${url}`);
+    };
+
+    await render(<EventAdminPage />);
+    await admitEventAdmin();
+    expect((container.querySelector("select#game-day-selector") as HTMLSelectElement).value).toBe(
+      "day",
+    );
+    const gameSelect = container.querySelector("select#locked-game-id") as HTMLSelectElement;
+    await act(async () => {
+      setSelectValue(gameSelect, "game-identity");
+      await flush();
+    });
+    expect(gameSelect.value).toBe("game-identity");
+    await act(async () => {
+      setInputValue(
+        container.querySelector("input#locked-operation-id") as HTMLInputElement,
+        "correct-1",
+      );
+      await flush();
+    });
+    expect((container.querySelector("input#locked-operation-id") as HTMLInputElement).value).toBe(
+      "correct-1",
+    );
+    await act(async () => {
+      setTextareaValue(
+        container.querySelector("textarea#locked-end-state") as HTMLTextAreaElement,
+        JSON.stringify({ scoreByGameSide: { "side-a": 31, "side-b": 20 } }),
+      );
+      await flush();
+    });
+    expect((container.querySelector("select#game-day-selector") as HTMLSelectElement).value).toBe(
+      "day",
+    );
+    await clickButton("Preview Locked Game Correction");
+    await flushAct();
+    expect(container.textContent).toContain("Preview ready · correction");
+    await clickButton("Confirm Official Override");
+    expect(requests[0]).toMatchObject({
+      url: "/api/event-admin/events/event/game-days/day/event-games/game-identity/locked-correction",
+      body: {
+        operationId: "correct-1",
+        previewFingerprint: "correction-preview-v1",
+        overrideConfirmed: true,
+      },
+    });
+
+    await act(async () => {
+      setInputValue(
+        container.querySelector("input#locked-operation-id") as HTMLInputElement,
+        "reopen-1",
+      );
+      await flush();
+    });
+    await clickButton("Preview Game Reopening");
+    expect(container.textContent).toContain("Preview ready · reopen");
+    await clickButton("Confirm Game Reopening");
+    expect(requests[1]).toMatchObject({
+      url: "/api/event-admin/events/event/game-days/day/event-games/game-identity/reopen",
+      body: { operationId: "reopen-1", previewFingerprint: "reopening-preview-v1" },
+    });
+    expect(hubCalls).toBe(4);
+  });
+
+  test("Event Admin suppresses stale correction rejection and reopening network failure across Day and authority", async () => {
+    const pendingCorrection = deferred<Response>();
+    const pendingReopening = deferred<Response>();
+    let hubCalls = 0;
+    fetchHandler = async (input, init) => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      const method = init?.method ?? "GET";
+      if (url.includes("/api/event-admin/hub")) {
+        hubCalls += 1;
+        if (hubCalls === 1) return json({ status: "rejected" }, 401);
+        return json({
+          status: "accepted",
+          value: { ...lockedGameHub, selectedGameDayId: hubCalls > 1 ? "day-two" : "day" },
+        });
+      }
+      if (url.endsWith("/api/event-admin/admit"))
+        return json({ status: "admitted", sessionExpiresAtMs: 123_000 });
+      if (method === "POST" && url.endsWith("/locked-correction/preview"))
+        return json({
+          status: "accepted",
+          value: {
+            operation: "locked-game-correction",
+            fingerprint: "stale-correction",
+            impact: {
+              facts: "corrected",
+              lifecycle: { from: "finished", to: "finished", lock: "retained" },
+              timer: "unchanged",
+              authority: { controlGrant: "preserved", qr: "preserved", grantVersion: "preserved" },
+              sessions: { category: "terminated", count: 0 },
+              code: { category: "expired", count: 0 },
+              queuedDiscard: { category: "locked-replay", count: 0 },
+            },
+          },
+        });
+      if (method === "POST" && url.endsWith("/locked-correction")) return pendingCorrection.promise;
+      if (method === "POST" && url.endsWith("/reopen/preview"))
+        return json({
+          status: "accepted",
+          value: {
+            operation: "game-reopening",
+            fingerprint: "stale-reopening",
+            impact: {
+              facts: "preserved",
+              lifecycle: { from: "finished", to: "finished", lock: "removed" },
+              timer: "restarted",
+              authority: { controlGrant: "preserved", qr: "preserved", grantVersion: "preserved" },
+              sessions: { category: "terminated", count: 0 },
+              code: { category: "create-after-reopen", count: 0 },
+              queuedDiscard: { category: "locked-replay", count: 0 },
+            },
+          },
+        });
+      if (method === "POST" && url.endsWith("/reopen")) return pendingReopening.promise;
+      throw new Error(`Unexpected stale locked-game request: ${method} ${url}`);
+    };
+
+    await render(<EventAdminPage />);
+    await admitEventAdmin();
+    const gameSelect = container.querySelector("select#locked-game-id") as HTMLSelectElement;
+    await act(async () => {
+      setSelectValue(gameSelect, "game-identity");
+      await flush();
+    });
+    await act(async () => {
+      setInputValue(
+        container.querySelector("input#locked-operation-id") as HTMLInputElement,
+        "stale-correction",
+      );
+      await flush();
+    });
+    expect((container.querySelector("input#locked-operation-id") as HTMLInputElement).value).toBe(
+      "stale-correction",
+    );
+    await act(async () => {
+      setTextareaValue(
+        container.querySelector("textarea#locked-end-state") as HTMLTextAreaElement,
+        JSON.stringify({ scoreByGameSide: { "side-a": 31 } }),
+      );
+      await flush();
+    });
+    await clickButton("Preview Locked Game Correction");
+    await flushAct();
+    await clickButton("Confirm Locked Game Correction");
+    const daySelector = container.querySelector("select#game-day-selector") as HTMLSelectElement;
+    await act(async () => {
+      setSelectValue(daySelector, "day-two");
+      await flush();
+    });
+    pendingCorrection.resolve(json({ status: "rejected", detail: "stale correction" }, 409));
+    await flushAct();
+    expect(container.textContent).not.toContain("stale correction");
+
+    await act(async () => {
+      setInputValue(
+        container.querySelector("input#locked-operation-id") as HTMLInputElement,
+        "stale-reopening",
+      );
+      await flush();
+    });
+    await clickButton("Preview Game Reopening");
+    await flushAct();
+    await clickButton("Confirm Game Reopening");
+    await clickButton("Change authority");
+    pendingReopening.reject(new Error("stale reopening network"));
+    await flushAct();
+    expect(container.textContent).not.toContain("stale reopening network");
   });
 
   afterEach(async () => {
@@ -1881,6 +2124,16 @@ describe("Grant secret UI lifecycle", () => {
     )?.set;
     setter?.call(select, value);
     select.dispatchEvent(new testWindow.Event("change", { bubbles: true }) as unknown as Event);
+  }
+
+  function setTextareaValue(textarea: HTMLTextAreaElement, value: string) {
+    const setter = Object.getOwnPropertyDescriptor(
+      testWindow.HTMLTextAreaElement.prototype,
+      "value",
+    )?.set;
+    setter?.call(textarea, value);
+    textarea.dispatchEvent(new testWindow.Event("input", { bubbles: true }) as unknown as Event);
+    textarea.dispatchEvent(new testWindow.Event("change", { bubbles: true }) as unknown as Event);
   }
 
   function pitchManagerCodeHandler(


### PR DESCRIPTION
## Scope

Implements the locked-game correction and reopening work specified by #105 and #122.

- Correct locked games through the Event Game Record transaction seam, with preview-bound fingerprints, Event Admin authority, canonical rule validation, and automatic Official Override only for inconsistent facts.
- Reopen games without changing sporting facts; preserve the existing Control QR credential while invalidating old sessions and codes and allowing fresh eligible codes.
- Handle finished and unfinished timer lifecycles, bounded discard evidence for queued locked work, and non-replay after reopening.
- Commit linked, redacted Control, Event Administration, Override, and Grant-use audits atomically.
- Add migration 032 and SQLite-safe audit `valueChange` round-tripping.

The public projection remains ordinary result/timeline data without provenance. #121 and #123 are excluded.

## Checks

- `bun run test` — 913 passed, 0 failed
- Focused runtime, locked administration, migration/SQLite — 54 passed, 0 failed
- Real Technical Admin browser journey passed
- `bun run check`, `bun run build`, and `git diff --check` passed
