### PR TITLE
Fix public health readiness boundary

### DIFF
--- a/deploy/uptimerobot-monitoring.md
+++ b/deploy/uptimerobot-monitoring.md
@@ -2,9 +2,12 @@
 
 Quadball Timer exposes one deliberately minimal public readiness route at
 `/healthz`. It returns HTTP `200` and the fixed body `healthy` only when the
-Technical Admin store, Foundation database, migration/readiness checks, and
-authoritative write boundary are ready. Every unavailable or unsafe state
-returns HTTP `503` and the fixed body `unhealthy`. The response is
+core service boundary—the Technical Admin store and Foundation database,
+migrations, replay checks, required keys, and authoritative write boundary—is
+ready. Every unavailable or unsafe state returns HTTP `503` and the fixed body
+`unhealthy`. The public monitor does not require the separately optional Live
+Event runtime to be configured; Event, Ad Hoc, and Grant operations retain
+their own readiness and fail-closed boundaries. The response is
 `Cache-Control: no-store`; it never includes release, commit, runtime, schema,
 database, credential, object-count, dependency, or diagnostic information.
 
@@ -18,12 +21,23 @@ verification, but it has no UptimeRobot monitor obligation.
 
 ## Operator-owned UptimeRobot setup
 
-Create these two monitors in the operator-owned UptimeRobot account:
+Create these two monitors in the operator-owned UptimeRobot account. Use
+method `GET`, a five-minute interval, and the operator's existing Production
+availability contact group:
 
-| Monitor | URL | Expected result | Interval |
+| Monitor | UptimeRobot monitor type | URL | Expected result |
 | --- | --- | --- | --- |
-| Production Home | `https://timer.quadball.app/` | HTTP `200` | 5 minutes |
-| Production health | `https://timer.quadball.app/healthz` | HTTP `200` and body containing `healthy` | 5 minutes |
+| Production Home | HTTP(s) | `https://timer.quadball.app/` | status `200` |
+| Production health | HTTP(s) Keyword | `https://timer.quadball.app/healthz` | status `200`, alert when keyword `unhealthy` exists |
+
+For Production health, select the HTTP(s) Keyword monitor type and configure
+the exact keyword `unhealthy` with the `Keyword Exists` alert condition. The
+monitor must remain up only for a successful HTTP response whose body does not
+contain `unhealthy`; the UptimeRobot keyword condition must alert when that
+word appears. Do not configure a positive `healthy` substring match: `healthy`
+is contained in `unhealthy`. Do not use a private header, cookie, token, or
+account credential. The bounded local verification below checks the exact
+successful body `healthy\n` by comparing its UTF-8 bytes.
 
 Use UptimeRobot's free five-minute HTTP monitors. Do not configure a paid
 one-minute plan or a continuous WebSocket monitor for this SQM slice. Route
@@ -35,8 +49,38 @@ server environment, or deployment workflow.
 
 ## Bounded human verification
 
-After the Production route is deployed, the operator records only the monitor
-names, URLs, interval, and observed HTTP outcome in the deployment handoff.
-Do not export monitor credentials, response captures, or private UptimeRobot
-diagnostics. The external check is a human setup/verification step and is not
-run by the application test suite or deployment workflow.
+After the Production route is deployed, run this in fish from a trusted
+operator workstation:
+
+```fish
+set home_code (curl --silent --show-error --max-time 10 --output /dev/null --write-out '%{http_code}' https://timer.quadball.app/)
+if not test "$home_code" = 200
+    echo "Production Home returned HTTP $home_code" >&2
+    exit 1
+end
+set health_body (mktemp /tmp/quadball-timer-health-body.XXXXXX)
+set health_code (curl --silent --show-error --max-time 10 --output $health_body --write-out '%{http_code}' https://timer.quadball.app/healthz)
+if not test "$health_code" = 200
+    rm -f $health_body
+    echo "Production health returned HTTP $health_code" >&2
+    exit 1
+end
+set health_body_hex (od -An -tx1 -v $health_body | string join "" | string replace -a " " "")
+if not test "$health_body_hex" = 6865616c7468790a
+    rm -f $health_body
+    echo "Production health did not return the exact expected body" >&2
+    exit 1
+end
+rm -f $health_body
+```
+
+Then confirm the Production Home monitor reports status `200` and the
+Production health HTTP(s) Keyword monitor reports status `200` and remains up
+when `unhealthy` is absent. Confirm that a response containing `unhealthy`
+would trigger the configured keyword alert; do not copy response captures or
+private monitor diagnostics into the handoff.
+Record only the monitor names, URLs, interval, and observed HTTP outcome in
+the deployment handoff. Do not export monitor credentials, response captures,
+or private UptimeRobot diagnostics. This external check is a human
+setup/verification step and is not run by the application test suite or
+deployment workflow.

