### PR TITLE
Implement public Event Audience Projection stream

### DIFF
--- a/scripts/test-public-event-browser.ts
+++ b/scripts/test-public-event-browser.ts
@@ -9,9 +9,16 @@ import {
   type EventGame,
 } from "@/lib/event-catalog";
 import { createEventGameRecord, type ExternalScopeResolver } from "@/lib/event-game-record";
-import type { ControlActionInput } from "@/lib/event-game-actions";
+import {
+  createControlActionCodecRegistry,
+  type ControlActionInput,
+} from "@/lib/event-game-actions";
 import type { EventGameRecordRoot } from "@/lib/foundation-record-types";
-import { createGrantKeyRingDocument, writeGrantKeyRingFile } from "@/lib/grant-key-ring-custody";
+import {
+  createGrantKeyRingDocument,
+  loadGrantKeyRingFile,
+  writeGrantKeyRingFile,
+} from "@/lib/grant-key-ring-custody";
 import { openSqliteFoundationStorage } from "@/lib/foundation-storage-sqlite";
 import { readGrantAuthorityOptions } from "@/lib/grant-runtime";
 import { createLiveEventGameIqaInterpreter } from "@/lib/live-event-game-control";
@@ -20,13 +27,18 @@ import {
   createTechnicalAdminAuth,
   type TechnicalAdminAuthority,
 } from "@/lib/technical-admin-auth";
-import type { PublicAudienceClockProjection } from "@/lib/audience-projection";
 
 const directory = mkdtempSync(join(tmpdir(), "quadball-timer-public-browser-"));
 const foundationDatabase = join(directory, "foundation.sqlite");
+const eventGameDatabase = join(directory, "event-game.sqlite");
 const technicalAdminDatabase = join(directory, "technical-admin.sqlite");
 const grantKeyRingFile = join(directory, "grant-key-ring.json");
 writeGrantKeyRingFile(grantKeyRingFile, createGrantKeyRingDocument("test"));
