### PR TITLE
Promote verified backups through the root boundary

### DIFF
--- a/deploy/activation-maintenance-root.sh
+++ b/deploy/activation-maintenance-root.sh
@@ -35,8 +35,196 @@ esac
 focused_test_mode="${QBT_FOCUSED_TEST_MODE:-}"
 focused_test_root="${QBT_FOCUSED_TEST_ROOT:-}"
 focused_failure_phase="${QBT_FOCUSED_FAILURE_PHASE:-}"
+test_harness_mode=0
+mv_command="mv"
+stat_command="stat"
+skip_chown=0
+before_previous_rm_command=""
 ad_hoc_database="$database_dir/ad-hoc.sqlite"
 ad_hoc_environment_identity="$environment:$public_origin"
+
+configure_promotion_test_hooks() {
+  if [[ "$test_harness_mode" != 1 ]]; then
+    return 0
+  fi
+  [[ "$EUID" -ne 0 && -n "$focused_test_root" && "$focused_test_root" == /* ]] || {
+    echo "Promotion test hooks require a non-root absolute disposable root." >&2
+    return 2
+  }
+  case "$focused_test_root" in
+    /|*..*|*//* )
+      echo "Promotion test hooks require a safe disposable root." >&2
+      return 2
+      ;;
+  esac
+  [[ -d "$focused_test_root" && ! -L "$focused_test_root" ]] || {
+    echo "Promotion test hooks require a real disposable root." >&2
+    return 2
+  }
+  local resolved_test_root=""
+  resolved_test_root="$(cd -- "$focused_test_root" 2>/dev/null && pwd -P)" || {
+    echo "Promotion test hooks require an accessible disposable root." >&2
+    return 2
+  }
+  [[ "$resolved_test_root" == "$focused_test_root" ]] || {
+    echo "Promotion test hooks require a canonical disposable root." >&2
+    return 2
+  }
+  mv_command="${QBT_FOCUSED_TEST_MV:-mv}"
+  stat_command="${QBT_FOCUSED_TEST_STAT:-stat}"
+  skip_chown="${QBT_FOCUSED_TEST_SKIP_CHOWN:-0}"
+  before_previous_rm_command="${QBT_FOCUSED_TEST_BEFORE_PREVIOUS_RM:-}"
+}
+
+promote_verified_backup_as_root() {
+  local candidate_directory="$1"
+  local manifest_path="$2"
+  local release_attempt_id="$3"
+  local retained_pointer="$backup_directory/retained"
+  local retained_version="$backup_directory/verified-$release_attempt_id"
+  local temporary_pointer="$backup_directory/.retained-$release_attempt_id.tmp"
+  local previous_target=""
+  local previous_path=""
+  local previous_identity=""
+  local previous_cleanup_allowed=0
+  local previous_cleanup_warning=""
+
+  [[ "$candidate_directory" == "$backup_directory/.candidate-$release_attempt_id" ]] || {
+    echo "Unsafe backup candidate path." >&2
+    return 1
+  }
+  [[ "$manifest_path" == "$candidate_directory"/* && "$manifest_path" != *..* ]] || {
+    echo "Unsafe backup manifest path." >&2
+    return 1
+  }
+  [[ -d "$candidate_directory" && ! -L "$candidate_directory" ]] || {
+    echo "Production backup candidate directory is not a regular directory." >&2
+    return 1
+  }
+  [[ -f "$manifest_path" && ! -L "$manifest_path" ]] || {
+    echo "Production backup manifest is not a regular file." >&2
+    return 1
+  }
+  if [[ -e "$retained_pointer" || -L "$retained_pointer" ]]; then
+    [[ -L "$retained_pointer" ]] || {
+      echo "Retained backup pointer is not a symlink." >&2
+      return 1
+    }
+    previous_target="$(readlink -- "$retained_pointer")"
+    [[ "$previous_target" != "verified-$release_attempt_id" ]] || {
+      echo "Production backup release is already retained." >&2
+      return 1
+    }
+    if [[ ! "$previous_target" =~ ^verified-[A-Za-z0-9._-]+$ ]]; then
+      previous_cleanup_warning="previous retained backup cleanup skipped: target namespace is invalid"
+    else
+      previous_path="$backup_directory/$previous_target"
+      if [[ ! -d "$previous_path" || -L "$previous_path" ]]; then
+        previous_cleanup_warning="previous retained backup cleanup skipped: target is not a directory"
+      elif [[ "$($realpath_command -e -- "$previous_path")" != "$previous_path" ]]; then
+        previous_cleanup_warning="previous retained backup cleanup skipped: target is not canonical"
+      elif [[ "$focused_test_mode" != 1 ]] && ! previous_identity="$($stat_command -c '%d:%i' -- "$previous_path")"; then
+        previous_cleanup_warning="previous retained backup cleanup skipped: target identity unavailable"
+      else
+        previous_cleanup_allowed=1
+      fi
+    fi
+  fi
+  if [[ -e "$retained_version" || -L "$retained_version" ]]; then
+    [[ -d "$retained_version" && ! -L "$retained_version" ]] || {
+      echo "Retained backup destination is not a regular directory." >&2
+      return 1
+    }
+    if ! rm -rf -- "$retained_version"; then
+      echo "Retained backup destination could not be replaced." >&2
+      return 1
+    fi
+  fi
+  if ! rm -f -- "$temporary_pointer"; then
+    echo "Temporary retained backup pointer could not be removed." >&2
+    return 1
+  fi
+
+  # The service has just finished the full semantic re-verification. Freeze
+  # that exact candidate under root ownership before moving it into the
+  # retained area; the service group never receives write access to the
+  # root-controlled backup parent or retained snapshot.
+  local candidate_symlink=""
+  if ! candidate_symlink="$(find -P "$candidate_directory" -type l -print -quit)"; then
+    echo "Production backup candidate could not be inspected." >&2
+    return 1
+  fi
+  if [[ -n "$candidate_symlink" ]]; then
+    echo "Production backup candidate contains a symlink." >&2
+    return 1
+  fi
+  if [[ "$skip_chown" != 1 ]]; then
+    if ! chown -R root:root -- "$candidate_directory"; then
+      echo "Production backup candidate could not be root-owned." >&2
+      return 1
+    fi
+  fi
+  if ! find -P "$candidate_directory" -type d -exec chmod 0700 {} +; then
+    echo "Production backup candidate directory modes could not be fixed." >&2
+    return 1
+  fi
+  if ! find -P "$candidate_directory" -type f -exec chmod 0600 {} +; then
+    echo "Production backup candidate file modes could not be fixed." >&2
+    return 1
+  fi
+
+  if ! mv -- "$candidate_directory" "$retained_version"; then
+    echo "Verified backup promotion failed before pointer replacement." >&2
+    return 1
+  fi
+  if ! ln -s -- "$(basename -- "$retained_version")" "$temporary_pointer"; then
+    echo "Verified backup promotion failed before pointer replacement." >&2
+    rm -rf -- "$retained_version"
+    return 1
+  fi
+  if [[ "$focused_test_mode" == 1 ]]; then
+    # BSD mv follows a symlink destination.  Focused mode is disposable and
+    # non-root, so remove only this validated pointer before the replacement;
+    # Production runs on Linux and uses mv -T for a true no-dereference rename.
+    if ! rm -f -- "$retained_pointer" || ! "$mv_command" -- "$temporary_pointer" "$retained_pointer"; then
+      echo "Verified backup promotion failed before pointer replacement." >&2
+      rm -f -- "$temporary_pointer"
+      rm -rf -- "$retained_version"
+      return 1
+    fi
+  elif ! "$mv_command" -T -- "$temporary_pointer" "$retained_pointer"; then
+    echo "Verified backup promotion failed before pointer replacement." >&2
+    rm -f -- "$temporary_pointer"
+    rm -rf -- "$retained_version"
+    return 1
+  fi
+  local cleanup_warning="$previous_cleanup_warning"
+  if [[ -n "$previous_target" && "$previous_cleanup_allowed" == 1 ]]; then
+    local current_previous_target=""
+    if [[ -n "$before_previous_rm_command" ]]; then
+      "$before_previous_rm_command" "$previous_path"
+    fi
+    if ! current_previous_target="$(readlink -- "$retained_pointer")" ||
+      [[ "$current_previous_target" != "$(basename -- "$retained_version")" ]] ||
+      [[ ! -d "$previous_path" || -L "$previous_path" ]] ||
+      [[ "$($realpath_command -e -- "$previous_path")" != "$previous_path" ]] ||
+      [[ "$focused_test_mode" != 1 && "$($stat_command -c '%d:%i' -- "$previous_path")" != "$previous_identity" ]]; then
+      cleanup_warning="previous retained backup cleanup failed"
+    elif ! rm -rf -- "$previous_path"; then
+      cleanup_warning="previous retained backup cleanup failed"
+    else
+      cleanup_warning=""
+    fi
+  fi
+  if [[ -n "$cleanup_warning" ]]; then
+    printf '{"pointerCommitted":true,"retainedTarget":"%s","cleanupWarning":"%s"}\n' \
+      "$(basename -- "$retained_version")" "$cleanup_warning"
+  else
+    printf '{"pointerCommitted":true,"retainedTarget":"%s","cleanupWarning":null}\n' \
+      "$(basename -- "$retained_version")"
+  fi
+}
+
 if [[ "$focused_test_mode" == 1 ]]; then
   [[ "$EUID" -ne 0 && -n "$focused_test_root" && "$focused_test_root" == /* ]] || {
     echo "Focused activation mode requires a non-root disposable absolute root." >&2
@@ -49,6 +237,7 @@ if [[ "$focused_test_mode" == 1 ]]; then
   focused_test_root_resolved="$(cd -- "$focused_test_root" && pwd -P)" || { echo "Focused activation root is inaccessible." >&2; exit 2; }
   [[ "$focused_test_root_resolved" == "$focused_test_root" ]] || { echo "Focused activation root is not canonical." >&2; exit 2; }
   focused_test_root="$focused_test_root_resolved"
+  test_harness_mode=1
   export QBT_FOCUSED_TEST_ROOT="$focused_test_root"
   release_base="$focused_test_root${release_base}"
   database_dir="$focused_test_root${database_dir}"
@@ -58,6 +247,7 @@ if [[ "$focused_test_mode" == 1 ]]; then
   key_ring_file="$focused_test_root${key_ring_file}"
   [[ -n "$backup_directory" ]] && backup_directory="$focused_test_root${backup_directory}"
 fi
+configure_promotion_test_hooks || exit 2
 systemctl_command="${QBT_FOCUSED_TEST_SYSTEMCTL:-systemctl}"
 runuser_command="${QBT_FOCUSED_TEST_RUNUSER:-/usr/sbin/runuser}"
 flock_command="${QBT_FOCUSED_TEST_FLOCK:-flock}"
@@ -141,7 +331,10 @@ fi
 set +e
 foundation_backup_directory="$operation_backup_directory"
 [[ "$command" == "promote" ]] && foundation_backup_directory="$backup_directory"
-"$runuser_command" -u "$service_user" -- env -i PATH=/usr/bin:/bin \
+root_promotion=""
+[[ "$command" == "promote" ]] && root_promotion=1
+if [[ "$command" == "promote" ]]; then
+  maintenance_output="$("$runuser_command" -u "$service_user" -- env -i PATH=/usr/bin:/bin \
   QUADBALL_ENVIRONMENT="$environment" \
   NODE_ENV=production \
   PUBLIC_ORIGIN="$public_origin" \
@@ -159,9 +352,47 @@ foundation_backup_directory="$operation_backup_directory"
   QBT_FOCUSED_TEST_ROOT="$focused_test_root" \
   AD_HOC_ENVIRONMENT_ID="$ad_hoc_environment_identity" \
   QBT_FOCUSED_FAILURE_PHASE="$focused_failure_phase" \
+  QBT_ROOT_PROMOTION="$root_promotion" \
+  "$release_dir/quadball-timer" --production-activation "$command" 2>&1)"
+  rc=$?
+else
+  "$runuser_command" -u "$service_user" -- env -i PATH=/usr/bin:/bin \
+  QUADBALL_ENVIRONMENT="$environment" \
+  NODE_ENV=production \
+  PUBLIC_ORIGIN="$public_origin" \
+  TECHNICAL_ADMIN_DATABASE="$technical_admin_database" \
+  FOUNDATION_DATABASE="$foundation_database" \
+  AD_HOC_DATABASE="$ad_hoc_database" \
+  EVENT_GAME_DATABASE="$database_dir/event-game.sqlite" \
+  GRANT_KEY_RING_FILE="$key_ring_file" \
+  FOUNDATION_BACKUP_DIRECTORY="$foundation_backup_directory" \
+  RELEASE_ATTEMPT_ID="$release_attempt_id" \
+  SCHEMA_COMPATIBILITY="$schema_compatibility" \
+  RELEASE_MANIFEST_PATH="$release_dir/release-manifest.json" \
+  BACKUP_MANIFEST_PATH="$manifest_path" \
+  QBT_FOCUSED_TEST_MODE="$focused_test_mode" \
+  QBT_FOCUSED_TEST_ROOT="$focused_test_root" \
+  AD_HOC_ENVIRONMENT_ID="$ad_hoc_environment_identity" \
+  QBT_FOCUSED_FAILURE_PHASE="$focused_failure_phase" \
+  QBT_ROOT_PROMOTION="$root_promotion" \
   "$release_dir/quadball-timer" --production-activation "$command"
-rc=$?
+  rc=$?
+fi
 set -e
+if [[ "$command" == "promote" ]]; then
+  if (( rc != 0 )); then
+    if (( ${#maintenance_output} > 4096 )); then
+      printf '%s\n' "${maintenance_output:0:4096}" >&2
+      echo "Activation maintenance output truncated." >&2
+    else
+      printf '%s\n' "$maintenance_output" >&2
+    fi
+  else
+    if ! promote_verified_backup_as_root "$operation_backup_directory" "$manifest_path" "$release_attempt_id"; then
+      rc=1
+    fi
+  fi
+fi
 if (( rc != 0 )) && [[ "$command" == "backup" || "$command" == "verify-backup" || "$command" == "promote" ]]; then
   if [[ "$focused_test_mode" == 1 ]]; then chmod -R u+w "$operation_backup_directory" 2>/dev/null || true; rm -rf "$operation_backup_directory"; else chmod -R u+w -- "$operation_backup_directory" 2>/dev/null || true; rm -rf -- "$operation_backup_directory"; fi
 fi

--- a/src/lib/production-activation-cli.ts
+++ b/src/lib/production-activation-cli.ts
@@ -253,6 +253,15 @@ export async function runProductionActivationCli(argv: readonly string[]): Promi
       return { manifest, metadata };
     };
     if (command === "promote") {
+      // The root maintenance wrapper owns the backup parent and performs the
+      // final pointer swap.  The service user still performs the complete
+      // candidate re-verification here, but must not attempt to rename the
+      // candidate into the root-controlled retained area.
+      if (process.env.QBT_ROOT_PROMOTION === "1") {
+        const { manifest } = await verifyCandidate();
+        console.log(JSON.stringify({ verified: true, snapshotId: manifest.snapshotId }));
+        return 0;
+      }
       const promotion = await promoteVerifiedBackup({
         backupDirectory,
         candidateDirectory,

--- a/src/lib/production-activation.focused.ts
+++ b/src/lib/production-activation.focused.ts
@@ -147,9 +147,15 @@ describe("disposable activation SQLite integration", () => {
       );
       await chmod(realpathStub, 0o755);
 
-      const run = async (command: string, heldPath = "", manifestPath = "", failurePhase = "") => {
+      const run = async (
+        command: string,
+        heldPath = "",
+        manifestPath = "",
+        failurePhase = "",
+        releasePath = releaseDirectory,
+      ) => {
         const child = Bun.spawn(
-          ["bash", wrapper, "production", releaseDirectory, command, manifestPath],
+          ["bash", wrapper, "production", releasePath, command, manifestPath],
           {
             env: {
               PATH: `${binDirectory}:${process.env.PATH ?? ""}`,
@@ -160,6 +166,7 @@ describe("disposable activation SQLite integration", () => {
               QBT_FOCUSED_TEST_RUNUSER: runuserStub,
               QBT_FOCUSED_TEST_FLOCK: flockStub,
               QBT_FOCUSED_TEST_REALPATH: realpathStub,
+              QBT_FOCUSED_TEST_SKIP_CHOWN: "1",
               QBT_ACTIVATION_LOCK_HELD_PATH: heldPath,
               QBT_FOCUSED_FAILURE_PHASE: failurePhase,
             },
@@ -209,6 +216,44 @@ describe("disposable activation SQLite integration", () => {
           .code,
       ).not.toBe(0);
       expect((await run("promote", canonicalLock, manifestPath)).code).toBe(0);
+      const retainedDirectory = join(root, "var/backups/quadball-timer/verified-lock-test");
+      expect((await lstat(retainedDirectory)).mode & 0o777).toBe(0o700);
+      expect((await lstat(join(retainedDirectory, basename(manifestPath)))).mode & 0o777).toBe(
+        0o600,
+      );
+      expect(await pathExists(join(root, "var/backups/quadball-timer/.candidate-lock-test"))).toBe(
+        false,
+      );
+
+      const secondReleaseDirectory = join(root, "srv/quadball-timer/releases/lock-test-2");
+      await mkdir(secondReleaseDirectory, { recursive: true });
+      await Bun.write(
+        join(secondReleaseDirectory, "quadball-timer"),
+        await Bun.file(join(releaseDirectory, "quadball-timer")).arrayBuffer(),
+      );
+      await chmod(join(secondReleaseDirectory, "quadball-timer"), 0o755);
+      await writeFile(
+        join(secondReleaseDirectory, "release-manifest.json"),
+        JSON.stringify({ releaseAttemptId: "lock-test-2", schemaCompatibility: "foundation-v1" }),
+      );
+      const secondBackup = await run("backup", canonicalLock, "", "", secondReleaseDirectory);
+      expect(secondBackup.code, secondBackup.output).toBe(0);
+      const secondManifestPath = JSON.parse(secondBackup.output).manifestPath as string;
+      const secondPromote = await run(
+        "promote",
+        canonicalLock,
+        secondManifestPath,
+        "",
+        secondReleaseDirectory,
+      );
+      expect(secondPromote.code, secondPromote.output).toBe(0);
+      expect(await readlink(join(root, "var/backups/quadball-timer/retained"))).toBe(
+        "verified-lock-test-2",
+      );
+      expect(await pathExists(retainedDirectory)).toBe(false);
+      expect(
+        (await lstat(join(root, "var/backups/quadball-timer/verified-lock-test-2"))).mode & 0o777,
+      ).toBe(0o700);
       expect((await run("validate-migration", canonicalLock)).code).toBe(0);
       expect((await run("apply-migrations", canonicalLock)).code).toBe(0);
       expect((await run("readiness", canonicalLock)).code).toBe(0);

--- a/src/production-deployment.test.ts
+++ b/src/production-deployment.test.ts
@@ -1,10 +1,31 @@
 import { describe, expect, test } from "bun:test";
 import { Buffer } from "node:buffer";
 import { readFileSync } from "node:fs";
+import {
+  chmod,
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readlink,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
 import { join } from "node:path";
+import { tmpdir } from "node:os";
 import { resolveAdHocEnvironmentIdentity } from "@/lib/ad-hoc-games";
 
 const repositoryRoot = process.cwd();
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await lstat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 describe("Production deployment contract", () => {
   test("gives the service one private persistent state directory", () => {
@@ -159,6 +180,201 @@ describe("Production deployment contract", () => {
     expect(wrapper).toContain('PUBLIC_ORIGIN="$public_origin"');
     expect(wrapper).toContain("backup|verify-backup|promote");
     expect(wrapper).not.toContain("eval ");
+  });
+
+  test("keeps verified backup promotion in the root ownership boundary", () => {
+    const wrapper = readFileSync(
+      join(repositoryRoot, "deploy/activation-maintenance-root.sh"),
+      "utf8",
+    );
+
+    expect(wrapper).toContain("configure_promotion_test_hooks()");
+    expect(wrapper).toContain('mv_command="mv"');
+    expect(wrapper).toContain('stat_command="stat"');
+    expect(wrapper).toContain("skip_chown=0");
+    expect(wrapper).toContain('before_previous_rm_command=""');
+    expect(wrapper).toContain('QBT_ROOT_PROMOTION="$root_promotion"');
+    expect(wrapper).toContain("promote_verified_backup_as_root");
+    expect(wrapper).toContain('chown -R root:root -- "$candidate_directory"');
+    expect(wrapper).toContain('mv -- "$candidate_directory" "$retained_version"');
+    expect(wrapper).toContain('"$mv_command" -T -- "$temporary_pointer" "$retained_pointer"');
+    expect(wrapper).toContain("local previous_cleanup_allowed=0");
+    expect(wrapper).toContain('stat_command="${QBT_FOCUSED_TEST_STAT:-stat}"');
+    expect(wrapper).toContain('[[ -n "$previous_target" && "$previous_cleanup_allowed" == 1 ]]');
+    expect(wrapper).toContain(
+      '[[ "$command" == "promote" ]] && foundation_backup_directory="$backup_directory"',
+    );
+    expect(wrapper).toContain('[[ "$focused_test_mode" != 1 ]]');
+    expect(wrapper).toContain('"${maintenance_output:0:4096}"');
+  });
+
+  test("uses Linux mv -T to replace the retained pointer without following it", async () => {
+    if (process.platform !== "linux") return;
+
+    const wrapper = readFileSync(
+      join(repositoryRoot, "deploy/activation-maintenance-root.sh"),
+      "utf8",
+    );
+    const functionStart = wrapper.indexOf("configure_promotion_test_hooks() {");
+    const functionEnd = wrapper.indexOf('\n}\n\nif [[ "$focused_test_mode" == 1 ]]', functionStart);
+    expect(functionStart).toBeGreaterThanOrEqual(0);
+    expect(functionEnd).toBeGreaterThan(functionStart);
+    const functionSource = wrapper.slice(functionStart, functionEnd + 2);
+    const root = await mkdtemp(join(tmpdir(), "quadball-backup-promotion-contract-"));
+    const harness = join(root, "promote.sh");
+    const ambientHarness = join(root, "ambient-hooks.sh");
+    const run = async (
+      backupDirectory: string,
+      releaseAttemptId: string,
+      mvOverride?: string,
+      beforePreviousRmOverride?: string,
+    ) => {
+      const child = Bun.spawn(["bash", harness, backupDirectory, releaseAttemptId], {
+        cwd: root,
+        env: {
+          ...process.env,
+          QBT_FOCUSED_TEST_SKIP_CHOWN: "1",
+          ...(mvOverride === undefined ? {} : { QBT_FOCUSED_TEST_MV: mvOverride }),
+          ...(beforePreviousRmOverride === undefined
+            ? {}
+            : { QBT_FOCUSED_TEST_BEFORE_PREVIOUS_RM: beforePreviousRmOverride }),
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      return {
+        code: await child.exited,
+        output: `${await new Response(child.stdout).text()}${await new Response(child.stderr).text()}`,
+      };
+    };
+    try {
+      await writeFile(
+        ambientHarness,
+        `#!/usr/bin/env bash
+set -euo pipefail
+${functionSource}
+focused_test_root="$PWD"
+test_harness_mode=0
+mv_command=mv
+stat_command=stat
+skip_chown=0
+before_previous_rm_command=""
+configure_promotion_test_hooks
+printf '%s|%s|%s|%s\\n' "$mv_command" "$stat_command" "$skip_chown" "$before_previous_rm_command"
+`,
+      );
+      await chmod(ambientHarness, 0o755);
+      const ambient = Bun.spawn(["bash", ambientHarness], {
+        cwd: root,
+        env: {
+          ...process.env,
+          QBT_FOCUSED_TEST_MV: "/bin/false",
+          QBT_FOCUSED_TEST_STAT: "/bin/false",
+          QBT_FOCUSED_TEST_SKIP_CHOWN: "1",
+          QBT_FOCUSED_TEST_BEFORE_PREVIOUS_RM: "/bin/false",
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const ambientOutput = await new Response(ambient.stdout).text();
+      const ambientError = await new Response(ambient.stderr).text();
+      expect(await ambient.exited, ambientError).toBe(0);
+      expect(ambientOutput).toBe("mv|stat|0|\n");
+
+      await writeFile(
+        harness,
+        `#!/usr/bin/env bash
+set -euo pipefail
+${functionSource}
+backup_directory="$1"
+focused_test_mode=""
+focused_test_root="$PWD"
+test_harness_mode=1
+mv_command=mv
+stat_command=stat
+skip_chown=0
+before_previous_rm_command=""
+realpath_command=realpath
+configure_promotion_test_hooks
+release_attempt_id="$2"
+promote_verified_backup_as_root "$backup_directory/.candidate-$release_attempt_id" "$backup_directory/.candidate-$release_attempt_id/manifest.json" "$release_attempt_id"
+`,
+      );
+      await chmod(harness, 0o755);
+
+      const successRoot = join(root, "success");
+      const successCandidate = join(successRoot, ".candidate-new");
+      const successOld = join(successRoot, "verified-old");
+      await mkdir(successCandidate, { recursive: true });
+      await mkdir(successOld, { recursive: true });
+      await writeFile(join(successCandidate, "manifest.json"), "candidate\n");
+      await writeFile(join(successOld, "marker"), "old\n");
+      await symlink("verified-old", join(successRoot, "retained"));
+      const success = await run(successRoot, "new");
+      expect(success.code, success.output).toBe(0);
+      expect(await readlink(join(successRoot, "retained"))).toBe("verified-new");
+      expect(await pathExists(join(successRoot, "verified-new"))).toBe(true);
+      expect(await pathExists(successOld)).toBe(false);
+      expect(await pathExists(successCandidate)).toBe(false);
+
+      const invalidNamespaceRoot = join(root, "invalid-namespace");
+      const invalidNamespaceCandidate = join(invalidNamespaceRoot, ".candidate-new");
+      const invalidNamespaceOld = join(invalidNamespaceRoot, "unexpected-target");
+      await mkdir(invalidNamespaceCandidate, { recursive: true });
+      await mkdir(invalidNamespaceOld, { recursive: true });
+      await writeFile(join(invalidNamespaceCandidate, "manifest.json"), "candidate\n");
+      await writeFile(join(invalidNamespaceOld, "marker"), "must-retain\n");
+      await symlink("unexpected-target", join(invalidNamespaceRoot, "retained"));
+      const invalidNamespace = await run(invalidNamespaceRoot, "new");
+      expect(invalidNamespace.code, invalidNamespace.output).toBe(0);
+      expect(await readlink(join(invalidNamespaceRoot, "retained"))).toBe("verified-new");
+      expect(await readFile(join(invalidNamespaceOld, "marker"), "utf8")).toBe("must-retain\n");
+
+      const replacementRoot = join(root, "replacement-object");
+      const replacementCandidate = join(replacementRoot, ".candidate-new");
+      const replacementOld = join(replacementRoot, "verified-old");
+      const replacementScript = join(root, "replace-old.sh");
+      await mkdir(replacementCandidate, { recursive: true });
+      await mkdir(replacementOld, { recursive: true });
+      await writeFile(join(replacementCandidate, "manifest.json"), "candidate\n");
+      await writeFile(join(replacementOld, "marker"), "old\n");
+      await symlink("verified-old", join(replacementRoot, "retained"));
+      await writeFile(
+        replacementScript,
+        '#!/usr/bin/env bash\nset -euo pipefail\nrm -rf -- "$1"\nmkdir -p -- "$1"\nprintf \'replacement\\n\' > "$1/marker"\n',
+      );
+      await chmod(replacementScript, 0o755);
+      const replacement = await run(replacementRoot, "new", undefined, replacementScript);
+      expect(replacement.code, replacement.output).toBe(0);
+      expect(await readlink(join(replacementRoot, "retained"))).toBe("verified-new");
+      expect(await readFile(join(replacementOld, "marker"), "utf8")).toBe("replacement\n");
+      expect(replacement.output).toContain("cleanupWarning");
+
+      const failureRoot = join(root, "failure");
+      const failureCandidate = join(failureRoot, ".candidate-fail");
+      const failureOld = join(failureRoot, "verified-old");
+      const failureMv = join(root, "mv-fails.sh");
+      await mkdir(failureCandidate, { recursive: true });
+      await mkdir(failureOld, { recursive: true });
+      await writeFile(join(failureCandidate, "manifest.json"), "candidate\n");
+      await writeFile(join(failureOld, "marker"), "old\n");
+      await symlink("verified-old", join(failureRoot, "retained"));
+      await writeFile(
+        failureMv,
+        '#!/usr/bin/env bash\nif [[ "$1" == "-T" ]]; then exit 73; fi\nexec /bin/mv "$@"\n',
+      );
+      await chmod(failureMv, 0o755);
+      const failure = await run(failureRoot, "fail", failureMv);
+      expect(failure.code).not.toBe(0);
+      expect(failure.output.length).toBeLessThan(4096);
+      expect(await readlink(join(failureRoot, "retained"))).toBe("verified-old");
+      expect(await readFile(join(failureOld, "marker"), "utf8")).toBe("old\n");
+      expect(await pathExists(join(failureRoot, "verified-fail"))).toBe(false);
+      expect(await pathExists(failureCandidate)).toBe(false);
+      expect(await pathExists(join(failureRoot, ".retained-fail.tmp"))).toBe(false);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
   });
 
   test("documents the host-observed Production sudoers command path", () => {


### PR DESCRIPTION
## Summary

- keep complete Production backup re-verification under the service identity, then perform retained-backup publication inside the root ownership boundary
- freeze candidate ownership and modes before an atomic Linux `mv -T` retained-pointer swap; preserve the prior pointer until commit and clean only canonical identity-matched `verified-*` predecessors
- keep all regression hooks fail-closed behind a validated non-root disposable harness, while Production always uses fixed commands and mandatory ownership transfer

This repairs the Production promotion failure in deployment run `31907048903`, where candidate creation and verification succeeded but the service user could not rename/remove entries in the root-owned `0750` backup parent. Test deployed successfully and remains independent.

## Verification

- full ordinary suite: 895 passed, 20,372 assertions (final implementation before the one-line focused-harness environment correction)
- `bun run test:focused:activation` — 3 passed, 97 assertions on final commit
- `bun test --isolate src/production-deployment.test.ts` — 17 passed, 109 assertions on final commit
- `bun run check`
- Bash syntax and ShellCheck
- `git diff --check`

No Qualification tests were run. Live Production deployment verification remains required before #251 is closed.

Issue: #251
Spec: #158
