### PR TITLE
Complete accessible public Event journeys

### DIFF
--- a/scripts/test-public-event-browser.ts
+++ b/scripts/test-public-event-browser.ts
@@ -1,4 +1,4 @@
-import { chromium, type Page } from "playwright";
+import { chromium, type Locator, type Page, webkit } from "playwright";
 import tailwind from "bun-plugin-tailwind";
 import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { basename, join } from "node:path";
@@ -41,6 +41,9 @@ const encodeLiveEventKey = (key: Uint8Array | undefined) =>
   key === undefined ? "" : Buffer.from(key).toString("base64url");
 const port = 38_000 + Math.floor(Math.random() * 1_000);
 const origin = `http://127.0.0.1:${port}`;
+type DisconnectableWebSocketRoute = {
+  close(options?: { code?: number; reason?: string }): Promise<void>;
+};
 const environment = {
   ...process.env,
   NODE_ENV: "test",
@@ -63,6 +66,7 @@ let server: Bun.Subprocess | null = null;
 let serverStderr: Promise<string> | null = null;
 let harnessServer: ReturnType<typeof Bun.serve> | null = null;
 let browser: Awaited<ReturnType<typeof chromium.launch>> | null = null;
+let webkitBrowser: Awaited<ReturnType<typeof webkit.launch>> | null = null;
 let browserPage: Page | null = null;
 
 try {
@@ -122,17 +126,10 @@ try {
   const harnessOrigin = `http://127.0.0.1:${harnessServer.port}`;
 
   browser = await chromium.launch({ headless: true });
-  const context = await browser.newContext({ viewport: { width: 390, height: 844 } });
+  const context = await browser.newContext({ viewport: { width: 360, height: 844 } });
   const page = await context.newPage();
-  page.setDefaultTimeout(5_000);
   browserPage = page;
-  const consoleErrors: string[] = [];
-  page.on("pageerror", (error) => consoleErrors.push(error.message));
-  page.on("console", (message) => {
-    if (message.type() === "error" && !message.text().includes("Failed to load resource")) {
-      consoleErrors.push(message.text());
-    }
-  });
+  const consoleErrors = setupBrowserPage(page);
 
   const listResponse = await context.request.get(`${origin}/api/audience/events`);
   assert(listResponse.status() === 200, "seeded Audience list was unavailable");
@@ -149,6 +146,22 @@ try {
   await page.getByRole("heading", { name: "Published Current" }).waitFor();
   await page.getByRole("heading", { name: "Coming up" }).waitFor();
   await page.getByRole("heading", { name: "Event schedule" }).waitFor();
+  assert((await page.getByRole("main").count()) === 1, "public Event page has no main landmark");
+  const skipLink = page.getByRole("link", { name: "Skip to main content" });
+  await skipLink.focus();
+  assert(
+    await skipLink.evaluate((element) => document.activeElement === element),
+    "skip link could not receive keyboard focus",
+  );
+  assert(
+    (await skipLink.getAttribute("href")) === "#main-content" &&
+      (await page.locator("#main-content").count()) === 1,
+    "skip link did not provide a keyboard destination",
+  );
+  assert(
+    (await page.locator('[data-live-projection-status][role="status"]').count()) === 1,
+    "public Event did not expose a live-update status announcement",
+  );
   const liveNow = page.locator('[data-schedule-group="live-now"]');
   await liveNow.locator('[data-game-code="BUSY-2"]').waitFor();
   await liveNow.locator('[data-game-code="BUSY-3"]').waitFor();
@@ -179,7 +192,7 @@ try {
     "finished Game did not render its effective public Timeline",
   );
   assert(
-    (await page.locator('[data-schedule-group="coming-up"] h3').count()) === 1,
+    (await page.locator('[data-schedule-group="coming-up"] h3[id^="expected-"]').count()) === 1,
     "Coming up Games were not grouped by Expected Start",
   );
   await page.getByText("Pitch Pitch 1").first().waitFor();
@@ -193,30 +206,28 @@ try {
     await page.evaluate(
       () => document.documentElement.scrollWidth <= document.documentElement.clientWidth,
     ),
-    "phone-sized Event schedule overflows horizontally",
+    "360px phone-sized Event schedule overflows horizontally",
   );
 
   const harnessPage = await context.newPage();
-  harnessPage.setDefaultTimeout(5_000);
-  harnessPage.on("pageerror", (error) => consoleErrors.push(error.message));
-  harnessPage.on("console", (message) => {
-    if (message.type() === "error") consoleErrors.push(message.text());
-  });
+  setupBrowserPage(harnessPage, consoleErrors);
   await harnessPage.goto(`${harnessOrigin}/`);
   const harnessTimeline = harnessPage.locator("[data-game-timeline]");
   await harnessTimeline.waitFor();
   const harnessScroll = harnessTimeline.locator("[data-timeline-scroll-region]");
-  await harnessScroll.evaluate((element) => {
-    element.scrollTop = Math.floor(element.scrollHeight / 2);
-    element.dispatchEvent(new Event("scroll", { bubbles: true }));
-  });
+  await harnessScroll.hover();
+  await harnessPage.mouse.wheel(0, 600);
+  await harnessPage.waitForFunction(
+    (selector) => ((document.querySelector(selector) as HTMLElement | null)?.scrollTop ?? 0) > 8,
+    "[data-timeline-scroll-region]",
+  );
   const harnessBeforeNewPlay = await harnessScroll.evaluate((element) => ({
     bottomDistance: element.scrollHeight - element.clientHeight - element.scrollTop,
     scrollTop: element.scrollTop,
   }));
   assert(harnessBeforeNewPlay.scrollTop > 0, "Timeline harness could not leave the live edge");
   await harnessPage.getByRole("button", { name: "Deliver newer play while away" }).click();
-  await harnessPage.getByRole("button", { name: "New play" }).waitFor();
+  await harnessPage.getByRole("button", { name: "Show newest play" }).waitFor();
   const harnessAfterNewPlay = await harnessScroll.evaluate((element) => ({
     bottomDistance: element.scrollHeight - element.clientHeight - element.scrollTop,
     scrollTop: element.scrollTop,
@@ -225,7 +236,7 @@ try {
     Math.abs(harnessAfterNewPlay.bottomDistance - harnessBeforeNewPlay.bottomDistance) <= 4,
     "Timeline harness changed the older-entry viewport position",
   );
-  await harnessPage.getByRole("button", { name: "New play" }).click();
+  await harnessPage.getByRole("button", { name: "Show newest play" }).click();
   await harnessPage.waitForFunction(
     (selector) => ((document.querySelector(selector) as HTMLElement | null)?.scrollTop ?? 0) <= 8,
     "[data-timeline-scroll-region]",
@@ -236,11 +247,78 @@ try {
     "[data-timeline-scroll-region]",
   );
   assert(
-    (await harnessPage.getByRole("button", { name: "New play" }).count()) === 0,
+    (await harnessPage.getByRole("button", { name: "Show newest play" }).count()) === 0,
     "Timeline harness exposed New play at the live edge",
   );
 
+  const stableGamePath = `/events/${encodeURIComponent(seeded.currentId)}/games/${encodeURIComponent(
+    seeded.currentGames[1]!.game.eventGameId,
+  )}`;
+  await openEventAndActivateSpectatorGame(page, current, stableGamePath, {
+    expectedScore: "0",
+    expectedTimelineText: "Original Player",
+    focusGameLink: async (keyboardGameLink) => {
+      const keyboardAllEvents = page.getByRole("button", { name: "All events" });
+      await keyboardAllEvents.focus();
+      await page.keyboard.press("Shift+Tab");
+      assert(
+        await page.evaluate(
+          () =>
+            document.activeElement?.getAttribute("href") === "#main-content" &&
+            document.activeElement?.matches(":focus-visible") === true,
+        ),
+        "skip navigation did not receive visible keyboard focus",
+      );
+      await page.keyboard.press("Tab");
+      assert(
+        await keyboardAllEvents.evaluate((element) => document.activeElement === element),
+        "keyboard focus did not move from skip navigation to Event navigation",
+      );
+      await page.keyboard.press("Tab");
+      assert(
+        await keyboardGameLink.evaluate((element) => document.activeElement === element),
+        "keyboard focus did not move into schedule Game navigation",
+      );
+      await page.keyboard.press("Shift+Tab");
+      assert(
+        await keyboardAllEvents.evaluate((element) => document.activeElement === element),
+        "Shift-Tab did not return focus to Event navigation",
+      );
+      await page.keyboard.press("Tab");
+      assert(
+        await keyboardGameLink.evaluate((element) => document.activeElement === element),
+        "Tab did not restore focus to the canonical spectator Game link",
+      );
+      assert(
+        await keyboardGameLink.evaluate(
+          (element) =>
+            element.matches(":focus-visible") && getComputedStyle(element).boxShadow !== "none",
+        ),
+        "canonical spectator Game link did not expose visible keyboard focus styling",
+      );
+    },
+  });
+
+  await page.setViewportSize({ width: 1280, height: 900 });
+  await page.goto(`${origin}${current.canonicalPath}`);
+  await page.getByRole("heading", { name: "Published Current" }).waitFor();
+  assert(
+    await page.evaluate(
+      () => document.documentElement.scrollWidth <= document.documentElement.clientWidth,
+    ),
+    "desktop Event schedule overflows horizontally",
+  );
+  assert(
+    (await page.locator("[data-schedule-card]").count()) >= 5,
+    "desktop Event journey did not render the schedule",
+  );
+  await page.setViewportSize({ width: 360, height: 844 });
+
   const streamedGame = schedule.locator('[data-game-code="BUSY-2"]');
+  assert(
+    (await streamedGame.getByRole("link", { name: /Open spectator Game/ }).count()) === 1,
+    "schedule Game did not expose a keyboard-operable spectator link",
+  );
   const initialScore = await streamedGame.locator('[aria-label="Side A score"]').innerText();
   assert(initialScore === "0", "canonical Event page did not render the initial scoreboard");
   assert(
@@ -248,46 +326,13 @@ try {
     "canonical Event page unexpectedly rendered the future goal",
   );
 
-  const stableGamePath = `/events/${encodeURIComponent(seeded.currentId)}/games/${encodeURIComponent(
-    seeded.currentGames[1]!.game.eventGameId,
-  )}`;
-  await page.goto(`${origin}${stableGamePath}`);
-  await page.getByRole("heading", { name: "Busy Game 2" }).waitFor();
-  const stableGameScore = page.locator('[aria-label="Side A score"]');
-  await stableGameScore.waitFor();
-  assert(
-    (await stableGameScore.innerText()) === "0",
-    "stable Game page did not render its snapshot",
-  );
-  assert(
-    (await page.locator('[data-timeline-kind="goal"]').count()) === 0,
-    "stable Game page unexpectedly rendered the future goal",
-  );
-  await acceptCommittedGoal(seeded);
-  await page.waitForFunction(
-    () => document.querySelector('[aria-label="Side A score"]')?.textContent?.trim() === "10",
-  );
-  await page.locator('[data-timeline-kind="goal"]').first().waitFor();
-  assert(
-    page.url() === `${origin}${stableGamePath}`,
-    "stable Game stream update reloaded the page",
-  );
-
-  await page.goto(`${origin}${current.canonicalPath}`);
-  await page.getByRole("heading", { name: "Published Current" }).waitFor();
-  await page.waitForFunction(
-    (selector) => document.querySelector(selector)?.textContent?.trim() === "10",
-    '[data-game-code="BUSY-2"] [aria-label="Side A score"]',
-  );
-  await page.locator('[data-game-code="BUSY-2"] [data-timeline-kind="goal"]').first().waitFor();
-  assert(
-    page.url() === `${origin}${current.canonicalPath}`,
-    "stream update reloaded the Event page",
-  );
-  assert(
-    (await page.locator('[data-game-code="BUSY-2"][data-schedule-status="running"]').count()) >= 1,
-    "stream update removed the canonical schedule card",
-  );
+  await exerciseLiveSpectatorGameBehavior(page, seeded, current, stableGamePath, {
+    engineLabel: "Chromium",
+    initialRosterName: "Original Player",
+    correctedRosterName: "Corrected Player",
+    actionPrefix: "browser-convergence",
+    sportingOrder: 1_000,
+  });
 
   await page.getByRole("button", { name: "All events" }).click();
   await page.waitForURL(`${origin}/events?view=all`);
@@ -389,7 +434,32 @@ try {
   await page.waitForURL(`${origin}/events?view=all`);
   await page.unroute(`${origin}/api/audience/events/database-failure`);
 
-  await page.getByRole("button", { name: /Start an Ad Hoc Game/ }).click();
+  await page.goto(`${origin}${current.canonicalPath}`);
+  await page.getByRole("heading", { name: "Published Current" }).waitFor();
+  await page.getByText("Corrected Player").waitFor();
+  webkitBrowser = await webkit.launch({ headless: true });
+  try {
+    await runWebKitCriticalPath(webkitBrowser, seeded, current, stableGamePath);
+  } finally {
+    await webkitBrowser.close();
+    webkitBrowser = null;
+  }
+  await assertWithdrawnPublicEvent(page, current.name, "WebKit Corrected Player", "Chromium");
+  await page.goto(`${origin}/events?view=all`);
+  await page.getByRole("heading", { name: "Current Events" }).waitFor();
+  const adHoc = page.getByRole("button", { name: /Start an Ad Hoc Game/ });
+  await page.getByLabel("Away color").focus();
+  await page.keyboard.press("Tab");
+  assert(
+    await adHoc.evaluate(
+      (element) =>
+        document.activeElement === element &&
+        element.matches(":focus-visible") &&
+        getComputedStyle(element).boxShadow !== "none",
+    ),
+    "Ad Hoc handoff did not expose visible focus styling",
+  );
+  await page.keyboard.press("Enter");
   await page.waitForURL(new RegExp(`${origin}/game/adhoc-[a-zA-Z0-9_-]+$`));
   assert(consoleErrors.length === 0, `browser console errors: ${consoleErrors.join(" | ")}`);
   console.log(
@@ -406,6 +476,21 @@ try {
       unavailableDatabaseFailure: true,
       publishedSitemapExclusion: true,
       adHocHandoff: true,
+      keyboardAccessible: true,
+      semanticLandmarks: true,
+      liveUpdateAnnouncements: true,
+      spectatorGameNavigation: true,
+      keyboardTimeline: true,
+      stickyCompactScore: true,
+      timelineNewPlayPreservesContext: true,
+      effectiveGameCorrection: true,
+      reducedMotionTimeline: true,
+      webkitPublicCriticalPath: true,
+      webkitLiveConvergence: true,
+      webkitRosterReconnectRecovery: true,
+      webkitTimelineContextPreservation: true,
+      webkitEffectiveGameCorrection: true,
+      webkitPublicationWithdrawal: true,
     }),
   );
 } catch (error) {
@@ -420,6 +505,7 @@ try {
 } finally {
   if (browser) await browser.close();
   if (harnessServer) await harnessServer.stop(true);
+  if (webkitBrowser) await webkitBrowser.close();
   if (server) {
     server.kill();
     await server.exited;
@@ -436,6 +522,371 @@ type PublicEventFixture = {
   gameDays: string[];
   canonicalPath: string;
 };
+
+type SeededPublicEvent = Awaited<ReturnType<typeof seedDatabase>>;
+
+function setupBrowserPage(page: Page, errors: string[] = []) {
+  page.setDefaultTimeout(5_000);
+  page.on("pageerror", (error) => errors.push(error.message));
+  page.on("console", (message) => {
+    if (message.type() === "error" && !message.text().includes("Failed to load resource")) {
+      errors.push(message.text());
+    }
+  });
+  return errors;
+}
+
+async function openEventAndActivateSpectatorGame(
+  page: Page,
+  current: PublicEventFixture,
+  stableGamePath: string,
+  options: {
+    expectedScore: string;
+    expectedTimelineText: string;
+    focusGameLink: (gameLink: Locator) => Promise<void>;
+  },
+) {
+  await page.goto(`${origin}${current.canonicalPath}`);
+  await page.getByRole("heading", { name: current.name }).waitFor();
+  assert((await page.getByRole("main").count()) === 1, "public Event has no main landmark");
+  await page.getByRole("heading", { name: "Event schedule" }).waitFor();
+  await page.locator('[data-schedule-group="live-now"]').waitFor();
+  assert(
+    await page.evaluate(
+      () => document.documentElement.scrollWidth <= document.documentElement.clientWidth,
+    ),
+    "360px public Event overflows horizontally",
+  );
+  const gameLink = page.locator('[data-game-code="BUSY-2"] a[href*="/games/"]').first();
+  await options.focusGameLink(gameLink);
+  assert(
+    await gameLink.evaluate((element) => document.activeElement === element),
+    "spectator Game link was not focused before keyboard activation",
+  );
+  await page.keyboard.press("Enter");
+  await page.waitForURL(`${origin}${stableGamePath}`);
+  await page.getByRole("heading", { name: "Busy Game 2" }).waitFor();
+  assert(
+    page.url() === `${origin}${stableGamePath}`,
+    "keyboard activation did not navigate to the canonical spectator Game",
+  );
+  assert((await page.getByRole("main").count()) === 1, "spectator Game has no main landmark");
+  await page.waitForFunction(
+    (expectedScore) =>
+      document.querySelector('[aria-label="Side A score"]')?.textContent?.trim() === expectedScore,
+    options.expectedScore,
+  );
+  await page.getByText(options.expectedTimelineText).waitFor();
+  await page.locator('[data-timeline-scroll-region][role="region"][tabindex="0"]').waitFor();
+  await page.waitForFunction(
+    () =>
+      document
+        .querySelector("[data-live-projection-status]")
+        ?.textContent?.includes("connected") === true,
+  );
+}
+
+async function exerciseLiveSpectatorGameBehavior(
+  page: Page,
+  seeded: SeededPublicEvent,
+  current: PublicEventFixture,
+  stableGamePath: string,
+  options: {
+    engineLabel: string;
+    initialRosterName: string;
+    correctedRosterName: string;
+    actionPrefix: string;
+    sportingOrder: number;
+  },
+) {
+  const websocket = {
+    routeCount: 0,
+    activeRoute: null as DisconnectableWebSocketRoute | null,
+  };
+  await page.routeWebSocket(/\/ws$/, (route) => {
+    const serverRoute = route.connectToServer();
+    websocket.routeCount += 1;
+    websocket.activeRoute = route;
+    route.onMessage((message) => serverRoute.send(message));
+    serverRoute.onMessage((message) => route.send(message));
+  });
+  await page.goto(`${origin}${stableGamePath}`);
+  await page.getByRole("heading", { name: "Busy Game 2" }).waitFor();
+  assert(
+    (await page.getByRole("main").count()) === 1,
+    `${options.engineLabel} spectator Game has no main landmark`,
+  );
+  assert(
+    (await page.locator('[data-live-projection-status][role="status"]').count()) === 1,
+    `${options.engineLabel} spectator Game did not expose a live-update status announcement`,
+  );
+  const stableGameScore = page.locator('[aria-label="Side A score"]');
+  await stableGameScore.waitFor();
+  assert(
+    (await stableGameScore.innerText()) === "0",
+    `${options.engineLabel} stable Game page did not render its snapshot`,
+  );
+  assert(
+    (await page.locator('[data-timeline-kind="goal"]').count()) === 0,
+    `${options.engineLabel} stable Game page unexpectedly rendered a future goal`,
+  );
+  await publicRosterTimelineEntry(page, options.initialRosterName).waitFor();
+  const liveStatus = page.locator('[data-live-projection-status][role="status"]');
+  await page.waitForFunction(
+    () =>
+      document
+        .querySelector("[data-live-projection-status]")
+        ?.textContent?.includes("connected") === true,
+  );
+  const initialClock = await page.locator("[data-scoreboard-expanded] .font-mono").innerText();
+  await page.waitForFunction(
+    (initial) =>
+      document.querySelector("[data-scoreboard-expanded] .font-mono")?.textContent?.trim() !==
+      initial,
+    initialClock,
+  );
+  assert(initialClock.length > 0, `${options.engineLabel} did not render its live Clock`);
+
+  const firstWebSocketRoute = requireWebSocketRoute(websocket.activeRoute);
+  const firstWebSocketCount = websocket.routeCount;
+  await firstWebSocketRoute.close({
+    code: 1000,
+    reason: `${options.engineLabel} browser reconnect test`,
+  });
+  await liveStatus.waitFor({ state: "attached" });
+  await page.waitForFunction(
+    () =>
+      document
+        .querySelector("[data-live-projection-status]")
+        ?.textContent?.includes("reconnecting") === true,
+  );
+  await updateRosterMapping(seeded, options.correctedRosterName);
+  await page.waitForFunction(
+    () =>
+      document
+        .querySelector("[data-live-projection-status]")
+        ?.textContent?.includes("connected") === true,
+  );
+  const reconnectDeadline = Date.now() + 5_000;
+  while (websocket.routeCount <= firstWebSocketCount && Date.now() < reconnectDeadline) {
+    await Bun.sleep(50);
+  }
+  await publicRosterTimelineEntry(page, options.correctedRosterName).waitFor();
+  assert(
+    websocket.routeCount > firstWebSocketCount,
+    `${options.engineLabel} did not establish a replacement WebSocket after disconnect`,
+  );
+  assert(
+    (await publicRosterTimelineEntry(page, options.initialRosterName).count()) === 0,
+    `${options.engineLabel} retained the superseded roster label after recovery`,
+  );
+
+  await page.evaluate(() => window.scrollTo(0, document.documentElement.scrollHeight));
+  const compactScoreboard = page.locator(
+    '[data-scoreboard-compact][aria-label="Compact live scoreboard"]',
+  );
+  await compactScoreboard.waitFor({ state: "visible" });
+  assert(
+    await compactScoreboard.evaluate((element) => {
+      const rect = element.getBoundingClientRect();
+      return (
+        getComputedStyle(element).position === "sticky" &&
+        rect.top >= 0 &&
+        rect.top <= 16 &&
+        rect.right <= document.documentElement.clientWidth
+      );
+    }),
+    `${options.engineLabel} 360px Game did not expose a usable sticky compact score`,
+  );
+  await page.emulateMedia({ reducedMotion: "reduce" });
+  const timelineRegion = page.locator('[data-timeline-scroll-region][role="region"][tabindex="0"]');
+  await timelineRegion.scrollIntoViewIfNeeded();
+  await page.getByRole("button", { name: "Back to Event" }).focus();
+  await page.keyboard.press("Tab");
+  const timelineBefore = await timelineRegion.evaluate((element) => {
+    const region = element as HTMLDivElement;
+    const maximumScrollTop = region.scrollHeight - region.clientHeight;
+    region.scrollTop = Math.min(200, maximumScrollTop);
+    region.dispatchEvent(new Event("scroll", { bubbles: true }));
+    const regionRect = region.getBoundingClientRect();
+    const anchor = Array.from(region.querySelectorAll<HTMLElement>("[data-timeline-kind]")).find(
+      (entry) => {
+        const rect = entry.getBoundingClientRect();
+        return rect.top >= regionRect.top && rect.bottom <= regionRect.bottom;
+      },
+    );
+    return {
+      scrollTop: region.scrollTop,
+      scrollHeight: region.scrollHeight,
+      clientHeight: region.clientHeight,
+      focused: document.activeElement === region,
+      focusVisible: region.matches(":focus-visible"),
+      boxShadow: getComputedStyle(region).boxShadow,
+      reducedMotion: window.matchMedia("(prefers-reduced-motion: reduce)").matches,
+      scrollBehavior: getComputedStyle(region).scrollBehavior,
+      anchorText: anchor?.textContent ?? null,
+      anchorTop: anchor === undefined ? null : anchor.getBoundingClientRect().top - regionRect.top,
+    };
+  });
+  assert(
+    timelineBefore.scrollHeight > timelineBefore.clientHeight && timelineBefore.scrollTop > 8,
+    `${options.engineLabel} Timeline could not start away from the live edge`,
+  );
+  assert(
+    timelineBefore.focused &&
+      timelineBefore.focusVisible &&
+      timelineBefore.boxShadow !== "none" &&
+      timelineBefore.reducedMotion &&
+      timelineBefore.scrollBehavior === "auto",
+    `${options.engineLabel} reduced-motion Timeline was not active and keyboard-focused`,
+  );
+
+  await acceptCommittedGoal(seeded, options.actionPrefix, options.sportingOrder);
+  await page.waitForFunction(
+    () => document.querySelector('[aria-label="Side A score"]')?.textContent?.trim() === "10",
+  );
+  await page.locator('[data-timeline-kind="goal"]').first().waitFor();
+  const newPlay = page.getByRole("button", { name: "Show newest play" });
+  await newPlay.waitFor({ state: "visible" });
+  const timelineAfter = await timelineRegion.evaluate((element, anchorText) => {
+    const region = element as HTMLDivElement;
+    const anchor = Array.from(region.querySelectorAll<HTMLElement>("[data-timeline-kind]")).find(
+      (entry) => entry.textContent === anchorText,
+    );
+    return {
+      scrollTop: region.scrollTop,
+      scrollHeight: region.scrollHeight,
+      focused: document.activeElement === region,
+      anchorTop:
+        anchor === undefined
+          ? null
+          : anchor.getBoundingClientRect().top - region.getBoundingClientRect().top,
+    };
+  }, timelineBefore.anchorText);
+  const timelineHeightDelta = timelineAfter.scrollHeight - timelineBefore.scrollHeight;
+  assert(
+    timelineAfter.focused &&
+      timelineHeightDelta > 0 &&
+      timelineBefore.anchorText !== null &&
+      timelineBefore.anchorTop !== null &&
+      timelineAfter.anchorTop !== null &&
+      timelineAfter.scrollTop > timelineBefore.scrollTop &&
+      Math.abs(timelineAfter.anchorTop - timelineBefore.anchorTop) <= 10,
+    `${options.engineLabel} new play did not preserve Timeline position and focus: ${JSON.stringify({ timelineBefore, timelineAfter, timelineHeightDelta })}`,
+  );
+  assert(
+    (await newPlay.innerText()) === "New play",
+    `${options.engineLabel} did not expose the accessible New play action`,
+  );
+  await newPlay.focus();
+  await page.keyboard.press("Enter");
+  const activatedTimeline = await timelineRegion.evaluate((element) => ({
+    scrollTop: (element as HTMLDivElement).scrollTop,
+    focused: document.activeElement === element,
+    firstKind: element.querySelector("[data-timeline-kind]")?.getAttribute("data-timeline-kind"),
+  }));
+  assert(
+    activatedTimeline.scrollTop <= 8 &&
+      activatedTimeline.focused &&
+      activatedTimeline.firstKind === "goal",
+    `${options.engineLabel} reduced-motion New play activation lost the live edge or focus`,
+  );
+
+  await acceptCommittedGoalCorrection(seeded, options.actionPrefix);
+  await page.waitForFunction(
+    () =>
+      document.querySelector('[aria-label="Side A score"]')?.textContent?.trim() === "0" &&
+      document.querySelectorAll('[data-timeline-kind="goal"]').length === 0,
+  );
+  assert(
+    await timelineRegion.evaluate((element) => document.activeElement === element),
+    `${options.engineLabel} effective Game Correction stole Timeline focus`,
+  );
+  assert(
+    page.url() === `${origin}${stableGamePath}`,
+    `${options.engineLabel} stable Game update reloaded the page`,
+  );
+
+  await page.goto(`${origin}${current.canonicalPath}`);
+  await page.getByRole("heading", { name: current.name }).waitFor();
+  await page.waitForFunction(
+    (selector) => document.querySelector(selector)?.textContent?.trim() === "0",
+    '[data-game-code="BUSY-2"] [aria-label="Side A score"]',
+  );
+  assert(
+    (await page.locator('[data-game-code="BUSY-2"] [data-timeline-kind="goal"]').count()) === 0,
+    `${options.engineLabel} corrected Goal remained in the Event Timeline`,
+  );
+  await publicRosterTimelineEntry(page, options.correctedRosterName).waitFor();
+  assert(
+    (await page.locator('[data-game-code="BUSY-2"][data-schedule-status="running"]').count()) >= 1,
+    `${options.engineLabel} stream update removed the canonical schedule card`,
+  );
+}
+
+function publicRosterTimelineEntry(page: Page, publicName: string) {
+  return page
+    .locator('[data-timeline-kind="card"]')
+    .filter({ hasText: `Player #7 · ${publicName}` });
+}
+
+async function assertWithdrawnPublicEvent(
+  page: Page,
+  eventName: string,
+  rosterName: string,
+  engineLabel: string,
+) {
+  await page.getByRole("heading", { name: "Event unavailable" }).waitFor();
+  const withdrawnBody = await page.locator("body").innerText();
+  assert(!withdrawnBody.includes(eventName), `${engineLabel} retained the withdrawn Event name`);
+  assert(!withdrawnBody.includes(rosterName), `${engineLabel} retained withdrawn roster data`);
+  assert(
+    (await page.locator("[data-schedule-card]").count()) === 0,
+    `${engineLabel} retained the withdrawn Event schedule`,
+  );
+}
+
+async function runWebKitCriticalPath(
+  webkitInstance: Awaited<ReturnType<typeof webkit.launch>>,
+  seeded: SeededPublicEvent,
+  current: PublicEventFixture,
+  stableGamePath: string,
+) {
+  const context = await webkitInstance.newContext({ viewport: { width: 360, height: 844 } });
+  const page = await context.newPage();
+  const consoleErrors = setupBrowserPage(page);
+  try {
+    await openEventAndActivateSpectatorGame(page, current, stableGamePath, {
+      expectedScore: "0",
+      expectedTimelineText: "Corrected Player",
+      focusGameLink: async (gameLink) => {
+        await gameLink.focus();
+        assert(
+          await gameLink.evaluate(
+            (element) =>
+              document.activeElement === element && getComputedStyle(element).boxShadow !== "none",
+          ),
+          "WebKit spectator Game link did not expose visible keyboard focus",
+        );
+      },
+    });
+    await exerciseLiveSpectatorGameBehavior(page, seeded, current, stableGamePath, {
+      engineLabel: "WebKit",
+      initialRosterName: "Corrected Player",
+      correctedRosterName: "WebKit Corrected Player",
+      actionPrefix: "webkit-convergence",
+      sportingOrder: 1_100,
+    });
+    await withdrawPublishedEvent(seeded.currentId);
+    await assertWithdrawnPublicEvent(page, current.name, "WebKit Corrected Player", "WebKit");
+    assert(
+      consoleErrors.length === 0,
+      `WebKit browser console errors: ${consoleErrors.join(" | ")}`,
+    );
+  } finally {
+    await context.close();
+  }
+}
 
 async function seedDatabase() {
   const foundation = openSqliteFoundationStorage(foundationDatabase, {
@@ -484,6 +935,19 @@ async function createPublishedEvent(
   const games = withSchedule
     ? await createBusySchedule(catalog, authority, event.value.eventId, day.value.gameDayId)
     : [];
+  if (withSchedule) {
+    const rosterTeamId = games[1]?.game.sideB.eventTeamId;
+    if (rosterTeamId === null || rosterTeamId === undefined) {
+      throw new Error(`${name} roster Event Team was not confirmed`);
+    }
+    const roster = await catalog.upsertEventTeamRoster(
+      event.value.eventId,
+      rosterTeamId,
+      { playerNumber: 7, publicName: "Original Player" },
+      authority,
+    );
+    if (roster.status !== "accepted") throw new Error(`${name} roster creation failed`);
+  }
   const published = await catalog.changePublicationStatus(
     event.value.eventId,
     { status: "published", impactConfirmed: true },
@@ -503,6 +967,19 @@ async function createBusySchedule(
   const secondPitch = await catalog.createPitch(eventId, { name: "Pitch 2" }, authority);
   if (firstPitch.status !== "accepted" || secondPitch.status !== "accepted") {
     throw new Error("busy Event Pitch creation failed");
+  }
+  const blueTeam = await catalog.createEventTeam(
+    eventId,
+    { name: "Blue Team", defaultColor: "#2563eb" },
+    authority,
+  );
+  const redTeam = await catalog.createEventTeam(
+    eventId,
+    { name: "Red Team", defaultColor: "#dc2626" },
+    authority,
+  );
+  if (blueTeam.status !== "accepted" || redTeam.status !== "accepted") {
+    throw new Error("busy Event Team creation failed");
   }
   const now = Date.now();
   const starts = [
@@ -553,8 +1030,26 @@ async function createBusySchedule(
       authority,
     );
     if (game.status !== "accepted") throw new Error("busy Event Game creation failed");
+    const confirmed = await catalog.confirmGameplaySlotTeams(
+      eventId,
+      gameDayId,
+      slot.value.gameplaySlotId,
+      {
+        games: [
+          {
+            eventGameId: game.value.eventGameId,
+            sideAEventTeamId: blueTeam.value.eventTeamId,
+            sideBEventTeamId: redTeam.value.eventTeamId,
+          },
+        ],
+      },
+      authority,
+    );
+    if (confirmed.status !== "accepted") throw new Error("busy Event Team mapping failed");
+    const confirmedGame = confirmed.value[0];
+    if (confirmedGame === undefined) throw new Error("busy Event Team mapping returned no Game");
     created.push({
-      game: game.value,
+      game: confirmedGame,
       pitchId: pitchSlot.pitchId,
       pitchSlotId: pitchSlot.pitchSlotId,
     });
@@ -578,12 +1073,21 @@ async function seedCommittedGameRecords(seeded: {
   try {
     for (const [index, entry] of seeded.currentGames.entries()) {
       if (index > 2) continue;
+      const sideAEventTeamId = entry.game.sideA.eventTeamId;
+      const sideBEventTeamId = entry.game.sideB.eventTeamId;
+      if (sideAEventTeamId === null || sideBEventTeamId === null) {
+        throw new Error(
+          `confirmed Event Team identities are missing for ${entry.game.eventGameId}`,
+        );
+      }
       const root = createSeedRoot(
         seeded.currentId,
         seeded.currentGameDayId,
         entry.game.eventGameId,
         entry.pitchId,
         entry.pitchSlotId,
+        sideAEventTeamId,
+        sideBEventTeamId,
       );
       await seedEventGameRecord(foundation, root, createSeedScopeResolver(), index);
       await seedEventGameRecord(eventGameStorage, root, createEventGameSeedScopeResolver(), index);
@@ -611,6 +1115,36 @@ async function seedEventGameRecord(
     index === 0 ? createSeedForfeitAction(root) : createSeedClockAction(root),
   );
   if (action.status !== "accepted") throw new Error("busy Event action commit failed");
+  if (index === 1) {
+    for (let playerNumber = 20; playerNumber < 30; playerNumber += 1) {
+      const historyCard = await record.acceptAction(
+        createSeedAction(
+          root,
+          `seed-history-card-${root.eventGameId}-${playerNumber}`,
+          "card",
+          root.gameSides[1].id,
+          {
+            cardType: "blue",
+            playerNumber,
+            penaltyStart: "immediate",
+            sportingOrder: playerNumber,
+          },
+        ),
+      );
+      if (historyCard.status !== "accepted") {
+        throw new Error("busy Event Timeline history commit failed");
+      }
+    }
+    const card = await record.acceptAction(
+      createSeedAction(root, `seed-card-${root.eventGameId}`, "card", root.gameSides[1].id, {
+        cardType: "blue",
+        playerNumber: 7,
+        penaltyStart: "immediate",
+        sportingOrder: 100,
+      }),
+    );
+    if (card.status !== "accepted") throw new Error("busy Event card commit failed");
+  }
   if (index === 0) {
     const finished = await record.transitionLifecycle({
       ...root.lifecycle,
@@ -621,13 +1155,57 @@ async function seedEventGameRecord(
   }
 }
 
-async function acceptCommittedGoal(seeded: {
-  currentId: string;
-  currentGameDayId: string;
-  currentGames: readonly { game: EventGame; pitchId: string; pitchSlotId: string }[];
-}) {
+async function acceptCommittedGoal(
+  seeded: SeededPublicEvent,
+  actionPrefix: string,
+  sportingOrder: number,
+) {
+  await withCommittedGameStorages(
+    seeded,
+    "browser convergence Game is unavailable",
+    async (storage, entry, resolver, storageKind) =>
+      acceptGameRecordActionOnStorage(storage, entry, resolver, "browser convergence", (root) =>
+        createSeedAction(
+          root,
+          `${actionPrefix}-goal-${storageKind}`,
+          "goal",
+          root.gameSides[0]?.id ?? null,
+          { points: 10, sportingOrder },
+        ),
+      ),
+  );
+}
+
+async function acceptCommittedGoalCorrection(seeded: SeededPublicEvent, actionPrefix: string) {
+  await withCommittedGameStorages(
+    seeded,
+    "browser correction Game is unavailable",
+    async (storage, entry, resolver, storageKind) =>
+      acceptGameRecordActionOnStorage(storage, entry, resolver, "browser correction", (root) =>
+        createSeedCorrectionAction(
+          root,
+          `${actionPrefix}-goal-correction-${storageKind}`,
+          `${actionPrefix}-goal-${storageKind}`,
+          false,
+        ),
+      ),
+  );
+}
+
+async function withCommittedGameStorages(
+  seeded: {
+    currentGames: readonly { game: EventGame; pitchId: string; pitchSlotId: string }[];
+  },
+  unavailableMessage: string,
+  operation: (
+    storage: ReturnType<typeof openSqliteFoundationStorage>,
+    entry: { game: EventGame; pitchId: string; pitchSlotId: string },
+    resolver: ExternalScopeResolver,
+    storageKind: "catalog" | "runtime",
+  ) => Promise<void>,
+) {
   const entry = seeded.currentGames[1];
-  if (entry === undefined) throw new Error("browser convergence Game is unavailable");
+  if (entry === undefined) throw new Error(unavailableMessage);
   const runtime = openSqliteFoundationStorage(eventGameDatabase, {
     grantKeyRing: liveEventKeyRing,
   });
@@ -641,34 +1219,89 @@ async function acceptCommittedGoal(seeded: {
     };
     runtime.setReadinessContext(readinessContext);
     catalog.setReadinessContext(readinessContext);
-    await acceptGoalOnStorage(
-      catalog,
-      entry,
-      createSeedScopeResolver(),
-      "browser-convergence-goal-catalog",
-    );
-    await acceptGoalOnStorage(
-      runtime,
-      entry,
-      createEventGameSeedScopeResolver(),
-      "browser-convergence-goal-runtime",
-    );
+    await operation(catalog, entry, createSeedScopeResolver(), "catalog");
+    await operation(runtime, entry, createEventGameSeedScopeResolver(), "runtime");
   } finally {
     catalog.close();
     runtime.close();
   }
 }
 
-async function acceptGoalOnStorage(
+async function updateRosterMapping(
+  seeded: {
+    currentId: string;
+    currentGames: readonly { game: EventGame; pitchId: string; pitchSlotId: string }[];
+  },
+  publicName: string,
+) {
+  const entry = seeded.currentGames[1];
+  const eventTeamId = entry?.game.sideB.eventTeamId;
+  if (entry === undefined || eventTeamId === null || eventTeamId === undefined) {
+    throw new Error("browser roster correction Event Team is unavailable");
+  }
+  await withCatalogMutation(async (catalog, authority) => {
+    const result = await catalog.upsertEventTeamRoster(
+      seeded.currentId,
+      eventTeamId,
+      { playerNumber: 7, publicName },
+      authority,
+    );
+    if (result.status !== "accepted") {
+      throw new Error(`browser roster correction was rejected: ${JSON.stringify(result)}`);
+    }
+  });
+}
+
+async function withdrawPublishedEvent(eventId: string) {
+  await withCatalogMutation(async (catalog, authority) => {
+    const result = await catalog.changePublicationStatus(
+      eventId,
+      { status: "unpublished", impactConfirmed: true },
+      authority,
+    );
+    if (result.status !== "accepted") throw new Error("browser Event withdrawal was rejected");
+  });
+}
+
+async function withCatalogMutation(
+  operation: (
+    catalog: ReturnType<typeof createEventCatalog>,
+    authority: TechnicalAdminAuthority,
+  ) => Promise<void>,
+) {
+  const foundation = openSqliteFoundationStorage(foundationDatabase, {
+    grantKeyRing: readGrantAuthorityOptions("test", environment).keyRing,
+  });
+  await foundation.applyMigrations({ requireCandidate: false });
+  foundation.setReadinessContext({
+    actionCodecRegistry: createControlActionCodecRegistry(),
+    interpreter: createLiveEventGameIqaInterpreter(),
+  });
+  const catalog = createEventCatalog(createFoundationEventCatalogStorage(foundation), {});
+  const hostAuth = createTechnicalAdminAuth(
+    { environment: "test", origin: "https://timer.example", rpId: "timer.example" },
+    new MemoryTechnicalAdminAuthRepository(),
+  );
+  const authority = hostAuth.resolveHostLocalAuthority();
+  try {
+    await operation(catalog, authority);
+  } finally {
+    hostAuth.close();
+    foundation.close();
+  }
+}
+
+async function acceptGameRecordActionOnStorage(
   storage: ReturnType<typeof openSqliteFoundationStorage>,
   entry: { game: EventGame },
   resolver: ExternalScopeResolver,
-  operationId: string,
+  context: string,
+  createAction: (root: EventGameRecordRoot) => ControlActionInput,
 ) {
   const root = await storage.transaction((transaction) =>
     transaction.findRootByEventGameId(entry.game.eventGameId),
   );
-  if (root === null) throw new Error("browser convergence Event Game root is unavailable");
+  if (root === null) throw new Error(`${context} Event Game root is unavailable`);
   const record = createEventGameRecord(storage, {
     externalScopeResolver: resolver,
     interpreter: createLiveEventGameIqaInterpreter(),
@@ -676,16 +1309,11 @@ async function acceptGoalOnStorage(
   });
   const registered = await record.registerRoot(root);
   if (registered.status !== "registered" && registered.status !== "idempotent") {
-    throw new Error(`browser convergence Event Game registration failed: ${registered.status}`);
+    throw new Error(`${context} Event Game registration failed: ${registered.status}`);
   }
-  const accepted = await record.acceptAction(
-    createSeedAction(root, operationId, "goal", root.gameSides[0]?.id ?? null, {
-      points: 10,
-      sportingOrder: 1_000,
-    }),
-  );
+  const accepted = await record.acceptAction(createAction(root));
   if (accepted.status !== "accepted" && accepted.status !== "duplicate-accepted") {
-    throw new Error(`browser convergence goal was not accepted: ${accepted.status}`);
+    throw new Error(`${context} action was not accepted: ${accepted.status}`);
   }
 }
 
@@ -727,6 +1355,8 @@ function createSeedRoot(
   eventGameId: string,
   pitchId: string,
   pitchSlotId: string,
+  sideAEventTeamId: string,
+  sideBEventTeamId: string,
 ): EventGameRecordRoot {
   const createdAtMs = Date.now();
   return {
@@ -743,12 +1373,12 @@ function createSeedRoot(
     gameSides: [
       {
         id: `seed-side-${eventGameId}-a`,
-        eventTeamId: `seed-team-${eventGameId}-a`,
+        eventTeamId: sideAEventTeamId,
         teamInterpretationRef: "seed-team-a-v1",
       },
       {
         id: `seed-side-${eventGameId}-b`,
-        eventTeamId: `seed-team-${eventGameId}-b`,
+        eventTeamId: sideBEventTeamId,
         teamInterpretationRef: "seed-team-b-v1",
       },
     ],
@@ -790,6 +1420,26 @@ function createSeedForfeitAction(root: EventGameRecordRoot): ControlActionInput 
     root.gameSides[1].id,
     { resultKind: "forfeit", sportingOrder: 0 },
   );
+}
+
+function createSeedCorrectionAction(
+  root: EventGameRecordRoot,
+  operationId: string,
+  targetFactId: string,
+  effective: boolean,
+): ControlActionInput {
+  const trustedAtMs = Date.now();
+  return {
+    recordId: root.recordId,
+    eventGameId: root.eventGameId,
+    operationId,
+    kind: { id: "correction", version: "1" },
+    payload: { correctionId: operationId, targetFactId, effective },
+    causalPredecessorIds: [targetFactId],
+    occurrence: { trustedAtMs, clientOriginAtMs: trustedAtMs, source: "online" },
+    grant: { sessionId: "public-browser-seed", versionId: "public-browser-seed-v1" },
+    lifecycle: structuredClone(root.lifecycle),
+  };
 }
 
 function createSeedAction(
@@ -841,4 +1491,11 @@ async function waitForServer(url: string) {
 
 function assert(condition: boolean, message: string): asserts condition {
   if (!condition) throw new Error(message);
+}
+
+function requireWebSocketRoute(
+  route: DisconnectableWebSocketRoute | null,
+): DisconnectableWebSocketRoute {
+  if (route === null) throw new Error("public spectator Game did not open its WebSocket");
+  return route;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -75,3 +75,14 @@
 .score-pop-down {
   animation: score-pop-down-kf 420ms ease-out;
 }
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/src/pages/public-event-page.tsx
+++ b/src/pages/public-event-page.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent, CardDescription, CardHeader } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { getAdHocBrowserId } from "@/lib/ad-hoc-handoff";
@@ -55,14 +55,21 @@ export function PublicEventHomePage({ showAll = false }: { showAll?: boolean }) 
     >
       {events === null && !discoveryUnavailable ? (
         <div className="space-y-6">
-          <p className="rounded-2xl border bg-card/80 p-5 text-sm text-muted-foreground">
+          <p
+            className="rounded-2xl border bg-card/80 p-5 text-sm text-muted-foreground"
+            role="status"
+            aria-live="polite"
+          >
             Loading Published Events…
           </p>
           <StartAdHocGame />
         </div>
       ) : discoveryUnavailable ? (
         <div className="space-y-6">
-          <p className="rounded-2xl border bg-card/80 p-5 text-sm text-muted-foreground">
+          <p
+            className="rounded-2xl border bg-card/80 p-5 text-sm text-muted-foreground"
+            role="alert"
+          >
             Event discovery is unavailable.
           </p>
           <StartAdHocGame />
@@ -75,13 +82,18 @@ export function PublicEventHomePage({ showAll = false }: { showAll?: boolean }) 
 }
 
 export function PublicEventPage({ eventId }: { eventId: string }) {
-  const { event, unavailable } = usePublicEventProjection(eventId);
+  const { event, unavailable, connectionStatus } = usePublicEventProjection(eventId);
 
   if (unavailable) return <UnavailablePanel />;
   if (event === null) {
     return (
       <PublicShell title="Published Event" description="Loading public Event information…">
-        <p className="rounded-2xl border bg-card/80 p-5 text-sm text-muted-foreground">Loading…</p>
+        <p
+          className="rounded-2xl border bg-card/80 p-5 text-sm text-muted-foreground"
+          role="status"
+        >
+          Loading…
+        </p>
       </PublicShell>
     );
   }
@@ -98,10 +110,11 @@ export function PublicEventPage({ eventId }: { eventId: string }) {
             All events
           </Button>
         </div>
+        <LiveProjectionStatus status={connectionStatus} message={eventAnnouncement(event)} />
         <ScheduleBoard schedule={schedule} timeZone={event.timeZone} />
         <Card>
           <CardHeader>
-            <CardTitle>Game Days</CardTitle>
+            <h2 className="text-base leading-none font-semibold">Game Days</h2>
             <CardDescription>
               Published Event information from the authoritative catalog.
             </CardDescription>
@@ -120,7 +133,7 @@ export function PublicEventPage({ eventId }: { eventId: string }) {
             )}
             {event.teams.length > 0 && (
               <div>
-                <h2 className="text-sm font-semibold">Event Teams</h2>
+                <h3 className="text-sm font-semibold">Event Teams</h3>
                 <ul className="mt-2 grid gap-2 sm:grid-cols-2">
                   {event.teams.map((team) => (
                     <li
@@ -135,7 +148,7 @@ export function PublicEventPage({ eventId }: { eventId: string }) {
             )}
             {event.pitches.length > 1 && (
               <div>
-                <h2 className="text-sm font-semibold">Pitches</h2>
+                <h3 className="text-sm font-semibold">Pitches</h3>
                 <ul className="mt-2 flex flex-wrap gap-2">
                   {event.pitches.map((pitch) => (
                     <li key={pitch.name} className="rounded-full border px-3 py-1 text-sm">
@@ -155,6 +168,9 @@ export function PublicEventPage({ eventId }: { eventId: string }) {
 function usePublicEventProjection(eventId: string) {
   const [event, setEvent] = useState<PublicAudienceEventProjection | null>(null);
   const [unavailable, setUnavailable] = useState(false);
+  const [connectionStatus, setConnectionStatus] = useState<
+    "loading" | "connected" | "reconnecting" | "unavailable"
+  >("loading");
 
   useEffect(() => {
     let active = true;
@@ -164,6 +180,7 @@ function usePublicEventProjection(eventId: string) {
     let terminalUnavailable = false;
     setEvent(null);
     setUnavailable(false);
+    setConnectionStatus("loading");
 
     const readAuthoritativeEvent = async () => {
       const response = await fetch(`/api/audience/events/${encodeURIComponent(eventId)}`);
@@ -191,6 +208,7 @@ function usePublicEventProjection(eventId: string) {
       const connection = new WebSocket(publicEventWebSocketUrl());
       socket = connection;
       connection.onopen = () => {
+        setConnectionStatus("connected");
         connection.send(JSON.stringify({ type: "subscribe-public-event", eventId }));
       };
       connection.onmessage = (message) => {
@@ -207,15 +225,18 @@ function usePublicEventProjection(eventId: string) {
           terminalUnavailable = true;
           setEvent(null);
           setUnavailable(true);
+          setConnectionStatus("unavailable");
           connection.close();
           return;
         }
         if (result.status !== "applied" || replica.projection === null) return;
         setEvent(replica.projection);
+        setConnectionStatus("connected");
       };
       connection.onclose = () => {
         if (!active || terminalUnavailable || socket !== connection) return;
         socket = null;
+        setConnectionStatus("reconnecting");
         void recoverFromDisconnect();
       };
     };
@@ -223,13 +244,12 @@ function usePublicEventProjection(eventId: string) {
     recoverFromDisconnect = async () => {
       if (!active || terminalUnavailable || recovering) return;
       if (reconnectAttempts >= PUBLIC_EVENT_MAX_RECONNECT_ATTEMPTS) {
-        setEvent(null);
         setUnavailable(true);
+        setConnectionStatus("unavailable");
         return;
       }
       recovering = true;
       reconnectAttempts += 1;
-      setEvent(null);
       try {
         const nextEvent = await readAuthoritativeEvent();
         if (!active || terminalUnavailable) return;
@@ -238,8 +258,8 @@ function usePublicEventProjection(eventId: string) {
         connect(makeReplica(nextEvent));
       } catch {
         if (active) {
-          setEvent(null);
           setUnavailable(true);
+          setConnectionStatus("unavailable");
         }
       } finally {
         recovering = false;
@@ -257,6 +277,7 @@ function usePublicEventProjection(eventId: string) {
         if (active) {
           setEvent(null);
           setUnavailable(true);
+          setConnectionStatus("unavailable");
         }
       });
     return () => {
@@ -266,7 +287,7 @@ function usePublicEventProjection(eventId: string) {
     };
   }, [eventId]);
 
-  return { event, unavailable };
+  return { event, unavailable, connectionStatus };
 }
 
 const PUBLIC_EVENT_MAX_RECONNECT_ATTEMPTS = 2;
@@ -298,7 +319,7 @@ export function PublicEventGamePage({
   eventId: string;
   eventGameId: string;
 }) {
-  const { event, unavailable } = usePublicEventProjection(eventId);
+  const { event, unavailable, connectionStatus } = usePublicEventProjection(eventId);
   const game =
     event?.schedule.scheduleGames.find((candidate) => candidate.eventGameId === eventGameId) ??
     null;
@@ -326,7 +347,12 @@ export function PublicEventGamePage({
     if (event !== null) return <GameUnavailablePanel eventId={eventId} />;
     return (
       <PublicShell title="Live spectator Game" description="Loading public Game information…">
-        <p className="rounded-2xl border bg-card/80 p-5 text-sm text-muted-foreground">Loading…</p>
+        <p
+          className="rounded-2xl border bg-card/80 p-5 text-sm text-muted-foreground"
+          role="status"
+        >
+          Loading…
+        </p>
       </PublicShell>
     );
   }
@@ -356,6 +382,7 @@ export function PublicEventGamePage({
           </Button>
           <p className="text-sm text-muted-foreground">{game.pitch ?? "Event Game"}</p>
         </div>
+        <LiveProjectionStatus status={connectionStatus} message={gameAnnouncement(game)} />
         <div
           ref={scoreboardSentinelRef}
           aria-hidden="true"
@@ -443,7 +470,9 @@ export function PublicEventGamePage({
         </section>
         <Card>
           <CardHeader>
-            <CardTitle>Game Phase and operational status</CardTitle>
+            <h2 className="text-base leading-none font-semibold">
+              Game Phase and operational status
+            </h2>
             <CardDescription>
               Committed public information from the Event Game&apos;s Audience Projection.
             </CardDescription>
@@ -518,6 +547,8 @@ function PublicScoreSide({
       className={`min-w-0 rounded-2xl border-2 bg-card p-3 ${align === "right" ? "text-right" : "text-left"}`}
       style={{ borderColor: side.color ?? "hsl(var(--border))" }}
       data-side-id={sideId}
+      role="group"
+      aria-label={`${label}: ${side.name ?? "Unassigned Team"}, score ${side.score ?? "unavailable"}${isCatching ? ", flag catch" : ""}`}
     >
       <p className="text-xs font-semibold tracking-wide text-muted-foreground uppercase">{label}</p>
       <p className="mt-1 break-words text-base font-semibold leading-tight sm:text-xl">
@@ -757,9 +788,27 @@ function GameCard({
       <CardHeader className={compact ? "pb-3" : undefined}>
         <div className="flex flex-wrap items-start justify-between gap-2">
           <div>
-            <CardTitle className={compact ? "text-base" : "text-lg"}>
-              {game.gameDesignation ?? game.gameCode ?? "Scheduled Game"}
-            </CardTitle>
+            <h3 className={compact ? "text-base font-semibold" : "text-lg font-semibold"}>
+              <a
+                href={game.canonicalPath}
+                className="rounded-sm underline-offset-4 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                onClick={(click) => {
+                  if (
+                    click.button !== 0 ||
+                    click.metaKey ||
+                    click.ctrlKey ||
+                    click.shiftKey ||
+                    click.altKey
+                  )
+                    return;
+                  click.preventDefault();
+                  navigateTo(game.canonicalPath);
+                }}
+              >
+                {game.gameDesignation ?? game.gameCode ?? "Scheduled Game"}
+                <span className="sr-only"> Open spectator Game</span>
+              </a>
+            </h3>
             {game.gameDesignation !== null && game.gameCode !== null ? (
               <CardDescription>Game {game.gameCode}</CardDescription>
             ) : null}
@@ -1158,7 +1207,7 @@ function StartAdHocGame() {
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Start Ad Hoc Game</CardTitle>
+        <h2 className="text-base leading-none font-semibold">Start Ad Hoc Game</h2>
         <CardDescription>
           Need an unscheduled Game? Start one here as an equal Ad Hoc Controller.
         </CardDescription>
@@ -1203,6 +1252,7 @@ function StartAdHocGame() {
           </div>
         </div>
         <Button
+          type="button"
           className="w-full"
           disabled={creationPending}
           onClick={() => void handleCreateGame()}
@@ -1234,6 +1284,12 @@ function PublicShell({
 }) {
   return (
     <div className="mx-auto w-full max-w-5xl p-4 pb-12 sm:p-6">
+      <a
+        href="#main-content"
+        className="sr-only z-50 rounded-md bg-background px-3 py-2 text-sm font-semibold focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        Skip to main content
+      </a>
       <header className="mb-6 rounded-2xl border bg-card/80 p-5 shadow-sm backdrop-blur">
         <p className="text-xs font-semibold tracking-widest text-muted-foreground uppercase">
           Quadball Timer
@@ -1241,9 +1297,62 @@ function PublicShell({
         <h1 className="mt-2 text-3xl font-semibold tracking-tight">{title}</h1>
         <p className="mt-2 text-sm text-muted-foreground">{description}</p>
       </header>
-      {children}
+      <main id="main-content" tabIndex={-1}>
+        {children}
+      </main>
     </div>
   );
+}
+
+function LiveProjectionStatus({
+  status,
+  message,
+}: {
+  status: "loading" | "connected" | "reconnecting" | "unavailable";
+  message: string;
+}) {
+  const connectionMessage =
+    status === "reconnecting"
+      ? "Live updates reconnecting; the last committed view remains visible."
+      : status === "unavailable"
+        ? "Live updates are unavailable."
+        : status === "loading"
+          ? "Loading live updates."
+          : "Live updates connected.";
+  return (
+    <p
+      className="sr-only"
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      data-live-projection-status
+    >
+      {connectionMessage} {message}
+    </p>
+  );
+}
+
+function gameAnnouncement(game: PublicAudienceGameProjection): string {
+  return `${formatScoreAnnouncement(game)}. ${gamePhaseLabel(game.phase)}. ${operationalStatusLabel(game.operationalStatus)}.`;
+}
+
+function eventAnnouncement(event: PublicAudienceEventProjection): string {
+  const liveScores = event.schedule.runningGames.map(formatScoreAnnouncement).join("; ");
+  const liveSummary =
+    liveScores.length === 0
+      ? "There are no running Games."
+      : `${event.schedule.runningGames.length} running Game${event.schedule.runningGames.length === 1 ? "" : "s"}: ${liveScores}.`;
+  const timelineCount = event.schedule.scheduleGames.reduce(
+    (count, game) => count + game.timeline.length,
+    0,
+  );
+  return `${liveSummary} ${event.schedule.upcomingGames.length} upcoming Game${event.schedule.upcomingGames.length === 1 ? "" : "s"}. ${timelineCount} public Timeline entr${timelineCount === 1 ? "y" : "ies"}.`;
+}
+
+function formatScoreAnnouncement(game: PublicAudienceGameProjection): string {
+  const sideA = game.sideA.name ?? "Side A";
+  const sideB = game.sideB.name ?? "Side B";
+  return `${sideA} ${game.sideA.score ?? "unavailable"}, ${sideB} ${game.sideB.score ?? "unavailable"}`;
 }
 
 function UnavailablePanel() {

--- a/src/pages/public-game-timeline.test.tsx
+++ b/src/pages/public-game-timeline.test.tsx
@@ -124,6 +124,7 @@ describe("public Game Timeline browser seam", () => {
       await Promise.resolve();
     });
     expect(region.scrollTop).toBe(0);
+    expect(document.activeElement).toBe(region);
 
     height = 320;
     await act(async () => {

--- a/src/pages/public-game-timeline.tsx
+++ b/src/pages/public-game-timeline.tsx
@@ -43,10 +43,14 @@ export function PublicGameTimeline({
         {hasNewPlay ? (
           <button
             type="button"
+            aria-label="Show newest play"
             className="rounded-full border px-3 py-1 text-xs font-semibold text-primary hover:bg-accent focus:outline-none focus:ring-2 focus:ring-ring"
             onClick={() => {
               const node = scrollRef.current;
-              if (node !== null) node.scrollTo({ top: 0, behavior: "smooth" });
+              if (node !== null) {
+                node.scrollTo({ top: 0, behavior: prefersReducedMotion() ? "auto" : "smooth" });
+                node.focus({ preventScroll: true });
+              }
               atLiveEdgeRef.current = true;
               setHasNewPlay(false);
             }}
@@ -57,7 +61,9 @@ export function PublicGameTimeline({
       </div>
       <div
         ref={scrollRef}
-        className="max-h-[32rem] overflow-y-auto overscroll-contain rounded-xl border bg-muted/20 p-2"
+        className="max-h-[32rem] overflow-y-auto overscroll-contain rounded-xl border bg-muted/20 p-2 [overflow-anchor:none] focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
+        tabIndex={0}
+        role="region"
         onScroll={(event) => {
           const node = event.currentTarget;
           atLiveEdgeRef.current = node.scrollTop <= 8;
@@ -76,6 +82,14 @@ export function PublicGameTimeline({
         </ol>
       </div>
     </section>
+  );
+}
+
+function prefersReducedMotion(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches
   );
 }
 


### PR DESCRIPTION
## What changed

- completes the phone and desktop public journey from Event discovery through schedule and spectator Game
- adds semantic landmarks, skip navigation, keyboard-operable Game links, visible focus, and live/reconnect announcements
- preserves Timeline context and focus for new plays, respects reduced motion, and keeps the compact live score readable
- verifies real Chromium and WebKit convergence for Clock, score, Timeline, roster relabelling, correction, reconnect, and withdrawal
- keeps the existing Ad Hoc handoff discoverable after current/upcoming Event content

## Why

The composed public Event experience must be understandable and operable by first-time phone spectators and keyboard or assistive-technology users during SQM.

## Impact

Spectators can discover the current Event, navigate to a stable Game, follow committed changes without focus theft or reload, recover after disconnect, and see retained public data clear when the Event is hidden.

## Validation

- focused public projection, HTTP, WebSocket, component, and accessibility tests
- full ordinary suite: 958 tests, 20,693 assertions
- complete Chromium and WebKit public Event journey at phone and desktop sizes
- `bun run check`
- `bun run build`
- `git diff --check`

No Qualification, load, soak, crash, recovery, or exact-production-artifact workload was run.

Closes #139.

Stack: depends on #264 and #265.