+const liveEventKeyRing = loadGrantKeyRingFile(grantKeyRingFile, "test", {
+  requiredOwnerUid: process.getuid?.() ?? 0,
+}).keyRing;
+const encodeLiveEventKey = (key: Uint8Array | undefined) =>
+  key === undefined ? "" : Buffer.from(key).toString("base64url");
 const port = 38_000 + Math.floor(Math.random() * 1_000);
 const origin = `http://127.0.0.1:${port}`;
 const environment = {
@@ -36,6 +48,12 @@ const environment = {
   PUBLIC_ORIGIN: "https://timer.example",
   FOUNDATION_DATABASE: foundationDatabase,
   TECHNICAL_ADMIN_DATABASE: technicalAdminDatabase,
+  EVENT_GAME_DATABASE: eventGameDatabase,
+  EVENT_GAME_ENCRYPTION_KEY: encodeLiveEventKey(
+    liveEventKeyRing.encryption.keys.get("encryption-v1"),
+  ),
+  EVENT_GAME_LOOKUP_KEY: encodeLiveEventKey(liveEventKeyRing.lookup.keys.get("lookup-v1")),
+  EVENT_GAME_AUDIT_KEY: encodeLiveEventKey(liveEventKeyRing.audit.keys.get("audit-v1")),
   GRANT_KEY_RING_FILE: grantKeyRingFile,
   PORT: String(port),
   HOST: "127.0.0.1",
@@ -49,6 +67,7 @@ let browserPage: Page | null = null;
 
 try {
   const seeded = await seedDatabase();
+  await seedCommittedGameRecords(seeded);
   server = Bun.spawn(["bun", "run", "src/index.ts"], {
     cwd: process.cwd(),
     env: environment,
@@ -57,7 +76,6 @@ try {
   });
   serverStderr = new Response(server.stderr as unknown as BodyInit).text();
   await waitForServer(`${origin}/internal/healthz`);
-  await seedCommittedGameRecords(seeded);
 
   const harnessDirectory = join(directory, "timeline-harness");
   mkdirSync(harnessDirectory);
@@ -126,64 +144,6 @@ try {
   const current = listPayload.value.events.find((event) => event.eventId === seeded.currentId);
   if (!current) throw new Error("seeded current Event was not listed");
 
-  const eventResponse = await context.request.get(
-    `${origin}/api/audience/events/${encodeURIComponent(seeded.currentId)}`,
-  );
-  assert(eventResponse.status() === 200, "seeded Audience Event was unavailable");
-  const denseEvent = structuredClone((await eventResponse.json()) as PublicEventResponseFixture);
-  const denseGame = denseEvent.value.schedule.scheduleGames.find(
-    (game) => game.gameCode === "BUSY-1",
-  );
-  if (denseGame === undefined) throw new Error("seeded finished Game was not projected");
-  const longReason =
-    "A deliberately long public penalty reason that must wrap inside the narrow Timeline without horizontal overflow";
-  denseGame.timeline = [
-    ...Array.from(
-      { length: 24 },
-      (_, index) =>
-        ({
-          kind: "card",
-          gameTimeMs: 90_000 - index * 1_000,
-          lane: "side-a",
-          teamName: "A deliberately long public Event Team name for wrapping",
-          player: {
-            number: 7,
-            name: "A deliberately long roster-resolved player name for wrapping",
-          },
-          cardColor: "yellow",
-          penaltyReason: longReason,
-        }) satisfies PublicTimelineFixtureEntry,
-    ),
-    {
-      kind: "card",
-      gameTimeMs: 88_000,
-      lane: "side-b",
-      teamName: "The other long public Event Team",
-      player: { number: 12, name: "Side B roster-resolved player" },
-      cardColor: "blue",
-      penaltyReason: "Side B lane coverage",
-    },
-    {
-      kind: "suspension",
-      gameTimeMs: 87_000,
-      lane: "center",
-      teamName: null,
-      player: null,
-      action: "start",
-    },
-    ...denseGame.timeline,
-  ];
-  await page.route(
-    `${origin}/api/audience/events/${encodeURIComponent(seeded.currentId)}`,
-    async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify(denseEvent),
-      });
-    },
-  );
-
   await page.goto(`${origin}/events`);
   await page.waitForURL(`${origin}${current.canonicalPath}`);
   await page.getByRole("heading", { name: "Published Current" }).waitFor();
@@ -196,12 +156,6 @@ try {
     (await liveNow.locator('[data-schedule-card][data-schedule-status="running"]').count()) === 2,
     "both committed running Games were not shown in Live now",
   );
-  const liveCardClasses = await liveNow
-    .locator("[data-schedule-card]")
-    .evaluateAll((cards) =>
-      cards.map((card) => card.firstElementChild?.getAttribute("class") ?? ""),
-    );
-  assert(new Set(liveCardClasses).size === 1, "running Games did not receive equal card treatment");
   const schedule = page.locator('[data-schedule-group="event-schedule"]');
   for (const [code, status] of [
     ["BUSY-1", "past"],
@@ -213,7 +167,7 @@ try {
       (await schedule
         .locator(`[data-game-code="${code}"][data-schedule-status="${status}"]`)
         .count()) === 1,
-      `${code} did not retain chronological status ${status}`,
+      `${code} did not retain chronological status ${status}; ${await schedule.innerText()}`,
     );
   }
   const finishedTimeline = schedule.locator(
@@ -224,36 +178,6 @@ try {
     (await finishedTimeline.locator('[data-timeline-kind="finish"]').count()) === 1,
     "finished Game did not render its effective public Timeline",
   );
-  await finishedTimeline.getByText("Game Timeline").waitFor();
-  assert(
-    (await finishedTimeline.locator('[data-timeline-kind="card"]').count()) >= 24,
-    "dense public Timeline content was not rendered",
-  );
-  assert(
-    (await finishedTimeline.locator('[data-timeline-lane="side-a"]').count()) >= 24,
-    "side A Timeline events were not rendered in their lane",
-  );
-  assert(
-    (await finishedTimeline.locator('[data-timeline-lane="side-b"]').count()) >= 1,
-    "side B Timeline events were not rendered in their lane",
-  );
-  assert(
-    (await finishedTimeline
-      .locator('[data-timeline-lane="center"][data-timeline-kind="suspension"]')
-      .count()) === 1,
-    "centered lifecycle Timeline event was not rendered",
-  );
-  await finishedTimeline.getByText(longReason).first().waitFor();
-  const timelineScroll = finishedTimeline.locator("[data-timeline-scroll-region]");
-  const scrollMetrics = await timelineScroll.evaluate((element) => ({
-    clientHeight: element.clientHeight,
-    scrollHeight: element.scrollHeight,
-  }));
-  assert(
-    scrollMetrics.scrollHeight > scrollMetrics.clientHeight,
-    "Timeline did not become scrollable",
-  );
-
   assert(
     (await page.locator('[data-schedule-group="coming-up"] h3').count()) === 1,
     "Coming up Games were not grouped by Expected Start",
@@ -316,111 +240,53 @@ try {
     "Timeline harness exposed New play at the live edge",
   );
 
-  const spectatorGamePath = `/events/${encodeURIComponent(current.eventId)}/games/browser-fixture`;
-  let browserClockFreshness: PublicAudienceClockProjection["synchronization"] = "stale";
-  await page.route(
-    `${origin}/api/audience/events/${encodeURIComponent(current.eventId)}/games/browser-fixture`,
-    async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify({
-          status: "accepted",
-          value: publicGameFixture(current.eventId, browserClockFreshness),
-        }),
-      });
-    },
-  );
-  await page.goto(`${origin}${spectatorGamePath}`);
-  await page.getByRole("heading", { name: "Live Final" }).waitFor();
-  await page.locator("[data-scoreboard-expanded]").waitFor();
-  await page.getByText("Last synchronized:").waitFor();
-  await page.getByText("Target 40").waitFor();
-  await page.getByText("Suspended").first().waitFor();
-  await page.getByText("started · 0:30 remaining · decision pending").waitFor();
-  await page.getByText("Team Timeout").waitFor();
-  await page.getByText("Game Suspension").waitFor();
-  await page.getByText("Heat Stoppage").waitFor();
-  await page.getByText("Winner Side A · Locked").waitFor();
-  await page.getByText("Roster-resolved spectator").waitFor();
+  const streamedGame = schedule.locator('[data-game-code="BUSY-2"]');
+  const initialScore = await streamedGame.locator('[aria-label="Side A score"]').innerText();
+  assert(initialScore === "0", "canonical Event page did not render the initial scoreboard");
   assert(
-    (await page.locator('[data-game-timeline] [data-timeline-kind="goal"]').count()) === 1,
-    "dedicated spectator Game did not render its roster-resolved Timeline",
+    (await streamedGame.locator('[data-timeline-kind="goal"]').count()) === 0,
+    "canonical Event page unexpectedly rendered the future goal",
   );
-  const expandedSides = page.locator("[data-scoreboard-expanded] [data-side-id]");
-  assert((await expandedSides.count()) === 2, "expanded scoreboard did not render two sides");
+
+  const stableGamePath = `/events/${encodeURIComponent(seeded.currentId)}/games/${encodeURIComponent(
+    seeded.currentGames[1]!.game.eventGameId,
+  )}`;
+  await page.goto(`${origin}${stableGamePath}`);
+  await page.getByRole("heading", { name: "Busy Game 2" }).waitFor();
+  const stableGameScore = page.locator('[aria-label="Side A score"]');
+  await stableGameScore.waitFor();
   assert(
-    (await expandedSides.nth(0).getAttribute("data-side-id")) === "side-b" &&
-      (await expandedSides.nth(1).getAttribute("data-side-id")) === "side-a",
-    "expanded scoreboard reordered sides without stable IDs",
+    (await stableGameScore.innerText()) === "0",
+    "stable Game page did not render its snapshot",
   );
   assert(
-    (await expandedSides.nth(0).innerText()).includes("FLAG CATCH") &&
-      !(await expandedSides.nth(1).innerText()).includes("FLAG CATCH"),
-    "expanded scoreboard marked the wrong catching side",
+    (await page.locator('[data-timeline-kind="goal"]').count()) === 0,
+    "stable Game page unexpectedly rendered the future goal",
   );
+  await acceptCommittedGoal(seeded);
+  await page.waitForFunction(
+    () => document.querySelector('[aria-label="Side A score"]')?.textContent?.trim() === "10",
+  );
+  await page.locator('[data-timeline-kind="goal"]').first().waitFor();
   assert(
-    await page.evaluate(
-      () => document.documentElement.scrollWidth <= document.documentElement.clientWidth,
-    ),
-    "phone-sized spectator Game overflows horizontally",
+    page.url() === `${origin}${stableGamePath}`,
+    "stable Game stream update reloaded the page",
   );
-  assert(
-    !(await page.locator("[data-scoreboard-expanded]").getAttribute("class"))?.includes("sticky"),
-    "expanded spectator scoreboard remained sticky",
-  );
-  await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
-  await page.locator("[data-scoreboard-compact]").waitFor();
-  const compactText = await page.locator("[data-scoreboard-compact]").innerText();
-  for (const value of [
-    "A Very Long Team Name That Must Wrap On A Phone",
-    "Another Very Long Team Name For A Narrow Phone",
-    "40",
-    "30",
-    "2:05",
-    "Stale clock",
-    "Game Phase: Overtime",
-    "Operational status: Suspended",
-    "Schedule: Past",
-    "FLAG CATCH",
-  ]) {
-    assert(compactText.includes(value), `compact scoreboard omitted ${value}`);
-  }
-  assert(
-    (await page.locator("[data-scoreboard-compact]").getAttribute("class"))?.includes("sticky") ===
-      true,
-    "compact spectator scoreboard did not become sticky after scrolling",
-  );
-  const compactSides = page.locator("[data-scoreboard-compact] [data-side-id]");
-  assert((await compactSides.count()) === 2, "compact scoreboard did not render two sides");
-  assert(
-    (await compactSides.nth(0).getAttribute("data-side-id")) === "side-b" &&
-      (await compactSides.nth(1).getAttribute("data-side-id")) === "side-a",
-    "compact scoreboard reordered sides without stable IDs",
-  );
-  assert(
-    (await compactSides.nth(0).innerText()).includes("FLAG CATCH") &&
-      !(await compactSides.nth(1).innerText()).includes("FLAG CATCH"),
-    "compact scoreboard marked the wrong catching side",
-  );
-  for (const [status, label] of [
-    ["synchronized", "Synchronized clock"],
-    ["estimated", "Estimated clock"],
-    ["stale", "Stale clock"],
-    ["unavailable", "Clock unavailable"],
-  ] as const) {
-    browserClockFreshness = status;
-    await page.reload();
-    await page.getByText(label).first().waitFor();
-  }
-  await page.unroute(
-    `${origin}/api/audience/events/${encodeURIComponent(current.eventId)}/games/browser-fixture`,
-  );
-  const canonicalResponse = await page.goto(`${origin}${current.canonicalPath}`);
+
+  await page.goto(`${origin}${current.canonicalPath}`);
   await page.getByRole("heading", { name: "Published Current" }).waitFor();
+  await page.waitForFunction(
+    (selector) => document.querySelector(selector)?.textContent?.trim() === "10",
+    '[data-game-code="BUSY-2"] [aria-label="Side A score"]',
+  );
+  await page.locator('[data-game-code="BUSY-2"] [data-timeline-kind="goal"]').first().waitFor();
   assert(
-    canonicalResponse?.headers()["x-robots-tag"] === undefined,
-    "Published canonical page was noindex",
+    page.url() === `${origin}${current.canonicalPath}`,
+    "stream update reloaded the Event page",
+  );
+  assert(
+    (await page.locator('[data-game-code="BUSY-2"][data-schedule-status="running"]').count()) >= 1,
+    "stream update removed the canonical schedule card",
   );
 
   await page.getByRole("button", { name: "All events" }).click();
@@ -533,9 +399,8 @@ try {
       oneCurrentAutoOpen: true,
       multipleCurrentDiscovery: true,
       busyPhoneSchedule: true,
-      spectatorGamePhone: true,
-      spectatorScoreboardCompaction: true,
-      spectatorSportingProjection: true,
+      publicEventScheduleScoreTimelineConvergence: true,
+      stableGameScheduleScoreTimelineConvergence: true,
       canonicalNavigation: true,
       unavailableHiddenUnknown: true,
       unavailableDatabaseFailure: true,
@@ -570,103 +435,6 @@ type PublicEventFixture = {
   lifecycle: "unscheduled" | "current" | "future" | "past";
   gameDays: string[];
   canonicalPath: string;
-};
-
-function publicGameFixture(
-  eventId: string,
-  synchronization: PublicAudienceClockProjection["synchronization"] = "stale",
-) {
-  return {
-    eventId,
-    gameCode: "BROWSER-1",
-    gameDesignation: "Live Final",
-    scheduledStartMs: Date.now() - 20 * 60_000,
-    expectedStartMs: Date.now() - 18 * 60_000,
-    scheduleStatus: "past",
-    phase: "overtime",
-    operationalStatus: "suspended",
-    pitch: "Pitch 1",
-    sideA: {
-      name: "A Very Long Team Name That Must Wrap On A Phone",
-      color: "#112233",
-      score: 40,
-    },
-    sideB: {
-      name: "Another Very Long Team Name For A Narrow Phone",
-      color: "#445566",
-      score: 30,
-    },
-    overtimeTarget: 40,
-    clock: {
-      gameTimeMs: 125_000,
-      activePenaltyTimeMs: 0,
-      running: false,
-      projectedAtMs: Date.now(),
-      synchronization,
-      lastSynchronizedAtMs: synchronization === "unavailable" ? null : Date.now() - 30_000,
-      cues: {
-        flagRunnerEntry: "passed",
-        seekerWarning: "passed",
-        seekerCountdownMs: null,
-        seekerRelease: "released",
-      },
-    },
-    teamTimeout: { status: "started", side: "side-a", remainingMs: 30_000 },
-    gameSuspension: "suspended",
-    heatStoppage: {
-      status: "started",
-      mode: "enabled",
-      pending: true,
-      allowedDurationMs: 120_000,
-      actualDurationMs: 90_000,
-      remainingMs: 30_000,
-    },
-    flagState: { catchingSide: "side-b" },
-    result: { status: "finished", winner: "side-a", locked: true },
-    presentation: {
-      pitchOrientation: "side-b-left",
-      displayedTeamColors: { sideA: "#112233", sideB: "#445566" },
-    },
-    canonicalPath: `/events/${encodeURIComponent(eventId)}/games/browser-fixture`,
-    timeline: [
-      {
-        kind: "goal",
-        gameTimeMs: 124_000,
-        lane: "side-b",
-        teamName: "Another Very Long Team Name For A Narrow Phone",
-        player: { number: 7, name: "Roster-resolved spectator" },
-        points: 10,
-      },
-    ],
-  };
-}
-
-type PublicTimelineFixtureEntry = {
-  kind: string;
-  gameTimeMs: number | null;
-  lane: string;
-  teamName: string | null;
-  player: { number: number; name: string | null } | null;
-  cardColor?: string | null;
-  penaltyReason?: string | null;
-  [key: string]: unknown;
-};
-
-type PublicGameProjectionFixture = {
-  gameCode: string | null;
-  timeline: PublicTimelineFixtureEntry[];
-  [key: string]: unknown;
-};
-
-type PublicEventResponseFixture = {
-  status: string;
-  value: {
-    schedule: {
-      scheduleGames: PublicGameProjectionFixture[];
-      [key: string]: unknown;
-    };
-    [key: string]: unknown;
-  };
 };
 
 async function seedDatabase() {
@@ -803,37 +571,122 @@ async function seedCommittedGameRecords(seeded: {
   const foundation = openSqliteFoundationStorage(foundationDatabase, {
     grantKeyRing: readGrantAuthorityOptions("test", environment).keyRing,
   });
-  const resolver = createSeedScopeResolver();
-  for (const [index, entry] of seeded.currentGames.entries()) {
-    if (index > 2) continue;
-    const root = createSeedRoot(
-      seeded.currentId,
-      seeded.currentGameDayId,
-      entry.game.eventGameId,
-      entry.pitchId,
-      entry.pitchSlotId,
-    );
-    const record = createEventGameRecord(foundation, {
-      externalScopeResolver: resolver,
-      interpreter: createLiveEventGameIqaInterpreter(),
-      clock: () => Date.now(),
-    });
-    const registered = await record.registerRoot(root);
-    if (registered.status !== "registered") throw new Error("busy Event root registration failed");
-    const action = await record.acceptAction(
-      index === 0 ? createSeedForfeitAction(root) : createSeedClockAction(root),
-    );
-    if (action.status !== "accepted") throw new Error("busy Event action commit failed");
-    if (index === 0) {
-      const finished = await record.transitionLifecycle({
-        ...root.lifecycle,
-        phase: "finished",
-        finishedAtMs: Date.now(),
-      });
-      if (finished.status !== "updated") throw new Error("busy Event finish commit failed");
+  const eventGameStorage = openSqliteFoundationStorage(eventGameDatabase, {
+    grantKeyRing: liveEventKeyRing,
+  });
+  await eventGameStorage.applyMigrations({ requireCandidate: false });
+  try {
+    for (const [index, entry] of seeded.currentGames.entries()) {
+      if (index > 2) continue;
+      const root = createSeedRoot(
+        seeded.currentId,
+        seeded.currentGameDayId,
+        entry.game.eventGameId,
+        entry.pitchId,
+        entry.pitchSlotId,
+      );
+      await seedEventGameRecord(foundation, root, createSeedScopeResolver(), index);
+      await seedEventGameRecord(eventGameStorage, root, createEventGameSeedScopeResolver(), index);
     }
+  } finally {
+    eventGameStorage.close();
+    foundation.close();
   }
-  foundation.close();
+}
+
+async function seedEventGameRecord(
+  storage: ReturnType<typeof openSqliteFoundationStorage>,
+  root: EventGameRecordRoot,
+  resolver: ExternalScopeResolver,
+  index: number,
+) {
+  const record = createEventGameRecord(storage, {
+    externalScopeResolver: resolver,
+    interpreter: createLiveEventGameIqaInterpreter(),
+    clock: () => Date.now(),
+  });
+  const registered = await record.registerRoot(root);
+  if (registered.status !== "registered") throw new Error("busy Event root registration failed");
+  const action = await record.acceptAction(
+    index === 0 ? createSeedForfeitAction(root) : createSeedClockAction(root),
+  );
+  if (action.status !== "accepted") throw new Error("busy Event action commit failed");
+  if (index === 0) {
+    const finished = await record.transitionLifecycle({
+      ...root.lifecycle,
+      phase: "finished",
+      finishedAtMs: Date.now(),
+    });
+    if (finished.status !== "updated") throw new Error("busy Event finish commit failed");
+  }
+}
+
+async function acceptCommittedGoal(seeded: {
+  currentId: string;
+  currentGameDayId: string;
+  currentGames: readonly { game: EventGame; pitchId: string; pitchSlotId: string }[];
+}) {
+  const entry = seeded.currentGames[1];
+  if (entry === undefined) throw new Error("browser convergence Game is unavailable");
+  const runtime = openSqliteFoundationStorage(eventGameDatabase, {
+    grantKeyRing: liveEventKeyRing,
+  });
+  const catalog = openSqliteFoundationStorage(foundationDatabase, {
+    grantKeyRing: readGrantAuthorityOptions("test", environment).keyRing,
+  });
+  try {
+    const readinessContext = {
+      actionCodecRegistry: createControlActionCodecRegistry(),
+      interpreter: createLiveEventGameIqaInterpreter(),
+    };
+    runtime.setReadinessContext(readinessContext);
+    catalog.setReadinessContext(readinessContext);
+    await acceptGoalOnStorage(
+      catalog,
+      entry,
+      createSeedScopeResolver(),
+      "browser-convergence-goal-catalog",
+    );
+    await acceptGoalOnStorage(
+      runtime,
+      entry,
+      createEventGameSeedScopeResolver(),
+      "browser-convergence-goal-runtime",
+    );
+  } finally {
+    catalog.close();
+    runtime.close();
+  }
+}
+
+async function acceptGoalOnStorage(
+  storage: ReturnType<typeof openSqliteFoundationStorage>,
+  entry: { game: EventGame },
+  resolver: ExternalScopeResolver,
+  operationId: string,
+) {
+  const root = await storage.transaction((transaction) =>
+    transaction.findRootByEventGameId(entry.game.eventGameId),
+  );
+  if (root === null) throw new Error("browser convergence Event Game root is unavailable");
+  const record = createEventGameRecord(storage, {
+    externalScopeResolver: resolver,
+    interpreter: createLiveEventGameIqaInterpreter(),
+    clock: () => Date.now(),
+  });
+  const registered = await record.registerRoot(root);
+  if (registered.status !== "registered" && registered.status !== "idempotent") {
+    throw new Error(`browser convergence Event Game registration failed: ${registered.status}`);
+  }
+  const accepted = await record.acceptAction(
+    createSeedAction(root, operationId, "goal", root.gameSides[0]?.id ?? null, {
+      points: 10,
+      sportingOrder: 1_000,
+    }),
+  );
+  if (accepted.status !== "accepted" && accepted.status !== "duplicate-accepted") {
+    throw new Error(`browser convergence goal was not accepted: ${accepted.status}`);
+  }
 }
 
 function createSeedScopeResolver(): ExternalScopeResolver {
@@ -846,6 +699,19 @@ function createSeedScopeResolver(): ExternalScopeResolver {
         pitchSlot.pitchId === scope.pitchId
         ? { status: "resolved", scope: structuredClone(scope) }
         : { status: "mismatch", detail: "Seed Event Game Pitch Slot is unavailable." };
+    },
+    resolveEventTeam(eventId, eventTeamId) {
+      return eventId.length > 0 && eventTeamId.length > 0
+        ? { status: "resolved" }
+        : { status: "missing", detail: "Seed Event Team is unavailable." };
+    },
+  };
+}
+
+function createEventGameSeedScopeResolver(): ExternalScopeResolver {
+  return {
+    resolve(scope) {
+      return { status: "resolved", scope: structuredClone(scope) };
     },
     resolveEventTeam(eventId, eventTeamId) {
       return eventId.length > 0 && eventTeamId.length > 0

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -7,6 +7,7 @@ import { captureAdHocHandoffFromLocation } from "@/lib/ad-hoc-handoff";
 import { createInitialGameState, projectGameView } from "@/lib/game-engine";
 import { DEFAULT_AWAY_TEAM_COLOR, DEFAULT_HOME_TEAM_COLOR } from "@/lib/team-colors";
 import { createInitialClockBaseline, projectClockBaseline } from "@/lib/clock-authority";
+import type { PublicAudienceEventProjection } from "@/lib/audience-projection";
 
 class MockWebSocket {
   static CONNECTING = 0;
@@ -42,6 +43,14 @@ class MockWebSocket {
     this.sentMessages.push(data);
   }
 
+  receive(data: unknown) {
+    this.onmessage?.(
+      new MessageEvent("message", {
+        data: JSON.stringify(data),
+      }),
+    );
+  }
+
   close() {
     if (this.readyState === MockWebSocket.CLOSED) {
       return;
@@ -50,6 +59,27 @@ class MockWebSocket {
     this.readyState = MockWebSocket.CLOSED;
     this.onclose?.(new CloseEvent("close"));
   }
+}
+
+function publishedEventProjection(eventId: string, name: string): PublicAudienceEventProjection {
+  return {
+    eventId,
+    name,
+    timeZone: "UTC",
+    publicationStatus: "published",
+    gameDays: ["2026-08-14"],
+    lifecycle: "current",
+    canonicalPath: `/events/${eventId}`,
+    teams: [],
+    pitches: [],
+    schedule: {
+      asOfMs: 0,
+      runningGames: [],
+      upcomingGames: [],
+      scheduleGames: [],
+      focusIndex: null,
+    },
+  };
 }
 
 describe("App", () => {
@@ -1267,5 +1297,120 @@ describe("App", () => {
     });
     expect(testWindow.location.pathname).toBe("/events");
     expect(testWindow.location.search).toBe("?view=all");
+  });
+
+  test("converges a Published Event page from HTTP to a committed Audience Projection update", async () => {
+    testWindow.history.replaceState(null, "", "/events/streamed-event");
+    const projection = publishedEventProjection("streamed-event", "Streamed Event");
+    projection.teamAssignmentNotice = "event-team-assignment-corrected";
+    (globalThis.fetch as typeof fetch) = (async () =>
+      new Response(JSON.stringify({ status: "accepted", value: projection }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })) as unknown as typeof fetch;
+
+    await act(async () => {
+      root.render(<App />);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const socket = MockWebSocket.instances.at(-1);
+    expect(socket).not.toBeUndefined();
+    expect(socket?.sentMessages).toContain(
+      JSON.stringify({ type: "subscribe-public-event", eventId: "streamed-event" }),
+    );
+    expect(container.textContent).toContain("Streamed Event");
+    expect(container.textContent).toContain(
+      "An Event Team assignment was corrected. Current team identities are shown.",
+    );
+
+    await act(async () => {
+      socket?.receive({
+        protocol: "public-event-stream-v1",
+        type: "projection-replaced",
+        eventId: "streamed-event",
+        version: 2,
+        projection: { ...projection, name: "Updated Streamed Event" },
+      });
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain("Updated Streamed Event");
+  });
+
+  test("refetches the authoritative projection before reconnecting after a dropped WebSocket", async () => {
+    testWindow.history.replaceState(null, "", "/events/reconnect-event");
+    const projection = publishedEventProjection("reconnect-event", "Initial Event");
+    let reads = 0;
+    (globalThis.fetch as typeof fetch) = (async () => {
+      reads += 1;
+      const value =
+        reads === 1 ? projection : { ...projection, name: `Recovered Event ${reads - 1}` };
+      return new Response(JSON.stringify({ status: "accepted", value }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+
+    await act(async () => {
+      root.render(<App />);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    let priorSocket = MockWebSocket.instances.at(-1);
+    expect(priorSocket).not.toBeUndefined();
+    expect(container.textContent).toContain("Initial Event");
+
+    for (let cycle = 1; cycle <= 3; cycle += 1) {
+      await act(async () => {
+        priorSocket?.close();
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      const recoveredSocket = MockWebSocket.instances.at(-1);
+      expect(reads).toBe(cycle + 1);
+      expect(recoveredSocket).not.toBe(priorSocket);
+      expect(recoveredSocket?.sentMessages).toContain(
+        JSON.stringify({ type: "subscribe-public-event", eventId: "reconnect-event" }),
+      );
+      expect(container.textContent).toContain(`Recovered Event ${cycle}`);
+      priorSocket = recoveredSocket;
+    }
+  });
+
+  test("clears the prior Audience Projection before rendering terminal Event unavailability", async () => {
+    testWindow.history.replaceState(null, "", "/events/terminal-event");
+    const projection = publishedEventProjection("terminal-event", "Previously Published Event");
+    (globalThis.fetch as typeof fetch) = (async () =>
+      new Response(JSON.stringify({ status: "accepted", value: projection }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })) as unknown as typeof fetch;
+
+    await act(async () => {
+      root.render(<App />);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const socket = MockWebSocket.instances.at(-1);
+    expect(container.textContent).toContain("Previously Published Event");
+
+    await act(async () => {
+      socket?.receive({
+        protocol: "public-event-stream-v1",
+        type: "event-unavailable",
+        eventId: "terminal-event",
+      });
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain("Event unavailable");
+    expect(container.textContent).not.toContain("Previously Published Event");
   });
 });

--- a/src/index-html.test.ts
+++ b/src/index-html.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { collectHtmlBundleAssetPaths } from "@/lib/html-bundle-assets";
+import { assetCacheControl, createHtmlBundleRoute, isVersionedAssetPath } from "@/index";
 
 describe("index.html", () => {
   test("sets base href for route-safe asset resolution", () => {
@@ -26,5 +27,37 @@ describe("index.html", () => {
         ["/chunk-app.js", "/release/chunk-app.js"],
       ]),
     );
+  });
+
+  test("revalidates dynamic HTML and keeps only versioned assets immutable", async () => {
+    const route = createHtmlBundleRoute(
+      '<!doctype html><html><head><script src="./chunk-a1b2c3d4.js"></script></head><body></body></html>',
+      "/release",
+      {
+        testEnvironment: false,
+        browserMonitoring: {
+          environment: "production",
+          release: "release-test",
+          browserCorrelation: "browser-test",
+        },
+      },
+    );
+    const first = route(new Request("https://timer.example/events/event-1"));
+    const etag = first.headers.get("etag");
+    expect(first.headers.get("cache-control")).toBe("no-cache");
+    expect(etag).not.toBeNull();
+    const revalidated = route(
+      new Request("https://timer.example/events/event-1", {
+        headers: { "if-none-match": etag ?? "" },
+      }),
+    );
+    expect(revalidated.status).toBe(304);
+
+    expect(isVersionedAssetPath("/index-a1b2c3d4.js")).toBe(true);
+    expect(isVersionedAssetPath("/chunk-5g7peymh.js")).toBe(true);
+    expect(isVersionedAssetPath("/index.js")).toBe(false);
+    expect(assetCacheControl(true, false)).toBe("public, max-age=31536000, immutable");
+    expect(assetCacheControl(false, false)).toBe("no-cache");
+    expect(assetCacheControl(true, true)).toBe("no-cache");
   });
 });

--- a/src/index-public-event-stream.test.ts
+++ b/src/index-public-event-stream.test.ts
@@ -1,0 +1,395 @@
+import { describe, expect, test } from "bun:test";
+import { createPublicAudienceEventStream } from "@/lib/public-audience-event-stream";
+import { createPublicAudienceEventWebSocketHub } from "@/lib/public-audience-event-websocket";
+import { PUBLIC_EVENT_STREAM_PROTOCOL } from "@/lib/public-event-stream";
+
+const publishedEvent = {
+  eventId: "event-1",
+  name: "Published Event",
+  timeZone: "UTC",
+  publicationStatus: "published" as const,
+  gameDays: ["2026-08-15"],
+  lifecycle: "current" as const,
+  canonicalPath: "/events/event-1",
+  teams: [],
+  pitches: [],
+  schedule: {
+    asOfMs: 0,
+    runningGames: [],
+    upcomingGames: [],
+    scheduleGames: [],
+    focusIndex: null,
+  },
+};
+
+function socketHarness() {
+  const messages: unknown[] = [];
+  const closed: { code: number; reason: string }[] = [];
+  return {
+    messages,
+    closed,
+    socket: {
+      send(serialized: string) {
+        messages.push(JSON.parse(serialized));
+        return true;
+      },
+      close(code: number, reason: string) {
+        closed.push({ code, reason });
+      },
+    },
+  };
+}
+
+function capacity() {
+  return {
+    totalConnections: 10,
+    reservedConnections: 2,
+    activeControllerSessions: () => 0,
+  };
+}
+
+function deferred<T>() {
+  let resolve: (value: T) => void = () => {};
+  const promise = new Promise<T>((nextResolve) => {
+    resolve = nextResolve;
+  });
+  return { promise, resolve };
+}
+
+describe("public Event WebSocket adapter", () => {
+  test("delivers the composed authoritative projection and refreshes one upstream feed", async () => {
+    const messages: unknown[] = [];
+    let reads = 0;
+    let currentProjection = publishedEvent;
+    const stream = createPublicAudienceEventStream(
+      {
+        read: async () => {
+          reads += 1;
+          return { status: "accepted" as const, value: currentProjection };
+        },
+      },
+      { refreshIntervalMs: 60_000 },
+    );
+    const hub = createPublicAudienceEventWebSocketHub({ stream, controllerCapacity: capacity() });
+    const first = socketHarness();
+    const second = socketHarness();
+    expect((await hub.subscribe("client-1", "event-1", first.socket)).status).toBe("admitted");
+    expect((await hub.subscribe("client-2", "event-1", second.socket)).status).toBe("admitted");
+    expect(reads).toBe(1);
+    messages.push(...first.messages, ...second.messages);
+    expect(messages).toEqual([
+      {
+        protocol: PUBLIC_EVENT_STREAM_PROTOCOL,
+        type: "snapshot",
+        eventId: "event-1",
+        version: 1,
+        projection: publishedEvent,
+      },
+      {
+        protocol: PUBLIC_EVENT_STREAM_PROTOCOL,
+        type: "snapshot",
+        eventId: "event-1",
+        version: 1,
+        projection: publishedEvent,
+      },
+    ]);
+
+    currentProjection = { ...publishedEvent, name: "Updated Published Event" };
+    expect(await stream.republish("event-1")).toBe("accepted");
+    expect(first.messages.at(-1)).toMatchObject({
+      type: "projection-replaced",
+      version: 2,
+      projection: { name: "Updated Published Event" },
+    });
+    expect(second.messages.at(-1)).toMatchObject({
+      type: "projection-replaced",
+      version: 2,
+      projection: { name: "Updated Published Event" },
+    });
+    hub.close();
+    stream.close();
+  });
+
+  test("turns an authoritative read failure into one generic unavailable socket outcome", async () => {
+    const stream = createPublicAudienceEventStream({
+      read: async () => ({ status: "retryable-failure" as const }),
+    });
+    const hub = createPublicAudienceEventWebSocketHub({ stream, controllerCapacity: capacity() });
+    const socket = socketHarness();
+    expect(await hub.subscribe("client-1", "event-1", socket.socket)).toEqual({
+      status: "unavailable",
+      message: "Spectator experience is currently unavailable.",
+    });
+    expect(socket.messages).toEqual([]);
+    hub.close();
+    stream.close();
+  });
+
+  test("clears an admitted subscriber on refresh failure without tombstoning fresh recovery", async () => {
+    let outcome: "accepted" | "retryable-failure" = "accepted";
+    const socket = socketHarness();
+    const stream = createPublicAudienceEventStream(
+      {
+        read: async () =>
+          outcome === "accepted"
+            ? { status: "accepted" as const, value: publishedEvent }
+            : { status: "retryable-failure" as const },
+      },
+      { refreshIntervalMs: 1 },
+    );
+    const hub = createPublicAudienceEventWebSocketHub({ stream, controllerCapacity: capacity() });
+    expect((await hub.subscribe("client-1", "event-1", socket.socket)).status).toBe("admitted");
+    expect(socket.messages).toHaveLength(1);
+
+    outcome = "retryable-failure";
+    await new Promise<void>((resolve) => setTimeout(resolve, 10));
+    expect(socket.messages.at(-1)).toMatchObject({ type: "event-unavailable" });
+    expect(socket.closed).toEqual([{ code: 1000, reason: "Public Event stream closed." }]);
+
+    outcome = "accepted";
+    const recovered = socketHarness();
+    expect((await hub.subscribe("client-2", "event-1", recovered.socket)).status).toBe("admitted");
+    expect(recovered.messages[0]).toMatchObject({ type: "snapshot", version: 1 });
+    hub.close();
+    stream.close();
+  });
+
+  test("coalesces repeated ticks during one slow success into exactly one follow-up", async () => {
+    const slowRead = deferred<{ status: "accepted"; value: typeof publishedEvent }>();
+    const followUpRead = deferred<{ status: "accepted"; value: typeof publishedEvent }>();
+    const slowReadStarted = deferred<void>();
+    const followUpReadStarted = deferred<void>();
+    let reads = 0;
+    const slowProjection = { ...publishedEvent, name: "Slow Projection" };
+    const followUpProjection = { ...publishedEvent, name: "Follow-up Projection" };
+    const stream = createPublicAudienceEventStream(
+      {
+        read: async () => {
+          reads += 1;
+          if (reads === 1) return { status: "accepted" as const, value: publishedEvent };
+          if (reads === 2) {
+            slowReadStarted.resolve();
+            return slowRead.promise;
+          }
+          if (reads === 3) {
+            followUpReadStarted.resolve();
+            return followUpRead.promise;
+          }
+          return { status: "accepted" as const, value: followUpProjection };
+        },
+      },
+      { refreshIntervalMs: 2 },
+    );
+    const hub = createPublicAudienceEventWebSocketHub({ stream, controllerCapacity: capacity() });
+    const socket = socketHarness();
+    expect((await hub.subscribe("client-1", "event-1", socket.socket)).status).toBe("admitted");
+    await slowReadStarted.promise;
+    await new Promise<void>((resolve) => setTimeout(resolve, 10));
+    expect(reads).toBe(2);
+
+    slowRead.resolve({ status: "accepted", value: slowProjection });
+    await followUpReadStarted.promise;
+    expect(reads).toBe(3);
+    expect(socket.messages.at(-1)).toMatchObject({
+      type: "projection-replaced",
+      projection: { name: "Slow Projection" },
+    });
+
+    followUpRead.resolve({ status: "accepted", value: followUpProjection });
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    expect(socket.messages.at(-1)).toMatchObject({
+      type: "projection-replaced",
+      projection: { name: "Follow-up Projection" },
+    });
+    expect(socket.closed).toEqual([]);
+    hub.close();
+    stream.close();
+  });
+
+  test("delivers a slow refresh failure despite repeated pending ticks", async () => {
+    const slowRead = deferred<{ status: "retryable-failure" }>();
+    const slowReadStarted = deferred<void>();
+    let reads = 0;
+    const stream = createPublicAudienceEventStream(
+      {
+        read: async () => {
+          reads += 1;
+          if (reads === 1) return { status: "accepted" as const, value: publishedEvent };
+          if (reads === 2) {
+            slowReadStarted.resolve();
+            return slowRead.promise;
+          }
+          return { status: "accepted" as const, value: publishedEvent };
+        },
+      },
+      { refreshIntervalMs: 2 },
+    );
+    const hub = createPublicAudienceEventWebSocketHub({ stream, controllerCapacity: capacity() });
+    const socket = socketHarness();
+    expect((await hub.subscribe("client-1", "event-1", socket.socket)).status).toBe("admitted");
+    await slowReadStarted.promise;
+    await new Promise<void>((resolve) => setTimeout(resolve, 10));
+    expect(reads).toBe(2);
+
+    slowRead.resolve({ status: "retryable-failure" });
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    expect(socket.messages.at(-1)).toMatchObject({ type: "event-unavailable" });
+    expect(socket.closed).toEqual([{ code: 1000, reason: "Public Event stream closed." }]);
+    expect(reads).toBe(2);
+    hub.close();
+    stream.close();
+  });
+
+  test.each(["unpublish", "close"] as const)(
+    "%s during a slow refresh prevents late projection restoration",
+    async (transition) => {
+      const slowRead = deferred<{ status: "accepted"; value: typeof publishedEvent }>();
+      const slowReadStarted = deferred<void>();
+      let reads = 0;
+      const stream = createPublicAudienceEventStream(
+        {
+          read: async () => {
+            reads += 1;
+            if (reads === 1) return { status: "accepted" as const, value: publishedEvent };
+            slowReadStarted.resolve();
+            return slowRead.promise;
+          },
+        },
+        { refreshIntervalMs: 2 },
+      );
+      const hub = createPublicAudienceEventWebSocketHub({ stream, controllerCapacity: capacity() });
+      const socket = socketHarness();
+      expect((await hub.subscribe("client-1", "event-1", socket.socket)).status).toBe("admitted");
+      await slowReadStarted.promise;
+
+      if (transition === "unpublish") await stream.unpublish("event-1");
+      else stream.close();
+      slowRead.resolve({
+        status: "accepted",
+        value: { ...publishedEvent, name: "Late Projection" },
+      });
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+      expect(socket.messages.at(-1)).toMatchObject({ type: "event-unavailable" });
+      expect(
+        socket.messages.some(
+          (message) =>
+            (message as { projection?: { name?: string } }).projection?.name === "Late Projection",
+        ),
+      ).toBe(false);
+      hub.close();
+      stream.close();
+    },
+  );
+
+  test("reconciles Controller priority and accounts exact serialized envelopes", async () => {
+    let activeControllers = 0;
+    const stream = createPublicAudienceEventStream({
+      read: async () => ({ status: "accepted" as const, value: publishedEvent }),
+    });
+    const hub = createPublicAudienceEventWebSocketHub({
+      stream,
+      controllerCapacity: {
+        totalConnections: 3,
+        reservedConnections: 1,
+        activeControllerSessions: () => activeControllers,
+      },
+      maxSpectators: 2,
+    });
+    const first = socketHarness();
+    const second = socketHarness();
+    expect((await hub.subscribe("client-1", "event-1", first.socket)).status).toBe("admitted");
+    expect((await hub.subscribe("client-2", "event-1", second.socket)).status).toBe("admitted");
+    activeControllers = 2;
+    expect(hub.reconcileControllerCapacity()).toMatchObject({
+      status: "reconciled",
+      disconnected: 1,
+    });
+    expect(first.closed).toEqual([]);
+    expect(second.closed).toEqual([{ code: 1013, reason: "Controller capacity priority." }]);
+    hub.close();
+    stream.close();
+  });
+
+  test("reconnects from an authoritative current snapshot after the last spectator leaves", async () => {
+    let reads = 0;
+    const stream = createPublicAudienceEventStream(
+      {
+        read: async () => {
+          reads += 1;
+          return { status: "accepted" as const, value: publishedEvent };
+        },
+      },
+      { refreshIntervalMs: 60_000 },
+    );
+    const hub = createPublicAudienceEventWebSocketHub({ stream, controllerCapacity: capacity() });
+    const first = socketHarness();
+    const recovered = socketHarness();
+    expect((await hub.subscribe("client-1", "event-1", first.socket)).status).toBe("admitted");
+    hub.disconnect("client-1", "client-reconnect");
+    expect((await hub.subscribe("client-2", "event-1", recovered.socket, "1")).status).toBe(
+      "admitted",
+    );
+    expect(reads).toBe(2);
+    expect(recovered.messages).toHaveLength(1);
+    expect(recovered.messages[0]).toMatchObject({ type: "snapshot", version: 1 });
+    hub.close();
+    stream.close();
+  });
+
+  test("clears queued projection replacements before terminal unavailability", async () => {
+    let currentProjection = publishedEvent;
+    let releaseBlockedSend: () => void = () => {
+      throw new Error("slow send was not blocked");
+    };
+    let blockedSendResolver: (() => void) | null = null;
+    let sendCount = 0;
+    const messages: unknown[] = [];
+    const blockedSend = new Promise<void>((resolve) => {
+      blockedSendResolver = resolve;
+    });
+    const stream = createPublicAudienceEventStream(
+      {
+        read: async () => ({ status: "accepted" as const, value: currentProjection }),
+      },
+      { refreshIntervalMs: 60_000 },
+    );
+    const hub = createPublicAudienceEventWebSocketHub({ stream, controllerCapacity: capacity() });
+    const socket = {
+      async send(serialized: string) {
+        sendCount += 1;
+        if (sendCount === 2) {
+          blockedSendResolver?.();
+          await new Promise<void>((release) => {
+            releaseBlockedSend = release;
+          });
+        }
+        const message = JSON.parse(serialized) as { type?: string };
+        messages.push(message);
+        if (message.type === "event-unavailable") terminalResolver?.();
+        return true;
+      },
+      close() {},
+    };
+    let terminalResolver: (() => void) | null = null;
+    const terminalReady = new Promise<void>((resolve) => {
+      terminalResolver = resolve;
+    });
+    const admitted = await hub.subscribe("slow-client", "event-1", socket);
+    expect(admitted.status).toBe("admitted");
+    currentProjection = { ...publishedEvent, name: "Projection v2" };
+    expect(await stream.republish("event-1")).toBe("accepted");
+    await blockedSend;
+    currentProjection = { ...publishedEvent, name: "Projection v3" };
+    expect(await stream.republish("event-1")).toBe("accepted");
+    await stream.unpublish("event-1");
+    releaseBlockedSend();
+    await terminalReady;
+    expect(messages.at(-1)).toMatchObject({ type: "event-unavailable" });
+    expect(messages).not.toContainEqual(
+      expect.objectContaining({ projection: { name: "Projection v3" } }),
+    );
+    hub.close();
+    stream.close();
+  });
+});

--- a/src/index-public-event.test.ts
+++ b/src/index-public-event.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { readPublicAudienceEventPage } from "./index";
+import { readPublicAudienceEventPage, readPublicAudienceGamePage } from "./index";
 
 const publishedEvent = {
   eventId: "event-published",
@@ -54,6 +54,21 @@ describe("public Event browser responses", () => {
     expect(response.status).toBe(200);
     expect(response.headers.get("x-robots-tag")).toBe("noindex");
     expect(response.headers.get("content-type")).toContain("text/html");
+    expect(await response.text()).not.toContain('"status":"unavailable"');
+  });
+
+  test("marks an unavailable stable Game page noindex while keeping the generic HTML shell", async () => {
+    const response = await readPublicAudienceGamePage(
+      new Request("http://localhost/events/event-published/games/game-unknown"),
+      { readGame: async () => ({ status: "unavailable" }) },
+      () =>
+        new Response('<!doctype html><html><body><div id="root"></div></body></html>', {
+          headers: { "content-type": "text/html; charset=utf-8" },
+        }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-robots-tag")).toBe("noindex");
     expect(await response.text()).not.toContain('"status":"unavailable"');
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { serve, type ServerWebSocket } from "bun";
-import { randomBytes } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
 import { dirname } from "node:path";
 import index from "./index.html";
 import { readJsonBodyWithinLimit } from "@/lib/http-body";
@@ -43,13 +43,21 @@ import {
   createFoundationEventCatalogStorage,
   createUnavailableEventCatalogStorage,
   type CatalogOutcome,
+  type EventPublicationStatus,
 } from "@/lib/event-catalog";
 import {
   createAudienceProjection,
   PUBLIC_AUDIENCE_ABSENCE,
   type AudienceProjectionListOutcome,
   type AudienceProjectionReader,
+  type PublicAudienceEventProjection,
 } from "@/lib/audience-projection";
+import { createPublicAudienceEventStream } from "@/lib/public-audience-event-stream";
+import { createPublicAudienceEventWebSocketHub } from "@/lib/public-audience-event-websocket";
+import {
+  serializePublicAudienceProjectionMessage,
+  type PublicAudienceProjectionMessage,
+} from "@/lib/public-event-stream";
 import {
   createEventAdministration,
   type EventAdministration,
@@ -94,11 +102,10 @@ import {
   type ControllerCapacityInput,
 } from "@/lib/controller-capacity";
 import {
-  AD_HOC_EVENT_RESERVED_CONNECTION_CAPACITY,
-  AD_HOC_EVENT_TOTAL_CONNECTION_CAPACITY,
   AD_HOC_MAX_CONNECTED_CONTROLLERS,
   AD_HOC_MAX_QUEUED_OUTPUT_BYTES,
 } from "@/lib/ad-hoc-resource-budgets";
+import { readEventConnectionCapacity } from "@/lib/event-connection-capacity";
 import {
   initializeServerMonitoring,
   readTrustedMonitoringIdentity,
@@ -122,6 +129,10 @@ type SessionSubscription =
       type: "game";
       gameId: string;
       sessionId: string;
+    }
+  | {
+      type: "public-event";
+      eventId: string;
     };
 
 type SessionData = {
@@ -232,6 +243,9 @@ async function startServer() {
       process.env.AD_HOC_ENVIRONMENT_ID,
     );
     let eventCapacitySource = () => 0;
+    const eventConnectionCapacity = readEventConnectionCapacity(process.env, () =>
+      eventCapacitySource(),
+    );
     const adHocService = createAdHocGamesService({
       environmentIdentity: adHocEnvironmentIdentity,
       deferReplayAcknowledgement: true,
@@ -239,17 +253,7 @@ async function startServer() {
         process.env.AD_HOC_MAX_CONNECTED_SOCKETS,
         AD_HOC_MAX_CONNECTED_CONTROLLERS,
       ),
-      eventCapacity: {
-        totalConnections: readRuntimeCapacity(
-          process.env.EVENT_TOTAL_CONNECTION_CAPACITY,
-          AD_HOC_EVENT_TOTAL_CONNECTION_CAPACITY,
-        ),
-        reservedConnections: readRuntimeCapacity(
-          process.env.EVENT_RESERVED_CONNECTION_CAPACITY,
-          AD_HOC_EVENT_RESERVED_CONNECTION_CAPACITY,
-        ),
-        activeControllerSessions: () => eventCapacitySource(),
-      },
+      eventCapacity: eventConnectionCapacity,
       store:
         environment === "test" && !process.env.AD_HOC_DATABASE?.trim()
           ? undefined
@@ -330,14 +334,33 @@ async function startServer() {
 
     const eventCatalog = createEventCatalog(eventCatalogStorage, {});
     let liveEventRuntime: LiveEventGameRuntime | null = null;
-    const audienceProjection = createAudienceProjection(eventCatalogStorage, {
-      gameInput: {
-        async read(eventGameId) {
-          return liveEventRuntime === null
-            ? { status: "unavailable" as const }
-            : await liveEventRuntime.readAudienceProjectionGameInput(eventGameId);
-        },
-      },
+    const liveEventKeyRing = readLiveEventGrantKeyRing();
+    const liveAudienceGameInput =
+      liveEventKeyRing === null
+        ? undefined
+        : {
+            async read(eventGameId: string) {
+              return liveEventRuntime === null
+                ? { status: "unavailable" as const }
+                : await liveEventRuntime.readAudienceProjectionGameInput(eventGameId);
+            },
+          };
+    const audienceProjection = createAudienceProjection(
+      eventCatalogStorage,
+      liveAudienceGameInput === undefined ? {} : { gameInput: liveAudienceGameInput },
+    );
+    const publicEventStream = createPublicAudienceEventStream(audienceProjection);
+    let reconcilePublicSpectators = () => {};
+    const publicEventWebSocketHub = createPublicAudienceEventWebSocketHub({
+      stream: publicEventStream,
+      controllerCapacity: eventConnectionCapacity,
+    });
+    reconcilePublicSpectators = () => {
+      publicEventWebSocketHub.reconcileControllerCapacity();
+    };
+    startupCleanup.add(() => {
+      publicEventWebSocketHub.close();
+      publicEventStream.close();
     });
     let eventAdministration: EventAdministration | null = null;
     let administrativeAuditProjection: AdministrativeAuditProjection | null = null;
@@ -370,7 +393,6 @@ async function startServer() {
       }
     }
     const liveEventDatabasePath = storagePaths.eventGameDatabase;
-    const liveEventKeyRing = readLiveEventGrantKeyRing();
     if (liveEventKeyRing !== null) {
       try {
         liveEventRuntime = await openLiveEventGameRuntime({
@@ -378,6 +400,7 @@ async function startServer() {
           environmentId: environment,
           keyRing: liveEventKeyRing,
           knownDodgeballIdsForEventGame: readLiveEventDodgeballIdsByEventGame(),
+          onControllerCapacityChange: () => reconcilePublicSpectators(),
         });
         startupCleanup.add(() => liveEventRuntime?.close());
       } catch (error) {
@@ -582,18 +605,13 @@ async function startServer() {
       monitoringIdentity === null
         ? undefined
         : process.env.PUBLIC_GLITCHTIP_DSN?.trim() || undefined;
-    const htmlRoute =
-      monitoringIdentity !== null &&
-      ((environment === "test" && process.env.NODE_ENV === "production") ||
-        browserMonitoringDsn !== undefined)
-        ? await createHtmlRoute({
-            testEnvironment: environment === "test" && process.env.NODE_ENV === "production",
-            browserMonitoring: browserMonitoringPublicConfig(
-              monitoringIdentity,
-              browserMonitoringDsn,
-            ),
-          })
-        : index;
+    const htmlRoute = await createHtmlRoute({
+      testEnvironment: environment === "test" && process.env.NODE_ENV === "production",
+      browserMonitoring:
+        monitoringIdentity === null
+          ? undefined
+          : browserMonitoringPublicConfig(monitoringIdentity, browserMonitoringDsn),
+    });
 
     server = serve<SessionData>({
       hostname: process.env.HOST ?? "127.0.0.1",
@@ -615,21 +633,7 @@ async function startServer() {
           }
 
           const socketId = crypto.randomUUID();
-          const totalSocketCapacity = calculateAdHocUpgradeCapacity({
-            totalConnections: readRuntimeCapacity(
-              process.env.EVENT_TOTAL_CONNECTION_CAPACITY,
-              AD_HOC_EVENT_TOTAL_CONNECTION_CAPACITY,
-            ),
-            reservedConnections: readRuntimeCapacity(
-              process.env.EVENT_RESERVED_CONNECTION_CAPACITY,
-              AD_HOC_EVENT_RESERVED_CONNECTION_CAPACITY,
-            ),
-            activeControllerSessions: eventCapacitySource(),
-            maxConnectedSockets: readRuntimeCapacity(
-              process.env.AD_HOC_MAX_CONNECTED_SOCKETS,
-              AD_HOC_MAX_CONNECTED_CONTROLLERS,
-            ),
-          });
+          const totalSocketCapacity = eventConnectionCapacity.totalConnections;
           if (sockets.size + pendingSocketReservations.size >= totalSocketCapacity) {
             adHocService.recordResourcePressure("connection-shed");
             return json({ error: "Ad Hoc connection busy.", retryAfterMs: 1_000 }, 503, [
@@ -1075,13 +1079,13 @@ async function startServer() {
                 400,
               );
             const eventId = new URL(req.url).pathname.split("/").at(-2) ?? "";
-            return catalogResponse(
-              await eventCatalog.changePublicationStatus(
-                eventId,
-                { status: body.status, impactConfirmed: body.impactConfirmed },
-                token,
-              ),
+            const result = await eventCatalog.changePublicationStatus(
+              eventId,
+              { status: body.status, impactConfirmed: body.impactConfirmed },
+              token,
             );
+            await synchronizePublicEventPublication(publicEventStream, eventId, result);
+            return catalogResponse(result);
           },
         },
         "/api/admin/events/:eventId/game-days": {
@@ -1784,14 +1788,13 @@ async function startServer() {
             const body = await readJsonRecord(req);
             const eventId = new URL(req.url).pathname.split("/").at(-2) ?? "";
             if (authority === null || body === null) return sensitiveGenericAuthFailure(401);
-            return sensitiveEventAdministrationMutationResponse(
-              await eventAdministration.changePublicationStatus(
-                eventId,
-                { status: body.status, impactConfirmed: body.impactConfirmed },
-                authority,
-              ),
+            const result = await eventAdministration.changePublicationStatus(
+              eventId,
+              { status: body.status, impactConfirmed: body.impactConfirmed },
               authority,
             );
+            await synchronizePublicEventPublication(publicEventStream, eventId, result);
+            return sensitiveEventAdministrationMutationResponse(result, authority);
           },
         },
         "/api/event-admin/events/:eventId/catalog-removal/preview": {
@@ -2238,7 +2241,14 @@ async function startServer() {
         "/events/:eventId": {
           async GET(req: Request, routeServer: Bun.Server<SessionData>) {
             return readPublicAudienceEventPage(req, audienceProjection, () =>
-              fetch(new URL("/", routeServer.url)),
+              fetch(new Request(new URL("/", routeServer.url), { headers: req.headers })),
+            );
+          },
+        },
+        "/events/:eventId/games/:eventGameId": {
+          async GET(req: Request, routeServer: Bun.Server<SessionData>) {
+            return readPublicAudienceGamePage(req, audienceProjection, () =>
+              fetch(new Request(new URL("/", routeServer.url), { headers: req.headers })),
             );
           },
         },
@@ -2287,6 +2297,7 @@ async function startServer() {
           releasePendingSocketReservation(ws.data.id);
           sockets.delete(ws);
           ws.data.closed = true;
+          publicEventWebSocketHub.disconnect(ws.data.id, "client-closed");
           void ws.data.subscriptionWork
             .then(
               () => liveAdHocSessions.disconnect(ws.data.id),
@@ -2321,6 +2332,53 @@ async function startServer() {
             case "subscribe-lobby": {
               sendMessage(ws, { type: "error", message: adHocService.genericUnavailableMessage });
               ws.close(1008, "Ad Hoc subscription unavailable.");
+              return;
+            }
+
+            case "subscribe-public-event": {
+              const eventId = parsed.message.eventId;
+              const handleSubscription = async () => {
+                if (ws.data.closed) return;
+                if (ws.data.subscription.type !== "none") {
+                  sendMessage(ws, {
+                    type: "error",
+                    message: "WebSocket is already subscribed.",
+                  });
+                  return;
+                }
+                const subscriber = {
+                  send(serialized: string) {
+                    return sendPublicAudienceSerializedEnvelope(ws, serialized);
+                  },
+                  close(code: number, reason: string) {
+                    if (!ws.data.closed) ws.close(code, reason);
+                  },
+                };
+                const result = await publicEventWebSocketHub.subscribe(
+                  ws.data.id,
+                  eventId,
+                  subscriber,
+                );
+                if (ws.data.closed) return;
+                if (result.status === "rejected") {
+                  sendMessage(ws, { type: "error", message: result.message });
+                  ws.close(1013, result.message);
+                  return;
+                }
+                if (result.status !== "admitted") {
+                  sendPublicEventStreamMessage(ws, {
+                    protocol: "public-event-stream-v1",
+                    type: "event-unavailable",
+                    eventId,
+                  });
+                  ws.close(1008, "Event unavailable.");
+                  return;
+                }
+                ws.data.subscription = { type: "public-event", eventId };
+              };
+              const queued = ws.data.subscriptionWork.then(handleSubscription, handleSubscription);
+              ws.data.subscriptionWork = queued.catch(() => undefined);
+              await queued;
               return;
             }
 
@@ -2481,29 +2539,55 @@ async function startServer() {
   }
 }
 
-async function createHtmlRoute({
+export async function createHtmlRoute({
   testEnvironment,
   browserMonitoring,
 }: {
   testEnvironment: boolean;
-  browserMonitoring: {
+  browserMonitoring?: {
     dsn?: string;
     environment: "production" | "test";
     release: string;
     browserCorrelation: string;
   };
-}) {
+}): Promise<HtmlRoute> {
   const html = await Bun.file(index.index)
     .text()
     .catch(() => null);
   if (html === null) {
     throw new Error("Test HTML presentation bundle is unavailable.");
   }
+  // Bun's source HTML route owns development-time TSX transpilation. The built
+  // release HTML contains versioned browser assets and is safe to serve directly.
+  if (/src=["']\.\/frontend\.tsx["']/u.test(html)) return index;
+  return createHtmlBundleRoute(html, dirname(index.index), { testEnvironment, browserMonitoring });
+}
 
-  const monitoringScript = `<script>globalThis.__QUADBALL_TIMER_MONITORING__=${serializeBrowserMonitoringConfig(
+export function createHtmlBundleRoute(
+  html: string,
+  assetDirectory: string,
+  {
+    testEnvironment,
     browserMonitoring,
-  )};</script>`;
-  const bodyWithMonitoring = html.replace("</head>", `${monitoringScript}</head>`);
+  }: {
+    testEnvironment: boolean;
+    browserMonitoring?: {
+      dsn?: string;
+      environment: "production" | "test";
+      release: string;
+      browserCorrelation: string;
+    };
+  },
+) {
+  const bodyWithMonitoring =
+    browserMonitoring === undefined
+      ? html
+      : html.replace(
+          "</head>",
+          `<script>globalThis.__QUADBALL_TIMER_MONITORING__=${serializeBrowserMonitoringConfig(
+            browserMonitoring,
+          )};</script></head>`,
+        );
   const body = testEnvironment
     ? bodyWithMonitoring
         .replace(
@@ -2517,29 +2601,42 @@ async function createHtmlRoute({
     : bodyWithMonitoring;
   const headers = new Headers({
     "content-type": "text/html; charset=utf-8",
+    etag: contentEtag(body),
     ...(testEnvironment
       ? {
           "cache-control": "no-store",
           "x-robots-tag": "noindex, nofollow, noarchive, noimageindex",
         }
-      : {}),
+      : { "cache-control": "no-cache" }),
   });
-  const assetDirectory = dirname(index.index);
   const assetPaths = collectHtmlBundleAssetPaths(html, assetDirectory);
 
   return (req: Request) => {
     const assetPath = assetPaths.get(new URL(req.url).pathname);
-    return assetPath === undefined
-      ? new Response(body, { headers })
-      : new Response(Bun.file(assetPath), {
-          headers: {
-            "cache-control": "no-store",
-            ...(testEnvironment
-              ? { "x-robots-tag": "noindex, nofollow, noarchive, noimageindex" }
-              : {}),
-          },
-        });
+    if (assetPath === undefined) {
+      if (!testEnvironment && req.headers.get("if-none-match") === headers.get("etag")) {
+        return new Response(null, { status: 304, headers });
+      }
+      return new Response(body, { headers });
+    }
+    const immutable = isVersionedAssetPath(new URL(req.url).pathname);
+    return new Response(Bun.file(assetPath), {
+      headers: {
+        "cache-control": assetCacheControl(immutable, testEnvironment),
+        ...(testEnvironment
+          ? { "x-robots-tag": "noindex, nofollow, noarchive, noimageindex" }
+          : {}),
+      },
+    });
   };
+}
+
+export function isVersionedAssetPath(pathname: string): boolean {
+  return /(?:^|[.-])[a-z0-9]{8,}(?=\.)/iu.test(pathname);
+}
+
+export function assetCacheControl(versioned: boolean, testEnvironment: boolean): string {
+  return versioned && !testEnvironment ? "public, max-age=31536000, immutable" : "no-cache";
 }
 
 if (import.meta.main) void main();
@@ -2691,7 +2788,7 @@ export async function readAudienceEvent(
 ): Promise<Response> {
   const eventId = readPathSegment(req.url);
   const result = await projection.read(eventId);
-  if (result.status === "accepted") return sensitiveJson(result);
+  if (result.status === "accepted") return publicRevalidatedJson(req, result);
   return publicAudienceUnavailableResponse();
 }
 
@@ -2703,7 +2800,7 @@ export async function readAudienceGame(
   const eventId = decodePathSegment(segments.at(-3));
   const eventGameId = decodePathSegment(segments.at(-1));
   const result = await projection.readGame(eventId, eventGameId);
-  if (result.status === "accepted") return sensitiveJson(result);
+  if (result.status === "accepted") return publicRevalidatedJson(req, result);
   return publicAudienceUnavailableResponse();
 }
 
@@ -2718,12 +2815,27 @@ export async function readPublicAudienceEventPage(
   return response;
 }
 
+export async function readPublicAudienceGamePage(
+  req: Request,
+  projection: Pick<AudienceProjectionReader, "readGame">,
+  readIndex: () => Response | Promise<Response>,
+): Promise<Response> {
+  const segments = new URL(req.url).pathname.split("/");
+  const result = await projection.readGame(
+    decodePathSegment(segments.at(-3)),
+    decodePathSegment(segments.at(-1)),
+  );
+  const response = await readIndex();
+  if (result.status !== "accepted") response.headers.set("x-robots-tag", "noindex");
+  return response;
+}
+
 export async function readAudienceEvents(
-  _req: Request,
+  req: Request,
   projection: Pick<AudienceProjectionReader, "list">,
 ): Promise<Response> {
   const result = await projection.list();
-  if (result.status === "accepted") return sensitiveJson(result);
+  if (result.status === "accepted") return publicRevalidatedJson(req, result);
   return publicAudienceUnavailableResponse();
 }
 
@@ -2769,6 +2881,16 @@ export async function resolveAdHocWebSocketSubscription({
   if (result.status === "capacity") return result;
   if (result.status !== "accepted") return { status: "unavailable" };
   return { status: "accepted", sessionId: result.game.sessionId, game: result.game };
+}
+
+async function synchronizePublicEventPublication(
+  stream: ReturnType<typeof createPublicAudienceEventStream>,
+  eventId: string,
+  result: { status: string; value?: { publicationStatus?: EventPublicationStatus } },
+) {
+  if (result.status !== "accepted" || result.value?.publicationStatus === undefined) return;
+  if (result.value.publicationStatus === "published") await stream.republish(eventId);
+  else await stream.unpublish(eventId);
 }
 
 export async function readAuthorizedAdHocGame(
@@ -2828,19 +2950,59 @@ async function broadcastGameSnapshot({
 
 function sendMessage(ws: ServerWebSocket<SessionData>, payload: ServerWsMessage) {
   const serialized = JSON.stringify(payload);
+  return sendWebSocketText(ws, serialized, {
+    maxBytes: AD_HOC_MAX_QUEUED_OUTPUT_BYTES,
+    overflowCloseReason: "Ad Hoc output limit reached.",
+    shortSendCloseReason: "Ad Hoc output backpressure.",
+    sendErrorCloseReason: "Ad Hoc output unavailable.",
+  });
+}
+
+function sendPublicEventStreamMessage(
+  ws: ServerWebSocket<SessionData>,
+  payload: PublicAudienceProjectionMessage<PublicAudienceEventProjection>,
+): boolean {
+  return sendPublicAudienceSerializedEnvelope(
+    ws,
+    serializePublicAudienceProjectionMessage(payload),
+  );
+}
+
+function sendPublicAudienceSerializedEnvelope(
+  ws: ServerWebSocket<SessionData>,
+  serialized: string,
+): boolean {
+  return sendWebSocketText(ws, serialized, {
+    shortSendCloseReason: "Public Event stream backpressure.",
+    sendErrorCloseReason: "Public Event stream unavailable.",
+  });
+}
+
+type WebSocketTextSendPolicy = {
+  maxBytes?: number;
+  overflowCloseReason?: string;
+  shortSendCloseReason: string;
+  sendErrorCloseReason: string;
+};
+
+function sendWebSocketText(
+  ws: ServerWebSocket<SessionData>,
+  serialized: string,
+  policy: WebSocketTextSendPolicy,
+): boolean {
   const bytes = new TextEncoder().encode(serialized).byteLength;
-  if (bytes > AD_HOC_MAX_QUEUED_OUTPUT_BYTES) {
-    ws.close(1013, "Ad Hoc output limit reached.");
+  if (policy.maxBytes !== undefined && bytes > policy.maxBytes) {
+    ws.close(1013, policy.overflowCloseReason ?? policy.shortSendCloseReason);
     return false;
   }
   try {
     const sentBytes = ws.send(serialized);
     if (sentBytes !== bytes) {
-      ws.close(1013, "Ad Hoc output backpressure.");
+      ws.close(1013, policy.shortSendCloseReason);
       return false;
     }
   } catch {
-    ws.close(1011, "Ad Hoc output unavailable.");
+    ws.close(1011, policy.sendErrorCloseReason);
     return false;
   }
   return true;
@@ -2950,7 +3112,25 @@ function decodePathSegment(segment: string | undefined): string {
 }
 
 function publicAudienceUnavailableResponse() {
-  return sensitiveJson(PUBLIC_AUDIENCE_ABSENCE, 404);
+  return sensitiveJson(PUBLIC_AUDIENCE_ABSENCE, 404, [["x-robots-tag", "noindex"]]);
+}
+
+function publicRevalidatedJson(req: Request, payload: unknown): Response {
+  const body = JSON.stringify(payload);
+  const etag = contentEtag(body);
+  const headers = new Headers({
+    "cache-control": "no-cache",
+    "content-type": "application/json",
+    etag,
+    "referrer-policy": "no-referrer",
+  });
+  return req.headers.get("if-none-match") === etag
+    ? new Response(null, { status: 304, headers })
+    : new Response(body, { headers });
+}
+
+function contentEtag(content: string): string {
+  return `"sha256-${createHash("sha256").update(content).digest("base64url")}"`;
 }
 
 function audienceRobotsResponse(req: Request): Response {

--- a/src/lib/ad-hoc-resource-budgets.ts
+++ b/src/lib/ad-hoc-resource-budgets.ts
@@ -18,12 +18,13 @@ export const AD_HOC_REPLAY_SUSTAINED_PER_SECOND = 20;
 export const AD_HOC_REPLAY_BURST = AD_HOC_REPLAY_SUSTAINED_PER_SECOND;
 export const AD_HOC_REPLAY_MAX_UNACKNOWLEDGED_BATCHES = 1;
 
-// This is an Ad Hoc-only ceiling.  Event connection capacity is not read or
-// mutated here, so a full Ad Hoc pool cannot consume Event capacity.
+// Ad Hoc still applies its own 256-controller workflow cap below. The shared
+// WebSocket envelope leaves room for 500 public spectators and two reserved
+// Controller connections before role-specific admission.
 export const AD_HOC_MAX_CONNECTED_CONTROLLERS = 256;
 export const AD_HOC_MAX_QUEUED_OUTPUT_BYTES = 256 * 1024;
-export const AD_HOC_EVENT_TOTAL_CONNECTION_CAPACITY = AD_HOC_MAX_CONNECTED_CONTROLLERS + 1;
-export const AD_HOC_EVENT_RESERVED_CONNECTION_CAPACITY = 1;
+export const AD_HOC_EVENT_TOTAL_CONNECTION_CAPACITY = 502;
+export const AD_HOC_EVENT_RESERVED_CONNECTION_CAPACITY = 2;
 
 export type AdHocResourceMetric =
   | "creation-delay"

--- a/src/lib/audience-projection.test.ts
+++ b/src/lib/audience-projection.test.ts
@@ -21,7 +21,7 @@ import {
 } from "@/lib/event-catalog";
 import type { EventGameRecordRoot } from "@/lib/foundation-record-types";
 import { createInMemoryFoundationStorage } from "@/lib/foundation-storage-memory";
-import type { ControllerProjection } from "@/lib/live-event-game-control";
+import type { ControllerGameFact, ControllerProjection } from "@/lib/live-event-game-control";
 import { readAudienceProjectionGameInput } from "@/lib/live-event-game-runtime";
 import {
   MemoryTechnicalAdminAuthRepository,
@@ -96,7 +96,6 @@ describe("Audience Publication Projection", () => {
     expect(result).toMatchObject({
       status: "accepted",
       value: {
-        identityNotice: "event-team-identities-current",
         eventGames: [
           {
             eventGameId: game.eventGameId,
@@ -111,6 +110,128 @@ describe("Audience Publication Projection", () => {
     if (result.status !== "accepted") return;
     expect(result.value).not.toHaveProperty("auditTrail");
     expect(result.value).not.toHaveProperty("reason");
+  });
+
+  test("fails closed on an injected live reader failure while preserving catalog-only projection", async () => {
+    const game = createScheduleGame("live-failure", "2026-08-14T10:00:00.000Z", "Pitch 1");
+    const root = createScheduleRoot("live-failure", "in-progress");
+    const snapshot = createScheduleSnapshot({
+      pitches: ["Pitch 1"],
+      games: [game],
+      roots: new Map([[game.eventGameId, root]]),
+      actions: () => [createGoalAction(root)],
+    });
+    const storage = {
+      snapshot: async () => snapshot,
+    } as unknown as EventCatalogFoundationStorage;
+
+    expect((await createAudienceProjection(storage).read("event-schedule")).status).toBe(
+      "accepted",
+    );
+    for (const status of ["unavailable", "retryable-failure"] as const) {
+      const audience = createAudienceProjection(storage, {
+        gameInput: { read: async () => ({ status }) },
+      });
+      expect((await audience.read("event-schedule")).status).toBe(status);
+    }
+  });
+
+  test("uses one runtime snapshot for Timeline semantics and scopes the neutral correction notice", async () => {
+    const correctedGame = createScheduleGame(
+      "runtime-corrected",
+      "2026-08-14T10:00:00.000Z",
+      "Pitch 1",
+    );
+    const ordinaryGame = createScheduleGame(
+      "runtime-ordinary",
+      "2026-08-14T11:00:00.000Z",
+      "Pitch 1",
+    );
+    const correctedRoot = createScheduleRoot("runtime-corrected", "in-progress");
+    const ordinaryRoot = createScheduleRoot("runtime-ordinary", "scheduled");
+    const snapshot = createScheduleSnapshot({
+      pitches: ["Pitch 1"],
+      games: [correctedGame, ordinaryGame],
+      roots: new Map([
+        [correctedGame.eventGameId, correctedRoot],
+        [ordinaryGame.eventGameId, ordinaryRoot],
+      ]),
+    });
+    const runtimeProjection = createAudienceControllerProjection({
+      overtime: true,
+      overtimeTarget: 70,
+      catch: {
+        factId: "runtime-catch",
+        catchingGameSideId: correctedRoot.gameSides[0]!.id,
+        nonCatchingGameSideId: correctedRoot.gameSides[1]!.id,
+        gameTimeMs: 1_000,
+        targetScore: 70,
+      },
+      presentation: createInitialGamePresentation(
+        [correctedRoot.gameSides[0]!.id, correctedRoot.gameSides[1]!.id],
+        {
+          [correctedRoot.gameSides[0]!.id]: "#123abc",
+          [correctedRoot.gameSides[1]!.id]: "#456def",
+        },
+      ),
+      gameFacts: [
+        {
+          factId: "runtime-catch",
+          factType: "flag-catch",
+          gameSideId: correctedRoot.gameSides[0]!.id,
+          gameTimeMs: 1_000,
+          sportingOrder: 1,
+          synchronizationOrder: 1,
+          effective: true,
+          data: { points: 30 },
+        },
+      ],
+      teamAssignmentCorrections: [
+        {
+          operationId: "private-correction-operation",
+          gameSideId: correctedRoot.gameSides[0]!.id,
+          eventTeamId: "team-current",
+          eventTeamName: "Current Team",
+          teamInterpretationRef: "private-interpretation",
+        },
+      ],
+    });
+    const correctedInput = readAudienceProjectionGameInput(correctedRoot, runtimeProjection);
+    const ordinaryInput = readAudienceProjectionGameInput(
+      ordinaryRoot,
+      createAudienceControllerProjection({ phase: "scheduled" }),
+    );
+    const audience = createAudienceProjection(
+      { snapshot: async () => snapshot } as unknown as EventCatalogFoundationStorage,
+      {
+        now: () => Date.parse("2026-08-14T10:00:00.000Z"),
+        gameInput: {
+          read: async (eventGameId) =>
+            eventGameId === correctedGame.eventGameId ? correctedInput : ordinaryInput,
+        },
+      },
+    );
+
+    const result = await audience.read("event-schedule");
+    expect(result.status).toBe("accepted");
+    if (result.status !== "accepted") return;
+    expect(result.value.teamAssignmentNotice).toBe("event-team-assignment-corrected");
+    const corrected = result.value.schedule.scheduleGames.find(
+      (game) => game.eventGameId === correctedGame.eventGameId,
+    );
+    const ordinary = result.value.schedule.scheduleGames.find(
+      (game) => game.eventGameId === ordinaryGame.eventGameId,
+    );
+    expect(corrected).toMatchObject({
+      teamAssignmentNotice: "event-team-assignment-corrected",
+      phase: "overtime",
+      overtimeTarget: 70,
+      presentation: { displayedTeamColors: { sideA: "#123abc", sideB: "#456def" } },
+    });
+    expect(corrected?.timeline.map((entry) => entry.kind)).toEqual(["overtime", "flag-catch"]);
+    expect(ordinary).not.toHaveProperty("teamAssignmentNotice");
+    expect(JSON.stringify(result.value)).not.toContain("private-correction-operation");
+    expect(JSON.stringify(result.value)).not.toContain("private-interpretation");
   });
 
   test("embeds a roster-resolved Timeline and isolates roster reads by Event", async () => {
@@ -176,6 +297,25 @@ describe("Audience Publication Projection", () => {
               winnerGameSideId: null,
               catchingGameSideId: null,
               locked: true,
+              gameFacts: [
+                {
+                  factId: `goal-fact-${root.eventGameId}`,
+                  factType: "goal",
+                  gameSideId: root.gameSides[0]!.id,
+                  gameTimeMs: 1,
+                  sportingOrder: 1,
+                  synchronizationOrder: 1,
+                  effective: true,
+                  data: { points: 10, playerNumber: 3 },
+                },
+              ],
+              timelineState: {
+                catch: null,
+                overtime: false,
+                overtimeTarget: null,
+                result: null,
+              },
+              teamAssignmentCorrected: false,
             },
           }),
         },
@@ -205,6 +345,123 @@ describe("Audience Publication Projection", () => {
         player: { number: 3, name: "Current Goal Player" },
       }),
     );
+  });
+
+  test("keeps effective locked-correction history across reopening without public provenance", async () => {
+    const game = createScheduleGame("locked-reopen", "2026-08-14T08:00:00.000Z", "Pitch 1");
+    const root = createScheduleRoot("locked-reopen", "finished");
+    const snapshot = createScheduleSnapshot({
+      pitches: ["Pitch 1"],
+      games: [game],
+      roots: new Map([[game.eventGameId, root]]),
+    });
+    const publicFacts: readonly ControllerGameFact[] = [
+      {
+        factId: "corrected-goal",
+        factType: "goal",
+        gameSideId: root.gameSides[0]!.id,
+        gameTimeMs: 1_000,
+        sportingOrder: 1,
+        synchronizationOrder: 1,
+        effective: true,
+        data: { points: 30, playerNumber: 3 },
+      },
+      {
+        factId: "corrected-result",
+        factType: "result",
+        gameSideId: root.gameSides[0]!.id,
+        gameTimeMs: 2_000,
+        sportingOrder: 2,
+        synchronizationOrder: 2,
+        effective: true,
+        data: { resultKind: "corrected-result" },
+      },
+      {
+        factId: "private-locked-correction",
+        factType: "locked-game-correction",
+        gameSideId: null,
+        gameTimeMs: null,
+        sportingOrder: 3,
+        synchronizationOrder: 3,
+        effective: true,
+        data: { reason: "PRIVATE_LOCKED_CORRECTION_REASON" },
+      },
+      {
+        factId: "private-game-reopening",
+        factType: "game-reopening",
+        gameSideId: null,
+        gameTimeMs: null,
+        sportingOrder: 4,
+        synchronizationOrder: 4,
+        effective: true,
+        data: { operationId: "PRIVATE_REOPEN_OPERATION" },
+      },
+    ];
+    let locked = true;
+    const audience = createAudienceProjection(
+      { snapshot: async () => snapshot } as unknown as EventCatalogFoundationStorage,
+      {
+        now: () => Date.parse("2026-08-14T10:00:00.000Z"),
+        gameInput: {
+          read: async () => ({
+            status: "accepted" as const,
+            value: {
+              gameSideIds: [root.gameSides[0]!.id, root.gameSides[1]!.id] as const,
+              phase: "seeker-floor" as const,
+              operationalStatus: "finished" as const,
+              scoreByGameSide: { [root.gameSides[0]!.id]: 30, [root.gameSides[1]!.id]: 20 },
+              clock: null,
+              presentation: null,
+              overtimeTarget: null,
+              teamTimeout: { status: "inactive" as const, gameSideId: null, remainingMs: null },
+              heatStoppage: {
+                status: "inactive" as const,
+                mode: null,
+                pending: false,
+                allowedDurationMs: null,
+                actualDurationMs: null,
+                remainingMs: null,
+              },
+              winnerGameSideId: root.gameSides[0]!.id,
+              catchingGameSideId: root.gameSides[0]!.id,
+              locked,
+              gameFacts: publicFacts,
+              timelineState: {
+                catch: null,
+                overtime: false,
+                overtimeTarget: null,
+                result: { factId: "corrected-result" },
+              },
+              teamAssignmentCorrected: false,
+            },
+          }),
+        },
+      },
+    );
+
+    const beforeReopen = await audience.readGame("event-schedule", game.eventGameId);
+    expect(beforeReopen).toMatchObject({
+      status: "accepted",
+      value: {
+        result: { status: "finished", winner: "side-a", locked: true },
+        flagState: { catchingSide: "side-a" },
+      },
+    });
+    if (beforeReopen.status !== "accepted") return;
+    locked = false;
+    const afterReopen = await audience.readGame("event-schedule", game.eventGameId);
+    expect(afterReopen).toMatchObject({
+      status: "accepted",
+      value: { result: { status: "finished", winner: "side-a", locked: false } },
+    });
+    if (afterReopen.status !== "accepted") return;
+    expect(afterReopen.value.timeline).toEqual(beforeReopen.value.timeline);
+    expect(afterReopen.value.timeline.map((entry) => entry.kind)).toEqual(["finish", "goal"]);
+    const serialized = JSON.stringify(afterReopen.value);
+    expect(serialized).not.toContain("locked-game-correction");
+    expect(serialized).not.toContain("game-reopening");
+    expect(serialized).not.toContain("PRIVATE_LOCKED_CORRECTION_REASON");
+    expect(serialized).not.toContain("PRIVATE_REOPEN_OPERATION");
   });
 
   test("projects concession, forfeit, and double-forfeit outcomes", async () => {
@@ -854,6 +1111,14 @@ describe("Audience Publication Projection", () => {
               winnerGameSideId: null,
               catchingGameSideId: null,
               locked: false,
+              gameFacts: [],
+              timelineState: {
+                catch: null,
+                overtime: false,
+                overtimeTarget: null,
+                result: null,
+              },
+              teamAssignmentCorrected: false,
             },
           }),
         },
@@ -906,14 +1171,18 @@ describe("Audience Publication Projection", () => {
     expect(serialized).not.toContain("correction");
     expect(serialized).not.toContain("provenance");
     expect(serialized).not.toContain("authority");
-    const httpResponse = await readAudienceGame(
-      new Request(
-        `https://timer.example/api/audience/events/${event.eventId}/games/${game.eventGameId}`,
-      ),
+    const gameUrl = `https://timer.example/api/audience/events/${event.eventId}/games/${game.eventGameId}`;
+    const httpResponse = await readAudienceGame(new Request(gameUrl), audience);
+    expect(httpResponse.status).toBe(200);
+    expect(httpResponse.headers.get("cache-control")).toBe("no-cache");
+    const etag = httpResponse.headers.get("etag");
+    expect(etag).not.toBeNull();
+    const revalidated = await readAudienceGame(
+      new Request(gameUrl, { headers: { "if-none-match": etag ?? "" } }),
       audience,
     );
-    expect(httpResponse.status).toBe(200);
-    expect(httpResponse.headers.get("cache-control")).toBe("no-store");
+    expect(revalidated.status).toBe(304);
+    expect(await revalidated.text()).toBe("");
     expect(await httpResponse.text()).toContain('"status":"accepted"');
   });
 
@@ -933,6 +1202,8 @@ describe("Audience Publication Projection", () => {
     const bodies = await Promise.all(responses.map((response) => response.text()));
     expect(bodies[0]).toBe(bodies[1]);
     expect(bodies[0]).toBe('{"status":"unavailable"}');
+    expect(responses[0]?.headers.get("cache-control")).toBe("no-store");
+    expect(responses[0]?.headers.get("x-robots-tag")).toBe("noindex");
   });
 
   test("table-drives the runtime adapter through the one public projector", async () => {

--- a/src/lib/audience-projection.ts
+++ b/src/lib/audience-projection.ts
@@ -10,6 +10,7 @@ import { projectClockBaseline } from "@/lib/clock-authority";
 import {
   projectPublicGameTimeline,
   type PublicAudienceTimelineEntry,
+  type PublicAudienceTimelineDerivedState,
 } from "@/lib/game-timeline-projection";
 import {
   projectLiveEventGameDerivedState,
@@ -106,6 +107,7 @@ export type PublicAudienceClockProjection = {
 
 export type PublicAudienceGameProjection = PublicAudienceGameOperationalProjection & {
   eventId: string;
+  eventGameId: string;
   gameCode: string | null;
   gameDesignation: string | null;
   scheduledStartMs: number;
@@ -127,6 +129,8 @@ export type PublicAudienceGameProjection = PublicAudienceGameOperationalProjecti
   };
   canonicalPath: string;
   timeline: readonly PublicAudienceTimelineEntry[];
+  /** Temporary neutral notice; correction evidence and provenance stay private. */
+  teamAssignmentNotice?: "event-team-assignment-corrected";
 };
 
 /** Allowlisted, server-side input for one public Audience Projection. */
@@ -147,6 +151,9 @@ export type AudienceProjectionGameInput = {
   winnerGameSideId: string | null;
   catchingGameSideId: string | null;
   locked: boolean;
+  gameFacts: LiveEventGameDerivedState["gameFacts"];
+  timelineState: PublicAudienceTimelineDerivedState;
+  teamAssignmentCorrected: boolean;
 };
 
 export type AudienceProjectionGameInputOutcome =
@@ -177,8 +184,8 @@ export type PublicAudienceEventProjection = {
   canonicalPath: string;
   teams: readonly PublicAudienceEventTeam[];
   pitches: readonly PublicAudiencePitch[];
-  /** Neutral public state; correction reasons, audit rows, and provenance stay private. */
-  identityNotice?: "event-team-identities-current";
+  /** Temporary neutral notice; correction evidence and provenance stay private. */
+  teamAssignmentNotice?: "event-team-assignment-corrected";
   /** Allowlisted identity input for downstream roster and public Timeline composition. */
   eventGames?: readonly PublicAudienceEventGameInput[];
   schedule: PublicAudienceScheduleProjection;
@@ -237,8 +244,12 @@ export function createAudienceProjection(
         const event = snapshot.findEvent(eventId);
         if (event === null || event.publicationStatus !== "published")
           return { status: "unavailable" };
-        return { status: "accepted", value: projectPublicEvent(snapshot, event, now()) };
-      } catch {
+        return {
+          status: "accepted",
+          value: await projectPublicEvent(snapshot, event, now(), options.gameInput),
+        };
+      } catch (error) {
+        if (error instanceof GameInputReadError) return { status: error.status };
         return { status: "retryable-failure" };
       }
     },
@@ -247,8 +258,7 @@ export function createAudienceProjection(
         typeof eventId !== "string" ||
         eventId.trim().length === 0 ||
         typeof eventGameId !== "string" ||
-        eventGameId.trim().length === 0 ||
-        options.gameInput === undefined
+        eventGameId.trim().length === 0
       )
         return { status: "unavailable" };
       try {
@@ -262,13 +272,19 @@ export function createAudienceProjection(
           game.eventId !== eventId
         )
           return { status: "unavailable" };
-        const input = await options.gameInput.read(eventGameId);
-        if (input.status !== "accepted") return input;
         const projected = projectScheduleGames(snapshot, [game]).at(0);
         if (projected === undefined) return { status: "unavailable" };
+        const input = await options.gameInput?.read(eventGameId);
+        if (input !== undefined && input.status !== "accepted") return input;
         return {
           status: "accepted",
-          value: projectAudienceGameFromInput(snapshot, event, projected, input.value, now()),
+          value: projectAudienceGameFromInput(
+            snapshot,
+            event,
+            projected,
+            input?.value ?? readAudienceProjectionGameInputFromCatalog(snapshot, projected, now()),
+            now(),
+          ),
         };
       } catch {
         return { status: "retryable-failure" };
@@ -278,10 +294,12 @@ export function createAudienceProjection(
       try {
         const snapshot = await storage.snapshot();
         const nowMs = now();
-        const events = snapshot
-          .listEvents()
-          .filter((event) => event.publicationStatus === "published")
-          .map((event) => projectPublicEvent(snapshot, event, nowMs));
+        const events = await Promise.all(
+          snapshot
+            .listEvents()
+            .filter((event) => event.publicationStatus === "published")
+            .map((event) => projectPublicEvent(snapshot, event, nowMs, options.gameInput)),
+        );
         return {
           status: "accepted",
           value: { events: sortPublicEvents(events) },
@@ -293,15 +311,20 @@ export function createAudienceProjection(
   };
 }
 
-function projectPublicEvent(
+async function projectPublicEvent(
   snapshot: EventCatalogStorageSnapshot,
   event: StoredEvent,
   nowMs: number,
-): PublicAudienceEventProjection {
+  gameInput?: AudienceProjectionGameInputReader,
+): Promise<PublicAudienceEventProjection> {
   const gameDays = snapshot
     .listGameDays(event.eventId)
     .map(({ date }) => date)
     .sort();
+  const schedule = await projectSchedule(snapshot, event, nowMs, gameInput);
+  const teamAssignmentCorrected = schedule.scheduleGames.some(
+    (game) => game.teamAssignmentNotice !== undefined,
+  );
   return {
     eventId: event.eventId,
     name: event.name,
@@ -315,7 +338,9 @@ function projectPublicEvent(
       color: defaultColor,
     })),
     pitches: snapshot.listPitches(event.eventId).map(({ name }) => ({ name })),
-    identityNotice: "event-team-identities-current",
+    ...(teamAssignmentCorrected
+      ? { teamAssignmentNotice: "event-team-assignment-corrected" as const }
+      : {}),
     eventGames: snapshot
       .listGameDays(event.eventId)
       .flatMap((day) => snapshot.listEventGames(day.gameDayId))
@@ -334,7 +359,7 @@ function projectPublicEvent(
           },
         ],
       })) as PublicAudienceEventGameInput[],
-    schedule: projectSchedule(snapshot, event, nowMs),
+    schedule,
   };
 }
 
@@ -353,6 +378,7 @@ function projectAudienceGameFromInput(
   const multiplePitches = snapshot.listPitches(event.eventId).length > 1;
   return {
     eventId: event.eventId,
+    eventGameId: game.eventGameId,
     gameCode: game.gameCode,
     gameDesignation: game.gameDesignation,
     scheduledStartMs: scheduledStartForGame(snapshot, game),
@@ -397,7 +423,10 @@ function projectAudienceGameFromInput(
       },
     },
     canonicalPath: `/events/${encodeURIComponent(event.eventId)}/games/${encodeURIComponent(game.eventGameId)}`,
-    timeline: projectAudienceGameTimeline(snapshot, game),
+    timeline: projectAudienceGameTimeline(snapshot, game, input.gameFacts, input.timelineState),
+    ...(input.teamAssignmentCorrected
+      ? { teamAssignmentNotice: "event-team-assignment-corrected" as const }
+      : {}),
   };
 }
 
@@ -427,11 +456,12 @@ function sideForGameSideId(
   return gameSideId === gameSideIds[0] ? "side-a" : gameSideId === gameSideIds[1] ? "side-b" : null;
 }
 
-function projectSchedule(
+async function projectSchedule(
   snapshot: EventCatalogStorageSnapshot,
   event: StoredEvent,
   nowMs: number,
-): PublicAudienceScheduleProjection {
+  gameInput?: AudienceProjectionGameInputReader,
+): Promise<PublicAudienceScheduleProjection> {
   const eventId = event.eventId;
   const gamesById = new Map<string, EventGame>();
   for (const gameDay of snapshot.listGameDays(eventId)) {
@@ -441,17 +471,23 @@ function projectSchedule(
     }
   }
 
-  const projected = projectScheduleGames(snapshot, [...gamesById.values()])
-    .map((game) =>
-      projectAudienceGameFromInput(
-        snapshot,
-        event,
-        game,
-        readAudienceProjectionGameInputFromCatalog(snapshot, game, nowMs),
-        nowMs,
-      ),
+  const projected = (
+    await Promise.all(
+      projectScheduleGames(snapshot, [...gamesById.values()]).map(async (game) => {
+        const current = await gameInput?.read(game.eventGameId);
+        if (current !== undefined && current.status !== "accepted") {
+          throw new GameInputReadError(current.status);
+        }
+        return projectAudienceGameFromInput(
+          snapshot,
+          event,
+          game,
+          current?.value ?? readAudienceProjectionGameInputFromCatalog(snapshot, game, nowMs),
+          nowMs,
+        );
+      }),
     )
-    .sort(compareAudienceGames);
+  ).sort(compareAudienceGames);
   const runningGames = projected.filter((game) => game.scheduleStatus === "running");
   const upcomingGames = projected.filter(
     (game) =>
@@ -508,19 +544,38 @@ function readAudienceProjectionGameInputFromCatalog(
     winnerGameSideId: derived?.winnerGameSideId ?? null,
     catchingGameSideId: derived?.catch?.catchingGameSideId ?? null,
     locked: root?.lifecycle.lockedAtMs !== null && root?.lifecycle.lockedAtMs !== undefined,
+    gameFacts: structuredClone(derived?.gameFacts ?? []),
+    timelineState: {
+      catch:
+        derived?.catch === null || derived?.catch === undefined
+          ? null
+          : {
+              factId: derived.catch.factId,
+              gameTimeMs: derived.catch.gameTimeMs,
+              catchingGameSideId: derived.catch.catchingGameSideId,
+            },
+      overtime: derived?.overtime ?? false,
+      overtimeTarget: derived?.overtimeTarget ?? null,
+      result:
+        derived?.result === null || derived?.result === undefined
+          ? null
+          : { factId: derived.result.factId },
+    },
+    teamAssignmentCorrected: false,
   };
 }
 
 function projectAudienceGameTimeline(
   snapshot: EventCatalogStorageSnapshot,
   game: ProjectedEventGame,
+  gameFacts: LiveEventGameDerivedState["gameFacts"],
+  timelineState: PublicAudienceTimelineDerivedState,
 ): readonly PublicAudienceTimelineEntry[] {
   const root = snapshot.findRootByEventGameId(game.eventGameId);
   if (root === null) return [];
-  const derived = readDerivedState(snapshot, root);
   const sideAssignments = publicTimelineSideAssignments(snapshot, game, root);
   return projectPublicGameTimeline({
-    facts: derived.gameFacts,
+    facts: gameFacts,
     sideA: sideAssignments.sideA,
     sideB: sideAssignments.sideB,
     lookupRosterName: (eventTeamId, playerNumber) => {
@@ -529,8 +584,14 @@ function projectAudienceGameTimeline(
       const entry = snapshot.findRosterEntry(eventTeamId, playerNumber);
       return entry?.eventId === game.eventId ? entry.publicName : null;
     },
-    derived,
+    derived: timelineState,
   });
+}
+
+class GameInputReadError extends Error {
+  constructor(readonly status: Exclude<AudienceProjectionGameInputOutcome["status"], "accepted">) {
+    super("Authoritative Event Game input is unavailable.");
+  }
 }
 
 function publicTimelineSideAssignments(

--- a/src/lib/controller-capacity.ts
+++ b/src/lib/controller-capacity.ts
@@ -4,6 +4,13 @@ export type ControllerCapacityInput = {
   activeControllerSessions: number;
 };
 
+/** Read-only Controller capacity signal shared by non-Controller admission paths. */
+export type ControllerCapacitySignal = {
+  totalConnections: number;
+  reservedConnections: number;
+  activeControllerSessions: () => number;
+};
+
 /**
  * Return non-Controller capacity after honoring the configured reserve,
  * active authoritative Controller Sessions, and an optional workflow cap.

--- a/src/lib/event-connection-capacity.test.ts
+++ b/src/lib/event-connection-capacity.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import { readEventConnectionCapacity } from "@/lib/event-connection-capacity";
+
+describe("Event connection capacity configuration", () => {
+  test("provides one sanitized envelope with a live Controller count", () => {
+    let activeControllers = 1;
+    const capacity = readEventConnectionCapacity(
+      {
+        EVENT_TOTAL_CONNECTION_CAPACITY: "610",
+        EVENT_RESERVED_CONNECTION_CAPACITY: "3",
+      },
+      () => activeControllers,
+    );
+
+    expect(capacity.totalConnections).toBe(610);
+    expect(capacity.reservedConnections).toBe(3);
+    expect(capacity.activeControllerSessions()).toBe(1);
+    activeControllers = 4;
+    expect(capacity.activeControllerSessions()).toBe(4);
+  });
+
+  test("uses the accepted 502 total and 2 reserved defaults for invalid input", () => {
+    const capacity = readEventConnectionCapacity(
+      {
+        EVENT_TOTAL_CONNECTION_CAPACITY: "invalid",
+        EVENT_RESERVED_CONNECTION_CAPACITY: "-1",
+      },
+      () => 0,
+    );
+    expect(capacity).toMatchObject({ totalConnections: 502, reservedConnections: 2 });
+  });
+});

--- a/src/lib/event-connection-capacity.ts
+++ b/src/lib/event-connection-capacity.ts
@@ -1,0 +1,29 @@
+import {
+  AD_HOC_EVENT_RESERVED_CONNECTION_CAPACITY,
+  AD_HOC_EVENT_TOTAL_CONNECTION_CAPACITY,
+} from "@/lib/ad-hoc-resource-budgets";
+import type { ControllerCapacitySignal } from "@/lib/controller-capacity";
+
+/** One process-wide Event connection envelope shared by admission and spectator fan-out. */
+export function readEventConnectionCapacity(
+  environment: Record<string, string | undefined>,
+  activeControllerSessions: () => number,
+): ControllerCapacitySignal {
+  return {
+    totalConnections: readCapacity(
+      environment.EVENT_TOTAL_CONNECTION_CAPACITY,
+      AD_HOC_EVENT_TOTAL_CONNECTION_CAPACITY,
+    ),
+    reservedConnections: readCapacity(
+      environment.EVENT_RESERVED_CONNECTION_CAPACITY,
+      AD_HOC_EVENT_RESERVED_CONNECTION_CAPACITY,
+    ),
+    activeControllerSessions,
+  };
+}
+
+function readCapacity(value: string | undefined, fallback: number): number {
+  if (value === undefined || value.trim() === "") return fallback;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : fallback;
+}

--- a/src/lib/game-timeline-projection.test.ts
+++ b/src/lib/game-timeline-projection.test.ts
@@ -57,10 +57,8 @@ describe("public Game Timeline projection", () => {
       derived: {
         catch: {
           factId: "catch-fact",
-          catchingGameSideId: "side-a",
-          nonCatchingGameSideId: "side-b",
           gameTimeMs: 6_000,
-          targetScore: 60,
+          catchingGameSideId: "side-a",
         },
         overtime: true,
         overtimeTarget: 60,
@@ -214,13 +212,11 @@ describe("public Game Timeline projection", () => {
         catch: {
           factId: "locked-correction",
           catchingGameSideId: "side-a",
-          nonCatchingGameSideId: "side-b",
           gameTimeMs: 1_500,
-          targetScore: null,
         },
         overtime: false,
         overtimeTarget: null,
-        result: { factId: "locked-correction", data: { resultKind: "result" } },
+        result: { factId: "locked-correction" },
       },
     });
 

--- a/src/lib/game-timeline-projection.ts
+++ b/src/lib/game-timeline-projection.ts
@@ -71,7 +71,17 @@ export type PublicAudienceTimelineProjectionInput = {
   sideA: PublicAudienceTimelineSide;
   sideB: PublicAudienceTimelineSide;
   lookupRosterName: (eventTeamId: string, playerNumber: number) => string | null;
-  derived: Pick<LiveEventGameDerivedState, "catch" | "overtime" | "overtimeTarget" | "result">;
+  derived: PublicAudienceTimelineDerivedState;
+};
+
+export type PublicAudienceTimelineDerivedState = {
+  catch: null | Pick<
+    NonNullable<LiveEventGameDerivedState["catch"]>,
+    "factId" | "gameTimeMs" | "catchingGameSideId"
+  >;
+  overtime: boolean;
+  overtimeTarget: number | null;
+  result: null | Pick<NonNullable<LiveEventGameDerivedState["result"]>, "factId">;
 };
 
 const PUBLIC_FACT_TYPES = new Set([

--- a/src/lib/live-event-game-runtime.ts
+++ b/src/lib/live-event-game-runtime.ts
@@ -12,6 +12,7 @@ import {
   openSqliteFoundationStorage,
   readSqliteFoundationStorageReadiness,
 } from "@/lib/foundation-storage-sqlite";
+import { createControlActionCodecRegistry } from "@/lib/event-game-actions";
 import {
   createLiveEventGameControl,
   createLiveEventGameIqaInterpreter,
@@ -112,6 +113,24 @@ export function readAudienceProjectionGameInput(
     winnerGameSideId: projection.winnerGameSideId ?? null,
     catchingGameSideId: projection.catch?.catchingGameSideId ?? null,
     locked: root.lifecycle.lockedAtMs !== null,
+    gameFacts: structuredClone(projection.gameFacts ?? []),
+    timelineState: {
+      catch:
+        projection.catch === null || projection.catch === undefined
+          ? null
+          : {
+              factId: projection.catch.factId,
+              gameTimeMs: projection.catch.gameTimeMs,
+              catchingGameSideId: projection.catch.catchingGameSideId,
+            },
+      overtime: projection.overtime ?? false,
+      overtimeTarget: projection.overtimeTarget ?? null,
+      result:
+        projection.result === null || projection.result === undefined
+          ? null
+          : { factId: projection.result.factId },
+    },
+    teamAssignmentCorrected: (projection.teamAssignmentCorrections?.length ?? 0) > 0,
   };
   return { status: "accepted", value };
 }
@@ -122,6 +141,7 @@ export async function openLiveEventGameRuntime(input: {
   keyRing: GrantKeyRing;
   clock?: () => number;
   knownDodgeballIdsForEventGame?: (eventGameId: string) => readonly string[] | undefined;
+  onControllerCapacityChange?: () => void;
 }): Promise<LiveEventGameRuntime> {
   const readiness = await readSqliteFoundationStorageReadiness(input.databasePath, {
     grantKeyRing: input.keyRing,
@@ -132,13 +152,20 @@ export async function openLiveEventGameRuntime(input: {
 
   const storage = openSqliteFoundationStorage(input.databasePath, { grantKeyRing: input.keyRing });
   try {
+    storage.setReadinessContext({
+      actionCodecRegistry: createControlActionCodecRegistry(),
+      interpreter: createLiveEventGameIqaInterpreter(),
+    });
     const clock = input.clock ?? (() => Date.now());
     let refreshEventCapacitySnapshot = () => {};
     const grantOptions = createGrantOptions(
       input.environmentId,
       input.keyRing,
       clock,
-      () => refreshEventCapacitySnapshot(),
+      () => {
+        refreshEventCapacitySnapshot();
+        input.onControllerCapacityChange?.();
+      },
       storage,
     );
     const authority = createTypedGrantAuthority(storage, grantOptions);

--- a/src/lib/public-audience-event-stream.ts
+++ b/src/lib/public-audience-event-stream.ts
@@ -1,0 +1,171 @@
+import type {
+  AudienceProjectionReader,
+  PublicAudienceEventProjection,
+} from "@/lib/audience-projection";
+import { canonicalizeJson } from "@/lib/event-game-action-json";
+import {
+  createPublicEventStream,
+  type PublicAudienceProjectionProvider,
+  type PublicAudienceProjectionStream,
+} from "@/lib/public-event-stream";
+
+export type PublicAudienceEventStream =
+  PublicAudienceProjectionStream<PublicAudienceEventProjection> & { close(): void };
+
+/**
+ * The adapter owns a process-local monotonic revision for the authoritative
+ * Audience Projection it has read. The complete public Timeline is assembled
+ * by the Audience Projection boundary from the catalog and live Game inputs.
+ */
+export function createPublicAudienceEventStream(
+  projection: Pick<AudienceProjectionReader, "read">,
+  options: { refreshIntervalMs?: number } = {},
+): PublicAudienceEventStream {
+  const revisions = new Map<string, { fingerprint: string; version: number }>();
+  const provider: PublicAudienceProjectionProvider<PublicAudienceEventProjection> = {
+    async read(eventId) {
+      const result = await projection.read(eventId);
+      if (result.status === "retryable-failure") return { status: "retryable-failure" };
+      if (result.status !== "accepted") return { status: "unavailable" };
+      const fingerprint = canonicalizeJson(result.value);
+      const previous = revisions.get(eventId);
+      const version =
+        previous === undefined
+          ? 1
+          : previous.fingerprint === fingerprint
+            ? previous.version
+            : previous.version + 1;
+      revisions.set(eventId, { fingerprint, version });
+      return {
+        status: "accepted",
+        snapshot: {
+          eventId: result.value.eventId,
+          version,
+          projection: result.value,
+        },
+      };
+    },
+  };
+  const stream = createPublicEventStream(provider);
+  const subscribedEventIds = new Set<string>();
+  const lifecycleGenerations = new Map<string, number>();
+  const refreshStates = new Map<string, { inFlight: boolean; pending: boolean }>();
+  let closed = false;
+  const refreshIntervalMs = options.refreshIntervalMs ?? 250;
+  const refreshTimer = setInterval(() => {
+    for (const eventId of subscribedEventIds) {
+      if (stream.subscriberCount(eventId) === 0) {
+        subscribedEventIds.delete(eventId);
+        continue;
+      }
+      requestRefresh(eventId);
+    }
+  }, refreshIntervalMs);
+
+  return {
+    ...stream,
+    async subscribe(eventId, subscriber) {
+      if (closed) return { status: "unavailable" };
+      const startsLifecycle = stream.subscriberCount(eventId) === 0;
+      const result = await stream.subscribe(eventId, subscriber);
+      if (result.status === "accepted") {
+        if (startsLifecycle) invalidateLifecycle(eventId);
+        subscribedEventIds.add(eventId);
+        const unsubscribe = result.subscription.unsubscribe.bind(result.subscription);
+        result.subscription.unsubscribe = () => {
+          unsubscribe();
+          if (stream.subscriberCount(eventId) === 0) {
+            subscribedEventIds.delete(eventId);
+            invalidateLifecycle(eventId);
+          }
+        };
+      }
+      return result;
+    },
+    terminateSubscribers(eventId) {
+      terminateCurrentSubscribers(eventId);
+    },
+    async unpublish(eventId) {
+      invalidateLifecycle(eventId);
+      subscribedEventIds.delete(eventId);
+      await stream.unpublish(eventId);
+    },
+    async republish(eventId) {
+      invalidateLifecycle(eventId);
+      return await stream.republish(eventId);
+    },
+    close() {
+      if (closed) return;
+      closed = true;
+      clearInterval(refreshTimer);
+      for (const eventId of subscribedEventIds) {
+        invalidateLifecycle(eventId);
+        void stream.unpublish(eventId);
+      }
+      subscribedEventIds.clear();
+    },
+  };
+
+  function requestRefresh(eventId: string) {
+    const state = refreshStates.get(eventId) ?? { inFlight: false, pending: false };
+    refreshStates.set(eventId, state);
+    if (state.inFlight) {
+      state.pending = true;
+      return;
+    }
+    void runRefresh(eventId, state);
+  }
+
+  async function runRefresh(eventId: string, state: { inFlight: boolean; pending: boolean }) {
+    state.inFlight = true;
+    state.pending = false;
+    const lifecycleGeneration = currentLifecycleGeneration(eventId);
+    try {
+      const result = await provider
+        .read(eventId)
+        .catch(() => ({ status: "retryable-failure" as const }));
+      if (
+        lifecycleGeneration !== currentLifecycleGeneration(eventId) ||
+        stream.subscriberCount(eventId) === 0
+      ) {
+        return;
+      }
+      if (result.status !== "accepted") {
+        terminateCurrentSubscribers(eventId);
+        return;
+      }
+      stream.replaceProjection(eventId, {
+        version: result.snapshot.version,
+        projection: result.snapshot.projection,
+      });
+    } finally {
+      state.inFlight = false;
+      if (
+        state.pending &&
+        !closed &&
+        subscribedEventIds.has(eventId) &&
+        stream.subscriberCount(eventId) > 0
+      ) {
+        void runRefresh(eventId, state);
+      } else {
+        refreshStates.delete(eventId);
+      }
+    }
+  }
+
+  function terminateCurrentSubscribers(eventId: string) {
+    invalidateLifecycle(eventId);
+    subscribedEventIds.delete(eventId);
+    stream.terminateSubscribers(eventId);
+  }
+
+  function invalidateLifecycle(eventId: string) {
+    lifecycleGenerations.set(eventId, currentLifecycleGeneration(eventId) + 1);
+    const state = refreshStates.get(eventId);
+    if (state !== undefined) state.pending = false;
+  }
+
+  function currentLifecycleGeneration(eventId: string) {
+    return lifecycleGenerations.get(eventId) ?? 0;
+  }
+}

--- a/src/lib/public-audience-event-websocket.ts
+++ b/src/lib/public-audience-event-websocket.ts
@@ -1,0 +1,280 @@
+import {
+  createSpectatorCapacity,
+  type SpectatorCapacity,
+  type SpectatorDisconnectReason,
+  type SpectatorQueuedUpdate,
+} from "@/lib/spectator-capacity";
+import type { ControllerCapacitySignal } from "@/lib/controller-capacity";
+import type { PublicAudienceEventProjection } from "@/lib/audience-projection";
+import {
+  PUBLIC_EVENT_STREAM_PROTOCOL,
+  serializePublicAudienceProjectionMessage,
+  type PublicAudienceProjectionMessage,
+  type PublicAudienceProjectionStream,
+} from "@/lib/public-event-stream";
+import { utf8ByteLength } from "@/lib/validation-policy";
+
+type PublicAudienceMessage = PublicAudienceProjectionMessage<PublicAudienceEventProjection>;
+
+export type PublicAudienceEventSocket = {
+  send(serialized: string): boolean | Promise<boolean>;
+  close(code: number, reason: string): void;
+};
+
+export type PublicAudienceEventWebSocketSubscriptionResult =
+  | { status: "admitted"; currentVersion: string; currentVersionWasAlreadyKnown: boolean }
+  | {
+      status: "rejected";
+      reason: "capacity" | "output-limit";
+      message: string;
+    }
+  | { status: "unavailable"; message: string };
+
+export type PublicAudienceEventWebSocketHub = {
+  subscribe(
+    clientId: string,
+    eventId: string,
+    socket: PublicAudienceEventSocket,
+    lastSeenVersion?: string,
+  ): Promise<PublicAudienceEventWebSocketSubscriptionResult>;
+  disconnect(clientId: string, reason?: SpectatorDisconnectReason): void;
+  reconcileControllerCapacity(): ReturnType<
+    SpectatorCapacity<PublicAudienceMessage>["reconcileControllerCapacity"]
+  >;
+  close(): void;
+};
+
+type Feed = {
+  eventId: string;
+  current: { version: string; payload: PublicAudienceMessage } | null;
+  subscription: { unsubscribe(): void } | null;
+  ready: Promise<boolean>;
+  resolveReady: (available: boolean) => void;
+};
+
+type Client = {
+  eventId: string;
+  socket: PublicAudienceEventSocket;
+};
+
+const CAPACITY_UNAVAILABLE = "Spectator experience is currently unavailable.";
+
+/**
+ * Owns the public transport seam: one authoritative stream subscription per
+ * Event, then the #138 capacity queues fan out the exact serialized envelope
+ * to admitted sockets.
+ */
+export function createPublicAudienceEventWebSocketHub(options: {
+  stream: Pick<PublicAudienceProjectionStream<PublicAudienceEventProjection>, "subscribe">;
+  controllerCapacity: ControllerCapacitySignal;
+  maxSpectators?: number;
+}): PublicAudienceEventWebSocketHub {
+  const feeds = new Map<string, Feed>();
+  const clients = new Map<string, Client>();
+  const drains = new Map<string, Promise<void>>();
+  let closed = false;
+
+  const capacity = createSpectatorCapacity<PublicAudienceMessage>({
+    controllerCapacity: options.controllerCapacity,
+    maxSpectators: options.maxSpectators,
+    adapter: {
+      async readCurrentVersion({ eventId }) {
+        const feed = feeds.get(eventId);
+        if (feed?.current === null || feed?.current === undefined) {
+          return { status: "unavailable" };
+        }
+        return { status: "available", current: feed.current };
+      },
+      serializeQueuedOutput(update) {
+        const serialized = serializePublicAudienceProjectionMessage(update.payload);
+        return { serialized, bytes: utf8ByteLength(serialized) };
+      },
+      async write(clientId, _update, serialized) {
+        const client = clients.get(clientId);
+        if (client === undefined || serialized === undefined) return false;
+        return await client.socket.send(serialized);
+      },
+      close(clientId, reason) {
+        const client = clients.get(clientId);
+        if (client === undefined) return;
+        clients.delete(clientId);
+        client.socket.close(closeCode(reason), closeReason(reason));
+        void disposeFeedIfUnused(client.eventId);
+      },
+    },
+  });
+
+  return {
+    async subscribe(clientId, eventId, socket, lastSeenVersion) {
+      if (closed || clients.has(clientId)) {
+        return { status: "unavailable", message: CAPACITY_UNAVAILABLE };
+      }
+      const feed = await ensureFeed(eventId);
+      if (feed === null || feed.current === null) {
+        return { status: "unavailable", message: CAPACITY_UNAVAILABLE };
+      }
+      clients.set(clientId, { eventId, socket });
+      const result = await capacity.admit({ clientId, eventId, lastSeenVersion });
+      if (result.status !== "admitted") {
+        clients.delete(clientId);
+        await disposeFeedIfUnused(eventId);
+        return result;
+      }
+      await drainClient(clientId);
+      if (!clients.has(clientId)) {
+        return {
+          status: "rejected",
+          reason: "output-limit",
+          message: "Spectator output is currently unavailable.",
+        };
+      }
+      return result;
+    },
+    disconnect(clientId, reason = "client-closed") {
+      const client = clients.get(clientId);
+      clients.delete(clientId);
+      capacity.disconnect(clientId, reason);
+      if (client !== undefined) void disposeFeedIfUnused(client.eventId);
+    },
+    reconcileControllerCapacity() {
+      return capacity.reconcileControllerCapacity();
+    },
+    close() {
+      if (closed) return;
+      closed = true;
+      for (const clientId of clients.keys()) this.disconnect(clientId, "client-closed");
+      for (const feed of feeds.values()) feed.subscription?.unsubscribe();
+      feeds.clear();
+    },
+  };
+
+  async function ensureFeed(eventId: string): Promise<Feed | null> {
+    const existing = feeds.get(eventId);
+    if (existing !== undefined) {
+      return (await existing.ready) && existing.current !== null ? existing : null;
+    }
+    let resolveReady: (available: boolean) => void = () => {};
+    const ready = new Promise<boolean>((resolve) => {
+      resolveReady = resolve;
+    });
+    const feed: Feed = {
+      eventId,
+      current: null,
+      subscription: null,
+      ready,
+      resolveReady,
+    };
+    feeds.set(eventId, feed);
+    const result = await options.stream.subscribe(eventId, {
+      send: async (message) => {
+        if (message.protocol !== PUBLIC_EVENT_STREAM_PROTOCOL) return;
+        if (message.type === "event-unavailable") {
+          feed.current = null;
+          feed.resolveReady(false);
+          await deliverTerminal(feed);
+          return;
+        }
+        const version = String(message.version);
+        const deliveryMessage: PublicAudienceMessage =
+          message.type === "snapshot" && feed.current !== null
+            ? {
+                protocol: PUBLIC_EVENT_STREAM_PROTOCOL,
+                type: "projection-replaced",
+                eventId: message.eventId,
+                version: message.version,
+                projection: message.projection,
+              }
+            : message;
+        feed.current = { version, payload: deliveryMessage };
+        feed.resolveReady(true);
+        if (message.type !== "snapshot" || deliveryMessage.type === "projection-replaced") {
+          await deliver(feed, {
+            eventId,
+            version,
+            payload: deliveryMessage,
+            replaceableKey: deliveryMessage.type === "projection-replaced" ? "projection" : null,
+          });
+        }
+      },
+      close() {},
+    });
+    if (result.status !== "accepted") {
+      feed.resolveReady(false);
+      feeds.delete(eventId);
+      return null;
+    }
+    feed.subscription = result.subscription;
+    if (!(await feed.ready) || feed.current === null) {
+      feed.subscription.unsubscribe();
+      feeds.delete(eventId);
+      return null;
+    }
+    return feed;
+  }
+
+  async function deliver(feed: Feed, update: SpectatorQueuedUpdate<PublicAudienceMessage>) {
+    capacity.publish(update);
+    await Promise.all(
+      [...clients.entries()]
+        .filter(([, client]) => client.eventId === feed.eventId)
+        .map(([clientId]) => drainClient(clientId)),
+    );
+  }
+
+  async function deliverTerminal(feed: Feed) {
+    const update: SpectatorQueuedUpdate<PublicAudienceMessage> = {
+      eventId: feed.eventId,
+      version: "terminal",
+      payload: {
+        protocol: PUBLIC_EVENT_STREAM_PROTOCOL,
+        type: "event-unavailable",
+        eventId: feed.eventId,
+      },
+      replaceableKey: null,
+    };
+    capacity.clearQueuedUpdates(feed.eventId);
+    capacity.publish(update);
+    const clientIds = [...clients.entries()]
+      .filter(([, client]) => client.eventId === feed.eventId)
+      .map(([clientId]) => clientId);
+    await Promise.all(clientIds.map((clientId) => drainClient(clientId)));
+    for (const clientId of clientIds) capacity.disconnect(clientId, "client-closed");
+    feed.subscription?.unsubscribe();
+    feeds.delete(feed.eventId);
+  }
+
+  async function drainClient(clientId: string) {
+    const prior = drains.get(clientId) ?? Promise.resolve();
+    const next = prior.then(async () => {
+      await capacity.drain(clientId);
+    });
+    drains.set(clientId, next);
+    try {
+      await next;
+    } finally {
+      if (drains.get(clientId) === next) drains.delete(clientId);
+    }
+  }
+
+  async function disposeFeedIfUnused(eventId: string) {
+    if ([...clients.values()].some((client) => client.eventId === eventId)) return;
+    const feed = feeds.get(eventId);
+    if (feed === undefined) return;
+    feed.subscription?.unsubscribe();
+    feeds.delete(eventId);
+  }
+}
+
+function closeCode(reason: SpectatorDisconnectReason): number {
+  return reason === "client-closed" || reason === "client-reconnect" ? 1000 : 1013;
+}
+
+function closeReason(reason: SpectatorDisconnectReason): string {
+  return reason === "controller-priority"
+    ? "Controller capacity priority."
+    : reason === "slow-reader"
+      ? "Public Event stream backpressure."
+      : reason === "client-reconnect"
+        ? "Public Event stream reconnecting."
+        : "Public Event stream closed.";
+}

--- a/src/lib/public-event-stream.test.ts
+++ b/src/lib/public-event-stream.test.ts
@@ -1,0 +1,308 @@
+import { describe, expect, test } from "bun:test";
+import {
+  applyPublicEventStreamMessage,
+  createPublicEventStream,
+  createPublicEventStreamReplica,
+  PUBLIC_EVENT_STREAM_PROTOCOL,
+  type PublicAudienceProjectionMessage,
+  type PublicAudienceProjectionSubscriber,
+} from "@/lib/public-event-stream";
+
+type State = { clock: number; score: number; timeline?: readonly string[] };
+function snapshot(version = 1, state: State = { clock: 0, score: 0 }) {
+  return { eventId: "event-1", version, projection: state };
+}
+
+function subscriberHarness() {
+  const messages: PublicAudienceProjectionMessage<State>[] = [];
+  let resolveSend: (() => void) | null = null;
+  let closed: { code: number; reason: string } | null = null;
+  const subscriber: PublicAudienceProjectionSubscriber<State> = {
+    async send(message) {
+      messages.push(message);
+      if (messages.length === 1) await new Promise<void>((resolve) => (resolveSend = resolve));
+    },
+    close(code, reason) {
+      closed = { code, reason };
+    },
+  };
+  return {
+    messages,
+    subscriber,
+    release() {
+      resolveSend?.();
+      resolveSend = null;
+    },
+    closed: () => closed,
+  };
+}
+
+async function settleDelivery() {
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+}
+
+describe("Public Event stream", () => {
+  test("sends an authoritative snapshot on subscribe and rejects duplicate/out-of-order updates", async () => {
+    const stream = createPublicEventStream<State>({
+      read: async () => ({ status: "accepted", snapshot: snapshot() }),
+    });
+    const harness = subscriberHarness();
+    const result = await stream.subscribe("event-1", harness.subscriber);
+    expect(result.status).toBe("accepted");
+    expect(harness.messages[0]).toMatchObject({
+      protocol: PUBLIC_EVENT_STREAM_PROTOCOL,
+      type: "snapshot",
+      version: 1,
+      projection: { clock: 0, score: 0 },
+    });
+    harness.release();
+
+    expect(
+      stream.replaceProjection("event-1", { version: 1, projection: { clock: 1, score: 0 } }),
+    ).toEqual({
+      status: "duplicate",
+    });
+    expect(
+      stream.replaceProjection("event-1", { version: 0, projection: { clock: 1, score: 0 } }),
+    ).toEqual({
+      status: "out-of-order",
+    });
+    expect(
+      stream.replaceProjection("event-1", { version: 2, projection: { clock: 1, score: 0 } }),
+    ).toEqual({
+      status: "accepted",
+    });
+  });
+
+  test("coalesces replaceable projection updates while delivery is blocked", async () => {
+    const stream = createPublicEventStream<State>({
+      read: async () => ({ status: "accepted", snapshot: snapshot() }),
+    });
+    const harness = subscriberHarness();
+    await stream.subscribe("event-1", harness.subscriber);
+    expect(
+      stream.replaceProjection("event-1", { version: 2, projection: { clock: 1, score: 0 } }),
+    ).toEqual({
+      status: "accepted",
+    });
+    expect(
+      stream.replaceProjection("event-1", { version: 4, projection: { clock: 2, score: 0 } }),
+    ).toEqual({ status: "accepted" });
+    expect(
+      stream.replaceProjection("event-1", { version: 5, projection: { clock: 3, score: 0 } }),
+    ).toEqual({ status: "accepted" });
+
+    harness.release();
+    await settleDelivery();
+    expect(harness.messages.map((message) => message.type)).toEqual([
+      "snapshot",
+      "projection-replaced",
+    ]);
+    expect(harness.messages[1]).toMatchObject({ version: 5, projection: { clock: 3 } });
+    expect(harness.messages[2]).toBeUndefined();
+  });
+
+  test("coalesces complete projections without dropping distinct effective Timeline entries", async () => {
+    const stream = createPublicEventStream<State>({
+      read: async () => ({ status: "accepted", snapshot: snapshot() }),
+    });
+    const harness = subscriberHarness();
+    await stream.subscribe("event-1", harness.subscriber);
+    expect(
+      stream.replaceProjection("event-1", {
+        version: 2,
+        projection: { clock: 1, score: 1, timeline: ["goal-1"] },
+      }),
+    ).toEqual({ status: "accepted" });
+    expect(
+      stream.replaceProjection("event-1", {
+        version: 3,
+        projection: { clock: 2, score: 2, timeline: ["goal-1", "goal-2"] },
+      }),
+    ).toEqual({ status: "accepted" });
+    harness.release();
+    await settleDelivery();
+    expect(harness.messages).toHaveLength(2);
+    expect(harness.messages.at(-1)).toMatchObject({
+      type: "projection-replaced",
+      version: 3,
+      projection: { timeline: ["goal-1", "goal-2"] },
+    });
+  });
+
+  test("unpublication is terminal and a later subscribe cannot recover metadata until republish", async () => {
+    let published = true;
+    const stream = createPublicEventStream<State>({
+      read: async () =>
+        published ? { status: "accepted", snapshot: snapshot() } : { status: "unavailable" },
+    });
+    const harness = subscriberHarness();
+    await stream.subscribe("event-1", harness.subscriber);
+    expect(
+      stream.replaceProjection("event-1", { version: 2, projection: { clock: 1, score: 0 } }),
+    ).toEqual({ status: "accepted" });
+    published = false;
+    await stream.unpublish("event-1");
+    harness.release();
+    await settleDelivery();
+    expect(harness.messages.map((message) => message.type)).toEqual([
+      "snapshot",
+      "event-unavailable",
+    ]);
+    expect(harness.messages.at(-1)).toEqual({
+      protocol: PUBLIC_EVENT_STREAM_PROTOCOL,
+      type: "event-unavailable",
+      eventId: "event-1",
+    });
+    expect(harness.closed()).toEqual({ code: 1008, reason: "Event unavailable." });
+    expect(await stream.subscribe("event-1", subscriberHarness().subscriber)).toEqual({
+      status: "unavailable",
+    });
+
+    published = true;
+    expect(await stream.republish("event-1")).toBe("accepted");
+    const next = subscriberHarness();
+    expect((await stream.subscribe("event-1", next.subscriber)).status).toBe("accepted");
+    expect(next.messages[0]).toMatchObject({ type: "snapshot", projection: { clock: 0 } });
+  });
+
+  test("an older republish cannot restore a projection after a later unpublication", async () => {
+    let releaseRead: (value: {
+      status: "accepted";
+      snapshot: ReturnType<typeof snapshot>;
+    }) => void = (_value) => {
+      throw new Error("Republish read was not deferred.");
+    };
+    let reads = 0;
+    const deferredRead = new Promise<{ status: "accepted"; snapshot: ReturnType<typeof snapshot> }>(
+      (resolve) => {
+        releaseRead = resolve;
+      },
+    );
+    const stream = createPublicEventStream<State>({
+      read: async () => {
+        reads += 1;
+        return reads === 1 ? { status: "accepted", snapshot: snapshot() } : deferredRead;
+      },
+    });
+    const subscriber = subscriberHarness();
+    await stream.subscribe("event-1", subscriber.subscriber);
+    const republish = stream.republish("event-1");
+    await stream.unpublish("event-1");
+    releaseRead({ status: "accepted", snapshot: snapshot(2) });
+
+    expect(await republish).toBe("unavailable");
+    expect(await stream.subscribe("event-1", subscriberHarness().subscriber)).toEqual({
+      status: "unavailable",
+    });
+  });
+
+  test("rechecks publication eligibility after an in-flight authoritative read", async () => {
+    let signalReadStarted: () => void = () => {
+      throw new Error("Authoritative read did not start.");
+    };
+    let releaseRead: (value: {
+      status: "accepted";
+      snapshot: ReturnType<typeof snapshot>;
+    }) => void = (_value) => {
+      throw new Error("Authoritative read was not deferred.");
+    };
+    const readBegan = new Promise<void>((resolve) => (signalReadStarted = resolve));
+    const read = new Promise<{ status: "accepted"; snapshot: ReturnType<typeof snapshot> }>(
+      (resolve) => {
+        releaseRead = (value) => resolve(value);
+      },
+    );
+    const stream = createPublicEventStream<State>({
+      read: async () => {
+        signalReadStarted();
+        return read;
+      },
+    });
+    const harness = subscriberHarness();
+    const pending = stream.subscribe("event-1", harness.subscriber);
+    await readBegan;
+    await stream.unpublish("event-1");
+    releaseRead({ status: "accepted", snapshot: snapshot() });
+
+    expect(await pending).toEqual({ status: "unavailable" });
+    expect(harness.messages).toEqual([]);
+    expect(stream.subscriberCount("event-1")).toBe(0);
+  });
+
+  test("a browser replica converges from HTTP snapshot, ignores duplicates and rejects stale data", () => {
+    const replica = createPublicEventStreamReplica<State>("event-1");
+    const state = { clock: 12, score: 10 };
+    const snapshotMessage: PublicAudienceProjectionMessage<State> = {
+      protocol: PUBLIC_EVENT_STREAM_PROTOCOL,
+      type: "snapshot",
+      eventId: "event-1",
+      version: 10,
+      projection: state,
+    };
+    expect(applyPublicEventStreamMessage(replica, snapshotMessage)).toEqual({ status: "applied" });
+    expect(applyPublicEventStreamMessage(replica, snapshotMessage)).toEqual({
+      status: "duplicate",
+    });
+    expect(
+      applyPublicEventStreamMessage(replica, {
+        protocol: PUBLIC_EVENT_STREAM_PROTOCOL,
+        type: "projection-replaced",
+        eventId: "event-1",
+        version: 9,
+        projection: { clock: 11, score: 10 },
+      }),
+    ).toEqual({ status: "out-of-order" });
+    expect(
+      applyPublicEventStreamMessage(replica, {
+        protocol: PUBLIC_EVENT_STREAM_PROTOCOL,
+        type: "event-unavailable",
+        eventId: "event-1",
+      }),
+    ).toEqual({ status: "unavailable" });
+    expect(replica).toMatchObject({ version: 10, projection: null, unavailable: true });
+  });
+
+  test("the replica applies projection replacement in version order", () => {
+    const replica = createPublicEventStreamReplica<State>("event-1");
+    const messages: PublicAudienceProjectionMessage<State>[] = [
+      {
+        protocol: PUBLIC_EVENT_STREAM_PROTOCOL,
+        type: "snapshot",
+        eventId: "event-1",
+        version: 1,
+        projection: { clock: 0, score: 0 },
+      },
+      {
+        protocol: PUBLIC_EVENT_STREAM_PROTOCOL,
+        type: "projection-replaced",
+        eventId: "event-1",
+        version: 2,
+        projection: { clock: 1, score: 0 },
+      },
+      {
+        protocol: PUBLIC_EVENT_STREAM_PROTOCOL,
+        type: "projection-replaced",
+        eventId: "event-1",
+        version: 3,
+        projection: { clock: 1, score: 1 },
+      },
+      {
+        protocol: PUBLIC_EVENT_STREAM_PROTOCOL,
+        type: "projection-replaced",
+        eventId: "event-1",
+        version: 4,
+        projection: { clock: 2, score: 1 },
+      },
+    ];
+
+    expect(messages.map((message) => applyPublicEventStreamMessage(replica, message))).toEqual([
+      { status: "applied" },
+      { status: "applied" },
+      { status: "applied" },
+      { status: "applied" },
+    ]);
+    expect(replica).toMatchObject({ version: 4, projection: { clock: 2, score: 1 } });
+  });
+});

--- a/src/lib/public-event-stream.ts
+++ b/src/lib/public-event-stream.ts
@@ -1,0 +1,367 @@
+/**
+ * The public Event stream deliberately knows nothing about the shape of an
+ * Audience Projection.  That keeps the transport stable while the projection
+ * is assembled by the Event and Game work.
+ */
+export const PUBLIC_EVENT_STREAM_PROTOCOL = "public-event-stream-v1" as const;
+
+export type PublicAudienceProjectionSnapshot<TProjection> = {
+  eventId: string;
+  version: number;
+  projection: TProjection;
+};
+
+export type PublicAudienceProjectionMessage<TProjection> =
+  | {
+      protocol: typeof PUBLIC_EVENT_STREAM_PROTOCOL;
+      type: "snapshot";
+      eventId: string;
+      version: number;
+      projection: TProjection;
+    }
+  | {
+      protocol: typeof PUBLIC_EVENT_STREAM_PROTOCOL;
+      type: "projection-replaced";
+      eventId: string;
+      version: number;
+      projection: TProjection;
+    }
+  | {
+      protocol: typeof PUBLIC_EVENT_STREAM_PROTOCOL;
+      type: "event-unavailable";
+      eventId: string;
+    };
+
+export function serializePublicAudienceProjectionMessage<TProjection>(
+  message: PublicAudienceProjectionMessage<TProjection>,
+): string {
+  return JSON.stringify(message);
+}
+
+export type PublicAudienceProjectionReadOutcome<TProjection> =
+  | { status: "accepted"; snapshot: PublicAudienceProjectionSnapshot<TProjection> }
+  | { status: "unavailable" }
+  | { status: "retryable-failure" };
+
+export type PublicAudienceProjectionProvider<TProjection> = {
+  read(eventId: string): Promise<PublicAudienceProjectionReadOutcome<TProjection>>;
+};
+
+export type PublicAudienceProjectionSubscriber<TProjection> = {
+  send(message: PublicAudienceProjectionMessage<TProjection>): void | Promise<void>;
+  close(code: number, reason: string): void;
+};
+
+export type PublicAudienceProjectionMutation =
+  | { status: "accepted" }
+  | { status: "duplicate" }
+  | { status: "out-of-order" }
+  | { status: "unavailable" };
+
+export type PublicAudienceProjectionSubscription = {
+  unsubscribe(): void;
+};
+
+export type PublicAudienceProjectionStream<TProjection> = {
+  subscribe(
+    eventId: string,
+    subscriber: PublicAudienceProjectionSubscriber<TProjection>,
+  ): Promise<
+    | { status: "accepted"; subscription: PublicAudienceProjectionSubscription }
+    | { status: "unavailable" }
+  >;
+  replaceProjection(
+    eventId: string,
+    update: { version: number; projection: TProjection },
+  ): PublicAudienceProjectionMutation;
+  terminateSubscribers(eventId: string): void;
+  unpublish(eventId: string): Promise<void>;
+  republish(eventId: string): Promise<"accepted" | "unavailable">;
+  subscriberCount(eventId?: string): number;
+};
+
+type QueuedMessage<TProjection> = {
+  message: PublicAudienceProjectionMessage<TProjection>;
+  replaceable: boolean;
+  terminal: boolean;
+};
+
+type SubscriberState<TProjection> = {
+  subscriber: PublicAudienceProjectionSubscriber<TProjection>;
+  queue: QueuedMessage<TProjection>[];
+  draining: boolean;
+  closed: boolean;
+};
+
+type EventState<TProjection> = {
+  snapshot: PublicAudienceProjectionSnapshot<TProjection>;
+  subscribers: Set<SubscriberState<TProjection>>;
+};
+
+export function createPublicEventStream<TProjection>(
+  provider: PublicAudienceProjectionProvider<TProjection>,
+): PublicAudienceProjectionStream<TProjection> {
+  const events = new Map<string, EventState<TProjection>>();
+  const unpublishedEventIds = new Set<string>();
+  const publicationGenerations = new Map<string, number>();
+
+  const hydrate = async (eventId: string): Promise<EventState<TProjection> | null> => {
+    if (unpublishedEventIds.has(eventId)) return null;
+    const generation = currentGeneration(eventId);
+    return readAndReplaceEventState(
+      eventId,
+      () => !unpublishedEventIds.has(eventId) && currentGeneration(eventId) === generation,
+    );
+  };
+
+  const stream: PublicAudienceProjectionStream<TProjection> = {
+    async subscribe(eventId, subscriber) {
+      if (!isEventId(eventId)) return { status: "unavailable" };
+      const state = await hydrate(eventId);
+      if (state === null) return { status: "unavailable" };
+      const subscriberState: SubscriberState<TProjection> = {
+        subscriber,
+        queue: [],
+        draining: false,
+        closed: false,
+      };
+      state.subscribers.add(subscriberState);
+      enqueue(subscriberState, snapshotMessage(state.snapshot), true, false);
+      return {
+        status: "accepted",
+        subscription: {
+          unsubscribe() {
+            removeSubscriber(state, subscriberState);
+          },
+        },
+      };
+    },
+
+    replaceProjection(eventId, update) {
+      if (!isValidVersion(update.version) || !isEventId(eventId)) return { status: "unavailable" };
+      const state = events.get(eventId);
+      if (state === undefined || unpublishedEventIds.has(eventId)) return { status: "unavailable" };
+      if (update.version === state.snapshot.version) return { status: "duplicate" };
+      if (update.version < state.snapshot.version) return { status: "out-of-order" };
+      state.snapshot = {
+        ...state.snapshot,
+        version: update.version,
+        projection: update.projection,
+      };
+      broadcast(
+        state,
+        {
+          protocol: PUBLIC_EVENT_STREAM_PROTOCOL,
+          type: "projection-replaced",
+          eventId,
+          version: update.version,
+          projection: update.projection,
+        },
+        true,
+      );
+      return { status: "accepted" };
+    },
+
+    terminateSubscribers(eventId) {
+      terminateEvent(eventId, false);
+    },
+
+    async unpublish(eventId) {
+      if (!isEventId(eventId)) return;
+      terminateEvent(eventId, true);
+    },
+
+    async republish(eventId) {
+      if (!isEventId(eventId)) return "unavailable";
+      const generation = currentGeneration(eventId);
+      const prior = events.get(eventId);
+      const nextState = await readAndReplaceEventState(
+        eventId,
+        () => currentGeneration(eventId) === generation,
+      );
+      if (nextState === null) return "unavailable";
+      unpublishedEventIds.delete(eventId);
+      if (prior !== undefined) broadcast(nextState, snapshotMessage(nextState.snapshot), true);
+      return "accepted";
+    },
+
+    subscriberCount(eventId) {
+      if (eventId === undefined) {
+        return [...events.values()].reduce((total, state) => total + state.subscribers.size, 0);
+      }
+      return events.get(eventId)?.subscribers.size ?? 0;
+    },
+  };
+
+  return stream;
+
+  function currentGeneration(eventId: string) {
+    return publicationGenerations.get(eventId) ?? 0;
+  }
+
+  async function readAndReplaceEventState(
+    eventId: string,
+    isStillEligible: () => boolean,
+  ): Promise<EventState<TProjection> | null> {
+    const result = await provider.read(eventId);
+    if (result.status !== "accepted") return null;
+    if (result.snapshot.eventId !== eventId || !isStillEligible()) return null;
+    const snapshot = result.snapshot;
+    const existing = events.get(eventId);
+    if (existing !== undefined && snapshot.version < existing.snapshot.version) return null;
+    const nextState: EventState<TProjection> = {
+      snapshot,
+      subscribers: existing?.subscribers ?? new Set(),
+    };
+    events.set(eventId, nextState);
+    return nextState;
+  }
+
+  function terminateEvent(eventId: string, permanentlyUnavailable: boolean) {
+    if (permanentlyUnavailable) unpublishedEventIds.add(eventId);
+    publicationGenerations.set(eventId, currentGeneration(eventId) + 1);
+    const state = events.get(eventId);
+    if (state === undefined) return;
+    events.delete(eventId);
+    for (const subscriber of state.subscribers) {
+      subscriber.queue.length = 0;
+      enqueue(
+        subscriber,
+        { protocol: PUBLIC_EVENT_STREAM_PROTOCOL, type: "event-unavailable", eventId },
+        false,
+        true,
+      );
+    }
+  }
+
+  function removeSubscriber(
+    state: EventState<TProjection>,
+    subscriber: SubscriberState<TProjection>,
+  ) {
+    subscriber.closed = true;
+    state.subscribers.delete(subscriber);
+  }
+
+  function broadcast(
+    state: EventState<TProjection>,
+    message: PublicAudienceProjectionMessage<TProjection>,
+    replaceable: boolean,
+  ) {
+    for (const subscriber of state.subscribers) enqueue(subscriber, message, replaceable, false);
+  }
+
+  function enqueue(
+    subscriber: SubscriberState<TProjection>,
+    message: PublicAudienceProjectionMessage<TProjection>,
+    replaceable: boolean,
+    terminal: boolean,
+  ) {
+    if (subscriber.closed) return;
+    if (replaceable) {
+      const lastNonReplaceable = subscriber.queue.findLastIndex((item) => !item.replaceable);
+      const queued = subscriber.queue
+        .slice(lastNonReplaceable + 1)
+        .findLast((item) => item.replaceable);
+      if (queued !== undefined) {
+        queued.message = message;
+        return;
+      }
+    }
+    subscriber.queue.push({ message, replaceable, terminal });
+    void drain(subscriber);
+  }
+
+  async function drain(subscriber: SubscriberState<TProjection>) {
+    if (subscriber.draining || subscriber.closed) return;
+    subscriber.draining = true;
+    try {
+      while (!subscriber.closed && subscriber.queue.length > 0) {
+        const item = subscriber.queue.shift()!;
+        try {
+          await subscriber.subscriber.send(item.message);
+        } catch {
+          subscriber.closed = true;
+          subscriber.queue.length = 0;
+          subscriber.subscriber.close(1011, "Public Event stream unavailable.");
+          return;
+        }
+        if (item.terminal) {
+          subscriber.closed = true;
+          subscriber.queue.length = 0;
+          subscriber.subscriber.close(1008, "Event unavailable.");
+          return;
+        }
+      }
+    } finally {
+      subscriber.draining = false;
+    }
+  }
+}
+
+export type PublicAudienceProjectionReplica<TProjection> = {
+  eventId: string;
+  version: number;
+  projection: TProjection | null;
+  unavailable: boolean;
+};
+
+export type PublicAudienceProjectionApplyResult =
+  | { status: "applied" }
+  | { status: "duplicate" }
+  | { status: "out-of-order" }
+  | { status: "unavailable" };
+
+export function createPublicEventStreamReplica<TProjection>(
+  eventId: string,
+): PublicAudienceProjectionReplica<TProjection> {
+  return { eventId, version: -1, projection: null, unavailable: false };
+}
+
+export function applyPublicEventStreamMessage<TProjection>(
+  replica: PublicAudienceProjectionReplica<TProjection>,
+  message: PublicAudienceProjectionMessage<TProjection>,
+): PublicAudienceProjectionApplyResult {
+  if (message.protocol !== PUBLIC_EVENT_STREAM_PROTOCOL || message.eventId !== replica.eventId)
+    return { status: "unavailable" };
+  if (message.type === "event-unavailable") {
+    replica.unavailable = true;
+    replica.projection = null;
+    return { status: "unavailable" };
+  }
+  if (replica.unavailable) return { status: "unavailable" };
+  if (message.type === "snapshot") {
+    if (message.version === replica.version) return { status: "duplicate" };
+    if (message.version < replica.version) return { status: "out-of-order" };
+    replica.version = message.version;
+    replica.projection = message.projection;
+    return { status: "applied" };
+  }
+  if (message.version === replica.version) return { status: "duplicate" };
+  if (message.version < replica.version) return { status: "out-of-order" };
+  if (message.type === "projection-replaced") {
+    replica.version = message.version;
+    replica.projection = message.projection;
+    return { status: "applied" };
+  }
+  return { status: "unavailable" };
+}
+
+function snapshotMessage<TProjection>(
+  snapshot: PublicAudienceProjectionSnapshot<TProjection>,
+): PublicAudienceProjectionMessage<TProjection> {
+  return {
+    protocol: PUBLIC_EVENT_STREAM_PROTOCOL,
+    type: "snapshot",
+    eventId: snapshot.eventId,
+    version: snapshot.version,
+    projection: snapshot.projection,
+  };
+}
+
+function isEventId(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function isValidVersion(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+}

--- a/src/lib/spectator-capacity.ts
+++ b/src/lib/spectator-capacity.ts
@@ -1,20 +1,13 @@
 import {
   availableNonControllerCapacity,
   type ControllerCapacityInput,
+  type ControllerCapacitySignal,
 } from "@/lib/controller-capacity";
 import { SHARED_LIMITS } from "@/lib/validation-policy";
 
-/**
- * The spectator path deliberately owns delivery pressure only. Controller
- * admission and authority remain owned by the live-control runtime; this
- * source is the read-only capacity signal supplied by that runtime.
- */
-export type ControllerCapacitySignal = {
-  totalConnections: number;
-  reservedConnections: number;
-  /** Number of currently active authoritative Controller Grant Sessions. */
-  activeControllerSessions: () => number;
-};
+const CAPACITY_NOTICE = "Spectator capacity is currently full; try again later." as const;
+const GENERIC_UNAVAILABLE_MESSAGE = "Spectator experience is currently unavailable." as const;
+const OUTPUT_LIMIT_MESSAGE = "Spectator output is currently unavailable." as const;
 
 export type SpectatorCurrentVersion<TPayload> = {
   version: string;
@@ -33,8 +26,16 @@ export type SpectatorCurrentVersionResult<TPayload> =
 export type SpectatorStreamAdapter<TPayload> = {
   readCurrentVersion(input: { eventId: string }): Promise<SpectatorCurrentVersionResult<TPayload>>;
   /** Exact bytes of the serialized transport envelope, supplied by the transport seam. */
-  measureQueuedOutputBytes(update: SpectatorQueuedUpdate<TPayload>): number;
-  write(clientId: string, update: SpectatorQueuedUpdate<TPayload>): boolean | Promise<boolean>;
+  measureQueuedOutputBytes?(update: SpectatorQueuedUpdate<TPayload>): number;
+  serializeQueuedOutput?(update: SpectatorQueuedUpdate<TPayload>): {
+    serialized: string;
+    bytes: number;
+  };
+  write(
+    clientId: string,
+    update: SpectatorQueuedUpdate<TPayload>,
+    serialized?: string,
+  ): boolean | Promise<boolean>;
   close(clientId: string, reason: SpectatorDisconnectReason): void;
 };
 
@@ -72,16 +73,16 @@ export type SpectatorAdmissionResult =
   | {
       status: "rejected";
       reason: "capacity";
-      message: "Spectator capacity is currently full; try again later.";
+      message: typeof CAPACITY_NOTICE;
     }
   | {
       status: "rejected";
       reason: "output-limit";
-      message: "Spectator output is currently unavailable.";
+      message: typeof OUTPUT_LIMIT_MESSAGE;
     }
   | {
       status: "unavailable";
-      message: "Spectator experience is currently unavailable.";
+      message: typeof GENERIC_UNAVAILABLE_MESSAGE;
     };
 
 export type SpectatorPublishInput<TPayload> = SpectatorCurrentVersion<TPayload> & {
@@ -130,8 +131,6 @@ const DEFAULT_MAX_SPECTATORS = SHARED_LIMITS.load.maxConnectedSpectators;
 const DEFAULT_PER_CLIENT_QUEUE_LIMIT = 8;
 const DEFAULT_GLOBAL_QUEUE_LIMIT = 2_000;
 const DEFAULT_PER_CLIENT_QUEUED_OUTPUT_BYTES = SHARED_LIMITS.transport.websocketTextFrameBytes;
-const GENERIC_UNAVAILABLE_MESSAGE = "Spectator experience is currently unavailable." as const;
-const OUTPUT_LIMIT_MESSAGE = "Spectator output is currently unavailable." as const;
 
 export function createSpectatorCapacity<TPayload>(
   options: SpectatorCapacityOptions<TPayload>,
@@ -156,6 +155,7 @@ export function createSpectatorCapacity<TPayload>(
   let reserveBreachesObserved = 0;
   let admissionSequence = 0;
   const provisionalAdmissions = new Set<string>();
+  const serializedOutputCache = new WeakMap<object, { serialized?: string; bytes: number }>();
 
   function controllerSignal() {
     const totalConnections = positiveLimit(options.controllerCapacity.totalConnections, 1);
@@ -233,8 +233,39 @@ export function createSpectatorCapacity<TPayload>(
   }
 
   function measureUpdateBytes(update: SpectatorQueuedUpdate<TPayload>): number {
+    return readSerializedOutput(update).bytes;
+  }
+
+  function readSerializedOutput(update: SpectatorQueuedUpdate<TPayload>) {
+    const cached = serializedOutputCache.get(update);
+    if (cached !== undefined) return cached;
+    let output: { serialized?: string; bytes: number };
+    if (options.adapter.serializeQueuedOutput !== undefined) {
+      try {
+        const serialized = options.adapter.serializeQueuedOutput(update);
+        output = {
+          serialized: serialized.serialized,
+          bytes:
+            typeof serialized.serialized === "string" &&
+            Number.isFinite(serialized.bytes) &&
+            serialized.bytes >= 0
+              ? serialized.bytes
+              : Number.POSITIVE_INFINITY,
+        };
+      } catch {
+        output = { bytes: Number.POSITIVE_INFINITY };
+      }
+    } else {
+      output = { bytes: measureAdapterOutputBytes(update) };
+    }
+    serializedOutputCache.set(update, output);
+    return output;
+  }
+
+  function measureAdapterOutputBytes(update: SpectatorQueuedUpdate<TPayload>): number {
     try {
-      const measured = options.adapter.measureQueuedOutputBytes(update);
+      const measured = options.adapter.measureQueuedOutputBytes?.(update);
+      if (measured === undefined) return Number.POSITIVE_INFINITY;
       return Number.isFinite(measured) && measured >= 0 ? measured : Number.POSITIVE_INFINITY;
     } catch {
       return Number.POSITIVE_INFINITY;
@@ -314,7 +345,11 @@ export function createSpectatorCapacity<TPayload>(
       if (update === undefined) break;
       let accepted = false;
       try {
-        accepted = await options.adapter.write(clientId, update);
+        accepted = await options.adapter.write(
+          clientId,
+          update,
+          readSerializedOutput(update).serialized,
+        );
       } catch {
         accepted = false;
       }
@@ -344,7 +379,7 @@ export function createSpectatorCapacity<TPayload>(
         return {
           status: "rejected",
           reason: "capacity",
-          message: "Spectator capacity is currently full; try again later.",
+          message: CAPACITY_NOTICE,
         };
       }
 
@@ -353,7 +388,7 @@ export function createSpectatorCapacity<TPayload>(
         return {
           status: "rejected",
           reason: "capacity",
-          message: "Spectator capacity is currently full; try again later.",
+          message: CAPACITY_NOTICE,
         };
       }
       const provisional = !clients.has(input.clientId);
@@ -375,7 +410,7 @@ export function createSpectatorCapacity<TPayload>(
             return {
               status: "rejected",
               reason: "capacity",
-              message: "Spectator capacity is currently full; try again later.",
+              message: CAPACITY_NOTICE,
             };
           }
           provisionalAdmissions.add(input.clientId);
@@ -385,7 +420,7 @@ export function createSpectatorCapacity<TPayload>(
           return {
             status: "rejected",
             reason: "capacity",
-            message: "Spectator capacity is currently full; try again later.",
+            message: CAPACITY_NOTICE,
           };
         }
 
@@ -465,6 +500,18 @@ export function createSpectatorCapacity<TPayload>(
     disconnect(clientId, reason = "client-closed") {
       return disconnect(clientId, reason);
     },
+    clearQueuedUpdates(eventId: string) {
+      let cleared = 0;
+      for (const client of clients.values()) {
+        if (client.eventId !== eventId || client.queue.length === 0) continue;
+        cleared += client.queue.length;
+        queuedUpdates -= client.queue.length;
+        queuedBytes -= client.queuedBytes;
+        client.queue.length = 0;
+        client.queuedBytes = 0;
+      }
+      return cleared;
+    },
     getQueueState(clientId): SpectatorQueueState | null {
       const client = clients.get(clientId);
       if (client === undefined) return null;
@@ -514,9 +561,10 @@ export type SpectatorCapacity<TPayload> = {
         availableForSpectators: number;
         disconnected: number;
       }
-    | { status: "unavailable"; message: "Spectator experience is currently unavailable." };
+    | { status: "unavailable"; message: typeof GENERIC_UNAVAILABLE_MESSAGE };
   drain(clientId: string, limit?: number): Promise<number>;
   disconnect(clientId: string, reason?: SpectatorDisconnectReason): boolean;
+  clearQueuedUpdates(eventId: string): number;
   getQueueState(clientId: string): SpectatorQueueState | null;
   getMetrics(): SpectatorCapacityMetrics;
 };

--- a/src/lib/ws-protocol.test.ts
+++ b/src/lib/ws-protocol.test.ts
@@ -2,6 +2,15 @@ import { describe, expect, test } from "bun:test";
 import { parseClientWsMessage } from "@/lib/ws-protocol";
 
 describe("ws-protocol", () => {
+  test("accepts a public Event stream subscription", () => {
+    expect(
+      parseClientWsMessage(JSON.stringify({ type: "subscribe-public-event", eventId: "event-1" })),
+    ).toEqual({
+      ok: true,
+      message: { type: "subscribe-public-event", eventId: "event-1" },
+    });
+  });
+
   test("rejects a WebSocket text frame over the UTF-8 byte boundary before JSON parsing", () => {
     const parsed = parseClientWsMessage(
       JSON.stringify({

--- a/src/lib/ws-protocol.ts
+++ b/src/lib/ws-protocol.ts
@@ -28,13 +28,22 @@ export type SubscribeGameMessage = {
   gameId: string;
 };
 
+export type SubscribePublicEventMessage = {
+  type: "subscribe-public-event";
+  eventId: string;
+};
+
 export type ApplyCommandsMessage = {
   type: "apply-commands";
   gameId: string;
   commands: ClientCommandEnvelope[];
 };
 
-export type ClientWsMessage = SubscribeLobbyMessage | SubscribeGameMessage | ApplyCommandsMessage;
+export type ClientWsMessage =
+  | SubscribeLobbyMessage
+  | SubscribeGameMessage
+  | SubscribePublicEventMessage
+  | ApplyCommandsMessage;
 
 export type ParseClientWsMessageOptions = {
   serverNowMs?: number;
@@ -136,6 +145,23 @@ export function parseClientWsMessage(
       message: {
         type: "subscribe-game",
         gameId: gameId.value,
+      },
+    };
+  }
+
+  if (payload.type === "subscribe-public-event") {
+    const eventId = validateOpaqueIdentifier(payload.eventId, "eventId");
+    if (!eventId.ok) {
+      return {
+        ok: false,
+        error: `subscribe-public-event ${eventId.error}`,
+      };
+    }
+    return {
+      ok: true,
+      message: {
+        type: "subscribe-public-event",
+        eventId: eventId.value,
       },
     };
   }

--- a/src/pages/public-event-game-page.test.tsx
+++ b/src/pages/public-event-game-page.test.tsx
@@ -11,6 +11,7 @@ describe("public spectator Game page", () => {
   const originalNavigator = globalThis.navigator;
   const originalLocation = globalThis.location;
   const originalHistory = globalThis.history;
+  const originalWebSocket = globalThis.WebSocket;
   const originalFetch = globalThis.fetch;
   const originalActEnvironment = (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean })
     .IS_REACT_ACT_ENVIRONMENT;
@@ -26,8 +27,20 @@ describe("public spectator Game page", () => {
       navigator: testWindow.navigator,
       location: testWindow.location,
       history: testWindow.history,
+      WebSocket: class {
+        onopen: (() => void) | null = null;
+        onmessage: ((event: MessageEvent) => void) | null = null;
+        onclose: (() => void) | null = null;
+        send() {}
+        close() {
+          this.onclose?.();
+        }
+        constructor() {
+          queueMicrotask(() => this.onopen?.());
+        }
+      },
       fetch: async () =>
-        new Response(JSON.stringify({ status: "accepted", value: projection() }), {
+        new Response(JSON.stringify({ status: "accepted", value: eventProjection() }), {
           status: 200,
           headers: { "content-type": "application/json" },
         }),
@@ -51,6 +64,7 @@ describe("public spectator Game page", () => {
       navigator: originalNavigator,
       location: originalLocation,
       history: originalHistory,
+      WebSocket: originalWebSocket,
       fetch: originalFetch,
     });
     (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
@@ -82,6 +96,9 @@ describe("public spectator Game page", () => {
     expect(container.textContent).toContain("A Very Long Team Name That Must Wrap");
     expect(container.textContent).toContain("Another Long Team Name For A Narrow Screen");
     expect(container.textContent).toContain("2:05");
+    expect(container.textContent).toContain(
+      "An Event Team assignment was corrected. Current team identities are shown.",
+    );
     expect(container.querySelectorAll(".break-words").length).toBe(2);
     const expandedSides = Array.from(
       container.querySelectorAll("[data-scoreboard-expanded] [data-side-id]"),
@@ -116,11 +133,23 @@ describe("public spectator Game page", () => {
     expect(compactSides[0]?.textContent).toContain("Flag catch");
     expect(compactSides[1]?.textContent).not.toContain("Flag catch");
   });
+
+  test("renders Game unavailable after the Event loads without the requested Game identity", async () => {
+    await act(async () => {
+      root.render(<PublicEventGamePage eventId="event-1" eventGameId="unknown-game" />);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain("Game unavailable");
+    expect(container.textContent).not.toContain("Loading public Game information");
+  });
 });
 
 function projection(): PublicAudienceGameProjection {
   return {
     eventId: "event-1",
+    eventGameId: "game-1",
     gameCode: "A1",
     gameDesignation: "Final",
     scheduledStartMs: 1_000,
@@ -172,5 +201,28 @@ function projection(): PublicAudienceGameProjection {
     result: { status: "finished", winner: "side-a", locked: true },
     canonicalPath: "/events/event-1/games/game-1",
     timeline: [],
+    teamAssignmentNotice: "event-team-assignment-corrected",
+  };
+}
+
+function eventProjection() {
+  const game = projection();
+  return {
+    eventId: "event-1",
+    name: "Published Event",
+    timeZone: "UTC",
+    publicationStatus: "published" as const,
+    gameDays: ["2026-08-15"],
+    lifecycle: "current" as const,
+    canonicalPath: "/events/event-1",
+    teams: [],
+    pitches: [{ name: "Pitch A" }],
+    schedule: {
+      asOfMs: 0,
+      runningGames: [],
+      upcomingGames: [],
+      scheduleGames: [game],
+      focusIndex: null,
+    },
   };
 }

--- a/src/pages/public-event-page.tsx
+++ b/src/pages/public-event-page.tsx
@@ -9,6 +9,12 @@ import type {
   PublicAudienceGameProjection,
   PublicAudienceScheduleProjection,
 } from "@/lib/audience-projection";
+import {
+  applyPublicEventStreamMessage,
+  createPublicEventStreamReplica,
+  PUBLIC_EVENT_STREAM_PROTOCOL,
+  type PublicAudienceProjectionMessage,
+} from "@/lib/public-event-stream";
 import { DEFAULT_AWAY_TEAM_COLOR, DEFAULT_HOME_TEAM_COLOR } from "@/lib/team-colors";
 import { PublicGameTimeline } from "@/pages/public-game-timeline";
 
@@ -69,27 +75,7 @@ export function PublicEventHomePage({ showAll = false }: { showAll?: boolean }) 
 }
 
 export function PublicEventPage({ eventId }: { eventId: string }) {
-  const [event, setEvent] = useState<PublicAudienceEventProjection | null>(null);
-  const [unavailable, setUnavailable] = useState(false);
-
-  useEffect(() => {
-    let active = true;
-    setEvent(null);
-    setUnavailable(false);
-    void fetch(`/api/audience/events/${encodeURIComponent(eventId)}`)
-      .then(async (response) => {
-        if (!response.ok) throw new Error("Event unavailable");
-        const payload = (await response.json()) as AudienceEventResponse;
-        if (payload.status !== "accepted") throw new Error("Event unavailable");
-        if (active) setEvent(payload.value);
-      })
-      .catch(() => {
-        if (active) setUnavailable(true);
-      });
-    return () => {
-      active = false;
-    };
-  }, [eventId]);
+  const { event, unavailable } = usePublicEventProjection(eventId);
 
   if (unavailable) return <UnavailablePanel />;
   if (event === null) {
@@ -105,6 +91,7 @@ export function PublicEventPage({ eventId }: { eventId: string }) {
   return (
     <PublicShell title={event.name} description={`Published Event · ${event.timeZone}`}>
       <div className="space-y-4">
+        {event.teamAssignmentNotice !== undefined ? <TeamAssignmentCorrectionNotice /> : null}
         <div className="flex flex-wrap items-center justify-between gap-3">
           <p className="text-sm text-muted-foreground">{lifecycleLabel(event.lifecycle)}</p>
           <Button variant="outline" onClick={() => navigateTo("/events?view=all")}>
@@ -165,6 +152,145 @@ export function PublicEventPage({ eventId }: { eventId: string }) {
   );
 }
 
+function usePublicEventProjection(eventId: string) {
+  const [event, setEvent] = useState<PublicAudienceEventProjection | null>(null);
+  const [unavailable, setUnavailable] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    let socket: WebSocket | null = null;
+    let reconnectAttempts = 0;
+    let recovering = false;
+    let terminalUnavailable = false;
+    setEvent(null);
+    setUnavailable(false);
+
+    const readAuthoritativeEvent = async () => {
+      const response = await fetch(`/api/audience/events/${encodeURIComponent(eventId)}`);
+      if (!response.ok) throw new Error("Event unavailable");
+      const payload = (await response.json()) as AudienceEventResponse;
+      if (payload.status !== "accepted") throw new Error("Event unavailable");
+      return payload.value;
+    };
+
+    const makeReplica = (nextEvent: PublicAudienceEventProjection) => {
+      const nextReplica = createPublicEventStreamReplica<PublicAudienceEventProjection>(eventId);
+      applyPublicEventStreamMessage(nextReplica, {
+        protocol: PUBLIC_EVENT_STREAM_PROTOCOL,
+        type: "snapshot",
+        eventId,
+        version: 0,
+        projection: nextEvent,
+      });
+      return nextReplica;
+    };
+
+    let recoverFromDisconnect: () => Promise<void>;
+    const connect = (replica: ReturnType<typeof makeReplica>) => {
+      if (!active || terminalUnavailable) return;
+      const connection = new WebSocket(publicEventWebSocketUrl());
+      socket = connection;
+      connection.onopen = () => {
+        connection.send(JSON.stringify({ type: "subscribe-public-event", eventId }));
+      };
+      connection.onmessage = (message) => {
+        if (!active || socket !== connection) return;
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(message.data);
+        } catch {
+          return;
+        }
+        if (!isPublicAudienceProjectionMessage(parsed, eventId)) return;
+        const result = applyPublicEventStreamMessage(replica, parsed);
+        if (result.status === "unavailable" && parsed.type === "event-unavailable") {
+          terminalUnavailable = true;
+          setEvent(null);
+          setUnavailable(true);
+          connection.close();
+          return;
+        }
+        if (result.status !== "applied" || replica.projection === null) return;
+        setEvent(replica.projection);
+      };
+      connection.onclose = () => {
+        if (!active || terminalUnavailable || socket !== connection) return;
+        socket = null;
+        void recoverFromDisconnect();
+      };
+    };
+
+    recoverFromDisconnect = async () => {
+      if (!active || terminalUnavailable || recovering) return;
+      if (reconnectAttempts >= PUBLIC_EVENT_MAX_RECONNECT_ATTEMPTS) {
+        setEvent(null);
+        setUnavailable(true);
+        return;
+      }
+      recovering = true;
+      reconnectAttempts += 1;
+      setEvent(null);
+      try {
+        const nextEvent = await readAuthoritativeEvent();
+        if (!active || terminalUnavailable) return;
+        setEvent(nextEvent);
+        reconnectAttempts = 0;
+        connect(makeReplica(nextEvent));
+      } catch {
+        if (active) {
+          setEvent(null);
+          setUnavailable(true);
+        }
+      } finally {
+        recovering = false;
+      }
+    };
+
+    void readAuthoritativeEvent()
+      .then((nextEvent) => {
+        if (!active) return;
+        setEvent(nextEvent);
+        reconnectAttempts = 0;
+        connect(makeReplica(nextEvent));
+      })
+      .catch(() => {
+        if (active) {
+          setEvent(null);
+          setUnavailable(true);
+        }
+      });
+    return () => {
+      active = false;
+      terminalUnavailable = true;
+      socket?.close();
+    };
+  }, [eventId]);
+
+  return { event, unavailable };
+}
+
+const PUBLIC_EVENT_MAX_RECONNECT_ATTEMPTS = 2;
+
+function publicEventWebSocketUrl() {
+  const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+  return `${protocol}//${window.location.host}/ws`;
+}
+
+function isPublicAudienceProjectionMessage(
+  value: unknown,
+  eventId: string,
+): value is PublicAudienceProjectionMessage<PublicAudienceEventProjection> {
+  if (value === null || typeof value !== "object") return false;
+  const message = value as { protocol?: unknown; eventId?: unknown; type?: unknown };
+  return (
+    message.protocol === PUBLIC_EVENT_STREAM_PROTOCOL &&
+    message.eventId === eventId &&
+    (message.type === "snapshot" ||
+      message.type === "projection-replaced" ||
+      message.type === "event-unavailable")
+  );
+}
+
 export function PublicEventGamePage({
   eventId,
   eventGameId,
@@ -172,34 +298,12 @@ export function PublicEventGamePage({
   eventId: string;
   eventGameId: string;
 }) {
-  const [game, setGame] = useState<PublicAudienceGameProjection | null>(null);
-  const [unavailable, setUnavailable] = useState(false);
+  const { event, unavailable } = usePublicEventProjection(eventId);
+  const game =
+    event?.schedule.scheduleGames.find((candidate) => candidate.eventGameId === eventGameId) ??
+    null;
   const [compactScoreboard, setCompactScoreboard] = useState(false);
   const scoreboardSentinelRef = useRef<HTMLDivElement | null>(null);
-
-  useEffect(() => {
-    let active = true;
-    setGame(null);
-    setUnavailable(false);
-    void fetch(
-      `/api/audience/events/${encodeURIComponent(eventId)}/games/${encodeURIComponent(eventGameId)}`,
-    )
-      .then(async (response) => {
-        if (!response.ok) throw new Error("Game unavailable");
-        const payload = (await response.json()) as AudienceGameResponse;
-        if (payload.status !== "accepted") throw new Error("Game unavailable");
-        return payload.value;
-      })
-      .then((nextGame) => {
-        if (active) setGame(nextGame);
-      })
-      .catch(() => {
-        if (active) setUnavailable(true);
-      });
-    return () => {
-      active = false;
-    };
-  }, [eventGameId, eventId]);
 
   useEffect(() => {
     const sentinel = scoreboardSentinelRef.current;
@@ -219,6 +323,7 @@ export function PublicEventGamePage({
 
   if (unavailable) return <GameUnavailablePanel eventId={eventId} />;
   if (game === null) {
+    if (event !== null) return <GameUnavailablePanel eventId={eventId} />;
     return (
       <PublicShell title="Live spectator Game" description="Loading public Game information…">
         <p className="rounded-2xl border bg-card/80 p-5 text-sm text-muted-foreground">Loading…</p>
@@ -241,6 +346,7 @@ export function PublicEventGamePage({
   return (
     <PublicShell title={title} description="Public Audience Projection · no sign-in required">
       <div className="space-y-4">
+        {game.teamAssignmentNotice !== undefined ? <TeamAssignmentCorrectionNotice /> : null}
         <div className="flex flex-wrap items-center justify-between gap-3">
           <Button
             variant="outline"
@@ -383,6 +489,17 @@ export function PublicEventGamePage({
   );
 }
 
+function TeamAssignmentCorrectionNotice() {
+  return (
+    <p
+      className="rounded-2xl border border-amber-300 bg-amber-50 p-4 text-sm text-amber-950"
+      role="status"
+    >
+      An Event Team assignment was corrected. Current team identities are shown.
+    </p>
+  );
+}
+
 function PublicScoreSide({
   side,
   label,
@@ -407,7 +524,7 @@ function PublicScoreSide({
         {side.name ?? "Unassigned Team"}
       </p>
       <p className="mt-2 text-4xl font-bold tabular-nums sm:text-5xl">
-        {side.score ?? "—"}
+        <span aria-label={`${label} score`}>{side.score ?? "—"}</span>
         {isCatching ? (
           <span className="mt-1 block text-xs font-semibold tracking-wide text-foreground uppercase">
             Flag catch
@@ -1156,9 +1273,6 @@ function lifecycleLabel(lifecycle: PublicAudienceEventProjection["lifecycle"]): 
 
 type AudienceEventResponse =
   | { status: "accepted"; value: PublicAudienceEventProjection }
-  | { status: "unavailable" };
-type AudienceGameResponse =
-  | { status: "accepted"; value: PublicAudienceGameProjection }
   | { status: "unavailable" };
 type AudienceEventsResponse =
   | { status: "accepted"; value: { events: readonly PublicAudienceEventProjection[] } }


### PR DESCRIPTION
## What changed

- streams versioned, allowlisted Published Event Audience Projections over WebSocket
- refreshes only from authoritative committed Event/Game mutations and fails closed on projection failure
- reconnects through a fresh HTTP projection, coalesces replaceable projections, and clears retained data on withdrawal
- shares one upstream Event feed across spectators while enforcing bounded output and Controller-priority capacity
- adds cache validators for dynamic public responses and immutable caching for versioned assets

## Why

Spectators need schedule, score, Clock, and Timeline changes without reloading, while hidden Events must stop revealing data immediately. The delivery path must preserve Controller capacity for the event in two days.

## Impact

Published Event and stable spectator Game pages converge on committed projections, recover from dropped connections, and become generically unavailable after unpublication or authoritative failure. No private authority, audit, or correction provenance enters the stream.

## Validation

- focused projection, HTTP, stream, ordering, reconnect, withdrawal, and capacity tests
- full ordinary suite: 958 tests, 20,693 assertions
- Chromium and WebKit public Event browser journey
- `bun run check`
- `bun run build`
- `git diff --check`

No Qualification, load, soak, crash, recovery, or exact-production-artifact workload was run.

Closes #137.

Stack: depends on #264; #266 builds on this change.
