### PR TITLE
Complete GlitchTip capture setup isolation

### DIFF
--- a/deploy/monitoring.md
+++ b/deploy/monitoring.md
@@ -11,6 +11,24 @@ environment or any server credential. Both values are optional, so a missing or
 failed monitoring transport never changes an application response or authority
 decision.
 
+The two environments use separate DSN pairs and must not reuse one another's
+values:
+
+| Environment | Server DSN | Browser DSN | Root-controlled file | Service group |
+| --- | --- | --- | --- | --- |
+| Production | `GLITCHTIP_DSN` | `PUBLIC_GLITCHTIP_DSN` | `/etc/quadball-timer/production.env` | `quadball-timer` |
+| Test | `GLITCHTIP_DSN` | `PUBLIC_GLITCHTIP_DSN` | `/etc/quadball-timer/test.env` | `quadball-timer-test` |
+
+The server DSN is never sent to a browser. The browser DSN is intentionally
+public Sentry-compatible configuration, but remains outside the release and is
+injected only by the matching Environment service. Install both files as
+`root:<service-group>` with mode `0640`: Production uses
+`root:quadball-timer` and Test uses `root:quadball-timer-test`, matching the
+systemd units above. The optional Production file must be created with that
+ownership before enabling Production delivery. Do not print either DSN while
+checking the files: inspect only file metadata and the allowlisted variable
+names.
+
 To exercise server delivery, from the Test host run this bounded transient unit.
 It runs as the Test service identity, loads the root-controlled Test
 `EnvironmentFile`, uses the immutable compiled release as its working directory,
@@ -28,7 +46,7 @@ sudo systemd-run --wait --collect --pipe --quiet \
   /srv/quadball-timer-test/current/quadball-timer --emit-test-monitoring-error
 ```
 
-The command emits one fixed harmless event and has no public HTTP route. It must
+The command emits one fixed harmless exception and has no public HTTP route. It must
 never be run against the Production environment. The repository convenience
 command is `bun run monitoring:test` for non-deployed local Test configuration.
 
@@ -41,7 +59,9 @@ window.dispatchEvent(
 );
 ```
 
-Confirm that one browser event arrives with the Test Environment and active
-release tags. Do not paste the event payload, credentials, cookies, or any
-issue/workflow evidence; this check records only the operator's pass/fail
+Confirm that exactly one browser error arrives with the Test Environment and
+active immutable release/correlation tags, and that its displayed exception is
+the generic redacted application shape rather than the dispatched message or
+any browser/request data. Do not paste the event payload, credentials, cookies,
+or any issue/workflow evidence; record only the operator's pass/fail
 observation.

--- a/src/index.ts
+++ b/src/index.ts
@@ -2653,7 +2653,7 @@ async function emitTestMonitoringError(): Promise<void> {
     dsn: process.env.GLITCHTIP_DSN?.trim() || undefined,
   });
   if (!monitoring.enabled) throw new Error("GLITCHTIP_DSN is not configured.");