--- a/src/index.ts
+++ b/src/index.ts
@@ -2197,10 +2197,6 @@ async function startServer() {
         "/healthz": createPublicHealthRoute({
           foundationStorage,
           technicalAdminAuth,
-          authoritativeServices: {
-            eventAdministration: eventAdministration !== null,
-            liveEventRuntime,
-          },
         }),
         "/internal/healthz": {
           GET(req: Request) {

--- a/src/lib/public-health.operation-boundaries.test.ts
+++ b/src/lib/public-health.operation-boundaries.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+import { createAdHocGamesService, createInMemoryAdHocStore } from "@/lib/ad-hoc-games";
+import { createEventAdministration } from "@/lib/event-administration";
+import { createInMemoryFoundationStorage } from "@/lib/foundation-storage-memory";
+import { createGrantAuthority } from "@/lib/grant-authority";
+import { createGrantTestAuthorityVerifier } from "@/lib/grant-authority-test-support";
+import { createGrantTestKeyRing } from "@/lib/grant-authority-contract";
+import {
+  MemoryTechnicalAdminAuthRepository,
+  createTechnicalAdminAuth,
+} from "@/lib/technical-admin-auth";
+
+function grantOptions() {
+  return {
+    environmentId: "test",
+    clock: { nowMs: () => 1_000 },
+    randomness: { bytes: (length: number) => new Uint8Array(length).fill(7) },
+    keyRing: createGrantTestKeyRing(),
+    controlScopeResolver: {
+      resolve: () => ({ status: "unavailable" as const, detail: "scope unavailable" }),
+    },
+    privilegedAuthorityVerifier: createGrantTestAuthorityVerifier(),
+  };
+}
+
+describe("public health operation boundaries", () => {
+  test("keeps Event, Ad Hoc, and Grant operations fail-closed independently", async () => {
+    const adHocStore = {
+      ...createInMemoryAdHocStore(),
+      createGame() {
+        throw new Error("Ad Hoc storage unavailable");
+      },
+    };
+    const adHoc = createAdHocGamesService({ store: adHocStore, now: () => 1_000 });
+    expect(await adHoc.create({ homeName: "Home", awayName: "Away" })).toMatchObject({
+      status: "rejected",
+      reason: "unavailable",
+    });
+
+    const storage = createInMemoryFoundationStorage();
+    const grants = createGrantAuthority(storage, grantOptions());
+    const eventAdministration = createEventAdministration({ storage, grants });
+    const technicalAdmin = createTechnicalAdminAuth(
+      { environment: "test", origin: "https://timer.example", rpId: "timer.example" },
+      new MemoryTechnicalAdminAuthRepository(),
+    ).resolveHostLocalAuthority();
+    storage.close();
+
+    expect(
+      await eventAdministration.createEventAdminGrant("event-unavailable", {
+        ...technicalAdmin,
+      }),
+    ).toMatchObject({ status: "retryable-failure" });
+    expect(
+      await grants.createControlGrant({
+        authority: { kind: "technical-admin", id: "test-admin" },
+        scope: {
+          eventId: "event-unavailable",
+          gameDayId: "day-unavailable",
+          pitchId: "pitch-unavailable",
+          pitchSlotId: "slot-unavailable",
+        },
+      }),
+    ).toMatchObject({ status: "rejected", reason: "unavailable" });
+  });
+});

--- a/src/lib/public-health.test.ts
+++ b/src/lib/public-health.test.ts
@@ -11,15 +11,6 @@ const readyTechnicalAdmin = {
   }),
 };
 
-const readyLiveEventRuntime = {
-  readiness: async () => sqliteReadiness("normal"),
-};
-
-const readyAuthoritativeServices = {
-  eventAdministration: true,
-  liveEventRuntime: readyLiveEventRuntime,
-};
-
 function sqliteReadiness(
   writePressure: "unknown" | "normal" | "unsafe",
 ): FoundationStorageReadiness {
@@ -80,6 +71,25 @@ const sensitiveReadinessFailure: Pick<FoundationStorage, "readiness"> = {
   }),
 };
 
