### PR TITLE
Implement roster-resolved public Game Timeline

### DIFF
--- a/scripts/public-game-timeline-browser-harness.tsx
+++ b/scripts/public-game-timeline-browser-harness.tsx
@@ -1,0 +1,72 @@
+import { useState } from "react";
+import { createRoot } from "react-dom/client";
+import type { PublicAudienceTimelineEntry } from "@/lib/game-timeline-projection";
+import { PublicGameTimeline } from "@/pages/public-game-timeline";
+import "@/index.css";
+
+const initialEntries: readonly PublicAudienceTimelineEntry[] = Array.from(
+  { length: 24 },
+  (_, index) => ({
+    kind: "goal" as const,
+    gameTimeMs: 120_000 - index * 1_000,
+    lane: index % 2 === 0 ? ("side-a" as const) : ("side-b" as const),
+    teamName: index % 2 === 0 ? "Harness Side A" : "Harness Side B",
+    player: { number: index + 1, name: `Harness Player ${index + 1}` },
+    points: 10,
+  }),
+);
+
+function PublicGameTimelineBrowserHarness() {
+  const [entries, setEntries] = useState(initialEntries);
+  return (
+    <main className="mx-auto max-w-3xl space-y-4 p-4">
+      <h1 className="text-xl font-semibold">Public Game Timeline browser harness</h1>
+      <div className="flex flex-wrap gap-2">
+        <button
+          type="button"
+          className="rounded border px-3 py-2 text-sm"
+          onClick={() =>
+            setEntries((current) => [
+              {
+                kind: "goal",
+                gameTimeMs: 121_000,
+                lane: "side-a",
+                teamName: "Harness Side A",
+                player: { number: 99, name: "Harness Newer Player" },
+                points: 10,
+              },
+              ...current,
+            ])
+          }
+        >
+          Deliver newer play while away
+        </button>
+        <button
+          type="button"
+          className="rounded border px-3 py-2 text-sm"
+          onClick={() =>
+            setEntries((current) => [
+              {
+                kind: "card",
+                gameTimeMs: 122_000,
+                lane: "side-b",
+                teamName: "Harness Side B",
+                player: { number: 88, name: "Harness Live-edge Player" },
+                cardColor: "blue",
+                penaltyReason: "Harness live-edge update",
+              },
+              ...current,
+            ])
+          }
+        >
+          Deliver newer play at live edge
+        </button>
+      </div>
+      <PublicGameTimeline entries={entries} />
+    </main>
+  );
+}
+
+const rootElement = document.getElementById("root");
+if (rootElement === null) throw new Error("Timeline harness root is missing.");
+createRoot(rootElement).render(<PublicGameTimelineBrowserHarness />);

--- a/scripts/test-public-event-browser.ts
+++ b/scripts/test-public-event-browser.ts
@@ -1,6 +1,7 @@
 import { chromium, type Page } from "playwright";
-import { mkdtempSync, rmSync } from "node:fs";
-import { join } from "node:path";
+import tailwind from "bun-plugin-tailwind";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { basename, join } from "node:path";
 import { tmpdir } from "node:os";
 import {
   createEventCatalog,
@@ -42,6 +43,7 @@ const environment = {
 
 let server: Bun.Subprocess | null = null;
 let serverStderr: Promise<string> | null = null;
+let harnessServer: ReturnType<typeof Bun.serve> | null = null;
 let browser: Awaited<ReturnType<typeof chromium.launch>> | null = null;
 let browserPage: Page | null = null;
 
@@ -56,6 +58,50 @@ try {
   serverStderr = new Response(server.stderr as unknown as BodyInit).text();
   await waitForServer(`${origin}/internal/healthz`);
   await seedCommittedGameRecords(seeded);
+
+  const harnessDirectory = join(directory, "timeline-harness");
+  mkdirSync(harnessDirectory);
+  const harnessBuild = await Bun.build({
+    entrypoints: [join(process.cwd(), "scripts/public-game-timeline-browser-harness.tsx")],
+    outdir: harnessDirectory,
+    plugins: [tailwind],
+    target: "browser",
+    format: "esm",
+    sourcemap: "none",
+  });
+  if (!harnessBuild.success) {
+    throw new Error(
+      `Timeline browser harness build failed: ${harnessBuild.logs.map((log) => log.message).join("; ")}`,
+    );
+  }
+  const harnessEntry = harnessBuild.outputs.find((output) => output.kind === "entry-point");
+  if (harnessEntry === undefined) throw new Error("Timeline browser harness entry is missing.");
+  const harnessAssets = new Map(
+    harnessBuild.outputs.map((output) => [basename(output.path), output.path]),
+  );
+  const harnessScript = basename(harnessEntry.path);
+  const harnessStylesheet = [...harnessAssets.keys()].find((name) => name.endsWith(".css"));
+  harnessServer = Bun.serve({
+    port: 0,
+    fetch(request) {
+      const pathname = new URL(request.url).pathname;
+      if (pathname === "/") {
+        return new Response(
+          `<!doctype html><html><head><meta name="viewport" content="width=device-width, initial-scale=1">${
+            harnessStylesheet === undefined
+              ? ""
+              : `<link rel="stylesheet" href="/${harnessStylesheet}">`
+          }</head><body><div id="root"></div><script type="module" src="/${harnessScript}"></script></body></html>`,
+          { headers: { "content-type": "text/html" } },
+        );
+      }
+      const assetPath = harnessAssets.get(pathname.slice(1));
+      return assetPath === undefined
+        ? new Response("Not found", { status: 404 })
+        : new Response(Bun.file(assetPath));
+    },
+  });
+  const harnessOrigin = `http://127.0.0.1:${harnessServer.port}`;
 
   browser = await chromium.launch({ headless: true });
   const context = await browser.newContext({ viewport: { width: 390, height: 844 } });
@@ -79,6 +125,64 @@ try {
   assert(listPayload.status === "accepted", "seeded Audience list was not accepted");
   const current = listPayload.value.events.find((event) => event.eventId === seeded.currentId);
   if (!current) throw new Error("seeded current Event was not listed");
+
+  const eventResponse = await context.request.get(
+    `${origin}/api/audience/events/${encodeURIComponent(seeded.currentId)}`,
+  );
+  assert(eventResponse.status() === 200, "seeded Audience Event was unavailable");
+  const denseEvent = structuredClone((await eventResponse.json()) as PublicEventResponseFixture);
+  const denseGame = denseEvent.value.schedule.scheduleGames.find(
+    (game) => game.gameCode === "BUSY-1",
+  );
+  if (denseGame === undefined) throw new Error("seeded finished Game was not projected");
+  const longReason =
+    "A deliberately long public penalty reason that must wrap inside the narrow Timeline without horizontal overflow";
+  denseGame.timeline = [
+    ...Array.from(
+      { length: 24 },
+      (_, index) =>
+        ({
+          kind: "card",
+          gameTimeMs: 90_000 - index * 1_000,
+          lane: "side-a",
+          teamName: "A deliberately long public Event Team name for wrapping",
+          player: {
+            number: 7,
+            name: "A deliberately long roster-resolved player name for wrapping",
+          },
+          cardColor: "yellow",
+          penaltyReason: longReason,
+        }) satisfies PublicTimelineFixtureEntry,
+    ),
+    {
+      kind: "card",
+      gameTimeMs: 88_000,
+      lane: "side-b",
+      teamName: "The other long public Event Team",
+      player: { number: 12, name: "Side B roster-resolved player" },
+      cardColor: "blue",
+      penaltyReason: "Side B lane coverage",
+    },
+    {
+      kind: "suspension",
+      gameTimeMs: 87_000,
+      lane: "center",
+      teamName: null,
+      player: null,
+      action: "start",
+    },
+    ...denseGame.timeline,
+  ];
+  await page.route(
+    `${origin}/api/audience/events/${encodeURIComponent(seeded.currentId)}`,
+    async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(denseEvent),
+      });
+    },
+  );
 
   await page.goto(`${origin}/events`);
   await page.waitForURL(`${origin}${current.canonicalPath}`);
@@ -112,6 +216,44 @@ try {
       `${code} did not retain chronological status ${status}`,
     );
   }
+  const finishedTimeline = schedule.locator(
+    '[data-game-code="BUSY-1"][data-schedule-status="past"] [data-game-timeline]',
+  );
+  await finishedTimeline.waitFor();
+  assert(
+    (await finishedTimeline.locator('[data-timeline-kind="finish"]').count()) === 1,
+    "finished Game did not render its effective public Timeline",
+  );
+  await finishedTimeline.getByText("Game Timeline").waitFor();
+  assert(
+    (await finishedTimeline.locator('[data-timeline-kind="card"]').count()) >= 24,
+    "dense public Timeline content was not rendered",
+  );
+  assert(
+    (await finishedTimeline.locator('[data-timeline-lane="side-a"]').count()) >= 24,
+    "side A Timeline events were not rendered in their lane",
+  );
+  assert(
+    (await finishedTimeline.locator('[data-timeline-lane="side-b"]').count()) >= 1,
+    "side B Timeline events were not rendered in their lane",
+  );
+  assert(
+    (await finishedTimeline
+      .locator('[data-timeline-lane="center"][data-timeline-kind="suspension"]')
+      .count()) === 1,
+    "centered lifecycle Timeline event was not rendered",
+  );
+  await finishedTimeline.getByText(longReason).first().waitFor();
+  const timelineScroll = finishedTimeline.locator("[data-timeline-scroll-region]");
+  const scrollMetrics = await timelineScroll.evaluate((element) => ({
+    clientHeight: element.clientHeight,
+    scrollHeight: element.scrollHeight,
+  }));
+  assert(
+    scrollMetrics.scrollHeight > scrollMetrics.clientHeight,
+    "Timeline did not become scrollable",
+  );
+
   assert(
     (await page.locator('[data-schedule-group="coming-up"] h3').count()) === 1,
     "Coming up Games were not grouped by Expected Start",
@@ -128,6 +270,50 @@ try {
       () => document.documentElement.scrollWidth <= document.documentElement.clientWidth,
     ),
     "phone-sized Event schedule overflows horizontally",
+  );
+
+  const harnessPage = await context.newPage();
+  harnessPage.setDefaultTimeout(5_000);
+  harnessPage.on("pageerror", (error) => consoleErrors.push(error.message));
+  harnessPage.on("console", (message) => {
+    if (message.type() === "error") consoleErrors.push(message.text());
+  });
+  await harnessPage.goto(`${harnessOrigin}/`);
+  const harnessTimeline = harnessPage.locator("[data-game-timeline]");
+  await harnessTimeline.waitFor();
+  const harnessScroll = harnessTimeline.locator("[data-timeline-scroll-region]");
+  await harnessScroll.evaluate((element) => {
+    element.scrollTop = Math.floor(element.scrollHeight / 2);
+    element.dispatchEvent(new Event("scroll", { bubbles: true }));
+  });
+  const harnessBeforeNewPlay = await harnessScroll.evaluate((element) => ({
+    bottomDistance: element.scrollHeight - element.clientHeight - element.scrollTop,
+    scrollTop: element.scrollTop,
+  }));
+  assert(harnessBeforeNewPlay.scrollTop > 0, "Timeline harness could not leave the live edge");
+  await harnessPage.getByRole("button", { name: "Deliver newer play while away" }).click();
+  await harnessPage.getByRole("button", { name: "New play" }).waitFor();
+  const harnessAfterNewPlay = await harnessScroll.evaluate((element) => ({
+    bottomDistance: element.scrollHeight - element.clientHeight - element.scrollTop,
+    scrollTop: element.scrollTop,
+  }));
+  assert(
+    Math.abs(harnessAfterNewPlay.bottomDistance - harnessBeforeNewPlay.bottomDistance) <= 4,
+    "Timeline harness changed the older-entry viewport position",
+  );
+  await harnessPage.getByRole("button", { name: "New play" }).click();
+  await harnessPage.waitForFunction(
+    (selector) => ((document.querySelector(selector) as HTMLElement | null)?.scrollTop ?? 0) <= 8,
+    "[data-timeline-scroll-region]",
+  );
+  await harnessPage.getByRole("button", { name: "Deliver newer play at live edge" }).click();
+  await harnessPage.waitForFunction(
+    (selector) => ((document.querySelector(selector) as HTMLElement | null)?.scrollTop ?? 0) <= 8,
+    "[data-timeline-scroll-region]",
+  );
+  assert(
+    (await harnessPage.getByRole("button", { name: "New play" }).count()) === 0,
+    "Timeline harness exposed New play at the live edge",
   );
 
   const spectatorGamePath = `/events/${encodeURIComponent(current.eventId)}/games/browser-fixture`;
