### PR TITLE
Codify the Controller freshness boundary

### DIFF
--- a/src/lib/controller-reconnect.test.ts
+++ b/src/lib/controller-reconnect.test.ts
@@ -11,6 +11,8 @@ import {
   rebindControllerReplica,
   reconcileControllerReplay,
   serializeControllerReplica,
+  CONTROLLER_STALE_DISCONNECTED_AFTER_MS,
+  deriveControllerConnectionStatus,
   type ControllerReplicaStorage,
 } from "@/lib/controller-reconnect";
 import {
@@ -20,6 +22,38 @@ import {
 import { createInitialClockBaseline, projectClockBaseline } from "@/lib/clock-authority";
 
 describe("Controller reconnect replica", () => {
+  test("fails clear at the configured stale boundary with an injected clock", () => {
+    const lastSynchronizedAtMs = 10_000;
+    expect(
+      deriveControllerConnectionStatus({
+        lastSynchronizedAtMs,
+        nowMs: lastSynchronizedAtMs + CONTROLLER_STALE_DISCONNECTED_AFTER_MS - 1,
+        online: true,
+      }),
+    ).toBe("fresh");
+    expect(
+      deriveControllerConnectionStatus({
+        lastSynchronizedAtMs,
+        nowMs: lastSynchronizedAtMs + CONTROLLER_STALE_DISCONNECTED_AFTER_MS,
+        online: true,
+      }),
+    ).toBe("stale");
+    expect(
+      deriveControllerConnectionStatus({
+        lastSynchronizedAtMs,
+        nowMs: lastSynchronizedAtMs + CONTROLLER_STALE_DISCONNECTED_AFTER_MS + 1,
+        online: true,
+      }),
+    ).toBe("stale");
+    expect(
+      deriveControllerConnectionStatus({
+        lastSynchronizedAtMs,
+        nowMs: lastSynchronizedAtMs + 1,
+        online: false,
+      }),
+    ).toBe("disconnected");
+  });
+
   test("optimistically retains immutable identity, causal dependencies, and original occurrence evidence", () => {
     let state = createReplica();
     const first = dispatchControllerAction(state, goal("goal-1", "fact-1"), { nowMs: 100 });

--- a/src/lib/controller-reconnect.ts
+++ b/src/lib/controller-reconnect.ts
@@ -37,6 +37,34 @@ import {
 
 export const CONTROLLER_REPLICA_VERSION = "controller-replica-v3" as const;
 export const CONTROLLER_REPLICA_STORAGE_KEY = "quadball:event-controller-replica";
+/** A Controller must revalidate after five seconds without a fresh server response. */
+export const CONTROLLER_STALE_DISCONNECTED_AFTER_MS = 5_000 as const;
+
+export type ControllerConnectionStatus = "fresh" | "stale" | "disconnected";
+
+/**
+ * Shared monotonic freshness contract for the browser Controller reconnect seam.
+ * Offline transport is disconnected immediately; an online session is stale at
+ * (and only at) the configured five-second boundary after its last response.
+ */
+export function deriveControllerConnectionStatus(input: {
+  lastSynchronizedAtMs: number | null;
+  nowMs: number;
+  online: boolean;
+}): ControllerConnectionStatus {
+  if (!input.online) return "disconnected";
+  if (
+    input.lastSynchronizedAtMs === null ||
+    !Number.isFinite(input.lastSynchronizedAtMs) ||
+    !Number.isFinite(input.nowMs) ||
+    input.nowMs < input.lastSynchronizedAtMs
+  ) {
+    return "disconnected";
+  }
+  return input.nowMs - input.lastSynchronizedAtMs < CONTROLLER_STALE_DISCONNECTED_AFTER_MS
+    ? "fresh"
+    : "stale";
+}
 
 export function controllerReplicaStorageKey(eventGameId?: string): string {
   return eventGameId === undefined

--- a/src/pages/event-game-controller-page.test.tsx
+++ b/src/pages/event-game-controller-page.test.tsx
@@ -4,6 +4,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { Window } from "happy-dom";
 import { EventGameControllerPage } from "@/pages/event-game-controller-page";
 import {
+  CONTROLLER_STALE_DISCONNECTED_AFTER_MS,
   controllerReplicaStorageKey,
   createControllerReplica,
   dispatchControllerAction,
@@ -26,8 +27,12 @@ describe("Event Game Controller reconnect browser seam", () => {
   let container: HTMLDivElement;
   let root: Root;
   let replayMode: "lost" | "success" | "deferred" | "retryable";
+  let refreshMode: "immediate" | "deferred";
   let openBodies: Record<string, unknown>[];
   let replayCalls: number;
+  let refreshCalls: number;
+  let deferredRefresh: ((response: Response) => void) | null;
+  let deferredRefreshResponse: Response | null;
   let replayBodies: Record<string, any>[];
   let intentCalls: number;
   let intentBodies: Record<string, any>[];
@@ -45,8 +50,12 @@ describe("Event Game Controller reconnect browser seam", () => {
 
   beforeEach(() => {
     replayMode = "lost";
+    refreshMode = "immediate";
     openBodies = [];
     replayCalls = 0;
+    refreshCalls = 0;
+    deferredRefresh = null;
+    deferredRefreshResponse = null;
     replayBodies = [];
     intentCalls = 0;
     intentBodies = [];
@@ -132,6 +141,7 @@ describe("Event Game Controller reconnect browser seam", () => {
           return replayResponse;
         }
         if (url.endsWith("/api/event-control/refresh")) {
+          refreshCalls += 1;
           if (refreshRejected) return new Response("rejected", { status: 401 });
           if (switchRequested) {
             return new Response(
@@ -143,7 +153,7 @@ describe("Event Game Controller reconnect browser seam", () => {
               { status: 200, headers: { "content-type": "application/json" } },
             );
           }
-          return new Response(
+          const refreshResponse = new Response(
             JSON.stringify({
               status: "authorized",
               session: {
@@ -156,6 +166,13 @@ describe("Event Game Controller reconnect browser seam", () => {
             }),
             { status: 200, headers: { "content-type": "application/json" } },
           );
+          if (refreshMode === "deferred") {
+            deferredRefreshResponse = refreshResponse;
+            return await new Promise<Response>((resolve) => {
+              deferredRefresh = resolve;
+            });
+          }
+          return refreshResponse;
         }
         if (url.endsWith("/api/event-control/intent")) {
           intentCalls += 1;
@@ -247,6 +264,45 @@ describe("Event Game Controller reconnect browser seam", () => {
       await Promise.resolve();
       await Promise.resolve();
     });
+  }
+
+  function installControllerIntervalProbe() {
+    let tick: (() => void) | null = null;
+    const cleared: number[] = [];
+    const intervalId = 97;
+    const originalSetInterval = testWindow.setInterval;
+    const originalClearInterval = testWindow.clearInterval;
+    Object.defineProperty(testWindow, "setInterval", {
+      configurable: true,
+      value: (callback: TimerHandler, timeout?: number) => {
+        if (timeout === 250 && typeof callback === "function") {
+          tick = callback as () => void;
+          return intervalId;
+        }
+        throw new Error(`Unexpected interval: ${String(timeout)}`);
+      },
+    });
+    Object.defineProperty(testWindow, "clearInterval", {
+      configurable: true,
+      value: (id: number) => {
+        if (id === intervalId) cleared.push(id);
+        else throw new Error(`Unexpected interval clear: ${String(id)}`);
+      },
+    });
+    return {
+      tick: () => tick?.(),
+      wasCleared: () => cleared.includes(intervalId),
+      restore: () => {
+        Object.defineProperty(testWindow, "setInterval", {
+          configurable: true,
+          value: originalSetInterval,
+        });
+        Object.defineProperty(testWindow, "clearInterval", {
+          configurable: true,
+          value: originalClearInterval,
+        });
+      },
+    };
   }
 
   function setInputValue(input: HTMLInputElement, value: string) {
@@ -1356,6 +1412,71 @@ describe("Event Game Controller reconnect browser seam", () => {
     expect(replayCalls).toBe(2);
     expect(container.textContent).not.toContain("retained for reconnect replay");
     expect(container.textContent).toContain("Clock resynchronized.");
+  });
+
+  test("observes the literal 5,000 ms status boundary before foreground reconciliation", async () => {
+    const probe = installControllerIntervalProbe();
+    await enterAndOpen();
+    const status = container.querySelector<HTMLElement>("[data-controller-freshness]");
+    expect(status?.getAttribute("role")).toBe("status");
+    expect(status?.getAttribute("aria-live")).toBe("polite");
+    expect(CONTROLLER_STALE_DISCONNECTED_AFTER_MS).toBe(5_000);
+    monotonicNow = 4_999;
+    await act(async () => probe.tick());
+    expect(status?.textContent).toContain("fresh");
+    monotonicNow = 5_000;
+    await act(async () => probe.tick());
+    expect(status?.textContent).toContain("stale");
+    monotonicNow = 5_001;
+    await act(async () => probe.tick());
+    expect(status?.textContent).toContain("stale");
+    refreshMode = "deferred";
+    await act(async () => {
+      document.dispatchEvent(new testWindow.Event("visibilitychange") as unknown as Event);
+      await Promise.resolve();
+    });
+    expect(refreshCalls).toBe(1);
+    expect(status?.textContent).toContain("stale");
+    const pendingRefresh = deferredRefresh;
+    const pendingResponse = deferredRefreshResponse;
+    expect(pendingRefresh).not.toBeNull();
+    expect(pendingResponse).not.toBeNull();
+    await act(async () => {
+      pendingRefresh?.(pendingResponse as Response);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(status?.textContent).toContain("fresh");
+    await act(async () => {
+      root.unmount();
+      await Promise.resolve();
+    });
+    expect(probe.wasCleared()).toBe(true);
+    probe.restore();
+  });
+
+  test("local optimistic clock projection cannot renew freshness after lost transport", async () => {
+    const probe = installControllerIntervalProbe();
+    await enterAndOpen();
+    Object.defineProperty(testWindow.navigator, "onLine", { configurable: true, value: false });
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('button[aria-label="Start game clock"]')?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    Object.defineProperty(testWindow.navigator, "onLine", { configurable: true, value: true });
+    monotonicNow = 4_999;
+    await act(async () => probe.tick());
+    expect(container.querySelector("[data-controller-freshness]")?.textContent).toContain("fresh");
+    monotonicNow = 5_000;
+    await act(async () => probe.tick());
+    expect(container.querySelector("[data-controller-freshness]")?.textContent).toContain("stale");
+    await act(async () => {
+      root.unmount();
+      await Promise.resolve();
+    });
+    expect(probe.wasCleared()).toBe(true);
+    probe.restore();
   });
 
   test("unmount and remount restores persisted work before foreground replay", async () => {

--- a/src/pages/event-game-controller-page.tsx
+++ b/src/pages/event-game-controller-page.tsx
@@ -46,6 +46,8 @@ import {
   persistControllerReplica,
   rebindControllerReplica,
   reconcileControllerReplay,
+  deriveControllerConnectionStatus,
+  type ControllerConnectionStatus,
   type ControllerReplicaLoad,
   type ControllerReplicaState,
   type ControllerReplayBatchResponse,
@@ -137,6 +139,8 @@ export function EventGameControllerPage() {
   >({});
   const [clockRunning, setClockRunning] = useState(false);
   const [clockReceiptAnchor, setClockReceiptAnchor] = useState<ClockReceiptAnchor | null>(null);
+  const [controllerConnectionStatus, setControllerConnectionStatus] =
+    useState<ControllerConnectionStatus>("disconnected");
   const [localMonotonicMs, setLocalMonotonicMs] = useState(readMonotonicNow);
   const [clockCorrectionInput, setClockCorrectionInput] = useState("");
   const [takeoverAdjustmentInput, setTakeoverAdjustmentInput] = useState("");
@@ -168,6 +172,8 @@ export function EventGameControllerPage() {
   const activeReplayRef = useRef<ActiveReplay | null>(null);
   const queuedReplayRef = useRef<ReplayRequest | null>(null);
   const resynchronizationTimerRef = useRef<number | null>(null);
+  const lastControllerSyncAtRef = useRef<number | null>(null);
+  const controllerConnectionStatusRef = useRef<ControllerConnectionStatus>("disconnected");
   const [durabilityWarning, setDurabilityWarning] = useState<string | null>(
     persistedReplicaLoad.warning,
   );
@@ -176,7 +182,11 @@ export function EventGameControllerPage() {
   const qrDialogRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    const timer = window.setInterval(() => setLocalMonotonicMs(readMonotonicNow()), 250);
+    const timer = window.setInterval(() => {
+      const nowMs = readMonotonicNow();
+      setLocalMonotonicMs(nowMs);
+      updateControllerConnectionStatus(nowMs);
+    }, 250);
     return () => {
       window.clearInterval(timer);
       if (resynchronizationTimerRef.current !== null) {
@@ -184,6 +194,23 @@ export function EventGameControllerPage() {
       }
     };
   }, []);
+
+  function updateControllerConnectionStatus(nowMs = readMonotonicNow()) {
+    const next = deriveControllerConnectionStatus({
+      lastSynchronizedAtMs: lastControllerSyncAtRef.current,
+      nowMs,
+      online: navigator.onLine !== false,
+    });
+    if (controllerConnectionStatusRef.current === next) return next;
+    controllerConnectionStatusRef.current = next;
+    setControllerConnectionStatus(next);
+    return next;
+  }
+
+  function markControllerSynchronized() {
+    lastControllerSyncAtRef.current = readMonotonicNow();
+    updateControllerConnectionStatus(lastControllerSyncAtRef.current);
+  }
 
   const clockProjection =
     clockReceiptAnchor === null
@@ -253,6 +280,7 @@ export function EventGameControllerPage() {
     const reconcileWhenForegrounded = () => {
       if (document.visibilityState === "hidden") return;
       projectClockImmediately();
+      updateControllerConnectionStatus();
       void (async () => {
         const revalidated = await refreshController(true);
         if (revalidated && replicaRef.current !== null) {
@@ -1329,7 +1357,7 @@ export function EventGameControllerPage() {
         { nowMs: Math.floor(readMonotonicNow()) },
       );
       commitReplica(dispatched.state);
-      receiveProjection(dispatched.state.projection);
+      receiveProjection(dispatched.state.projection, { markSynchronized: false });
       setMessage(
         intent.type === "clock-takeover"
           ? "Emergency clock takeover retained for synchronization."
@@ -1347,10 +1375,11 @@ export function EventGameControllerPage() {
 
   function receiveProjection(
     nextProjection: ControllerProjection | null,
-    options: { resynchronized?: boolean } = {},
+    options: { markSynchronized?: boolean; resynchronized?: boolean } = {},
   ) {
     setProjection(nextProjection);
     setProjectionStatus(nextProjection === null ? "unavailable" : "available");
+    if (options.markSynchronized !== false) markControllerSynchronized();
     setClockRunning(nextProjection?.clock.running ?? false);
     setClockReceiptAnchor(
       nextProjection === null
@@ -1415,6 +1444,9 @@ export function EventGameControllerPage() {
     }
     setSessionBearer(null);
     setEventGameId(null);
+    lastControllerSyncAtRef.current = null;
+    controllerConnectionStatusRef.current = "disconnected";
+    setControllerConnectionStatus("disconnected");
     setProjection(null);
     setProjectionStatus("unavailable");
     setClockRunning(false);
@@ -1520,6 +1552,18 @@ export function EventGameControllerPage() {
             <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain [&_button]:min-h-11">
               <div className="rounded-lg border bg-muted/30 p-3 text-sm">
                 <p className="font-medium">Controller Device: {eventGameId}</p>
+                <p
+                  role="status"
+                  aria-live="polite"
+                  data-controller-freshness="true"
+                  className="mt-1 text-muted-foreground"
+                >
+                  {controllerConnectionStatus === "fresh"
+                    ? "Controller connection: fresh"
+                    : controllerConnectionStatus === "stale"
+                      ? "Controller connection: stale; reconnect to reconcile"
+                      : "Controller connection: disconnected; reconnect to reconcile"}
+                </p>
                 <p className="mt-1 text-muted-foreground">
                   {projection?.commencement.status === "commenced"
                     ? "Game Commencement is irreversible."


### PR DESCRIPTION
## Summary

- define a shared monotonic Controller freshness contract with an explicit 5,000 ms stale boundary
- show fresh, stale, and disconnected Controller connection states in the Event Game Controller
- reconcile immediately when the page returns to the foreground or the browser reconnects
- keep local optimistic Clock projections from masquerading as successful server synchronization

## Why

The final Spec #83 audit found that #97 described a five-second stale transition but did not explicitly implement and prove the boundary. Without this contract, an online Controller with an unreachable server could continue presenting locally projected state as fresh, especially after optimistic Clock interactions.

## Impact

Operators now receive a truthful, accessible connection status. The Controller becomes stale exactly five seconds after its last successful server response, disconnected immediately when offline, and fresh again only after successful reconciliation.

## Validation

- focused reconnect and Controller browser suites — 56 passed
- `bun run test:focused:event-game-routes` — 6 passed
- `bun run check`
- `bun run test` — 938 passed on the accepted candidate
- `bun run build`
- `git diff --check`

Closes #97
