### PR TITLE
Make Ad Hoc departure resumable

### DIFF
--- a/scripts/test-ad-hoc-browser.ts
+++ b/scripts/test-ad-hoc-browser.ts
@@ -298,9 +298,115 @@ async function run() {
         await second.getByRole("button", { name: "Start game" }).click();
         await first.getByText("Running", { exact: true }).waitFor();
         await second.getByRole("button", { name: "Pause game" }).click();
-        await second.getByRole("button", { name: "Leave", exact: true }).click();
+        const leaveButton = second.getByRole("button", { name: "Leave", exact: true });
+        await leaveButton.click();
+        await second.getByRole("dialog").waitFor();
+        await second.getByRole("dialog").press("Escape");
+        await second.waitForFunction(() => document.activeElement?.textContent?.includes("Leave"));
+        await leaveButton.click();
+        await second.getByRole("dialog").getByRole("button", { name: "Stay in game" }).click();
+        await second.waitForFunction(() => document.activeElement?.textContent?.includes("Leave"));
+        await leaveButton.click();
+        const leaveDialog = second.getByRole("dialog");
+        await leaveDialog.locator("..").click({ position: { x: 1, y: 1 } });
+        await second.waitForFunction(() => document.activeElement?.textContent?.includes("Leave"));
+        await leaveButton.click();
+        await second.getByRole("dialog").getByRole("button", { name: "Leave game" }).click();
         if (new URL(second.url()).pathname !== "/") await second.waitForURL(`${origin}/`);
+
+        const postLeaveStorageState = await secondContext.storageState();
+        await second.goto(origin);
+        await second.getByRole("button", { name: "Return to game" }).click();
+        await waitForGameRoute(second, gameId);
         await first.getByText("Paused", { exact: true }).waitFor();
+
+        const creationContext = await browser!.newContext({
+          ignoreHTTPSErrors: true,
+          storageState: postLeaveStorageState,
+        });
+        const creationPage = await creationContext.newPage();
+        creationPage.setDefaultTimeout(15_000);
+        const creationOrder: string[] = [];
+        creationPage.on("request", (request) => {
+          if (request.method() !== "POST") return;
+          const pathname = new URL(request.url()).pathname;
+          if (pathname === "/api/games") creationOrder.push("create");
+          if (pathname.endsWith("/leave")) creationOrder.push("finalize");
+        });
+        await creationPage.goto(origin);
+        const startButton = creationPage.getByRole("button", { name: /Start an Ad Hoc Game/ });
+        await startButton.click();
+        await creationPage.getByRole("dialog").waitFor();
+        if (creationOrder.length !== 0)
+          throw new Error(
+            "Ad Hoc creation or finalization started before replacement confirmation.",
+          );
+        await creationPage.getByRole("dialog").getByRole("button", { name: "Cancel" }).click();
+        await creationPage.waitForFunction(() =>
+          document.activeElement?.textContent?.includes("Start an Ad Hoc Game"),
+        );
+        await startButton.click();
+        await creationPage.getByRole("dialog").getByRole("button", { name: "Continue" }).click();
+        try {
+          await creationPage.waitForURL(/\/game\/adhoc-/u);
+        } catch (error) {
+          throw new Error(
+            `Creation did not navigate; order=${creationOrder.join(",")}; url=${creationPage.url()}; text=${(await creationPage.locator("body").textContent()) ?? ""}; cause=${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+        const creationIndex = creationOrder.indexOf("create");
+        if (
+          creationIndex <= 0 ||
+          creationOrder.slice(0, creationIndex).some((entry) => entry !== "finalize")
+        )
+          throw new Error(`Ad Hoc creation order was ${creationOrder.join(",")}.`);
+        await creationPage.getByRole("button", { name: "Leave", exact: true }).click();
+        await creationPage.getByRole("dialog").getByRole("button", { name: "Leave game" }).click();
+        await creationPage.waitForURL(`${origin}/`);
+        const admissionStorageState = await creationContext.storageState();
+        await creationContext.close();
+
+        const alternateSnapshot = await first.evaluate(async (id) => {
+          const response = await fetch(`/api/games/${id}`);
+          return (await response.json()) as { game?: { controlQr?: string | null } };
+        }, creationRetryGameId);
+        const alternateQr = alternateSnapshot.game?.controlQr;
+        if (typeof alternateQr !== "string")
+          throw new Error("Alternate Ad Hoc handoff QR was unavailable.");
+        const admissionContext = await browser!.newContext({
+          ignoreHTTPSErrors: true,
+          storageState: admissionStorageState,
+        });
+        const admissionPage = await admissionContext.newPage();
+        admissionPage.setDefaultTimeout(15_000);
+        const admissionOrder: string[] = [];
+        admissionPage.on("request", (request) => {
+          if (request.method() !== "POST") return;
+          const pathname = new URL(request.url()).pathname;
+          if (pathname.endsWith("/admit")) admissionOrder.push("admit");
+          if (pathname.endsWith("/leave")) admissionOrder.push("finalize");
+        });
+        await admissionPage.goto(
+          `${origin}/#adhoc-game=${encodeURIComponent(creationRetryGameId)}&adhoc-control=${encodeURIComponent(alternateQr)}`,
+        );
+        await admissionPage.getByRole("dialog").waitFor();
+        if (admissionOrder.length !== 0)
+          throw new Error("Ad Hoc admission started before replacement confirmation.");
+        await admissionPage.getByRole("dialog").getByRole("button", { name: "Continue" }).click();
+        try {
+          await waitForGameRoute(admissionPage, creationRetryGameId);
+        } catch (error) {
+          throw new Error(
+            `Admission did not navigate; order=${admissionOrder.join(",")}; url=${admissionPage.url()}; text=${(await admissionPage.locator("body").textContent()) ?? ""}; cause=${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+        const admissionIndex = admissionOrder.indexOf("admit");
+        if (
+          admissionIndex <= 0 ||
+          admissionOrder.slice(0, admissionIndex).some((entry) => entry !== "finalize")
+        )
+          throw new Error(`Ad Hoc admission order was ${admissionOrder.join(",")}.`);
+        await admissionContext.close();
 
         environment.AD_HOC_MAX_CONNECTED_SOCKETS = "1";
         await stopServer();

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -169,6 +169,153 @@ describe("App", () => {
     });
   });
 
+  test("keeps the Home Return card visible when one current Event would auto-redirect", async () => {
+    testWindow.history.pushState(null, "", "/events");
+    testWindow.localStorage.setItem(
+      "quadball:controller-departure",
+      JSON.stringify({
+        version: "controller-departure-v1",
+        status: "returnable",
+        departure: {
+          workflow: "ad-hoc",
+          gameId: "adhoc-return",
+          navigationPath: "/game/adhoc-return",
+          identity: { title: "Ad Hoc Game", homeName: "Home", awayName: "Away" },
+        },
+        expiresAtMs: Date.now() + 300_000,
+        blockedGameIds: [],
+        pendingFinalizations: [],
+        reconciliationPending: [],
+      }),
+    );
+    const eventFetch = Object.assign(
+      async () =>
+        new Response(
+          JSON.stringify({
+            status: "accepted",
+            value: { events: [publishedEventProjection("event-1", "Current Event")] },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      { preconnect: () => undefined },
+    );
+    globalThis.fetch = eventFetch as typeof fetch;
+    await act(async () => {
+      root.render(<App />);
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    });
+    expect(testWindow.location.pathname).toBe("/events");
+    expect(container.textContent).toContain("Return to Ad Hoc Game");
+  });
+
+  test("terminates the rendered Controller when Return reconciliation proves the Game unavailable", async () => {
+    testWindow.localStorage.setItem(
+      "quadball:controller-departure",
+      JSON.stringify({
+        version: "controller-departure-v1",
+        status: "returned",
+        blockedGameIds: [],
+        pendingFinalizations: [],
+        reconciliationPending: [
+          {
+            workflow: "ad-hoc",
+            gameId: "test-game",
+            navigationPath: "/game/test-game",
+            identity: { title: "Ad Hoc Game", homeName: "Home", awayName: "Away" },
+          },
+        ],
+      }),
+    );
+    const unavailableFetch = Object.assign(async () => new Response("Not found", { status: 404 }), {
+      preconnect: () => undefined,
+    });
+    globalThis.fetch = unavailableFetch as typeof fetch;
+    await act(async () => {
+      root.render(<App />);
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    });
+    expect(container.textContent).toContain("Ad Hoc Game unavailable.");
+    expect(container.querySelector('button[name="Start game"]')).toBeNull();
+  });
+
+  test("renders replacement confirmation on a different direct Game route before connecting", async () => {
+    testWindow.localStorage.setItem(
+      "quadball:controller-departure",
+      JSON.stringify({
+        version: "controller-departure-v1",
+        status: "returnable",
+        departure: {
+          workflow: "ad-hoc",
+          gameId: "adhoc-previous",
+          navigationPath: "/game/adhoc-previous",
+          identity: { title: "Ad Hoc Game", homeName: "Basel", awayName: "Zurich" },
+        },
+        expiresAtMs: Date.now() + 300_000,
+        blockedGameIds: [],
+        pendingFinalizations: [],
+        reconciliationPending: [],
+      }),
+    );
+    await act(async () => {
+      root.render(<App />);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(container.querySelector('[role="dialog"]')?.textContent).toContain(
+      "Leave the previous game?",
+    );
+    expect(container.textContent).toContain("Basel vs Zurich");
+    expect(MockWebSocket.instances).toHaveLength(0);
+  });
+
+  test("treats a direct route to the returnable Game as Return before connecting", async () => {
+    testWindow.localStorage.setItem(
+      "quadball:controller-departure",
+      JSON.stringify({
+        version: "controller-departure-v1",
+        status: "returnable",
+        departure: {
+          workflow: "ad-hoc",
+          gameId: "test-game",
+          navigationPath: "/game/test-game",
+          identity: { title: "Ad Hoc Game", homeName: "Home", awayName: "Away" },
+        },
+        expiresAtMs: Date.now() + 300_000,
+        blockedGameIds: [],
+        pendingFinalizations: [],
+        reconciliationPending: [],
+      }),
+    );
+    await act(async () => {
+      root.render(<App />);
+      for (let attempt = 0; attempt < 5; attempt += 1)
+        await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    });
+
+    const stored = JSON.parse(
+      testWindow.localStorage.getItem("quadball:controller-departure") ?? "null",
+    ) as { status?: unknown } | null;
+    expect(stored?.status).toBe("returned");
+    expect(container.querySelector('[role="dialog"]')).toBeNull();
+    expect(container.textContent).toContain("Tap game time or team names to adjust.");
+  });
+
+  test("fails closed and clears a retained Ad Hoc replica when lifecycle storage is corrupt", async () => {
+    testWindow.localStorage.setItem("quadball:controller-departure", "{truncated");
+    testWindow.localStorage.setItem("quadball:ad-hoc-controller:test-game", "retained replica");
+    await act(async () => {
+      root.render(<App />);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain("Ad Hoc Game unavailable.");
+    expect(testWindow.localStorage.getItem("quadball:ad-hoc-controller:test-game")).toBeNull();
+    expect(MockWebSocket.instances).toHaveLength(0);
+  });
+
   test("parses the stable public Event route", () => {
     expect(parseRoute("/events/event-123", "")).toEqual({
       type: "event",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import type { ControllerRole } from "@/lib/game-types";
 import { ColorTestPage } from "@/pages/color-test-page";
@@ -19,6 +19,7 @@ import {
   PublicEventPage,
 } from "@/pages/public-event-page";
 import { TechnicalAdminPage } from "@/pages/technical-admin-page";
+import { useControllerDepartureEntry } from "@/components/controller-departure";
 import "./index.css";
 
 type Route =
@@ -136,27 +137,38 @@ export function App({
 
 function AdHocHandoffPage({ handoff }: { handoff: AdHocHandoff }) {
   const [message, setMessage] = useState("Joining Ad Hoc Game…");
+  const handoffTriggerRef = useRef<HTMLButtonElement | null>(null);
+  const startedRef = useRef(false);
+
+  const admit = useCallback(async () => {
+    setMessage("Joining Ad Hoc Game…");
+    try {
+      const response = await fetch(`/api/games/${handoff.gameId}/admit`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ controlQr: handoff.controlQr, browserId: getAdHocBrowserId() }),
+      });
+      if (!response.ok) throw new Error("unavailable");
+      navigateTo(`/game/${handoff.gameId}`);
+      return true;
+    } catch {
+      setMessage("Ad Hoc Game unavailable.");
+      return false;
+    }
+  }, [handoff.controlQr, handoff.gameId]);
+  const entry = useControllerDepartureEntry({
+    destination: { kind: "admit-ad-hoc", gameId: handoff.gameId },
+    triggerRef: handoffTriggerRef,
+    onCommitted: admit,
+    onUnavailable: () => setMessage("Ad Hoc Game unavailable."),
+    onCancelled: () => setMessage("Join cancelled. Your Controller return is still available."),
+  });
 
   useEffect(() => {
-    let cancelled = false;
-    void fetch(`/api/games/${handoff.gameId}/admit`, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ controlQr: handoff.controlQr, browserId: getAdHocBrowserId() }),
-    })
-      .then(async (response) => {
-        if (!response.ok) throw new Error("unavailable");
-        if (cancelled) return;
-        navigateTo(`/game/${handoff.gameId}`);
-      })
-      .catch(() => {
-        if (!cancelled) setMessage("Ad Hoc Game unavailable.");
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [handoff.controlQr, handoff.gameId]);
+    if (startedRef.current) return;
+    startedRef.current = true;
+    void entry.begin().catch(() => setMessage("Ad Hoc Game unavailable."));
+  }, [entry]);
 
   return (
     <div className="mx-auto flex min-h-screen w-full max-w-xl items-center p-6">
@@ -164,8 +176,18 @@ function AdHocHandoffPage({ handoff }: { handoff: AdHocHandoff }) {
         <CardHeader>
           <CardTitle>Ad Hoc Controller handoff</CardTitle>
           <CardDescription>{message}</CardDescription>
+          <button
+            ref={handoffTriggerRef}
+            type="button"
+            className="mt-4 rounded-md border px-3 py-2 text-sm font-medium"
+            disabled={entry.busy}
+            onClick={() => void entry.begin()}
+          >
+            Join this Ad Hoc Game
+          </button>
         </CardHeader>
       </Card>
+      {entry.dialog}
     </div>
   );
 }

--- a/src/components/controller-departure.tsx
+++ b/src/components/controller-departure.tsx
@@ -1,0 +1,378 @@
+import { useCallback, useEffect, useRef, useState, type ReactNode, type RefObject } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  getBrowserControllerDeparture,
+  type ControllerDepartureDestination,
+  type ControllerDepartureOutcome,
+  type ControllerDepartureReference,
+} from "@/lib/controller-departure";
+
+export function ControllerDepartureReturnCard() {
+  const departureModule = getBrowserControllerDeparture();
+  const [projection, setProjection] = useState(() => departureModule.project());
+  const [message, setMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    const refresh = () => setProjection(departureModule.project());
+    const interval = window.setInterval(refresh, 1_000);
+    const unsubscribe = departureModule.subscribe(refresh);
+    return () => {
+      window.clearInterval(interval);
+      unsubscribe();
+    };
+  }, [departureModule]);
+
+  if (projection.status !== "returnable") return null;
+  const departure = projection.departure;
+  return (
+    <section
+      aria-labelledby="controller-return-title"
+      className="rounded-2xl border-2 border-amber-400 bg-amber-50 p-5 shadow-sm"
+    >
+      <p className="text-xs font-semibold uppercase tracking-[0.16em] text-amber-800">
+        Controller return
+      </p>
+      <h2 id="controller-return-title" className="mt-1 text-xl font-semibold text-amber-950">
+        Return to {departure.identity.title}
+      </h2>
+      <p className="mt-1 text-sm text-amber-900">
+        {departure.identity.homeName} vs {departure.identity.awayName}
+      </p>
+      {departure.identity.detail === undefined ? null : (
+        <p className="mt-1 text-xs text-amber-800">{departure.identity.detail}</p>
+      )}
+      {message === null ? null : (
+        <p className="mt-3 text-sm font-medium text-rose-800" role="alert">
+          {message}
+        </p>
+      )}
+      <Button
+        className="mt-4 min-h-11 w-full sm:w-auto"
+        onClick={() => {
+          setMessage(null);
+          void departureModule
+            .transition({
+              type: "return",
+              gameId: departure.gameId,
+              online: navigator.onLine !== false,
+            })
+            .then((outcome) => {
+              if (outcome.status === "resumed") navigateTo(departure.navigationPath);
+              else {
+                setProjection(departureModule.project());
+                setMessage("This Controller return is no longer available.");
+              }
+            });
+        }}
+      >
+        Return to game
+      </Button>
+    </section>
+  );
+}
+
+export function useControllerDepartureEntry({
+  destination,
+  triggerRef,
+  onCommitted,
+  onUnavailable,
+  onCancelled,
+}: {
+  destination: ControllerDepartureDestination;
+  triggerRef: RefObject<HTMLElement | null>;
+  onCommitted: () => boolean | void | Promise<boolean | void>;
+  onUnavailable: () => void;
+  onCancelled?: () => void;
+}): { begin(): Promise<void>; dialog: ReactNode; busy: boolean } {
+  const departureModule = getBrowserControllerDeparture();
+  const destinationRef = useRef(destination);
+  const onCommittedRef = useRef(onCommitted);
+  const onUnavailableRef = useRef(onUnavailable);
+  const onCancelledRef = useRef(onCancelled);
+  destinationRef.current = destination;
+  onCommittedRef.current = onCommitted;
+  onUnavailableRef.current = onUnavailable;
+  onCancelledRef.current = onCancelled;
+  const [prompt, setPrompt] = useState<
+    Extract<ControllerDepartureOutcome, { status: "needs-confirmation" }> | undefined
+  >();
+  const [busy, setBusy] = useState(false);
+  const busyRef = useRef(false);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const resolve = useCallback(
+    async (initial: ControllerDepartureOutcome) => {
+      let outcome = initial;
+      while (outcome.status === "authorized") {
+        outcome = await departureModule.transition({
+          type: "commit-entry",
+          authorization: outcome.authorization,
+        });
+      }
+      if (!mountedRef.current) return;
+      if (outcome.status === "needs-confirmation") {
+        setPrompt(outcome);
+        busyRef.current = false;
+        setBusy(false);
+        return;
+      }
+      if (outcome.status === "committed") {
+        setPrompt(undefined);
+        let succeeded = false;
+        try {
+          succeeded = (await onCommittedRef.current()) !== false;
+        } catch {
+          succeeded = false;
+        }
+        const completed =
+          outcome.completion === undefined
+            ? { status: "unavailable" as const }
+            : await departureModule.transition({
+                type: "complete-entry",
+                completion: outcome.completion,
+                succeeded,
+              });
+        busyRef.current = false;
+        if (mountedRef.current) setBusy(false);
+        if (succeeded && completed.status !== "committed") onUnavailableRef.current();
+        return;
+      }
+      setPrompt(undefined);
+      busyRef.current = false;
+      setBusy(false);
+      onUnavailableRef.current();
+    },
+    [departureModule],
+  );
+
+  const begin = useCallback(async () => {
+    if (busyRef.current) return;
+    busyRef.current = true;
+    setBusy(true);
+    const outcome = await departureModule.transition({
+      type: "request-entry",
+      destination: destinationRef.current,
+      online: navigator.onLine !== false,
+    });
+    await resolve(outcome);
+  }, [departureModule, resolve]);
+
+  const dialog =
+    prompt === undefined ? null : (
+      <ControllerReplacementDialog
+        departure={prompt.departure}
+        triggerRef={triggerRef}
+        busy={busy}
+        onCancel={() => {
+          const request = prompt.request;
+          setPrompt(undefined);
+          busyRef.current = false;
+          setBusy(false);
+          void departureModule.transition({ type: "cancel-entry", request });
+          onCancelledRef.current?.();
+        }}
+        onConfirm={() => {
+          if (busyRef.current) return;
+          busyRef.current = true;
+          setBusy(true);
+          void departureModule
+            .transition({
+              type: "confirm-entry",
+              request: prompt.request,
+              online: navigator.onLine !== false,
+            })
+            .then(resolve);
+        }}
+      />
+    );
+
+  return { begin, dialog, busy };
+}
+
+function ControllerDepartureDialog({
+  title,
+  description,
+  safeLabel,
+  confirmLabel,
+  titleId,
+  descriptionId,
+  triggerRef,
+  onCancel,
+  onConfirm,
+  busy,
+}: {
+  title: string;
+  description: string;
+  safeLabel: string;
+  confirmLabel: string;
+  titleId: string;
+  descriptionId: string;
+  triggerRef: RefObject<HTMLElement | null>;
+  onCancel: () => void;
+  onConfirm: () => void;
+  busy: boolean;
+}) {
+  const safeButtonRef = useRef<HTMLButtonElement | null>(null);
+  const confirmButtonRef = useRef<HTMLButtonElement | null>(null);
+  const restoreFocus = () => window.setTimeout(() => triggerRef.current?.focus(), 0);
+  const dismiss = () => {
+    if (busy) return;
+    onCancel();
+    restoreFocus();
+  };
+  useEffect(() => {
+    safeButtonRef.current?.focus();
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        dismiss();
+        return;
+      }
+      if (event.key !== "Tab") return;
+      const focusable = [safeButtonRef.current, confirmButtonRef.current].filter(
+        (element): element is HTMLButtonElement => element !== null && !element.disabled,
+      );
+      if (focusable.length === 0) return;
+      const first = focusable[0]!;
+      const last = focusable[focusable.length - 1]!;
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  });
+  return (
+    <div
+      className="fixed inset-0 z-50 grid place-items-center bg-slate-950/45 p-4"
+      role="presentation"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) dismiss();
+      }}
+    >
+      <div
+        className="w-full max-w-sm rounded-2xl border border-slate-200 bg-white p-5 shadow-2xl"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={descriptionId}
+        onMouseDown={(event) => event.stopPropagation()}
+      >
+        <h2 id={titleId} className="text-lg font-semibold text-slate-950">
+          {title}
+        </h2>
+        <p id={descriptionId} className="mt-2 text-sm text-slate-700">
+          {description}
+        </p>
+        <div className="mt-5 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+          <Button ref={safeButtonRef} variant="outline" onClick={dismiss} disabled={busy}>
+            {safeLabel}
+          </Button>
+          <Button
+            ref={confirmButtonRef}
+            onClick={() => {
+              restoreFocus();
+              onConfirm();
+            }}
+            disabled={busy}
+          >
+            {confirmLabel}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function ControllerLeaveDialog({
+  triggerRef,
+  onCancel,
+  onConfirm,
+  busy = false,
+}: {
+  triggerRef: RefObject<HTMLElement | null>;
+  onCancel: () => void;
+  onConfirm: () => void;
+  busy?: boolean;
+}) {
+  return (
+    <ControllerDepartureDialog
+      title="Leave this game?"
+      description="You can return from Home for five minutes. After that, this browser will lose control access."
+      safeLabel="Stay in game"
+      confirmLabel="Leave game"
+      titleId="controller-leave-title"
+      descriptionId="controller-leave-description"
+      triggerRef={triggerRef}
+      onCancel={onCancel}
+      onConfirm={onConfirm}
+      busy={busy}
+    />
+  );
+}
+
+function ControllerReplacementDialog({
+  departure,
+  triggerRef,
+  onCancel,
+  onConfirm,
+  busy = false,
+}: {
+  departure: ControllerDepartureReference;
+  triggerRef: RefObject<HTMLElement | null>;
+  onCancel: () => void;
+  onConfirm: () => void;
+  busy?: boolean;
+}) {
+  return (
+    <ControllerDepartureDialog
+      title="Leave the previous game?"
+      description={`Returning to ${departure.identity.homeName} vs ${departure.identity.awayName} will no longer be available after you start or join another game.`}
+      safeLabel="Cancel"
+      confirmLabel="Continue"
+      titleId="controller-replacement-title"
+      descriptionId="controller-replacement-description"
+      triggerRef={triggerRef}
+      onCancel={onCancel}
+      onConfirm={onConfirm}
+      busy={busy}
+    />
+  );
+}
+
+export function controllerDepartureReference(input: {
+  workflow: ControllerDepartureReference["workflow"];
+  gameId: string;
+  homeName: string;
+  awayName: string;
+  navigationPath?: string;
+  detail?: string;
+}): ControllerDepartureReference {
+  return {
+    workflow: input.workflow,
+    gameId: input.gameId,
+    navigationPath: input.navigationPath ?? `/game/${input.gameId}`,
+    identity: {
+      title: input.workflow === "ad-hoc" ? "Ad Hoc Game" : "Event Game",
+      homeName: input.homeName,
+      awayName: input.awayName,
+      ...(input.detail === undefined ? {} : { detail: input.detail }),
+    },
+  };
+}
+
+function navigateTo(path: string) {
+  window.history.pushState(null, "", path);
+  window.dispatchEvent(new PopStateEvent("popstate"));
+}

--- a/src/lib/controller-departure.test.ts
+++ b/src/lib/controller-departure.test.ts
@@ -1,0 +1,561 @@
+import { describe, expect, test } from "bun:test";
+import {
+  CONTROLLER_LEAVE_GRACE_MS,
+  controllerDepartureBlocksGame,
+  createControllerDeparture,
+  createInMemoryControllerDepartureAdapters,
+  type ControllerDepartureReference,
+} from "@/lib/controller-departure";
+
+const departure = (gameId: string): ControllerDepartureReference => ({
+  workflow: "ad-hoc",
+  gameId,
+  navigationPath: `/game/${gameId}`,
+  identity: { title: "Ad Hoc Game", homeName: "Basel", awayName: "Zurich" },
+});
+
+describe("Controller Departure", () => {
+  test("keeps the newest opportunity and blocks every superseded game", async () => {
+    const adapters = createInMemoryControllerDepartureAdapters({ nowMs: 100 });
+    const module = createControllerDeparture(adapters);
+    await module.transition({ type: "leave", departure: departure("adhoc-a"), online: false });
+    const result = await module.transition({
+      type: "leave",
+      departure: departure("adhoc-b"),
+      online: false,
+      nowMs: 200,
+    });
+    expect(result).toMatchObject({
+      status: "left",
+      projection: { departure: { gameId: "adhoc-b" } },
+    });
+    expect(controllerDepartureBlocksGame(module.project(), "adhoc-a")).toBe(true);
+    expect(adapters.clearedReplicas).toContain("adhoc-a");
+    expect(
+      (await module.transition({ type: "return", gameId: "adhoc-a", online: false })).status,
+    ).toBe("unavailable");
+  });
+
+  test("requires confirmation before replacing a return opportunity", async () => {
+    const finalized: string[] = [];
+    const adapters = createInMemoryControllerDepartureAdapters({
+      departure: departure("adhoc-a"),
+      finalize: async (value) => {
+        finalized.push(value.gameId);
+        return "accepted";
+      },
+    });
+    const module = createControllerDeparture(adapters);
+    const request = await module.transition({
+      type: "request-entry",
+      destination: { kind: "new-ad-hoc" },
+      online: true,
+    });
+    expect(request).toMatchObject({
+      status: "needs-confirmation",
+      departure: { gameId: "adhoc-a" },
+    });
+    if (request.status !== "needs-confirmation") throw new Error("Expected replacement request.");
+    const decision = await module.transition({
+      type: "confirm-entry",
+      request: request.request,
+      online: true,
+    });
+    expect(decision.status).toBe("authorized");
+    if (decision.status !== "authorized") throw new Error("Expected replacement authorization.");
+    const committed = await module.transition({
+      type: "commit-entry",
+      authorization: decision.authorization,
+    });
+    expect(committed).toMatchObject({ status: "committed" });
+    if (committed.status !== "committed" || committed.completion === undefined)
+      throw new Error("Expected entry completion.");
+    expect(
+      await module.transition({
+        type: "complete-entry",
+        completion: committed.completion,
+        succeeded: true,
+      }),
+    ).toMatchObject({ status: "committed" });
+    expect(finalized).toEqual(["adhoc-a"]);
+    expect(controllerDepartureBlocksGame(module.project(), "adhoc-a")).toBe(true);
+  });
+
+  test("defers offline expiry and retries accepted finalization after a restart", async () => {
+    const finalized: string[] = [];
+    const adapters = createInMemoryControllerDepartureAdapters({
+      nowMs: 0,
+      departure: departure("adhoc-a"),
+      finalize: async (value) => {
+        finalized.push(value.gameId);
+        return "accepted";
+      },
+    });
+    const first = createControllerDeparture(adapters);
+    adapters.setOnline(false);
+    expect(
+      await first.transition({ type: "expire", online: false, nowMs: CONTROLLER_LEAVE_GRACE_MS }),
+    ).toEqual({ status: "expired", finalization: "deferred" });
+    expect(first.project()).toMatchObject({
+      status: "blocked",
+      pendingFinalizations: [{ gameId: "adhoc-a" }],
+    });
+    first.dispose();
+    const restarted = createControllerDeparture(adapters);
+    adapters.setOnline(true);
+    await flushRetries();
+    expect(finalized).toEqual(["adhoc-a"]);
+    expect(restarted.project()).toMatchObject({ status: "blocked", pendingFinalizations: [] });
+  });
+
+  test("keeps deferred expiry when later finalization is unavailable", async () => {
+    let result: "accepted" | "unavailable" | "deferred" = "unavailable";
+    const adapters = createInMemoryControllerDepartureAdapters({
+      nowMs: 0,
+      departure: departure("adhoc-a"),
+      finalize: async () => result,
+    });
+    const module = createControllerDeparture(adapters);
+    adapters.setOnline(false);
+    await module.transition({ type: "expire", online: false, nowMs: CONTROLLER_LEAVE_GRACE_MS });
+    adapters.setOnline(true);
+    await flushRetries();
+    expect(module.project()).toMatchObject({ status: "blocked", pendingFinalizations: [] });
+    expect(adapters.clearedReplicas).toContain("adhoc-a");
+    result = "accepted";
+  });
+
+  test("retains pending finalization after an adapter failure", async () => {
+    let attempts = 0;
+    const adapters = createInMemoryControllerDepartureAdapters({
+      nowMs: 0,
+      departure: departure("adhoc-a"),
+      finalize: async () => {
+        attempts += 1;
+        if (attempts === 1) throw new Error("transport failure");
+        return "accepted";
+      },
+    });
+    const module = createControllerDeparture(adapters);
+    expect(
+      await module.transition({ type: "expire", online: true, nowMs: CONTROLLER_LEAVE_GRACE_MS }),
+    ).toEqual({
+      status: "expired",
+      finalization: "deferred",
+    });
+    expect(module.project()).toMatchObject({ pendingFinalizations: [{ gameId: "adhoc-a" }] });
+    adapters.setOnline(false);
+    adapters.setOnline(true);
+    await flushRetries();
+    expect(attempts).toBe(2);
+    expect(module.project()).toMatchObject({ pendingFinalizations: [] });
+  });
+
+  test("offline Return survives restart and reconciles without clearing a valid replica", async () => {
+    let reconcileResult: "available" | "transient" | "unavailable" = "available";
+    const adapters = createInMemoryControllerDepartureAdapters({
+      departure: departure("adhoc-a"),
+      reconcile: async () => reconcileResult,
+    });
+    const first = createControllerDeparture(adapters);
+    adapters.setOnline(false);
+    expect(await first.transition({ type: "return", gameId: "adhoc-a", online: false })).toEqual({
+      status: "resumed",
+      mode: "offline",
+    });
+    first.dispose();
+    const restarted = createControllerDeparture(adapters);
+    adapters.setOnline(true);
+    await flushRetries();
+    expect(restarted.project()).toMatchObject({ status: "returned", reconciliationPending: [] });
+    expect(adapters.clearedReplicas).toEqual([]);
+  });
+
+  test("authoritative unavailability after offline Return blocks reopening and clears its replica", async () => {
+    const adapters = createInMemoryControllerDepartureAdapters({
+      departure: departure("adhoc-a"),
+      reconcile: async () => "unavailable",
+    });
+    const module = createControllerDeparture(adapters);
+    adapters.setOnline(false);
+    await module.transition({ type: "return", gameId: "adhoc-a", online: false });
+    adapters.setOnline(true);
+    await flushRetries();
+    expect(controllerDepartureBlocksGame(module.project(), "adhoc-a")).toBe(true);
+    expect(adapters.clearedReplicas).toContain("adhoc-a");
+  });
+
+  test("transient reconciliation failure does not invalidate offline Return", async () => {
+    const adapters = createInMemoryControllerDepartureAdapters({
+      departure: departure("adhoc-a"),
+      reconcile: async () => "transient",
+    });
+    const module = createControllerDeparture(adapters);
+    adapters.setOnline(false);
+    await module.transition({ type: "return", gameId: "adhoc-a", online: false });
+    adapters.setOnline(true);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(controllerDepartureBlocksGame(module.project(), "adhoc-a")).toBe(false);
+    expect(module.project()).toMatchObject({ reconciliationPending: [{ gameId: "adhoc-a" }] });
+  });
+
+  test("fails closed when persistence cannot write", async () => {
+    const module = createControllerDeparture({
+      persistence: {
+        read: () => ({ status: "empty", revision: 0 }),
+        write: () => false,
+        clear: () => undefined,
+      },
+    });
+    expect(await module.transition({ type: "leave", departure: departure("adhoc-a") })).toEqual({
+      status: "unavailable",
+    });
+  });
+
+  test("serializes retry-in-flight before a newer Leave and preserves the newest departure", async () => {
+    let releaseRetry!: (result: "accepted" | "deferred" | "unavailable") => void;
+    let finalizeCalls = 0;
+    const retryResult = new Promise<"accepted" | "deferred" | "unavailable">((resolve) => {
+      releaseRetry = resolve;
+    });
+    const adapters = createInMemoryControllerDepartureAdapters({
+      nowMs: 0,
+      departure: departure("adhoc-a"),
+      finalize: async () => {
+        finalizeCalls += 1;
+        return retryResult;
+      },
+    });
+    const module = createControllerDeparture(adapters);
+    adapters.setOnline(false);
+    await module.transition({ type: "expire", online: false, nowMs: CONTROLLER_LEAVE_GRACE_MS });
+    adapters.setOnline(true);
+    await Promise.resolve();
+    const leave = module.transition({
+      type: "leave",
+      departure: departure("adhoc-b"),
+      online: false,
+      nowMs: CONTROLLER_LEAVE_GRACE_MS + 1,
+    });
+    expect(finalizeCalls).toBe(1);
+    releaseRetry("accepted");
+    expect(await leave).toMatchObject({
+      status: "left",
+      projection: { departure: { gameId: "adhoc-b" } },
+    });
+    expect(module.project()).toMatchObject({
+      status: "returnable",
+      departure: { gameId: "adhoc-b" },
+    });
+    expect(controllerDepartureBlocksGame(module.project(), "adhoc-a")).toBe(true);
+  });
+
+  test("does not finalize or clear a replica when superseding Leave cannot persist", async () => {
+    let state = {
+      status: "returnable" as const,
+      revision: 0,
+      departure: departure("adhoc-a"),
+      expiresAtMs: CONTROLLER_LEAVE_GRACE_MS,
+      blockedGameIds: [],
+      pendingFinalizations: [],
+      reconciliationPending: [],
+    };
+    let writes = 0;
+    const cleared: string[] = [];
+    const finalized: string[] = [];
+    const clock = createInMemoryControllerDepartureAdapters({ nowMs: 0 }).clock;
+    const module = createControllerDeparture({
+      clock,
+      persistence: {
+        read: () => state,
+        write: () => {
+          writes += 1;
+          return false;
+        },
+        clear: () => undefined,
+      },
+      replica: { clear: (gameId) => cleared.push(gameId), clearAll: () => undefined },
+      authority: {
+        finalize: async (value) => {
+          finalized.push(value.gameId);
+          return "accepted";
+        },
+        reconcile: async () => "available",
+      },
+    });
+    expect(
+      await module.transition({ type: "leave", departure: departure("adhoc-b"), online: true }),
+    ).toEqual({ status: "unavailable" });
+    expect(writes).toBe(1);
+    expect(state.departure.gameId).toBe("adhoc-a");
+    expect(cleared).toEqual([]);
+    expect(finalized).toEqual([]);
+  });
+
+  test("does not finalize or clear a replica when confirmed replacement cannot persist", async () => {
+    const initial = {
+      status: "returnable" as const,
+      revision: 0,
+      departure: departure("adhoc-a"),
+      expiresAtMs: CONTROLLER_LEAVE_GRACE_MS,
+      blockedGameIds: [],
+      pendingFinalizations: [],
+      reconciliationPending: [],
+    };
+    const cleared: string[] = [];
+    const finalized: string[] = [];
+    const clock = createInMemoryControllerDepartureAdapters({ nowMs: 0 }).clock;
+    const module = createControllerDeparture({
+      clock,
+      persistence: {
+        read: () => initial,
+        write: () => false,
+        clear: () => undefined,
+      },
+      replica: { clear: (gameId) => cleared.push(gameId), clearAll: () => undefined },
+      authority: {
+        finalize: async (value) => {
+          finalized.push(value.gameId);
+          return "accepted";
+        },
+        reconcile: async () => "available",
+      },
+    });
+    const request = await module.transition({
+      type: "request-entry",
+      destination: { kind: "new-ad-hoc" },
+    });
+    expect(request.status).toBe("needs-confirmation");
+    if (request.status !== "needs-confirmation") throw new Error("Expected replacement request.");
+    expect(await module.transition({ type: "confirm-entry", request: request.request })).toEqual({
+      status: "unavailable",
+    });
+    expect(cleared).toEqual([]);
+    expect(finalized).toEqual([]);
+  });
+
+  test("re-prompts when departure B supersedes the departure shown by dialog A", async () => {
+    const adapters = createInMemoryControllerDepartureAdapters({
+      departure: departure("adhoc-a"),
+    });
+    const dialogModule = createControllerDeparture(adapters);
+    const writerModule = createControllerDeparture(adapters);
+    const requested = await dialogModule.transition({
+      type: "request-entry",
+      destination: { kind: "new-ad-hoc" },
+      online: false,
+    });
+    expect(requested).toMatchObject({
+      status: "needs-confirmation",
+      departure: { gameId: "adhoc-a" },
+    });
+    if (requested.status !== "needs-confirmation") throw new Error("Expected dialog A.");
+
+    await writerModule.transition({
+      type: "leave",
+      departure: departure("adhoc-b"),
+      online: false,
+      nowMs: 100,
+    });
+    const staleConfirm = await dialogModule.transition({
+      type: "confirm-entry",
+      request: requested.request,
+      online: false,
+    });
+    expect(staleConfirm).toMatchObject({
+      status: "needs-confirmation",
+      departure: { gameId: "adhoc-b" },
+    });
+  });
+
+  test("invalidates an authorization when a newer departure is persisted", async () => {
+    const adapters = createInMemoryControllerDepartureAdapters();
+    const entryModule = createControllerDeparture(adapters);
+    const writerModule = createControllerDeparture(adapters);
+    const authorized = await entryModule.transition({
+      type: "request-entry",
+      destination: { kind: "new-ad-hoc" },
+      online: false,
+    });
+    if (authorized.status !== "authorized") throw new Error("Expected entry authorization.");
+
+    await writerModule.transition({
+      type: "leave",
+      departure: departure("adhoc-b"),
+      online: false,
+    });
+    const staleCommit = await entryModule.transition({
+      type: "commit-entry",
+      authorization: authorized.authorization,
+    });
+    expect(staleCommit).toMatchObject({
+      status: "needs-confirmation",
+      departure: { gameId: "adhoc-b" },
+    });
+  });
+
+  test("merges a retry result into a newer revision written by another module", async () => {
+    let releaseRetry!: (result: "accepted" | "deferred" | "unavailable") => void;
+    const retryResult = new Promise<"accepted" | "deferred" | "unavailable">((resolve) => {
+      releaseRetry = resolve;
+    });
+    const adapters = createInMemoryControllerDepartureAdapters({
+      nowMs: 0,
+      departure: departure("adhoc-a"),
+      finalize: async () => retryResult,
+    });
+    const retryModule = createControllerDeparture(adapters);
+    adapters.setOnline(false);
+    await retryModule.transition({
+      type: "expire",
+      online: false,
+      nowMs: CONTROLLER_LEAVE_GRACE_MS,
+    });
+    adapters.setOnline(true);
+    await Promise.resolve();
+    adapters.setOnline(false);
+    const writerModule = createControllerDeparture(adapters);
+    await writerModule.transition({
+      type: "leave",
+      departure: departure("adhoc-b"),
+      online: false,
+      nowMs: CONTROLLER_LEAVE_GRACE_MS + 1,
+    });
+    releaseRetry("accepted");
+    await flushRetries();
+
+    expect(retryModule.project()).toMatchObject({
+      status: "returnable",
+      departure: { gameId: "adhoc-b" },
+      pendingFinalizations: [],
+    });
+    expect(controllerDepartureBlocksGame(retryModule.project(), "adhoc-a")).toBe(true);
+  });
+
+  test("treats direct entry to the returnable Game as Return and cancels expiry", async () => {
+    let finalized = 0;
+    const adapters = createInMemoryControllerDepartureAdapters({
+      nowMs: 0,
+      departure: departure("adhoc-a"),
+      finalize: async () => {
+        finalized += 1;
+        return "accepted";
+      },
+    });
+    adapters.setOnline(false);
+    const module = createControllerDeparture(adapters);
+    const entry = await module.transition({
+      type: "request-entry",
+      destination: { kind: "resume-ad-hoc", gameId: "adhoc-a" },
+      online: false,
+    });
+    expect(entry.status).toBe("authorized");
+    expect(module.project()).toMatchObject({
+      status: "returned",
+      reconciliationPending: [{ gameId: "adhoc-a" }],
+    });
+    adapters.advanceTo(CONTROLLER_LEAVE_GRACE_MS + 1);
+    await flushRetries();
+    expect(module.project().status).toBe("returned");
+    expect(finalized).toBe(0);
+  });
+
+  test("fails closed on corrupt lifecycle state and only recovers through fresh admission", async () => {
+    const adapters = createInMemoryControllerDepartureAdapters({
+      projection: { status: "failed-closed", revision: 7 },
+    });
+    const module = createControllerDeparture(adapters);
+    expect(module.project()).toMatchObject({ status: "failed-closed" });
+    expect(adapters.clearAllCount).toBe(1);
+    expect(
+      await module.transition({
+        type: "request-entry",
+        destination: { kind: "resume-ad-hoc", gameId: "adhoc-retained" },
+      }),
+    ).toEqual({ status: "unavailable" });
+    const fresh = await module.transition({
+      type: "request-entry",
+      destination: { kind: "admit-ad-hoc", gameId: "adhoc-fresh" },
+    });
+    if (fresh.status !== "authorized") throw new Error("Expected fresh admission authorization.");
+    const committed = await module.transition({
+      type: "commit-entry",
+      authorization: fresh.authorization,
+    });
+    expect(committed).toMatchObject({ status: "committed" });
+    if (committed.status !== "committed" || committed.completion === undefined)
+      throw new Error("Expected admission completion.");
+    expect(module.project()).toMatchObject({ status: "failed-closed" });
+    expect(
+      await module.transition({
+        type: "complete-entry",
+        completion: committed.completion,
+        succeeded: false,
+      }),
+    ).toMatchObject({ status: "committed" });
+    expect(module.project()).toMatchObject({ status: "failed-closed" });
+
+    const retry = await module.transition({
+      type: "request-entry",
+      destination: { kind: "admit-ad-hoc", gameId: "adhoc-fresh" },
+    });
+    if (retry.status !== "authorized") throw new Error("Expected fresh admission retry.");
+    const retryCommitted = await module.transition({
+      type: "commit-entry",
+      authorization: retry.authorization,
+    });
+    if (retryCommitted.status !== "committed" || retryCommitted.completion === undefined)
+      throw new Error("Expected retry completion.");
+    expect(
+      await module.transition({
+        type: "complete-entry",
+        completion: retryCommitted.completion,
+        succeeded: true,
+      }),
+    ).toMatchObject({ status: "committed" });
+    expect(module.project()).toMatchObject({ status: "empty" });
+  });
+
+  test("keeps browser finalization retryable for network, 429, and 5xx failures", async () => {
+    const originalFetch = globalThis.fetch;
+    const statuses = ["network", 429, 503, 200] as const;
+    let calls = 0;
+    globalThis.fetch = (async () => {
+      const status = statuses[calls++] ?? 200;
+      if (status === "network") throw new Error("offline");
+      return new Response(null, { status });
+    }) as unknown as typeof fetch;
+    try {
+      const base = createInMemoryControllerDepartureAdapters({
+        nowMs: 0,
+        departure: departure("adhoc-a"),
+      });
+      const module = createControllerDeparture({
+        clock: base.clock,
+        persistence: base.persistence,
+        connectivity: base.connectivity,
+        replica: base.replica,
+      });
+      base.setOnline(false);
+      await module.transition({ type: "expire", online: false, nowMs: CONTROLLER_LEAVE_GRACE_MS });
+      for (const expectedCalls of [1, 2, 3, 4]) {
+        base.setOnline(true);
+        await flushRetries();
+        expect(calls).toBe(expectedCalls);
+        if (expectedCalls < 4) {
+          expect(module.project()).toMatchObject({ pendingFinalizations: [{ gameId: "adhoc-a" }] });
+          base.setOnline(false);
+        }
+      }
+      expect(module.project()).toMatchObject({ pendingFinalizations: [] });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
+
+async function flushRetries() {
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+}

--- a/src/lib/controller-departure.ts
+++ b/src/lib/controller-departure.ts
@@ -1,0 +1,1061 @@
+import { clearAdHocControllerSession } from "@/lib/ad-hoc-controller-session";
+import { validateOpaqueIdentifier } from "@/lib/validation-policy";
+
+export const CONTROLLER_LEAVE_GRACE_MS = 5 * 60_000;
+export const CONTROLLER_DEPARTURE_STORAGE_KEY = "quadball:controller-departure";
+const CONTROLLER_DEPARTURE_VERSION = "controller-departure-v2" as const;
+const LEGACY_CONTROLLER_DEPARTURE_VERSION = "controller-departure-v1" as const;
+const AD_HOC_CONTROLLER_STORAGE_PREFIX = "quadball:ad-hoc-controller:";
+
+export type ControllerDepartureWorkflow = "ad-hoc" | "event";
+
+export type ControllerDepartureReference = {
+  workflow: ControllerDepartureWorkflow;
+  gameId: string;
+  navigationPath: string;
+  identity: { title: string; homeName: string; awayName: string; detail?: string };
+};
+
+type ControllerDepartureStateFields = {
+  blockedGameIds: string[];
+  pendingFinalizations: ControllerDepartureReference[];
+  reconciliationPending: ControllerDepartureReference[];
+};
+
+type Revisioned = { revision: number };
+
+type ControllerDepartureState =
+  | { status: "empty" }
+  | { status: "failed-closed" }
+  | ({
+      status: "returnable";
+      departure: ControllerDepartureReference;
+      expiresAtMs: number;
+    } & ControllerDepartureStateFields)
+  | ({ status: "returned" } & ControllerDepartureStateFields)
+  | ({ status: "blocked"; gameId: string } & ControllerDepartureStateFields);
+
+type WithRevision<T> = T extends unknown ? T & Revisioned : never;
+
+export type ControllerDepartureProjection = WithRevision<ControllerDepartureState>;
+
+export type ControllerDepartureDestination =
+  | { kind: "new-ad-hoc" }
+  | { kind: "admit-ad-hoc"; gameId: string }
+  | { kind: "resume-ad-hoc"; gameId: string };
+
+export type ControllerDepartureEntryRequest = {
+  id: string;
+  destination: ControllerDepartureDestination;
+  revision: number;
+};
+
+export type ControllerDepartureEntryAuthorization = {
+  id: string;
+  destination: ControllerDepartureDestination;
+  revision: number;
+};
+
+export type ControllerDepartureEntryCompletion = ControllerDepartureEntryAuthorization;
+
+export type ControllerDepartureIntent =
+  | { type: "leave"; departure: ControllerDepartureReference; nowMs?: number; online?: boolean }
+  | { type: "return"; gameId: string; online: boolean; nowMs?: number }
+  | { type: "expire"; online: boolean; nowMs?: number }
+  | {
+      type: "request-entry";
+      destination: ControllerDepartureDestination;
+      online?: boolean;
+      nowMs?: number;
+    }
+  | { type: "confirm-entry"; request: ControllerDepartureEntryRequest; online?: boolean }
+  | { type: "cancel-entry"; request: ControllerDepartureEntryRequest }
+  | { type: "commit-entry"; authorization: ControllerDepartureEntryAuthorization }
+  | {
+      type: "complete-entry";
+      completion: ControllerDepartureEntryCompletion;
+      succeeded: boolean;
+    };
+
+export type ControllerDepartureOutcome =
+  | { status: "left"; projection: ControllerDepartureProjection }
+  | { status: "resumed"; mode: "online" | "offline" }
+  | { status: "unavailable" }
+  | { status: "expired"; finalization: "accepted" | "deferred" | "unavailable" }
+  | { status: "no-op" }
+  | {
+      status: "needs-confirmation";
+      departure: ControllerDepartureReference;
+      request: ControllerDepartureEntryRequest;
+    }
+  | { status: "authorized"; authorization: ControllerDepartureEntryAuthorization }
+  | { status: "committed"; completion?: ControllerDepartureEntryCompletion }
+  | { status: "cancelled" };
+
+export type ControllerDepartureClock = {
+  now(): number;
+  schedule(delayMs: number, callback: () => void): unknown;
+  cancel(handle: unknown): void;
+};
+
+export type ControllerDeparturePersistence = {
+  read(): ControllerDepartureProjection;
+  write(projection: ControllerDepartureProjection): boolean | void;
+  clear(): void;
+  subscribe?(callback: () => void): () => void;
+};
+
+export type ControllerDepartureAuthority = {
+  finalize(
+    departure: ControllerDepartureReference,
+  ): Promise<"accepted" | "deferred" | "unavailable">;
+  reconcile(
+    departure: ControllerDepartureReference,
+  ): Promise<"available" | "transient" | "unavailable">;
+};
+
+export type ControllerDepartureConnectivity = {
+  isOnline(): boolean;
+  onOnline(callback: () => void): () => void;
+};
+
+export type ControllerDepartureReplica = {
+  clear(gameId: string): void;
+  clearAll(): void;
+};
+
+export type ControllerDepartureAdapters = {
+  clock: ControllerDepartureClock;
+  persistence: ControllerDeparturePersistence;
+  authority: ControllerDepartureAuthority;
+  connectivity: ControllerDepartureConnectivity;
+  replica: ControllerDepartureReplica;
+};
+
+export type ControllerDepartureModule = {
+  project(): ControllerDepartureProjection;
+  transition(intent: ControllerDepartureIntent): Promise<ControllerDepartureOutcome>;
+  subscribe(callback: () => void): () => void;
+  dispose(): void;
+};
+
+export function controllerDepartureBlocksGame(
+  projection: ControllerDepartureProjection,
+  gameId: string,
+): boolean {
+  return (
+    projection.status === "failed-closed" ||
+    (projection.status !== "empty" && projection.blockedGameIds.includes(gameId))
+  );
+}
+
+export function createControllerDeparture(
+  adapters: Partial<ControllerDepartureAdapters> = {},
+): ControllerDepartureModule {
+  const clock = adapters.clock ?? createBrowserClock();
+  const persistence = adapters.persistence ?? createBrowserPersistence();
+  const authority = adapters.authority ?? createBrowserAuthority();
+  const connectivity = adapters.connectivity ?? createBrowserConnectivity();
+  const replica = adapters.replica ?? createBrowserReplica();
+  let expiryHandle: unknown = null;
+  let disposed = false;
+  let lifecycleQueue = Promise.resolve();
+  let entryCounter = 0;
+  let writingPersistence = false;
+  const pendingEntries = new Map<string, ControllerDepartureEntryRequest>();
+  const issuedAuthorizations = new Map<string, ControllerDepartureEntryAuthorization>();
+  const invalidatedAuthorizations = new Map<string, ControllerDepartureEntryAuthorization>();
+  const pendingCompletions = new Map<string, ControllerDepartureEntryCompletion>();
+  const subscribers = new Set<() => void>();
+
+  const readStored = (): ControllerDepartureProjection => {
+    try {
+      return normalizeProjection(persistence.read());
+    } catch {
+      return { status: "failed-closed", revision: 0 };
+    }
+  };
+  const notify = () => {
+    for (const callback of subscribers) callback();
+  };
+  const invalidateAuthorizations = () => {
+    for (const [id, authorization] of issuedAuthorizations)
+      invalidatedAuthorizations.set(id, authorization);
+    issuedAuthorizations.clear();
+  };
+  const writeFrom = (
+    base: ControllerDepartureProjection,
+    next: ControllerDepartureState,
+  ): ControllerDepartureProjection | null => {
+    const latest = readStored();
+    if (latest.revision !== base.revision) return null;
+    const revisioned = { ...next, revision: base.revision + 1 } as ControllerDepartureProjection;
+    try {
+      writingPersistence = true;
+      const written = persistence.write(revisioned) !== false;
+      writingPersistence = false;
+      if (!written) return null;
+      invalidateAuthorizations();
+      notify();
+      return revisioned;
+    } catch {
+      writingPersistence = false;
+      return null;
+    }
+  };
+  const enqueue = <T>(operation: () => Promise<T>): Promise<T> => {
+    const next = lifecycleQueue.then(operation, operation);
+    lifecycleQueue = next.then(
+      () => undefined,
+      () => undefined,
+    );
+    return next;
+  };
+  const clearReplica = (gameId: string) => {
+    try {
+      replica.clear(gameId);
+    } catch {
+      // Persisted fail-closed state remains authoritative for this browser.
+    }
+  };
+  const clearAllReplicas = () => {
+    try {
+      replica.clearAll();
+    } catch {
+      // The failed-closed projection still prevents retained replicas from being used.
+    }
+  };
+  const scheduleExpiry = (expiresAtMs: number) => {
+    if (expiryHandle !== null) clock.cancel(expiryHandle);
+    expiryHandle = clock.schedule(Math.max(0, expiresAtMs - clock.now()), () => {
+      expiryHandle = null;
+      void transition({ type: "expire", online: connectivity.isOnline(), nowMs: clock.now() });
+    });
+  };
+  const cancelExpiry = () => {
+    if (expiryHandle !== null) clock.cancel(expiryHandle);
+    expiryHandle = null;
+  };
+  const newEntryId = () => {
+    entryCounter += 1;
+    return `entry-${entryCounter}`;
+  };
+  const issueAuthorization = (
+    destination: ControllerDepartureDestination,
+    revision: number,
+  ): ControllerDepartureOutcome => {
+    const authorization = { id: newEntryId(), destination, revision };
+    issuedAuthorizations.set(authorization.id, authorization);
+    return { status: "authorized", authorization };
+  };
+  const requestConfirmation = (
+    departure: ControllerDepartureReference,
+    destination: ControllerDepartureDestination,
+    revision: number,
+  ): ControllerDepartureOutcome => {
+    const request = { id: newEntryId(), destination, revision };
+    pendingEntries.set(request.id, request);
+    return { status: "needs-confirmation", departure, request };
+  };
+
+  const callFinalizations = async (departures: ControllerDepartureReference[]) => {
+    const results = new Map<string, "accepted" | "deferred" | "unavailable">();
+    for (const departure of departures) {
+      let result: "accepted" | "deferred" | "unavailable" = "deferred";
+      try {
+        result = await authority.finalize(departure);
+      } catch {
+        result = "deferred";
+      }
+      results.set(departure.gameId, result);
+    }
+    return results;
+  };
+  const callReconciliations = async (departures: ControllerDepartureReference[]) => {
+    const results = new Map<string, "available" | "transient" | "unavailable">();
+    for (const departure of departures) {
+      let result: "available" | "transient" | "unavailable" = "transient";
+      try {
+        result = await authority.reconcile(departure);
+      } catch {
+        result = "transient";
+      }
+      results.set(departure.gameId, result);
+    }
+    return results;
+  };
+  const settleAuthorityResults = (
+    finalizations: Map<string, "accepted" | "deferred" | "unavailable">,
+    reconciliations: Map<string, "available" | "transient" | "unavailable">,
+  ) => {
+    const latest = readStored();
+    if (latest.status === "empty" || latest.status === "failed-closed") return latest;
+    const fields = projectionFields(latest);
+    const pendingFinalizations = fields.pendingFinalizations.filter(
+      (departure) =>
+        finalizations.get(departure.gameId) === "deferred" || !finalizations.has(departure.gameId),
+    );
+    const reconciliationPending = fields.reconciliationPending.filter(
+      (departure) =>
+        reconciliations.get(departure.gameId) === "transient" ||
+        !reconciliations.has(departure.gameId),
+    );
+    const unavailableGameIds = [
+      ...[...finalizations]
+        .filter(([, result]) => result === "unavailable")
+        .map(([gameId]) => gameId),
+      ...[...reconciliations]
+        .filter(([, result]) => result === "unavailable")
+        .map(([gameId]) => gameId),
+    ];
+    const blockedGameIds = unique([...fields.blockedGameIds, ...unavailableGameIds]);
+    if (
+      sameDepartures(pendingFinalizations, fields.pendingFinalizations) &&
+      sameDepartures(reconciliationPending, fields.reconciliationPending) &&
+      sameStrings(blockedGameIds, fields.blockedGameIds)
+    )
+      return latest;
+    const written = writeFrom(latest, {
+      ...withoutRevision(latest),
+      blockedGameIds,
+      pendingFinalizations,
+      reconciliationPending,
+    } as ControllerDepartureState);
+    if (written !== null) {
+      for (const gameId of unavailableGameIds) clearReplica(gameId);
+      return written;
+    }
+    return readStored();
+  };
+  const retryPending = async () => {
+    if (disposed || !connectivity.isOnline()) return;
+    const snapshot = readStored();
+    if (snapshot.status === "empty" || snapshot.status === "failed-closed") return;
+    const fields = projectionFields(snapshot);
+    if (fields.pendingFinalizations.length === 0 && fields.reconciliationPending.length === 0)
+      return;
+    const finalizations = await callFinalizations(fields.pendingFinalizations);
+    const reconciliations = await callReconciliations(fields.reconciliationPending);
+    settleAuthorityResults(finalizations, reconciliations);
+  };
+  const queueRetry = () => {
+    void enqueue(retryPending);
+  };
+
+  const expire = async (online: boolean, nowMs: number): Promise<ControllerDepartureOutcome> => {
+    const current = readStored();
+    if (current.status !== "returnable" || current.expiresAtMs > nowMs) return { status: "no-op" };
+    const pendingFinalizations = uniqueDepartures([
+      ...current.pendingFinalizations,
+      current.departure,
+    ]);
+    const next = writeFrom(current, {
+      status: "blocked",
+      gameId: current.departure.gameId,
+      blockedGameIds: unique([...current.blockedGameIds, current.departure.gameId]),
+      pendingFinalizations,
+      reconciliationPending: current.reconciliationPending,
+    });
+    if (next === null) return { status: "unavailable" };
+    cancelExpiry();
+    clearReplica(current.departure.gameId);
+    if (!online) return { status: "expired", finalization: "deferred" };
+    const results = await callFinalizations(pendingFinalizations);
+    settleAuthorityResults(results, new Map());
+    return {
+      status: "expired",
+      finalization: results.get(current.departure.gameId) ?? "deferred",
+    };
+  };
+
+  const leave = async (
+    intent: Extract<ControllerDepartureIntent, { type: "leave" }>,
+    nowMs: number,
+  ): Promise<ControllerDepartureOutcome> => {
+    let current = readStored();
+    if (current.status === "returnable" && current.expiresAtMs <= nowMs) {
+      await expire(intent.online ?? connectivity.isOnline(), nowMs);
+      current = readStored();
+    }
+    if (current.status === "failed-closed") return { status: "unavailable" };
+    const fields = projectionFields(current);
+    const superseded = current.status === "returnable" ? current.departure : null;
+    const pendingFinalizations =
+      superseded === null
+        ? fields.pendingFinalizations
+        : uniqueDepartures([...fields.pendingFinalizations, superseded]);
+    const blockedGameIds =
+      superseded === null
+        ? fields.blockedGameIds
+        : unique([...fields.blockedGameIds, superseded.gameId]);
+    const next = writeFrom(current, {
+      status: "returnable",
+      departure: intent.departure,
+      expiresAtMs: nowMs + CONTROLLER_LEAVE_GRACE_MS,
+      blockedGameIds,
+      pendingFinalizations,
+      reconciliationPending: fields.reconciliationPending,
+    });
+    if (next === null) return { status: "unavailable" };
+    if (superseded !== null) clearReplica(superseded.gameId);
+    if ((intent.online ?? connectivity.isOnline()) && pendingFinalizations.length > 0) {
+      const results = await callFinalizations(pendingFinalizations);
+      settleAuthorityResults(results, new Map());
+    }
+    const latest = readStored();
+    if (latest.status === "returnable" && latest.departure.gameId === intent.departure.gameId)
+      scheduleExpiry(latest.expiresAtMs);
+    return { status: "left", projection: latest };
+  };
+
+  const returnToGame = async (
+    gameId: string,
+    online: boolean,
+  ): Promise<ControllerDepartureOutcome> => {
+    const current = readStored();
+    if (current.status !== "returnable" || current.departure.gameId !== gameId)
+      return { status: "unavailable" };
+    if (!online) {
+      const next = writeFrom(current, {
+        status: "returned",
+        blockedGameIds: current.blockedGameIds,
+        pendingFinalizations: current.pendingFinalizations,
+        reconciliationPending: uniqueDepartures([
+          ...current.reconciliationPending,
+          current.departure,
+        ]),
+      });
+      if (next === null) return { status: "unavailable" };
+      cancelExpiry();
+      return { status: "resumed", mode: "offline" };
+    }
+    const departure = current.departure;
+    const results = await callReconciliations([departure]);
+    const latest = readStored();
+    if (
+      latest.revision !== current.revision ||
+      latest.status !== "returnable" ||
+      latest.departure.gameId !== gameId
+    )
+      return { status: "unavailable" };
+    const result = results.get(gameId) ?? "transient";
+    if (result === "unavailable") {
+      const next = writeFrom(latest, {
+        status: "blocked",
+        gameId,
+        blockedGameIds: unique([...latest.blockedGameIds, gameId]),
+        pendingFinalizations: latest.pendingFinalizations,
+        reconciliationPending: latest.reconciliationPending,
+      });
+      if (next === null) return { status: "unavailable" };
+      cancelExpiry();
+      clearReplica(gameId);
+      return { status: "unavailable" };
+    }
+    const next = writeFrom(latest, {
+      status: "returned",
+      blockedGameIds: latest.blockedGameIds,
+      pendingFinalizations: latest.pendingFinalizations,
+      reconciliationPending:
+        result === "transient"
+          ? uniqueDepartures([...latest.reconciliationPending, departure])
+          : latest.reconciliationPending,
+    });
+    if (next === null) return { status: "unavailable" };
+    cancelExpiry();
+    if (result === "transient") queueRetry();
+    return { status: "resumed", mode: "online" };
+  };
+
+  const requestEntry = async (
+    destination: ControllerDepartureDestination,
+    online: boolean,
+    nowMs: number,
+  ): Promise<ControllerDepartureOutcome> => {
+    let current = readStored();
+    if (current.status === "returnable" && current.expiresAtMs <= nowMs) {
+      await expire(online, nowMs);
+      current = readStored();
+    }
+    if (current.status === "failed-closed") {
+      return destination.kind === "resume-ad-hoc"
+        ? { status: "unavailable" }
+        : issueAuthorization(destination, current.revision);
+    }
+    const gameId = destinationGameId(destination);
+    if (gameId !== null && controllerDepartureBlocksGame(current, gameId))
+      return { status: "unavailable" };
+    if (
+      destination.kind === "resume-ad-hoc" &&
+      current.status === "returnable" &&
+      current.departure.gameId === destination.gameId
+    ) {
+      const returned = await returnToGame(destination.gameId, online);
+      if (returned.status !== "resumed") return returned;
+      current = readStored();
+      return issueAuthorization(destination, current.revision);
+    }
+    if (current.status === "returnable")
+      return requestConfirmation(current.departure, destination, current.revision);
+    return issueAuthorization(destination, current.revision);
+  };
+
+  const confirmEntry = async (
+    request: ControllerDepartureEntryRequest,
+    online: boolean,
+  ): Promise<ControllerDepartureOutcome> => {
+    const pending = pendingEntries.get(request.id);
+    if (pending === undefined || !destinationMatches(pending.destination, request.destination))
+      return { status: "unavailable" };
+    const current = readStored();
+    if (
+      pending.revision !== request.revision ||
+      current.revision !== request.revision ||
+      current.status !== "returnable"
+    ) {
+      pendingEntries.delete(request.id);
+      return requestEntry(request.destination, online, clock.now());
+    }
+    const pendingFinalizations = uniqueDepartures([
+      ...current.pendingFinalizations,
+      current.departure,
+    ]);
+    const next = writeFrom(current, {
+      status: "blocked",
+      gameId: current.departure.gameId,
+      blockedGameIds: unique([...current.blockedGameIds, current.departure.gameId]),
+      pendingFinalizations,
+      reconciliationPending: current.reconciliationPending,
+    });
+    if (next === null) return { status: "unavailable" };
+    pendingEntries.delete(request.id);
+    clearReplica(current.departure.gameId);
+    if (online) {
+      const results = await callFinalizations(pendingFinalizations);
+      settleAuthorityResults(results, new Map());
+    }
+    const latest = readStored();
+    if (latest.status === "returnable")
+      return requestConfirmation(latest.departure, request.destination, latest.revision);
+    return issueAuthorization(request.destination, latest.revision);
+  };
+
+  const commitEntry = async (
+    authorization: ControllerDepartureEntryAuthorization,
+  ): Promise<ControllerDepartureOutcome> => {
+    const issued = issuedAuthorizations.get(authorization.id);
+    const invalidated = invalidatedAuthorizations.get(authorization.id);
+    issuedAuthorizations.delete(authorization.id);
+    invalidatedAuthorizations.delete(authorization.id);
+    const current = readStored();
+    const known = issued ?? invalidated;
+    if (known === undefined) return { status: "unavailable" };
+    if (
+      !destinationMatches(known.destination, authorization.destination) ||
+      known.revision !== authorization.revision
+    )
+      return { status: "unavailable" };
+    if (invalidated !== undefined || current.revision !== authorization.revision)
+      return requestEntry(authorization.destination, connectivity.isOnline(), clock.now());
+    if (current.status === "failed-closed" && authorization.destination.kind === "resume-ad-hoc")
+      return { status: "unavailable" };
+    const completion = { ...authorization };
+    pendingCompletions.set(completion.id, completion);
+    return { status: "committed", completion };
+  };
+
+  const completeEntry = async (
+    completion: ControllerDepartureEntryCompletion,
+    succeeded: boolean,
+  ): Promise<ControllerDepartureOutcome> => {
+    const pending = pendingCompletions.get(completion.id);
+    pendingCompletions.delete(completion.id);
+    if (
+      pending === undefined ||
+      !destinationMatches(pending.destination, completion.destination) ||
+      pending.revision !== completion.revision
+    )
+      return { status: "unavailable" };
+    if (!succeeded) return { status: "committed" };
+    const current = readStored();
+    if (current.revision !== completion.revision) return { status: "committed" };
+    if (current.status !== "failed-closed") return { status: "committed" };
+    return writeFrom(current, { status: "empty" }) === null
+      ? { status: "unavailable" }
+      : { status: "committed" };
+  };
+
+  const transitionInternal = async (
+    intent: ControllerDepartureIntent,
+  ): Promise<ControllerDepartureOutcome> => {
+    const nowMs = "nowMs" in intent && intent.nowMs !== undefined ? intent.nowMs : clock.now();
+    if (!Number.isSafeInteger(nowMs) || nowMs < 0) return { status: "unavailable" };
+    switch (intent.type) {
+      case "leave":
+        return leave(intent, nowMs);
+      case "return":
+        return returnToGame(intent.gameId, intent.online);
+      case "expire":
+        return expire(intent.online, nowMs);
+      case "request-entry":
+        return requestEntry(intent.destination, intent.online ?? connectivity.isOnline(), nowMs);
+      case "confirm-entry":
+        return confirmEntry(intent.request, intent.online ?? connectivity.isOnline());
+      case "cancel-entry":
+        pendingEntries.delete(intent.request.id);
+        return { status: "cancelled" };
+      case "commit-entry":
+        return commitEntry(intent.authorization);
+      case "complete-entry":
+        return completeEntry(intent.completion, intent.succeeded);
+    }
+  };
+  const transition = (intent: ControllerDepartureIntent) =>
+    enqueue(() => transitionInternal(intent));
+
+  let initial = readStored();
+  if (initial.status === "failed-closed") {
+    clearAllReplicas();
+    initial = writeFrom(initial, { status: "failed-closed" }) ?? {
+      status: "failed-closed",
+      revision: initial.revision,
+    };
+  }
+  if (initial.status === "returnable") scheduleExpiry(initial.expiresAtMs);
+  const removeOnlineListener = connectivity.onOnline(queueRetry);
+  const removePersistenceListener =
+    persistence.subscribe?.(() => {
+      if (writingPersistence) return;
+      invalidateAuthorizations();
+      const current = readStored();
+      if (current.status === "failed-closed") clearAllReplicas();
+      if (current.status === "returnable") scheduleExpiry(current.expiresAtMs);
+      else cancelExpiry();
+      notify();
+      queueRetry();
+    }) ?? (() => undefined);
+  if (
+    connectivity.isOnline() &&
+    initial.status !== "empty" &&
+    initial.status !== "failed-closed" &&
+    (initial.pendingFinalizations.length > 0 || initial.reconciliationPending.length > 0)
+  )
+    queueRetry();
+
+  return {
+    project() {
+      const projection = readStored();
+      if (projection.status !== "returnable" || projection.expiresAtMs > clock.now())
+        return projection;
+      return {
+        status: "blocked",
+        gameId: projection.departure.gameId,
+        revision: projection.revision,
+        blockedGameIds: unique([...projection.blockedGameIds, projection.departure.gameId]),
+        pendingFinalizations: uniqueDepartures([
+          ...projection.pendingFinalizations,
+          projection.departure,
+        ]),
+        reconciliationPending: projection.reconciliationPending,
+      };
+    },
+    transition,
+    subscribe(callback) {
+      subscribers.add(callback);
+      return () => subscribers.delete(callback);
+    },
+    dispose() {
+      disposed = true;
+      cancelExpiry();
+      removeOnlineListener();
+      removePersistenceListener();
+      pendingEntries.clear();
+      issuedAuthorizations.clear();
+      invalidatedAuthorizations.clear();
+      subscribers.clear();
+    },
+  };
+}
+
+const browserModules = new WeakMap<object, ControllerDepartureModule>();
+
+export function getBrowserControllerDeparture(): ControllerDepartureModule {
+  const owner = typeof window === "undefined" ? globalThis : window;
+  const existing = browserModules.get(owner);
+  if (existing !== undefined) return existing;
+  const created = createControllerDeparture();
+  browserModules.set(owner, created);
+  return created;
+}
+
+export function createInMemoryControllerDepartureAdapters(
+  options: {
+    nowMs?: number;
+    departure?: ControllerDepartureReference;
+    expiresAtMs?: number;
+    projection?: ControllerDepartureProjection;
+    finalize?: ControllerDepartureAuthority["finalize"];
+    reconcile?: ControllerDepartureAuthority["reconcile"];
+  } = {},
+): ControllerDepartureAdapters & {
+  advanceTo(nowMs: number): void;
+  setOnline(value: boolean): void;
+  clearedReplicas: string[];
+  clearAllCount: number;
+} {
+  let nowMs = options.nowMs ?? 0;
+  let online = true;
+  let projection: ControllerDepartureProjection =
+    options.projection ??
+    (options.departure === undefined
+      ? { status: "empty", revision: 0 }
+      : {
+          status: "returnable",
+          revision: 0,
+          departure: options.departure,
+          expiresAtMs: options.expiresAtMs ?? nowMs + CONTROLLER_LEAVE_GRACE_MS,
+          blockedGameIds: [],
+          pendingFinalizations: [],
+          reconciliationPending: [],
+        });
+  const scheduled = new Map<number, () => void>();
+  const onlineListeners = new Set<() => void>();
+  const persistenceListeners = new Set<() => void>();
+  const clearedReplicas: string[] = [];
+  let clearAllCount = 0;
+  let nextHandle = 0;
+  const adapters = {
+    clock: {
+      now: () => nowMs,
+      schedule(delayMs: number, callback: () => void) {
+        const handle = nextHandle++;
+        scheduled.set(handle, callback);
+        return handle;
+      },
+      cancel(handle: unknown) {
+        if (typeof handle === "number") scheduled.delete(handle);
+      },
+    },
+    persistence: {
+      read: () => projection,
+      write(next: ControllerDepartureProjection) {
+        projection = next;
+        for (const callback of persistenceListeners) callback();
+      },
+      clear() {
+        projection = { status: "empty", revision: projection.revision + 1 };
+        for (const callback of persistenceListeners) callback();
+      },
+      subscribe(callback: () => void) {
+        persistenceListeners.add(callback);
+        return () => persistenceListeners.delete(callback);
+      },
+    },
+    authority: {
+      finalize: options.finalize ?? (async () => "accepted" as const),
+      reconcile: options.reconcile ?? (async () => "available" as const),
+    },
+    connectivity: {
+      isOnline: () => online,
+      onOnline(callback: () => void) {
+        onlineListeners.add(callback);
+        return () => onlineListeners.delete(callback);
+      },
+    },
+    replica: {
+      clear: (gameId: string) => clearedReplicas.push(gameId),
+      clearAll: () => {
+        clearAllCount += 1;
+        adapters.clearAllCount = clearAllCount;
+      },
+    },
+    advanceTo(value: number) {
+      nowMs = value;
+      for (const [handle, callback] of scheduled) {
+        scheduled.delete(handle);
+        callback();
+      }
+    },
+    setOnline(value: boolean) {
+      const becameOnline = !online && value;
+      online = value;
+      if (becameOnline) for (const callback of onlineListeners) callback();
+    },
+    clearedReplicas,
+    clearAllCount,
+  } satisfies ControllerDepartureAdapters & {
+    advanceTo(nowMs: number): void;
+    setOnline(value: boolean): void;
+    clearedReplicas: string[];
+    clearAllCount: number;
+  };
+  return adapters;
+}
+
+function createBrowserClock(): ControllerDepartureClock {
+  return {
+    now: () => Date.now(),
+    schedule: (delayMs, callback) =>
+      typeof window === "undefined"
+        ? globalThis.setTimeout(callback, delayMs)
+        : window.setTimeout(callback, delayMs),
+    cancel: (handle) =>
+      typeof window === "undefined"
+        ? globalThis.clearTimeout(handle as ReturnType<typeof setTimeout>)
+        : window.clearTimeout(handle as number),
+  };
+}
+
+function createBrowserConnectivity(): ControllerDepartureConnectivity {
+  if (typeof window === "undefined")
+    return { isOnline: () => true, onOnline: () => () => undefined };
+  return {
+    isOnline: browserIsOnline,
+    onOnline(callback) {
+      window.addEventListener("online", callback);
+      return () => window.removeEventListener("online", callback);
+    },
+  };
+}
+
+function createBrowserPersistence(): ControllerDeparturePersistence {
+  const changedEvent = "quadball:controller-departure-changed";
+  return {
+    read() {
+      try {
+        const raw = window.localStorage.getItem(CONTROLLER_DEPARTURE_STORAGE_KEY);
+        if (raw === null) return { status: "empty", revision: 0 };
+        const value = JSON.parse(raw) as unknown;
+        if (isStoredDeparture(value)) return normalizeProjection(value);
+        if (isLegacyStoredDeparture(value)) return normalizeProjection({ ...value, revision: 0 });
+        return { status: "failed-closed", revision: 0 };
+      } catch {
+        return { status: "failed-closed", revision: 0 };
+      }
+    },
+    write(projection) {
+      try {
+        window.localStorage.setItem(
+          CONTROLLER_DEPARTURE_STORAGE_KEY,
+          JSON.stringify({ version: CONTROLLER_DEPARTURE_VERSION, ...projection }),
+        );
+        window.dispatchEvent(new window.Event(changedEvent));
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    clear() {
+      try {
+        window.localStorage.removeItem(CONTROLLER_DEPARTURE_STORAGE_KEY);
+        window.dispatchEvent(new window.Event(changedEvent));
+      } catch {}
+    },
+    subscribe(callback) {
+      const refresh = () => callback();
+      window.addEventListener("storage", refresh);
+      window.addEventListener(changedEvent, refresh);
+      return () => {
+        window.removeEventListener("storage", refresh);
+        window.removeEventListener(changedEvent, refresh);
+      };
+    },
+  };
+}
+
+function createBrowserAuthority(): ControllerDepartureAuthority {
+  return {
+    async finalize(departure) {
+      if (departure.workflow !== "ad-hoc") return "deferred";
+      try {
+        const response = await fetch(`/api/games/${encodeURIComponent(departure.gameId)}/leave`, {
+          method: "POST",
+          credentials: "same-origin",
+        });
+        if (response.ok) return "accepted";
+        return response.status === 401 ||
+          response.status === 403 ||
+          response.status === 404 ||
+          response.status === 410
+          ? "unavailable"
+          : "deferred";
+      } catch {
+        return "deferred";
+      }
+    },
+    async reconcile(departure) {
+      if (departure.workflow !== "ad-hoc") return "available";
+      try {
+        const response = await fetch(`/api/games/${encodeURIComponent(departure.gameId)}`, {
+          credentials: "same-origin",
+        });
+        if (response.ok) return "available";
+        return response.status === 404 || response.status === 410 ? "unavailable" : "transient";
+      } catch {
+        return "transient";
+      }
+    },
+  };
+}
+
+function createBrowserReplica(): ControllerDepartureReplica {
+  return {
+    clear: clearAdHocControllerSession,
+    clearAll() {
+      try {
+        const keys: string[] = [];
+        for (let index = 0; index < window.localStorage.length; index += 1) {
+          const key = window.localStorage.key(index);
+          if (key?.startsWith(AD_HOC_CONTROLLER_STORAGE_PREFIX)) keys.push(key);
+        }
+        for (const key of keys) window.localStorage.removeItem(key);
+      } catch {
+        // The failed-closed lifecycle projection still blocks local control.
+      }
+    },
+  };
+}
+
+function browserIsOnline() {
+  return typeof navigator === "undefined" || navigator.onLine !== false;
+}
+
+function projectionFields(
+  projection: ControllerDepartureProjection,
+): ControllerDepartureStateFields {
+  return projection.status === "empty" || projection.status === "failed-closed"
+    ? { blockedGameIds: [], pendingFinalizations: [], reconciliationPending: [] }
+    : projection;
+}
+
+function withoutRevision(projection: ControllerDepartureProjection): ControllerDepartureState {
+  const { revision: _revision, ...rest } = projection;
+  return rest as ControllerDepartureState;
+}
+
+function normalizeProjection(
+  projection: ControllerDepartureProjection | (ControllerDepartureState & { revision?: number }),
+): ControllerDepartureProjection {
+  const revision = isSafeTimestamp(projection.revision) ? projection.revision : 0;
+  if (projection.status === "empty" || projection.status === "failed-closed")
+    return { status: projection.status, revision };
+  return {
+    ...projection,
+    revision,
+    blockedGameIds: unique(projection.blockedGameIds),
+    pendingFinalizations: uniqueDepartures(projection.pendingFinalizations),
+    reconciliationPending: uniqueDepartures(projection.reconciliationPending),
+  };
+}
+
+function destinationGameId(destination: ControllerDepartureDestination) {
+  return destination.kind === "new-ad-hoc" ? null : destination.gameId;
+}
+
+function destinationMatches(
+  left: ControllerDepartureDestination,
+  right: ControllerDepartureDestination,
+) {
+  return (
+    left.kind === right.kind &&
+    (left.kind === "new-ad-hoc" || right.kind === "new-ad-hoc" || left.gameId === right.gameId)
+  );
+}
+
+function unique(values: string[]) {
+  return [...new Set(values)];
+}
+
+function uniqueDepartures(values: ControllerDepartureReference[]) {
+  const byGameId = new Map<string, ControllerDepartureReference>();
+  for (const departure of values) byGameId.set(departure.gameId, departure);
+  return [...byGameId.values()];
+}
+
+function sameStrings(left: string[], right: string[]) {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
+function sameDepartures(
+  left: ControllerDepartureReference[],
+  right: ControllerDepartureReference[],
+) {
+  return sameStrings(
+    left.map((departure) => departure.gameId),
+    right.map((departure) => departure.gameId),
+  );
+}
+
+function isStoredDeparture(value: unknown): value is ControllerDepartureProjection & {
+  version: typeof CONTROLLER_DEPARTURE_VERSION;
+} {
+  return (
+    isRecord(value) &&
+    value.version === CONTROLLER_DEPARTURE_VERSION &&
+    isSafeTimestamp(value.revision) &&
+    isProjectionBody(value)
+  );
+}
+
+function isLegacyStoredDeparture(value: unknown): value is Exclude<
+  ControllerDepartureState,
+  { status: "failed-closed" }
+> & {
+  version: typeof LEGACY_CONTROLLER_DEPARTURE_VERSION;
+} {
+  return (
+    isRecord(value) &&
+    value.version === LEGACY_CONTROLLER_DEPARTURE_VERSION &&
+    isProjectionBody(value) &&
+    value.status !== "failed-closed"
+  );
+}
+
+function isProjectionBody(value: Record<string, any>) {
+  if (value.status === "empty" || value.status === "failed-closed") return true;
+  if (value.status === "returned") return isStateFields(value);
+  if (value.status === "blocked")
+    return validateOpaqueIdentifier(value.gameId, "gameId").ok && isStateFields(value);
+  return (
+    value.status === "returnable" &&
+    isSafeTimestamp(value.expiresAtMs) &&
+    isDeparture(value.departure) &&
+    isStateFields(value)
+  );
+}
+
+function isStateFields(value: Record<string, any>) {
+  return (
+    Array.isArray(value.blockedGameIds) &&
+    value.blockedGameIds.every((id: unknown) => validateOpaqueIdentifier(id, "gameId").ok) &&
+    Array.isArray(value.pendingFinalizations) &&
+    value.pendingFinalizations.every(isDeparture) &&
+    Array.isArray(value.reconciliationPending) &&
+    value.reconciliationPending.every(isDeparture)
+  );
+}
+
+function isDeparture(value: unknown): value is ControllerDepartureReference {
+  if (!isRecord(value) || (value.workflow !== "ad-hoc" && value.workflow !== "event")) return false;
+  if (
+    !validateOpaqueIdentifier(value.gameId, "gameId").ok ||
+    typeof value.navigationPath !== "string" ||
+    !value.navigationPath.startsWith("/")
+  )
+    return false;
+  if (!isRecord(value.identity)) return false;
+  return (
+    typeof value.identity.title === "string" &&
+    typeof value.identity.homeName === "string" &&
+    typeof value.identity.awayName === "string" &&
+    (value.identity.detail === undefined || typeof value.identity.detail === "string")
+  );
+}
+
+function isSafeTimestamp(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+}
+
+function isRecord(value: unknown): value is Record<string, any> {
+  return typeof value === "object" && value !== null;
+}

--- a/src/lib/game-page-support.ts
+++ b/src/lib/game-page-support.ts
@@ -37,7 +37,15 @@ export const FLAG_STATUS_SHOW_FROM_MS = 18 * ONE_MINUTE_MS;
 export const FLAG_STATUS_HIDE_AFTER_MS = FLAG_RELEASE_MS + 30_000;
 const RELEASE_EVENT_VISIBLE_MS = 30_000;
 
-export function useGameConnection({ gameId, role }: { gameId: string; role: ControllerRole }) {
+export function useGameConnection({
+  gameId,
+  role,
+  blocked = false,
+}: {
+  gameId: string;
+  role: ControllerRole;
+  blocked?: boolean;
+}) {
   const wsUrl = useMemo(createWebSocketUrl, []);
   const [baseState, setBaseState] = useState<GameState | null>(null);
   const authoritativeStateRef = useRef<GameState | null>(null);
@@ -140,6 +148,24 @@ export function useGameConnection({ gameId, role }: { gameId: string; role: Cont
 
   useEffect(() => {
     let cancelled = false;
+    if (blocked) {
+      wsRef.current?.close();
+      wsRef.current = null;
+      subscribedToServerGameRef.current = false;
+      pendingRef.current = [];
+      outcomesRef.current = {};
+      authoritativeStateRef.current = null;
+      replayInFlightRef.current = false;
+      setBaseState(null);
+      setControlQr(null);
+      setPendingCommands([]);
+      setLocalOnlyState(false);
+      setConnectionState("offline");
+      setError("Ad Hoc Game unavailable.");
+      return () => {
+        cancelled = true;
+      };
+    }
     let recoveredFromLocal = false;
     if (role === "controller") {
       const persisted = loadPersistedControllerSession(gameId);
@@ -287,6 +313,7 @@ export function useGameConnection({ gameId, role }: { gameId: string; role: Cont
     };
   }, [
     flushPendingCommands,
+    blocked,
     gameId,
     persistControllerSession,
     reconcileWithServer,
@@ -298,7 +325,7 @@ export function useGameConnection({ gameId, role }: { gameId: string; role: Cont
 
   const dispatchCommand = useCallback(
     (command: GameCommand) => {
-      if (role !== "controller") return;
+      if (role !== "controller" || blocked) return;
       setBaseState((previous) => {
         if (authoritativeStateRef.current === null && previous === null) return previous;
         commandCounterRef.current += 1;
@@ -321,7 +348,14 @@ export function useGameConnection({ gameId, role }: { gameId: string; role: Cont
         return next;
       });
     },
-    [clockOffsetMs, flushPendingCommands, persistControllerSession, role, setPendingCommands],
+    [
+      blocked,
+      clockOffsetMs,
+      flushPendingCommands,
+      persistControllerSession,
+      role,
+      setPendingCommands,
+    ],
   );
   return {
     baseState,

--- a/src/pages/game-page.tsx
+++ b/src/pages/game-page.tsx
@@ -34,7 +34,15 @@ import {
   willFlagCatchWin,
 } from "@/lib/game-page-support";
 import { buildAdHocControlQrPayload } from "@/lib/ad-hoc-handoff";
-import { clearAdHocControllerSession } from "@/lib/ad-hoc-controller-session";
+import {
+  ControllerLeaveDialog,
+  controllerDepartureReference,
+  useControllerDepartureEntry,
+} from "@/components/controller-departure";
+import {
+  controllerDepartureBlocksGame,
+  getBrowserControllerDeparture,
+} from "@/lib/controller-departure";
 import {
   DEFAULT_AWAY_TEAM_COLOR,
   DEFAULT_HOME_TEAM_COLOR,
@@ -83,6 +91,10 @@ export function GamePage({ gameId, role }: { gameId: string; role: ControllerRol
   const [renamingTeam, setRenamingTeam] = useState<TeamId | null>(null);
   const [pendingWinConfirmation, setPendingWinConfirmation] =
     useState<PendingWinConfirmation | null>(null);
+  const [leaveDialogOpen, setLeaveDialogOpen] = useState(false);
+  const [leavePending, setLeavePending] = useState(false);
+  const [entryReady, setEntryReady] = useState(role !== "controller");
+  const [entryError, setEntryError] = useState<string | null>(null);
   const [scorePulse, setScorePulse] = useState<{ home: -1 | 0 | 1; away: -1 | 0 | 1 }>({
     home: 0,
     away: 0,
@@ -102,8 +114,16 @@ export function GamePage({ gameId, role }: { gameId: string; role: ControllerRol
   const leftTeamNameButtonRef = useRef<HTMLButtonElement | null>(null);
   const rightTeamNameButtonRef = useRef<HTMLButtonElement | null>(null);
   const [displayTeamNameHeightPx, setDisplayTeamNameHeightPx] = useState<number | null>(null);
+  const leaveTriggerRef = useRef<HTMLButtonElement | null>(null);
+  const entryTriggerRef = useRef<HTMLButtonElement | null>(null);
+  const entryStartedForRef = useRef<string | null>(null);
+  const departureModule = getBrowserControllerDeparture();
 
   const nowMs = useNow(250);
+
+  const departureProjection = departureModule.project();
+  const departureBlocked =
+    role === "controller" && controllerDepartureBlocksGame(departureProjection, gameId);
 
   const {
     baseState,
@@ -117,20 +137,69 @@ export function GamePage({ gameId, role }: { gameId: string; role: ControllerRol
   } = useGameConnection({
     gameId,
     role,
+    blocked: departureBlocked || !entryReady,
   });
   const [leaveMessage, setLeaveMessage] = useState<string | null>(null);
+  const entry = useControllerDepartureEntry({
+    destination: { kind: "resume-ad-hoc", gameId },
+    triggerRef: entryTriggerRef,
+    onCommitted: () => {
+      setEntryError(null);
+      setEntryReady(true);
+    },
+    onUnavailable: () => {
+      setEntryReady(false);
+      setEntryError("Ad Hoc Game unavailable.");
+    },
+    onCancelled: () => {
+      setEntryReady(false);
+      setEntryError("Entry cancelled. Your Controller return is still available.");
+    },
+  });
+
+  useEffect(() => {
+    if (role !== "controller") {
+      setEntryReady(true);
+      return;
+    }
+    if (entryStartedForRef.current === gameId) return;
+    entryStartedForRef.current = gameId;
+    setEntryReady(false);
+    void entry.begin();
+  }, [entry, gameId, role]);
+
+  useEffect(
+    () =>
+      departureModule.subscribe(() => {
+        const projection = departureModule.project();
+        if (controllerDepartureBlocksGame(projection, gameId)) {
+          setEntryReady(false);
+          setEntryError("Ad Hoc Game unavailable.");
+        }
+      }),
+    [departureModule, gameId],
+  );
 
   const leaveAdHocGame = useCallback(async () => {
     setLeaveMessage(null);
-    try {
-      const response = await fetch(`/api/games/${gameId}/leave`, { method: "POST" });
-      if (!response.ok) throw new Error("leave failed");
-      clearAdHocControllerSession(gameId);
+    setLeavePending(true);
+    const outcome = await departureModule.transition({
+      type: "leave",
+      departure: controllerDepartureReference({
+        workflow: "ad-hoc",
+        gameId,
+        homeName,
+        awayName,
+      }),
+    });
+    setLeavePending(false);
+    if (outcome.status === "left") {
+      setLeaveDialogOpen(false);
       navigateTo("/");
-    } catch {
+    } else {
       setLeaveMessage("Ad Hoc Game unavailable.");
     }
-  }, [gameId]);
+  }, [awayName, departureModule, gameId, homeName]);
 
   useEffect(() => {
     if (baseState !== null) {
@@ -511,21 +580,26 @@ export function GamePage({ gameId, role }: { gameId: string; role: ControllerRol
 
   if (gameView === null || liveState === null) {
     return (
-      <div className="mx-auto flex min-h-screen w-full max-w-3xl items-center justify-center p-6">
-        <Card className="w-full">
-          <CardHeader>
-            <CardTitle>{error ?? "Loading game"}</CardTitle>
-            <CardDescription>
-              {error === null ? "Waiting for snapshot from server." : "Return to the Games page."}
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <Button variant="outline" onClick={() => navigateTo("/")}>
-              Back to games
-            </Button>
-          </CardContent>
-        </Card>
-      </div>
+      <>
+        {entry.dialog}
+        <div className="mx-auto flex min-h-screen w-full max-w-3xl items-center justify-center p-6">
+          <Card className="w-full">
+            <CardHeader>
+              <CardTitle>{entryError ?? error ?? "Loading game"}</CardTitle>
+              <CardDescription>
+                {entryError === null && error === null
+                  ? "Waiting for snapshot from server."
+                  : "Return to the Games page."}
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Button ref={entryTriggerRef} variant="outline" onClick={() => navigateTo("/")}>
+                Back to games
+              </Button>
+            </CardContent>
+          </Card>
+        </div>
+      </>
     );
   }
 
@@ -795,6 +869,17 @@ export function GamePage({ gameId, role }: { gameId: string; role: ControllerRol
 
   return (
     <div className="h-[100dvh] overflow-hidden bg-slate-100 p-2 text-slate-900">
+      {entry.dialog}
+      {leaveDialogOpen ? (
+        <ControllerLeaveDialog
+          triggerRef={leaveTriggerRef}
+          busy={leavePending}
+          onCancel={() => {
+            setLeaveDialogOpen(false);
+          }}
+          onConfirm={() => void leaveAdHocGame()}
+        />
+      ) : null}
       <div className="mx-auto grid h-full w-full max-w-[460px] grid-rows-[auto_auto_minmax(0,1fr)_auto_auto] gap-2">
         <section className="rounded-2xl border border-slate-300 bg-white px-3 py-2 shadow-[0_8px_18px_rgba(15,23,42,0.08)]">
           <div className="flex items-start justify-between gap-2">
@@ -838,10 +923,11 @@ export function GamePage({ gameId, role }: { gameId: string; role: ControllerRol
               </Button>
               {controller ? (
                 <Button
+                  ref={leaveTriggerRef}
                   variant="outline"
                   size="sm"
                   className="h-7 border-slate-300 bg-white px-2 text-[11px] text-slate-800 hover:bg-slate-100"
-                  onClick={() => void leaveAdHocGame()}
+                  onClick={() => setLeaveDialogOpen(true)}
                 >
                   Leave
                 </Button>

--- a/src/pages/public-event-page.tsx
+++ b/src/pages/public-event-page.tsx
@@ -17,10 +17,16 @@ import {
 } from "@/lib/public-event-stream";
 import { DEFAULT_AWAY_TEAM_COLOR, DEFAULT_HOME_TEAM_COLOR } from "@/lib/team-colors";
 import { PublicGameTimeline } from "@/pages/public-game-timeline";
+import {
+  ControllerDepartureReturnCard,
+  useControllerDepartureEntry,
+} from "@/components/controller-departure";
+import { getBrowserControllerDeparture } from "@/lib/controller-departure";
 
 export function PublicEventHomePage({ showAll = false }: { showAll?: boolean }) {
   const [events, setEvents] = useState<readonly PublicAudienceEventProjection[] | null>(null);
   const [discoveryUnavailable, setDiscoveryUnavailable] = useState(false);
+  const departureModule = getBrowserControllerDeparture();
 
   useEffect(() => {
     let active = true;
@@ -34,7 +40,7 @@ export function PublicEventHomePage({ showAll = false }: { showAll?: boolean }) 
       .then((nextEvents) => {
         if (!active) return;
         const current = nextEvents.filter((event) => event.lifecycle === "current");
-        if (!showAll && current.length === 1) {
+        if (!showAll && current.length === 1 && departureModule.project().status !== "returnable") {
           navigateTo(current[0]!.canonicalPath);
           return;
         }
@@ -46,7 +52,7 @@ export function PublicEventHomePage({ showAll = false }: { showAll?: boolean }) 
     return () => {
       active = false;
     };
-  }, [showAll]);
+  }, [departureModule, showAll]);
 
   return (
     <PublicShell
@@ -55,6 +61,7 @@ export function PublicEventHomePage({ showAll = false }: { showAll?: boolean }) 
     >
       {events === null && !discoveryUnavailable ? (
         <div className="space-y-6">
+          <ControllerDepartureReturnCard />
           <p
             className="rounded-2xl border bg-card/80 p-5 text-sm text-muted-foreground"
             role="status"
@@ -66,6 +73,7 @@ export function PublicEventHomePage({ showAll = false }: { showAll?: boolean }) 
         </div>
       ) : discoveryUnavailable ? (
         <div className="space-y-6">
+          <ControllerDepartureReturnCard />
           <p
             className="rounded-2xl border bg-card/80 p-5 text-sm text-muted-foreground"
             role="alert"
@@ -75,7 +83,10 @@ export function PublicEventHomePage({ showAll = false }: { showAll?: boolean }) 
           <StartAdHocGame />
         </div>
       ) : (
-        <EventDiscovery events={events ?? []} />
+        <div className="space-y-6">
+          <ControllerDepartureReturnCard />
+          <EventDiscovery events={events ?? []} />
+        </div>
       )}
     </PublicShell>
   );
@@ -1104,105 +1115,130 @@ function StartAdHocGame() {
   const [creationAlert, setCreationAlert] = useState(false);
   const [creationPending, setCreationPending] = useState(false);
   const creationPendingRef = useRef(false);
+  const creationAttemptRef = useRef(0);
   const creationRetryTimerRef = useRef<number | null>(null);
+  const beginCreateGameRef = useRef<((attempt?: number) => Promise<void>) | null>(null);
   const mountedRef = useRef(true);
+  const replacementTriggerRef = useRef<HTMLButtonElement | null>(null);
 
-  useEffect(
-    () => () => {
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
       mountedRef.current = false;
       if (creationRetryTimerRef.current !== null)
         window.clearTimeout(creationRetryTimerRef.current);
       creationRetryTimerRef.current = null;
       creationPendingRef.current = false;
-    },
-    [],
-  );
+    };
+  }, []);
 
-  const handleCreateGame = useCallback(
-    async (attempt = 0) => {
-      if (!mountedRef.current) return;
-      if (attempt === 0) {
-        if (creationPendingRef.current) return;
-        creationPendingRef.current = true;
-        setCreationPending(true);
-      }
-      setCreationAlert(false);
-      setCreationStatus(attempt === 0 ? "Creating Ad Hoc Game…" : "Retrying Ad Hoc Game…");
+  const createGame = useCallback(async () => {
+    const attempt = creationAttemptRef.current;
+    if (!mountedRef.current) return false;
+    setCreationAlert(false);
+    setCreationStatus(attempt === 0 ? "Creating Ad Hoc Game…" : "Retrying Ad Hoc Game…");
 
-      let response: Response;
-      try {
-        response = await fetch("/api/games", {
-          method: "POST",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify({
-            homeName,
-            awayName,
-            homeColor,
-            awayColor,
-            browserId: getAdHocBrowserId(),
-          }),
-        });
-      } catch {
-        if (mountedRef.current) {
-          setCreationAlert(true);
-          setCreationStatus("Ad Hoc Game unavailable. Try again later.");
-        }
-        creationPendingRef.current = false;
-        setCreationPending(false);
-        return;
-      }
-      if (!mountedRef.current) return;
-
-      if (!response.ok) {
-        const payload = (await response.json().catch(() => null)) as {
-          error?: unknown;
-          retryAfterMs?: unknown;
-        } | null;
-        const capacityMessage =
-          typeof payload?.error === "string" && payload.error.startsWith("Ad Hoc capacity")
-            ? payload.error
-            : null;
-        if (response.status === 429 && attempt < 3 && capacityMessage === null) {
-          const headerDelayMs = Number(response.headers.get("retry-after")) * 1_000;
-          const retryAfterMs = Math.min(
-            30_000,
-            Math.max(
-              1_000,
-              typeof payload?.retryAfterMs === "number" ? payload.retryAfterMs : headerDelayMs,
-            ),
-          );
-          setCreationStatus(
-            `Ad Hoc creation busy. Retrying in ${Math.ceil(retryAfterMs / 1_000)}s.`,
-          );
-          if (creationRetryTimerRef.current !== null)
-            window.clearTimeout(creationRetryTimerRef.current);
-          creationRetryTimerRef.current = window.setTimeout(() => {
-            creationRetryTimerRef.current = null;
-            void handleCreateGame(attempt + 1);
-          }, retryAfterMs);
-          return;
-        }
+    let response: Response;
+    try {
+      response = await fetch("/api/games", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          homeName,
+          awayName,
+          homeColor,
+          awayColor,
+          browserId: getAdHocBrowserId(),
+        }),
+      });
+    } catch {
+      if (mountedRef.current) {
         setCreationAlert(true);
-        setCreationStatus(capacityMessage ?? "Ad Hoc Game unavailable. Try again later.");
-        creationPendingRef.current = false;
-        setCreationPending(false);
-        return;
+        setCreationStatus("Ad Hoc Game unavailable. Try again later.");
       }
+      creationPendingRef.current = false;
+      setCreationPending(false);
+      return false;
+    }
+    if (!mountedRef.current) return false;
 
-      const payload = (await response.json()) as { gameId?: string };
-      if (typeof payload.gameId === "string") {
+    if (!response.ok) {
+      const payload = (await response.json().catch(() => null)) as {
+        error?: unknown;
+        retryAfterMs?: unknown;
+      } | null;
+      const capacityMessage =
+        typeof payload?.error === "string" && payload.error.startsWith("Ad Hoc capacity")
+          ? payload.error
+          : null;
+      if (response.status === 429 && attempt < 3 && capacityMessage === null) {
+        const headerDelayMs = Number(response.headers.get("retry-after")) * 1_000;
+        const retryAfterMs = Math.min(
+          30_000,
+          Math.max(
+            1_000,
+            typeof payload?.retryAfterMs === "number" ? payload.retryAfterMs : headerDelayMs,
+          ),
+        );
+        setCreationStatus(`Ad Hoc creation busy. Retrying in ${Math.ceil(retryAfterMs / 1_000)}s.`);
         creationPendingRef.current = false;
         setCreationPending(false);
-        navigateTo(`/game/${payload.gameId}`);
-        return;
+        if (creationRetryTimerRef.current !== null)
+          window.clearTimeout(creationRetryTimerRef.current);
+        creationRetryTimerRef.current = window.setTimeout(() => {
+          creationRetryTimerRef.current = null;
+          void beginCreateGameRef.current?.(attempt + 1);
+        }, retryAfterMs);
+        return false;
       }
       setCreationAlert(true);
-      setCreationStatus("Ad Hoc Game unavailable. Try again later.");
+      setCreationStatus(capacityMessage ?? "Ad Hoc Game unavailable. Try again later.");
+      creationPendingRef.current = false;
+      setCreationPending(false);
+      return false;
+    }
+
+    const payload = (await response.json()) as { gameId?: string };
+    if (typeof payload.gameId === "string") {
+      creationPendingRef.current = false;
+      setCreationPending(false);
+      navigateTo(`/game/${payload.gameId}`);
+      return true;
+    }
+    setCreationAlert(true);
+    setCreationStatus("Ad Hoc Game unavailable. Try again later.");
+    creationPendingRef.current = false;
+    setCreationPending(false);
+    return false;
+  }, [awayColor, awayName, homeColor, homeName]);
+  const entry = useControllerDepartureEntry({
+    destination: { kind: "new-ad-hoc" },
+    triggerRef: replacementTriggerRef,
+    onCommitted: async () => {
+      creationPendingRef.current = true;
+      setCreationPending(true);
+      return await createGame();
+    },
+    onUnavailable: () => {
+      setCreationAlert(true);
+      setCreationStatus("The previous Controller return is no longer available.");
       creationPendingRef.current = false;
       setCreationPending(false);
     },
-    [awayColor, awayName, homeColor, homeName],
+    onCancelled: () => {
+      creationPendingRef.current = false;
+      setCreationPending(false);
+    },
+  });
+  const beginCreateGame = useCallback(
+    async (attempt = 0) => {
+      if (!mountedRef.current || creationPendingRef.current) return;
+      creationAttemptRef.current = attempt;
+      await entry.begin();
+    },
+    [entry],
   );
+  beginCreateGameRef.current = beginCreateGame;
 
   return (
     <Card>
@@ -1252,10 +1288,11 @@ function StartAdHocGame() {
           </div>
         </div>
         <Button
+          ref={replacementTriggerRef}
           type="button"
           className="w-full"
-          disabled={creationPending}
-          onClick={() => void handleCreateGame()}
+          disabled={creationPending || entry.busy}
+          onClick={() => void beginCreateGame()}
         >
           Start an Ad Hoc Game <span className="sr-only">Create new game</span>
         </Button>
@@ -1269,6 +1306,7 @@ function StartAdHocGame() {
           </p>
         ) : null}
       </CardContent>
+      {entry.dialog}
     </Card>
   );
 }


### PR DESCRIPTION
Closes #268.

## What changed

- adds a deep Controller Departure module for confirmed, five-minute Ad Hoc Leave and Return
- persists only non-secret lifecycle references and keeps offline expiry/finalization fail-closed
- centralizes creation, QR admission, and direct-route replacement confirmation behind revision-bound entry transitions
- adds the prominent Home Return experience and accessible Leave/replacement dialogs
- preserves equal Ad Hoc Controller authority and clears only the departing browser's local replica

## Why

An accidental Leave could previously revoke the only practical route back into a live Ad Hoc Game. This makes departure reversible for five minutes while preserving authoritative removal, capacity cleanup, and final revocation semantics.

## User impact

Controllers can confirm Leave, return from Home during the grace period, and safely replace that opportunity when entering another Game. Offline Return remains available but is terminated generically when later reconciliation proves authority unavailable.

## Validation

- `bun run check`
- `bun run build`
- `bun test --isolate src/lib/controller-departure.test.ts src/App.test.tsx` (50 passed)
- `bun run test:focused:adhoc-browser`
- accepted ticket branch: `bun run test` (1,006 passed, 0 failed)
- merged-base diff: `git diff --check origin/main...HEAD`

The merged-base coordinator also started the broadened current-main full suite; it remained CPU-active beyond three minutes and was stopped after the ticket-focused and browser gates passed. No Qualification Test was added or run.
