### PR TITLE
Make Production backup promotion handoff explicit

### DIFF
--- a/deploy/activation-maintenance-root.sh
+++ b/deploy/activation-maintenance-root.sh
@@ -382,7 +382,7 @@ if [[ "$command" == "promote" ]]; then
   AD_HOC_ENVIRONMENT_ID="$ad_hoc_environment_identity" \
   QBT_FOCUSED_FAILURE_PHASE="$focused_failure_phase" \
   QBT_ROOT_PROMOTION="$root_promotion" \
-  "$release_dir/quadball-timer" --production-activation "$command" 2>&1)"
+  "$release_dir/quadball-timer" --production-activation "$command" --root-promotion 2>&1)"
   rc=$?
 else
   "$runuser_command" -u "$service_user" -- env -i PATH=/usr/bin:/bin \

--- a/src/lib/production-activation-cli.ts
+++ b/src/lib/production-activation-cli.ts
@@ -47,6 +47,8 @@ function injectFocusedFailure(phase: FocusedFailurePhase): void {
 /** Host-local maintenance entrypoint used by the shipped compiled executable. */
 export async function runProductionActivationCli(argv: readonly string[]): Promise<number> {
   const command = argv[0] as MaintenanceCommand | undefined;
+  const rootPromotionRequested =
+    process.env.QBT_ROOT_PROMOTION === "1" || argv.includes("--root-promotion");
   if (
     command !== "backup" &&
     command !== "verify-backup" &&
@@ -257,7 +259,7 @@ export async function runProductionActivationCli(argv: readonly string[]): Promi
       // final pointer swap.  The service user still performs the complete
       // candidate re-verification here, but must not attempt to rename the
       // candidate into the root-controlled retained area.
-      if (process.env.QBT_ROOT_PROMOTION === "1") {
+      if (rootPromotionRequested) {
         const { manifest } = await verifyCandidate();
         console.log(JSON.stringify({ verified: true, snapshotId: manifest.snapshotId }));
         return 0;

--- a/src/production-deployment.test.ts
+++ b/src/production-deployment.test.ts
@@ -194,6 +194,9 @@ describe("Production deployment contract", () => {
     expect(wrapper).toContain("skip_chown=0");
     expect(wrapper).toContain('before_previous_rm_command=""');
     expect(wrapper).toContain('QBT_ROOT_PROMOTION="$root_promotion"');
+    expect(wrapper).toContain(
+      '"$release_dir/quadball-timer" --production-activation "$command" --root-promotion 2>&1',
+    );
     expect(wrapper).toContain("promote_verified_backup_as_root");
     expect(wrapper).toContain('chown -R root:root -- "$candidate_directory"');
     expect(wrapper).toContain('mv -- "$candidate_directory" "$retained_version"');
@@ -209,6 +212,31 @@ describe("Production deployment contract", () => {
     );
     expect(wrapper).toContain('[[ "$focused_test_mode" != 1 ]]');
     expect(wrapper).toContain('"${maintenance_output:0:4096}"');
+  });
+
+  test("keeps service cleanup out of the root-owned promotion handoff", () => {
+    const activationCli = readFileSync(
+      join(repositoryRoot, "src/lib/production-activation-cli.ts"),
+      "utf8",
+    );
+    const wrapper = readFileSync(
+      join(repositoryRoot, "deploy/activation-maintenance-root.sh"),
+      "utf8",
+    );
+    expect(activationCli).toContain(
+      'process.env.QBT_ROOT_PROMOTION === "1" || argv.includes("--root-promotion")',
+    );
+    expect(activationCli).toContain("if (rootPromotionRequested)");
+    expect(activationCli).toContain(
+      "console.log(JSON.stringify({ verified: true, snapshotId: manifest.snapshotId }));",
+    );
+    expect(activationCli).toContain("const promotion = await promoteVerifiedBackup({");
+    expect(wrapper).toContain("--root-promotion");
+    expect(wrapper).toContain("promote_verified_backup_as_root");
+    expect(wrapper).toContain("if (( rc != 0 )); then");
+    expect(wrapper).toContain(
+      'if (( rc != 0 )) && [[ "$command" == "backup" || "$command" == "verify-backup" || "$command" == "promote" ]]; then',
+    );
   });
 
   test("uses Linux mv -T to replace the retained pointer without following it", async () => {


### PR DESCRIPTION
## What changed

- make the Production backup-promotion handoff explicit with `--root-promotion`
- let the candidate executable re-verify the backup without attempting service-user cleanup after the handoff
- retain the existing root-owned pointer promotion and bounded failure cleanup

## Why

Production deployment run 31910655276 verified its pre-migration backup, then the service-user promotion path tried to remove the root-owned candidate and failed with `EACCES`. The explicit marker keeps cleanup ownership at the privileged wrapper boundary.

## Operator impact

The reviewed wrapper was installed on `jannis.rocks` before this PR:

- installed wrapper SHA-256: `abcf02a4af337fb57bd78a6d2bddab37c5db422cd51892137d70660d40a1b36d`
- previous wrapper preserved as `.pre-251`
- Production and Test services remained active

After merge, the deployment from `main` still needs live verification. Production and Test outcomes remain independent.

## Verification

- `bun test --isolate ./src/production-deployment.test.ts` — 18 passed, 121 assertions
- `bun run check`
- `bun run build:executable`
- `bash -n deploy/activation-maintenance-root.sh`
- ShellCheck through `bun run check`
- `git diff --check`
- full ordinary suite before the conflict-free final rebase — 939 passed, 0 failed

References #251 and #158.