@@ -156,6 +342,11 @@ try {
   await page.getByText("Game Suspension").waitFor();
   await page.getByText("Heat Stoppage").waitFor();
   await page.getByText("Winner Side A · Locked").waitFor();
+  await page.getByText("Roster-resolved spectator").waitFor();
+  assert(
+    (await page.locator('[data-game-timeline] [data-timeline-kind="goal"]').count()) === 1,
+    "dedicated spectator Game did not render its roster-resolved Timeline",
+  );
   const expandedSides = page.locator("[data-scoreboard-expanded] [data-side-id]");
   assert((await expandedSides.count()) === 2, "expanded scoreboard did not render two sides");
   assert(
@@ -363,6 +554,7 @@ try {
   process.exitCode = 1;
 } finally {
   if (browser) await browser.close();
+  if (harnessServer) await harnessServer.stop(true);
   if (server) {
     server.kill();
     await server.exited;
@@ -436,8 +628,46 @@ function publicGameFixture(
       displayedTeamColors: { sideA: "#112233", sideB: "#445566" },
     },
     canonicalPath: `/events/${encodeURIComponent(eventId)}/games/browser-fixture`,
+    timeline: [
+      {
+        kind: "goal",
+        gameTimeMs: 124_000,
+        lane: "side-b",
+        teamName: "Another Very Long Team Name For A Narrow Phone",
+        player: { number: 7, name: "Roster-resolved spectator" },
+        points: 10,
+      },
+    ],
   };
 }
+
+type PublicTimelineFixtureEntry = {
+  kind: string;
+  gameTimeMs: number | null;
+  lane: string;
+  teamName: string | null;
+  player: { number: number; name: string | null } | null;
+  cardColor?: string | null;
+  penaltyReason?: string | null;
+  [key: string]: unknown;
+};
+
+type PublicGameProjectionFixture = {
+  gameCode: string | null;
+  timeline: PublicTimelineFixtureEntry[];
+  [key: string]: unknown;
+};
+
+type PublicEventResponseFixture = {
+  status: string;
+  value: {
+    schedule: {
+      scheduleGames: PublicGameProjectionFixture[];
+      [key: string]: unknown;
+    };
+    [key: string]: unknown;
+  };
+};
 
 async function seedDatabase() {
   const foundation = openSqliteFoundationStorage(foundationDatabase, {

--- a/src/lib/audience-projection.test.ts
+++ b/src/lib/audience-projection.test.ts
@@ -15,6 +15,8 @@ import {
   type EventGame,
   type GameplaySlot,
   type PitchSlot,
+  type StoredEventTeam,
+  type StoredRosterEntry,
   type StoredEvent,
 } from "@/lib/event-catalog";
 import type { EventGameRecordRoot } from "@/lib/foundation-record-types";
@@ -109,6 +111,138 @@ describe("Audience Publication Projection", () => {
     if (result.status !== "accepted") return;
     expect(result.value).not.toHaveProperty("auditTrail");
     expect(result.value).not.toHaveProperty("reason");
+  });
+
+  test("embeds a roster-resolved Timeline and isolates roster reads by Event", async () => {
+    const game = createScheduleGame("timeline", "2026-08-14T08:00:00.000Z", "Pitch 1");
+    game.sideA = {
+      ...game.sideA,
+      eventTeamId: "team-corrected",
+      eventTeamName: "Correction-time Blue",
+    };
+    const root = createScheduleRoot("timeline", "finished");
+    const snapshot = createScheduleSnapshot({
+      pitches: ["Pitch 1"],
+      games: [game],
+      roots: new Map([[game.eventGameId, root]]),
+      actions: () => [createGoalAction(root)],
+      eventTeams: [
+        eventTeam("team-a", "event-schedule", "Original Team"),
+        eventTeam("team-corrected", "event-schedule", "Renamed After Correction"),
+        eventTeam("team-other-event", "other-event", "Wrong Event Team"),
+      ],
+      roster: [
+        rosterEntry("roster-original", "event-schedule", "team-a", 3, "Wrong Original Player"),
+        rosterEntry(
+          "roster-corrected",
+          "event-schedule",
+          "team-corrected",
+          3,
+          "Current Goal Player",
+        ),
+        rosterEntry(
+          "roster-other",
+          "other-event",
+          "team-other-event",
+          3,
+          "Private Other Event Name",
+        ),
+      ],
+    });
+    const audience = createAudienceProjection(
+      { snapshot: async () => snapshot } as unknown as EventCatalogFoundationStorage,
+      {
+        now: () => Date.parse("2026-08-14T10:00:00.000Z"),
+        gameInput: {
+          read: async () => ({
+            status: "accepted" as const,
+            value: {
+              gameSideIds: [root.gameSides[0]!.id, root.gameSides[1]!.id] as const,
+              phase: "seeker-floor" as const,
+              operationalStatus: "finished" as const,
+              scoreByGameSide: {},
+              clock: null,
+              presentation: null,
+              overtimeTarget: null,
+              teamTimeout: { status: "inactive" as const, gameSideId: null, remainingMs: null },
+              heatStoppage: {
+                status: "inactive" as const,
+                mode: null,
+                pending: false,
+                allowedDurationMs: null,
+                actualDurationMs: null,
+                remainingMs: null,
+              },
+              winnerGameSideId: null,
+              catchingGameSideId: null,
+              locked: true,
+            },
+          }),
+        },
+      },
+    );
+
+    const result = await audience.read("event-schedule");
+    expect(result).toMatchObject({ status: "accepted" });
+    if (result.status !== "accepted") return;
+    const timeline = result.value.schedule.scheduleGames[0]?.timeline ?? [];
+    expect(timeline).toContainEqual(
+      expect.objectContaining({
+        kind: "goal",
+        teamName: "Correction-time Blue",
+        player: { number: 3, name: "Current Goal Player" },
+      }),
+    );
+    expect(JSON.stringify(timeline)).not.toContain("Private Other Event Name");
+
+    const dedicatedGame = await audience.readGame("event-schedule", game.eventGameId);
+    expect(dedicatedGame).toMatchObject({ status: "accepted" });
+    if (dedicatedGame.status !== "accepted") return;
+    expect(dedicatedGame.value.timeline).toContainEqual(
+      expect.objectContaining({
+        kind: "goal",
+        teamName: "Correction-time Blue",
+        player: { number: 3, name: "Current Goal Player" },
+      }),
+    );
+  });
+
+  test("projects concession, forfeit, and double-forfeit outcomes", async () => {
+    const games = [
+      createScheduleGame("concession", "2026-08-14T08:00:00.000Z", "Pitch 1"),
+      createScheduleGame("forfeit", "2026-08-14T08:01:00.000Z", "Pitch 1"),
+      createScheduleGame("double-forfeit", "2026-08-14T08:02:00.000Z", "Pitch 1"),
+    ];
+    const roots = new Map(
+      games.map((game) => [game.eventGameId, createScheduleRoot(game.eventGameId, "finished")]),
+    );
+    const outcomeByGame: Record<string, "concession" | "forfeit" | "double-forfeit"> = {
+      concession: "concession",
+      forfeit: "forfeit",
+      "double-forfeit": "double-forfeit",
+    };
+    const snapshot = createScheduleSnapshot({
+      pitches: ["Pitch 1"],
+      games,
+      roots,
+      actions: (root) => [createOutcomeAction(root, outcomeByGame[root.eventGameId]!)],
+    });
+    const audience = createAudienceProjection(
+      { snapshot: async () => snapshot } as unknown as EventCatalogFoundationStorage,
+      { now: () => Date.parse("2026-08-14T10:00:00.000Z") },
+    );
+
+    const result = await audience.read("event-schedule");
+    expect(result).toMatchObject({ status: "accepted" });
+    if (result.status !== "accepted") return;
+    expect(
+      result.value.schedule.scheduleGames.map(
+        (game) => game.timeline.find((entry) => entry.kind === "finish")?.outcome,
+      ),
+    ).toEqual(["concession", "forfeit", "double-forfeit"]);
+    expect(result.value.schedule.scheduleGames[2]?.timeline).toContainEqual(
+      expect.objectContaining({ kind: "finish", lane: "center", teamName: null }),
+    );
   });
 
   test("groups every running Game, uses a half-open one-hour horizon, and orders the schedule", async () => {
@@ -629,6 +763,7 @@ describe("Audience Publication Projection", () => {
     const snapshot = {
       findEvent: (eventId: string) => (eventId === event.eventId ? event : null),
       findEventGame: (eventGameId: string) => (eventGameId === game.eventGameId ? game : null),
+      findRootByEventGameId: () => null,
       findGameplaySlot: () => ({
         gameplaySlotId: "slot-public",
         eventId: event.eventId,
@@ -1096,6 +1231,8 @@ function createScheduleSnapshot(input: {
   expectedDelay?: () => number;
   placement?: (game: EventGame) => { pitchSlotId?: string; gameplaySlotId?: string };
   actions?: (root: EventGameRecordRoot) => ReturnType<typeof createFinishedAction>[];
+  eventTeams?: StoredEventTeam[];
+  roster?: StoredRosterEntry[];
 }): EventCatalogStorageSnapshot {
   const event: StoredEvent = {
     eventId: "event-schedule",
@@ -1168,10 +1305,16 @@ function createScheduleSnapshot(input: {
     findEvent: (eventId: string) => (eventId === event.eventId ? event : null),
     listEvents: () => [event],
     listGameDays: () => [gameDay],
-    findEventTeam: () => null,
-    listEventTeams: () => [],
-    listRoster: () => [],
-    findRosterEntry: () => null,
+    findEventTeam: (eventTeamId: string) =>
+      input.eventTeams?.find((team) => team.eventTeamId === eventTeamId) ?? null,
+    listEventTeams: (eventId: string) =>
+      input.eventTeams?.filter((team) => team.eventId === eventId) ?? [],
+    listRoster: (eventTeamId: string) =>
+      input.roster?.filter((entry) => entry.eventTeamId === eventTeamId) ?? [],
+    findRosterEntry: (eventTeamId: string, playerNumber: number) =>
+      input.roster?.find(
+        (entry) => entry.eventTeamId === eventTeamId && entry.playerNumber === playerNumber,
+      ) ?? null,
     findPitch: (pitchId: string) => pitchRows.find((pitch) => pitch.pitchId === pitchId) ?? null,
     listPitches: () => pitchRows,
     findGameplaySlot: (slotId: string): GameplaySlot | null => {
@@ -1215,8 +1358,30 @@ function createGoalAction(
     factType: "goal",
     gameSideId,
     gameTimeMs: 1,
-    data: { points: 10, sportingOrder: 1 },
+    data: { points: 10, playerNumber: 3, sportingOrder: 1 },
   });
+}
+
+function eventTeam(eventTeamId: string, eventId: string, name: string): StoredEventTeam {
+  return { eventTeamId, eventId, name, defaultColor: "#112233", createdAtMs: 1, updatedAtMs: 1 };
+}
+
+function rosterEntry(
+  rosterEntryId: string,
+  eventId: string,
+  eventTeamId: string,
+  playerNumber: number,
+  publicName: string,
+): StoredRosterEntry {
+  return {
+    rosterEntryId,
+    eventId,
+    eventTeamId,
+    playerNumber,
+    publicName,
+    createdAtMs: 1,
+    updatedAtMs: 1,
+  };
 }
 
 function createClockAction(root: EventGameRecordRoot) {
@@ -1251,6 +1416,19 @@ function createFinishedAction(root: EventGameRecordRoot) {
     gameSideId: root.gameSides[0]?.id ?? "side-a",
     gameTimeMs: 0,
     data: { resultKind: "concession", sportingOrder: 0 },
+  });
+}
+
+function createOutcomeAction(
+  root: EventGameRecordRoot,
+  factType: "concession" | "forfeit" | "double-forfeit",
+) {
+  return createStoredAction(root, `${factType}-${root.eventGameId}`, {
+    factId: `${factType}-fact-${root.eventGameId}`,
+    factType,
+    gameSideId: factType === "double-forfeit" ? null : (root.gameSides[0]?.id ?? "side-a"),
+    gameTimeMs: 0,
+    data: { resultKind: factType, sportingOrder: 0 },
   });
 }
 

--- a/src/lib/audience-projection.ts
+++ b/src/lib/audience-projection.ts
@@ -8,6 +8,10 @@ import type {
 import { projectScheduleGames } from "@/lib/event-catalog";
 import { projectClockBaseline } from "@/lib/clock-authority";
 import {
+  projectPublicGameTimeline,
+  type PublicAudienceTimelineEntry,
+} from "@/lib/game-timeline-projection";
+import {
   projectLiveEventGameDerivedState,
   type LiveEventGameDerivedState,
 } from "@/lib/live-event-game-control";
@@ -122,6 +126,7 @@ export type PublicAudienceGameProjection = PublicAudienceGameOperationalProjecti
     displayedTeamColors: { sideA: string | null; sideB: string | null };
   };
   canonicalPath: string;
+  timeline: readonly PublicAudienceTimelineEntry[];
 };
 
 /** Allowlisted, server-side input for one public Audience Projection. */
@@ -392,6 +397,7 @@ function projectAudienceGameFromInput(
       },
     },
     canonicalPath: `/events/${encodeURIComponent(event.eventId)}/games/${encodeURIComponent(game.eventGameId)}`,
+    timeline: projectAudienceGameTimeline(snapshot, game),
   };
 }
 
@@ -502,6 +508,83 @@ function readAudienceProjectionGameInputFromCatalog(
     winnerGameSideId: derived?.winnerGameSideId ?? null,
     catchingGameSideId: derived?.catch?.catchingGameSideId ?? null,
     locked: root?.lifecycle.lockedAtMs !== null && root?.lifecycle.lockedAtMs !== undefined,
+  };
+}
+
+function projectAudienceGameTimeline(
+  snapshot: EventCatalogStorageSnapshot,
+  game: ProjectedEventGame,
+): readonly PublicAudienceTimelineEntry[] {
+  const root = snapshot.findRootByEventGameId(game.eventGameId);
+  if (root === null) return [];
+  const derived = readDerivedState(snapshot, root);
+  const sideAssignments = publicTimelineSideAssignments(snapshot, game, root);
+  return projectPublicGameTimeline({
+    facts: derived.gameFacts,
+    sideA: sideAssignments.sideA,
+    sideB: sideAssignments.sideB,
+    lookupRosterName: (eventTeamId, playerNumber) => {
+      const team = snapshot.findEventTeam(eventTeamId);
+      if (team === null || team.eventId !== game.eventId) return null;
+      const entry = snapshot.findRosterEntry(eventTeamId, playerNumber);
+      return entry?.eventId === game.eventId ? entry.publicName : null;
+    },
+    derived,
+  });
+}
+
+function publicTimelineSideAssignments(
+  snapshot: EventCatalogStorageSnapshot,
+  game: ProjectedEventGame,
+  root: ReturnType<EventCatalogStorageSnapshot["findRootByEventGameId"]>,
+) {
+  const sideA = root?.gameSides[0];
+  const sideB = root?.gameSides[1];
+  const sideAUsesCatalogAssignment = game.sideA.eventTeamId !== null;
+  const sideBUsesCatalogAssignment = game.sideB.eventTeamId !== null;
+  return {
+    sideA: timelineSide(
+      snapshot,
+      game.eventId,
+      sideA?.id ?? game.sideA.sideId,
+      sideAUsesCatalogAssignment
+        ? game.sideA.eventTeamId
+        : (sideA?.eventTeamId ?? game.sideA.eventTeamId),
+      sideAUsesCatalogAssignment
+        ? (game.sideA.eventTeamName ?? game.sideA.sourceLabel)
+        : sideA === undefined
+          ? (game.sideA.eventTeamName ?? game.sideA.sourceLabel)
+          : undefined,
+    ),
+    sideB: timelineSide(
+      snapshot,
+      game.eventId,
+      sideB?.id ?? game.sideB.sideId,
+      sideBUsesCatalogAssignment
+        ? game.sideB.eventTeamId
+        : (sideB?.eventTeamId ?? game.sideB.eventTeamId),
+      sideBUsesCatalogAssignment
+        ? (game.sideB.eventTeamName ?? game.sideB.sourceLabel)
+        : sideB === undefined
+          ? (game.sideB.eventTeamName ?? game.sideB.sourceLabel)
+          : undefined,
+    ),
+  };
+}
+
+function timelineSide(
+  snapshot: EventCatalogStorageSnapshot,
+  eventId: string,
+  sideId: string,
+  eventTeamId: string | null,
+  fallbackName?: string | null,
+) {
+  const candidate = eventTeamId === null ? null : snapshot.findEventTeam(eventTeamId);
+  const team = candidate?.eventId === eventId ? candidate : null;
+  return {
+    sideId,
+    eventTeamId,
+    teamName: fallbackName ?? team?.name ?? null,
   };
 }
 

--- a/src/lib/game-timeline-projection.test.ts
+++ b/src/lib/game-timeline-projection.test.ts
@@ -1,0 +1,355 @@
+import { describe, expect, test } from "bun:test";
+import type { ControllerGameFact } from "@/lib/live-event-game-control";
+import { projectPublicGameTimeline } from "@/lib/game-timeline-projection";
+
+const sideA = { sideId: "side-a", eventTeamId: "team-a", teamName: "Blue" } as const;
+const sideB = { sideId: "side-b", eventTeamId: "team-b", teamName: "Red" } as const;
+
+describe("public Game Timeline projection", () => {
+  test("projects every registered public kind, including penalty consequences and player data", () => {
+    const facts = [
+      fact("goal", "side-a", 1_000, { points: 10, playerNumber: 3 }),
+      fact("card", "side-b", 2_000, { cardType: "yellow", playerNumber: 7 }),
+      fact(
+        "penalty-reason",
+        "side-b",
+        2_000,
+        { targetCardFactId: "card-fact", reason: "conduct" },
+        "reason-fact",
+      ),
+      fact("timeout", "side-a", 3_000, { timeoutAction: "stoppage" }),
+      fact("suspension", null, 4_000, { suspensionAction: "start" }),
+      fact("heat-stoppage", null, 5_000, { heatAction: "start" }),
+      fact("flag-catch", "side-a", 6_000, { points: 30, playerNumber: 1 }),
+      fact("penalty-release", "side-b", 7_000, {
+        playerKey: "side-b:7",
+        releaseCause: "score",
+        serviceDurationMs: 60_000,
+      }),
+      fact(
+        "penalty-release-consequence",
+        "side-b",
+        8_000,
+        {
+          playerKey: "side-b:7",
+          releaseCause: "automatic",
+          serviceDurationMs: 60_000,
+          sourceFactId: "card-fact",
+          privateOperationId: "private-operation",
+        },
+        "consequence-fact",
+      ),
+      fact("result", null, 9_000, { resultKind: "winner" }),
+      fact("clock", null, 1_200_000, { command: "set-running", running: false }),
+    ];
+    const timeline = projectPublicGameTimeline({
+      facts,
+      sideA,
+      sideB,
+      lookupRosterName: (eventTeamId, playerNumber) =>
+        eventTeamId === "team-a" && playerNumber === 3
+          ? "Goal Player"
+          : eventTeamId === "team-a" && playerNumber === 1
+            ? "Catcher"
+            : eventTeamId === "team-b" && playerNumber === 7
+              ? "Card Player"
+              : null,
+      derived: {
+        catch: {
+          factId: "catch-fact",
+          catchingGameSideId: "side-a",
+          nonCatchingGameSideId: "side-b",
+          gameTimeMs: 6_000,
+          targetScore: 60,
+        },
+        overtime: true,
+        overtimeTarget: 60,
+        result: null,
+      },
+    });
+
+    expect(timeline.map((entry) => entry.kind)).toEqual([
+      "seeker-release",
+      "finish",
+      "penalty",
+      "penalty",
+      "overtime",
+      "flag-catch",
+      "heat-stoppage",
+      "suspension",
+      "timeout",
+      "card",
+      "goal",
+    ]);
+    expect(timeline.find((entry) => entry.kind === "goal")).toMatchObject({
+      gameTimeMs: 1_000,
+      player: { number: 3, name: "Goal Player" },
+      points: 10,
+    });
+    expect(timeline.find((entry) => entry.kind === "flag-catch")).toMatchObject({
+      player: { number: 1, name: "Catcher" },
+    });
+    expect(timeline.filter((entry) => entry.kind === "penalty")).toHaveLength(2);
+    expect(timeline.find((entry) => entry.kind === "card")).toMatchObject({
+      player: { number: 7, name: "Card Player" },
+      cardColor: "yellow",
+      penaltyReason: "conduct",
+    });
+    expect(JSON.stringify(timeline)).not.toContain("private-operation");
+  });
+
+  test("keeps missing Game Clock time absent and does not call roster lookup for an unassigned side", () => {
+    let lookupCalls = 0;
+    const timeline = projectPublicGameTimeline({
+      facts: [
+        fact(
+          "goal",
+          "side-a",
+          null,
+          { points: 10, playerNumber: 4 },
+          "untimed-goal",
+          true,
+          999_999,
+        ),
+      ],
+      sideA: { sideId: "side-a", eventTeamId: null, teamName: "Unassigned" },
+      sideB,
+      lookupRosterName: () => {
+        lookupCalls += 1;
+        return "must-not-be-called";
+      },
+      derived: { catch: null, overtime: false, overtimeTarget: null, result: null },
+    });
+
+    expect(timeline[0]).toEqual({
+      kind: "goal",
+      gameTimeMs: null,
+      lane: "side-a",
+      teamName: "Unassigned",
+      player: { number: 4, name: null },
+      points: 10,
+    });
+    expect(lookupCalls).toBe(0);
+    expect(JSON.stringify(timeline)).not.toContain("999999");
+  });
+
+  test("uses semantic Sporting Order before synchronization for equal Game Clock times", () => {
+    const timeline = projectPublicGameTimeline({
+      facts: [
+        fact("goal", "side-a", 100, { points: 10 }, "arrived-late", true, 10, 99),
+        fact("card", "side-b", 100, { cardType: "blue" }, "sporting-late", true, 20, 1),
+      ],
+      sideA,
+      sideB,
+      lookupRosterName: () => null,
+      derived: { catch: null, overtime: false, overtimeTarget: null, result: null },
+    });
+
+    expect(timeline.map((entry) => entry.kind)).toEqual(["card", "goal"]);
+  });
+
+  test("uses explicit close-play Sporting Order before retained Game Clock times", () => {
+    const timeline = projectPublicGameTimeline({
+      facts: [
+        fact("goal", "side-a", 100, { points: 10 }, "clock-later", true, 101, 1),
+        fact(
+          "flag-catch",
+          "side-b",
+          100,
+          {
+            points: 30,
+            sportingOrderAdjudication: { relatedFactId: "clock-later", relation: "after" },
+          },
+          "sporting-later",
+          true,
+          100,
+          2,
+        ),
+      ],
+      sideA,
+      sideB,
+      lookupRosterName: () => null,
+      derived: { catch: null, overtime: false, overtimeTarget: null, result: null },
+    });
+
+    expect(timeline.map((entry) => entry.kind)).toEqual(["flag-catch", "goal"]);
+    expect(timeline.map((entry) => entry.gameTimeMs)).toEqual([100, 100]);
+  });
+
+  test("keeps newer Game Clock time ahead of a later Sporting Order", () => {
+    const timeline = projectPublicGameTimeline({
+      facts: [
+        fact("goal", "side-a", 101, { points: 10 }, "clock-newer", true, 1, 1),
+        fact(
+          "flag-catch",
+          "side-b",
+          100,
+          {
+            points: 30,
+            sportingOrderAdjudication: { relatedFactId: "clock-newer", relation: "after" },
+          },
+          "sporting-later",
+          true,
+          2,
+          2,
+        ),
+      ],
+      sideA,
+      sideB,
+      lookupRosterName: () => null,
+      derived: { catch: null, overtime: false, overtimeTarget: null, result: null },
+    });
+
+    expect(timeline.map((entry) => entry.kind)).toEqual(["goal", "flag-catch"]);
+    expect(timeline.map((entry) => entry.gameTimeMs)).toEqual([101, 100]);
+  });
+
+  test("includes a derived corrected flag catch when the correction replaces the fact", () => {
+    const timeline = projectPublicGameTimeline({
+      facts: [fact("result", "locked-correction", 1_500, { resultKind: "result" })],
+      sideA,
+      sideB,
+      lookupRosterName: () => null,
+      derived: {
+        catch: {
+          factId: "locked-correction",
+          catchingGameSideId: "side-a",
+          nonCatchingGameSideId: "side-b",
+          gameTimeMs: 1_500,
+          targetScore: null,
+        },
+        overtime: false,
+        overtimeTarget: null,
+        result: { factId: "locked-correction", data: { resultKind: "result" } },
+      },
+    });
+
+    expect(timeline).toContainEqual(
+      expect.objectContaining({
+        kind: "flag-catch",
+        gameTimeMs: 1_500,
+        lane: "side-a",
+        points: 30,
+      }),
+    );
+  });
+
+  test("re-resolves effective facts after supersession, reinstatement, and roster correction", () => {
+    const facts = [
+      fact("goal", "side-a", 100, { points: 10, playerNumber: 4 }, "superseded", false),
+      fact("correction", null, 101, { privateReason: "private-correction" }, "private-correction"),
+      fact(
+        "locked-correction",
+        null,
+        102,
+        { privateReason: "locked-private-reason" },
+        "locked-correction",
+      ),
+      fact("goal", "side-a", 100, { points: 20, playerNumber: 4 }, "reinstated", true),
+      fact("card", "side-a", 90, { cardType: "blue", playerNumber: 8 }, "unmapped-card"),
+    ];
+    const input = {
+      facts,
+      sideA,
+      sideB,
+      derived: { catch: null, overtime: false, overtimeTarget: null, result: null },
+    } as const;
+    const before = projectPublicGameTimeline({ ...input, lookupRosterName: () => null });
+    const after = projectPublicGameTimeline({
+      ...input,
+      lookupRosterName: (eventTeamId, playerNumber) =>
+        eventTeamId === "team-a" && playerNumber === 4 ? "Corrected Name" : null,
+    });
+
+    expect(before.map((entry) => entry.kind)).toEqual(["goal", "card"]);
+    expect(before.find((entry) => entry.kind === "goal")).toMatchObject({
+      points: 20,
+      player: { number: 4, name: null },
+    });
+    expect(after.find((entry) => entry.kind === "goal")).toMatchObject({
+      points: 20,
+      player: { number: 4, name: "Corrected Name" },
+    });
+    expect(after.find((entry) => entry.kind === "card")).toMatchObject({
+      player: { number: 8, name: null },
+      penaltyReason: null,
+    });
+    expect(JSON.stringify(after)).not.toContain("private-correction");
+    expect(JSON.stringify(after)).not.toContain("locked-private-reason");
+  });
+
+  test("follows a corrected stable Game Side assignment without copying identity into the fact", () => {
+    const timeline = projectPublicGameTimeline({
+      facts: [fact("goal", "side-a", 500, { points: 10, playerNumber: 9 })],
+      sideA: { sideId: "side-a", eventTeamId: "corrected-team", teamName: "Corrected Team" },
+      sideB,
+      lookupRosterName: (eventTeamId, playerNumber) =>
+        eventTeamId === "corrected-team" && playerNumber === 9 ? "Corrected Player" : null,
+      derived: { catch: null, overtime: false, overtimeTarget: null, result: null },
+    });
+
+    expect(timeline[0]).toMatchObject({
+      kind: "goal",
+      lane: "side-a",
+      teamName: "Corrected Team",
+      player: { number: 9, name: "Corrected Player" },
+    });
+    expect(JSON.stringify(timeline)).not.toContain("corrected-team");
+  });
+
+  test("orders timed events first and keeps presentation out of Timeline history", () => {
+    const timeline = projectPublicGameTimeline({
+      facts: [fact("goal", "side-a", 500, { points: 10 })],
+      sideA,
+      sideB,
+      lookupRosterName: () => null,
+      derived: { catch: null, overtime: false, overtimeTarget: null, result: null },
+    });
+
+    expect(timeline.map((entry) => entry.kind)).toEqual(["goal"]);
+    expect(JSON.stringify(timeline)).not.toContain("presentation");
+  });
+
+  test("keeps high-entropy private payloads outside the public allowlist", () => {
+    const timeline = projectPublicGameTimeline({
+      facts: [
+        fact("unknown-private-fact", null, 99, {
+          grantSessionId: "private-session-sentinel",
+          auditTrailId: "private-audit-sentinel",
+          credential: "private-credential-sentinel",
+          internalId: "private-internal-id-sentinel",
+        }),
+        fact("correction", null, 98, { correctionReason: "private-reason-sentinel" }),
+      ],
+      sideA,
+      sideB,
+      lookupRosterName: () => null,
+      derived: { catch: null, overtime: false, overtimeTarget: null, result: null },
+    });
+
+    expect(timeline).toEqual([]);
+    expect(JSON.stringify(timeline)).not.toMatch(/sentinel/);
+  });
+});
+
+function fact(
+  factType: string,
+  gameSideId: string | null,
+  gameTimeMs: number | null,
+  data: Record<string, unknown>,
+  factId = `${factType}-fact`,
+  effective = true,
+  sportingOrder = gameTimeMs ?? 0,
+  synchronizationOrder = sportingOrder,
+): ControllerGameFact {
+  return {
+    factId,
+    factType,
+    gameSideId,
+    gameTimeMs,
+    sportingOrder,
+    synchronizationOrder,
+    effective,
+    data: data as ControllerGameFact["data"],
+  };
+}

--- a/src/lib/game-timeline-projection.ts
+++ b/src/lib/game-timeline-projection.ts
@@ -1,0 +1,461 @@
+import type { ActionJsonValue } from "@/lib/event-game-actions";
+import {
+  orderControllerGameFacts,
+  type ControllerGameFact,
+  type LiveEventGameDerivedState,
+} from "@/lib/live-event-game-control";
+import { parseLivePenaltyPlayerKey } from "@/lib/live-event-penalties";
+
+export type PublicAudienceTimelineKind =
+  | "goal"
+  | "card"
+  | "penalty"
+  | "timeout"
+  | "suspension"
+  | "heat-stoppage"
+  | "seeker-release"
+  | "flag-catch"
+  | "overtime"
+  | "finish";
+
+export type PublicAudienceTimelineLane = "side-a" | "side-b" | "center";
+
+export type PublicAudienceTimelinePlayer = {
+  number: number;
+  name: string | null;
+};
+
+type PublicAudienceTimelineEntryBase = {
+  gameTimeMs: number | null;
+  lane: PublicAudienceTimelineLane;
+  teamName: string | null;
+};
+
+type PlayerBearingEntry = PublicAudienceTimelineEntryBase & {
+  player: PublicAudienceTimelinePlayer | null;
+};
+
+export type PublicAudienceTimelineEntry =
+  | (PlayerBearingEntry & { kind: "goal"; points: number })
+  | (PlayerBearingEntry & {
+      kind: "card";
+      cardColor: "blue" | "yellow" | "red" | "ejection" | null;
+      penaltyReason: string | null;
+    })
+  | (PlayerBearingEntry & {
+      kind: "penalty";
+      release:
+        | { kind: "selection"; cause: string; serviceDurationMs: number | null }
+        | { kind: "consequence"; cause: string; serviceDurationMs: number | null };
+    })
+  | (PublicAudienceTimelineEntryBase & { kind: "timeout"; action: string | null })
+  | (PublicAudienceTimelineEntryBase & { kind: "suspension"; action: string | null })
+  | (PublicAudienceTimelineEntryBase & { kind: "heat-stoppage"; action: string | null })
+  | (PublicAudienceTimelineEntryBase & { kind: "seeker-release" })
+  | (PlayerBearingEntry & { kind: "flag-catch"; points: number })
+  | (PublicAudienceTimelineEntryBase & { kind: "overtime"; targetScore: number | null })
+  | (PublicAudienceTimelineEntryBase & {
+      kind: "finish";
+      outcome: "result" | "concession" | "forfeit" | "double-forfeit";
+      resultKind: string | null;
+    });
+
+export type PublicAudienceTimelineSide = {
+  sideId: string;
+  eventTeamId: string | null;
+  teamName: string | null;
+};
+
+export type PublicAudienceTimelineProjectionInput = {
+  facts: readonly ControllerGameFact[];
+  sideA: PublicAudienceTimelineSide;
+  sideB: PublicAudienceTimelineSide;
+  lookupRosterName: (eventTeamId: string, playerNumber: number) => string | null;
+  derived: Pick<LiveEventGameDerivedState, "catch" | "overtime" | "overtimeTarget" | "result">;
+};
+
+const PUBLIC_FACT_TYPES = new Set([
+  "goal",
+  "card",
+  "flag-catch",
+  "concession",
+  "forfeit",
+  "double-forfeit",
+  "result",
+  "timeout",
+  "suspension",
+  "heat-stoppage",
+  "penalty-release",
+  "penalty-release-consequence",
+]);
+const SEEKER_RELEASE_GAME_TIME_MS = 20 * 60 * 1000;
+
+type OrderedTimelineEntry = PublicAudienceTimelineEntry & {
+  absentTimeOrderKey: number;
+  canonicalFactOrder: number;
+  synchronizationOrder: number;
+  sequence: number;
+};
+
+/**
+ * Assemble the public history from effective semantic facts. Raw actions,
+ * correction objects, audit evidence, and unknown fact payloads never leave
+ * this allowlist boundary.
+ */
+export function projectPublicGameTimeline(
+  input: PublicAudienceTimelineProjectionInput,
+): readonly PublicAudienceTimelineEntry[] {
+  const sideById = new Map([
+    [input.sideA.sideId, { ...input.sideA, lane: "side-a" as const }],
+    [input.sideB.sideId, { ...input.sideB, lane: "side-b" as const }],
+  ]);
+  const effectiveFacts = orderControllerGameFacts(input.facts).filter((fact) => fact.effective);
+  const penaltyReasons = penaltyReasonsByCard(effectiveFacts);
+  const entries: OrderedTimelineEntry[] = [];
+
+  effectiveFacts.forEach((fact, sequence) => {
+    if (fact.factType === "clock" || fact.factType === "penalty-reason") return;
+    if (!PUBLIC_FACT_TYPES.has(fact.factType)) return;
+
+    const data = recordData(fact.data);
+    const side = fact.gameSideId === null ? undefined : sideById.get(fact.gameSideId);
+    const common = {
+      gameTimeMs: fact.gameTimeMs,
+      lane: side?.lane ?? "center",
+      teamName: side?.teamName ?? null,
+    } as const;
+    switch (fact.factType) {
+      case "goal":
+        addEntry(
+          entries,
+          {
+            ...common,
+            kind: "goal",
+            points: numberValue(data?.points) ?? 10,
+            player: playerForFact(fact, side, input.lookupRosterName, effectiveFacts),
+          },
+          sequence,
+          fact.synchronizationOrder,
+          sequence,
+        );
+        break;
+      case "card":
+        addEntry(
+          entries,
+          {
+            ...common,
+            kind: "card",
+            cardColor: cardColorFor(data),
+            penaltyReason: penaltyReasons.get(fact.factId) ?? null,
+            player: playerForFact(fact, side, input.lookupRosterName, effectiveFacts),
+          },
+          sequence,
+          fact.synchronizationOrder,
+          sequence,
+        );
+        break;
+      case "flag-catch":
+        addEntry(
+          entries,
+          {
+            ...common,
+            kind: "flag-catch",
+            points: numberValue(data?.points) ?? 30,
+            player: playerForFact(fact, side, input.lookupRosterName, effectiveFacts),
+          },
+          sequence,
+          fact.synchronizationOrder,
+          sequence,
+        );
+        break;
+      case "concession":
+      case "forfeit":
+      case "double-forfeit":
+      case "result":
+        addEntry(
+          entries,
+          {
+            ...common,
+            kind: "finish",
+            lane: fact.factType === "double-forfeit" ? "center" : common.lane,
+            teamName: fact.factType === "double-forfeit" ? null : common.teamName,
+            outcome: fact.factType,
+            resultKind: stringValue(data?.resultKind),
+          },
+          sequence,
+          fact.synchronizationOrder,
+          sequence,
+        );
+        break;
+      case "timeout":
+        addEntry(
+          entries,
+          { ...common, kind: "timeout", action: stringValue(data?.timeoutAction) },
+          sequence,
+          fact.synchronizationOrder,
+          sequence,
+        );
+        break;
+      case "suspension":
+        addEntry(
+          entries,
+          {
+            ...common,
+            kind: "suspension",
+            lane: "center",
+            teamName: null,
+            action: stringValue(data?.suspensionAction),
+          },
+          sequence,
+          fact.synchronizationOrder,
+          sequence,
+        );
+        break;
+      case "heat-stoppage":
+        addEntry(
+          entries,
+          {
+            ...common,
+            kind: "heat-stoppage",
+            lane: "center",
+            teamName: null,
+            action: stringValue(data?.heatAction),
+          },
+          sequence,
+          fact.synchronizationOrder,
+          sequence,
+        );
+        break;
+      case "penalty-release":
+      case "penalty-release-consequence":
+        addEntry(
+          entries,
+          {
+            ...common,
+            kind: "penalty",
+            player: playerForFact(fact, side, input.lookupRosterName, effectiveFacts),
+            release: {
+              kind: fact.factType === "penalty-release" ? "selection" : "consequence",
+              cause: stringValue(data?.releaseCause) ?? "released",
+              serviceDurationMs: numberValue(data?.serviceDurationMs),
+            },
+          },
+          sequence,
+          fact.synchronizationOrder,
+          sequence,
+        );
+        break;
+    }
+  });
+
+  const seekerRelease = synthesizeSeekerRelease(effectiveFacts);
+  if (seekerRelease !== null) entries.push(seekerRelease);
+
+  if (input.derived.catch !== null && !entries.some((entry) => entry.kind === "flag-catch")) {
+    const catchFact = effectiveFacts.find((fact) => fact.factId === input.derived.catch?.factId);
+    const side = sideById.get(input.derived.catch.catchingGameSideId);
+    const catchFactOrder =
+      catchFact === undefined ? effectiveFacts.length : effectiveFacts.indexOf(catchFact);
+    addEntry(
+      entries,
+      {
+        kind: "flag-catch",
+        gameTimeMs: input.derived.catch.gameTimeMs,
+        lane: side?.lane ?? "center",
+        teamName: side?.teamName ?? null,
+        player:
+          catchFact === undefined
+            ? null
+            : playerForFact(catchFact, side, input.lookupRosterName, effectiveFacts),
+        points: numberValue(recordData(catchFact?.data)?.points) ?? 30,
+      },
+      catchFactOrder,
+      catchFact?.synchronizationOrder ?? 0,
+      catchFactOrder,
+    );
+  }
+
+  if (input.derived.overtime && input.derived.catch !== null) {
+    const catchEntry = entries.find(
+      (entry) =>
+        entry.kind === "flag-catch" && entry.gameTimeMs === input.derived.catch?.gameTimeMs,
+    );
+    if (catchEntry !== undefined) {
+      addEntry(
+        entries,
+        {
+          kind: "overtime",
+          gameTimeMs: input.derived.catch.gameTimeMs,
+          lane: "center",
+          teamName: null,
+          targetScore: input.derived.overtimeTarget ?? null,
+        },
+        catchEntry.canonicalFactOrder,
+        catchEntry.synchronizationOrder,
+        catchEntry.sequence + 1,
+      );
+    }
+  }
+
+  if (input.derived.result !== null && !entries.some((entry) => entry.kind === "finish")) {
+    const resultFact = effectiveFacts.find((fact) => fact.factId === input.derived.result?.factId);
+    if (resultFact !== undefined) {
+      const side = resultFact.gameSideId === null ? undefined : sideById.get(resultFact.gameSideId);
+      addEntry(
+        entries,
+        {
+          kind: "finish",
+          gameTimeMs: resultFact.gameTimeMs,
+          lane: side?.lane ?? "center",
+          teamName: side?.teamName ?? null,
+          outcome: "result",
+          resultKind: stringValue(recordData(resultFact.data)?.resultKind),
+        },
+        effectiveFacts.indexOf(resultFact),
+        resultFact.synchronizationOrder,
+        effectiveFacts.indexOf(resultFact),
+      );
+    }
+  }
+
+  return entries
+    .sort(compareTimelineEntries)
+    .map(
+      ({
+        absentTimeOrderKey: _absentTimeOrderKey,
+        canonicalFactOrder: _canonicalFactOrder,
+        synchronizationOrder: _synchronizationOrder,
+        sequence: _sequence,
+        ...entry
+      }) => entry,
+    );
+}
+
+function synthesizeSeekerRelease(
+  effectiveFacts: readonly ControllerGameFact[],
+): OrderedTimelineEntry | null {
+  const source = effectiveFacts.findLast(
+    (fact) =>
+      fact.factType === "clock" &&
+      fact.gameTimeMs !== null &&
+      fact.gameTimeMs >= SEEKER_RELEASE_GAME_TIME_MS,
+  );
+  if (source === undefined || source.gameTimeMs === null) return null;
+  return {
+    kind: "seeker-release",
+    gameTimeMs: SEEKER_RELEASE_GAME_TIME_MS,
+    lane: "center",
+    teamName: null,
+    absentTimeOrderKey: source.synchronizationOrder,
+    canonicalFactOrder: effectiveFacts.indexOf(source),
+    synchronizationOrder: source.synchronizationOrder,
+    sequence: effectiveFacts.indexOf(source),
+  };
+}
+
+function penaltyReasonsByCard(facts: readonly ControllerGameFact[]): Map<string, string> {
+  const reasons = new Map<string, string>();
+  for (const fact of facts) {
+    if (fact.factType !== "penalty-reason") continue;
+    const data = recordData(fact.data);
+    const target = stringValue(data?.targetCardFactId);
+    const reason = stringValue(data?.reason);
+    if (target !== null && reason !== null) reasons.set(target, reason);
+  }
+  return reasons;
+}
+
+function playerForFact(
+  fact: ControllerGameFact,
+  side: (PublicAudienceTimelineSide & { lane: PublicAudienceTimelineLane }) | undefined,
+  lookupRosterName: PublicAudienceTimelineProjectionInput["lookupRosterName"],
+  facts: readonly ControllerGameFact[],
+): PublicAudienceTimelinePlayer | null {
+  const data = recordData(fact.data);
+  let playerNumber = numberValue(data?.playerNumber);
+  if (
+    playerNumber === null &&
+    (fact.factType === "penalty-release" || fact.factType === "penalty-release-consequence")
+  ) {
+    const playerKey = stringValue(data?.playerKey);
+    playerNumber =
+      playerKey === null ? null : (parseLivePenaltyPlayerKey(playerKey)?.playerNumber ?? null);
+  }
+  if (
+    playerNumber === null &&
+    (fact.factType === "penalty-release" || fact.factType === "penalty-release-consequence")
+  ) {
+    const sourceFactId = stringValue(data?.sourceFactId);
+    const source = facts.find((candidate) => candidate.factId === sourceFactId);
+    playerNumber = numberValue(recordData(source?.data)?.playerNumber);
+  }
+  if (playerNumber === null) return null;
+  return {
+    number: playerNumber,
+    name:
+      side?.eventTeamId === null || side?.eventTeamId === undefined
+        ? null
+        : lookupRosterName(side.eventTeamId, playerNumber),
+  };
+}
+
+function cardColorFor(
+  data: Record<string, unknown> | null,
+): "blue" | "yellow" | "red" | "ejection" | null {
+  return data?.cardType === "blue" ||
+    data?.cardType === "yellow" ||
+    data?.cardType === "red" ||
+    data?.cardType === "ejection"
+    ? data.cardType
+    : null;
+}
+
+function addEntry(
+  entries: OrderedTimelineEntry[],
+  entry: PublicAudienceTimelineEntry,
+  canonicalFactOrder: number,
+  synchronizationOrder: number,
+  sequence: number,
+  absentTimeOrderKey = synchronizationOrder,
+) {
+  entries.push({
+    ...entry,
+    absentTimeOrderKey,
+    canonicalFactOrder,
+    synchronizationOrder,
+    sequence,
+  });
+}
+
+function compareTimelineEntries(left: OrderedTimelineEntry, right: OrderedTimelineEntry): number {
+  if (left.gameTimeMs === null && right.gameTimeMs !== null) return 1;
+  if (left.gameTimeMs !== null && right.gameTimeMs === null) return -1;
+  if (left.gameTimeMs !== null && right.gameTimeMs !== null) {
+    return (
+      right.gameTimeMs - left.gameTimeMs ||
+      right.canonicalFactOrder - left.canonicalFactOrder ||
+      right.synchronizationOrder - left.synchronizationOrder ||
+      right.sequence - left.sequence
+    );
+  }
+  return (
+    right.absentTimeOrderKey - left.absentTimeOrderKey ||
+    right.canonicalFactOrder - left.canonicalFactOrder ||
+    right.synchronizationOrder - left.synchronizationOrder ||
+    right.sequence - left.sequence
+  );
+}
+
+function recordData(value: ActionJsonValue | undefined): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function numberValue(value: unknown): number | null {
+  return typeof value === "number" && Number.isSafeInteger(value) ? value : null;
+}
+
+function stringValue(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}

--- a/src/lib/live-event-penalties.test.ts
+++ b/src/lib/live-event-penalties.test.ts
@@ -3,6 +3,7 @@ import {
   deriveLivePenaltyProjection,
   LIVE_PENALTY_MINUTE_MS,
   LIVE_SEEKER_RELEASE_MS,
+  parseLivePenaltyPlayerKey,
   type LivePenaltyFact,
 } from "@/lib/live-event-penalties";
 
@@ -44,6 +45,15 @@ function card(
 }
 
 describe("live Event Game penalty timing", () => {
+  test("parses only canonical side:number penalty player keys", () => {
+    expect(parseLivePenaltyPlayerKey("away:7")).toEqual({
+      gameSideId: "away",
+      playerNumber: 7,
+    });
+    expect(parseLivePenaltyPlayerKey("away:unknown:card-1")).toBeNull();
+    expect(parseLivePenaltyPlayerKey("away:not-a-number")).toBeNull();
+  });
+
   test("blue and yellow have one expirable minute while red has two consecutive non-expirable minutes", () => {
     const projection = deriveLivePenaltyProjection(
       [

--- a/src/lib/live-event-penalties.ts
+++ b/src/lib/live-event-penalties.ts
@@ -1,4 +1,5 @@
 import type { ActionJsonValue } from "@/lib/event-game-actions";
+import { validatePlayerNumber } from "@/lib/validation-policy";
 
 export const LIVE_PENALTY_MINUTE_MS = 60_000;
 export const LIVE_SEEKER_RELEASE_MS = 20 * LIVE_PENALTY_MINUTE_MS;
@@ -14,6 +15,21 @@ export const LIVE_PENALTY_REASONS = [
 export type LivePenaltyReason = (typeof LIVE_PENALTY_REASONS)[number];
 export type LiveCardType = "blue" | "yellow" | "red" | "ejection";
 export type LivePenaltyStart = "immediate" | "sticks-up" | "seeker-release";
+
+export type LivePenaltyPlayerKey = {
+  gameSideId: string;
+  playerNumber: number;
+};
+
+/** Parse the canonical side:number key used by durable penalty facts. */
+export function parseLivePenaltyPlayerKey(value: string): LivePenaltyPlayerKey | null {
+  const separator = value.lastIndexOf(":");
+  if (separator <= 0 || separator === value.length - 1) return null;
+  const gameSideId = value.slice(0, separator);
+  const playerNumber = Number(value.slice(separator + 1));
+  const validated = validatePlayerNumber(playerNumber);
+  return validated.ok ? { gameSideId, playerNumber: validated.value } : null;
+}
 
 export type LivePenaltyFact = {
   factId: string;

--- a/src/lib/locked-event-game-administration.test.ts
+++ b/src/lib/locked-event-game-administration.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createFoundationAcceptance } from "@/lib/foundation-acceptance";
+import { createAudienceProjection } from "@/lib/audience-projection";
 import { createEventAdministration } from "@/lib/event-administration";
 import { createEventCatalog, createFoundationEventCatalogStorage } from "@/lib/event-catalog";
 import { createEventGameRecord } from "@/lib/event-game-record";
@@ -14,6 +15,7 @@ import {
 import { createInMemoryFoundationStorage } from "@/lib/foundation-storage-memory";
 import type { FoundationStorage } from "@/lib/foundation-storage";
 import { openSqliteFoundationStorage } from "@/lib/foundation-storage-sqlite";
+import { readAudienceProjectionGameInput } from "@/lib/live-event-game-runtime";
 import { createGrantAuthorityVerifier } from "@/lib/grant-authority";
 import type { GrantAuthorityOptions } from "@/lib/grant-authority";
 import { createTypedGrantAuthority } from "@/lib/grant-management";
@@ -258,6 +260,98 @@ describe("locked Event Game administration", () => {
       expect.arrayContaining([expect.objectContaining({ factType: "locked-game-correction" })]),
     );
     expect(JSON.stringify(projection)).not.toContain("locked-game-correction");
+  });
+
+  test("projects accepted locked correction and reopening through the public Audience seam", async () => {
+    const fixture = await createFixture();
+    const catalogStorage = createFoundationEventCatalogStorage(fixture.storage);
+    const catalog = createEventCatalog(catalogStorage, { clock: { nowMs: () => 3_000 } });
+    expect(
+      await catalog.changePublicationStatus(
+        fixture.eventId,
+        { status: "published" },
+        fixture.technical,
+      ),
+    ).toMatchObject({ status: "accepted" });
+    const control = fixture.createControl();
+    const audience = createAudienceProjection(catalogStorage, {
+      now: () => 3_000,
+      gameInput: {
+        read: async (eventGameId) => {
+          const root = await fixture.storage.readRoot(fixture.recordId);
+          return readAudienceProjectionGameInput(
+            root,
+            await control.readControllerProjection(eventGameId),
+          );
+        },
+      },
+    });
+    const correctionOperationId = "audience-seam-locked-correction";
+    const correction = await fixture.administration.correctLockedEventGame(
+      fixture.eventId,
+      fixture.eventGameId,
+      {
+        operationId: correctionOperationId,
+        endState: {
+          scoreByGameSide: { "side-a": 30, "side-b": 20 },
+          winnerGameSideId: "side-a",
+          flagCatchingGameSideId: "side-a",
+          catchTimeMs: 1_500,
+          endTimeMs: 2_000,
+        },
+      },
+      fixture.technical,
+    );
+    expect(correction).toMatchObject({ status: "accepted", value: { lockRetained: true } });
+
+    const locked = await audience.readGame(fixture.eventId, fixture.eventGameId);
+    expect(locked).toMatchObject({
+      status: "accepted",
+      value: {
+        sideA: { score: 30 },
+        sideB: { score: 20 },
+        flagState: { catchingSide: "side-a" },
+        result: { status: "finished", winner: "side-a", locked: true },
+      },
+    });
+    if (locked.status !== "accepted") throw new Error("Expected locked public projection.");
+    expect(locked.value.timeline).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: "flag-catch", gameTimeMs: 1_500 }),
+        expect.objectContaining({ kind: "finish", outcome: "result" }),
+      ]),
+    );
+    const lockedTimeline = locked.value.timeline;
+    const lockedPublicJson = JSON.stringify(locked.value);
+    expect(lockedPublicJson).not.toContain(correctionOperationId);
+    expect(lockedPublicJson).not.toContain("locked-game-correction");
+    expect(lockedPublicJson).not.toContain("event-admin");
+
+    const reopenOperationId = "audience-seam-game-reopening";
+    expect(
+      await fixture.administration.reopenEventGame(
+        fixture.eventId,
+        fixture.eventGameId,
+        { operationId: reopenOperationId },
+        fixture.technical,
+      ),
+    ).toMatchObject({ status: "accepted", value: { lockRemoved: true } });
+
+    const reopened = await audience.readGame(fixture.eventId, fixture.eventGameId);
+    expect(reopened).toMatchObject({
+      status: "accepted",
+      value: { result: { status: "finished", winner: "side-a", locked: false } },
+    });
+    if (reopened.status !== "accepted") throw new Error("Expected reopened public projection.");
+    expect(reopened.value.sideA.score).toBe(30);
+    expect(reopened.value.sideB.score).toBe(20);
+    expect(reopened.value.flagState).toEqual({ catchingSide: "side-a" });
+    expect(reopened.value.timeline).toEqual(lockedTimeline);
+    const reopenedPublicJson = JSON.stringify(reopened.value);
+    expect(reopenedPublicJson).not.toContain(correctionOperationId);
+    expect(reopenedPublicJson).not.toContain(reopenOperationId);
+    expect(reopenedPublicJson).not.toContain("game-reopening");
+    expect(reopenedPublicJson).not.toContain("event-admin");
   });
 
   test("requires one confirmation for an inconsistent correction and records Official Override", async () => {

--- a/src/pages/public-event-game-page.test.tsx
+++ b/src/pages/public-event-game-page.test.tsx
@@ -171,5 +171,6 @@ function projection(): PublicAudienceGameProjection {
     flagState: { catchingSide: "side-b" },
     result: { status: "finished", winner: "side-a", locked: true },
     canonicalPath: "/events/event-1/games/game-1",
+    timeline: [],
   };
 }

--- a/src/pages/public-event-page.tsx
+++ b/src/pages/public-event-page.tsx
@@ -10,6 +10,7 @@ import type {
   PublicAudienceScheduleProjection,
 } from "@/lib/audience-projection";
 import { DEFAULT_AWAY_TEAM_COLOR, DEFAULT_HOME_TEAM_COLOR } from "@/lib/team-colors";
+import { PublicGameTimeline } from "@/pages/public-game-timeline";
 
 export function PublicEventHomePage({ showAll = false }: { showAll?: boolean }) {
   const [events, setEvents] = useState<readonly PublicAudienceEventProjection[] | null>(null);
@@ -80,10 +81,7 @@ export function PublicEventPage({ eventId }: { eventId: string }) {
         if (!response.ok) throw new Error("Event unavailable");
         const payload = (await response.json()) as AudienceEventResponse;
         if (payload.status !== "accepted") throw new Error("Event unavailable");
-        return payload.value;
-      })
-      .then((nextEvent) => {
-        if (active) setEvent(nextEvent);
+        if (active) setEvent(payload.value);
       })
       .catch(() => {
         if (active) setUnavailable(true);
@@ -371,10 +369,13 @@ export function PublicEventGamePage({
               <StatusValue label="Heat Stoppage" value={heatLabel(game.heatStoppage)} />
               <StatusValue label="Result" value={resultLabel(game.result)} />
             </dl>
-            <p className="rounded-xl border border-dashed p-3 text-muted-foreground">
-              Public play history will be added by the Timeline work; this page shows the committed
-              scoreboard projection.
-            </p>
+            {game.timeline.length > 0 ? (
+              <PublicGameTimeline entries={game.timeline} />
+            ) : (
+              <p className="rounded-xl border border-dashed p-3 text-muted-foreground">
+                No public play history is available yet.
+              </p>
+            )}
           </CardContent>
         </Card>
       </div>
@@ -691,6 +692,9 @@ function GameCard({
             )
           ) : null}
         </div>
+        {(!compact || game.scheduleStatus === "past") && game.timeline.length > 0 ? (
+          <PublicGameTimeline entries={game.timeline} />
+        ) : null}
       </CardContent>
     </Card>
   );

--- a/src/pages/public-game-timeline.test.tsx
+++ b/src/pages/public-game-timeline.test.tsx
@@ -1,0 +1,171 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { Window } from "happy-dom";
+import type {
+  PublicAudienceTimelineEntry,
+  PublicAudienceTimelineLane,
+  PublicAudienceTimelinePlayer,
+} from "@/lib/game-timeline-projection";
+import { PublicGameTimeline } from "@/pages/public-game-timeline";
+
+describe("public Game Timeline browser seam", () => {
+  const originalWindow = globalThis.window;
+  const originalDocument = globalThis.document;
+  const originalActEnvironment = (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean })
+    .IS_REACT_ACT_ENVIRONMENT;
+  let testWindow: Window;
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    testWindow = new Window({ url: "http://timer.quadball.app/events/current" });
+    Object.assign(globalThis, {
+      window: testWindow,
+      document: testWindow.document,
+      IS_REACT_ACT_ENVIRONMENT: true,
+    });
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+      await Promise.resolve();
+    });
+    container.remove();
+    testWindow.close();
+    Object.assign(globalThis, {
+      window: originalWindow,
+      document: originalDocument,
+      IS_REACT_ACT_ENVIRONMENT: originalActEnvironment,
+    });
+  });
+
+  test("wraps long public content and preserves both scroll positions on new play", async () => {
+    const initialEntries = [
+      entry("goal", 60_000, "A very long team name that must wrap inside the timeline", {
+        number: 7,
+        name: "Avery A. Player with a deliberately long roster-resolved name",
+      }),
+      entry("card", 50_000, "Card with a long penalty reason", { number: 4, name: null }),
+      entry("timeout", 40_000, "Team timeout", null, "side-b"),
+      entry("suspension", 30_000, "Game suspension", null, "center"),
+    ];
+
+    await act(async () => {
+      root.render(<PublicGameTimeline entries={initialEntries} />);
+      await Promise.resolve();
+    });
+    expect(container.textContent).toContain(
+      "Avery A. Player with a deliberately long roster-resolved name",
+    );
+    expect(container.textContent).toContain("Player #4");
+    expect(container.textContent).toContain("Team Timeout");
+    expect(container.textContent).toContain("Game Suspension");
+    expect(container.textContent).toContain(
+      "A very long reason that should remain readable without widening the page",
+    );
+    expect(container.textContent).not.toContain("undefined");
+    expect(container.querySelector('[data-timeline-lane="side-a"]')).not.toBeNull();
+    expect(container.querySelector('[data-timeline-lane="side-b"]')).not.toBeNull();
+    expect(container.querySelector('[data-timeline-lane="center"]')).not.toBeNull();
+    expect(
+      container.querySelector('[data-timeline-lane="side-a"] [data-timeline-content]')?.className,
+    ).toContain("sm:col-start-1");
+    expect(
+      container.querySelector('[data-timeline-lane="side-b"] [data-timeline-content]')?.className,
+    ).toContain("sm:col-start-3");
+    expect(
+      container.querySelector('[data-timeline-lane="center"] [data-timeline-content]')?.className,
+    ).toContain("sm:col-span-3");
+    expect(container.querySelectorAll("[data-timeline-spine]").length).toBe(4);
+
+    const region = container.querySelector(
+      "[data-timeline-scroll-region]",
+    ) as HTMLDivElement | null;
+    if (region === null) throw new Error("Expected timeline scroll region.");
+    let height = 200;
+    Object.defineProperty(region, "scrollHeight", {
+      configurable: true,
+      get: () => height,
+    });
+    region.scrollTo = ((optionsOrX: ScrollToOptions | number) => {
+      region.scrollTop = typeof optionsOrX === "number" ? optionsOrX : (optionsOrX.top ?? 0);
+    }) as typeof region.scrollTo;
+
+    await act(async () => {
+      root.render(<PublicGameTimeline entries={initialEntries.slice(0, 1)} />);
+      await Promise.resolve();
+    });
+    region.scrollTop = 80;
+    region.dispatchEvent(new testWindow.Event("scroll", { bubbles: true }) as unknown as Event);
+    height = 260;
+    await act(async () => {
+      root.render(
+        <PublicGameTimeline
+          entries={[
+            entry("timeout", 70_000, "A newly arrived play"),
+            ...initialEntries.slice(0, 1),
+          ]}
+        />,
+      );
+      await Promise.resolve();
+    });
+    expect(region.scrollTop).toBe(140);
+    expect(container.querySelector("button")?.textContent).toBe("New play");
+
+    await act(async () => {
+      container
+        .querySelector("button")
+        ?.dispatchEvent(new testWindow.Event("click", { bubbles: true }) as unknown as Event);
+      await Promise.resolve();
+    });
+    expect(region.scrollTop).toBe(0);
+
+    height = 320;
+    await act(async () => {
+      root.render(
+        <PublicGameTimeline
+          entries={[
+            entry("goal", 80_000, "Live-edge play"),
+            entry("timeout", 70_000, "A newly arrived play"),
+            ...initialEntries.slice(0, 1),
+          ]}
+        />,
+      );
+      await Promise.resolve();
+    });
+    expect(region.scrollTop).toBe(0);
+    expect(container.querySelector("button")).toBeNull();
+  });
+});
+
+function entry(
+  kind: PublicAudienceTimelineEntry["kind"],
+  gameTimeMs: number,
+  _detail: string,
+  player: PublicAudienceTimelinePlayer | null = null,
+  lane: PublicAudienceTimelineLane = "side-a",
+): PublicAudienceTimelineEntry {
+  const base = {
+    gameTimeMs,
+    lane,
+    teamName: "A very long team name that must wrap inside the timeline",
+  };
+  if (kind === "goal") return { ...base, kind, points: 10, player };
+  if (kind === "card") {
+    return {
+      ...base,
+      kind,
+      player,
+      cardColor: "yellow",
+      penaltyReason: "A very long reason that should remain readable without widening the page",
+    };
+  }
+  if (kind === "timeout") return { ...base, kind, action: "stoppage" };
+  if (kind === "suspension") return { ...base, kind, action: "start" };
+  throw new Error(`Unsupported browser fixture kind: ${kind}`);
+}

--- a/src/pages/public-game-timeline.tsx
+++ b/src/pages/public-game-timeline.tsx
@@ -1,0 +1,181 @@
+import { useId, useLayoutEffect, useRef, useState } from "react";
+import type {
+  PublicAudienceTimelineEntry,
+  PublicAudienceTimelineLane,
+} from "@/lib/game-timeline-projection";
+
+export function PublicGameTimeline({
+  entries,
+}: {
+  entries: readonly PublicAudienceTimelineEntry[];
+}) {
+  const headingId = useId();
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const previousHeightRef = useRef<number | null>(null);
+  const atLiveEdgeRef = useRef(true);
+  const [hasNewPlay, setHasNewPlay] = useState(false);
+  const signature = JSON.stringify(entries);
+
+  useLayoutEffect(() => {
+    const node = scrollRef.current;
+    if (node === null) return;
+    const previousHeight = previousHeightRef.current;
+    if (previousHeight !== null && !atLiveEdgeRef.current) {
+      node.scrollTop += node.scrollHeight - previousHeight;
+      setHasNewPlay(true);
+    } else if (atLiveEdgeRef.current) {
+      node.scrollTop = 0;
+    }
+    previousHeightRef.current = node.scrollHeight;
+  }, [signature]);
+
+  if (entries.length === 0) return null;
+
+  return (
+    <section className="space-y-2" aria-labelledby={headingId} data-game-timeline>
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div>
+          <h3 id={headingId} className="text-base font-semibold">
+            Game Timeline
+          </h3>
+          <p className="text-xs text-muted-foreground">Newest first · effective public play</p>
+        </div>
+        {hasNewPlay ? (
+          <button
+            type="button"
+            className="rounded-full border px-3 py-1 text-xs font-semibold text-primary hover:bg-accent focus:outline-none focus:ring-2 focus:ring-ring"
+            onClick={() => {
+              const node = scrollRef.current;
+              if (node !== null) node.scrollTo({ top: 0, behavior: "smooth" });
+              atLiveEdgeRef.current = true;
+              setHasNewPlay(false);
+            }}
+          >
+            New play
+          </button>
+        ) : null}
+      </div>
+      <div
+        ref={scrollRef}
+        className="max-h-[32rem] overflow-y-auto overscroll-contain rounded-xl border bg-muted/20 p-2"
+        onScroll={(event) => {
+          const node = event.currentTarget;
+          atLiveEdgeRef.current = node.scrollTop <= 8;
+          if (atLiveEdgeRef.current) setHasNewPlay(false);
+        }}
+        data-timeline-scroll-region
+        aria-label="Game Timeline"
+      >
+        <ol className="space-y-2">
+          {entries.map((entry, index) => (
+            <TimelineEntry
+              key={`${entry.kind}-${entry.gameTimeMs ?? "unknown"}-${index}`}
+              entry={entry}
+            />
+          ))}
+        </ol>
+      </div>
+    </section>
+  );
+}
+
+function TimelineEntry({ entry }: { entry: PublicAudienceTimelineEntry }) {
+  const display = timelineDisplay(entry);
+  return (
+    <li
+      className="grid gap-2 rounded-lg border bg-card p-3 text-sm sm:grid-cols-[minmax(0,1fr)_6rem_minmax(0,1fr)]"
+      data-timeline-kind={entry.kind}
+      data-timeline-lane={entry.lane}
+    >
+      <div
+        className="relative flex min-h-12 flex-col items-center justify-center gap-1 sm:col-start-2 sm:row-start-1"
+        data-timeline-spine
+      >
+        <span className="absolute inset-y-0 w-px bg-slate-300" aria-hidden="true" />
+        <span className="relative z-10 rounded bg-muted px-1.5 py-0.5 font-mono text-xs text-muted-foreground">
+          {formatGameTime(entry.gameTimeMs)}
+        </span>
+        <span className="relative z-10 h-2 w-2 rounded-full bg-primary" aria-hidden="true" />
+      </div>
+      <div className={`min-w-0 break-words ${laneClass(entry.lane)}`} data-timeline-content>
+        <div className="flex items-center gap-2 sm:hidden">
+          <span className="font-sans text-xs text-muted-foreground">{display.label}</span>
+        </div>
+        <p className="font-medium sm:pt-1">{display.summary}</p>
+        {entry.teamName !== null ? (
+          <p className="text-xs text-muted-foreground">{entry.teamName}</p>
+        ) : null}
+        {"player" in entry && entry.player !== null ? (
+          <p className="text-xs text-muted-foreground">
+            Player #{entry.player.number}
+            {entry.player.name === null ? "" : ` · ${entry.player.name}`}
+          </p>
+        ) : null}
+        {entry.kind === "card" && entry.penaltyReason !== null ? (
+          <p className="text-xs text-muted-foreground">Penalty Reason: {entry.penaltyReason}</p>
+        ) : null}
+        {entry.kind === "card" && entry.cardColor !== null ? (
+          <p className="text-xs text-muted-foreground">Card color: {entry.cardColor}</p>
+        ) : null}
+      </div>
+    </li>
+  );
+}
+
+function timelineDisplay(entry: PublicAudienceTimelineEntry): { label: string; summary: string } {
+  switch (entry.kind) {
+    case "goal":
+      return { label: "Goal", summary: `Goal · ${entry.points} points` };
+    case "card":
+      return { label: "Card", summary: `Card · ${entry.cardColor ?? "recorded"}` };
+    case "penalty":
+      return {
+        label: "Penalty",
+        summary: `Penalty · ${entry.release.cause.replaceAll("-", " ")}`,
+      };
+    case "timeout":
+      return {
+        label: "Team Timeout",
+        summary: `Team Timeout · ${entry.action?.replaceAll("-", " ") ?? "recorded"}`,
+      };
+    case "suspension":
+      return {
+        label: "Game Suspension",
+        summary: `Game Suspension · ${entry.action?.replaceAll("-", " ") ?? "recorded"}`,
+      };
+    case "heat-stoppage":
+      return {
+        label: "Heat Stoppage",
+        summary: `Heat Stoppage · ${entry.action?.replaceAll("-", " ") ?? "recorded"}`,
+      };
+    case "seeker-release":
+      return { label: "Seeker Release", summary: "Seekers released" };
+    case "flag-catch":
+      return { label: "Flag Catch", summary: `Flag Catch · ${entry.points} points` };
+    case "overtime":
+      return { label: "Overtime", summary: `Overtime · target ${entry.targetScore ?? "set"}` };
+    case "finish":
+      return {
+        label: "Game Finish",
+        summary: `Game Finish · ${entry.resultKind?.replaceAll("-", " ") ?? entry.outcome.replaceAll("-", " ")}`,
+      };
+  }
+}
+
+function laneClass(lane: PublicAudienceTimelineLane): string {
+  switch (lane) {
+    case "side-a":
+      return "sm:col-start-1 sm:row-start-1 sm:border-r-2 sm:border-primary/30 sm:pr-4 sm:text-right";
+    case "side-b":
+      return "sm:col-start-3 sm:row-start-1 sm:border-l-2 sm:border-primary/30 sm:pl-4";
+    case "center":
+      return "sm:col-span-3 sm:col-start-1 sm:row-start-2 sm:justify-self-center sm:max-w-2xl sm:text-center";
+  }
+}
+
+function formatGameTime(gameTimeMs: number | null): string {
+  if (gameTimeMs === null) return "Game time unavailable";
+  const minutes = Math.floor(gameTimeMs / 60_000);
+  const seconds = Math.floor((gameTimeMs % 60_000) / 1_000);
+  return `${minutes}:${String(seconds).padStart(2, "0")}`;
+}


### PR DESCRIPTION
## What changed

- projects a complete, newest-first public Game Timeline from effective Game Facts
- resolves current public player names through the Event Team roster while retaining number-only fallback
- preserves stable Game Side identity across Event Team assignment correction and locked-Game correction/reopening
- renders side lanes, public event detail, dense content, and reader-preserving new-play behavior

## Why

Spectators need one public account of the effective Game history. Roster corrections must relabel that account without rewriting retained Game Facts or exposing administrative provenance.

## Impact

Published Event and spectator Game projections now include the roster-resolved Timeline. Missing roster mappings remain ordinary, corrections and reopening rebuild the effective public view, and private correction/audit data remains excluded.

## Validation

- focused Audience Projection, Timeline, runtime, component, and browser tests
- full ordinary suite: 958 tests, 20,693 assertions
- Chromium and WebKit public Event browser journey
- `bun run check`
- `bun run build`
- `git diff --check`

No Qualification, load, soak, crash, recovery, or exact-production-artifact workload was run.

Closes #136.

Stack: bottom PR; #265 and #266 build on this change.