-  monitoring.captureMessage("Quadball Timer Test monitoring event", {
+  monitoring.captureException(new Error("Quadball Timer Test monitoring error"), {
     category: "test-monitoring",
     component: "host-local",
     operation: "emit-test-error",

--- a/src/lib/monitoring-browser.test.ts
+++ b/src/lib/monitoring-browser.test.ts
@@ -1,10 +1,35 @@
 import { describe, expect, test } from "bun:test";
 import {
   createReactRootErrorHandlers,
+  initializeBrowserMonitoring,
   installBrowserMonitoringListeners,
 } from "@/lib/monitoring-browser";
 
 describe("browser monitoring listeners", () => {
+  test("isolates browser monitoring initialization failure", () => {
+    const target = { addEventListener() {} };
+
+    expect(() =>
+      initializeBrowserMonitoring(
+        {
+          dsn: "https://public@example.test/1",
+          environment: "test",
+          release: "release-test",
+          browserCorrelation: "browser-test",
+        },
+        {
+          init() {
+            throw new Error("transport setup unavailable");
+          },
+          withScope() {},
+          captureException() {},
+          captureMessage() {},
+        },
+        target,
+      ),
+    ).not.toThrow();
+  });
+
   test("converts window errors and rejected promises into bounded capture calls", () => {
     const listeners = new Map<string, EventListener>();
     const target = {
@@ -34,6 +59,23 @@ describe("browser monitoring listeners", () => {
     expect(captures[1]?.error).toBeInstanceOf(Error);
   });
 
+  test("isolates a failing capture callback from browser event handling", () => {
+    const listeners = new Map<string, EventListener>();
+    const target = {
+      addEventListener(type: string, listener: EventListener) {
+        listeners.set(type, listener);
+      },
+    };
+    installBrowserMonitoringListeners(target, () => {
+      throw new Error("transport unavailable");
+    });
+
+    expect(() => listeners.get("error")?.(new Event("error"))).not.toThrow();
+    expect(() =>
+      listeners.get("unhandledrejection")?.(new Event("unhandledrejection")),
+    ).not.toThrow();
+  });
+
   test("exposes all React 19 root error callback seams", () => {
     const handlers = createReactRootErrorHandlers();
     expect(Object.keys(handlers).sort()).toEqual([
@@ -43,6 +85,24 @@ describe("browser monitoring listeners", () => {
     ]);
     expect(() =>
       handlers.onRecoverableError(new Error("private team name"), { componentStack: "" }),
+    ).not.toThrow();
+  });
+
+  test("uses no-op React 19 handlers when Sentry setup fails", () => {
+    const handlers = createReactRootErrorHandlers({
+      reactErrorHandler() {
+        throw new Error("React monitoring setup unavailable");
+      },
+    });
+
+    expect(() =>
+      handlers.onCaughtError(new Error("application failure"), { componentStack: "" }),
+    ).not.toThrow();
+    expect(() =>
+      handlers.onRecoverableError(new Error("application failure"), { componentStack: "" }),
+    ).not.toThrow();
+    expect(() =>
+      handlers.onUncaughtError(new Error("application failure"), { componentStack: "" }),
     ).not.toThrow();
   });
 });

--- a/src/lib/monitoring-browser.ts
+++ b/src/lib/monitoring-browser.ts
@@ -21,27 +21,63 @@ export type ReactRootErrorHandlers = {
   onUncaughtError: (error: unknown, errorInfo: ErrorInfo) => void;
 };
 
-export function initializeBrowserMonitoring(config: BrowserMonitoringConfig): void {
+type BrowserMonitoringClient = {
+  init(options: Parameters<typeof Sentry.init>[0]): void;
+  withScope(callback: (scope: { setTags(tags: Record<string, string>): void }) => void): void;
+  captureException(error: unknown): void;
+  captureMessage(message: string): void;
+};
+
+const defaultBrowserMonitoringClient: BrowserMonitoringClient = {
+  init(options) {
+    Sentry.init(options);
+  },
+  withScope(callback) {
+    Sentry.withScope((scope) => callback(scope));
+  },
+  captureException(error) {
+    Sentry.captureException(error);
+  },
+  captureMessage(message) {
+    Sentry.captureMessage(message);
+  },
+};
+
+type ReactErrorHandlerClient = {
+  reactErrorHandler: typeof Sentry.reactErrorHandler;
+};
+
+export function initializeBrowserMonitoring(
+  config: BrowserMonitoringConfig,
+  client: BrowserMonitoringClient = defaultBrowserMonitoringClient,
+  target: BrowserMonitoringEventTarget = window,
+): void {
   if (config.dsn === undefined || config.dsn.length === 0) return;
 
-  Sentry.init({
-    dsn: config.dsn,
-    environment: config.environment,
-    release: config.release,
-    defaultIntegrations: false,
-    sendDefaultPii: false,
-    tracesSampleRate: 0,
-    beforeSend(event) {
-      return redactSentryEvent(event, config) as typeof event;
-    },
-  });
-
-  installBrowserMonitoringListeners(window, (error, context) => {
-    Sentry.withScope((scope) => {
-      scope.setTags(safeMonitoringTags(context));
-      Sentry.captureException(error);
+  try {
+    client.init({
+      dsn: config.dsn,
+      environment: config.environment,
+      release: config.release,
+      defaultIntegrations: false,
+      sendDefaultPii: false,
+      tracesSampleRate: 0,
+      beforeSend(event) {
+        return redactSentryEvent(event, config) as typeof event;
+      },
     });
-  });
+
+    installBrowserMonitoringListeners(target, (error, context) => {
+      safelyCapture(() => {
+        client.withScope((scope) => {
+          scope.setTags(safeMonitoringTags(context));
+          client.captureException(error);
+        });
+      });
+    });
+  } catch {
+    // Monitoring setup is observational and must never prevent application startup.
+  }
 }
 
 export function installBrowserMonitoringListeners(
@@ -50,19 +86,23 @@ export function installBrowserMonitoringListeners(
 ): void {
   target.addEventListener("error", (event) => {
     const errorEvent = event as ErrorEvent;
-    capture(errorEvent.error ?? new Error(errorEvent.message || "Browser error"), {
-      category: "browser",
-      component: "window",
+    safelyCapture(() => {
+      capture(errorEvent.error ?? new Error(errorEvent.message || "Browser error"), {
+        category: "browser",
+        component: "window",
+      });
     });
   });
   target.addEventListener("unhandledrejection", (event) => {
     const rejectionEvent = event as PromiseRejectionEvent;
-    capture(
-      rejectionEvent.reason instanceof Error
-        ? rejectionEvent.reason
-        : new Error("Unhandled browser rejection"),
-      { category: "browser", component: "promise" },
-    );
+    safelyCapture(() => {
+      capture(
+        rejectionEvent.reason instanceof Error
+          ? rejectionEvent.reason
+          : new Error("Unhandled browser rejection"),
+        { category: "browser", component: "promise" },
+      );
+    });
   });
 }
 
@@ -71,8 +111,19 @@ export function installBrowserMonitoringListeners(
  * Sentry's beforeSend callback applies the same redaction boundary as browser
  * and server errors.
  */
-export function createReactRootErrorHandlers(): ReactRootErrorHandlers {
-  const handler = Sentry.reactErrorHandler();
+export function createReactRootErrorHandlers(
+  client: ReactErrorHandlerClient = Sentry,
+): ReactRootErrorHandlers {
+  let handler: ReturnType<typeof Sentry.reactErrorHandler>;
+  try {
+    handler = client.reactErrorHandler();
+  } catch {
+    return {
+      onCaughtError() {},
+      onRecoverableError() {},
+      onUncaughtError() {},
+    };
+  }
   const isolated = (error: unknown, errorInfo: ErrorInfo): void => {
     try {
       handler(error, errorInfo);
@@ -88,8 +139,18 @@ export function createReactRootErrorHandlers(): ReactRootErrorHandlers {
 }
 
 export function captureBrowserMessage(message: string, context?: MonitoringContext): void {
-  Sentry.withScope((scope) => {
-    scope.setTags(safeMonitoringTags(context));
-    Sentry.captureMessage(message);
+  safelyCapture(() => {
+    defaultBrowserMonitoringClient.withScope((scope) => {
+      scope.setTags(safeMonitoringTags(context));
+      defaultBrowserMonitoringClient.captureMessage(message);
+    });
   });
+}
+
+function safelyCapture(capture: () => void): void {
+  try {
+    capture();
+  } catch {
+    // Monitoring is observational and must never alter application behavior.
+  }
 }

--- a/src/lib/monitoring-server.test.ts
+++ b/src/lib/monitoring-server.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { createBrowserCorrelation, readTrustedMonitoringIdentity } from "@/lib/monitoring-server";
+import {
+  createBrowserCorrelation,
+  initializeServerMonitoring,
+  readTrustedMonitoringIdentity,
+} from "@/lib/monitoring-server";
 
 describe("trusted monitoring release identity", () => {
   test("does not fabricate a deployed identity when the immutable manifest is unavailable", async () => {
@@ -26,5 +30,31 @@ describe("trusted monitoring release identity", () => {
       release: "sha-commit-run-123-attempt-1",
       browserCorrelation: createBrowserCorrelation("sha-commit-run-123-attempt-1"),
     });
+  });
+});
+
+describe("monitoring setup boundary", () => {
+  test("disables a server client when initialization fails", async () => {
+    const monitoring = initializeServerMonitoring(
+      {
+        dsn: "https://public@example.test/1",
+        environment: "test",
+        release: "release-test",
+        browserCorrelation: "browser-test",
+      },
+      {
+        init() {
+          throw new Error("transport setup unavailable");
+        },
+        withScope() {},
+        captureException() {},
+        captureMessage() {},
+        flush: async () => true,
+      },
+    );
+
+    expect(monitoring.enabled).toBe(false);
+    expect(() => monitoring.captureException(new Error("application failure"))).not.toThrow();
+    expect(await monitoring.flush()).toBe(true);
   });
 });

--- a/src/lib/monitoring-server.ts
+++ b/src/lib/monitoring-server.ts
@@ -20,6 +20,32 @@ export type ServerMonitoringOptions = MonitoringIdentity & {
   dsn?: string;
 };
 
+type ServerMonitoringClient = {
+  init(options: Parameters<typeof Sentry.init>[0]): void;
+  withScope(callback: (scope: { setTags(tags: Record<string, string>): void }) => void): void;
+  captureException(error: unknown): void;
+  captureMessage(message: string): void;
+  flush(timeoutMs: number): Promise<boolean>;
+};
+
+const defaultServerMonitoringClient: ServerMonitoringClient = {
+  init(options) {
+    Sentry.init(options);
+  },
+  withScope(callback) {
+    Sentry.withScope((scope) => callback(scope));
+  },
+  captureException(error) {
+    Sentry.captureException(error);
+  },
+  captureMessage(message) {
+    Sentry.captureMessage(message);
+  },
+  flush(timeoutMs) {
+    return Sentry.flush(timeoutMs);
+  },
+};
+
 export async function readTrustedMonitoringIdentity(
   environment: MonitoringIdentity["environment"],
   environmentVariables: Record<string, string | undefined> = process.env,
@@ -55,37 +81,52 @@ export function createBrowserCorrelation(release: string): string {
   return `release-${createHash("sha256").update(release).digest("hex").slice(0, 16)}`;
 }
 
-export function initializeServerMonitoring(options: ServerMonitoringOptions): ServerMonitoring {
+export function initializeServerMonitoring(
+  options: ServerMonitoringOptions,
+  client: ServerMonitoringClient = defaultServerMonitoringClient,
+): ServerMonitoring {
   if (options.dsn === undefined || options.dsn.length === 0) return createDisabledMonitoring();
 
-  Sentry.init({
-    dsn: options.dsn,
-    environment: options.environment,
-    release: options.release,
-    defaultIntegrations: false,
-    sendDefaultPii: false,
-    tracesSampleRate: 0,
-    beforeSend(event) {
-      return redactSentryEvent(event, options) as typeof event;
-    },
-  });
+  try {
+    client.init({
+      dsn: options.dsn,
+      environment: options.environment,
+      release: options.release,
+      defaultIntegrations: false,
+      sendDefaultPii: false,
+      tracesSampleRate: 0,
+      beforeSend(event) {
+        return redactSentryEvent(event, options) as typeof event;
+      },
+    });
+  } catch {
+    return createDisabledMonitoring();
+  }
 
   return {
     enabled: true,
     captureException(error, context) {
-      Sentry.withScope((scope) => {
-        scope.setTags(safeMonitoringTags(context));
-        Sentry.captureException(error);
+      safelyCapture(() => {
+        client.withScope((scope) => {
+          scope.setTags(safeMonitoringTags(context));
+          client.captureException(error);
+        });
       });
     },
     captureMessage(message, context) {
-      Sentry.withScope((scope) => {
-        scope.setTags(safeMonitoringTags(context));
-        Sentry.captureMessage(message);
+      safelyCapture(() => {
+        client.withScope((scope) => {
+          scope.setTags(safeMonitoringTags(context));
+          client.captureMessage(message);
+        });
       });
     },
     flush(timeoutMs = 2_000) {
-      return Sentry.flush(timeoutMs).catch(() => false);
+      try {
+        return client.flush(timeoutMs).catch(() => false);
+      } catch {
+        return Promise.resolve(false);
+      }
     },
   };
 }
@@ -101,4 +142,12 @@ function createDisabledMonitoring(): ServerMonitoring {
     captureMessage() {},
     flush: async () => true,
   };
+}
+
+function safelyCapture(capture: () => void): void {
+  try {
+    capture();
+  } catch {
+    // Monitoring is observational and must never alter application behavior.
+  }
 }

--- a/src/production-deployment.test.ts
+++ b/src/production-deployment.test.ts
@@ -48,6 +48,15 @@ describe("Production deployment contract", () => {
     expect(unit).toContain("EnvironmentFile=-/etc/quadball-timer/production.env");
   });
 
+  test("documents Environment-specific GlitchTip DSN file ownership", () => {
+    const monitoring = readFileSync(join(repositoryRoot, "deploy/monitoring.md"), "utf8");
+
+    expect(monitoring).toContain("`/etc/quadball-timer/production.env` | `quadball-timer`");
+    expect(monitoring).toContain("`/etc/quadball-timer/test.env` | `quadball-timer-test`");
+    expect(monitoring).toContain("Production uses\n`root:quadball-timer`");
+    expect(monitoring).toContain("`root:quadball-timer-test`");
+  });
+
   test("builds one shared immutable artifact for independent environment jobs", () => {
     const workflow = readFileSync(
       join(repositoryRoot, ".github/workflows/deploy-production.yml"),


### PR DESCRIPTION
## What changed

- Isolates synchronous Sentry initialization/setup, capture, listener, React 19 handler, and flush failures in server/browser monitoring.
- Emits one fixed harmless Test exception through the host-local CLI.
- Keeps strict allowlisted event redaction and trusted release/Environment identity, and documents separate Production/Test DSNs with matching root-owned 0640 env files.
- Adds Fast fake-client init-failure and browser/server monitoring coverage.

## Why

Monitoring setup failures could escape before normal application startup, while SQM needs actionable GlitchTip capture without affecting application operation or leaking secrets.

## Impact

Monitoring remains observational. If setup or delivery fails, application operation continues and monitoring is disabled or ignored. No public diagnostic route, broad telemetry, tracing, profiling, replay, tracking, or journal ingestion is added.

## Root cause

The existing Sentry-compatible clients had safe capture/flush paths but left synchronous SDK initialization/setup outside the isolation boundary. The correction adds narrow client seams, catches initialization/listener/React setup failures, and returns disabled/no-op behavior.

## Verification

- Focused monitoring/deployment Fast suite: 39 passed.
- `bun run test`: 989 passed.
- `bun run check` passed with only pre-existing unrelated lint warnings.
- `bun run build` passed.
- Independent Standards and Spec review: no actionable findings.
- Qualification workloads were not invoked.

## Operator-owned follow-up

Privileged DSN installation and restart remain operator-owned; see `/tmp/quadball-timer-issue-164-handoff.md`. Install separate Production/Test `GLITCHTIP_DSN` and `PUBLIC_GLITCHTIP_DSN` values in root-owned mode-0640 env files with groups `quadball-timer` and `quadball-timer-test`; do not print DSNs. After an approved restart, perform the documented bounded Test-only server and browser delivery verification and record pass/fail only. No automatic issue closure is included; external acceptance remains with the coordinator.
