### PR TITLE
Implement host-local Production restore (#166)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,13 @@ Install the root-owned maintenance wrapper once on the host:
 sudo install -o root -g root -m 0755 deploy/activation-maintenance-root.sh /usr/local/sbin/quadball-timer-activation-maintenance
 ```
 
+For an explicitly authorized host-local Production restore, log in as
+`deploy-quadball-timer` and run the immutable current release's
+`deploy/restore-production.sh --manifest /var/backups/quadball-timer/verified-<release-id>/<snapshot-id>.manifest.json`.
+The operator entry point owns the activation lock, stops the service, invokes the
+root maintenance boundary, and performs bounded post-restart checks. Deploy,
+monitoring, and browser paths never invoke it.
+
 For the bounded first-time or repair bootstrap of the Production/Test host
 contract, use `docs/agents/issue-165-pre-merge-handoff.md`.
 

--- a/deploy/activate-release.sh
+++ b/deploy/activate-release.sh
@@ -325,6 +325,7 @@ verify_bundle() {
     "deploy/activate-release.sh"
     "deploy/activate-test-release.sh"
     "deploy/activation-maintenance-root.sh"
+    "deploy/restore-production.sh"
     "deploy/systemd/quadball-timer-test.service"
     "deploy/systemd/quadball-timer.service"
     "quadball-timer"

--- a/deploy/activate-test-release.sh
+++ b/deploy/activate-test-release.sh
@@ -262,6 +262,7 @@ verify_bundle() {
     "deploy/activate-release.sh"
     "deploy/activate-test-release.sh"
     "deploy/activation-maintenance-root.sh"
+    "deploy/restore-production.sh"
     "deploy/systemd/quadball-timer.service"
     "deploy/systemd/quadball-timer-test.service"
     "quadball-timer"

--- a/deploy/activation-maintenance-root.sh
+++ b/deploy/activation-maintenance-root.sh
@@ -5,6 +5,45 @@ environment="${1:-}"
 release_dir="${2:-}"
 command="${3:-}"
 manifest_path="${4:-}"
+restore_report_emitted=0
+restore_result_emitted=0
+restore_error_fd=2
+if [[ "$command" == restore ]]; then
+  exec 8>&2
+  exec 2>/dev/null
+  restore_error_fd=8
+fi
+
+restore_preparation_failure() {
+  local outcome="$1"
+  local status="${2:-1}"
+  printf '{"restored":false,"outcome":"%s","cutoverCompleted":false,"technicalAdminAuth":{"outcome":"not-attempted","credentialPreserved":false,"reEnrollmentRequired":false}}\n' "$outcome" >&${restore_error_fd}
+  restore_report_emitted=1
+  exit "$status"
+}
+
+maintenance_preflight_failure() {
+  local outcome="$1"
+  local status="$2"
+  local message="$3"
+  if [[ "$command" == restore ]]; then
+    restore_preparation_failure "$outcome" "$status"
+  fi
+  echo "$message" >&2
+  exit "$status"
+}
+
+# shellcheck disable=SC2329
+restore_exit_report() {
+  local status="$?"
+  trap - EXIT
+  if [[ "$command" == restore && "$restore_report_emitted" == 0 ]]; then
+    printf '{"restored":false,"outcome":"restore-preparation-failed","cutoverCompleted":false,"technicalAdminAuth":{"outcome":"not-attempted","credentialPreserved":false,"reEnrollmentRequired":false}}\n' >&"${restore_error_fd}"
+  fi
+  exit "$status"
+}
+trap restore_exit_report EXIT
+
 case "$environment" in
   production)
     service_user="quadball-timer"
@@ -277,10 +316,14 @@ if [[ "$focused_test_mode" == 1 ]]; then
   [[ -n "$backup_directory" ]] && backup_directory="$focused_test_root${backup_directory}"
 fi
 configure_promotion_test_hooks || exit 2
+owner_identity_command="${QBT_FOCUSED_TEST_OWNER_SEAM:-}"
 systemctl_command="${QBT_FOCUSED_TEST_SYSTEMCTL:-systemctl}"
 runuser_command="${QBT_FOCUSED_TEST_RUNUSER:-/usr/sbin/runuser}"
 flock_command="${QBT_FOCUSED_TEST_FLOCK:-flock}"
 realpath_command="${QBT_FOCUSED_TEST_REALPATH:-realpath}"
+readlink_command="${QBT_FOCUSED_TEST_READLINK:-readlink}"
+install_command="${QBT_FOCUSED_TEST_INSTALL:-/usr/bin/install}"
+mktemp_command="${QBT_FOCUSED_TEST_MKTEMP:-mktemp}"
 [[ "$release_dir" == "$release_base"/releases/* ]] || { echo "Unsafe release path." >&2; exit 2; }
 [[ "$release_dir" != *..* && "$release_dir" != *//* ]] || { echo "Unsafe release path." >&2; exit 2; }
 [[ -d "$release_dir" && ! -L "$release_dir" ]] || { echo "Unsafe release path." >&2; exit 2; }
@@ -293,12 +336,14 @@ resolved_release_dir="$($realpath_command -e -- "$release_dir")"
   echo "Maintenance release is incomplete." >&2
   exit 1
 }
-release_attempt_id="$(sed -n 's/.*"releaseAttemptId":"\([^"]*\)".*/\1/p' "$release_dir/release-manifest.json")"
-schema_compatibility="$(sed -n 's/.*"schemaCompatibility":"\([^"]*\)".*/\1/p' "$release_dir/release-manifest.json")"
-[[ -n "$release_attempt_id" && -n "$schema_compatibility" ]] || {
-  echo "Maintenance release identity is incomplete." >&2
-  exit 1
-}
+if ! release_attempt_id="$(sed -n 's/.*"releaseAttemptId":"\([^"]*\)".*/\1/p' "$release_dir/release-manifest.json")"; then
+  maintenance_preflight_failure release-identity-invalid 1 "Maintenance release identity is unreadable."
+fi
+if ! schema_compatibility="$(sed -n 's/.*"schemaCompatibility":"\([^"]*\)".*/\1/p' "$release_dir/release-manifest.json")"; then
+  maintenance_preflight_failure release-identity-invalid 1 "Maintenance release identity is unreadable."
+fi
+[[ -n "$release_attempt_id" && -n "$schema_compatibility" ]] ||
+  maintenance_preflight_failure release-identity-invalid 1 "Maintenance release identity is incomplete."
 [[ "$release_attempt_id" =~ ^[A-Za-z0-9._-]+$ && "$(basename -- "$release_dir")" == "$release_attempt_id" ]] || {
   echo "Maintenance release identity does not match its path." >&2
   exit 2
@@ -308,11 +353,14 @@ schema_compatibility="$(sed -n 's/.*"schemaCompatibility":"\([^"]*\)".*/\1/p' "$
   exit 2
 }
 case "$command" in
-  backup|verify-backup|promote)
+  backup|verify-backup|promote|restore)
     [[ "$environment" == production ]] || { echo "Production backup operations only." >&2; exit 2; }
     [[ "${SUDO_USER:-}" == "$expected_caller" ]] || { echo "Invalid maintenance caller." >&2; exit 2; }
-    [[ "$($systemctl_command is-active quadball-timer 2>/dev/null || true)" == inactive ]] || { echo "Production service must be inactive." >&2; exit 1; }
-    exec 9>"$release_base/.activation.lock"
+    service_state="$($systemctl_command is-active quadball-timer 2>/dev/null || true)"
+    [[ "$service_state" == inactive || "$service_state" == failed ]] || { echo "Production service must be inactive or failed." >&2; exit 1; }
+    if ! exec 9>"$release_base/.activation.lock"; then
+      maintenance_preflight_failure activation-lock-unavailable 1 "Activation lock could not be opened."
+    fi
     if QBT_ACTIVATION_LOCK_PATH="$release_base/.activation.lock" "$flock_command" -n 9; then echo "Activation lock is not held by the orchestrator." >&2; exit 1; fi
     ;;
   validate-migration|apply-migrations)
@@ -321,12 +369,12 @@ case "$command" in
     exec 9>"$release_base/.activation.lock"
     if QBT_ACTIVATION_LOCK_PATH="$release_base/.activation.lock" "$flock_command" -n 9; then echo "Activation lock is not held by the orchestrator." >&2; exit 1; fi
     ;;
-  readiness|preflight)
+  readiness|authoritative-operation|preflight)
     [[ "${SUDO_USER:-}" == "$expected_caller" ]] || { echo "Invalid maintenance caller." >&2; exit 2; }
     ;;
   *) echo "Unsupported maintenance operation." >&2; exit 2 ;;
 esac
-if [[ "$environment" == production && "$command" != readiness && "$command" != preflight && "$command" != validate-migration && "$command" != apply-migrations ]]; then
+if [[ "$environment" == production && "$command" != readiness && "$command" != authoritative-operation && "$command" != preflight && "$command" != validate-migration && "$command" != apply-migrations ]]; then
   if [[ -e "$backup_directory" || -L "$backup_directory" ]]; then
     [[ -d "$backup_directory" && ! -L "$backup_directory" ]] || { echo "Backup root is missing or symlinked." >&2; exit 2; }
     [[ "$($realpath_command -e -- "$backup_directory")" == "$backup_directory" ]] || { echo "Backup root is not canonical." >&2; exit 2; }
@@ -338,6 +386,91 @@ if [[ "$environment" == production && "$command" != readiness && "$command" != p
     [[ "$(stat -c '%U:%G:%a' "$backup_directory")" == "root:${service_user}:750" ]] || { echo "Backup root ownership or mode drifted." >&2; exit 2; }
   fi
 fi
+
+stage_restore_input() {
+  local source_path="$1"
+  local destination_name="$2"
+  local destination_path="$restore_workspace/$destination_name"
+  local before_identity=""
+  local after_identity=""
+  local source_copy_path="$source_path"
+
+  [[ "$destination_name" =~ ^[A-Za-z0-9._-]+$ ]] || return 1
+  [[ "$source_path" == "$snapshot_directory"/* && "$source_path" != *..* ]] || return 1
+  [[ -f "$source_path" && ! -L "$source_path" ]] || return 1
+  [[ "$($realpath_command -e -- "$source_path")" == "$source_path" ]] || return 1
+  if [[ "$focused_test_mode" == 1 && -n "$owner_identity_command" ]]; then
+    [[ "$($owner_identity_command "$source_path")" == root:root:600 ]] || return 1
+  elif [[ "$focused_test_mode" != 1 ]]; then
+    [[ "$($stat_command -c '%U:%G:%a' -- "$source_path")" == root:root:600 ]] || return 1
+  fi
+  if [[ "$focused_test_mode" == 1 ]]; then
+    before_identity="$($stat_command -f '%d:%i:%z:%m' -- "$source_path")" || return 1
+  else
+    before_identity="$($stat_command -L -c '%d:%i:%s:%Y' -- "$source_path")" || return 1
+    exec 7<"$source_path" || return 1
+    source_copy_path="/proc/self/fd/7"
+    [[ "$($readlink_command "$source_copy_path")" == "$source_path" ]] || {
+      exec 7<&-
+      return 1
+    }
+    held_identity="$($stat_command -L -c '%d:%i:%s:%Y' -- "$source_copy_path")" || {
+      exec 7<&-
+      return 1
+    }
+    [[ "$before_identity" == "$held_identity" ]] || {
+      exec 7<&-
+      return 1
+    }
+  fi
+  local original_umask
+  original_umask="$(umask)"
+  umask 077
+  set -o noclobber
+  if ! exec 6>"$destination_path"; then
+    set +o noclobber
+    umask "$original_umask"
+    [[ "$focused_test_mode" == 1 ]] || exec 7<&-
+    return 1
+  fi
+  set +o noclobber
+  umask "$original_umask"
+  if [[ "$focused_test_mode" == 1 ]]; then
+    cat "$source_copy_path" >&6 || { exec 6>&-; return 1; }
+  else
+    cat <"$source_copy_path" >&6 || { exec 6>&-; exec 7<&-; return 1; }
+  fi
+  if [[ "$focused_test_mode" != 1 ]]; then
+    sync -f -- "$destination_path" || { exec 6>&-; exec 7<&-; return 1; }
+  fi
+  exec 6>&-
+  chmod 0600 "$destination_path" || return 1
+  if [[ "$focused_test_mode" != 1 ]]; then
+    chown "$service_user:$service_user" -- "$destination_path" || return 1
+  fi
+  if [[ "$focused_test_mode" == 1 ]]; then
+    [[ "$($stat_command -f '%Lp' -- "$destination_path")" == 600 ]] || return 1
+    if [[ -n "$owner_identity_command" ]]; then
+      [[ "$($owner_identity_command "$destination_path")" == quadball-timer:quadball-timer:600 ]] || return 1
+    fi
+  else
+    [[ "$($stat_command -c '%U:%G:%a' -- "$destination_path")" == "${service_user}:${service_user}:600" ]] || return 1
+  fi
+  [[ -f "$destination_path" && ! -L "$destination_path" ]] || return 1
+  [[ "$($realpath_command -e -- "$destination_path")" == "$destination_path" ]] || return 1
+  if [[ "$focused_test_mode" == 1 ]]; then
+    [[ "$($stat_command -f '%Lp' -- "$destination_path")" == 600 ]] || return 1
+    after_identity="$($stat_command -f '%d:%i:%z:%m' -- "$source_path")" || return 1
+  else
+    [[ "$($stat_command -c '%U:%G:%a' -- "$destination_path")" == "${service_user}:${service_user}:600" ]] || return 1
+    after_identity="$($stat_command -L -c '%d:%i:%s:%Y' -- "$source_path")" || return 1
+    held_identity="$($stat_command -L -c '%d:%i:%s:%Y' -- "$source_copy_path")" || return 1
+    exec 7<&-
+  fi
+  [[ "$before_identity" == "$after_identity" ]] || return 1
+  [[ "$focused_test_mode" == 1 || "$before_identity" == "$held_identity" ]] || return 1
+}
+
 if [[ "$command" == "backup" ]]; then
   operation_backup_directory="$backup_directory/.candidate-${release_attempt_id}"
   if [[ "$focused_test_mode" == 1 ]]; then rm -rf "$operation_backup_directory"; mkdir -p "$operation_backup_directory"; chmod 0700 "$operation_backup_directory"; else rm -rf -- "$operation_backup_directory"; install -d -o "$service_user" -g "$service_user" -m 0700 "$operation_backup_directory"; fi
@@ -356,13 +489,78 @@ if [[ "$command" == "promote" ]]; then
   [[ "$manifest_path" == "$candidate_directory"/* && "$manifest_path" != *..* ]] || { echo "Unsafe backup manifest path." >&2; exit 2; }
   manifest_path="$($realpath_command -e -- "$manifest_path")"
   [[ "$manifest_path" == "$candidate_directory"/* && ! -L "$manifest_path" ]] || { echo "Backup manifest is not canonical." >&2; exit 2; }
+elif [[ "$command" == "restore" ]]; then
+  [[ "$environment" == production ]] || { echo "Production restore operations only." >&2; exit 2; }
+  [[ -n "$manifest_path" && "$manifest_path" == "$backup_directory"/* && "$manifest_path" != *..* ]] || { echo "Unsafe restore manifest path." >&2; exit 2; }
+  manifest_path="$($realpath_command -e -- "$manifest_path")"
+  [[ "$manifest_path" == "$backup_directory"/* && ! -L "$manifest_path" ]] || { echo "Restore manifest is not canonical." >&2; exit 2; }
+  [[ "$(basename -- "$(dirname -- "$manifest_path")")" =~ ^verified-[A-Za-z0-9._-]+$ ]] || { echo "Restore requires a promoted verified snapshot." >&2; exit 2; }
+  [[ "$(basename -- "$manifest_path")" =~ ^[A-Za-z0-9._-]+\.manifest\.json$ ]] || { echo "Restore manifest filename is unsafe." >&2; exit 2; }
+fi
+restore_workspace=""
+if [[ "$command" == "restore" ]]; then
+  restore_workspace="$($mktemp_command -d "$backup_directory/.restore-${release_attempt_id}-XXXXXX")" || {
+    echo "Restore workspace could not be allocated." >&2
+    exit 1
+  }
+  [[ "$restore_workspace" == "$backup_directory/.restore-${release_attempt_id}-"* && "$restore_workspace" != *..* ]] || {
+    echo "Restore workspace identity is unsafe." >&2
+    exit 2
+  }
+  if ! "$install_command" -d -o root -g root -m 0700 "$restore_workspace" >/dev/null 2>&1; then
+    echo "Restore workspace could not be prepared." >&2
+    exit 1
+  fi
+  [[ -d "$restore_workspace" && ! -L "$restore_workspace" ]] || {
+    echo "Restore workspace is not a regular directory." >&2
+    exit 2
+  }
+  [[ "$($realpath_command -e -- "$restore_workspace")" == "$restore_workspace" ]] || {
+    echo "Restore workspace is not canonical." >&2
+    exit 2
+  }
+  if [[ "$focused_test_mode" != 1 ]]; then
+    [[ "$(stat -c '%U:%G:%a' "$restore_workspace")" == "root:root:700" ]] || {
+      echo "Restore workspace staging ownership or mode drifted." >&2
+      exit 2
+    }
+  fi
+  snapshot_directory="$(dirname -- "$manifest_path")"
+  snapshot_id="$(basename -- "$manifest_path" .manifest.json)"
+  [[ "$snapshot_id" =~ ^[A-Za-z0-9._-]{1,128}$ ]] || {
+    echo "Restore snapshot identity is unsafe." >&2
+    exit 2
+  }
+  [[ "$(basename -- "$snapshot_directory")" =~ ^verified-[A-Za-z0-9._-]+$ ]] || {
+    restore_preparation_failure restore-selection-invalid 2
+  }
+  stage_restore_input "$manifest_path" "$(basename -- "$manifest_path")" || {
+    restore_preparation_failure restore-staging-failed 1
+  }
+  stage_restore_input "$snapshot_directory/$snapshot_id.sqlite" "$snapshot_id.sqlite" || {
+    restore_preparation_failure restore-staging-failed 1
+  }
+  stage_restore_input "$snapshot_directory/$snapshot_id.ad-hoc.sqlite" "$snapshot_id.ad-hoc.sqlite" || {
+    restore_preparation_failure restore-staging-failed 1
+  }
+  stage_restore_input "$snapshot_directory/$snapshot_id.deployment.json" "$snapshot_id.deployment.json" || {
+    restore_preparation_failure restore-staging-failed 1
+  }
+  if [[ "$focused_test_mode" != 1 ]]; then
+    chown "$service_user:$service_user" -- "$restore_workspace" ||
+      restore_preparation_failure restore-staging-failed 1
+    chmod 0700 -- "$restore_workspace" || restore_preparation_failure restore-staging-failed 1
+    [[ "$(stat -c '%U:%G:%a' "$restore_workspace")" == "${service_user}:${service_user}:700" ]] ||
+      restore_preparation_failure restore-staging-failed 1
+  fi
+  manifest_path="$restore_workspace/$(basename -- "$manifest_path")"
 fi
 set +e
 foundation_backup_directory="$operation_backup_directory"
 [[ "$command" == "promote" ]] && foundation_backup_directory="$backup_directory"
 root_promotion=""
 [[ "$command" == "promote" ]] && root_promotion=1
-if [[ "$command" == "promote" ]]; then
+if [[ "$command" == "promote" || "$command" == "restore" ]]; then
   maintenance_output="$("$runuser_command" -u "$service_user" -- env -i PATH=/usr/bin:/bin \
   QUADBALL_ENVIRONMENT="$environment" \
   NODE_ENV=production \
@@ -377,6 +575,7 @@ if [[ "$command" == "promote" ]]; then
   SCHEMA_COMPATIBILITY="$schema_compatibility" \
   RELEASE_MANIFEST_PATH="$release_dir/release-manifest.json" \
   BACKUP_MANIFEST_PATH="$manifest_path" \
+  RESTORE_WORKSPACE_DIRECTORY="$restore_workspace" \
   QBT_FOCUSED_TEST_MODE="$focused_test_mode" \
   QBT_FOCUSED_TEST_ROOT="$focused_test_root" \
   AD_HOC_ENVIRONMENT_ID="$ad_hoc_environment_identity" \
@@ -408,6 +607,17 @@ else
   rc=$?
 fi
 set -e
+if [[ "$command" == "restore" ]]; then
+  bounded_restore_report="$(printf '%s\n' "$maintenance_output" | grep -m1 -E '^\{"restored":true,"restoreId":|^\{"restored":false,"outcome":' || true)"
+  if [[ -z "$bounded_restore_report" ]]; then
+    bounded_restore_report='{"restored":false,"outcome":"restore-preparation-failed","cutoverCompleted":false,"technicalAdminAuth":{"outcome":"not-attempted","credentialPreserved":false,"reEnrollmentRequired":false}}'
+  fi
+  technical_admin_auth="$(printf '%s\n' "$bounded_restore_report" | sed -n -E 's/.*"technicalAdminAuth":(\{"outcome":"[^"]+","credentialPreserved":(true|false),"reEnrollmentRequired":(true|false)\}).*/\1/p')"
+  if [[ -z "$technical_admin_auth" ]]; then
+    technical_admin_auth='{"outcome":"not-attempted","credentialPreserved":false,"reEnrollmentRequired":false}'
+  fi
+  restore_report_emitted=1
+fi
 if [[ "$command" == "promote" ]]; then
   if (( rc != 0 )); then
     if (( ${#maintenance_output} > 4096 )); then
@@ -421,6 +631,19 @@ if [[ "$command" == "promote" ]]; then
       rc=1
     fi
   fi
+fi
+if (( rc == 0 )) && [[ "$command" == "restore" ]]; then
+  if ! "$systemctl_command" restart "$service_name" >/dev/null 2>&1 ||
+    [[ "$($systemctl_command is-active "$service_name" 2>/dev/null || true)" != active ]]
+  then
+    printf '{"restored":false,"outcome":"cutover-completed-readiness-failed","cutoverCompleted":true,"restartVerified":false,"technicalAdminAuth":%s,"authorityResurrectionWarning":"Restoring an older snapshot may resurrect Grants, Grant Sessions, Ad Hoc Controller sessions, or QR-admitting state changed after the snapshot."}\n' "$technical_admin_auth" >&${restore_error_fd}
+    restore_result_emitted=1
+    rc=12
+  fi
+fi
+if [[ "$command" == restore && "$restore_result_emitted" == 0 ]]; then
+  printf '%s\n' "$bounded_restore_report"
+  restore_result_emitted=1
 fi
 if (( rc != 0 )) && [[ "$command" == "backup" || "$command" == "verify-backup" || "$command" == "promote" ]]; then
   if [[ "$focused_test_mode" == 1 ]]; then chmod -R u+w "$operation_backup_directory" 2>/dev/null || true; rm -rf "$operation_backup_directory"; else chmod -R u+w -- "$operation_backup_directory" 2>/dev/null || true; rm -rf -- "$operation_backup_directory"; fi

--- a/deploy/restore-production.sh
+++ b/deploy/restore-production.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+base_dir="/srv/quadball-timer"
+backup_directory="/var/backups/quadball-timer"
+service_name="quadball-timer"
+port="3000"
+public_origin="https://timer.quadball.app"
+maintenance_wrapper="/usr/local/sbin/quadball-timer-activation-maintenance"
+manifest_path=""
+focused_test_mode="${QBT_FOCUSED_TEST_MODE:-}"
+focused_test_root="${QBT_FOCUSED_TEST_ROOT:-}"
+
+restore_preparation_failure() {
+  local outcome="$1"
+  local status="${2:-1}"
+  printf '{"restored":false,"outcome":"%s","cutoverCompleted":false,"technicalAdminAuth":{"outcome":"not-attempted","credentialPreserved":false,"reEnrollmentRequired":false}}\n' "$outcome" >&2
+  exit "$status"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --base-dir|--manifest|--service|--port|--maintenance-wrapper)
+      [[ $# -ge 2 && -n "${2:-}" ]] || restore_preparation_failure operator-authorization-failed 2
+      case "$1" in
+        --base-dir) base_dir="$2" ;;
+        --manifest) manifest_path="$2" ;;
+        --service) service_name="$2" ;;
+        --port) port="$2" ;;
+        --maintenance-wrapper) maintenance_wrapper="$2" ;;
+      esac
+      shift 2 || restore_preparation_failure operator-authorization-failed 2
+      ;;
+    *) restore_preparation_failure operator-authorization-failed 2 ;;
+  esac
+done
+
+if [[ "$focused_test_mode" == 1 ]]; then
+  [[ "$EUID" -ne 0 && -n "$focused_test_root" && "$focused_test_root" == /* ]] || {
+    restore_preparation_failure operator-authorization-failed 2
+  }
+  case "$focused_test_root" in
+    /|*..*|*//* )
+      restore_preparation_failure operator-authorization-failed 2
+      ;;
+  esac
+  [[ -d "$focused_test_root" && ! -L "$focused_test_root" ]] || {
+    restore_preparation_failure operator-authorization-failed 2
+  }
+  focused_test_root="$(cd -- "$focused_test_root" && pwd -P)" || restore_preparation_failure operator-authorization-failed 2
+  [[ "$focused_test_root" == "$QBT_FOCUSED_TEST_ROOT" ]] || restore_preparation_failure operator-authorization-failed 2
+  base_dir="$focused_test_root/srv/quadball-timer"
+  backup_directory="$focused_test_root/var/backups/quadball-timer"
+  maintenance_wrapper="${QBT_FOCUSED_TEST_MAINTENANCE_WRAPPER:-$focused_test_root/bin/maintenance-wrapper}"
+  public_origin="${QBT_FOCUSED_TEST_PUBLIC_ORIGIN:-http://127.0.0.1:${port}}"
+fi
+
+systemctl_command="${QBT_FOCUSED_TEST_SYSTEMCTL:-systemctl}"
+sudo_command="${QBT_FOCUSED_TEST_SUDO:-sudo}"
+flock_command="${QBT_FOCUSED_TEST_FLOCK:-flock}"
+readlink_command="${QBT_FOCUSED_TEST_READLINK:-readlink}"
+sed_command="${QBT_FOCUSED_TEST_SED:-sed}"
+curl_command="${QBT_FOCUSED_TEST_CURL:-curl}"
+sleep_command="${QBT_FOCUSED_TEST_SLEEP:-sleep}"
+readiness_attempts="${QBT_FOCUSED_TEST_READINESS_ATTEMPTS:-5}"
+if ! operator_identity="$(id -un)"; then
+  restore_preparation_failure operator-authorization-failed 2
+fi
+if [[ "$focused_test_mode" == 1 ]]; then
+  operator_identity="${QBT_FOCUSED_TEST_OPERATOR:-$operator_identity}"
+fi
+
+if [[ "$focused_test_mode" != 1 && "$EUID" -eq 0 || "$operator_identity" != deploy-quadball-timer ]]; then
+  restore_preparation_failure operator-authorization-failed 2
+fi
+if [[ ! "$service_name" =~ ^[A-Za-z0-9_.@-]+$ || ! "$port" =~ ^[0-9]+$ ]] ||
+  (( port < 1 || port > 65535 )); then
+  restore_preparation_failure operator-authorization-failed 2
+fi
+if [[ "$focused_test_mode" != 1 ]] &&
+  [[ "$base_dir" != /srv/quadball-timer || "$backup_directory" != /var/backups/quadball-timer ||
+    "$maintenance_wrapper" != /usr/local/sbin/quadball-timer-activation-maintenance ]]; then
+  restore_preparation_failure operator-authorization-failed 2
+fi
+[[ "$manifest_path" == "$backup_directory"/verified-*/*.manifest.json && "$manifest_path" != *..* ]] || {
+  restore_preparation_failure restore-selection-invalid 2
+}
+release_dir="$($readlink_command -f -- "$base_dir/current" 2>/dev/null || true)"
+[[ "$release_dir" == "$base_dir"/releases/* && -d "$release_dir" && ! -L "$release_dir" ]] || {
+  restore_preparation_failure release-identity-invalid 2
+}
+
+if ! exec 9>"$base_dir/.activation.lock"; then
+  restore_preparation_failure activation-lock-unavailable 1
+fi
+if ! "$flock_command" -n 9; then
+  restore_preparation_failure activation-lock-unavailable 1
+fi
+service_state="$("$systemctl_command" is-active "$service_name" 2>/dev/null || true)"
+if [[ "$service_state" == active ]]; then
+  if ! "$sudo_command" systemctl stop "$service_name" >/dev/null 2>&1; then
+    restore_preparation_failure service-quiescence-failed 1
+  fi
+fi
+service_state="$("$systemctl_command" is-active "$service_name" 2>/dev/null || true)"
+if [[ "$service_state" != inactive && "$service_state" != failed ]]; then
+  restore_preparation_failure service-quiescence-failed 1
+fi
+
+if [[ ! -f "$release_dir/release-manifest.json" || -L "$release_dir/release-manifest.json" ]]; then
+  restore_preparation_failure release-identity-invalid 1
+fi
+if ! expected_release_id="$($sed_command -n 's/.*"releaseAttemptId":"\([^"]*\)".*/\1/p' "$release_dir/release-manifest.json")" ||
+  ! expected_digest="$($sed_command -n 's/.*"executableSha256":"\([0-9a-f]\{64\}\)".*/\1/p' "$release_dir/release-manifest.json")" ||
+  ! expected_schema="$($sed_command -n 's/.*"schemaCompatibility":"\([^"]*\)".*/\1/p' "$release_dir/release-manifest.json")" ||
+  [[ -z "$expected_release_id" || -z "$expected_digest" || -z "$expected_schema" ]]; then
+  restore_preparation_failure release-identity-invalid 1
+fi
+check_release_identity() {
+  local identity
+  identity="$("$curl_command" --fail --silent --max-time 2 "http://127.0.0.1:${port}/internal/release")" || return 1
+  grep -Fq "\"releaseAttemptId\":\"${expected_release_id}\"" <<<"$identity" &&
+    grep -Fq "\"executableSha256\":\"${expected_digest}\"" <<<"$identity" &&
+    grep -Fq "\"runningExecutableSha256\":\"${expected_digest}\"" <<<"$identity" &&
+    grep -Fq "\"schemaCompatibility\":\"${expected_schema}\"" <<<"$identity"
+}
+check_public_health() {
+  "$curl_command" --fail --silent --max-time 2 "${public_origin}/healthz" |
+    grep -Fxq "healthy"
+}
+check_public_home() {
+  "$curl_command" --fail --silent --max-time 2 "${public_origin}/" |
+    grep -qi "<!doctype html"
+}
+check_post_restart_readiness() {
+  local attempt
+  for ((attempt = 1; attempt <= readiness_attempts; attempt++)); do
+    if [[ "$("$systemctl_command" is-active "$service_name" 2>/dev/null || true)" == active ]] &&
+      "$curl_command" --fail --silent --max-time 2 "http://127.0.0.1:${port}/internal/healthz" >/dev/null &&
+      check_release_identity
+    then return 0; fi
+    "$sleep_command" 1
+  done
+  return 1
+}
+check_representative_event_read() {
+  "$curl_command" --fail --silent --max-time 2 \
+    "${public_origin}/api/audience/events" >/dev/null
+}
+check_authoritative_operation() {
+  local operation
+  operation="$("$sudo_command" "$maintenance_wrapper" production "$release_dir" authoritative-operation "" 2>/dev/null)" || return 1
+  grep -Fq '"ok":true' <<<"$operation"
+}
+set +e
+restore_report="$("$sudo_command" "$maintenance_wrapper" production "$release_dir" restore "$manifest_path" 2>&1)"
+restore_rc=$?
+set -e
+bounded_restore_report="$(printf '%s\n' "$restore_report" | grep -m1 -E '^\{"restored":true,"restoreId":|^\{"restored":false,"outcome":' || true)"
+if [[ -z "$bounded_restore_report" ]]; then
+  bounded_restore_report='{"restored":false,"outcome":"restore-preparation-failed","cutoverCompleted":false,"technicalAdminAuth":{"outcome":"not-attempted","credentialPreserved":false,"reEnrollmentRequired":false}}'
+fi
+technical_admin_auth="$(printf '%s\n' "$bounded_restore_report" | sed -n -E 's/.*"technicalAdminAuth":(\{"outcome":"[^"]+","credentialPreserved":(true|false),"reEnrollmentRequired":(true|false)\}).*/\1/p')"
+if [[ -z "$technical_admin_auth" ]]; then
+  technical_admin_auth='{"outcome":"not-attempted","credentialPreserved":false,"reEnrollmentRequired":false}'
+fi
+authority_resurrection_warning='Restoring an older snapshot may resurrect Grants, Grant Sessions, Ad Hoc Controller sessions, or QR-admitting state changed after the snapshot.'
+restore_outcome="$(printf '%s\n' "$bounded_restore_report" | sed -n -E 's/^\{"restored":[^,]*,"outcome":"([^"]+)".*/\1/p')"
+case "$restore_outcome" in
+  restore-preparation-failed|restore-selection-invalid|restore-staging-failed|release-identity-invalid|activation-lock-unavailable|service-quiescence-failed|operator-authorization-failed)
+    ;;
+  *) restore_outcome="restore-failed" ;;
+esac
+stop_after_failure() {
+  local state
+  "$sudo_command" systemctl stop "$service_name" >/dev/null 2>&1 || return 1
+  state="$("$systemctl_command" is-active "$service_name" 2>/dev/null || true)"
+  [[ "$state" == inactive || "$state" == failed ]]
+}
+if (( restore_rc == 12 )); then
+  if stop_after_failure; then
+    printf '{"restored":false,"outcome":"cutover-completed-readiness-failed","cutoverCompleted":true,"restartVerified":false,"serviceStopped":true,"technicalAdminAuth":%s,"authorityResurrectionWarning":"%s"}\n' "$technical_admin_auth" "$authority_resurrection_warning" >&2
+  else
+    printf '{"restored":false,"outcome":"cutover-completed-readiness-failed","cutoverCompleted":true,"restartVerified":false,"serviceStopped":false,"technicalAdminAuth":%s,"authorityResurrectionWarning":"%s"}\n' "$technical_admin_auth" "$authority_resurrection_warning" >&2
+  fi
+  exit 12
+fi
+if (( restore_rc != 0 )); then
+  if grep -Fq '"cutoverCompleted":true' <<<"$bounded_restore_report"; then
+    if stop_after_failure; then
+      printf '{"restored":false,"outcome":"cutover-completed-restore-failed","cutoverCompleted":true,"serviceStopped":true,"technicalAdminAuth":%s,"authorityResurrectionWarning":"%s"}\n' "$technical_admin_auth" "$authority_resurrection_warning" >&2
+    else
+      printf '{"restored":false,"outcome":"cutover-completed-restore-failed","cutoverCompleted":true,"serviceStopped":false,"technicalAdminAuth":%s,"authorityResurrectionWarning":"%s"}\n' "$technical_admin_auth" "$authority_resurrection_warning" >&2
+    fi
+    exit 12
+  fi
+  if stop_after_failure; then
+    printf '{"restored":false,"outcome":"%s","cutoverCompleted":false,"serviceStopped":true,"technicalAdminAuth":%s}\n' "$restore_outcome" "$technical_admin_auth" >&2
+  else
+    printf '{"restored":false,"outcome":"%s","cutoverCompleted":false,"serviceStopped":false,"technicalAdminAuth":%s}\n' "$restore_outcome" "$technical_admin_auth" >&2
+  fi
+  exit 1
+fi
+
+if ! check_post_restart_readiness || ! check_public_home || ! check_public_health ||
+  ! check_representative_event_read || ! check_authoritative_operation; then
+  if stop_after_failure; then
+    printf '{"restored":false,"outcome":"cutover-completed-readiness-failed","cutoverCompleted":true,"restartVerified":true,"postRestartVerified":false,"serviceStopped":true,"technicalAdminAuth":%s,"authorityResurrectionWarning":"%s"}\n' "$technical_admin_auth" "$authority_resurrection_warning" >&2
+  else
+    printf '{"restored":false,"outcome":"cutover-completed-readiness-failed","cutoverCompleted":true,"restartVerified":true,"postRestartVerified":false,"serviceStopped":false,"technicalAdminAuth":%s,"authorityResurrectionWarning":"%s"}\n' "$technical_admin_auth" "$authority_resurrection_warning" >&2
+  fi
+  exit 12
+fi
+printf '%s\n' "$bounded_restore_report"
+printf '{"restored":true,"outcome":"cutover-completed","postRestartVerified":true,"technicalAdminAuth":%s}\n' "$technical_admin_auth"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "format": "bunx --bun oxfmt \"**/*.{js,jsx,ts,tsx,mjs,cjs}\" \"!docs/**\"",
     "format:check": "bunx --bun oxfmt \"**/*.{js,jsx,ts,tsx,mjs,cjs}\" \"!docs/**\" --check",
     "lint": "bunx --bun oxlint --type-aware --type-check --ignore-pattern \"docs/**\"",
-    "lint:shell": "shellcheck deploy/activate-release.sh deploy/activate-test-release.sh deploy/activation-maintenance-root.sh",
+    "lint:shell": "shellcheck deploy/activate-release.sh deploy/activate-test-release.sh deploy/activation-maintenance-root.sh deploy/restore-production.sh",
     "check:bun-version": "bun scripts/check-bun-version.ts",
     "check:testing-policy": "bun scripts/check-testing-policy.ts",
     "check": "bun run check:bun-version && bun run check:testing-policy && bun run format:check && bun run lint && bun run lint:shell"

--- a/scripts/create-release-bundle.ts
+++ b/scripts/create-release-bundle.ts
@@ -30,6 +30,7 @@ const sourceByBundlePath: Record<string, string> = {
   "deploy/activate-release.sh": "deploy/activate-release.sh",
   "deploy/activate-test-release.sh": "deploy/activate-test-release.sh",
   "deploy/activation-maintenance-root.sh": "deploy/activation-maintenance-root.sh",
+  "deploy/restore-production.sh": "deploy/restore-production.sh",
   "deploy/systemd/quadball-timer.service": "deploy/systemd/quadball-timer.service",
   "deploy/systemd/quadball-timer-test.service": "deploy/systemd/quadball-timer-test.service",
 };

--- a/src/lib/foundation-recovery.test.ts
+++ b/src/lib/foundation-recovery.test.ts
@@ -323,8 +323,11 @@ describe("Event foundation recovery", () => {
       });
       await expectRejected(rollback.restore(manifestPath), "fast rollback");
       expect(adHoc.readLive()).toBe("newer-live-state");
-      expect(existsSync(`${adHocPath}.failed-fast-rollback-restore`)).toBe(false);
-      expect(existsSync(`${livePath}.failed-fast-rollback-restore`)).toBe(false);
+      expect(existsSync(`${adHocPath}.failed-fast-rollback-restore`)).toBe(true);
+      expect(await readFile(`${adHocPath}.failed-fast-rollback-restore`, "utf8")).toBe(
+        "newer-live-state",
+      );
+      expect(existsSync(`${livePath}.failed-fast-rollback-restore`)).toBe(true);
       harness.storage.close();
     });
   });
@@ -473,6 +476,9 @@ describe("Event foundation recovery", () => {
       });
       expect(recovery.restore(manifestPath)).rejects.toThrow("injected replacement failure");
       expect(existsSync(livePath)).toBe(true);
+      expect(
+        existsSync(join(backupDirectory, "verify-2.restore-attempt", "foundation.sqlite.staged")),
+      ).toBe(true);
       expect(existsSync(technicalAdminPath)).toBe(true);
       for (const privatePath of [livePath, `${livePath}.quarantine`]) {
         expect(lstatSync(privatePath).mode & 0o777).toBe(0o600);
@@ -507,21 +513,23 @@ describe("Event foundation recovery", () => {
           }
         },
       });
-      const restored = await recovery.restore(manifestPath);
-      expect(restored).toMatchObject({
-        completed: true,
-        completionEvidencePath: null,
-        completionEvidenceStatus: "write-failed",
+      const failure = await recovery.restore(manifestPath).then(
+        () => null,
+        (error: unknown) => error,
+      );
+      expect(failure).toMatchObject({
+        phase: "post-cutover-evidence",
+        cutoverCompleted: true,
       });
-      expect(JSON.parse(readFileSync(restored.evidencePath, "utf8"))).toMatchObject({
-        status: "pending-replacement",
-        restoreId: restored.restoreId,
-        snapshotId: manifest.snapshotId,
-      });
+      if (!(failure instanceof Error)) throw new Error("Expected completion evidence failure.");
+      const restoreId = "restore-completion-io";
+      expect(existsSync(join(backupDirectory, `${restoreId}.restore-completed.json`))).toBe(false);
+      expect(existsSync(`${livePath}.failed-${restoreId}`)).toBe(true);
       expect(
-        existsSync(join(backupDirectory, `${restored.restoreId}.restore-completed.json`)),
-      ).toBe(false);
-      expect(existsSync(restored.failedDatabasePath)).toBe(true);
+        existsSync(
+          join(backupDirectory, `${restoreId}.restore-attempt`, "foundation.sqlite.staged"),
+        ),
+      ).toBe(true);
       const reopened = openSqliteFoundationStorage(livePath, {
         grantKeyRing: initial.keyRing,
         grantValidationContext: { environmentId: "test", keyRing: initial.keyRing },
@@ -543,8 +551,9 @@ describe("Event foundation recovery", () => {
       const manifestPath = join(backupDirectory, `${manifest.snapshotId}.manifest.json`);
       const backupPath = join(backupDirectory, manifest.databaseFile);
       const stagedPath = join(
-        dirname(livePath),
-        ".foundation.sqlite.restore-pre-reevaluation-race.staged",
+        backupDirectory,
+        "restore-pre-reevaluation-race.restore-attempt",
+        "foundation.sqlite.staged",
       );
       const displacedPath = `${stagedPath}.verified-inode`;
       const recovery = createFoundationRecovery(initial.storage, {
@@ -575,7 +584,11 @@ describe("Event foundation recovery", () => {
       const initial = await createHarness(livePath, backupDirectory, () => ids.shift() ?? "extra");
       const manifest = await initial.recovery.createPreDeploymentBackup();
       const manifestPath = join(backupDirectory, `${manifest.snapshotId}.manifest.json`);
-      const stagedPath = join(dirname(livePath), ".foundation.sqlite.restore-stage-race.staged");
+      const stagedPath = join(
+        backupDirectory,
+        "restore-stage-race.restore-attempt",
+        "foundation.sqlite.staged",
+      );
       const displacedPath = `${stagedPath}.verified-inode`;
       const recovery = createFoundationRecovery(initial.storage, {
         ...initial.options,
@@ -610,8 +623,9 @@ describe("Event foundation recovery", () => {
       const manifest = await initial.recovery.createPreDeploymentBackup();
       const manifestPath = join(backupDirectory, `${manifest.snapshotId}.manifest.json`);
       const stagedPath = join(
-        dirname(livePath),
-        ".foundation.sqlite.restore-stage-mutation.staged",
+        backupDirectory,
+        "restore-stage-mutation.restore-attempt",
+        "foundation.sqlite.staged",
       );
       const recovery = createFoundationRecovery(initial.storage, {
         ...initial.options,
@@ -742,9 +756,14 @@ describe("Event foundation recovery", () => {
       if (!(sanitationFailure instanceof Error)) {
         throw new Error("Expected auth sanitation to abort the restore.");
       }
+      expect(sanitationFailure).toMatchObject({
+        phase: "auth-sanitation",
+        cutoverCompleted: false,
+        technicalAdminAuth: { outcome: "sanitation-failed" },
+      });
       expect(sanitationFailure.message).toContain("sanitation failed before replacement");
       expect(replacementAttempted).toBe(false);
-      expect(existsSync(livePath + ".failed-restore")).toBe(false);
+      expect(existsSync(livePath + ".failed-restore")).toBe(true);
       const evidence = JSON.parse(
         readFileSync(join(backupDirectory, "restore.restore-evidence.json"), "utf8"),
       );
@@ -753,6 +772,86 @@ describe("Event foundation recovery", () => {
         technicalAdminAuth: { outcome: "sanitation-failed" },
       });
       expect(JSON.stringify(evidence)).not.toMatch(/credential|origin|session|schema|path/i);
+      harness.storage.close();
+    });
+  });
+
+  test("reports untouched auth and preserves evidence when failure precedes the adapter", async () => {
+    await withRecoveryPaths(async ({ livePath, backupDirectory }) => {
+      const harness = await createHarness(livePath, backupDirectory, () => "before-auth");
+      const manifest = await harness.recovery.createPreDeploymentBackup();
+      let adapterCalled = false;
+      const recovery = createFoundationRecovery(harness.storage, {
+        ...harness.options,
+        technicalAdminAuth: {
+          ...harness.options.technicalAdminAuth,
+          adapter: {
+            async prepareForFoundationRestore() {
+              adapterCalled = true;
+              return { outcome: "preserved-transients-invalidated" as const };
+            },
+          },
+        },
+        faultInjector(phase) {
+          if (phase === "after-authoritative-quiescence") {
+            throw new Error("injected before auth adapter");
+          }
+        },
+      });
+      const failure = await recovery
+        .restore(join(backupDirectory, `${manifest.snapshotId}.manifest.json`))
+        .then(
+          () => null,
+          (error: unknown) => error,
+        );
+      expect(failure).toMatchObject({
+        phase: "auth-sanitation",
+        cutoverCompleted: false,
+        technicalAdminAuth: {
+          outcome: "not-attempted",
+          credentialPreserved: false,
+          reEnrollmentRequired: false,
+        },
+      });
+      expect(adapterCalled).toBe(false);
+      expect(existsSync(`${livePath}.failed-before-auth`)).toBe(true);
+      expect(
+        existsSync(
+          join(backupDirectory, "before-auth.restore-attempt", "foundation.sqlite.staged"),
+        ),
+      ).toBe(true);
+      harness.storage.close();
+    });
+  });
+
+  test("preserves evaluated restore evidence after post-cutover inspection failure", async () => {
+    await withRecoveryPaths(async ({ livePath, backupDirectory }) => {
+      const ids = ["snapshot", "verify-backup", "restore", "verify-restore"];
+      const harness = await createHarness(livePath, backupDirectory, () => ids.shift() ?? "extra");
+      const manifest = await harness.recovery.createPreDeploymentBackup();
+      const recovery = createFoundationRecovery(harness.storage, {
+        ...harness.options,
+        faultInjector(phase) {
+          if (phase === "after-post-cutover-inspection") {
+            throw new Error("injected post-cutover inspection failure");
+          }
+        },
+      });
+
+      const failure = await recovery
+        .restore(join(backupDirectory, `${manifest.snapshotId}.manifest.json`))
+        .then(
+          () => null,
+          (error: unknown) => error,
+        );
+      expect(failure).toMatchObject({
+        phase: "post-cutover-evidence",
+        cutoverCompleted: true,
+      });
+      expect(existsSync(`${livePath}.failed-restore`)).toBe(true);
+      expect(
+        existsSync(join(backupDirectory, "restore.restore-attempt", "foundation.sqlite.staged")),
+      ).toBe(true);
       harness.storage.close();
     });
   });
@@ -793,6 +892,15 @@ describe("Event foundation recovery", () => {
       if (!(replacementFailure instanceof Error)) {
         throw new Error("Expected Foundation replacement to fail.");
       }
+      expect(replacementFailure).toMatchObject({
+        phase: "foundation-replacement",
+        cutoverCompleted: false,
+        technicalAdminAuth: {
+          outcome: "preserved-transients-invalidated",
+          credentialPreserved: true,
+          reEnrollmentRequired: false,
+        },
+      });
       expect(replacementFailure.message).toContain("injected Foundation replacement failure");
       expect(readFileSync(technicalAdminPath, "utf8")).toBe("preserved-credential-no-transients");
       harness.storage.close();

--- a/src/lib/foundation-recovery.ts
+++ b/src/lib/foundation-recovery.ts
@@ -45,6 +45,7 @@ import type { FoundationStorageTransaction } from "@/lib/foundation-storage";
 import type { AdHocRecoveryAdapter, AdHocRecoveryFacts } from "@/lib/ad-hoc-games";
 import type {
   TechnicalAdminAuth,
+  TechnicalAdminRecoveryResult,
   TechnicalAdminRestorePreparationRequest,
   TechnicalAdminRestorePreparationResult,
 } from "@/lib/technical-admin-auth";
@@ -111,6 +112,7 @@ export type FoundationRecoveryOptions = {
       | "after-restore-staging"
       | "after-authoritative-quiescence"
       | "after-final-authority-evaluation"
+      | "after-post-cutover-inspection"
       | "after-live-preserved"
       | "before-live-replacement"
       | "before-completed-restore-evidence",
@@ -159,6 +161,8 @@ export type FoundationRecovery = {
     completionEvidencePath: string | null;
     completionEvidenceStatus: "written" | "write-failed";
     potentiallyNewerWork: boolean | null;
+    technicalAdminAuth: FoundationRestoreSuccessTechnicalAdminReport;
+    authorityResurrectionWarning: string;
   }>;
   importControllerRecovery(
     input: RecoveryImportInput,
@@ -168,6 +172,37 @@ export type FoundationRecovery = {
 export type FoundationRestoreOptions = {
   technicalAdminAuthMode?: TechnicalAdminRestorePreparationRequest["mode"];
 };
+
+export type FoundationRestoreFailurePhase =
+  | "staging"
+  | "auth-sanitation"
+  | "pre-cutover-validation"
+  | "foundation-replacement"
+  | "post-cutover-evidence";
+type FoundationRestoreSuccessTechnicalAdminReport = Exclude<
+  TechnicalAdminRecoveryResult,
+  { outcome: "not-attempted" | "sanitation-failed" }
+>;
+type FoundationRestoreTechnicalAdminReport = TechnicalAdminRecoveryResult;
+
+export class FoundationRestoreFailure extends Error {
+  readonly technicalAdminAuth: FoundationRestoreTechnicalAdminReport;
+  readonly phase: FoundationRestoreFailurePhase;
+  readonly cutoverCompleted: boolean;
+
+  constructor(
+    cause: unknown,
+    technicalAdminAuth: FoundationRestoreTechnicalAdminReport,
+    phase: FoundationRestoreFailurePhase,
+    cutoverCompleted: boolean,
+  ) {
+    super(cause instanceof Error ? cause.message : "Foundation restore failed.");
+    this.name = "FoundationRestoreFailure";
+    this.technicalAdminAuth = technicalAdminAuth;
+    this.phase = phase;
+    this.cutoverCompleted = cutoverCompleted;
+  }
+}
 
 export function createFoundationRecovery(
   storage: SqliteFoundationStorage,
@@ -345,13 +380,14 @@ export function createFoundationRecovery(
     const manifest = await readManifest(manifestPath, backupDirectory);
     const backupPath = resolveBackupDatabasePath(manifestPath, manifest, backupDirectory);
     const restoreId = boundedId(createId(), "restoreId");
-    const stagedPath = join(liveDirectory, `.${basename(livePath)}.${restoreId}.staged`);
+    const restoreAttemptDirectory = join(backupDirectory, `${restoreId}.restore-attempt`);
+    const stagedPath = join(restoreAttemptDirectory, `${basename(livePath)}.staged`);
     const failedDatabasePath = `${livePath}.failed-${restoreId}`;
     const adHocLivePath = options.adHoc?.databasePath ?? null;
     const stagedAdHocPath =
       adHocLivePath === null
         ? null
-        : join(dirname(adHocLivePath), `.${basename(adHocLivePath)}.${restoreId}.staged`);
+        : join(restoreAttemptDirectory, `${basename(adHocLivePath)}.staged`);
     const failedAdHocDatabasePath =
       adHocLivePath === null ? null : `${adHocLivePath}.failed-${restoreId}`;
     const evidencePath = join(backupDirectory, `${restoreId}.restore-evidence.json`);
@@ -362,8 +398,25 @@ export function createFoundationRecovery(
     let staged: SqliteFoundationStorage | undefined;
     let stagedIdentity: StableFileIdentity | null = null;
     let stagedAdHocIdentity: StableFileIdentity | null = null;
+    const stagedSidecarIdentities = new Map<string, StableFileIdentity>();
     let evidenceIdentity: StableFileIdentity | null = null;
+    let cutoverCompleted = false;
+    let restoreSucceeded = false;
+    let restorePhase: FoundationRestoreFailurePhase = "staging";
+    let technicalAdminAuthReport: FoundationRestoreTechnicalAdminReport = {
+      outcome: "not-attempted",
+      credentialPreserved: false,
+      reEnrollmentRequired: false,
+    };
+    const rememberStagedSidecars = async () => {
+      for (const sidecarPath of [`${stagedPath}-wal`, `${stagedPath}-shm`]) {
+        if (stagedSidecarIdentities.has(sidecarPath) || !(await pathExists(sidecarPath))) continue;
+        stagedSidecarIdentities.set(sidecarPath, stableIdentity(await lstat(sidecarPath)));
+      }
+    };
     try {
+      await mkdir(restoreAttemptDirectory, { mode: 0o700 });
+      await assertOwnedPrivateDirectory(restoreAttemptDirectory, "restore attempt workspace");
       await assertPathAbsent(failedDatabasePath, "failed Event foundation image");
       if (failedAdHocDatabasePath !== null)
         await assertPathAbsent(failedAdHocDatabasePath, "failed Ad Hoc image");
@@ -412,6 +465,7 @@ export function createFoundationRecovery(
       // Both authoritative writer domains are closed before the final current-fact
       // evaluation. Any writer already queued drains before this boundary; any
       // later writer is rejected by the closed repositories.
+      restorePhase = "auth-sanitation";
       await options.technicalAdminAuth.quiesce();
       await storage.quiesceForRecovery();
       await options.adHoc?.quiesceForRecovery();
@@ -423,6 +477,7 @@ export function createFoundationRecovery(
       );
       const technicalAdminAuthEvidence =
         redactTechnicalAdminRestoreResult(technicalAdminAuthResult);
+      technicalAdminAuthReport = toTechnicalAdminRecoveryResult(technicalAdminAuthResult);
       if (technicalAdminAuthResult.outcome === "sanitation-failed") {
         evidenceIdentity = await writeJsonFile(
           evidencePath,
@@ -442,6 +497,9 @@ export function createFoundationRecovery(
         );
         throw new Error("Technical Admin authentication sanitation failed before replacement.");
       }
+      const technicalAdminAuthSuccessReport =
+        toTechnicalAdminSuccessResult(technicalAdminAuthResult);
+      restorePhase = "pre-cutover-validation";
       // The finite auth result is committed to the pending record before any
       // Foundation replacement. A later replacement rollback changes only
       // Foundation state and leaves the already-sanitized auth store untouched.
@@ -474,13 +532,35 @@ export function createFoundationRecovery(
           keyRing: options.keyRing,
         },
       });
+      await rememberStagedSidecars();
       staged.setReadinessContext(options.readinessContext);
-      await reevaluateRestoredAuthority(staged, options.grant);
-      const stagedReadiness = await staged.readiness();
+      let stagedReadiness = await staged.readiness();
+      if (!stagedReadiness.ok) {
+        const migration = await staged.migrationPreflight();
+        if (migration.status !== "pending" && migration.status !== "missing") {
+          throw new Error("Restored staging database has incompatible migrations.");
+        }
+        try {
+          await staged.applyMigrations({ requireCandidate: false });
+        } finally {
+          await rememberStagedSidecars();
+        }
+        stagedReadiness = await staged.readiness();
+      }
+      try {
+        await reevaluateRestoredAuthority(staged, options.grant);
+      } finally {
+        await rememberStagedSidecars();
+      }
+      stagedReadiness = await staged.readiness();
       if (!stagedReadiness.ok || stagedReadiness.evidence?.keys.missingCount !== 0) {
         throw new Error("Restored staging database did not pass independent readiness.");
       }
-      await staged.quiesceForRecovery();
+      try {
+        await staged.quiesceForRecovery();
+      } finally {
+        await rememberStagedSidecars();
+      }
       staged = undefined;
       const reevaluatedStagedIdentity = await assertOwnedPrivateFile(
         stagedPath,
@@ -515,6 +595,7 @@ export function createFoundationRecovery(
         identity: StableFileIdentity;
       }> = [];
       const installedPaths: Array<{ path: string; identity: StableFileIdentity }> = [];
+      restorePhase = "foundation-replacement";
       try {
         const failedLiveIdentity = await moveToExclusivePath(
           livePath,
@@ -584,6 +665,10 @@ export function createFoundationRecovery(
             stagedIdentity,
           ),
         });
+        // Once the candidate has replaced the live Foundation path, report the
+        // cutover boundary truthfully even if a later sidecar or Ad Hoc move
+        // fails and the bounded rollback path is entered.
+        cutoverCompleted = true;
         stagedIdentity = null;
         for (const suffix of ["-wal", "-shm"] as const) {
           if (await pathExists(`${stagedPath}${suffix}`)) {
@@ -639,16 +724,18 @@ export function createFoundationRecovery(
           await syncDirectory(dirname(adHocLivePath));
         }
       } catch (error) {
-        for (const installed of installedPaths.reverse())
+        for (const installed of installedPaths.reverse()) {
+          const preservedCandidatePath = join(
+            restoreAttemptDirectory,
+            `installed-${basename(installed.path)}`,
+          );
+          await copyStablePrivateFile(installed.path, preservedCandidatePath);
           await removeStablePath(installed.path, installed.identity);
+        }
         for (const moved of movedSidecars.reverse()) {
-          if (await pathExists(moved.from))
-            await moveToExclusivePath(
-              moved.from,
-              moved.to,
-              "recovery rollback image",
-              moved.identity,
-            );
+          if (await pathExists(moved.from)) {
+            await copyStablePrivateFile(moved.from, moved.to);
+          }
         }
         await syncDirectory(liveDirectory);
         if (adHocLivePath !== null && dirname(adHocLivePath) !== liveDirectory) {
@@ -656,11 +743,21 @@ export function createFoundationRecovery(
         }
         throw error;
       }
+      cutoverCompleted = true;
+      restorePhase = "post-cutover-evidence";
+      // Keep an evaluated candidate copy in the retryable attempt workspace. It
+      // is transient only on complete success and remains evidence on every
+      // later inspection or evidence failure.
+      stagedIdentity = await copyStablePrivateFile(livePath, stagedPath);
+      if (stagedAdHocPath !== null && adHocLivePath !== null) {
+        stagedAdHocIdentity = await copyStablePrivateFile(adHocLivePath, stagedAdHocPath);
+      }
       const restoredFacts = safelyInspectClosedDatabase(livePath);
       const restoredAdHocFacts =
         options.adHoc !== undefined && adHocLivePath !== null
           ? options.adHoc.inspectRecoveryDatabase(adHocLivePath)
           : null;
+      options.faultInjector?.("after-post-cutover-inspection");
       const evidence = {
         version: RECOVERY_EVIDENCE_VERSION,
         kind: "restore",
@@ -692,19 +789,10 @@ export function createFoundationRecovery(
             ? manifest.restoredGrantVersions
             : redactGrantVersions(restoredFacts),
       };
-      let completionEvidencePath: string | null = null;
-      let completionEvidenceStatus: "written" | "write-failed" = "write-failed";
-      try {
-        await assertStablePrivateFile(evidencePath, evidenceIdentity, "pending restore evidence");
-        options.faultInjector?.("before-completed-restore-evidence");
-        await writeAtomicJsonFile(completionEvidenceCandidatePath, evidence);
-        completionEvidencePath = completionEvidenceCandidatePath;
-        completionEvidenceStatus = "written";
-      } catch {
-        // Cutover is already complete. The immutable, synced pending record and
-        // explicit return state prevent a write failure from being reported as
-        // a failed restore or inviting an unsafe retry.
-      }
+      await assertStablePrivateFile(evidencePath, evidenceIdentity, "pending restore evidence");
+      options.faultInjector?.("before-completed-restore-evidence");
+      await writeAtomicJsonFile(completionEvidenceCandidatePath, evidence);
+      restoreSucceeded = true;
       return {
         restoreId,
         failedDatabasePath,
@@ -715,20 +803,50 @@ export function createFoundationRecovery(
             : null,
         completed: true as const,
         evidencePath,
-        completionEvidencePath,
-        completionEvidenceStatus,
+        completionEvidencePath: completionEvidenceCandidatePath,
+        completionEvidenceStatus: "written" as const,
         potentiallyNewerWork,
+        technicalAdminAuth: technicalAdminAuthSuccessReport,
+        authorityResurrectionWarning:
+          "Restoring an older snapshot may resurrect Grants, Grant Sessions, Ad Hoc Controller sessions, or QR-admitting state changed after the snapshot.",
       };
+    } catch (error) {
+      try {
+        if (!(await pathExists(failedDatabasePath)) && (await pathExists(livePath))) {
+          await copyStablePrivateFile(livePath, failedDatabasePath);
+        }
+      } catch {
+        // Preserve the bounded failure classification even if evidence I/O is
+        // unavailable; never replace it with a raw filesystem exception.
+      }
+      try {
+        if (
+          failedAdHocDatabasePath !== null &&
+          adHocLivePath !== null &&
+          !(await pathExists(failedAdHocDatabasePath)) &&
+          (await pathExists(adHocLivePath))
+        ) {
+          await copyStablePrivateFile(adHocLivePath, failedAdHocDatabasePath);
+        }
+      } catch {
+        // The original Foundation failure and auth outcome remain authoritative.
+      }
+      throw new FoundationRestoreFailure(
+        error,
+        technicalAdminAuthReport,
+        restorePhase,
+        cutoverCompleted,
+      );
     } finally {
       staged?.close();
-      if (stagedIdentity !== null) await removeStablePath(stagedPath, stagedIdentity);
-      if (stagedAdHocIdentity !== null && stagedAdHocPath !== null)
-        await removeStablePath(stagedAdHocPath, stagedAdHocIdentity);
-      await rm(`${stagedPath}-wal`, { force: true });
-      await rm(`${stagedPath}-shm`, { force: true });
-      if (stagedAdHocPath !== null) {
-        await rm(`${stagedAdHocPath}-wal`, { force: true });
-        await rm(`${stagedAdHocPath}-shm`, { force: true });
+      if (restoreSucceeded) {
+        if (stagedIdentity !== null) await removeMatchingStablePath(stagedPath, stagedIdentity);
+        if (stagedAdHocIdentity !== null && stagedAdHocPath !== null)
+          await removeMatchingStablePath(stagedAdHocPath, stagedAdHocIdentity);
+        for (const [sidecarPath, identity] of stagedSidecarIdentities) {
+          await removeMatchingStablePath(sidecarPath, identity);
+        }
+        await rm(restoreAttemptDirectory, { recursive: true, force: true });
       }
     }
   }
@@ -889,6 +1007,50 @@ async function prepareTechnicalAdminForRestore(
     // The composition boundary deliberately exposes no adapter or storage error.
   }
   return { outcome: "sanitation-failed" };
+}
+
+function toTechnicalAdminRecoveryResult(
+  result: TechnicalAdminRestorePreparationResult,
+): Exclude<TechnicalAdminRecoveryResult, { outcome: "not-attempted" }> {
+  if (result.outcome === "preserved-transients-invalidated") {
+    return {
+      outcome: result.outcome,
+      credentialPreserved: true,
+      reEnrollmentRequired: false,
+    };
+  }
+  if (result.outcome === "re-enrollment-required") {
+    return {
+      outcome: result.outcome,
+      credentialPreserved: false,
+      reEnrollmentRequired: true,
+    };
+  }
+  return {
+    outcome: "sanitation-failed",
+    credentialPreserved: false,
+    reEnrollmentRequired: false,
+  };
+}
+
+function toTechnicalAdminSuccessResult(
+  result: TechnicalAdminRestorePreparationResult,
+): FoundationRestoreSuccessTechnicalAdminReport {
+  if (result.outcome === "preserved-transients-invalidated") {
+    return {
+      outcome: result.outcome,
+      credentialPreserved: true,
+      reEnrollmentRequired: false,
+    };
+  }
+  if (result.outcome === "re-enrollment-required") {
+    return {
+      outcome: result.outcome,
+      credentialPreserved: false,
+      reEnrollmentRequired: true,
+    };
+  }
+  throw new Error("Technical Admin sanitation did not produce a successful recovery result.");
 }
 
 function redactTechnicalAdminRestoreResult(
@@ -1357,6 +1519,18 @@ async function assertOwnedPrivateFile(path: string, label: string): Promise<Stab
   return stableIdentity(info);
 }
 
+async function assertOwnedPrivateDirectory(path: string, label: string): Promise<void> {
+  const info = await lstat(path);
+  const currentUid = process.getuid?.();
+  if (
+    info.isSymbolicLink() ||
+    !info.isDirectory() ||
+    (info.mode & 0o777) !== 0o700 ||
+    (currentUid !== undefined && info.uid !== currentUid)
+  )
+    throw new Error(`${label} must be an owned non-symlink 0700 directory.`);
+}
+
 async function assertStablePrivateFile(
   path: string,
   expected: StableFileIdentity,
@@ -1364,6 +1538,26 @@ async function assertStablePrivateFile(
 ): Promise<void> {
   const current = await assertOwnedPrivateFile(path, label);
   if (!samePhysicalFile(current, expected)) {
+    throw new Error(`${label} changed file identity during recovery.`);
+  }
+}
+
+async function assertStableSourceFile(
+  path: string,
+  expected: StableFileIdentity,
+  label: string,
+): Promise<void> {
+  const info = await lstat(path);
+  const currentUid = process.getuid?.();
+  if (
+    info.isSymbolicLink() ||
+    !info.isFile() ||
+    (currentUid !== undefined && info.uid !== currentUid)
+  ) {
+    throw new Error(`${label} must be an owned non-symlink regular file.`);
+  }
+  const current = stableIdentity(info);
+  if (!sameFileSnapshot(current, expected)) {
     throw new Error(`${label} changed file identity during recovery.`);
   }
 }
@@ -1379,17 +1573,25 @@ async function assertStableFileIdentity(
   }
 }
 
-async function readStablePrivateFile(path: string): Promise<Buffer> {
+async function readStablePrivateFile(path: string, requirePrivateMode = true): Promise<Buffer> {
   const handle = await openFile(path, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
   try {
     const before = stableIdentity(await handle.stat());
-    await assertStablePrivateFile(path, before, "recovery source file");
+    if (requirePrivateMode) {
+      await assertStablePrivateFile(path, before, "recovery source file");
+    } else {
+      await assertStableSourceFile(path, before, "recovery source file");
+    }
     const content = await handle.readFile();
     const after = stableIdentity(await handle.stat());
     if (!sameFileSnapshot(before, after)) {
       throw new Error("Recovery source file changed while it was read.");
     }
-    await assertStablePrivateFile(path, before, "recovery source file");
+    if (requirePrivateMode) {
+      await assertStablePrivateFile(path, before, "recovery source file");
+    } else {
+      await assertStableSourceFile(path, before, "recovery source file");
+    }
     return content;
   } finally {
     await handle.close();
@@ -1401,19 +1603,28 @@ async function copyStablePrivateFile(
   destinationPath: string,
   expectedSha256?: string,
 ): Promise<StableFileIdentity> {
-  const content = await readStablePrivateFile(sourcePath);
-  if (
-    expectedSha256 !== undefined &&
-    createHash("sha256").update(content).digest("hex") !== expectedSha256
-  )
-    throw new Error("Verified backup file identity does not match its manifest.");
-  const destination = await openFile(
-    destinationPath,
-    fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_NOFOLLOW,
-    0o600,
-  );
+  const source = await openFile(sourcePath, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
+  let sourceIdentity: StableFileIdentity | null = null;
+  let destination: Awaited<ReturnType<typeof openFile>> | undefined;
   let openedIdentity: StableFileIdentity | null = null;
   try {
+    sourceIdentity = stableIdentity(await source.stat());
+    await assertStableSourceFile(sourcePath, sourceIdentity, "recovery source file");
+    const content = await source.readFile();
+    const afterReadIdentity = stableIdentity(await source.stat());
+    if (!sameFileSnapshot(sourceIdentity, afterReadIdentity)) {
+      throw new Error("Recovery source file changed while it was read.");
+    }
+    if (
+      expectedSha256 !== undefined &&
+      createHash("sha256").update(content).digest("hex") !== expectedSha256
+    )
+      throw new Error("Verified backup file identity does not match its manifest.");
+    destination = await openFile(
+      destinationPath,
+      fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_NOFOLLOW,
+      0o600,
+    );
     await destination.chmod(0o600);
     openedIdentity = stableIdentity(await destination.stat());
     await assertStablePrivateFile(destinationPath, openedIdentity, "recovery copy");
@@ -1425,12 +1636,16 @@ async function copyStablePrivateFile(
     }
     await assertStablePrivateFile(destinationPath, writtenIdentity, "recovery copy");
     await destination.close();
+    destination = undefined;
+    await assertStableSourceFile(sourcePath, sourceIdentity, "recovery source file");
     await assertStablePrivateFile(destinationPath, writtenIdentity, "recovery copy");
     return writtenIdentity;
   } catch (error) {
-    await destination.close().catch(() => undefined);
+    await destination?.close().catch(() => undefined);
     if (openedIdentity !== null) await removeStablePath(destinationPath, openedIdentity);
     throw error;
+  } finally {
+    await source.close();
   }
 }
 
@@ -1447,16 +1662,20 @@ async function moveToExclusivePath(
     destinationCreated = true;
     const destinationIdentity = await assertOwnedPrivateFile(destinationPath, label);
     if (!sameFileSnapshot(sourceIdentity, destinationIdentity)) {
-      throw new Error(`${label} source changed before exclusive publication.`);
+      throw new Error(
+        `${label} source changed before exclusive publication; file identity changed.`,
+      );
     }
     const currentSource = await assertOwnedPrivateFile(sourcePath, `${label} source`);
     if (!sameFileSnapshot(sourceIdentity, currentSource)) {
-      throw new Error(`${label} source changed during exclusive publication.`);
+      throw new Error(
+        `${label} source changed during exclusive publication; file identity changed.`,
+      );
     }
     await unlink(sourcePath);
     const publishedIdentity = await assertOwnedPrivateFile(destinationPath, label);
     if (!sameFileSnapshot(sourceIdentity, publishedIdentity)) {
-      throw new Error(`${label} changed after exclusive publication.`);
+      throw new Error(`${label} changed after exclusive publication; file identity changed.`);
     }
     return publishedIdentity;
   } catch (error) {
@@ -1479,7 +1698,9 @@ async function tightenStableOwnedFile(
     }
     const before = stableIdentity(beforeInfo);
     if (!sameFileSnapshot(before, expected)) {
-      throw new Error(`${label} source changed before exclusive publication.`);
+      throw new Error(
+        `${label} source changed before exclusive publication; file identity changed.`,
+      );
     }
     await assertStableFileIdentity(path, before, `${label} source`);
     await handle.chmod(0o600);
@@ -1513,6 +1734,10 @@ async function removeStablePath(path: string, expected: StableFileIdentity): Pro
     throw new Error("Refusing to remove a recovery path whose file identity changed.");
   }
   await unlink(path);
+}
+
+async function removeMatchingStablePath(path: string, expected: StableFileIdentity): Promise<void> {
+  await removeStablePath(path, expected).catch(() => undefined);
 }
 
 function resolveBackupDatabasePath(

--- a/src/lib/production-activation-cli.ts
+++ b/src/lib/production-activation-cli.ts
@@ -1,6 +1,8 @@
+import { createHash } from "node:crypto";
+import { Database } from "bun:sqlite";
 import { createControlActionCodecRegistry } from "./event-game-actions";
 import { createLiveEventGameIqaInterpreter } from "./live-event-game-control";
-import { createFoundationRecovery } from "./foundation-recovery";
+import { createFoundationRecovery, FoundationRestoreFailure } from "./foundation-recovery";
 import { createSqliteAdHocRecoveryAdapter, resolveAdHocEnvironmentIdentity } from "./ad-hoc-games";
 import {
   openSqliteFoundationStorage,
@@ -9,21 +11,40 @@ import {
 import { readGrantAuthorityOptions } from "./grant-runtime";
 import { readRuntimeConfig } from "./runtime-config";
 import {
+  createSqliteTechnicalAdminAuthRepository,
+  createTechnicalAdminAuth,
+  type TechnicalAdminStorageIdentity,
+} from "./technical-admin-auth";
+import {
   assertProductionBackupMetadata,
   requireProductionAdHocBackup,
   promoteVerifiedBackup,
   type ProductionBackupMetadata,
 } from "./production-activation";
-import { lstat, readFile, writeFile } from "node:fs/promises";
-import { basename, dirname, join, resolve } from "node:path";
+import { constants as fsConstants } from "node:fs";
+import {
+  chmod,
+  lstat,
+  mkdir,
+  open as openFile,
+  readFile,
+  readdir,
+  realpath,
+  rename,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
+import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
 
 type MaintenanceCommand =
   | "backup"
   | "verify-backup"
   | "promote"
+  | "restore"
   | "validate-migration"
   | "apply-migrations"
   | "readiness"
+  | "authoritative-operation"
   | "preflight";
 
 type FocusedFailurePhase =
@@ -31,9 +52,11 @@ type FocusedFailurePhase =
   | "backup-create"
   | "backup-verify"
   | "backup-promote"
+  | "restore"
   | "candidate-validation"
   | "live-migration"
-  | "readiness";
+  | "readiness"
+  | "authoritative-operation-write";
 
 function injectFocusedFailure(phase: FocusedFailurePhase): void {
   if (
@@ -53,20 +76,36 @@ export async function runProductionActivationCli(argv: readonly string[]): Promi
     command !== "backup" &&
     command !== "verify-backup" &&
     command !== "promote" &&
+    command !== "restore" &&
     command !== "validate-migration" &&
     command !== "apply-migrations" &&
     command !== "readiness" &&
+    command !== "authoritative-operation" &&
     command !== "preflight"
   ) {
     console.error("Unknown activation maintenance command.");
     return 2;
   }
 
-  const { technicalAdmin, storagePaths } = readRuntimeConfig();
-  const grant = readGrantAuthorityOptions(technicalAdmin.environment);
+  let technicalAdmin: ReturnType<typeof readRuntimeConfig>["technicalAdmin"];
+  let storagePaths: ReturnType<typeof readRuntimeConfig>["storagePaths"];
+  let grant: ReturnType<typeof readGrantAuthorityOptions>;
+  try {
+    ({ technicalAdmin, storagePaths } = readRuntimeConfig());
+    grant = readGrantAuthorityOptions(technicalAdmin.environment);
+  } catch (error) {
+    if (command === "restore") {
+      emitBoundedRestoreFailure(error);
+      return 1;
+    }
+    throw error;
+  }
   if (
     technicalAdmin.environment !== "production" &&
-    (command === "backup" || command === "verify-backup" || command === "promote")
+    (command === "backup" ||
+      command === "verify-backup" ||
+      command === "promote" ||
+      command === "restore")
   ) {
     throw new Error("Production backup operations are unavailable in the Test Environment.");
   }
@@ -85,16 +124,73 @@ export async function runProductionActivationCli(argv: readonly string[]): Promi
     );
     return readiness.ok ? 0 : 1;
   }
-  const storage = openSqliteFoundationStorage(storagePaths.foundationDatabase, {
-    grantKeyRing: grant.keyRing,
-    grantValidationContext: { environmentId: technicalAdmin.environment, keyRing: grant.keyRing },
-  });
+  if (command === "authoritative-operation") {
+    let transactionOpen = false;
+    const database = new Database(storagePaths.foundationDatabase);
+    try {
+      const digestBefore = createHash("sha256")
+        .update(await readFile(storagePaths.foundationDatabase))
+        .digest("hex");
+      database.exec("BEGIN IMMEDIATE");
+      transactionOpen = true;
+      if (
+        process.env.QBT_FOCUSED_TEST_MODE === "1" &&
+        process.env.QBT_FOCUSED_FAILURE_PHASE === "authoritative-operation-write"
+      ) {
+        database.exec("PRAGMA query_only = ON");
+      }
+      database.exec(`
+        CREATE TABLE __quadball_restore_writeability_probe (id INTEGER PRIMARY KEY);
+        INSERT INTO __quadball_restore_writeability_probe (id) VALUES (1);
+      `);
+      database.exec("ROLLBACK");
+      transactionOpen = false;
+      const probeAbsent =
+        database
+          .query(
+            "SELECT 1 AS present FROM sqlite_master WHERE type = 'table' AND name = '__quadball_restore_writeability_probe'",
+          )
+          .get() === null;
+      const digestAfter = createHash("sha256")
+        .update(await readFile(storagePaths.foundationDatabase))
+        .digest("hex");
+      if (!probeAbsent || digestAfter !== digestBefore) {
+        throw new Error("Bounded authoritative operation changed Foundation state.");
+      }
+      console.log(JSON.stringify({ ok: true, operation: "bounded-writeability-probe" }));
+      return 0;
+    } catch {
+      if (transactionOpen) {
+        try {
+          database.exec("ROLLBACK");
+        } catch {
+          // The bounded failure remains non-secret and fail closed.
+        }
+      }
+      console.log(JSON.stringify({ ok: false, operation: "bounded-writeability-probe" }));
+      return 1;
+    } finally {
+      database.close();
+    }
+  }
+  let storage: ReturnType<typeof openSqliteFoundationStorage> | null = null;
+  let technicalAdminRepository: ReturnType<typeof createSqliteTechnicalAdminAuthRepository> | null =
+    null;
+  let technicalAdminAuth: ReturnType<typeof createTechnicalAdminAuth> | null = null;
+  let technicalAdminStoragePresent = true;
+  // A missing store remains the canonical reason: "missing"; invalid filesystem
+  // objects are rejected before the repository can follow or mutate them.
+  let technicalAdminStorageReason: "missing" | "invalid" | "incompatible" = "missing";
   const readinessContext = {
     actionCodecRegistry: createControlActionCodecRegistry(),
     interpreter: createLiveEventGameIqaInterpreter(),
   };
-  storage.setReadinessContext(readinessContext);
   try {
+    storage = openSqliteFoundationStorage(storagePaths.foundationDatabase, {
+      grantKeyRing: grant.keyRing,
+      grantValidationContext: { environmentId: technicalAdmin.environment, keyRing: grant.keyRing },
+    });
+    storage.setReadinessContext(readinessContext);
     if (command === "preflight") {
       injectFocusedFailure("preflight");
       const migration = await storage.migrationPreflight();
@@ -127,11 +223,165 @@ export async function runProductionActivationCli(argv: readonly string[]): Promi
     if (command === "promote" && sourceReleaseAttemptId === undefined) {
       throw new Error("Release identity is required for backup promotion.");
     }
+    if (command === "restore" && sourceReleaseAttemptId === undefined) {
+      throw new Error("Release identity is required for Production restore.");
+    }
+    if (
+      command === "restore" &&
+      (sourceReleaseAttemptId === undefined ||
+        !/^[A-Za-z0-9._-]{1,128}$/.test(sourceReleaseAttemptId))
+    ) {
+      throw new Error("Production restore release identity is unsafe.");
+    }
+    const manifestPath = process.env.BACKUP_MANIFEST_PATH;
+    let restoreManifestPath = manifestPath;
+    const restoreDirectory =
+      command === "restore" ? process.env.RESTORE_WORKSPACE_DIRECTORY?.trim() || null : null;
+    if (command === "restore") {
+      if (manifestPath === undefined || restoreDirectory === null) {
+        throw new Error("Restore workspace and manifest are required.");
+      }
+      const expectedRestoreDirectoryPrefix = join(
+        backupDirectory,
+        `.restore-${sourceReleaseAttemptId}-`,
+      );
+      const resolvedRestoreDirectory = resolve(restoreDirectory);
+      if (
+        !resolvedRestoreDirectory.startsWith(expectedRestoreDirectoryPrefix) ||
+        !/^[A-Za-z0-9._-]{6,128}$/u.test(
+          resolvedRestoreDirectory.slice(expectedRestoreDirectoryPrefix.length),
+        )
+      ) {
+        throw new Error("Restore workspace is outside the bounded restore directory.");
+      }
+      const restoreDirectoryInfo = await lstat(resolvedRestoreDirectory);
+      const selectedManifestPath = resolve(manifestPath);
+      const rootStagedManifest = dirname(selectedManifestPath) === resolvedRestoreDirectory;
+      const currentUid = process.getuid?.();
+      if (
+        !restoreDirectoryInfo.isDirectory() ||
+        restoreDirectoryInfo.isSymbolicLink() ||
+        (restoreDirectoryInfo.mode & 0o777) !== 0o700 ||
+        (currentUid !== undefined && restoreDirectoryInfo.uid !== currentUid)
+      ) {
+        throw new Error("Restore workspace is not a private directory.");
+      }
+      await copyStableRestoreFile(
+        storagePaths.foundationDatabase,
+        join(resolvedRestoreDirectory, "failed-live-foundation.sqlite"),
+      );
+      if (rootStagedManifest) {
+        const stagedEntries = await readdir(resolvedRestoreDirectory);
+        if (stagedEntries.length !== 5) {
+          throw new Error("Restore workspace contains an unexpected staged input set.");
+        }
+        for (const stagedEntry of stagedEntries) {
+          const stagedInfo = await lstat(join(resolvedRestoreDirectory, stagedEntry));
+          if (
+            !stagedInfo.isFile() ||
+            stagedInfo.isSymbolicLink() ||
+            (stagedInfo.mode & 0o777) !== 0o600 ||
+            (currentUid !== undefined && stagedInfo.uid !== currentUid)
+          ) {
+            throw new Error("Restore workspace contains an unsafe staged input.");
+          }
+        }
+      } else if ((await readdir(resolvedRestoreDirectory)).length !== 1) {
+        throw new Error("Restore workspace contains unexpected input.");
+      }
+      if (!rootStagedManifest) {
+        const selectedManifestRelativePath = relative(backupDirectory, selectedManifestPath);
+        if (
+          selectedManifestRelativePath === "" ||
+          isAbsolute(selectedManifestRelativePath) ||
+          selectedManifestRelativePath.startsWith("..") ||
+          !/^verified-[A-Za-z0-9._-]+$/u.test(basename(dirname(selectedManifestPath)))
+        ) {
+          throw new Error("Production restore requires a promoted verified snapshot.");
+        }
+      }
+      const selectedManifestInfo = await lstat(selectedManifestPath);
+      if (!selectedManifestInfo.isFile() || selectedManifestInfo.isSymbolicLink()) {
+        throw new Error("Restore manifest is not a regular file.");
+      }
+      const selectedManifest = JSON.parse(await readFile(selectedManifestPath, "utf8")) as {
+        snapshotId?: unknown;
+        databaseFile?: unknown;
+        adHoc?: { databaseFile?: unknown } | null;
+      };
+      if (
+        typeof selectedManifest.snapshotId !== "string" ||
+        typeof selectedManifest.databaseFile !== "string" ||
+        !/^[A-Za-z0-9._-]{1,128}$/.test(selectedManifest.snapshotId) ||
+        selectedManifest.databaseFile !== `${selectedManifest.snapshotId}.sqlite`
+      ) {
+        throw new Error("Restore manifest database identity is invalid.");
+      }
+      if (basename(selectedManifestPath) !== `${selectedManifest.snapshotId}.manifest.json`) {
+        throw new Error("Restore manifest filename does not match its snapshot identity.");
+      }
+      const selectedDatabasePath = join(
+        dirname(selectedManifestPath),
+        selectedManifest.databaseFile,
+      );
+      const selectedDatabaseInfo = await lstat(selectedDatabasePath);
+      if (!selectedDatabaseInfo.isFile() || selectedDatabaseInfo.isSymbolicLink()) {
+        throw new Error("Restore database is not a regular file.");
+      }
+      if (
+        selectedManifest.adHoc === null ||
+        typeof selectedManifest.adHoc !== "object" ||
+        typeof selectedManifest.adHoc.databaseFile !== "string" ||
+        selectedManifest.adHoc.databaseFile !== `${selectedManifest.snapshotId}.ad-hoc.sqlite`
+      ) {
+        throw new Error("Restore Ad Hoc database identity is invalid.");
+      }
+      const selectedAdHocPath = join(
+        dirname(selectedManifestPath),
+        selectedManifest.adHoc.databaseFile,
+      );
+      const selectedAdHocInfo = await lstat(selectedAdHocPath);
+      if (!selectedAdHocInfo.isFile() || selectedAdHocInfo.isSymbolicLink()) {
+        throw new Error("Restore Ad Hoc database is not a regular file.");
+      }
+      const selectedDeploymentPath = join(
+        dirname(selectedManifestPath),
+        `${selectedManifest.snapshotId}.deployment.json`,
+      );
+      const selectedDeploymentInfo = await lstat(selectedDeploymentPath);
+      if (!selectedDeploymentInfo.isFile() || selectedDeploymentInfo.isSymbolicLink()) {
+        throw new Error("Restore deployment metadata is not a regular file.");
+      }
+      if (!rootStagedManifest) {
+        await copyStableRestoreFile(
+          selectedManifestPath,
+          join(resolvedRestoreDirectory, basename(selectedManifestPath)),
+        );
+        await copyStableRestoreFile(
+          selectedDatabasePath,
+          join(resolvedRestoreDirectory, selectedManifest.databaseFile),
+        );
+        await copyStableRestoreFile(
+          selectedAdHocPath,
+          join(resolvedRestoreDirectory, selectedManifest.adHoc.databaseFile),
+        );
+        await copyStableRestoreFile(
+          selectedDeploymentPath,
+          join(resolvedRestoreDirectory, basename(selectedDeploymentPath)),
+        );
+      }
+      restoreManifestPath = selectedManifestPath;
+    }
     const candidateDirectory =
       command === "promote"
         ? join(backupDirectory, `.candidate-${sourceReleaseAttemptId}`)
         : backupDirectory;
-    const recoveryDirectory = command === "promote" ? candidateDirectory : backupDirectory;
+    const recoveryDirectory =
+      command === "promote"
+        ? candidateDirectory
+        : command === "restore" && restoreDirectory !== null
+          ? restoreDirectory
+          : backupDirectory;
     const expectedAdHocDatabasePath = join(
       dirname(storagePaths.foundationDatabase),
       "ad-hoc.sqlite",
@@ -177,18 +427,24 @@ export async function runProductionActivationCli(argv: readonly string[]): Promi
         interpreter: readinessContext.interpreter,
       },
       technicalAdminAuth: {
-        // Backup-only activation deliberately supplies no live auth-store
-        // path; #81 requires this option for restore but creation never uses
-        // it. Policy A keeps the separate Technical Admin store out of scope.
-        databasePath: join(recoveryDirectory, ".technical-admin-unused"),
+        databasePath: storagePaths.technicalAdminDatabase,
         // The activation script has already stopped the service. This seam is
         // intentionally separate and never opens, copies, or mutates auth data.
         async quiesce() {},
-        // #165 does not expose Foundation restore. Keep the current Policy A
-        // adapter boundary fail-closed without pulling #166 into activation.
+        // Defer the mutable auth adapter until the selected snapshot has passed
+        // staging and verification; a missing store remains non-mutating.
         adapter: {
-          async prepareForFoundationRestore() {
-            throw new Error("Foundation restore is not part of Production activation.");
+          async prepareForFoundationRestore(request) {
+            if (!technicalAdminStoragePresent) {
+              return {
+                outcome: "re-enrollment-required" as const,
+                reason: technicalAdminStorageReason,
+              };
+            }
+            if (technicalAdminAuth === null) {
+              throw new Error("Technical Admin restore adapter is unavailable.");
+            }
+            return technicalAdminAuth.prepareForFoundationRestore(request);
           },
         },
       },
@@ -197,7 +453,7 @@ export async function runProductionActivationCli(argv: readonly string[]): Promi
       injectFocusedFailure("backup-create");
       const manifest = await recovery.createPreDeploymentBackup();
       const adHoc = requireProductionAdHocBackup(manifest);
-      const manifestPath = join(backupDirectory, `${manifest.snapshotId}.manifest.json`);
+      const createdManifestPath = join(backupDirectory, `${manifest.snapshotId}.manifest.json`);
       const schemaCompatibility = process.env.SCHEMA_COMPATIBILITY;
       if (sourceReleaseAttemptId === undefined || schemaCompatibility === undefined) {
         throw new Error("Release and schema identity are required for a Production backup.");
@@ -222,10 +478,77 @@ export async function runProductionActivationCli(argv: readonly string[]): Promi
         `${JSON.stringify(metadata)}\n`,
         { mode: 0o600, flag: "wx" },
       );
-      console.log(JSON.stringify({ manifestPath, snapshotId: manifest.snapshotId, metadata }));
+      console.log(
+        JSON.stringify({
+          manifestPath: createdManifestPath,
+          snapshotId: manifest.snapshotId,
+          metadata,
+        }),
+      );
       return 0;
     }
-    const manifestPath = process.env.BACKUP_MANIFEST_PATH;
+    if (command === "restore") {
+      injectFocusedFailure("restore");
+      if (restoreManifestPath === undefined) throw new Error("Backup manifest path is required.");
+      const verifiedManifest = await recovery.verifyBackup(restoreManifestPath);
+      const deploymentPath = join(
+        dirname(restoreManifestPath),
+        `${verifiedManifest.snapshotId}.deployment.json`,
+      );
+      const metadata = JSON.parse(
+        await readFile(deploymentPath, "utf8"),
+      ) as ProductionBackupMetadata;
+      const schemaCompatibility = process.env.SCHEMA_COMPATIBILITY;
+      if (schemaCompatibility === undefined) {
+        throw new Error("Schema compatibility is required for Production restore.");
+      }
+      assertProductionBackupMetadata(
+        { manifest: verifiedManifest, metadata },
+        {
+          sourceReleaseAttemptId: metadata.sourceReleaseAttemptId,
+          schemaCompatibility: metadata.schemaCompatibility,
+        },
+      );
+      if (metadata.schemaCompatibility !== schemaCompatibility) {
+        throw new Error("Selected restore snapshot is incompatible with this release.");
+      }
+      if (restoreDirectory === null) throw new Error("Restore workspace is required.");
+      const technicalAdminStorage = await prepareTechnicalAdminStorageForRestore(
+        storagePaths.technicalAdminDatabase,
+        join(restoreDirectory, "technical-admin-auth-evidence"),
+        {
+          environment: technicalAdmin.environment,
+          origin: technicalAdmin.origin,
+          rpId: technicalAdmin.rpId,
+        },
+      );
+      technicalAdminStoragePresent = technicalAdminStorage.present;
+      if (!technicalAdminStorage.present) {
+        technicalAdminStorageReason = technicalAdminStorage.reason;
+      }
+      if (technicalAdminStoragePresent) {
+        technicalAdminRepository = createSqliteTechnicalAdminAuthRepository(
+          storagePaths.technicalAdminDatabase,
+          {
+            environment: technicalAdmin.environment,
+            origin: technicalAdmin.origin,
+            rpId: technicalAdmin.rpId,
+          },
+        );
+        technicalAdminAuth = createTechnicalAdminAuth(technicalAdmin, technicalAdminRepository);
+      }
+      const restored = await recovery.restore(restoreManifestPath);
+      console.log(
+        JSON.stringify({
+          restored: true,
+          restoreId: restored.restoreId,
+          potentiallyNewerWork: restored.potentiallyNewerWork,
+          technicalAdminAuth: restored.technicalAdminAuth,
+          authorityResurrectionWarning: restored.authorityResurrectionWarning,
+        }),
+      );
+      return 0;
+    }
     const schemaCompatibility = process.env.SCHEMA_COMPATIBILITY;
     if (manifestPath === undefined) throw new Error("Backup manifest path is required.");
     if (sourceReleaseAttemptId === undefined || schemaCompatibility === undefined) {
@@ -277,7 +600,313 @@ export async function runProductionActivationCli(argv: readonly string[]): Promi
     const { manifest } = await verifyCandidate();
     console.log(JSON.stringify({ verified: true, snapshotId: manifest.snapshotId }));
     return 0;
+  } catch (error) {
+    if (command !== "restore") throw error;
+    emitBoundedRestoreFailure(error);
+    return 1;
   } finally {
-    storage.close();
+    technicalAdminAuth?.close();
+    technicalAdminRepository?.close();
+    storage?.close();
   }
+}
+
+export type TechnicalAdminStorageRestorePreparation =
+  | { present: true }
+  | { present: false; reason: "missing" | "invalid" | "incompatible" };
+
+const requiredTechnicalAdminStorageColumns = {
+  technical_admin_credentials: ["credential_id", "public_key_json", "sign_count", "created_at_ms"],
+  technical_admin_enrollment: ["token_hash", "expires_at_ms", "used_at_ms"],
+  technical_admin_challenges: [
+    "challenge_id",
+    "challenge",
+    "purpose",
+    "session_id",
+    "fresh_purpose",
+    "expires_at_ms",
+    "used_at_ms",
+  ],
+  technical_admin_sessions: [
+    "session_id",
+    "token_hash",
+    "created_at_ms",
+    "last_seen_at_ms",
+    "absolute_expires_at_ms",
+    "revoked_at_ms",
+    "csrf_token_hash",
+    "fresh_verified_at_ms",
+    "fresh_verified_purpose",
+  ],
+  technical_admin_storage_identity: ["id", "environment", "origin", "rp_id"],
+  technical_admin_state: ["id", "generation"],
+  technical_admin_operational_logs: [
+    "log_id",
+    "at_ms",
+    "event",
+    "outcome",
+    "environment",
+    "generation",
+    "session_reference",
+    "source_correlation",
+  ],
+  technical_admin_alerts: [
+    "alert_id",
+    "at_ms",
+    "event",
+    "environment",
+    "generation",
+    "source_correlation",
+  ],
+} as const;
+
+export async function prepareTechnicalAdminStorageForRestore(
+  databasePath: string,
+  evidenceDirectory: string,
+  expectedIdentity: TechnicalAdminStorageIdentity,
+): Promise<TechnicalAdminStorageRestorePreparation> {
+  let info: Awaited<ReturnType<typeof lstat>>;
+  try {
+    info = await lstat(databasePath);
+  } catch (error) {
+    if (isMissingPathError(error)) return { present: false, reason: "missing" };
+    throw new Error("Technical Admin storage cannot be inspected.");
+  }
+
+  let reason: "invalid" | "incompatible" | null = null;
+  if (!info.isFile() || info.isSymbolicLink()) {
+    reason = "invalid";
+  } else {
+    let inspection: Database | null = null;
+    try {
+      inspection = new Database(databasePath, { readonly: true, strict: true });
+      const quickCheck = inspection.query("PRAGMA quick_check").get() as {
+        quick_check?: string;
+      } | null;
+      if (quickCheck?.quick_check !== "ok") {
+        reason = "invalid";
+      } else {
+        const schemaInspection = inspection;
+        const tables = new Set(
+          (
+            inspection.query("SELECT name FROM sqlite_master WHERE type = 'table'").all() as Array<{
+              name: string;
+            }>
+          ).map(({ name }) => name),
+        );
+        const schemaCompatible = Object.entries(requiredTechnicalAdminStorageColumns).every(
+          ([table, requiredColumns]) => {
+            if (!tables.has(table)) return false;
+            const columns = new Set(
+              (
+                schemaInspection.query(`PRAGMA table_info(${table})`).all() as Array<{
+                  name: string;
+                }>
+              ).map(({ name }) => name),
+            );
+            return requiredColumns.every((column) => columns.has(column));
+          },
+        );
+        if (!schemaCompatible) {
+          reason = "incompatible";
+        } else {
+          const identities = inspection
+            .query(
+              "SELECT environment, origin, rp_id FROM technical_admin_storage_identity WHERE id = 1",
+            )
+            .all() as Array<{ environment: string; origin: string; rp_id: string }>;
+          const [identity, ...additionalIdentities] = identities;
+          if (
+            identity === undefined ||
+            additionalIdentities.length !== 0 ||
+            identity.environment !== expectedIdentity.environment ||
+            identity.origin !== expectedIdentity.origin ||
+            identity.rp_id !== expectedIdentity.rpId
+          ) {
+            reason = "incompatible";
+          }
+        }
+      }
+    } catch {
+      reason = "invalid";
+    } finally {
+      inspection?.close();
+    }
+  }
+
+  if (reason === null) return { present: true };
+
+  await mkdir(evidenceDirectory, { mode: 0o700 });
+  const evidencePath = join(evidenceDirectory, basename(databasePath));
+  await rename(databasePath, evidencePath);
+  for (const suffix of ["-wal", "-shm"] as const) {
+    try {
+      await lstat(`${databasePath}${suffix}`);
+      await rename(`${databasePath}${suffix}`, `${evidencePath}${suffix}`);
+    } catch (error) {
+      if (!isMissingPathError(error)) {
+        throw new Error("Technical Admin storage evidence cannot be preserved.");
+      }
+    }
+  }
+
+  const replacement = createSqliteTechnicalAdminAuthRepository(databasePath, expectedIdentity);
+  replacement.close();
+  await chmod(databasePath, 0o600);
+  return { present: false, reason };
+}
+
+type RestoreFileIdentity = {
+  dev: number;
+  ino: number;
+  size: number;
+  mtimeMs: number;
+};
+type RestoreFileStat = RestoreFileIdentity & { isFile: boolean; mode: number };
+
+export async function copyStableRestoreFile(
+  sourcePath: string,
+  destinationPath: string,
+  expectedSha256?: string,
+): Promise<void> {
+  const resolvedSourcePath = resolve(sourcePath);
+  if ((await realpath(resolvedSourcePath)) !== resolvedSourcePath) {
+    throw new Error("Restore source is not canonical.");
+  }
+  const source = await openFile(resolvedSourcePath, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
+  let destination: Awaited<ReturnType<typeof openFile>> | null = null;
+  let destinationIdentity: RestoreFileStat | null = null;
+  try {
+    const sourceBefore = restoreFileIdentity(await source.stat());
+    if (!sourceBefore.isFile) throw new Error("Restore source is not a regular file.");
+    const content = await source.readFile();
+    const sourceRead = restoreFileIdentity(await source.stat());
+    if (!sameRestoreFileSnapshot(sourceBefore, sourceRead)) {
+      throw new Error("Restore source changed while it was copied.");
+    }
+    if ((await realpath(resolvedSourcePath)) !== resolvedSourcePath) {
+      throw new Error("Restore source changed its canonical identity while it was copied.");
+    }
+    const sourcePathIdentity = restoreFileIdentity(await lstat(resolvedSourcePath));
+    if (!sameRestoreFileSnapshot(sourceBefore, sourcePathIdentity)) {
+      throw new Error("Restore source changed file identity while it was copied.");
+    }
+    if (
+      expectedSha256 !== undefined &&
+      createHash("sha256").update(content).digest("hex") !== expectedSha256
+    ) {
+      throw new Error("Restore source content does not match its manifest.");
+    }
+
+    destination = await openFile(
+      destinationPath,
+      fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_NOFOLLOW,
+      0o600,
+    );
+    await destination.chmod(0o600);
+    destinationIdentity = restoreFileIdentity(await destination.stat());
+    if (!destinationIdentity.isFile) throw new Error("Restore destination is not a regular file.");
+    await destination.writeFile(content);
+    await destination.sync();
+    const destinationWritten = restoreFileIdentity(await destination.stat());
+    if (!sameRestoreFileIdentity(destinationIdentity, destinationWritten)) {
+      throw new Error("Restore destination changed while it was copied.");
+    }
+    const sourceAfter = restoreFileIdentity(await source.stat());
+    const sourcePathAfter = restoreFileIdentity(await lstat(resolvedSourcePath));
+    if (
+      !sameRestoreFileSnapshot(sourceBefore, sourceAfter) ||
+      !sameRestoreFileSnapshot(sourceBefore, sourcePathAfter)
+    ) {
+      throw new Error("Restore source changed before private copy completion.");
+    }
+    await destination.close();
+    destination = null;
+    const destinationPathIdentity = restoreFileIdentity(await lstat(destinationPath));
+    if (
+      !destinationPathIdentity.isFile ||
+      (destinationPathIdentity.mode & 0o777) !== 0o600 ||
+      !sameRestoreFileIdentity(destinationIdentity, destinationPathIdentity)
+    ) {
+      throw new Error("Restore destination changed after private copy completion.");
+    }
+  } catch (error) {
+    await destination?.close().catch(() => undefined);
+    if (destinationIdentity !== null) {
+      try {
+        const current = restoreFileIdentity(await lstat(destinationPath));
+        if (sameRestoreFileIdentity(destinationIdentity, current)) await unlink(destinationPath);
+      } catch {
+        // The bounded restore failure is reported by the caller; never remove a substituted path.
+      }
+    }
+    throw error;
+  } finally {
+    await source.close();
+  }
+}
+
+function restoreFileIdentity(info: {
+  dev: number;
+  ino: number;
+  size: number;
+  mtimeMs: number;
+  mode?: number;
+  isFile?: () => boolean;
+  isSymbolicLink?: () => boolean;
+}): RestoreFileStat {
+  return {
+    dev: info.dev,
+    ino: info.ino,
+    size: info.size,
+    mtimeMs: info.mtimeMs,
+    mode: info.mode ?? 0,
+    isFile: info.isFile?.() ?? true,
+  };
+}
+
+function sameRestoreFileIdentity(left: RestoreFileStat, right: RestoreFileStat): boolean {
+  return left.dev === right.dev && left.ino === right.ino;
+}
+
+function sameRestoreFileSnapshot(left: RestoreFileStat, right: RestoreFileStat): boolean {
+  return (
+    sameRestoreFileIdentity(left, right) &&
+    left.size === right.size &&
+    left.mtimeMs === right.mtimeMs &&
+    left.isFile === right.isFile
+  );
+}
+
+function emitBoundedRestoreFailure(error: unknown): void {
+  const foundationFailure = error instanceof FoundationRestoreFailure ? error : null;
+  console.error(
+    JSON.stringify({
+      restored: false,
+      outcome: boundedRestoreFailureOutcome(foundationFailure),
+      cutoverCompleted: foundationFailure?.cutoverCompleted ?? false,
+      technicalAdminAuth: foundationFailure?.technicalAdminAuth ?? {
+        outcome: "not-attempted",
+        credentialPreserved: false,
+        reEnrollmentRequired: false,
+      },
+    }),
+  );
+}
+
+function isMissingPathError(error: unknown): boolean {
+  return typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT";
+}
+
+function boundedRestoreFailureOutcome(
+  failure: FoundationRestoreFailure | null,
+):
+  | "restore-preparation-failed"
+  | "auth-sanitation-failed"
+  | "foundation-replacement-failed"
+  | "cutover-completed-evidence-failed" {
+  if (failure?.phase === "auth-sanitation") return "auth-sanitation-failed";
+  if (failure?.phase === "foundation-replacement") return "foundation-replacement-failed";
+  if (failure?.phase === "post-cutover-evidence") return "cutover-completed-evidence-failed";
+  return "restore-preparation-failed";
 }

--- a/src/lib/production-activation.focused.ts
+++ b/src/lib/production-activation.focused.ts
@@ -7,6 +7,7 @@ import {
   mkdir,
   mkdtemp,
   readFile,
+  readdir,
   readlink,
   realpath as fsRealpath,
   rm,
@@ -79,7 +80,8 @@ describe("disposable activation SQLite integration", () => {
         grantValidationContext: { environmentId: "production", keyRing },
       });
       await legacy.applyMigrations({ requireCandidate: false });
-      legacy.close();
+      await legacy.quiesceForRecovery();
+      Bun.gc(true);
       const adHocEnvironmentIdentity = "production:https://timer.quadball.app";
       const adHocStore = openSqliteAdHocStore(adHocPath, adHocEnvironmentIdentity);
       const adHocService = createAdHocGamesService({
@@ -128,11 +130,14 @@ describe("disposable activation SQLite integration", () => {
       const systemctlStub = join(binDirectory, "systemctl");
       await writeFile(
         systemctlStub,
-        '#!/bin/sh\n[ "$1" = is-active ] && { echo inactive; exit 0; }; exit 0\n',
+        '#!/bin/sh\nif [ "$1" = restart ]; then touch "$QBT_FOCUSED_RESTORE_STARTED"; exit 0; fi\nif [ "$1" = is-active ]; then if [ "$2" = quadball-timer ] && [ -f "$QBT_FOCUSED_RESTORE_STARTED" ]; then echo active; rm -f "$QBT_FOCUSED_RESTORE_STARTED"; else echo inactive; fi; exit 0; fi\nexit 0\n',
       );
       await chmod(systemctlStub, 0o755);
       const runuserStub = join(binDirectory, "runuser");
-      await writeFile(runuserStub, '#!/bin/sh\nshift 3\nexec "$@"\n');
+      await writeFile(
+        runuserStub,
+        '#!/bin/sh\nprintf "runuser\\n" >> "$QBT_FOCUSED_RUNUSER_LOG"\nshift 3\nexec "$@"\n',
+      );
       await chmod(runuserStub, 0o755);
       const flockStub = join(binDirectory, "flock");
       await writeFile(
@@ -146,6 +151,18 @@ describe("disposable activation SQLite integration", () => {
         '#!/bin/sh\n[ "$1" = -e ] && shift\n[ "$1" = -- ] && shift\n/bin/realpath "$@"\n',
       );
       await chmod(realpathStub, 0o755);
+      const installStub = join(binDirectory, "install");
+      await writeFile(
+        installStub,
+        '#!/bin/sh\nprintf "%s\\n" "$*" >> "$QBT_FOCUSED_INSTALL_LOG"\npath=""\nfor arg in "$@"; do path="$arg"; done\nmkdir -p "$path"\nchmod 0700 "$path"\n',
+      );
+      await chmod(installStub, 0o755);
+      const ownerSeam = join(binDirectory, "owner-seam");
+      await writeFile(
+        ownerSeam,
+        '#!/bin/sh\ncase "$1" in *verified-*) identity="root:root:600" ;; *) identity="quadball-timer:quadball-timer:600" ;; esac\ncase "${QBT_FOCUSED_OWNER_SEAM_MODE:-valid}:$1" in source-wrong:*verified-*) identity="quadball-timer:quadball-timer:600" ;; destination-wrong:*) identity="root:root:600" ;; esac\nprintf "%s %s\\n" "$1" "$identity" >> "${QBT_FOCUSED_OWNER_SEAM_LOG:-/dev/null}"\nprintf "%s\\n" "$identity"\n',
+      );
+      await chmod(ownerSeam, 0o755);
 
       const run = async (
         command: string,
@@ -153,6 +170,7 @@ describe("disposable activation SQLite integration", () => {
         manifestPath = "",
         failurePhase = "",
         releasePath = releaseDirectory,
+        ownerMode = "valid",
       ) => {
         const child = Bun.spawn(
           ["bash", wrapper, "production", releasePath, command, manifestPath],
@@ -167,6 +185,13 @@ describe("disposable activation SQLite integration", () => {
               QBT_FOCUSED_TEST_FLOCK: flockStub,
               QBT_FOCUSED_TEST_REALPATH: realpathStub,
               QBT_FOCUSED_TEST_SKIP_CHOWN: "1",
+              QBT_FOCUSED_TEST_INSTALL: installStub,
+              QBT_FOCUSED_TEST_OWNER_SEAM: ownerSeam,
+              QBT_FOCUSED_OWNER_SEAM_LOG: join(root, "owner-seam.log"),
+              QBT_FOCUSED_OWNER_SEAM_MODE: ownerMode,
+              QBT_FOCUSED_RUNUSER_LOG: join(root, "runuser.log"),
+              QBT_FOCUSED_INSTALL_LOG: join(root, "install.log"),
+              QBT_FOCUSED_RESTORE_STARTED: join(root, "restore-started"),
               QBT_ACTIVATION_LOCK_HELD_PATH: heldPath,
               QBT_FOCUSED_FAILURE_PHASE: failurePhase,
             },
@@ -181,10 +206,33 @@ describe("disposable activation SQLite integration", () => {
       };
 
       const canonicalLock = join(root, "srv/quadball-timer/.activation.lock");
-      const preflightDigest = digest(foundationPath);
       const preflight = await run("preflight", canonicalLock);
       expect(preflight.code, preflight.output).toBe(0);
-      expect(digest(foundationPath)).toBe(preflightDigest);
+      const foundationDigestBeforeProbe = digest(foundationPath);
+      const authoritativeOperation = await run("authoritative-operation", canonicalLock);
+      expect(authoritativeOperation.code, authoritativeOperation.output).toBe(0);
+      expect(authoritativeOperation.output).toContain('"operation":"bounded-writeability-probe"');
+      expect(digest(foundationPath)).toBe(foundationDigestBeforeProbe);
+      const probedFoundation = new Database(foundationPath, { readonly: true });
+      expect(
+        probedFoundation
+          .query(
+            "SELECT 1 AS present FROM sqlite_master WHERE type = 'table' AND name = '__quadball_restore_writeability_probe'",
+          )
+          .get(),
+      ).toBeNull();
+      probedFoundation.close();
+      const deniedAuthoritativeOperation = await run(
+        "authoritative-operation",
+        canonicalLock,
+        "",
+        "authoritative-operation-write",
+      );
+      expect(deniedAuthoritativeOperation.code, deniedAuthoritativeOperation.output).toBe(1);
+      expect(deniedAuthoritativeOperation.output).toContain(
+        '"ok":false,"operation":"bounded-writeability-probe"',
+      );
+      expect(digest(foundationPath)).toBe(foundationDigestBeforeProbe);
       expect((await run("readiness", canonicalLock)).code).not.toBe(0);
       expect(
         (await run("backup", join(root, "var/lib/quadball-timer/.activation.lock"))).code,
@@ -193,6 +241,8 @@ describe("disposable activation SQLite integration", () => {
       expect(backup.code, backup.output).toBe(0);
       const manifestPath = JSON.parse(backup.output).manifestPath as string;
       const backupManifest = JSON.parse(await readFile(manifestPath, "utf8")) as {
+        snapshotId?: string;
+        databaseFile?: string;
         adHoc?: { databaseFile?: string; facts?: { environmentIdentity?: string } };
       };
       expect(backupManifest.adHoc?.databaseFile).toBeTruthy();
@@ -216,6 +266,121 @@ describe("disposable activation SQLite integration", () => {
           .code,
       ).not.toBe(0);
       expect((await run("promote", canonicalLock, manifestPath)).code).toBe(0);
+      const retainedTarget = await readlink(join(root, "var/backups/quadball-timer/retained"));
+      const retainedManifestPath = join(
+        root,
+        "var/backups/quadball-timer",
+        retainedTarget,
+        basename(manifestPath),
+      );
+      for (const retainedInput of [
+        retainedManifestPath,
+        join(dirname(retainedManifestPath), backupManifest.databaseFile ?? ""),
+        join(dirname(retainedManifestPath), backupManifest.adHoc?.databaseFile ?? ""),
+        join(dirname(retainedManifestPath), `${backupManifest.snapshotId}.deployment.json`),
+      ]) {
+        await chmod(retainedInput, 0o600);
+        expect((await lstat(retainedInput)).mode & 0o777).toBe(0o600);
+      }
+      await writeFile(join(root, "runuser.log"), "");
+      const wrongSourceOwner = await run(
+        "restore",
+        canonicalLock,
+        retainedManifestPath,
+        "",
+        releaseDirectory,
+        "source-wrong",
+      );
+      expect(wrongSourceOwner.code, wrongSourceOwner.output).not.toBe(0);
+      expect(wrongSourceOwner.output).toContain('"outcome":"restore-staging-failed"');
+      expect(await readFile(join(root, "runuser.log"), "utf8")).toBe("");
+
+      const wrongDestinationOwner = await run(
+        "restore",
+        canonicalLock,
+        retainedManifestPath,
+        "",
+        releaseDirectory,
+        "destination-wrong",
+      );
+      expect(wrongDestinationOwner.code, wrongDestinationOwner.output).not.toBe(0);
+      expect(wrongDestinationOwner.output).toContain('"outcome":"restore-staging-failed"');
+      expect(await readFile(join(root, "runuser.log"), "utf8")).toBe("");
+
+      const restore = await run("restore", canonicalLock, retainedManifestPath);
+      expect(restore.code, restore.output).toBe(0);
+      const restoreWorkspaces = (await readdir(join(root, "var/backups/quadball-timer"))).filter(
+        (entry) => entry.startsWith(".restore-lock-test-") && entry !== "retained",
+      );
+      let restoreWorkspace: string | undefined;
+      for (const candidate of restoreWorkspaces) {
+        if (
+          await pathExists(
+            join(root, "var/backups/quadball-timer", candidate, "technical-admin-auth-evidence"),
+          )
+        ) {
+          restoreWorkspace = candidate;
+          break;
+        }
+      }
+      expect(restoreWorkspace).toBeTruthy();
+      if (restoreWorkspace !== undefined) {
+        for (const stagedInput of await readdir(
+          join(root, "var/backups/quadball-timer", restoreWorkspace),
+        )) {
+          if (stagedInput === "technical-admin-auth-evidence") {
+            expect(
+              (await lstat(join(root, "var/backups/quadball-timer", restoreWorkspace, stagedInput)))
+                .mode & 0o777,
+            ).toBe(0o700);
+            continue;
+          }
+          expect(
+            (await lstat(join(root, "var/backups/quadball-timer", restoreWorkspace, stagedInput)))
+              .mode & 0o777,
+          ).toBe(0o600);
+        }
+      }
+      expect(await readFile(join(root, "install.log"), "utf8")).toContain(
+        "-d -o root -g root -m 0700",
+      );
+      const ownerSeamLog = await readFile(join(root, "owner-seam.log"), "utf8");
+      expect(ownerSeamLog).toContain("root:root:600");
+      expect(ownerSeamLog).toContain("quadball-timer:quadball-timer:600");
+      const restoreReport = JSON.parse(restore.output) as {
+        restoreId: string;
+        technicalAdminAuth: {
+          credentialPreserved: boolean;
+          reEnrollmentRequired: boolean;
+        };
+        authorityResurrectionWarning: string;
+      };
+      expect(restoreReport.technicalAdminAuth).toMatchObject({
+        outcome: "re-enrollment-required",
+        credentialPreserved: false,
+        reEnrollmentRequired: true,
+      });
+      expect(restoreReport.authorityResurrectionWarning).toContain("older snapshot");
+      expect(
+        await pathExists(
+          join(root, `var/lib/quadball-timer/foundation.sqlite.failed-${restoreReport.restoreId}`),
+        ),
+      ).toBe(true);
+      await rm(join(root, "var/backups/quadball-timer/.restore-lock-test"), {
+        recursive: true,
+        force: true,
+      });
+      const boundedRestoreFailure = await run(
+        "restore",
+        canonicalLock,
+        retainedManifestPath,
+        "restore",
+      );
+      expect(boundedRestoreFailure.code, boundedRestoreFailure.output).not.toBe(0);
+      expect(boundedRestoreFailure.output).toContain('"outcome":"restore-preparation-failed"');
+      expect(boundedRestoreFailure.output).not.toContain(root);
+      expect(boundedRestoreFailure.output).not.toContain("ENOENT");
+
       const retainedDirectory = join(root, "var/backups/quadball-timer/verified-lock-test");
       expect((await lstat(retainedDirectory)).mode & 0o777).toBe(0o700);
       expect((await lstat(join(retainedDirectory, basename(manifestPath)))).mode & 0o777).toBe(
@@ -263,7 +428,35 @@ describe("disposable activation SQLite integration", () => {
         .get() as { schema_version: number };
       migrated.close();
       expect(latestSchema.schema_version).toBe(Number(schemaVersion));
-      expect(digest(authPath)).toBe(authDigest);
+      expect(digest(authPath)).not.toBe(authDigest);
+      const restoredAuth = new Database(authPath, { readonly: true });
+      expect(
+        restoredAuth
+          .query(
+            "SELECT environment, origin, rp_id FROM technical_admin_storage_identity WHERE id = 1",
+          )
+          .get(),
+      ).toEqual({
+        environment: "production",
+        origin: "https://timer.quadball.app",
+        rp_id: "timer.quadball.app",
+      });
+      restoredAuth.close();
+      expect(restoreWorkspace).toBeTruthy();
+      if (restoreWorkspace !== undefined) {
+        const incompatibleEvidencePath = join(
+          root,
+          "var/backups/quadball-timer",
+          restoreWorkspace,
+          "technical-admin-auth-evidence",
+          "technical-admin.sqlite",
+        );
+        const incompatibleEvidence = new Database(incompatibleEvidencePath, { readonly: true });
+        expect(incompatibleEvidence.query("SELECT value FROM auth_canary").get()).toEqual({
+          value: "private",
+        });
+        incompatibleEvidence.close();
+      }
 
       const expectFocusedFailure = async (
         command: string,
@@ -657,7 +850,7 @@ function createRecovery(
       async quiesce() {},
       adapter: {
         async prepareForFoundationRestore() {
-          throw new Error("Foundation restore is not part of Production activation.");
+          return { outcome: "re-enrollment-required", reason: "missing" as const };
         },
       },
     },

--- a/src/lib/release-manifest.ts
+++ b/src/lib/release-manifest.ts
@@ -12,6 +12,7 @@ export const RELEASE_BUNDLE_ALLOWLIST = [
   "deploy/activate-release.sh",
   "deploy/activate-test-release.sh",
   "deploy/activation-maintenance-root.sh",
+  "deploy/restore-production.sh",
   "deploy/systemd/quadball-timer.service",
   "deploy/systemd/quadball-timer-test.service",
 ] as const;

--- a/src/lib/technical-admin-auth.ts
+++ b/src/lib/technical-admin-auth.ts
@@ -112,6 +112,29 @@ export type TechnicalAdminRestorePreparationResult =
     }
   | { outcome: "sanitation-failed" };
 
+/** The bounded restore outcome exposed after the adapter boundary. */
+export type TechnicalAdminRecoveryResult =
+  | {
+      outcome: "not-attempted";
+      credentialPreserved: false;
+      reEnrollmentRequired: false;
+    }
+  | {
+      outcome: "preserved-transients-invalidated";
+      credentialPreserved: true;
+      reEnrollmentRequired: false;
+    }
+  | {
+      outcome: "re-enrollment-required";
+      credentialPreserved: false;
+      reEnrollmentRequired: true;
+    }
+  | {
+      outcome: "sanitation-failed";
+      credentialPreserved: false;
+      reEnrollmentRequired: false;
+    };
+
 export type TechnicalAdminOperationalLog = {
   atMs: number;
   event:

--- a/src/production-activation-fast.test.ts
+++ b/src/production-activation-fast.test.ts
@@ -55,6 +55,7 @@ async function createRelease(base: string): Promise<string> {
     "deploy/activate-release.sh",
     "deploy/activate-test-release.sh",
     "deploy/activation-maintenance-root.sh",
+    "deploy/restore-production.sh",
     "deploy/systemd/quadball-timer.service",
     "deploy/systemd/quadball-timer-test.service",
     "quadball-timer",

--- a/src/production-deployment.test.ts
+++ b/src/production-deployment.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
 import { Buffer } from "node:buffer";
 import { readFileSync } from "node:fs";
 import {
@@ -6,6 +7,7 @@ import {
   lstat,
   mkdir,
   mkdtemp,
+  realpath as fsRealpath,
   readFile,
   readlink,
   rm,
@@ -15,6 +17,10 @@ import {
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { resolveAdHocEnvironmentIdentity } from "@/lib/ad-hoc-games";
+import {
+  copyStableRestoreFile,
+  prepareTechnicalAdminStorageForRestore,
+} from "@/lib/production-activation-cli";
 
 const repositoryRoot = process.cwd();
 
@@ -187,7 +193,6 @@ describe("Production deployment contract", () => {
       join(repositoryRoot, "deploy/activation-maintenance-root.sh"),
       "utf8",
     );
-
     expect(wrapper).toContain("configure_promotion_test_hooks()");
     expect(wrapper).toContain('mv_command="mv"');
     expect(wrapper).toContain('stat_command="stat"');
@@ -403,6 +408,359 @@ promote_verified_backup_as_root "$backup_directory/.candidate-$release_attempt_i
       expect(await pathExists(join(failureRoot, "verified-fail"))).toBe(false);
       expect(await pathExists(failureCandidate)).toBe(false);
       expect(await pathExists(join(failureRoot, ".retained-fail.tmp"))).toBe(false);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("keeps Production restore host-local with an owned workspace and bounded readiness", () => {
+    const wrapper = readFileSync(
+      join(repositoryRoot, "deploy/activation-maintenance-root.sh"),
+      "utf8",
+    );
+    const operator = readFileSync(join(repositoryRoot, "deploy/restore-production.sh"), "utf8");
+
+    expect(wrapper).toContain('install_command="${QBT_FOCUSED_TEST_INSTALL:-/usr/bin/install}"');
+    expect(wrapper).toContain('mktemp_command="${QBT_FOCUSED_TEST_MKTEMP:-mktemp}"');
+    expect(wrapper).toContain(".restore-${release_attempt_id}-XXXXXX");
+    expect(wrapper).toContain('install_command" -d -o root -g root -m 0700');
+    expect(wrapper).toContain('RESTORE_WORKSPACE_DIRECTORY="$restore_workspace"');
+    expect(wrapper).toContain('source_copy_path="/proc/self/fd/7"');
+    expect(wrapper).toContain("== root:root:600");
+    expect(wrapper).toContain("set -o noclobber");
+    expect(wrapper).toContain('exec 6>"$destination_path"');
+    expect(wrapper).toContain('exec 7<"$source_path"');
+    expect(wrapper).toContain('cat <"$source_copy_path" >&6');
+    expect(wrapper).toContain('sync -f -- "$destination_path"');
+    expect(wrapper).toContain('chown "$service_user:$service_user" -- "$destination_path"');
+    expect(wrapper).toContain('"${service_user}:${service_user}:600"');
+    expect(wrapper).toContain("QBT_FOCUSED_TEST_OWNER_SEAM");
+    expect(wrapper).toContain('"outcome":"cutover-completed-readiness-failed"');
+    expect(operator).toContain('"$operator_identity" != deploy-quadball-timer');
+    expect(operator).toContain('exec 9>"$base_dir/.activation.lock"');
+    expect(operator).toContain('"$sudo_command" systemctl stop "$service_name"');
+    expect(operator).toContain("check_release_identity");
+    expect(operator).toContain("authoritative-operation");
+    expect(operator).toContain('"technicalAdminAuth":{"outcome":"not-attempted"');
+    expect(operator).toContain("/internal/healthz");
+    expect(operator).toContain("https://timer.quadball.app");
+    expect(operator).toContain("/healthz");
+    expect(operator).toContain("/api/audience/events");
+    expect(operator).toContain("check_authoritative_operation");
+    expect(operator).not.toContain('"serviceRecovered"');
+    expect(operator).not.toContain("systemctl restart");
+    expect(operator).not.toContain("/api/games");
+    expect(operator).not.toContain("activate-release.sh");
+  });
+
+  test("defers mutable Technical Admin restore access until snapshot verification", () => {
+    const activationCli = readFileSync(
+      join(repositoryRoot, "src/lib/production-activation-cli.ts"),
+      "utf8",
+    );
+    const verification = activationCli.indexOf(
+      "const verifiedManifest = await recovery.verifyBackup",
+    );
+    const authOpen = activationCli.indexOf(
+      "technicalAdminRepository = createSqliteTechnicalAdminAuthRepository",
+    );
+
+    expect(verification).toBeGreaterThanOrEqual(0);
+    expect(authOpen).toBeGreaterThan(verification);
+    expect(activationCli).toContain('"failed-live-foundation.sqlite"');
+    expect(activationCli.indexOf("prepareTechnicalAdminStorageForRestore(")).toBeGreaterThan(
+      verification,
+    );
+    expect(activationCli).toContain("technicalAdminStoragePresent = technicalAdminStorage.present");
+    expect(activationCli).toContain("reason: technicalAdminStorageReason");
+  });
+
+  test("keeps restore staging copies stable and no-follow at both boundaries", async () => {
+    const root = await mkdtemp(join(tmpdir(), "quadball-restore-copy-"));
+    const source = join(root, "source.sqlite");
+    const outside = join(root, "outside.sqlite");
+    const destination = join(root, "destination.sqlite");
+    const sourceReplacement = join(root, "source-replacement.sqlite");
+    try {
+      await writeFile(source, "candidate", { mode: 0o600 });
+      await writeFile(outside, "outside", { mode: 0o600 });
+      await symlink(outside, destination);
+      await expect(copyStableRestoreFile(source, destination)).rejects.toThrow();
+      expect(await readFile(outside, "utf8")).toBe("outside");
+
+      await rm(destination, { force: true });
+      await writeFile(sourceReplacement, "replacement", { mode: 0o600 });
+      await rm(source, { force: true });
+      await symlink(sourceReplacement, source);
+      await expect(copyStableRestoreFile(source, destination)).rejects.toThrow("canonical");
+      expect(await pathExists(destination)).toBe(false);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("displaces invalid and incompatible Technical Admin storage before re-enrollment", async () => {
+    const root = await fsRealpath(await mkdtemp(join(tmpdir(), "quadball-auth-restore-")));
+    const expectedIdentity = {
+      environment: "production" as const,
+      origin: "https://timer.quadball.app",
+      rpId: "timer.quadball.app",
+    };
+    const assertFreshIdentity = (databasePath: string) => {
+      const database = new Database(databasePath, { readonly: true });
+      const identity = database
+        .query(
+          "SELECT environment, origin, rp_id FROM technical_admin_storage_identity WHERE id = 1",
+        )
+        .get();
+      database.close();
+      expect(identity).toEqual({
+        environment: "production",
+        origin: "https://timer.quadball.app",
+        rp_id: "timer.quadball.app",
+      });
+    };
+
+    try {
+      const incompatibleRoot = join(root, "incompatible");
+      const incompatiblePath = join(incompatibleRoot, "technical-admin.sqlite");
+      const incompatibleEvidence = join(incompatibleRoot, "evidence");
+      await mkdir(incompatibleRoot, { recursive: true });
+      const incompatible = new Database(incompatiblePath);
+      incompatible.exec(
+        "CREATE TABLE technical_admin_storage_identity (id INTEGER PRIMARY KEY, environment TEXT, origin TEXT, rp_id TEXT); INSERT INTO technical_admin_storage_identity VALUES (1, 'test', 'https://test.timer.quadball.app', 'test.timer.quadball.app');",
+      );
+      incompatible.close();
+      await expect(
+        prepareTechnicalAdminStorageForRestore(
+          incompatiblePath,
+          incompatibleEvidence,
+          expectedIdentity,
+        ),
+      ).resolves.toEqual({ present: false, reason: "incompatible" });
+      assertFreshIdentity(incompatiblePath);
+      expect(await pathExists(join(incompatibleEvidence, "technical-admin.sqlite"))).toBe(true);
+
+      const malformedRoot = join(root, "malformed");
+      const malformedPath = join(malformedRoot, "technical-admin.sqlite");
+      const malformedEvidence = join(malformedRoot, "evidence");
+      await mkdir(malformedRoot, { recursive: true });
+      const malformed = new Database(malformedPath);
+      malformed.exec(
+        "CREATE TABLE technical_admin_storage_identity (id INTEGER PRIMARY KEY, environment TEXT, origin TEXT, rp_id TEXT); INSERT INTO technical_admin_storage_identity VALUES (1, 'production', 'https://timer.quadball.app', 'timer.quadball.app'); CREATE TABLE technical_admin_credentials (credential_id TEXT PRIMARY KEY);",
+      );
+      malformed.close();
+      await expect(
+        prepareTechnicalAdminStorageForRestore(malformedPath, malformedEvidence, expectedIdentity),
+      ).resolves.toEqual({ present: false, reason: "incompatible" });
+      assertFreshIdentity(malformedPath);
+      const preservedMalformed = new Database(join(malformedEvidence, "technical-admin.sqlite"), {
+        readonly: true,
+      });
+      expect(
+        preservedMalformed.query("PRAGMA table_info(technical_admin_credentials)").all(),
+      ).toHaveLength(1);
+      preservedMalformed.close();
+
+      const symlinkRoot = join(root, "symlink");
+      const symlinkPath = join(symlinkRoot, "technical-admin.sqlite");
+      const symlinkEvidence = join(symlinkRoot, "evidence");
+      const outsidePath = join(root, "outside.sqlite");
+      await mkdir(symlinkRoot, { recursive: true });
+      await writeFile(outsidePath, "outside evidence");
+      await symlink(outsidePath, symlinkPath);
+      await expect(
+        prepareTechnicalAdminStorageForRestore(symlinkPath, symlinkEvidence, expectedIdentity),
+      ).resolves.toEqual({ present: false, reason: "invalid" });
+      assertFreshIdentity(symlinkPath);
+      expect((await lstat(join(symlinkEvidence, "technical-admin.sqlite"))).isSymbolicLink()).toBe(
+        true,
+      );
+      expect(await readFile(outsidePath, "utf8")).toBe("outside evidence");
+
+      const directoryRoot = join(root, "directory");
+      const directoryPath = join(directoryRoot, "technical-admin.sqlite");
+      const directoryEvidence = join(directoryRoot, "evidence");
+      await mkdir(directoryPath, { recursive: true });
+      await writeFile(join(directoryPath, "marker"), "private evidence");
+      await expect(
+        prepareTechnicalAdminStorageForRestore(directoryPath, directoryEvidence, expectedIdentity),
+      ).resolves.toEqual({ present: false, reason: "invalid" });
+      assertFreshIdentity(directoryPath);
+      expect(
+        await readFile(join(directoryEvidence, "technical-admin.sqlite", "marker"), "utf8"),
+      ).toBe("private evidence");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("executes the host-local restore orchestrator fail-closed across service states", async () => {
+    const root = await fsRealpath(await mkdtemp(join(tmpdir(), "quadball-restore-operator-")));
+    const binDirectory = join(root, "bin");
+    const baseDirectory = join(root, "srv/quadball-timer");
+    const releaseDirectory = join(baseDirectory, "releases/restore-attempt");
+    const backupDirectory = join(root, "var/backups/quadball-timer");
+    const verifiedDirectory = join(backupDirectory, "verified-snapshot");
+    const manifestPath = join(verifiedDirectory, "snapshot.manifest.json");
+    const serviceState = join(root, "service-active");
+    const serviceLog = join(root, "service.log");
+    const systemctlStub = join(binDirectory, "systemctl");
+    const sudoStub = join(binDirectory, "sudo");
+    const flockStub = join(binDirectory, "flock");
+    const curlStub = join(binDirectory, "curl");
+    const sleepStub = join(binDirectory, "sleep");
+    const maintenanceStub = join(binDirectory, "maintenance-wrapper");
+    const operator = join(repositoryRoot, "deploy/restore-production.sh");
+
+    const run = async (outcome: string, active: boolean | "failed", curlFailure = false) => {
+      if (active === "failed") await writeFile(serviceState, "failed\n");
+      else if (active) await writeFile(serviceState, "active\n");
+      else await rm(serviceState, { force: true });
+      await writeFile(
+        join(root, "operator-outcome"),
+        `${outcome}\n${curlFailure ? "curl-failure" : "curl-ok"}\n`,
+      );
+      const child = Bun.spawn(["bash", operator, "--manifest", manifestPath], {
+        env: {
+          ...process.env,
+          PATH: `${binDirectory}:${process.env.PATH ?? ""}`,
+          QBT_FOCUSED_TEST_MODE: "1",
+          QBT_FOCUSED_TEST_ROOT: root,
+          QBT_FOCUSED_TEST_OPERATOR: "deploy-quadball-timer",
+          QBT_FOCUSED_TEST_SYSTEMCTL: systemctlStub,
+          QBT_FOCUSED_TEST_SUDO: sudoStub,
+          QBT_FOCUSED_TEST_FLOCK: flockStub,
+          QBT_FOCUSED_TEST_CURL: curlStub,
+          QBT_FOCUSED_TEST_SLEEP: sleepStub,
+          QBT_FOCUSED_TEST_READINESS_ATTEMPTS: "1",
+          QBT_FOCUSED_TEST_MAINTENANCE_WRAPPER: maintenanceStub,
+          QBT_OPERATOR_SERVICE_STATE: serviceState,
+          QBT_OPERATOR_SERVICE_LOG: serviceLog,
+          QBT_OPERATOR_OUTCOME_FILE: join(root, "operator-outcome"),
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      return {
+        code: await child.exited,
+        output: `${await new Response(child.stdout).text()}${await new Response(child.stderr).text()}`,
+      };
+    };
+
+    try {
+      await mkdir(binDirectory, { recursive: true });
+      await mkdir(releaseDirectory, { recursive: true });
+      await mkdir(verifiedDirectory, { recursive: true });
+      await symlink(releaseDirectory, join(baseDirectory, "current"));
+      await writeFile(
+        join(releaseDirectory, "release-manifest.json"),
+        JSON.stringify({
+          releaseAttemptId: "restore-attempt",
+          executableSha256: "a".repeat(64),
+          schemaCompatibility: "foundation-v1",
+        }),
+      );
+      await writeFile(manifestPath, "{}\n");
+      await writeFile(
+        systemctlStub,
+        `#!/bin/sh
+set -eu
+case "\${1:-}" in
+  is-active) if [ -f "$QBT_OPERATOR_SERVICE_STATE" ]; then if grep -q failed "$QBT_OPERATOR_SERVICE_STATE"; then echo failed; else echo active; fi; else echo inactive; fi ;;
+  stop) rm -f "$QBT_OPERATOR_SERVICE_STATE"; echo stop >> "$QBT_OPERATOR_SERVICE_LOG" ;;
+  restart) if grep -q curl-failure "$QBT_OPERATOR_OUTCOME_FILE" && [ "\${QBT_OPERATOR_RESTART_FAIL:-0}" = 1 ]; then exit 1; fi; printf 'active\n' > "$QBT_OPERATOR_SERVICE_STATE"; echo restart >> "$QBT_OPERATOR_SERVICE_LOG" ;;
+  *) exit 0 ;;
+esac
+`,
+      );
+      await writeFile(
+        sudoStub,
+        `#!/bin/sh
+set -eu
+if [ "\${1:-}" = systemctl ]; then shift; exec "$QBT_FOCUSED_TEST_SYSTEMCTL" "$@"; fi
+exec "$@"
+`,
+      );
+      await writeFile(flockStub, "#!/bin/sh\nexit 0\n");
+      await writeFile(sleepStub, "#!/bin/sh\nexit 0\n");
+      await writeFile(
+        curlStub,
+        `#!/bin/sh
+set -eu
+if grep -q curl-failure "$QBT_OPERATOR_OUTCOME_FILE"; then exit 1; fi
+case "$*" in
+  *internal/release*) printf '%s\\n' '{"releaseAttemptId":"restore-attempt","executableSha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","runningExecutableSha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","schemaCompatibility":"foundation-v1"}' ;;
+  */healthz) printf 'healthy\\n' ;;
+  */internal/healthz) printf '%s\\n' '{"ok":true}' ;;
+  */api/audience/events) printf '%s\\n' '{"events":[]}' ;;
+  */) printf '%s\\n' '<!doctype html>' ;;
+  *) exit 1 ;;
+esac
+`,
+      );
+      await writeFile(
+        maintenanceStub,
+        `#!/bin/sh
+set -eu
+if [ "\${3:-}" = authoritative-operation ]; then printf '%s\\n' '{"ok":true}'; exit 0; fi
+outcome="$(head -n1 "$QBT_OPERATOR_OUTCOME_FILE")"
+case "$outcome" in
+  success) touch "$QBT_OPERATOR_SERVICE_STATE"; printf '%s\\n' '{"restored":true,"restoreId":"restore-1","potentiallyNewerWork":false,"technicalAdminAuth":{"outcome":"preserved-transients-invalidated","credentialPreserved":true,"reEnrollmentRequired":false}}'; exit 0 ;;
+  pre-failure) printf '%s\\n' '{"restored":false,"outcome":"restore-preparation-failed","cutoverCompleted":false,"technicalAdminAuth":{"outcome":"not-attempted","credentialPreserved":false,"reEnrollmentRequired":false}}'; exit 1 ;;
+  post-failure) printf '%s\\n' '{"restored":false,"outcome":"foundation-replacement-failed","cutoverCompleted":true,"technicalAdminAuth":{"outcome":"preserved-transients-invalidated","credentialPreserved":true,"reEnrollmentRequired":false}}'; exit 1 ;;
+  *) exit 1 ;;
+esac
+`,
+      );
+      for (const path of [
+        systemctlStub,
+        sudoStub,
+        flockStub,
+        curlStub,
+        sleepStub,
+        maintenanceStub,
+      ]) {
+        await chmod(path, 0o755);
+      }
+
+      const preFailure = await run("pre-failure", true);
+      expect(preFailure.code, preFailure.output).toBe(1);
+      expect(preFailure.output).toContain('"outcome":"restore-preparation-failed"');
+      expect(preFailure.output).toContain('"outcome":"not-attempted"');
+      expect(preFailure.output).toContain('"serviceStopped":true');
+      expect(preFailure.output).not.toContain(root);
+      expect(await pathExists(serviceState)).toBe(false);
+
+      const initiallyInactive = await run("pre-failure", false);
+      expect(initiallyInactive.code, initiallyInactive.output).toBe(1);
+      expect(initiallyInactive.output).toContain('"serviceStopped":true');
+      expect(await pathExists(serviceState)).toBe(false);
+
+      const failedState = await run("pre-failure", "failed");
+      expect(failedState.code, failedState.output).toBe(1);
+      expect(failedState.output).toContain('"outcome":"restore-preparation-failed"');
+      expect(failedState.output).toContain('"technicalAdminAuth":{"outcome":"not-attempted"');
+      expect(failedState.output).toContain('"serviceStopped":true');
+      expect(await pathExists(serviceState)).toBe(false);
+
+      const postFailure = await run("post-failure", true);
+      expect(postFailure.code, postFailure.output).toBe(12);
+      expect(postFailure.output).toContain('"cutoverCompleted":true');
+      expect(postFailure.output).toContain('"outcome":"preserved-transients-invalidated"');
+      expect(await pathExists(serviceState)).toBe(false);
+
+      const success = await run("success", true);
+      expect(success.code, success.output).toBe(0);
+      expect(success.output).toContain('"restored":true');
+      expect(success.output).toContain('"outcome":"preserved-transients-invalidated"');
+      expect(await pathExists(serviceState)).toBe(true);
+
+      const verificationFailure = await run("success", true, true);
+      expect(verificationFailure.code, verificationFailure.output).toBe(12);
+      expect(verificationFailure.output).toContain('"postRestartVerified":false');
+      expect(verificationFailure.output).toContain('"cutoverCompleted":true');
+      expect(await pathExists(serviceState)).toBe(false);
     } finally {
       await rm(root, { recursive: true, force: true });
     }


### PR DESCRIPTION
## What changed

- add a deliberate host-local Production restore orchestrator and privileged staging boundary
- validate a selected Foundation snapshot together with its separately installed matching Grant key ring before replacement
- preserve failed live and evaluated restore evidence while composing Technical Admin Policy A sanitation and conditional re-enrollment
- report bounded, redacted pre-cutover, cutover, restart, and readiness outcomes without automatic retry or rollback of invalidated authority
- verify public/internal readiness, representative Event reads, and one rolled-back authoritative Foundation write

## Why

Production needs a minimum reliable operator-triggered recovery path that restores Foundation data with the matching Grant key ring while preserving authentication identity where valid and failing closed across filesystem, auth, replacement, and readiness failures.

Implements the code contract from #166 and its parent specification without automatically closing the issue. Operator installation and execution prerequisites remain after merge.

## Operator impact

- restore remains host-local and requires the documented operator authorization, exclusive Environment lock, and quiesced service
- the matching Grant key ring must be installed separately; the application and restore command never access 1Password
- failed live Foundation data and failed restore-attempt evidence are retained under bounded private identities
- older snapshots can resurrect stale Grant, Grant Session, Ad Hoc Controller session, or QR-admitting state; the restore result surfaces that consequence
- no restore, retry, alternate-snapshot selection, deployment, or server mutation is automatic

## Verification

- `bun run check`
- focused activation restore: 3 tests, 136 assertions
- targeted Foundation recovery, Production deployment, and Technical Admin auth: 80 tests, 829 assertions
- final Production deployment regression: 23 tests, 201 assertions
- ordinary Fast suite before the final narrow corrections: 991 tests, 22,291 assertions
- no Qualification workload or live Production restore rehearsal

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a>.</sub>