+const PUBLIC_INFORMATION_EXCLUSION =
+  /release|commit|source|workflow|sha|digest|hash|bun|runtime|schema|migration|database|sqlite|credential|secret|object|count|dependency|host|port|diagnostic|detail|stack|token|password/i;
+
+async function expectPublicHealthResponse(
+  response: Response,
+  status: number,
+  body: "healthy\n" | "unhealthy\n",
+) {
+  expect(response.status).toBe(status);
+  expect(await response.text()).toBe(body);
+  expect(response.headers.get("cache-control")).toBe("no-store");
+  expect(response.headers.get("content-type")).toBe("text/plain; charset=utf-8");
+  expect(response.headers.get("referrer-policy")).toBe("no-referrer");
+  expect(response.headers.get("x-content-type-options")).toBe("nosniff");
+  expect(`${body}\n${JSON.stringify([...response.headers])}`).not.toMatch(
+    PUBLIC_INFORMATION_EXCLUSION,
+  );
+}
+
 describe("public health contract", () => {
   test("mounts the literal /healthz route and serves its HTTP contract", async () => {
     const server = Bun.serve({
@@ -88,26 +98,20 @@ describe("public health contract", () => {
         "/healthz": createPublicHealthRoute({
           foundationStorage: readyFoundation,
           technicalAdminAuth: readyTechnicalAdmin,
-          authoritativeServices: readyAuthoritativeServices,
         }),
       },
     });
 
     try {
       const response = await fetch(new URL("/healthz", server.url));
-      expect(response.status).toBe(200);
-      expect(await response.text()).toBe("healthy\n");
-      expect(response.headers.get("cache-control")).toBe("no-store");
-      expect(response.headers.get("content-type")).toBe("text/plain; charset=utf-8");
-      expect(response.headers.get("referrer-policy")).toBe("no-referrer");
-      expect(response.headers.get("x-content-type-options")).toBe("nosniff");
+      await expectPublicHealthResponse(response, 200, "healthy\n");
       expect((await fetch(new URL("/not-healthz", server.url))).status).toBe(404);
     } finally {
       await server.stop(true);
     }
   });
 
-  test("returns only unhealthy when any authoritative boundary is unavailable", async () => {
+  test("returns only unhealthy when any core readiness boundary is unavailable", async () => {
     const unavailableTechnicalAdmin = {
       storageStatus: () => ({
         ...readyTechnicalAdmin.storageStatus(),
@@ -129,73 +133,63 @@ describe("public health contract", () => {
       {
         foundationStorage: undefined,
         technicalAdminAuth: readyTechnicalAdmin,
-        authoritativeServices: readyAuthoritativeServices,
       },
       {
         foundationStorage: sensitiveReadinessFailure,
         technicalAdminAuth: readyTechnicalAdmin,
-        authoritativeServices: readyAuthoritativeServices,
       },
       {
         foundationStorage: readyFoundation,
         technicalAdminAuth: unavailableTechnicalAdmin,
-        authoritativeServices: readyAuthoritativeServices,
       },
       {
         foundationStorage: readyFoundation,
         technicalAdminAuth: throwingTechnicalAdmin,
-        authoritativeServices: readyAuthoritativeServices,
       },
       {
         foundationStorage: throwingFoundation,
         technicalAdminAuth: readyTechnicalAdmin,
-        authoritativeServices: readyAuthoritativeServices,
-      },
-      {
-        foundationStorage: readyFoundation,
-        technicalAdminAuth: readyTechnicalAdmin,
-        authoritativeServices: {
-          eventAdministration: false,
-          liveEventRuntime: readyLiveEventRuntime,
-        },
-      },
-      {
-        foundationStorage: readyFoundation,
-        technicalAdminAuth: readyTechnicalAdmin,
-        authoritativeServices: { eventAdministration: true, liveEventRuntime: null },
-      },
-      {
-        foundationStorage: readyFoundation,
-        technicalAdminAuth: readyTechnicalAdmin,
-        authoritativeServices: {
-          eventAdministration: true,
-          liveEventRuntime: { readiness: async () => sqliteReadiness("unsafe") },
-        },
-      },
-      {
-        foundationStorage: readyFoundation,
-        technicalAdminAuth: readyTechnicalAdmin,
-        authoritativeServices: {
-          eventAdministration: true,
-          liveEventRuntime: {
-            readiness: async () => {
-              throw new Error("live runtime database diagnostic");
-            },
-          },
-        },
       },
     ]) {
       const response = await readPublicHealth(dependencies);
-      expect(response.status).toBe(503);
-      const body = await response.text();
-      expect(body).toBe("unhealthy\n");
-      expect(body).toMatch(/^(healthy|unhealthy)\n$/);
-      expect(response.headers.get("cache-control")).toBe("no-store");
-      expect(response.headers.get("content-type")).toBe("text/plain; charset=utf-8");
-      expect(`${body}\n${JSON.stringify([...response.headers])}`).not.toMatch(
-        /release|commit|source|workflow|sha|digest|hash|bun|runtime|schema|migration|database|sqlite|credential|secret|object|count|dependency|host|port|diagnostic|detail|stack|token|password/i,
-      );
+      await expectPublicHealthResponse(response, 503, "unhealthy\n");
     }
+  });
+
+  test("ignores caller authority and query/header variations for both outcomes", async () => {
+    const requests = [
+      new Request("https://timer.quadball.app/healthz"),
+      new Request("https://timer.quadball.app/healthz?eventId=private-event", {
+        headers: {
+          authorization: "Bearer caller-supplied-authority",
+          cookie: "session=caller-supplied-secret",
+          host: "attacker.example",
+          "x-forwarded-for": "203.0.113.7",
+        },
+      }),
+    ];
+    const healthyRoute = createPublicHealthRoute({
+      foundationStorage: readyFoundation,
+      technicalAdminAuth: readyTechnicalAdmin,
+    });
+    const unhealthyRoute = createPublicHealthRoute({
+      foundationStorage: sensitiveReadinessFailure,
+      technicalAdminAuth: readyTechnicalAdmin,
+    });
+
+    for (const request of requests) {
+      await expectPublicHealthResponse(await healthyRoute.GET(request), 200, "healthy\n");
+      await expectPublicHealthResponse(await unhealthyRoute.GET(request), 503, "unhealthy\n");
+    }
+  });
+
+  test("does not require the optional Live Event runtime for core service readiness", async () => {
+    expect(
+      await isPubliclyHealthy({
+        foundationStorage: readyFoundation,
+        technicalAdminAuth: readyTechnicalAdmin,
+      }),
+    ).toBe(true);
   });
 
   test("does not treat unsafe authoritative write pressure as healthy", async () => {
@@ -205,7 +199,6 @@ describe("public health contract", () => {
           readiness: async () => sqliteReadiness("unsafe"),
         },
         technicalAdminAuth: readyTechnicalAdmin,
-        authoritativeServices: readyAuthoritativeServices,
       }),
     ).toBe(false);
   });
@@ -222,7 +215,6 @@ describe("public health contract", () => {
             readiness: async () => readiness,
           },
           technicalAdminAuth: readyTechnicalAdmin,
-          authoritativeServices: readyAuthoritativeServices,
         }),
       ).toBe(false);
     }

--- a/src/lib/public-health.ts
+++ b/src/lib/public-health.ts
@@ -1,16 +1,13 @@
 import type { FoundationStorage } from "@/lib/foundation-storage";
-import type { LiveEventGameRuntime } from "@/lib/live-event-game-runtime";
 import type { TechnicalAdminAuth, TechnicalAdminStorageStatus } from "@/lib/technical-admin-auth";
 
-/** The intentionally small dependency surface of the public health contract. */
+/**
+ * The intentionally small core dependency surface of the public health contract. Optional
+ * Event, Ad Hoc, and Grant operation modules own their separate fail-closed boundaries.
+ */
 export type PublicHealthDependencies = {
   foundationStorage: Pick<FoundationStorage, "readiness"> | undefined;
   technicalAdminAuth: Pick<TechnicalAdminAuth, "storageStatus">;
-  /** The SQM-critical authoritative services that must remain available. */
-  authoritativeServices: {
-    eventAdministration: boolean;
-    liveEventRuntime: Pick<LiveEventGameRuntime, "readiness"> | null;
-  };
 };
 
 const PUBLIC_HEALTH_HEADERS = {
@@ -41,17 +38,6 @@ export function createPublicHealthRoute(dependencies: PublicHealthDependencies) 
 }
 
 export async function isPubliclyHealthy(dependencies: PublicHealthDependencies): Promise<boolean> {
-  if (
-    !dependencies.authoritativeServices.eventAdministration ||
-    dependencies.authoritativeServices.liveEventRuntime === null
-  ) {
-    return false;
-  }
-
-  if (!(await isFoundationStorageHealthy(dependencies.authoritativeServices.liveEventRuntime))) {
-    return false;
-  }
-
   let technicalAdminStatus: TechnicalAdminStorageStatus;
   try {
     technicalAdminStatus = dependencies.technicalAdminAuth.storageStatus();


### PR DESCRIPTION
## What changed

- Make public `/healthz` readiness depend on the core Technical Admin and Foundation readiness boundary only.
- Keep Foundation migration, replay, required-key, and write-pressure checks fail-closed.
- Keep Event, Ad Hoc, and Grant operation boundaries independently fail-closed when their own runtime is unavailable or unhealthy.
- Add fast regression coverage for the readiness boundary, operation boundaries, caller-input variations, and the fixed public information-exclusion contract.
- Document the production UptimeRobot Home and `/healthz` monitors, including the exact local verification and the Test monitor-free policy.

## Why

The public health endpoint was returning `503 unhealthy` while the application and Home page were operational. Public health was composed with the optional Live Event runtime, so an unavailable optional runtime incorrectly made core public readiness unhealthy.

## Developer and operator impact

Developers get a stable public readiness boundary that reports core application readiness without making optional Live Event availability a prerequisite. Operators can monitor the Home page and `/healthz` independently: Home must return HTTP 200, while `/healthz` must return HTTP 200 with the exact body `healthy` and must alert if the response contains `unhealthy`. Test remains monitor-free.

## Root cause

The optional Live Event runtime was falsely composed into core public health. This change removes that composition while leaving the real Foundation and operation-specific fail-closed checks in place.

## Checks

- `bun test --isolate src/lib/public-health.test.ts src/lib/public-health.operation-boundaries.test.ts` — 7 passed, 0 failed.
- `bun run check` — passed; only pre-existing unrelated oxlint warnings remain.
- Fish syntax validation of the runbook verification commands — passed.
- `git diff --check` — passed.

The ordinary full test command was attempted locally but interrupted after prolonged contention from unrelated concurrent Bun test processes; it produced no failure output. Qualification tests were not run.

## Remaining operator-owned verification

- Configure and verify the production UptimeRobot Home HTTP(s) monitor at a five-minute interval with expected HTTP status 200.
- Configure and verify the production UptimeRobot `/healthz` HTTP(s) Keyword monitor at a five-minute interval with expected HTTP status 200 and a keyword condition that alerts when `unhealthy` exists (or UptimeRobot's equivalent negative-condition configuration). Do not use a positive substring match for `healthy`, because `healthy` is contained in `unhealthy`.
- Run the fish-compatible checks in `deploy/uptimerobot-monitoring.md` and preserve each monitor result independently; the local health assertion compares the exact response bytes to `healthy\n`.
- Confirm live production monitor behavior after deployment. No credentials are required or included here.
