### PR TITLE
Complete Event administration workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "event:catalog": "bun scripts/event-catalog.ts",
     "event:admin": "bun scripts/event-admin.ts",
     "test:focused:technical-admin-browser": "bun scripts/test-technical-admin-browser.ts",
+    "test:focused:event-admin-browser-webkit": "bun scripts/test-event-admin-webkit.ts",
     "test:focused:public-event-browser": "bun scripts/test-public-event-browser.ts",
     "test:focused:event-game-controller-browser": "bun scripts/test-event-game-controller-browser.ts",
     "test:focused:event-game-routes": "bun test --isolate ./src/lib/live-event-game-transport.focused.ts",

--- a/scripts/test-event-admin-webkit.ts
+++ b/scripts/test-event-admin-webkit.ts
@@ -1,0 +1,225 @@
+#!/usr/bin/env bun
+import { webkit } from "playwright";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { openSqliteFoundationStorage } from "@/lib/foundation-storage-sqlite";
+import { createEventCatalog, createFoundationEventCatalogStorage } from "@/lib/event-catalog";
+import { createGrantAuthority } from "@/lib/grant-authority";
+import { readGrantAuthorityOptions } from "@/lib/grant-runtime";
+import {
+  MemoryTechnicalAdminAuthRepository,
+  createTechnicalAdminAuth,
+} from "@/lib/technical-admin-auth";
+import { createGrantKeyRingDocument, writeGrantKeyRingFile } from "@/lib/grant-key-ring-custody";
+
+const directory = mkdtempSync(join(tmpdir(), "quadball-timer-event-admin-webkit-"));
+const foundationPath = join(directory, "foundation.sqlite");
+const grantKeyRingPath = join(directory, "grant-key-ring.json");
+const port = 39_000 + Math.floor(Math.random() * 1_000);
+const origin = `https://localhost:${port}`;
+const environment = {
+  ...process.env,
+  NODE_ENV: "test",
+  QUADBALL_ENVIRONMENT: "test",
+  PUBLIC_ORIGIN: origin,
+  WEBAUTHN_RP_ID: "localhost",
+  TECHNICAL_ADMIN_DATABASE: join(directory, "technical-admin.sqlite"),
+  FOUNDATION_DATABASE: foundationPath,
+  GRANT_KEY_RING_FILE: grantKeyRingPath,
+  TLS_CERT_FILE: join(directory, "localhost.crt"),
+  TLS_KEY_FILE: join(directory, "localhost.key"),
+  PORT: String(port),
+};
+
+let server: Bun.Subprocess | null = null;
+let serverStderr: Promise<string> | null = null;
+let browser: Awaited<ReturnType<typeof webkit.launch>> | null = null;
+
+try {
+  const certificate = Bun.spawnSync([
+    "openssl",
+    "req",
+    "-x509",
+    "-newkey",
+    "rsa:2048",
+    "-nodes",
+    "-subj",
+    "/CN=localhost",
+    "-addext",
+    "subjectAltName=DNS:localhost",
+    "-days",
+    "1",
+    "-keyout",
+    environment.TLS_KEY_FILE,
+    "-out",
+    environment.TLS_CERT_FILE,
+  ]);
+  if (certificate.exitCode !== 0)
+    throw new Error("openssl could not create a temporary certificate.");
+
+  writeGrantKeyRingFile(grantKeyRingPath, createGrantKeyRingDocument("test"));
+  const grantOptions = readGrantAuthorityOptions("test", environment);
+  const foundation = openSqliteFoundationStorage(foundationPath, {
+    grantKeyRing: grantOptions.keyRing,
+  });
+  await foundation.applyMigrations();
+  const technical = createTechnicalAdminAuth(
+    { environment: "test", origin, rpId: "localhost" },
+    new MemoryTechnicalAdminAuthRepository(),
+  ).resolveHostLocalAuthority();
+  const catalog = createEventCatalog(createFoundationEventCatalogStorage(foundation), {});
+  const event = await catalog.createEvent({ name: "WebKit Event", timeZone: "UTC" }, technical);
+  if (event.status !== "accepted") throw new Error("WebKit setup Event creation failed.");
+  const day = await catalog.addGameDay(event.value.eventId, { date: "2026-08-14" }, technical);
+  if (day.status !== "accepted") throw new Error("WebKit setup Game Day creation failed.");
+  const grants = createGrantAuthority(foundation, grantOptions);
+  const created = await grants.createEventAdminGrant({
+    authority: technical,
+    scope: {
+      eventId: event.value.eventId,
+      eventTimeZone: "UTC",
+      finalGameDayDate: "2026-08-14",
+    },
+  });
+  if (created.status !== "created") throw new Error("WebKit setup Event Admin Grant failed.");
+  const revealed = await grants.revealGrant(created.grantId, technical);
+  if (revealed.status !== "revealed") throw new Error("WebKit setup Grant reveal failed.");
+  const admission = await grants.admitEventAdminGrant({
+    qrCredential: revealed.qrCredential,
+    browserContext: "webkit-critical-path",
+  });
+  if (admission.status !== "admitted") throw new Error("WebKit setup Grant admission failed.");
+  foundation.close();
+
+  server = Bun.spawn(["bun", "run", "src/index.ts"], {
+    cwd: process.cwd(),
+    env: environment,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  serverStderr = new Response(server.stderr as unknown as BodyInit).text();
+  try {
+    await waitForServer(server.stdout as unknown as ReadableStream<Uint8Array>);
+  } catch (error) {
+    server.kill();
+    await server.exited;
+    const detail = serverStderr === null ? "" : await serverStderr;
+    throw new Error(
+      `${error instanceof Error ? error.message : "WebKit test server failed."}\n${detail}`,
+    );
+  }
+  browser = await webkit.launch({ headless: true, timeout: 5_000 });
+  const context = await browser.newContext({ ignoreHTTPSErrors: true });
+  await context.addCookies([
+    {
+      name: "__Host-event-admin-session",
+      value: admission.sessionBearer,
+      url: origin,
+      httpOnly: true,
+      secure: true,
+      sameSite: "Strict",
+    },
+  ]);
+  const page = await context.newPage();
+  page.setDefaultTimeout(5_000);
+  await page.goto(`${origin}/event-admin?eventId=${event.value.eventId}`);
+  await page.getByText("Event Hub", { exact: true }).waitFor();
+  await page.getByRole("heading", { name: "Operations health" }).waitFor();
+  await page.getByText("Grant problems: 0", { exact: true }).waitFor();
+
+  await page.getByLabel("New Event Team name").fill("WebKit Blue");
+  await page.getByRole("button", { name: "Add Team" }).click();
+  await page.getByText("WebKit Blue", { exact: true }).first().waitFor();
+  await page.getByLabel("Roster Event Team").selectOption({ label: "WebKit Blue" });
+  await page.getByLabel("Player number").fill("7");
+  await page.getByLabel("Player public name").fill("WebKit Player");
+  await page.getByRole("button", { name: "Save Roster" }).click();
+  await page.getByText("#7 WebKit Player", { exact: true }).waitFor();
+  await page.getByLabel("New Pitch name").fill("WebKit Pitch");
+  await page.getByRole("button", { name: "Add Pitch" }).click();
+  await page.getByLabel("Pitch WebKit Pitch name").waitFor();
+  await page.getByLabel("Game Day", { exact: true }).selectOption({ index: 1 });
+  await page.getByLabel("Gameplay Slot sequence").fill("1");
+  await page.getByLabel("Gameplay Slot scheduled start").fill("2026-08-14T10:00");
+  await page.getByRole("button", { name: "Add Gameplay Slot" }).click();
+  await page
+    .getByText(/Slot 1.*10:00/u)
+    .last()
+    .waitFor();
+  await page.getByLabel("Gameplay Slot for Event Game").selectOption({ index: 1 });
+  await page.getByLabel("Pitch Slot for Event Game").selectOption({ index: 1 });
+  await page.getByLabel("Game Code").fill("WK-01");
+  await page.getByLabel("Game Designation").fill("WebKit Critical");
+  await page.getByLabel("Side A source label").fill("Winner A");
+  await page.getByLabel("Side B source label").fill("Winner B");
+  await page.getByRole("button", { name: "Add unresolved Event Game" }).click();
+  await page.getByText("Unresolved team assignments: 1", { exact: true }).waitFor();
+  await page.getByText("Grant problems: 1", { exact: true }).waitFor();
+
+  await page.setViewportSize({ width: 360, height: 900 });
+  const layout = await page.evaluate(() => {
+    const health = document.querySelector("section[aria-labelledby='operations-health-title']");
+    return {
+      healthFits: health !== null && health.scrollWidth <= health.clientWidth,
+      controlsFit: Array.from(document.querySelectorAll("button, input, select"))
+        .filter((element) => getComputedStyle(element).display !== "none")
+        .every((element) => {
+          const rect = element.getBoundingClientRect();
+          return rect.left >= -1 && rect.right <= window.innerWidth + 1;
+        }),
+    };
+  });
+  if (!layout.healthFits || !layout.controlsFit)
+    throw new Error(`WebKit critical path was not 360px-safe: ${JSON.stringify(layout)}`);
+  await page.setViewportSize({ width: 1280, height: 900 });
+  const focusTarget = page.getByRole("button", { name: "Refresh Slot setup" });
+  await focusTarget.focus();
+  const focusIndicator = await page.evaluate(() => {
+    const target = Array.from(document.querySelectorAll("button")).find(
+      (element) =>
+        element.textContent?.trim() === "Refresh Slot setup" ||
+        element.getAttribute("aria-label") === "Refresh Slot setup",
+    );
+    if (!(target instanceof HTMLElement)) return null;
+    const style = getComputedStyle(target);
+    return {
+      active: document.activeElement === target,
+      outline: `${style.outlineStyle}/${style.outlineWidth}`,
+      boxShadow: style.boxShadow,
+    };
+  });
+  if (
+    focusIndicator?.active !== true ||
+    (focusIndicator.outline === "none/0px" && focusIndicator.boxShadow === "none")
+  )
+    throw new Error(`WebKit focus indicator was not rendered: ${JSON.stringify(focusIndicator)}`);
+  await page.keyboard.press("Enter");
+  await page.getByRole("option", { name: "WebKit Critical", exact: true }).waitFor({
+    state: "attached",
+  });
+  console.log(JSON.stringify({ status: "passed", browser: "webkit", criticalAdminPath: true }));
+} finally {
+  if (browser !== null) await browser.close().catch(() => undefined);
+  if (server !== null) {
+    server.kill();
+    await server.exited;
+  }
+  rmSync(directory, { recursive: true, force: true });
+}
+
+async function waitForServer(stdout: ReadableStream<Uint8Array>) {
+  const reader = stdout.getReader();
+  const decoder = new TextDecoder();
+  let output = "";
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) throw new Error("WebKit test server exited before becoming ready.");
+      output += decoder.decode(value, { stream: true });
+      if (output.includes("Server running at")) return;
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}

--- a/scripts/test-technical-admin-browser.ts
+++ b/scripts/test-technical-admin-browser.ts
@@ -429,6 +429,14 @@ try {
   await eventAdminPage.getByLabel("Scanned Event Admin QR value").fill(revealedCredential);
   await eventAdminPage.getByRole("button", { name: "Admit Event Admin" }).click();
   await eventAdminPage.getByText("Event Hub", { exact: true }).waitFor();
+  await eventAdminPage.getByRole("heading", { name: "Operations health" }).waitFor();
+  assert(
+    (await eventAdminPage.getByText("Unresolved team assignments: 0", { exact: true }).count()) ===
+      1 &&
+      (await eventAdminPage.getByText("Schedule conflicts: 0", { exact: true }).count()) === 1 &&
+      (await eventAdminPage.getByText("Grant problems: 0", { exact: true }).count()) === 1,
+    "Event Hub did not expose its bounded operations health summary",
+  );
   await eventAdminPage.getByText("Administrative audit evidence", { exact: true }).waitFor();
   await eventAdminPage.getByText("Event Administration", { exact: true }).waitFor();
   await eventAdminPage.getByText("Grant Audit", { exact: true }).waitFor();
@@ -778,7 +786,7 @@ try {
   );
   const removalStatusText = await eventAdminPage
     .getByRole("status")
-    .filter({ hasText: "catalog descendants 0" })
+    .filter({ hasText: "catalog descendants" })
     .innerText();
   assert(
     removalStatusText.includes("catalog descendants 0") &&
@@ -1103,7 +1111,128 @@ try {
   );
   await eventAdminPage.getByRole("button", { name: "Add unresolved Event Game" }).click();
   assert((await secondGameResponsePromise).status() === 201, "second Event Game creation failed");
-  await eventAdminPage.getByRole("button", { name: "Refresh Slot setup" }).click();
+  await eventAdminPage.getByText("Unresolved team assignments: 1", { exact: true }).waitFor();
+  await eventAdminPage.getByText("Grant problems: 2", { exact: true }).waitFor();
+  await eventAdminPage.setViewportSize({ width: 360, height: 900 });
+  const eventHubLayout = await eventAdminPage.evaluate(() => ({
+    healthFits: (() => {
+      const section = document.querySelector("section[aria-labelledby='operations-health-title']");
+      return section !== null && section.scrollWidth <= section.clientWidth;
+    })(),
+    controlsStayInViewport: Array.from(document.querySelectorAll("button, input, select"))
+      .filter((element) => {
+        const style = getComputedStyle(element);
+        return style.display !== "none" && style.visibility !== "hidden";
+      })
+      .every((element) => {
+        const rect = element.getBoundingClientRect();
+        return rect.left >= -1 && rect.right <= window.innerWidth + 1;
+      }),
+    healthHeading: document.querySelector("#operations-health-title")?.textContent,
+    healthSectionLabel: document
+      .querySelector("section[aria-labelledby='operations-health-title']")
+      ?.getAttribute("aria-labelledby"),
+  }));
+  assert(
+    eventHubLayout.healthFits &&
+      eventHubLayout.controlsStayInViewport &&
+      eventHubLayout.healthHeading === "Operations health" &&
+      eventHubLayout.healthSectionLabel === "operations-health-title",
+    `Event Hub was not accessible and 360px-safe: ${JSON.stringify(eventHubLayout)}`,
+  );
+  await eventAdminPage.setViewportSize({ width: 1280, height: 900 });
+  const desktopAccessibility = await eventAdminPage.evaluate(() => {
+    const visible = Array.from(document.querySelectorAll("button, input, select")).filter(
+      (element) => {
+        const style = getComputedStyle(element);
+        return style.display !== "none" && style.visibility !== "hidden";
+      },
+    );
+    const unlabeled = visible.filter((element) => {
+      const labelledBy = element.getAttribute("aria-labelledby");
+      const label = element.getAttribute("aria-label");
+      const text = element.textContent?.trim();
+      const associated = element.id
+        ? document.querySelector(`label[for='${CSS.escape(element.id)}']`)?.textContent?.trim()
+        : undefined;
+      const ancestorLabel = element.closest("label")?.textContent?.trim();
+      return !labelledBy && !label && !text && !associated && !ancestorLabel;
+    });
+    const buttonByName = (name: string) =>
+      Array.from(document.querySelectorAll("button")).find(
+        (element) => element.textContent?.trim() === name,
+      ) ?? null;
+    const critical = [
+      document.querySelector("#game-day-selector"),
+      buttonByName("Add Team"),
+      buttonByName("Save Roster"),
+    ].filter((element): element is HTMLElement => element instanceof HTMLElement);
+    return {
+      unlabeled: unlabeled.map((element) => element.outerHTML.slice(0, 120)),
+      criticalTargets: critical.map((element) => {
+        const rect = element.getBoundingClientRect();
+        return { width: rect.width, height: rect.height };
+      }),
+      nonColorState: document.body.textContent?.includes("Operations health") === true,
+    };
+  });
+  assert(
+    desktopAccessibility.unlabeled.length === 0 &&
+      desktopAccessibility.criticalTargets.every(
+        ({ width, height }) => width >= 40 && height >= 40,
+      ) &&
+      desktopAccessibility.nonColorState,
+    `desktop admin accessibility evidence failed: ${JSON.stringify(desktopAccessibility)}`,
+  );
+  const focusableCount = await eventAdminPage.evaluate(
+    () => document.querySelectorAll("button, input, select, textarea, a[href], [tabindex]").length,
+  );
+  await eventAdminPage.evaluate(() => {
+    document.body.tabIndex = -1;
+    document.body.focus();
+  });
+  let focusOrderSteps = 0;
+  for (; focusOrderSteps <= focusableCount + 1; focusOrderSteps += 1) {
+    await eventAdminPage.keyboard.press("Tab");
+    const activeText = await eventAdminPage.evaluate(
+      () =>
+        document.activeElement?.textContent?.trim() ||
+        document.activeElement?.getAttribute("aria-label") ||
+        "",
+    );
+    if (activeText === "Refresh Slot setup") break;
+  }
+  assert(
+    focusOrderSteps <= focusableCount + 1,
+    "critical admin focus order did not reach the target deterministically",
+  );
+  const focusIndicator = await eventAdminPage.evaluate(() => {
+    const target = Array.from(document.querySelectorAll("button")).find(
+      (element) =>
+        element.textContent?.trim() === "Refresh Slot setup" ||
+        element.getAttribute("aria-label") === "Refresh Slot setup",
+    );
+    if (!(target instanceof HTMLElement)) return null;
+    const style = getComputedStyle(target);
+    return {
+      active: document.activeElement === target,
+      outline: `${style.outlineStyle}/${style.outlineWidth}`,
+      boxShadow: style.boxShadow,
+    };
+  });
+  assert(
+    focusIndicator?.active === true &&
+      ((focusIndicator.outline !== "none/0px" && !focusIndicator.outline.endsWith("/0px")) ||
+        focusIndicator.boxShadow !== "none"),
+    `critical admin focus indicator was not rendered: ${JSON.stringify(focusIndicator)}`,
+  );
+  const refreshSlotResponsePromise = eventAdminPage.waitForResponse(
+    (response) =>
+      response.url().includes("/api/event-admin/slot-setup?") &&
+      response.request().method() === "GET",
+  );
+  await eventAdminPage.keyboard.press("Enter");
+  await refreshSlotResponsePromise;
   await eventAdminPage
     .getByRole("option", { name: "Opening", exact: true })
     .waitFor({ state: "attached" });
@@ -1125,6 +1254,95 @@ try {
     publishedAudiencePayload.value?.auditTrail === undefined &&
       publishedAudiencePayload.value?.publicationStatus === "published",
     "anonymous projection leaked private publication history",
+  );
+  const rosterHubPayload = (await (
+    await eventAdminContext.request.get(`${origin}/api/event-admin/hub?eventId=${eventId}`)
+  ).json()) as {
+    status: string;
+    value?: {
+      event?: {
+        teams?: Array<{
+          eventTeamId: string;
+          name: string;
+          roster?: Array<{ playerNumber: number; publicName: string }>;
+        }>;
+        eventGames?: Array<{
+          eventGameId: string;
+          gameCode: string | null;
+          gameDesignation: string | null;
+          sideA: { eventTeamId: string | null; sourceLabel: string | null };
+          sideB: { eventTeamId: string | null; sourceLabel: string | null };
+          expectedStartMs: number;
+          expectedPlayingPeriod: { startMs: number; endMs: number };
+        }>;
+      };
+    };
+  };
+  const rosterTeamId = rosterHubPayload.value?.event?.teams?.find(
+    (team) => team.name === "Blue Updated",
+  )?.eventTeamId;
+  if (rosterTeamId === undefined) throw new Error("Roster Event Team was not projected.");
+  const readRosterFromOperationsHub = async () => {
+    const response = await eventAdminContext.request.get(
+      `${origin}/api/event-admin/hub?eventId=${eventId}`,
+    );
+    assert(response.status() === 200, "Event operations Hub was not available for roster lookup.");
+    return (await response.json()) as typeof rosterHubPayload;
+  };
+  const rosterEntry = (
+    payload: typeof rosterHubPayload,
+    playerNumber: number,
+  ): { playerNumber: number; publicName: string } | null =>
+    payload.value?.event?.teams
+      ?.find((team) => team.eventTeamId === rosterTeamId)
+      ?.roster?.find((entry) => entry.playerNumber === playerNumber) ?? null;
+  const retainedGameFacts = rosterHubPayload.value?.event?.eventGames?.map((game) => ({
+    eventGameId: game.eventGameId,
+    gameCode: game.gameCode,
+    gameDesignation: game.gameDesignation,
+    sideA: game.sideA,
+    sideB: game.sideB,
+    expectedStartMs: game.expectedStartMs,
+    expectedPlayingPeriod: game.expectedPlayingPeriod,
+  }));
+  if (retainedGameFacts === undefined) throw new Error("Retained Event Game facts were absent.");
+  const absentRoster = rosterEntry(rosterHubPayload, 8);
+  assert(
+    absentRoster === null,
+    "Event operations catalog lookup did not return semantic roster absence",
+  );
+  await eventAdminPage.getByLabel("Roster Event Team").selectOption({ label: "Blue Updated" });
+  await eventAdminPage.getByLabel("Player number").fill("8");
+  await eventAdminPage.getByLabel("Player public name").fill("Player Eight");
+  await eventAdminPage.getByRole("button", { name: "Save Roster" }).click();
+  await eventAdminPage.getByText("#8 Player Eight", { exact: true }).waitFor();
+  const addedRoster = rosterEntry(await readRosterFromOperationsHub(), 8);
+  assert(
+    addedRoster?.publicName === "Player Eight",
+    "Event operations catalog roster addition lookup failed",
+  );
+  await eventAdminPage.getByLabel("Player number").fill("8");
+  await eventAdminPage.getByLabel("Player public name").fill("Player Eight Corrected");
+  await eventAdminPage.getByRole("button", { name: "Save Roster" }).click();
+  await eventAdminPage.getByText("#8 Player Eight Corrected", { exact: true }).waitFor();
+  const correctedRosterHub = await readRosterFromOperationsHub();
+  const correctedRoster = rosterEntry(correctedRosterHub, 8);
+  assert(
+    correctedRoster?.publicName === "Player Eight Corrected",
+    "Event operations catalog roster correction lookup did not return the current public name",
+  );
+  const correctedGameFacts = correctedRosterHub.value?.event?.eventGames?.map((game) => ({
+    eventGameId: game.eventGameId,
+    gameCode: game.gameCode,
+    gameDesignation: game.gameDesignation,
+    sideA: game.sideA,
+    sideB: game.sideB,
+    expectedStartMs: game.expectedStartMs,
+    expectedPlayingPeriod: game.expectedPlayingPeriod,
+  }));
+  assert(
+    JSON.stringify(correctedGameFacts ?? []) === JSON.stringify(retainedGameFacts),
+    "roster correction changed retained Event Game facts",
   );
   const unpublishedButton = eventAdminPage.getByRole("button", {
     name: "Unpublished Event",

--- a/src/index-startup.focused.ts
+++ b/src/index-startup.focused.ts
@@ -1,20 +1,107 @@
 import { describe, expect, test } from "bun:test";
-import { chmod, mkdir, mkdtemp, rm } from "node:fs/promises";
+import {
+  access,
+  chmod,
+  constants,
+  mkdir,
+  mkdtemp,
+  readdir,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createGrantKeyRingDocument, writeGrantKeyRingFile } from "@/lib/grant-key-ring-custody";
 
 describe("server startup", () => {
+  test("keeps explicit writable state across an immutable-release restart", async () => {
+    const root = await mkdtemp(join(tmpdir(), "quadball-timer-startup-persistence-"));
+    const releaseDirectory = await buildReadOnlyRelease(root);
+    const stateDirectory = join(root, "state");
+    const technicalAdminDirectory = join(stateDirectory, "technical-admin");
+    const foundationDirectory = join(stateDirectory, "foundation");
+    const credentialsDirectory = join(stateDirectory, "credentials");
+    await mkdir(technicalAdminDirectory, { recursive: true, mode: 0o750 });
+    await mkdir(foundationDirectory, { recursive: true, mode: 0o750 });
+    await mkdir(credentialsDirectory, { recursive: true, mode: 0o750 });
+    await chmod(stateDirectory, 0o550);
+    const grantKeyRingPath = join(credentialsDirectory, "grant-key-ring.json");
+    const technicalAdminDatabase = join(technicalAdminDirectory, "technical-admin.sqlite");
+    const foundationDatabase = join(foundationDirectory, "foundation.sqlite");
+    writeGrantKeyRingFile(grantKeyRingPath, createGrantKeyRingDocument("test"));
+    await chmod(credentialsDirectory, 0o550);
+    const environment = {
+      NODE_ENV: "test",
+      QUADBALL_ENVIRONMENT: "test",
+      PUBLIC_ORIGIN: "https://test.timer.quadball.app",
+      TECHNICAL_ADMIN_DATABASE: technicalAdminDatabase,
+      FOUNDATION_DATABASE: foundationDatabase,
+      GRANT_KEY_RING_FILE: grantKeyRingPath,
+      HOST: "127.0.0.1",
+      PORT: "0",
+    };
+    const start = () =>
+      Bun.spawn([process.execPath, "run", "index.js"], {
+        cwd: releaseDirectory,
+        env: environment,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+    let server = start();
+    try {
+      const firstUrl = await readServerUrl(server.stdout);
+      expect(
+        (await fetch(new URL("/internal/healthz", firstUrl), { headers: { host: firstUrl.host } }))
+          .status,
+      ).toBe(200);
+      await access(technicalAdminDatabase, constants.W_OK);
+      await access(foundationDatabase, constants.W_OK);
+      await expectRejected(() => access(join(releaseDirectory, "index.js"), constants.W_OK));
+      await expectRejected(() =>
+        writeFile(join(releaseDirectory, "invalid-write-target"), "blocked"),
+      );
+      const firstState = await Promise.all([
+        stat(technicalAdminDatabase),
+        stat(foundationDatabase),
+      ]);
+      expect(firstState.every((entry) => entry.isFile() && entry.size > 0)).toBe(true);
+
+      server.kill();
+      await server.exited;
+      server = start();
+      const secondUrl = await readServerUrl(server.stdout);
+      expect(
+        (
+          await fetch(new URL("/internal/healthz", secondUrl), {
+            headers: { host: secondUrl.host },
+          })
+        ).status,
+      ).toBe(200);
+      const secondState = await Promise.all([
+        stat(technicalAdminDatabase),
+        stat(foundationDatabase),
+      ]);
+      expect(secondState.map((entry) => entry.ino)).toEqual(firstState.map((entry) => entry.ino));
+      expect(secondState.every((entry) => entry.isFile() && entry.size > 0)).toBe(true);
+    } finally {
+      server.kill();
+      await server.exited;
+      await restoreReleaseAccess(releaseDirectory);
+      await chmod(credentialsDirectory, 0o750);
+      await chmod(stateDirectory, 0o750);
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   test("starts from a read-only release while an unready Foundation leaves health available", async () => {
     const root = await mkdtemp(join(tmpdir(), "quadball-timer-startup-"));
-    const releaseDirectory = join(root, "release");
+    const releaseDirectory = await buildReadOnlyRelease(root);
     const stateDirectory = join(root, "state");
-    await mkdir(releaseDirectory, { mode: 0o750 });
     await mkdir(stateDirectory, { mode: 0o750 });
-    await chmod(releaseDirectory, 0o550);
     const grantKeyRingPath = join(stateDirectory, "grant-key-ring.json");
     writeGrantKeyRingFile(grantKeyRingPath, createGrantKeyRingDocument("test"));
-    const server = Bun.spawn([process.execPath, "run", join(process.cwd(), "src/index.ts")], {
+    const server = Bun.spawn([process.execPath, "run", "index.js"], {
       cwd: releaseDirectory,
       env: {
         NODE_ENV: "test",
@@ -44,19 +131,20 @@ describe("server startup", () => {
     } finally {
       server.kill();
       await server.exited;
-      await chmod(releaseDirectory, 0o750);
+      await restoreReleaseAccess(releaseDirectory);
       await rm(root, { recursive: true, force: true });
     }
   });
 
   test("keeps unrelated routes available when Foundation storage cannot be opened", async () => {
     const root = await mkdtemp(join(tmpdir(), "quadball-timer-startup-"));
+    const releaseDirectory = await buildReadOnlyRelease(root);
     const stateDirectory = join(root, "state");
     await mkdir(stateDirectory, { mode: 0o750 });
     const grantKeyRingPath = join(stateDirectory, "grant-key-ring.json");
     writeGrantKeyRingFile(grantKeyRingPath, createGrantKeyRingDocument("test"));
-    const server = Bun.spawn([process.execPath, "run", join(process.cwd(), "src/index.ts")], {
-      cwd: root,
+    const server = Bun.spawn([process.execPath, "run", "index.js"], {
+      cwd: releaseDirectory,
       env: {
         NODE_ENV: "test",
         QUADBALL_ENVIRONMENT: "test",
@@ -82,10 +170,47 @@ describe("server startup", () => {
     } finally {
       server.kill();
       await server.exited;
+      await restoreReleaseAccess(releaseDirectory);
       await rm(root, { recursive: true, force: true });
     }
   });
 });
+
+async function buildReadOnlyRelease(root: string): Promise<string> {
+  const releaseDirectory = join(root, "release");
+  await mkdir(releaseDirectory, { mode: 0o750 });
+  const build = Bun.spawn(
+    [process.execPath, "run", join(process.cwd(), "build.ts"), "--outdir", releaseDirectory],
+    { cwd: process.cwd(), stdout: "pipe", stderr: "pipe" },
+  );
+  const stdout = new Response(build.stdout as unknown as BodyInit).text();
+  const stderr = new Response(build.stderr as unknown as BodyInit).text();
+  const exitCode = await build.exited;
+  if (exitCode !== 0)
+    throw new Error(`Release build failed (${exitCode}).\n${await stdout}\n${await stderr}`);
+  const entry = join(releaseDirectory, "index.js");
+  const entryStat = await stat(entry);
+  expect(entryStat.isFile()).toBe(true);
+  for (const file of await readdir(releaseDirectory, { withFileTypes: true })) {
+    await chmod(join(releaseDirectory, file.name), file.isDirectory() ? 0o550 : 0o440);
+  }
+  await chmod(releaseDirectory, 0o550);
+  return releaseDirectory;
+}
+
+async function restoreReleaseAccess(releaseDirectory: string): Promise<void> {
+  await chmod(releaseDirectory, 0o750);
+}
+
+async function expectRejected(operation: () => Promise<unknown>): Promise<void> {
+  let rejected = false;
+  try {
+    await operation();
+  } catch {
+    rejected = true;
+  }
+  expect(rejected).toBe(true);
+}
 
 async function readServerUrl(stdout: ReadableStream<Uint8Array>): Promise<URL> {
   const reader = stdout.getReader();

--- a/src/index.ts
+++ b/src/index.ts
@@ -2937,13 +2937,13 @@ function isPublicEventPath(pathname: string): boolean {
 }
 
 function readPathSegment(url: string): string {
-  const segment = new URL(url).pathname.split("/").at(-1) ?? "";
-  return decodePathSegment(segment);
+  return decodePathSegment(new URL(url).pathname.split("/").at(-1));
 }
 
 function decodePathSegment(segment: string | undefined): string {
+  const value = segment ?? "";
   try {
-    return decodeURIComponent(segment ?? "");
+    return decodeURIComponent(value);
   } catch {
     return "";
   }

--- a/src/lib/event-administration.test.ts
+++ b/src/lib/event-administration.test.ts
@@ -14,7 +14,7 @@ import {
 import type { FoundationStorage, FoundationStorageSnapshot } from "@/lib/foundation-storage";
 import { createInMemoryFoundationStorage } from "@/lib/foundation-storage-memory";
 import { createGrantAuthority, createGrantAuthorityVerifier } from "@/lib/grant-authority";
-import type { GrantKeyRing } from "@/lib/grant-types";
+import type { ControlGrantScopeResolution, GrantKeyRing } from "@/lib/grant-types";
 import {
   MemoryTechnicalAdminAuthRepository,
   createTechnicalAdminAuth,
@@ -28,6 +28,135 @@ const keyRing: GrantKeyRing = {
 };
 
 describe("Event Administration handoff", () => {
+  test("projects bounded operations health without exposing Grant details", async () => {
+    let resolution: ControlGrantScopeResolution = {
+      status: "eligible",
+      eventGameId: "pending",
+    };
+    const fixture = createFixture(undefined, { resolve: () => resolution });
+    const event = await fixture.catalog.createEvent(
+      { name: "Operations Health Event", timeZone: "UTC" },
+      fixture.technical,
+    );
+    if (event.status !== "accepted") throw new Error("Expected Event.");
+    const day = await fixture.catalog.addGameDay(
+      event.value.eventId,
+      { date: "2026-08-14" },
+      fixture.technical,
+    );
+    const pitch = await fixture.catalog.createPitch(
+      event.value.eventId,
+      { name: "Pitch A" },
+      fixture.technical,
+    );
+    if (day.status !== "accepted" || pitch.status !== "accepted")
+      throw new Error("Expected schedule setup.");
+    const slot = await fixture.catalog.createGameplaySlot(
+      event.value.eventId,
+      day.value.gameDayId,
+      { sequence: 1, scheduledStart: "2026-08-14T10:00" },
+      fixture.technical,
+    );
+    if (slot.status !== "accepted") throw new Error("Expected Gameplay Slot.");
+    const pitchSlot = await fixture.storage.transaction(
+      (transaction) => transaction.listPitchSlots(day.value.gameDayId, pitch.value.pitchId)[0],
+    );
+    if (pitchSlot === undefined) throw new Error("Expected Pitch Slot.");
+    const game = await fixture.catalog.createEventGame(
+      event.value.eventId,
+      day.value.gameDayId,
+      {
+        gameplaySlotId: slot.value.gameplaySlotId,
+        pitchSlotId: pitchSlot.pitchSlotId,
+        sideA: { sourceLabel: "Winner A" },
+        sideB: { sourceLabel: "Winner B" },
+      },
+      fixture.technical,
+    );
+    if (game.status !== "accepted") throw new Error("Expected Event Game.");
+
+    resolution = { status: "eligible", eventGameId: game.value.eventGameId };
+    const control = await fixture.grants.createControlGrant({
+      authority: fixture.technical,
+      expiresAtMs: Date.parse("2026-08-14T12:00:01Z"),
+      scope: {
+        eventId: event.value.eventId,
+        gameDayId: day.value.gameDayId,
+        pitchId: pitch.value.pitchId,
+        pitchSlotId: pitchSlot.pitchSlotId,
+      },
+    });
+    if (control.status !== "created") throw new Error("Expected Control Grant.");
+
+    resolution = { status: "unavailable" };
+
+    const hub = await fixture.administration.openEventHub({
+      eventId: event.value.eventId,
+      authority: fixture.technical,
+    });
+    expect(hub).toMatchObject({
+      status: "accepted",
+      value: {
+        health: {
+          unresolvedTeamCount: 1,
+          scheduleConflictCount: 0,
+          teamScheduleConflictCount: 0,
+          grantProblemCount: 1,
+        },
+      },
+    });
+    if (hub.status === "accepted") {
+      expect(JSON.stringify(hub.value.health)).not.toMatch(
+        /grantId|grantVersion|credential|session|secret/iu,
+      );
+    }
+
+    resolution = { status: "empty" };
+    expect(
+      await fixture.administration.openEventHub({
+        eventId: event.value.eventId,
+        authority: fixture.technical,
+      }),
+    ).toMatchObject({ value: { health: { grantProblemCount: 1 } } });
+
+    resolution = { status: "eligible", eventGameId: game.value.eventGameId };
+    expect(
+      await fixture.administration.openEventHub({
+        eventId: event.value.eventId,
+        authority: fixture.technical,
+      }),
+    ).toMatchObject({ value: { health: { grantProblemCount: 0 } } });
+
+    const malformedIsUsable = await fixture.storage.transaction((transaction) => {
+      const grant = transaction.findGrantById(control.grantId);
+      if (grant === null) throw new Error("Expected stored Control Grant.");
+      return fixture.grants.isGrantCurrentlyUsableInTransaction(transaction, {
+        ...grant,
+        credential: { ...grant.credential, ciphertext: "malformed" },
+      });
+    });
+    expect(malformedIsUsable).toBe(false);
+
+    const beforeExpiredHealth = await fixture.storage.transaction((transaction) => ({
+      grant: transaction.findGrantById(control.grantId),
+      sessions: transaction.listGrantSessions(control.grantId),
+      audit: transaction.listGrantAudit(control.grantId),
+    }));
+    fixture.setNow(control.expiresAtMs ?? 0);
+    expect(
+      await fixture.administration.openEventHub({
+        eventId: event.value.eventId,
+        authority: fixture.technical,
+      }),
+    ).toMatchObject({ value: { health: { grantProblemCount: 1 } } });
+    const afterExpiredHealth = await fixture.storage.transaction((transaction) => ({
+      grant: transaction.findGrantById(control.grantId),
+      sessions: transaction.listGrantSessions(control.grantId),
+      audit: transaction.listGrantAudit(control.grantId),
+    }));
+    expect(afterExpiredHealth).toEqual(beforeExpiredHealth);
+  });
+
   test("previews and atomically removes an empty Event with its Event Admin authority", async () => {
     const fixture = createFixture();
     const event = await fixture.catalog.createEvent(
@@ -2811,9 +2940,7 @@ describe("Event Administration handoff", () => {
 
 function createFixture(
   storage: FoundationStorage = createInMemoryFoundationStorage(),
-  controlScopeResolver: {
-    resolve: () => { status: "eligible"; eventGameId: string } | { status: "unavailable" };
-  } = {
+  controlScopeResolver: Pick<import("@/lib/grant-types").ControlGrantScopeResolver, "resolve"> = {
     resolve: () => ({ status: "unavailable" as const }),
   },
 ) {

--- a/src/lib/event-administration.ts
+++ b/src/lib/event-administration.ts
@@ -71,6 +71,7 @@ import {
   type LockedGameCorrectionInput,
   type LockedGameCorrectionResult,
 } from "@/lib/locked-event-game-administration";
+import type { EventOperationsHealth } from "@/lib/event-operations-health";
 
 export const GENERIC_EVENT_HUB_AUTHORIZATION_FAILURE = Object.freeze({
   status: "rejected",
@@ -129,6 +130,7 @@ export type GrantCodeProjection = {
 
 export type EventHubProjection = {
   event: EventProjection;
+  health: EventOperationsHealth;
   selectedGameDayId: string | null;
   authority: "technical-admin" | "event-admin";
   grantSessionId: string | null;
@@ -1520,6 +1522,7 @@ export function createEventAdministration(
             return unauthorized();
           return accepted({
             event,
+            health: projectEventOperationsHealth(event, transaction, options),
             selectedGameDayId: gameDayId,
             authority: authorized.kind,
             grantSessionId: authorized.sessionId,
@@ -2408,6 +2411,45 @@ function authorizeControlManagementInTransaction(
   )
     return null;
   return { sessionExpiresAtMs: result.sessionExpiresAtMs ?? null };
+}
+
+function projectEventOperationsHealth(
+  event: EventProjection,
+  transaction: FoundationStorageTransaction,
+  options: EventAdministrationOptions,
+): EventOperationsHealth {
+  let unresolvedTeamCount = 0;
+  let scheduleConflictCount = 0;
+  let teamScheduleConflictCount = 0;
+  let grantProblemCount = 0;
+
+  for (const game of event.eventGames) {
+    if (game.sideA.eventTeamId === null || game.sideB.eventTeamId === null)
+      unresolvedTeamCount += 1;
+    if (game.scheduleConflict) scheduleConflictCount += 1;
+    if (game.teamScheduleConflict) teamScheduleConflictCount += 1;
+
+    const pitchSlot = transaction.findPitchSlot(game.pitchSlotId);
+    const pitch = pitchSlot === null ? null : transaction.findPitch(pitchSlot.pitchId);
+    const grant =
+      pitchSlot === null || pitch === null
+        ? null
+        : findControlGrantInTransaction(transaction, {
+            eventId: event.eventId,
+            gameDayId: game.gameDayId,
+            pitchId: pitch.pitchId,
+            pitchSlotId: pitchSlot.pitchSlotId,
+          });
+    if (grant === null || !options.grants.isGrantCurrentlyUsableInTransaction(transaction, grant))
+      grantProblemCount += 1;
+  }
+
+  return {
+    unresolvedTeamCount,
+    scheduleConflictCount,
+    teamScheduleConflictCount,
+    grantProblemCount,
+  };
 }
 
 function projectControlGrant(

--- a/src/lib/event-catalog.focused.ts
+++ b/src/lib/event-catalog.focused.ts
@@ -110,12 +110,21 @@ describe("Event operations catalog through foundation SQLite", () => {
       if (event.status !== "accepted") throw new Error("Expected Event.");
       const team = await catalog.createEventTeam(event.value.eventId, { name: "Blue" }, authority);
       if (team.status !== "accepted") throw new Error("Expected Team.");
+      expect(
+        await catalog.lookupAudienceRoster(event.value.eventId, team.value.eventTeamId, 12),
+      ).toMatchObject({
+        status: "accepted",
+        value: { playerNumber: 12, publicName: null },
+      });
       await catalog.upsertEventTeamRoster(
         event.value.eventId,
         team.value.eventTeamId,
         { playerNumber: 12, publicName: "Before" },
         authority,
       );
+      expect(
+        await catalog.lookupAudienceRoster(event.value.eventId, team.value.eventTeamId, 12),
+      ).toMatchObject({ status: "accepted", value: { publicName: "Before" } });
       const pitch = await catalog.createPitch(
         event.value.eventId,
         { name: "Pitch One" },
@@ -158,6 +167,98 @@ describe("Event operations catalog through foundation SQLite", () => {
       ]);
       reopenedFoundation.close();
     } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("covers the deterministic two-Day, six-Pitch, 96-Game production envelope", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "quadball-event-envelope-"));
+    const foundation = openSqliteFoundationStorage(join(directory, "catalog.sqlite"));
+    await foundation.applyMigrations();
+    try {
+      const catalog = createEventCatalog(createFoundationEventCatalogStorage(foundation), {
+        clock: { nowMs: () => Date.UTC(2026, 7, 14, 12) },
+      });
+      const event = await catalog.createEvent(
+        { name: "Envelope Event", timeZone: "UTC" },
+        authority,
+      );
+      if (event.status !== "accepted") throw new Error("Expected Event.");
+      const days = [];
+      for (const date of ["2026-08-14", "2026-08-15"]) {
+        const day = await catalog.addGameDay(event.value.eventId, { date }, authority);
+        if (day.status !== "accepted") throw new Error("Expected Game Day.");
+        days.push(day.value);
+      }
+      for (let pitchIndex = 1; pitchIndex <= 6; pitchIndex += 1) {
+        const pitch = await catalog.createPitch(
+          event.value.eventId,
+          { name: `Pitch ${pitchIndex}` },
+          authority,
+        );
+        if (pitch.status !== "accepted") throw new Error("Expected Pitch.");
+      }
+
+      let gameCount = 0;
+      for (const [dayIndex, day] of days.entries()) {
+        for (let sequence = 1; sequence <= 8; sequence += 1) {
+          const slot = await catalog.createGameplaySlot(
+            event.value.eventId,
+            day.gameDayId,
+            {
+              sequence,
+              scheduledStart: `2026-08-${14 + dayIndex}T${String(10 + sequence).padStart(2, "0")}:00`,
+            },
+            authority,
+          );
+          if (slot.status !== "accepted") throw new Error("Expected Gameplay Slot.");
+          const pitchSlots = await foundation.transaction((transaction) =>
+            transaction.listPitchSlots(day.gameDayId),
+          );
+          for (const pitchSlot of pitchSlots.filter(
+            (candidate) => candidate.gameplaySlotId === slot.value.gameplaySlotId,
+          )) {
+            const game = await catalog.createEventGame(
+              event.value.eventId,
+              day.gameDayId,
+              {
+                gameplaySlotId: slot.value.gameplaySlotId,
+                pitchSlotId: pitchSlot.pitchSlotId,
+                gameCode: `D${dayIndex + 1}-G${gameCount + 1}`,
+                sideA: { sourceLabel: "Winner A" },
+                sideB: { sourceLabel: "Winner B" },
+              },
+              authority,
+            );
+            if (game.status !== "accepted") throw new Error("Expected Event Game.");
+            gameCount += 1;
+          }
+        }
+      }
+
+      const projection = await catalog.inspectEvent(event.value.eventId, authority);
+      expect(projection.status).toBe("accepted");
+      if (projection.status !== "accepted") return;
+      expect(gameCount).toBe(96);
+      expect(projection.value.gameDays).toHaveLength(2);
+      expect(projection.value.gameDays.map((day) => day.date).sort()).toEqual([
+        "2026-08-14",
+        "2026-08-15",
+      ]);
+      expect(projection.value.pitches).toHaveLength(6);
+      expect(projection.value.pitches.map((pitch) => pitch.name).sort()).toEqual([
+        "Pitch 1",
+        "Pitch 2",
+        "Pitch 3",
+        "Pitch 4",
+        "Pitch 5",
+        "Pitch 6",
+      ]);
+      expect(projection.value.pitchSlots).toHaveLength(96);
+      expect(projection.value.eventGames).toHaveLength(96);
+      expect(projection.value.eventGames.every((game) => !game.scheduleConflict)).toBe(true);
+    } finally {
+      foundation.close();
       await rm(directory, { recursive: true, force: true });
     }
   });

--- a/src/lib/event-operations-health.ts
+++ b/src/lib/event-operations-health.ts
@@ -1,0 +1,21 @@
+export type EventOperationsHealth = {
+  unresolvedTeamCount: number;
+  scheduleConflictCount: number;
+  teamScheduleConflictCount: number;
+  grantProblemCount: number;
+};
+
+export function isEventOperationsHealth(value: unknown): value is EventOperationsHealth {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  const candidate = value as Record<string, unknown>;
+  return (
+    isNonnegativeSafeInteger(candidate.unresolvedTeamCount) &&
+    isNonnegativeSafeInteger(candidate.scheduleConflictCount) &&
+    isNonnegativeSafeInteger(candidate.teamScheduleConflictCount) &&
+    isNonnegativeSafeInteger(candidate.grantProblemCount)
+  );
+}
+
+function isNonnegativeSafeInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+}

--- a/src/lib/grant-management-policy.ts
+++ b/src/lib/grant-management-policy.ts
@@ -14,6 +14,7 @@ import type {
 import type { GrantAuthorityOptions } from "@/lib/grant-authority";
 import { DAY_MS } from "@/lib/grant-calendar";
 import { createAuditEntry, expireGrantIfDue } from "@/lib/grant-lifecycle";
+import { validateGrantScope } from "@/lib/grant-types";
 import type {
   ControlGrantScope,
   EventAdminGrantScope,
@@ -46,6 +47,41 @@ export function hasCurrentAdmissionEligibility(
       resolved.status === "eligible" &&
       validateOpaqueIdentifier(resolved.eventGameId, "eventGameId").ok
     );
+  } catch {
+    return false;
+  }
+}
+
+/** Read-only health composition seam for a Grant already selected by its owning projection. */
+export function isGrantCurrentlyUsableInTransaction(
+  snapshot: FoundationStorageSnapshot,
+  options: GrantAuthorityOptions,
+  grant: StoredGrant,
+): boolean {
+  try {
+    const nowMs = readNow(options);
+    if (grant.status !== "active") return false;
+    if (
+      grant.expiresAtMs !== null &&
+      (!Number.isSafeInteger(grant.expiresAtMs) || nowMs >= grant.expiresAtMs)
+    )
+      return false;
+    if (!validateGrantScope(grant.grantType, grant.scope).ok) return false;
+    const token = decryptCredential(grant.credential, bindingFor(options, grant), options.keyRing);
+    if (
+      token === null ||
+      grant.credential.lookupKeyVersion === null ||
+      typeof grant.credential.lookupDigest !== "string"
+    )
+      return false;
+    if (
+      !sameSecret(
+        grant.credential.lookupDigest,
+        computeLookupDigest(token, options.keyRing, grant.credential.lookupKeyVersion),
+      )
+    )
+      return false;
+    return hasCurrentAdmissionEligibility(options, grant, snapshot);
   } catch {
     return false;
   }

--- a/src/lib/grant-management-types.ts
+++ b/src/lib/grant-management-types.ts
@@ -276,6 +276,10 @@ export type TypedGrantAuthority = {
     transaction: FoundationStorageTransaction,
     input: { sessionBearer: string; readOnly?: boolean },
   ): TypedGrantAuthorization;
+  isGrantCurrentlyUsableInTransaction(
+    transaction: FoundationStorageTransaction,
+    grant: import("@/lib/grant-types").StoredGrant,
+  ): boolean;
   acceptControlGrantSessionSwitch(input: {
     sessionBearer: string;
   }): Promise<TypedControlGrantSwitch>;

--- a/src/lib/grant-management.ts
+++ b/src/lib/grant-management.ts
@@ -17,6 +17,7 @@ import {
 } from "@/lib/grant-management-credentials";
 import { recalculateExpiry, retireGrantInTransaction } from "@/lib/grant-management-lifecycle";
 import { listAudit, listSessions, listSessionsInTransaction } from "@/lib/grant-management-queries";
+import { isGrantCurrentlyUsableInTransaction } from "@/lib/grant-management-policy";
 import { admitGrantCode, createGrantCode, disableGrantCode } from "@/lib/grant-management-code";
 import {
   admitGrant,
@@ -123,6 +124,8 @@ export function createTypedGrantAuthority(
         : notifyLifecycleChange(authorizeGrant(storage, options, input), ["authorized"]),
     authorizeGrantInTransaction: (transaction, input) =>
       authorizeGrantInTransaction(transaction, options, input),
+    isGrantCurrentlyUsableInTransaction: (transaction, grant) =>
+      isGrantCurrentlyUsableInTransaction(transaction, options, grant),
     acceptControlGrantSessionSwitch: (input) =>
       notifyLifecycleChange(acceptControlGrantSessionSwitch(storage, options, input.sessionBearer)),
     authorizeControlGrantReplay: (input) => authorizeControlGrantReplay(storage, options, input),

--- a/src/pages/event-admin-page.tsx
+++ b/src/pages/event-admin-page.tsx
@@ -6,6 +6,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { AdministrativeAuditBrowser } from "@/pages/administrative-audit-browser";
 import { createGrantSecretOwner, type GrantSecretToken } from "@/lib/grant-secret-owner";
+import { isEventOperationsHealth, type EventOperationsHealth } from "@/lib/event-operations-health";
 
 type HubResponse = {
   status: "accepted";
@@ -71,6 +72,7 @@ type HubResponse = {
     };
     selectedGameDayId: string | null;
     authority: "technical-admin" | "event-admin";
+    health: EventOperationsHealth;
   };
 };
 
@@ -296,6 +298,7 @@ export function EventAdminPage({
   const [credential, setCredential] = useState("");
   const [grantCode, setGrantCode] = useState("");
   const [hub, setHub] = useState<HubResponse["value"] | null>(null);
+  const [healthUnavailable, setHealthUnavailable] = useState(false);
   const [selectedGameDayId, setSelectedGameDayId] = useState<string | null>(null);
   const [pitchManagerGameDayId, setPitchManagerGameDayId] = useState("");
   const [message, setMessage] = useState<string | null>(null);
@@ -446,6 +449,7 @@ export function EventAdminPage({
     invalidateLockedGameRequest();
     invalidateGrantSecrets();
     setHub(null);
+    setHealthUnavailable(false);
     setSelectedGameDayId(null);
     setPitchManagerGameDayId("");
     setTeamDrafts({});
@@ -546,6 +550,7 @@ export function EventAdminPage({
         | { status: "rejected" | "retryable-failure"; message?: string };
       if (!response.ok || payload.status !== "accepted")
         throw new Error("Unable to open the Event Hub.");
+      const validHealth = isEventOperationsHealth(payload.value.health);
       if (!secretOwner.current(token)) return;
       secretOwner.commit(token, () => {
         setTeamDrafts(
@@ -565,6 +570,7 @@ export function EventAdminPage({
           ),
         );
         setHub(payload.value);
+        setHealthUnavailable(!validHealth);
         setSelectedGameDayId(payload.value.selectedGameDayId);
         setSchedule({
           gameDayId: payload.value.selectedGameDayId ?? "",
@@ -1701,6 +1707,30 @@ export function EventAdminPage({
                 </p>
               </div>
               <AdministrativeAuditBrowser eventId={hub.event.eventId} route="event-admin" />
+              <section
+                aria-labelledby="operations-health-title"
+                className="space-y-2 rounded-lg border p-3"
+              >
+                <h2 className="font-semibold" id="operations-health-title">
+                  Operations health
+                </h2>
+                <p className="text-sm text-muted-foreground">
+                  Resolve these signals before handing a Game Day to operators. Counts are
+                  allowlisted summaries; Grant credentials and audit details stay private.
+                </p>
+                {healthUnavailable ? (
+                  <p role="status" aria-live="polite">
+                    Operations health unavailable. No readiness counts are shown.
+                  </p>
+                ) : (
+                  <ul className="grid gap-1 text-sm sm:grid-cols-2" aria-live="polite">
+                    <li>Unresolved team assignments: {hub.health.unresolvedTeamCount}</li>
+                    <li>Schedule conflicts: {hub.health.scheduleConflictCount}</li>
+                    <li>Team schedule conflicts: {hub.health.teamScheduleConflictCount}</li>
+                    <li>Grant problems: {hub.health.grantProblemCount}</li>
+                  </ul>
+                )}
+              </section>
               <div className="space-y-3 rounded-lg border p-3">
                 <div>
                   <p className="font-semibold">Locked Event Game administration</p>
@@ -2106,6 +2136,7 @@ export function EventAdminPage({
                     onChange={(event) => setTeamColor(event.target.value)}
                   />
                   <Button
+                    className="min-h-10"
                     disabled={busy || teamName.trim().length === 0}
                     onClick={() =>
                       void run(async () => {
@@ -2151,6 +2182,7 @@ export function EventAdminPage({
                     onChange={(event) => setPlayerName(event.target.value)}
                   />
                   <Button
+                    className="min-h-10"
                     disabled={
                       busy ||
                       rosterTeamId.length === 0 ||

--- a/src/pages/grant-secret-lifecycle.test.tsx
+++ b/src/pages/grant-secret-lifecycle.test.tsx
@@ -689,6 +689,41 @@ describe("Grant secret UI lifecycle", () => {
     expect(container.textContent).not.toContain("stale reopening network");
   });
 
+  test("Event Admin fails closed when Hub health is absent or malformed", async () => {
+    let hubCalls = 0;
+    fetchHandler = async (input, init) => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      const method = init?.method ?? "GET";
+      if (url.includes("/api/event-admin/hub")) {
+        hubCalls += 1;
+        return hubCalls === 1
+          ? json({ status: "accepted", value: eventHub })
+          : json({
+              status: "accepted",
+              value: {
+                ...eventHub,
+                health: {
+                  unresolvedTeamCount: "0",
+                  scheduleConflictCount: 0,
+                  teamScheduleConflictCount: 0,
+                  grantProblemCount: 0,
+                },
+              },
+            });
+      }
+      throw new Error(`Unexpected request: ${method} ${url}`);
+    };
+
+    await render(<EventAdminPage />);
+    expect(container.textContent).toContain("Operations health unavailable");
+    expect(container.textContent).not.toContain("Unresolved team assignments: 0");
+    await typeEventId("event-b");
+    await clickButton("Open as Technical Admin");
+    expect(container.textContent).toContain("Operations health unavailable");
+    expect(container.textContent).not.toContain("Grant problems: 0");
+  });
+
   afterEach(async () => {
     await act(async () => {
       root.unmount();


### PR DESCRIPTION
## Scope

Implements GitHub issue #123 under owning spec #105: the complete authenticated Event Administration workflow, stacked after the accepted #114/#121/#122 seams now present on `main`.

## What changed

- Adds bounded Event Operations Health as a required, shared projection. Health is read-only and fails closed for absent or malformed data; Grant problems reflect current expiry, erased/invalid credential material, exact scope, eligibility, and unavailable Control authority without exposing secrets or identifiers.
- Completes the authenticated Event Operations Hub/catalog workflow, including semantic roster absence -> addition -> correction/current public name, while retained Game Facts remain unchanged. No anonymous roster route or Public Event/Timeline composition is introduced.
- Exercises the deterministic production envelope of 96 Games across two Game Days and six Pitches.
- Validates startup from actual application input built into an immutable release tree, with only explicit Technical Admin/Foundation state writable, invalid writes rejected, and restart persistence verified.
- Covers Chromium and WebKit critical administration paths, keyboard/focus activation and rendered focus indicators, accessible names and non-color-only state, target sizes, and 360px/desktop layout evidence.
- Consumes #114, #121, and #122 through their final public seams; it does not re-own their production internals.

## Explicit exclusions

This PR does not implement public Timeline behavior, Public Event HTTP ownership, deployment or Production operations, or Qualification Tests.

## Checks

- `bun install --frozen-lockfile` (manifest and lockfile unchanged)
- Focused Event Administration health/catalog/Grant lifecycle/startup tests
- Chromium critical admin browser journey
- WebKit critical admin browser journey
- `bun run check`
- `bun run test`: 915 tests passed, 0 failed
- `bun run build`
- `git diff --check`

The reconciled branch remains one commit: `8cfc8ce6c3458a59b2c2ed8f890cf98f0565aeb5`, directly on `main` `8e54a21531a2fe0d7214d87079aa9d6196c19949`.
