### PR TITLE
Capture operational failures in GlitchTip (#168)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -114,6 +114,7 @@ jobs:
       phase: ${{ steps.deployment-outcome.outputs.phase }}
       releaseAttemptId: ${{ steps.deployment-outcome.outputs.releaseAttemptId }}
       failureCategory: ${{ steps.deployment-outcome.outputs.failureCategory }}
+      monitoringDelivery: ${{ steps.deployment-outcome.outputs.monitoringDelivery }}
     runs-on: ubuntu-latest
     environment:
       name: test
@@ -181,7 +182,7 @@ jobs:
           base_dir="${DEPLOY_BASE:-/srv/quadball-timer-test}"
           release_id="${RELEASE_ATTEMPT_ID}"
           stage_dir="${base_dir}/.staging/${release_id}"
-          ssh_opts="-i ${SSH_DIR}/id_ed25519 -o StrictHostKeyChecking=yes -o UserKnownHostsFile=${SSH_DIR}/known_hosts"
+          ssh_opts="-i ${SSH_DIR}/id_ed25519 -o StrictHostKeyChecking=yes -o UserKnownHostsFile=${SSH_DIR}/known_hosts -o ConnectTimeout=10 -o ServerAliveInterval=5 -o ServerAliveCountMax=1"
           cleanup_remote_stage() {
             ssh $ssh_opts "${DEPLOY_USER}@${DEPLOY_HOST}" "chmod -R u+w -- '${stage_dir}' 2>/dev/null || true; rm -rf -- '${stage_dir}'" || true
             rm -rf -- "$SSH_DIR"
@@ -194,7 +195,14 @@ jobs:
           activation_status=${PIPESTATUS[0]}
           set -e
           phase="$(sed -n 's/^ACTIVATION_PHASE=//p' "$RUNNER_TEMP/quadball-test-deployment.log" | tail -n 1)"
+          monitoring_delivery="unavailable"
+          if (( activation_status != 0 )); then
+            sleep 3
+            monitoring_delivery="$(timeout --signal=KILL 5s ssh $ssh_opts "${DEPLOY_USER}@${DEPLOY_HOST}" "reporter='${base_dir}/releases/${release_id}'; if [[ ! -x \"\$reporter/quadball-timer\" || ! -f \"\$reporter/release-manifest.json\" ]]; then reporter=\$(readlink -f '${base_dir}/current' 2>/dev/null || true); fi; [[ \"\$reporter\" == '${base_dir}/releases/'* ]] && sudo /usr/local/sbin/quadball-timer-activation-maintenance test \"\$reporter\" read-operational-delivery '${release_id}'" 2>/dev/null || true)"
+          fi
+          case "$monitoring_delivery" in sent|failed|unavailable) ;; *) monitoring_delivery="unavailable" ;; esac
           echo "DEPLOYMENT_PHASE=${phase:-activation}" >> "$GITHUB_ENV"
+          echo "MONITORING_DELIVERY=$monitoring_delivery" >> "$GITHUB_ENV"
           exit "$activation_status"
 
       - name: Record Test deployment outcome
@@ -204,6 +212,7 @@ jobs:
           JOB_STATUS: ${{ job.status }}
           RELEASE_ATTEMPT: ${{ env.RELEASE_ATTEMPT_ID }}
           FAILED_PHASE: ${{ env.DEPLOYMENT_PHASE }}
+          MONITORING_DELIVERY: ${{ env.MONITORING_DELIVERY || 'unavailable' }}
         run: |
           set -euo pipefail
           case "$JOB_STATUS" in
@@ -225,6 +234,7 @@ jobs:
             echo "phase=$phase"
             echo "releaseAttemptId=$RELEASE_ATTEMPT"
             echo "failureCategory=$failure_category"
+            echo "monitoringDelivery=$MONITORING_DELIVERY"
           } >> "$GITHUB_OUTPUT"
 
   deploy-production:
@@ -235,6 +245,7 @@ jobs:
       phase: ${{ steps.deployment-outcome.outputs.phase }}
       releaseAttemptId: ${{ steps.deployment-outcome.outputs.releaseAttemptId }}
       failureCategory: ${{ steps.deployment-outcome.outputs.failureCategory }}
+      monitoringDelivery: ${{ steps.deployment-outcome.outputs.monitoringDelivery }}
     runs-on: ubuntu-latest
     environment:
       name: production
@@ -306,7 +317,7 @@ jobs:
           app_port="${PROD_APP_PORT:-3000}"
           release_id="${RELEASE_ATTEMPT_ID}"
           stage_dir="${base_dir}/.staging/${release_id}"
-          ssh_opts="-i ${SSH_DIR}/id_ed25519 -o StrictHostKeyChecking=yes -o UserKnownHostsFile=${SSH_DIR}/known_hosts"
+          ssh_opts="-i ${SSH_DIR}/id_ed25519 -o StrictHostKeyChecking=yes -o UserKnownHostsFile=${SSH_DIR}/known_hosts -o ConnectTimeout=10 -o ServerAliveInterval=5 -o ServerAliveCountMax=1"
           cleanup_remote_stage() {
             ssh $ssh_opts "${DEPLOY_USER}@${DEPLOY_HOST}" "chmod -R u+w -- '${stage_dir}' 2>/dev/null || true; rm -rf -- '${stage_dir}'" || true
             rm -rf -- "$SSH_DIR"
@@ -319,7 +330,14 @@ jobs:
           activation_status=${PIPESTATUS[0]}
           set -e
           phase="$(sed -n 's/^ACTIVATION_PHASE=//p' "$RUNNER_TEMP/quadball-production-deployment.log" | tail -n 1)"
+          monitoring_delivery="unavailable"
+          if (( activation_status != 0 )); then
+            sleep 3
+            monitoring_delivery="$(timeout --signal=KILL 5s ssh $ssh_opts "${DEPLOY_USER}@${DEPLOY_HOST}" "reporter='${base_dir}/releases/${release_id}'; if [[ ! -x \"\$reporter/quadball-timer\" || ! -f \"\$reporter/release-manifest.json\" ]]; then reporter=\$(readlink -f '${base_dir}/current' 2>/dev/null || true); fi; [[ \"\$reporter\" == '${base_dir}/releases/'* ]] && sudo /usr/local/sbin/quadball-timer-activation-maintenance production \"\$reporter\" read-operational-delivery '${release_id}'" 2>/dev/null || true)"
+          fi
+          case "$monitoring_delivery" in sent|failed|unavailable) ;; *) monitoring_delivery="unavailable" ;; esac
           echo "DEPLOYMENT_PHASE=${phase:-activation}" >> "$GITHUB_ENV"
+          echo "MONITORING_DELIVERY=$monitoring_delivery" >> "$GITHUB_ENV"
           if (( activation_status != 0 )); then exit "$activation_status"; fi
           curl --fail --silent --show-error --max-time 10 https://timer.quadball.app/ | grep -qi "<!doctype html"
 
@@ -330,6 +348,7 @@ jobs:
           JOB_STATUS: ${{ job.status }}
           RELEASE_ATTEMPT: ${{ env.RELEASE_ATTEMPT_ID }}
           FAILED_PHASE: ${{ env.DEPLOYMENT_PHASE }}
+          MONITORING_DELIVERY: ${{ env.MONITORING_DELIVERY || 'unavailable' }}
         run: |
           set -euo pipefail
           case "$JOB_STATUS" in
@@ -351,6 +370,7 @@ jobs:
             echo "phase=$phase"
             echo "releaseAttemptId=$RELEASE_ATTEMPT"
             echo "failureCategory=$failure_category"
+            echo "monitoringDelivery=$MONITORING_DELIVERY"
           } >> "$GITHUB_OUTPUT"
 
   report:
@@ -364,9 +384,11 @@ jobs:
           TEST_STATUS: ${{ needs.deploy-test.outputs.status || needs.deploy-test.result }}
           TEST_PHASE: ${{ needs.deploy-test.outputs.phase || 'deployment' }}
           TEST_FAILURE_CATEGORY: ${{ needs.deploy-test.outputs.failureCategory || 'job-skipped' }}
+          TEST_MONITORING_DELIVERY: ${{ needs.deploy-test.outputs.monitoringDelivery || 'unavailable' }}
           PRODUCTION_STATUS: ${{ needs.deploy-production.outputs.status || needs.deploy-production.result }}
           PRODUCTION_PHASE: ${{ needs.deploy-production.outputs.phase || 'deployment' }}
           PRODUCTION_FAILURE_CATEGORY: ${{ needs.deploy-production.outputs.failureCategory || 'job-skipped' }}
+          PRODUCTION_MONITORING_DELIVERY: ${{ needs.deploy-production.outputs.monitoringDelivery || 'unavailable' }}
         run: |
           set -euo pipefail
           cat > deployment-report.json <<EOF
@@ -375,12 +397,14 @@ jobs:
             "test": {
               "status": "${TEST_STATUS}",
               "phase": "${TEST_PHASE}",
-              "failureCategory": "${TEST_FAILURE_CATEGORY}"
+              "failureCategory": "${TEST_FAILURE_CATEGORY}",
+              "monitoringDelivery": "${TEST_MONITORING_DELIVERY}"
             },
             "production": {
               "status": "${PRODUCTION_STATUS}",
               "phase": "${PRODUCTION_PHASE}",
-              "failureCategory": "${PRODUCTION_FAILURE_CATEGORY}"
+              "failureCategory": "${PRODUCTION_FAILURE_CATEGORY}",
+              "monitoringDelivery": "${PRODUCTION_MONITORING_DELIVERY}"
             }
           }
           EOF

--- a/deploy/activate-release.sh
+++ b/deploy/activate-release.sh
@@ -10,32 +10,77 @@ keep_releases=5
 expected_environment="production"
 maintenance_wrapper="/usr/local/sbin/quadball-timer-activation-maintenance"
 
+report_operational_failure() {
+  local operation="deployment"
+  if (( $# >= 3 )); then
+    case "${1:-}" in
+      deployment|backup|migration|restore|readiness) operation="$1"; shift ;;
+    esac
+  fi
+  local phase="$1" category="$2" outcome="${3:-failed}"
+  local reporter_release="${base_dir}/releases/${release_id}" reporter_command="report-operational"
+  [[ -x "$maintenance_wrapper" && -n "$release_id" ]] || return 0
+  if [[ ! -x "$reporter_release/quadball-timer" || ! -f "$reporter_release/release-manifest.json" ]]; then
+    reporter_release="$(realpath "${base_dir}/current" 2>/dev/null || true)"
+    [[ "$reporter_release" == "${base_dir}/releases/"* && -x "$reporter_release/quadball-timer" && -f "$reporter_release/release-manifest.json" ]] || return 0
+    reporter_command="report-operational-attempt"
+  fi
+  if [[ "$reporter_command" == report-operational-attempt ]]; then
+    nohup sudo "$maintenance_wrapper" production "$reporter_release" "$reporter_command" \
+      "$operation" "$phase" "$outcome" "$category" "$release_id" 9>&- </dev/null >/dev/null 2>&1 &
+  else
+    nohup sudo "$maintenance_wrapper" production "$reporter_release" "$reporter_command" \
+      "$operation" "$phase" "$outcome" "$category" 9>&- </dev/null >/dev/null 2>&1 &
+  fi
+}
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --base-dir) base_dir="${2:-}"; shift 2 ;;
-    --release) release_id="${2:-}"; shift 2 ;;
-    --staged-dir) staged_dir="${2:-}"; shift 2 ;;
-    --service) service_name="${2:-}"; shift 2 ;;
-    --port) port="${2:-}"; shift 2 ;;
-    --keep-releases) keep_releases="${2:-}"; shift 2 ;;
-    *) echo "Unknown argument: $1" >&2; exit 1 ;;
+    --base-dir|--release|--staged-dir|--service|--port|--keep-releases)
+      option="$1"
+      if (( $# < 2 )) || [[ -z "${2:-}" ]]; then
+        echo "Missing value for ${option}." >&2
+        report_operational_failure preflight atomic-install unavailable
+        printf 'unavailable\n' >&2
+        exit 1
+      fi
+      case "$option" in
+        --base-dir) base_dir="$2" ;;
+        --release) release_id="$2" ;;
+        --staged-dir) staged_dir="$2" ;;
+        --service) service_name="$2" ;;
+        --port) port="$2" ;;
+        --keep-releases) keep_releases="$2" ;;
+      esac
+      shift 2
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      report_operational_failure preflight atomic-install unavailable
+      printf 'unavailable\n' >&2
+      exit 1
+      ;;
   esac
 done
 
 if [[ ! "$release_id" =~ ^sha-[A-Za-z0-9._-]+-run-[A-Za-z0-9._-]+-attempt-[A-Za-z0-9._-]+$ ]]; then
   echo "Invalid release-attempt identity." >&2
+  printf 'unavailable\n' >&2
   exit 1
 fi
 if [[ ! "$service_name" =~ ^[A-Za-z0-9_.@-]+$ ]]; then
   echo "Invalid service value: ${service_name}" >&2
+  report_operational_failure preflight atomic-install
   exit 1
 fi
 if [[ ! "$port" =~ ^[0-9]+$ ]] || (( port < 1 || port > 65535 )); then
   echo "Invalid port value: ${port}" >&2
+  report_operational_failure preflight atomic-install
   exit 1
 fi
 if [[ ! "$keep_releases" =~ ^[1-9][0-9]*$ ]]; then
   echo "Invalid release retention value." >&2
+  report_operational_failure preflight atomic-install
   exit 1
 fi
 
@@ -255,13 +300,18 @@ candidate_dir=""
 service_stopped=0
 migration_attempted=0
 focused_failure_phase="${QBT_FOCUSED_FAILURE_PHASE:-}"
+export QBT_FOCUSED_FAILURE_PHASE="$focused_failure_phase"
 if [[ "${QBT_FOCUSED_TEST_BATCH:-}" != 1 || "$focused_failure_phase" == preflight ]]; then
-  check_environment_identity
+  if ! check_environment_identity; then
+    report_operational_failure preflight readiness
+    return 1
+  fi
 fi
 
 if [[ -n "$staged_dir" ]]; then
   if [[ "$staged_dir" != "$expected_staged_dir" ]]; then
     echo "Staging directory is outside the environment staging root." >&2
+    report_operational_failure preflight atomic-install
     return 1
   fi
   cleanup_staged=1
@@ -278,16 +328,25 @@ cleanup() {
     rm -rf -- "$candidate_dir"
   fi
   if (( service_stopped == 1 && migration_attempted == 0 )); then
-    sudo systemctl restart "$service_name" >/dev/null 2>&1 || true
+    if ! sudo systemctl restart "$service_name" >/dev/null 2>&1; then
+      report_operational_failure rollback-restart binary-rollback
+    fi
   fi
 }
 trap cleanup EXIT
 
 if [[ "${QBT_FOCUSED_TEST_BATCH:-}" != 1 ]]; then
-  mkdir -p -- "${base_dir}/releases" "${base_dir}/.staging"
-  exec 9>"${base_dir}/.activation.lock"
+  if ! mkdir -p -- "${base_dir}/releases" "${base_dir}/.staging"; then
+    report_operational_failure preflight atomic-install
+    return 1
+  fi
+  if ! exec 9>"${base_dir}/.activation.lock"; then
+    report_operational_failure preflight atomic-install
+    return 1
+  fi
   if ! flock -n 9; then
     echo "Another ${service_name} activation is already running." >&2
+    report_operational_failure preflight atomic-install
     return 1
   fi
 fi
@@ -358,28 +417,43 @@ verify_bundle() {
 if [[ -n "$staged_dir" ]]; then
   if [[ -e "$release_dir" ]]; then
     echo "Release-attempt identity already exists and cannot be overwritten: ${release_id}" >&2
+    report_operational_failure preflight atomic-install
     return 1
   fi
-  if [[ "${QBT_FOCUSED_TEST_RELEASE_VERIFIED:-}" != 1 ]]; then verify_bundle "$staged_dir"; fi
-  chmod u+w -- "$staged_dir"
-  mv -- "$staged_dir" "$release_dir"
+  if [[ "${QBT_FOCUSED_TEST_RELEASE_VERIFIED:-}" != 1 ]] && ! verify_bundle "$staged_dir"; then
+    report_operational_failure preflight atomic-install
+    return 1
+  fi
+  if ! chmod u+w -- "$staged_dir" || ! mv -- "$staged_dir" "$release_dir"; then
+    report_operational_failure preflight atomic-install
+    return 1
+  fi
   cleanup_staged=0
-  chmod -R a-w -- "$release_dir"
+  if ! chmod -R a-w -- "$release_dir"; then
+    report_operational_failure preflight atomic-install
+    return 1
+  fi
 else
   if [[ ! -d "$release_dir" ]]; then
     echo "Release directory does not exist: ${release_dir}" >&2
+    report_operational_failure preflight atomic-install
     return 1
   fi
-  if [[ "${QBT_FOCUSED_TEST_RELEASE_VERIFIED:-}" != 1 ]]; then verify_bundle "$release_dir"; fi
+  if [[ "${QBT_FOCUSED_TEST_RELEASE_VERIFIED:-}" != 1 ]] && ! verify_bundle "$release_dir"; then
+    report_operational_failure preflight atomic-install
+    return 1
+  fi
 fi
 
 if [[ "${QBT_FOCUSED_TEST_BATCH:-}" != 1 || "$focused_failure_phase" == preflight ]]; then
   if [[ ! -x "${release_dir}/quadball-timer" ]]; then
     echo "Compiled executable is missing or not executable: ${release_dir}/quadball-timer" >&2
+    report_operational_failure preflight atomic-install
     return 1
   fi
   if [[ "${QBT_FOCUSED_TEST_MODE:-}" != 1 ]] && ! grep -qw avx2 /proc/cpuinfo; then
     echo "Server CPU does not support AVX2, but this release uses bun-linux-x64-modern." >&2
+    report_operational_failure preflight atomic-install
     return 1
   fi
 
@@ -388,6 +462,7 @@ if [[ "${QBT_FOCUSED_TEST_BATCH:-}" != 1 || "$focused_failure_phase" == prefligh
   if [[ "$actual_exec_start" != *"$expected_exec_start"* ]]; then
     echo "Systemd service ${service_name} does not run ${expected_exec_start}." >&2
     echo "Current ExecStart: ${actual_exec_start:-<unavailable>}" >&2
+    report_operational_failure preflight atomic-install
     return 1
   fi
 fi
@@ -409,64 +484,92 @@ check_service_state_contract() {
   fi
 }
 if [[ "${QBT_FOCUSED_TEST_BATCH:-}" != 1 || "$focused_failure_phase" == preflight ]]; then
-  check_service_state_contract
-  schema_compatibility="$(sed -n 's/.*"schemaCompatibility":"\([^"]*\)".*/\1/p' "${release_dir}/release-manifest.json")"
-  [[ -n "$schema_compatibility" ]] || { echo "Release schema compatibility is missing." >&2; return 1; }
-  [[ -x "$maintenance_wrapper" ]] || { echo "Root maintenance boundary is not installed." >&2; return 1; }
-  available_kb="$(df -Pk /var/lib/quadball-timer | awk 'NR == 2 {print $4}')"
+  if ! check_service_state_contract; then
+    report_operational_failure preflight atomic-install
+    return 1
+  fi
+  schema_compatibility="$(sed -n 's/.*"schemaCompatibility":"\([^"]*\)".*/\1/p' "${release_dir}/release-manifest.json" || true)"
+  if [[ -z "$schema_compatibility" ]]; then
+    echo "Release schema compatibility is missing." >&2
+    report_operational_failure preflight schema-incompatibility
+    return 1
+  fi
+  if [[ ! -x "$maintenance_wrapper" ]]; then
+    echo "Root maintenance boundary is not installed." >&2
+    report_operational_failure preflight atomic-install
+    return 1
+  fi
+  available_kb="$(df -Pk /var/lib/quadball-timer 2>/dev/null | awk 'NR == 2 {print $4}' || true)"
   if [[ ! "$available_kb" =~ ^[0-9]+$ ]] || (( available_kb < 131072 )); then
     echo "Production state directory lacks the required disk reserve." >&2
+    report_operational_failure preflight atomic-install
     return 1
   fi
 fi
 echo "ACTIVATION_PHASE=migration"
-if ! inject_focused_failure preflight; then return 1; fi
 if ! sudo "$maintenance_wrapper" production "$release_dir" preflight >/dev/null; then
   echo "Production Foundation preflight/readiness failed; service was not stopped." >&2
+  # The maintenance CLI owns the semantic failure event. This shell-owned
+  # boundary only reports when the command cannot be entered at all.
   return 1
 fi
 echo "ACTIVATION_PHASE=backup"
 
 # The service owns the writer boundary. The compiled maintenance mode reuses
 # #81's Foundation recovery operation; it never opens the Technical Admin DB.
-if ! inject_focused_failure quiesce-stop; then return 1; fi
-sudo systemctl stop "$service_name"
+if ! inject_focused_failure quiesce-stop; then report_operational_failure quiesce-stop atomic-install; return 1; fi
+if ! sudo systemctl stop "$service_name"; then
+  report_operational_failure quiesce-stop atomic-install
+  return 1
+fi
 service_stopped=1
-if ! inject_focused_failure backup-create; then return 1; fi
 maintenance_json="$(sudo "$maintenance_wrapper" production "$release_dir" backup)" || {
   echo "Production backup creation failed; previous verified backup preserved." >&2
   return 1
 }
 manifest_path="$(sed -n 's/.*"manifestPath":"\([^"]*\)".*/\1/p' <<<"$maintenance_json")"
-[[ -n "$manifest_path" ]] || { echo "Production backup did not return a manifest." >&2; return 1; }
-if ! inject_focused_failure backup-verify; then return 1; fi
+if [[ -z "$manifest_path" ]]; then
+  echo "Production backup did not return a manifest." >&2
+  report_operational_failure backup backup-create backup-candidate
+  return 1
+fi
 if ! sudo "$maintenance_wrapper" production "$release_dir" verify-backup "$manifest_path"; then
   echo "Production backup independent verification failed; previous verified backup preserved." >&2
   return 1
 fi
-if ! inject_focused_failure backup-promote; then return 1; fi
 if ! sudo "$maintenance_wrapper" production "$release_dir" promote "$manifest_path"; then
   echo "Verified backup promotion failed; previous retained backup preserved." >&2
   return 1
 fi
 echo "ACTIVATION_PHASE=migration"
-if ! inject_focused_failure candidate-validation; then return 1; fi
 if ! sudo "$maintenance_wrapper" production "$release_dir" validate-migration; then
   echo "Disposable migration candidate did not reach readiness." >&2
   return 1
 fi
 migration_attempted=1
-if ! inject_focused_failure live-migration; then return 1; fi
 if ! sudo "$maintenance_wrapper" production "$release_dir" apply-migrations; then
   echo "Live migration failed; database preserved without automatic restore." >&2
   return 1
 fi
 
 echo "ACTIVATION_PHASE=activation"
-if ! inject_focused_failure release-switch; then return 1; fi
-ln -sfn -- "$release_dir" "$current_link"
+if ! inject_focused_failure release-switch; then report_operational_failure release-switch atomic-install; return 1; fi
+if ! ln -sfn -- "$release_dir" "$current_link"; then
+  report_operational_failure release-switch atomic-install
+  return 1
+fi
 
-restart_service() { inject_focused_failure rollback-restart || return 1; sudo systemctl restart "$service_name"; }
+restart_service() {
+  local phase="$1" category="$2"
+  if ! inject_focused_failure rollback-restart; then
+    report_operational_failure "$phase" "$category"
+    return 1
+  fi
+  if ! sudo systemctl restart "$service_name"; then
+    report_operational_failure "$phase" "$category"
+    return 1
+  fi
+}
 
 report_service_state() {
   local property value
@@ -549,24 +652,39 @@ prune_releases() {
   fi
 }
 
-if restart_service && check_health "$release_id" "$release_dir" && check_representative_behavior; then
-  prune_releases "$release_dir" "$previous_release"
-  if ! inject_focused_failure final-report; then return 1; fi
-  echo "Activated immutable release attempt ${release_id}."
-  return 0
+if restart_service startup atomic-install; then
+  if check_health "$release_id" "$release_dir" && check_representative_behavior; then
+    if ! prune_releases "$release_dir" "$previous_release"; then
+      report_operational_failure final-report atomic-install
+      return 1
+    fi
+    if ! inject_focused_failure final-report; then report_operational_failure final-report atomic-install; return 1; fi
+    echo "Activated immutable release attempt ${release_id}."
+    return 0
+  fi
+  report_operational_failure readiness readiness
 fi
 
 report_service_state
 echo "Deploy failed; attempting compatible binary rollback without restoring database state." >&2
 if [[ -n "$previous_release" && -d "$previous_release" ]] && compatible_previous_release; then
   previous_release_id="${previous_release##*/}"
-  ln -sfn -- "$previous_release" "$current_link"
-  if restart_service && check_health "$previous_release_id" "$previous_release"; then
-    echo "Rolled back to ${previous_release}." >&2
+  if ! ln -sfn -- "$previous_release" "$current_link"; then
+    report_operational_failure rollback-restart binary-rollback
+    return 1
+  fi
+  if restart_service rollback-restart binary-rollback; then
+    if check_health "$previous_release_id" "$previous_release"; then
+      echo "Rolled back to ${previous_release}." >&2
+    else
+      report_operational_failure rollback-restart binary-rollback
+      echo "Rollback of ${previous_release} failed health checks." >&2
+    fi
   else
     echo "Rollback of ${previous_release} failed health checks." >&2
   fi
 else
+  report_operational_failure rollback-restart binary-rollback
   echo "No compatible previous release available for rollback." >&2
 fi
 return 1
@@ -613,6 +731,7 @@ if [[ "${QBT_FOCUSED_TEST_BATCH:-}" == 1 ]]; then
     fi
     cleanup >>"${focused_batch_directory}/output" 2>&1 || true
     trap - EXIT
+    wait
     printf '%s\n' "$focused_batch_status" >"${focused_batch_directory}/status"
     readlink "$current_link" >"${focused_batch_directory}/current"
     printf '%s\n' "$(<"$QBT_FAST_POINTER")" >"${focused_batch_directory}/pointer"

--- a/deploy/activate-test-release.sh
+++ b/deploy/activate-test-release.sh
@@ -10,22 +10,65 @@ keep_releases=5
 expected_environment="test"
 maintenance_wrapper="/usr/local/sbin/quadball-timer-activation-maintenance"
 
+report_operational_failure() {
+  local operation="deployment"
+  if (( $# >= 3 )); then
+    case "${1:-}" in
+      deployment|backup|migration|restore|readiness) operation="$1"; shift ;;
+    esac
+  fi
+  local phase="$1" category="$2" outcome="${3:-failed}"
+  local reporter_release="${base_dir}/releases/${release_id}" reporter_command="report-operational"
+  [[ -x "$maintenance_wrapper" && -n "$release_id" ]] || return 0
+  if [[ ! -x "$reporter_release/quadball-timer" || ! -f "$reporter_release/release-manifest.json" ]]; then
+    reporter_release="$(realpath "${base_dir}/current" 2>/dev/null || true)"
+    [[ "$reporter_release" == "${base_dir}/releases/"* && -x "$reporter_release/quadball-timer" && -f "$reporter_release/release-manifest.json" ]] || return 0
+    reporter_command="report-operational-attempt"
+  fi
+  if [[ "$reporter_command" == report-operational-attempt ]]; then
+    nohup sudo "$maintenance_wrapper" test "$reporter_release" "$reporter_command" \
+      "$operation" "$phase" "$outcome" "$category" "$release_id" 9>&- </dev/null >/dev/null 2>&1 &
+  else
+    nohup sudo "$maintenance_wrapper" test "$reporter_release" "$reporter_command" \
+      "$operation" "$phase" "$outcome" "$category" 9>&- </dev/null >/dev/null 2>&1 &
+  fi
+}
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --base-dir) base_dir="${2:-}"; shift 2 ;;
-    --release) release_id="${2:-}"; shift 2 ;;
-    --staged-dir) staged_dir="${2:-}"; shift 2 ;;
-    --keep-releases) keep_releases="${2:-}"; shift 2 ;;
-    *) echo "Unknown argument: $1" >&2; exit 1 ;;
+    --base-dir|--release|--staged-dir|--keep-releases)
+      option="$1"
+      if (( $# < 2 )) || [[ -z "${2:-}" ]]; then
+        echo "Missing value for ${option}." >&2
+        report_operational_failure preflight atomic-install unavailable
+        printf 'unavailable\n' >&2
+        exit 1
+      fi
+      case "$option" in
+        --base-dir) base_dir="$2" ;;
+        --release) release_id="$2" ;;
+        --staged-dir) staged_dir="$2" ;;
+        --keep-releases) keep_releases="$2" ;;
+      esac
+      shift 2
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      report_operational_failure preflight atomic-install unavailable
+      printf 'unavailable\n' >&2
+      exit 1
+      ;;
   esac
 done
 
 if [[ ! "$release_id" =~ ^sha-[A-Za-z0-9._-]+-run-[A-Za-z0-9._-]+-attempt-[A-Za-z0-9._-]+$ ]]; then
   echo "Invalid Test release-attempt identity." >&2
+  printf 'unavailable\n' >&2
   exit 1
 fi
 if [[ ! "$keep_releases" =~ ^[1-9][0-9]*$ ]]; then
   echo "Invalid release retention value." >&2
+  printf 'unavailable\n' >&2
   exit 1
 fi
 
@@ -37,12 +80,19 @@ cleanup_staged=0
 service_stopped=0
 migration_attempted=0
 focused_failure_phase="${QBT_FOCUSED_FAILURE_PHASE:-}"
+export QBT_FOCUSED_FAILURE_PHASE="$focused_failure_phase"
 
 inject_focused_failure() {
   if [[ "${QBT_FOCUSED_TEST_MODE:-}" == 1 && "$EUID" -ne 0 && -n "${QBT_FOCUSED_TEST_ROOT:-}" && "$focused_failure_phase" == "$1" ]]; then
     echo "Focused activation failure at $1." >&2
     return 1
   fi
+}
+
+rollback_failure_reported=0
+report_binary_rollback_failure() {
+  rollback_failure_reported=1
+  report_operational_failure rollback-restart binary-rollback
 }
 if [[ "${QBT_FOCUSED_TEST_MODE:-}" == 1 ]]; then
   focused_test_root="${QBT_FOCUSED_TEST_ROOT:-}"
@@ -216,7 +266,11 @@ activation_wait_seconds() {
 }
 
 if [[ -n "$staged_dir" ]]; then
-  [[ "$staged_dir" == "$expected_staged_dir" ]] || { echo "Invalid Test staging directory." >&2; exit 1; }
+  if [[ "$staged_dir" != "$expected_staged_dir" ]]; then
+    echo "Invalid Test staging directory." >&2
+    report_operational_failure preflight atomic-install
+    exit 1
+  fi
   cleanup_staged=1
 fi
 
@@ -232,7 +286,10 @@ check_environment_identity() {
     return 1
   }
 }
-check_environment_identity
+if ! check_environment_identity; then
+  report_operational_failure preflight readiness
+  exit 1
+fi
 # shellcheck disable=SC2329
 cleanup() {
   if (( cleanup_staged == 1 )) && [[ -d "$staged_dir" ]]; then
@@ -240,14 +297,26 @@ cleanup() {
     rm -rf -- "$staged_dir"
   fi
   if (( service_stopped == 1 && migration_attempted == 0 )); then
-    sudo systemctl restart "$service_name" >/dev/null 2>&1 || true
+    if ! sudo systemctl restart "$service_name" >/dev/null 2>&1; then
+      report_binary_rollback_failure
+    fi
   fi
 }
 trap cleanup EXIT
 
-mkdir -p -- "${base_dir}/releases" "${base_dir}/.staging"
-exec 9>"${base_dir}/.activation.lock"
-if ! flock -n 9; then echo "Another ${service_name} activation is already running." >&2; exit 1; fi
+if ! mkdir -p -- "${base_dir}/releases" "${base_dir}/.staging"; then
+  report_operational_failure preflight atomic-install
+  exit 1
+fi
+if ! exec 9>"${base_dir}/.activation.lock"; then
+  report_operational_failure preflight atomic-install
+  exit 1
+fi
+if ! flock -n 9; then
+  echo "Another ${service_name} activation is already running." >&2
+  report_operational_failure preflight atomic-install
+  exit 1
+fi
 if [[ -L "$current_link" || -d "$current_link" ]]; then previous_release="$(readlink -f "$current_link" || true)"; fi
 
 verify_bundle() {
@@ -281,21 +350,44 @@ verify_bundle() {
 }
 
 if [[ -n "$staged_dir" ]]; then
-  [[ ! -e "$release_dir" ]] || { echo "Test release identity already exists and cannot be overwritten." >&2; exit 1; }
-  if [[ "${QBT_FOCUSED_TEST_RELEASE_VERIFIED:-}" != 1 ]]; then verify_bundle "$staged_dir"; fi
-  chmod u+w -- "$staged_dir"
-  mv -- "$staged_dir" "$release_dir"
+  [[ ! -e "$release_dir" ]] || { echo "Test release identity already exists and cannot be overwritten." >&2; report_operational_failure preflight atomic-install; exit 1; }
+  if [[ "${QBT_FOCUSED_TEST_RELEASE_VERIFIED:-}" != 1 ]] && ! verify_bundle "$staged_dir"; then
+    report_operational_failure preflight atomic-install
+    exit 1
+  fi
+  if ! chmod u+w -- "$staged_dir" || ! mv -- "$staged_dir" "$release_dir"; then
+    report_operational_failure preflight atomic-install
+    exit 1
+  fi
   cleanup_staged=0
-  chmod -R a-w -- "$release_dir"
+  if ! chmod -R a-w -- "$release_dir"; then
+    report_operational_failure preflight atomic-install
+    exit 1
+  fi
 else
-  [[ -d "$release_dir" ]] || { echo "Test release directory does not exist." >&2; exit 1; }
-  if [[ "${QBT_FOCUSED_TEST_RELEASE_VERIFIED:-}" != 1 ]]; then verify_bundle "$release_dir"; fi
+  [[ -d "$release_dir" ]] || {
+    echo "Test release directory does not exist." >&2
+    report_operational_failure preflight atomic-install
+    exit 1
+  }
+  if [[ "${QBT_FOCUSED_TEST_RELEASE_VERIFIED:-}" != 1 ]] && ! verify_bundle "$release_dir"; then
+    report_operational_failure preflight atomic-install
+    exit 1
+  fi
 fi
 
-grep -qw avx2 /proc/cpuinfo || { echo "Server CPU does not support AVX2, but this release uses bun-linux-x64-modern." >&2; exit 1; }
+if [[ "${QBT_FOCUSED_TEST_MODE:-}" != 1 ]] && ! grep -qw avx2 /proc/cpuinfo; then
+  echo "Server CPU does not support AVX2, but this release uses bun-linux-x64-modern." >&2
+  report_operational_failure preflight atomic-install
+  exit 1
+fi
 expected_exec_start="${current_link}/quadball-timer"
 actual_exec_start="$(systemctl show "$service_name" --property=ExecStart --value 2>/dev/null || true)"
-[[ "$actual_exec_start" == *"$expected_exec_start"* ]] || { echo "Test service does not run ${expected_exec_start}." >&2; exit 1; }
+if [[ "$actual_exec_start" != *"$expected_exec_start"* ]]; then
+  echo "Test service does not run ${expected_exec_start}." >&2
+  report_operational_failure preflight atomic-install
+  exit 1
+fi
 
 check_service_contract() {
   local state_directory state_directory_mode effective_environment
@@ -315,40 +407,65 @@ check_service_contract() {
     return 1
   fi
 }
-check_service_contract
+if ! check_service_contract; then
+  report_operational_failure preflight atomic-install
+  exit 1
+fi
 
-schema_compatibility="$(sed -n 's/.*"schemaCompatibility":"\([^"]*\)".*/\1/p' "${release_dir}/release-manifest.json")"
-[[ -n "$schema_compatibility" ]] || { echo "Release schema compatibility is missing." >&2; exit 1; }
-[[ -x "$maintenance_wrapper" ]] || { echo "Root maintenance boundary is not installed." >&2; exit 1; }
-available_kb="$(df -Pk /var/lib/quadball-timer-test | awk 'NR == 2 {print $4}')"
+schema_compatibility="$(sed -n 's/.*"schemaCompatibility":"\([^"]*\)".*/\1/p' "${release_dir}/release-manifest.json" || true)"
+if [[ -z "$schema_compatibility" ]]; then
+  echo "Release schema compatibility is missing." >&2
+  report_operational_failure preflight schema-incompatibility
+  exit 1
+fi
+if [[ ! -x "$maintenance_wrapper" ]]; then
+  echo "Root maintenance boundary is not installed." >&2
+  report_operational_failure preflight atomic-install
+  exit 1
+fi
+available_kb="$(df -Pk /var/lib/quadball-timer-test 2>/dev/null | awk 'NR == 2 {print $4}' || true)"
 if [[ ! "$available_kb" =~ ^[0-9]+$ ]] || (( available_kb < 16384 )); then
   echo "Test state directory lacks the required disk reserve." >&2
+  report_operational_failure preflight atomic-install
   exit 1
 fi
 echo "ACTIVATION_PHASE=migration"
-if ! inject_focused_failure preflight; then exit 1; fi
 if ! sudo "$maintenance_wrapper" test "$release_dir" preflight >/dev/null; then
   echo "Test Foundation preflight/readiness failed; service was not stopped." >&2
   exit 1
 fi
-if ! inject_focused_failure quiesce-stop; then exit 1; fi
-sudo systemctl stop "$service_name"
+if ! inject_focused_failure quiesce-stop; then report_operational_failure quiesce-stop atomic-install; exit 1; fi
+if ! sudo systemctl stop "$service_name"; then
+  report_operational_failure quiesce-stop atomic-install
+  exit 1
+fi
 service_stopped=1
-if ! inject_focused_failure candidate-validation; then exit 1; fi
 if ! sudo "$maintenance_wrapper" test "$release_dir" validate-migration; then
   echo "Disposable Test migration candidate did not reach readiness." >&2
   exit 1
 fi
-if ! inject_focused_failure live-migration; then exit 1; fi
 migration_attempted=1
 if ! sudo "$maintenance_wrapper" test "$release_dir" apply-migrations; then
   echo "Test migration failed; no backup was created or retained." >&2
   exit 1
 fi
 echo "ACTIVATION_PHASE=activation"
-if ! inject_focused_failure release-switch; then exit 1; fi
-ln -sfn -- "$release_dir" "$current_link"
-restart_service() { inject_focused_failure rollback-restart || return 1; sudo systemctl restart "$service_name"; }
+if ! inject_focused_failure release-switch; then report_operational_failure release-switch atomic-install; exit 1; fi
+if ! ln -sfn -- "$release_dir" "$current_link"; then
+  report_operational_failure release-switch atomic-install
+  exit 1
+fi
+restart_service() {
+  local phase="$1" category="$2"
+  if ! inject_focused_failure rollback-restart; then
+    report_operational_failure "$phase" "$category"
+    return 1
+  fi
+  if ! sudo systemctl restart "$service_name"; then
+    report_operational_failure "$phase" "$category"
+    return 1
+  fi
+}
 
 check_release_identity() {
   local selected_release_id="$1"
@@ -405,12 +522,12 @@ compatible_previous_release() {
 prune_releases() {
   local current_release="$1" rollback_release="$2" release_path release_root
   local -a all_releases
-  release_root="$("$realpath_command" -e -- "${base_dir}/releases")" || return 1
-  find "$release_root" -mindepth 1 -maxdepth 1 -type d -name '.prune-*' -print >&2
-  all_releases=()
-  while IFS= read -r release_path; do all_releases+=("$release_path"); done < <(
-    list_selectable_releases "$release_root"
-  )
+ release_root="$("$realpath_command" -e -- "${base_dir}/releases")" || return 1
+ find "$release_root" -mindepth 1 -maxdepth 1 -type d -name '.prune-*' -print >&2
+ all_releases=()
+ while IFS= read -r release_path; do all_releases+=("$release_path"); done < <(
+   list_selectable_releases "$release_root"
+ )
   local release_count=0
   if ((${#all_releases[@]} > 0)); then
     for release_path in "${all_releases[@]}"; do
@@ -421,25 +538,41 @@ prune_releases() {
   fi
 }
 
-if restart_service && check_health "$release_id" "$release_dir"; then
-  prune_releases "$release_dir" "$previous_release"
-  if ! inject_focused_failure final-report; then exit 1; fi
-  echo "Activated immutable Test release attempt ${release_id}."
-  exit 0
+if restart_service startup atomic-install; then
+  if check_health "$release_id" "$release_dir"; then
+    if ! prune_releases "$release_dir" "$previous_release"; then
+      report_operational_failure final-report atomic-install
+      exit 1
+    fi
+    if ! inject_focused_failure final-report; then report_operational_failure final-report atomic-install; exit 1; fi
+    echo "Activated immutable Test release attempt ${release_id}."
+    exit 0
+  fi
+  report_operational_failure readiness readiness
 fi
 echo "Test deployment failed; attempting compatible binary rollback without restoring data." >&2
 if [[ -n "$previous_release" && -d "$previous_release" ]] && compatible_previous_release; then
   previous_release_id="${previous_release##*/}"
-  ln -sfn -- "$previous_release" "$current_link"
-  if restart_service && check_health "$previous_release_id" "$previous_release"; then
-    echo "Rolled back Test to ${previous_release}." >&2
-    exit 1
+  if ! ln -sfn -- "$previous_release" "$current_link"; then
+    report_binary_rollback_failure
+  elif restart_service rollback-restart binary-rollback; then
+    if check_health "$previous_release_id" "$previous_release"; then
+      echo "Rolled back Test to ${previous_release}." >&2
+    else
+      report_binary_rollback_failure
+      echo "Test rollback failed health checks; stopping Test service fail-closed." >&2
+    fi
+  else
+    echo "Test rollback failed health checks; stopping Test service fail-closed." >&2
   fi
-  echo "Test rollback failed health checks; stopping Test service fail-closed." >&2
 else
+  report_binary_rollback_failure
   echo "No compatible previous Test release available for rollback." >&2
 fi
 if ! sudo systemctl stop "$service_name"; then
+  if [[ "$rollback_failure_reported" == 0 ]]; then
+    report_operational_failure quiesce-stop atomic-install
+  fi
   echo "Test fail-closed stop failed; service state is not trusted." >&2
 else
   echo "Test service stopped after failed activation." >&2

--- a/deploy/activation-maintenance-root.sh
+++ b/deploy/activation-maintenance-root.sh
@@ -17,6 +17,9 @@ fi
 restore_preparation_failure() {
   local outcome="$1"
   local status="${2:-1}"
+  if declare -F detach_operational_report >/dev/null; then
+    detach_operational_report restore staged-restore failed staged-restore
+  fi
   printf '{"restored":false,"outcome":"%s","cutoverCompleted":false,"technicalAdminAuth":{"outcome":"not-attempted","credentialPreserved":false,"reEnrollmentRequired":false}}\n' "$outcome" >&${restore_error_fd}
   restore_report_emitted=1
   exit "$status"
@@ -26,6 +29,9 @@ maintenance_preflight_failure() {
   local outcome="$1"
   local status="$2"
   local message="$3"
+  if [[ "$command" != restore ]] && declare -F report_early_root_preflight_failure >/dev/null; then
+    report_early_root_preflight_failure
+  fi
   if [[ "$command" == restore ]]; then
     restore_preparation_failure "$outcome" "$status"
   fi
@@ -55,6 +61,7 @@ case "$environment" in
     technical_admin_database="$database_dir/technical-admin.sqlite"
     foundation_database="$database_dir/foundation.sqlite"
     key_ring_file="/etc/quadball-timer/production-grant-key-ring.json"
+    environment_file="/etc/quadball-timer/production.env"
     backup_directory="/var/backups/quadball-timer"
     ;;
   test)
@@ -67,6 +74,7 @@ case "$environment" in
     technical_admin_database="$database_dir/technical-admin.sqlite"
     foundation_database="$database_dir/foundation.sqlite"
     key_ring_file="/etc/quadball-timer/test-grant-key-ring.json"
+    environment_file="/etc/quadball-timer/test.env"
     backup_directory=""
     ;;
   *) echo "Unsupported Environment." >&2; exit 2 ;;
@@ -81,6 +89,7 @@ skip_chown=0
 before_previous_rm_command=""
 ad_hoc_database="$database_dir/ad-hoc.sqlite"
 ad_hoc_environment_identity="$environment:$public_origin"
+operational_status_directory="/run/quadball-timer-operational-status"
 
 configure_promotion_test_hooks() {
   if [[ "$test_harness_mode" != 1 ]]; then
@@ -313,7 +322,9 @@ if [[ "$focused_test_mode" == 1 ]]; then
   technical_admin_database="$focused_test_root${technical_admin_database}"
   foundation_database="$focused_test_root${foundation_database}"
   key_ring_file="$focused_test_root${key_ring_file}"
+  environment_file="$focused_test_root${environment_file}"
   [[ -n "$backup_directory" ]] && backup_directory="$focused_test_root${backup_directory}"
+  operational_status_directory="$focused_test_root/run/quadball-timer-operational-status"
 fi
 configure_promotion_test_hooks || exit 2
 owner_identity_command="${QBT_FOCUSED_TEST_OWNER_SEAM:-}"
@@ -324,17 +335,64 @@ realpath_command="${QBT_FOCUSED_TEST_REALPATH:-realpath}"
 readlink_command="${QBT_FOCUSED_TEST_READLINK:-readlink}"
 install_command="${QBT_FOCUSED_TEST_INSTALL:-/usr/bin/install}"
 mktemp_command="${QBT_FOCUSED_TEST_MKTEMP:-mktemp}"
-[[ "$release_dir" == "$release_base"/releases/* ]] || { echo "Unsafe release path." >&2; exit 2; }
-[[ "$release_dir" != *..* && "$release_dir" != *//* ]] || { echo "Unsafe release path." >&2; exit 2; }
-[[ -d "$release_dir" && ! -L "$release_dir" ]] || { echo "Unsafe release path." >&2; exit 2; }
-resolved_release_dir="$($realpath_command -e -- "$release_dir")"
+operational_report_file=""
+operational_report_dispatched=0
+
+# Release validation happens before the full root dispatcher is available.
+# Once a canonical executable and manifest exist, any remaining validation
+# failure is still reported directly and detached; invalid/untrusted paths are
+# never executed merely to obtain monitoring evidence.
+report_early_root_preflight_failure() {
+  local candidate="$release_dir/quadball-timer" manifest="$release_dir/release-manifest.json"
+  local candidate_release dsn="" operation="deployment" phase="preflight" category="atomic-install"
+  trap - ERR
+  set +e
+  [[ "$operational_report_dispatched" == 0 && "$command" != report-operational && "$command" != report-operational-attempt && "$command" != read-operational-status && "$command" != read-operational-delivery ]] || return 0
+  [[ "$release_dir" == "$release_base"/releases/* && "$release_dir" != *..* && "$release_dir" != *//* ]] || return 0
+  [[ -d "$release_dir" && ! -L "$release_dir" ]] || return 0
+  [[ "$($realpath_command -e -- "$release_dir" 2>/dev/null)" == "$release_dir" ]] || return 0
+  [[ -x "$candidate" && -f "$candidate" && ! -L "$candidate" && -f "$manifest" && ! -L "$manifest" ]] || return 0
+  candidate_release="$(sed -n 's/.*"releaseAttemptId":"\([^"]*\)".*/\1/p' "$manifest" | head -n 1)"
+  [[ "$candidate_release" =~ ^[A-Za-z0-9._-]+$ ]] || candidate_release="$(basename -- "$release_dir")"
+  [[ "$candidate_release" =~ ^[A-Za-z0-9._-]+$ ]] || return 0
+  if [[ "$command" == restore ]]; then
+    operation="restore"
+    phase="staged-restore"
+    category="staged-restore"
+  fi
+  if [[ -f "$environment_file" && ! -L "$environment_file" ]]; then
+    dsn="$(sed -n -E 's/^[[:space:]]*GLITCHTIP_DSN=(.*)$/\1/p' "$environment_file" | head -n 1)"
+    case "$dsn" in
+      \"*\") dsn="${dsn:1:${#dsn}-2}" ;;
+      \'*\') dsn="${dsn:1:${#dsn}-2}" ;;
+    esac
+    [[ "$dsn" =~ ^https?://[^[:space:]]+$ ]] || dsn=""
+  fi
+  operational_report_dispatched=1
+  nohup "$runuser_command" -u "$service_user" -- env -i PATH=/usr/bin:/bin \
+    QUADBALL_ENVIRONMENT="$environment" NODE_ENV=production \
+    RELEASE_ATTEMPT_ID="$candidate_release" GLITCHTIP_DSN="$dsn" \
+    "$candidate" --emit-operational-failure --operation "$operation" \
+    --phase "$phase" --outcome failed --category "$category" \
+    9>&- </dev/null >/dev/null 2>&1 &
+}
+
+fail_root_preflight_validation() {
+  local message="$1" status="$2"
+  echo "$message" >&2
+  report_early_root_preflight_failure
+  exit "$status"
+}
+
+[[ "$release_dir" == "$release_base"/releases/* ]] || fail_root_preflight_validation "Unsafe release path." 2
+[[ "$release_dir" != *..* && "$release_dir" != *//* ]] || fail_root_preflight_validation "Unsafe release path." 2
+[[ -d "$release_dir" && ! -L "$release_dir" ]] || fail_root_preflight_validation "Unsafe release path." 2
+resolved_release_dir="$($realpath_command -e -- "$release_dir")" || fail_root_preflight_validation "Release path is not canonical." 2
 [[ "$resolved_release_dir" == "$release_base"/releases/* && "$resolved_release_dir" == "$release_dir" ]] || {
-  echo "Release path is not canonical." >&2
-  exit 2
+  fail_root_preflight_validation "Release path is not canonical." 2
 }
 [[ -x "$release_dir/quadball-timer" && -f "$release_dir/release-manifest.json" ]] || {
-  echo "Maintenance release is incomplete." >&2
-  exit 1
+  fail_root_preflight_validation "Maintenance release is incomplete." 1
 }
 if ! release_attempt_id="$(sed -n 's/.*"releaseAttemptId":"\([^"]*\)".*/\1/p' "$release_dir/release-manifest.json")"; then
   maintenance_preflight_failure release-identity-invalid 1 "Maintenance release identity is unreadable."
@@ -345,29 +403,286 @@ fi
 [[ -n "$release_attempt_id" && -n "$schema_compatibility" ]] ||
   maintenance_preflight_failure release-identity-invalid 1 "Maintenance release identity is incomplete."
 [[ "$release_attempt_id" =~ ^[A-Za-z0-9._-]+$ && "$(basename -- "$release_dir")" == "$release_attempt_id" ]] || {
-  echo "Maintenance release identity does not match its path." >&2
-  exit 2
+  fail_root_preflight_validation "Maintenance release identity does not match its path." 2
 }
 [[ ! -L "$release_dir/quadball-timer" && ! -L "$release_dir/release-manifest.json" ]] || {
-  echo "Maintenance release contains symlinked inputs." >&2
-  exit 2
+  fail_root_preflight_validation "Maintenance release contains symlinked inputs." 2
 }
+operational_event_release_attempt="$release_attempt_id"
+
+read_trusted_glitchtip_dsn() {
+  local raw
+  [[ -f "$environment_file" && ! -L "$environment_file" ]] || return 0
+  raw="$(sed -n -E 's/^[[:space:]]*GLITCHTIP_DSN=(.*)$/\1/p' "$environment_file" | head -n 1)"
+  case "$raw" in
+    \"*\") raw="${raw:1:${#raw}-2}" ;;
+    \'*\') raw="${raw:1:${#raw}-2}" ;;
+  esac
+  [[ "$raw" =~ ^https?://[^[:space:]]+$ ]] && (( ${#raw} <= 2048 )) || return 0
+  printf '%s' "$raw"
+}
+
+emit_operational_report() {
+  local operation="$1" phase="$2" outcome="$3" category="$4" delivery dsn
+  case "$operation" in
+    deployment|backup|migration|restore|readiness) ;;
+    *) return 0 ;;
+  esac
+  case "$phase" in
+    preflight|quiesce-stop|backup-create|backup-verify|backup-promote|candidate-validation|live-migration|staged-restore|release-switch|startup|readiness|rollback-restart|final-report) ;;
+    *) return 0 ;;
+  esac
+  case "$outcome" in failed|degraded|blocked|incompatible|rolled-back|unavailable) ;;
+    *) return 0 ;;
+  esac
+  case "$category" in
+    backup-candidate|migration-candidate|schema-incompatibility|binary-rollback|staged-restore|key-version|technical-admin-auth-sanitization|re-enrollment-required|atomic-install|readiness) ;;
+    *) return 0 ;;
+  esac
+  dsn="$(read_trusted_glitchtip_dsn)"
+  local -a reporter_command=(
+    "$runuser_command" -u "$service_user" -- env -i PATH=/usr/bin:/bin
+    QUADBALL_ENVIRONMENT="$environment"
+    NODE_ENV=production
+    RELEASE_ATTEMPT_ID="$operational_event_release_attempt"
+    GLITCHTIP_DSN="$dsn"
+    "$release_dir/quadball-timer" --emit-operational-failure
+    --operation "$operation" --phase "$phase" --outcome "$outcome" --category "$category"
+  )
+  if [[ "$focused_test_mode" == 1 ]]; then
+    delivery="$("${reporter_command[@]}" 2>/dev/null || true)"
+  else
+    delivery="$(/usr/bin/timeout --signal=KILL 2s "${reporter_command[@]}" 2>/dev/null || true)"
+  fi
+  case "$delivery" in sent|failed|unavailable) ;; *) delivery="unavailable" ;; esac
+  write_operational_status "$phase" "$category" "$delivery"
+}
+
+operational_status_path() {
+  printf '%s/status-%s-%s-%s' "$operational_status_directory" "$operational_event_release_attempt" "$1" "$2"
+}
+
+operational_latest_status_path() {
+  printf '%s/status-%s-latest' "$operational_status_directory" "$operational_event_release_attempt"
+}
+
+status_path_metadata() {
+  local path="$1"
+  if [[ "$(uname -s)" == Darwin ]]; then
+    /usr/bin/stat -f '%u:%g:%Lp' "$path" 2>/dev/null
+  else
+    "$stat_command" -c '%u:%g:%a' -- "$path" 2>/dev/null
+  fi
+}
+
+ensure_operational_status_directory() {
+  local expected_owner metadata resolved
+  if [[ "$focused_test_mode" == 1 ]]; then
+    mkdir -p -- "$operational_status_directory" 2>/dev/null || return 1
+    chmod 0700 "$operational_status_directory" 2>/dev/null || return 1
+    expected_owner="$(id -u):$(id -g):700"
+  else
+    /usr/bin/install -d -o root -g root -m 0700 -- "$operational_status_directory" 2>/dev/null || return 1
+    expected_owner="0:0:700"
+  fi
+  [[ -d "$operational_status_directory" && ! -L "$operational_status_directory" ]] || return 1
+  resolved="$($realpath_command -e -- "$operational_status_directory" 2>/dev/null)" || return 1
+  [[ "$resolved" == "$operational_status_directory" ]] || return 1
+  metadata="$(status_path_metadata "$operational_status_directory")" || return 1
+  [[ "$metadata" == "$expected_owner" ]]
+}
+
+write_operational_status_record() {
+  local status_path="$1" delivery="$2" temporary_path expected_owner metadata
+  ensure_operational_status_directory || return 0
+  temporary_path="$(mktemp "${status_path}.tmp.XXXXXX")" 2>/dev/null || return 0
+  printf '%s\n' "$delivery" >"$temporary_path" 2>/dev/null || { rm -f -- "$temporary_path"; return 0; }
+  chmod 0600 "$temporary_path" 2>/dev/null || { rm -f -- "$temporary_path" 2>/dev/null || true; return 0; }
+  if [[ "$focused_test_mode" == 1 ]]; then
+    expected_owner="$(id -u):$(id -g):600"
+  else
+    chown root:root "$temporary_path" 2>/dev/null || { rm -f -- "$temporary_path"; return 0; }
+    expected_owner="0:0:600"
+  fi
+  metadata="$(status_path_metadata "$temporary_path")" || { rm -f -- "$temporary_path"; return 0; }
+  [[ "$metadata" == "$expected_owner" ]] || { rm -f -- "$temporary_path"; return 0; }
+  if [[ "$focused_test_mode" == 1 ]]; then
+    mv -f -- "$temporary_path" "$status_path" 2>/dev/null || rm -f -- "$temporary_path" 2>/dev/null || true
+  else
+    mv -T -- "$temporary_path" "$status_path" 2>/dev/null || rm -f -- "$temporary_path" 2>/dev/null || true
+  fi
+}
+
+write_operational_status() {
+  local phase="$1" category="$2" delivery="$3"
+  write_operational_status_record "$(operational_status_path "$phase" "$category")" "$delivery"
+  write_operational_status_record "$(operational_latest_status_path)" "$delivery"
+}
+
+read_operational_status() {
+  local phase="$1" category="$2" status_path delivery="unavailable" expected_owner metadata resolved
+  ensure_operational_status_directory || { printf 'unavailable\n'; return 0; }
+  status_path="$(operational_status_path "$phase" "$category")"
+  if [[ -f "$status_path" && ! -L "$status_path" ]]; then
+    resolved="$($realpath_command -e -- "$status_path" 2>/dev/null || true)"
+    if [[ "$focused_test_mode" == 1 ]]; then
+      expected_owner="$(id -u):$(id -g):600"
+    else
+      expected_owner="0:0:600"
+    fi
+    metadata="$(status_path_metadata "$status_path" 2>/dev/null || true)"
+    if [[ "$resolved" == "$status_path" && "$metadata" == "$expected_owner" ]]; then
+      IFS= read -r delivery <"$status_path" || delivery="unavailable"
+    fi
+  fi
+  case "$delivery" in sent|failed|unavailable) ;; *) delivery="unavailable" ;; esac
+  printf '%s\n' "$delivery"
+}
+
+read_operational_delivery() {
+  local status_path delivery="unavailable" expected_owner metadata resolved
+  ensure_operational_status_directory || { printf 'unavailable\n'; return 0; }
+  status_path="$(operational_latest_status_path)"
+  if [[ -f "$status_path" && ! -L "$status_path" ]]; then
+    resolved="$($realpath_command -e -- "$status_path" 2>/dev/null || true)"
+    if [[ "$focused_test_mode" == 1 ]]; then
+      expected_owner="$(id -u):$(id -g):600"
+    else
+      expected_owner="0:0:600"
+    fi
+    metadata="$(status_path_metadata "$status_path" 2>/dev/null || true)"
+    if [[ "$resolved" == "$status_path" && "$metadata" == "$expected_owner" ]]; then
+      IFS= read -r delivery <"$status_path" || delivery="unavailable"
+    fi
+  fi
+  case "$delivery" in sent|failed|unavailable) ;; *) delivery="unavailable" ;; esac
+  printf '%s\n' "$delivery"
+}
+
+prepare_operational_report_file() {
+  local candidate
+  if [[ "$focused_test_mode" == 1 ]]; then
+    mkdir -p -- "$database_dir" || return 1
+    candidate="$database_dir/.operational-report-${release_attempt_id}"
+    : >"$candidate" || return 1
+    chmod 0600 "$candidate" || { rm -f -- "$candidate"; return 1; }
+  else
+    candidate="$(mktemp "$database_dir/.operational-report-${release_attempt_id}.XXXXXX")" || return 1
+    chown "$service_user:$service_user" "$candidate" || { rm -f -- "$candidate"; return 1; }
+    chmod 0600 "$candidate" || { rm -f -- "$candidate"; return 1; }
+  fi
+  operational_report_file="$candidate"
+}
+
+dispatch_operational_report() {
+  local line operation event_environment event_release phase outcome category
+  [[ -n "$operational_report_file" && -f "$operational_report_file" ]] || return 0
+  while IFS= read -r line; do
+    IFS=$'\t' read -r operation event_environment event_release phase outcome category <<<"$line"
+    [[ "$event_environment" == "$environment" ]] || continue
+    [[ "$event_release" == "$release_attempt_id" ]] || continue
+    case "$operation" in deployment|backup|migration|restore|readiness) ;; *) continue ;; esac
+    case "$phase" in preflight|quiesce-stop|backup-create|backup-verify|backup-promote|candidate-validation|live-migration|staged-restore|release-switch|startup|readiness|rollback-restart|final-report) ;; *) continue ;; esac
+    case "$outcome" in failed|degraded|blocked|incompatible|rolled-back|unavailable) ;; *) continue ;; esac
+    case "$category" in backup-candidate|migration-candidate|schema-incompatibility|binary-rollback|staged-restore|key-version|technical-admin-auth-sanitization|re-enrollment-required|atomic-install|readiness) ;; *) continue ;; esac
+    detach_operational_report "$operation" "$phase" "$outcome" "$category"
+    break
+  done <"$operational_report_file"
+  rm -f -- "$operational_report_file" || true
+}
+
+detach_operational_report() {
+  operational_report_dispatched=1
+  nohup "$0" "$environment" "$release_dir" report-operational \
+    "$1" "$2" "$3" "$4" 9>&- </dev/null >/dev/null 2>&1 &
+}
+
+# shellcheck disable=SC2329 # invoked by the ERR trap below
+report_unhandled_root_failure() {
+  local operation="deployment" phase="preflight" category="atomic-install"
+  trap - ERR
+  set +e
+  [[ "$operational_report_dispatched" == 0 ]] || return 0
+  case "$command" in
+    backup) operation="backup"; phase="backup-create"; category="backup-candidate" ;;
+    verify-backup) operation="backup"; phase="backup-verify"; category="backup-candidate" ;;
+    promote) operation="backup"; phase="backup-promote"; category="backup-candidate" ;;
+    validate-migration) operation="migration"; phase="candidate-validation"; category="migration-candidate" ;;
+    apply-migrations) operation="migration"; phase="live-migration"; category="migration-candidate" ;;
+    readiness) operation="readiness"; phase="readiness"; category="readiness" ;;
+    restore) operation="restore"; phase="staged-restore"; category="staged-restore" ;;
+  esac
+  detach_operational_report "$operation" "$phase" failed "$category"
+}
+
+# Any otherwise-unhandled root failure after the immutable release has been
+# validated is observationally queued once. The trap never waits for delivery
+# and cannot replace the authoritative command status.
+trap report_unhandled_root_failure ERR
+
+trusted_glitchtip_dsn="$(read_trusted_glitchtip_dsn)"
+
 case "$command" in
+  report-operational)
+    [[ "${SUDO_USER:-}" == "$expected_caller" ]] || { echo "Invalid maintenance caller." >&2; exit 2; }
+    [[ -n "$manifest_path" && -n "${5:-}" && -n "${6:-}" && -n "${7:-}" ]] || { echo "Operational report fields are incomplete." >&2; exit 2; }
+    emit_operational_report "$manifest_path" "$5" "$6" "$7"
+    exit 0
+    ;;
+  report-operational-attempt)
+    [[ "${SUDO_USER:-}" == "$expected_caller" ]] || { echo "Invalid maintenance caller." >&2; exit 2; }
+    [[ -n "$manifest_path" && -n "${5:-}" && -n "${6:-}" && -n "${7:-}" && -n "${8:-}" ]] || { echo "Operational report fields are incomplete." >&2; exit 2; }
+    [[ "$8" =~ ^[A-Za-z0-9._-]{1,128}$ ]] || { echo "Operational release identity is invalid." >&2; exit 2; }
+    operational_event_release_attempt="$8"
+    emit_operational_report "$manifest_path" "$5" "$6" "$7"
+    exit 0
+    ;;
+  read-operational-status)
+    [[ "${SUDO_USER:-}" == "$expected_caller" ]] || { echo "Invalid maintenance caller." >&2; exit 2; }
+    [[ -n "$manifest_path" && -n "${5:-}" ]] || { echo "Operational status fields are incomplete." >&2; exit 2; }
+    case "$manifest_path" in preflight|quiesce-stop|backup-create|backup-verify|backup-promote|candidate-validation|live-migration|staged-restore|release-switch|startup|readiness|rollback-restart|final-report) ;; *) exit 2 ;; esac
+    case "$5" in backup-candidate|migration-candidate|schema-incompatibility|binary-rollback|staged-restore|key-version|technical-admin-auth-sanitization|re-enrollment-required|atomic-install|readiness) ;; *) exit 2 ;; esac
+    read_operational_status "$manifest_path" "$5"
+    exit 0
+    ;;
+  read-operational-delivery)
+    [[ "${SUDO_USER:-}" == "$expected_caller" ]] || { echo "Invalid maintenance caller." >&2; exit 2; }
+    [[ "$manifest_path" =~ ^[A-Za-z0-9._-]{1,128}$ ]] || { echo "Operational release identity is invalid." >&2; exit 2; }
+    operational_event_release_attempt="$manifest_path"
+    read_operational_delivery
+    exit 0
+    ;;
   backup|verify-backup|promote|restore)
     [[ "$environment" == production ]] || { echo "Production backup operations only." >&2; exit 2; }
     [[ "${SUDO_USER:-}" == "$expected_caller" ]] || { echo "Invalid maintenance caller." >&2; exit 2; }
     service_state="$($systemctl_command is-active quadball-timer 2>/dev/null || true)"
-    [[ "$service_state" == inactive || "$service_state" == failed ]] || { echo "Production service must be inactive or failed." >&2; exit 1; }
+    if [[ "$service_state" != inactive && "$service_state" != failed ]]; then
+      echo "Production service must be inactive or failed." >&2
+      if [[ "$command" == restore ]]; then
+        detach_operational_report restore staged-restore failed staged-restore
+      else
+        detach_operational_report backup preflight failed atomic-install
+      fi
+      exit 1
+    fi
     if ! exec 9>"$release_base/.activation.lock"; then
       maintenance_preflight_failure activation-lock-unavailable 1 "Activation lock could not be opened."
     fi
-    if QBT_ACTIVATION_LOCK_PATH="$release_base/.activation.lock" "$flock_command" -n 9; then echo "Activation lock is not held by the orchestrator." >&2; exit 1; fi
+    if QBT_ACTIVATION_LOCK_PATH="$release_base/.activation.lock" "$flock_command" -n 9; then
+      echo "Activation lock is not held by the orchestrator." >&2
+      if [[ "$command" == restore ]]; then
+        detach_operational_report restore staged-restore failed staged-restore
+      else
+        detach_operational_report backup preflight failed atomic-install
+      fi
+      exit 1
+    fi
     ;;
   validate-migration|apply-migrations)
     [[ "${SUDO_USER:-}" == "$expected_caller" ]] || { echo "Invalid maintenance caller." >&2; exit 2; }
-    [[ "$($systemctl_command is-active "$service_name" 2>/dev/null || true)" == inactive ]] || { echo "Service must be inactive." >&2; exit 1; }
-    exec 9>"$release_base/.activation.lock"
-    if QBT_ACTIVATION_LOCK_PATH="$release_base/.activation.lock" "$flock_command" -n 9; then echo "Activation lock is not held by the orchestrator." >&2; exit 1; fi
+    [[ "$($systemctl_command is-active "$service_name" 2>/dev/null || true)" == inactive ]] || { echo "Service must be inactive." >&2; detach_operational_report migration preflight failed atomic-install; exit 1; }
+    if ! exec 9>"$release_base/.activation.lock"; then detach_operational_report migration preflight failed atomic-install; exit 1; fi
+    if QBT_ACTIVATION_LOCK_PATH="$release_base/.activation.lock" "$flock_command" -n 9; then echo "Activation lock is not held by the orchestrator." >&2; detach_operational_report migration preflight failed atomic-install; exit 1; fi
     ;;
   readiness|authoritative-operation|preflight)
     [[ "${SUDO_USER:-}" == "$expected_caller" ]] || { echo "Invalid maintenance caller." >&2; exit 2; }
@@ -375,15 +690,31 @@ case "$command" in
   *) echo "Unsupported maintenance operation." >&2; exit 2 ;;
 esac
 if [[ "$environment" == production && "$command" != readiness && "$command" != authoritative-operation && "$command" != preflight && "$command" != validate-migration && "$command" != apply-migrations ]]; then
+  root_preflight_operation="backup"
+  root_preflight_phase="preflight"
+  root_preflight_category="atomic-install"
+  if [[ "$command" == restore ]]; then
+    root_preflight_operation="restore"
+    root_preflight_phase="staged-restore"
+    root_preflight_category="staged-restore"
+  fi
   if [[ -e "$backup_directory" || -L "$backup_directory" ]]; then
-    [[ -d "$backup_directory" && ! -L "$backup_directory" ]] || { echo "Backup root is missing or symlinked." >&2; exit 2; }
-    [[ "$($realpath_command -e -- "$backup_directory")" == "$backup_directory" ]] || { echo "Backup root is not canonical." >&2; exit 2; }
+    [[ -d "$backup_directory" && ! -L "$backup_directory" ]] || { echo "Backup root is missing or symlinked." >&2; detach_operational_report "$root_preflight_operation" "$root_preflight_phase" failed "$root_preflight_category"; exit 2; }
+    [[ "$($realpath_command -e -- "$backup_directory")" == "$backup_directory" ]] || { echo "Backup root is not canonical." >&2; detach_operational_report "$root_preflight_operation" "$root_preflight_phase" failed "$root_preflight_category"; exit 2; }
   else
-    [[ "$($realpath_command -e -- "$(dirname -- "$backup_directory")")" == "$(dirname -- "$backup_directory")" ]] || { echo "Backup parent is not canonical." >&2; exit 2; }
-    if [[ "$focused_test_mode" == 1 ]]; then mkdir -p "$backup_directory"; chmod 0750 "$backup_directory"; else install -d -o root -g "$service_user" -m 0750 "$backup_directory"; fi
+    [[ "$($realpath_command -e -- "$(dirname -- "$backup_directory")")" == "$(dirname -- "$backup_directory")" ]] || { echo "Backup parent is not canonical." >&2; detach_operational_report "$root_preflight_operation" "$root_preflight_phase" failed "$root_preflight_category"; exit 2; }
+    if [[ "$focused_test_mode" == 1 ]]; then
+      if ! mkdir -p "$backup_directory" || ! chmod 0750 "$backup_directory"; then
+        detach_operational_report "$root_preflight_operation" "$root_preflight_phase" failed "$root_preflight_category"
+        exit 2
+      fi
+    elif ! install -d -o root -g "$service_user" -m 0750 "$backup_directory"; then
+      detach_operational_report "$root_preflight_operation" "$root_preflight_phase" failed "$root_preflight_category"
+      exit 2
+    fi
   fi
   if [[ "$focused_test_mode" != 1 ]]; then
-    [[ "$(stat -c '%U:%G:%a' "$backup_directory")" == "root:${service_user}:750" ]] || { echo "Backup root ownership or mode drifted." >&2; exit 2; }
+    [[ "$(stat -c '%U:%G:%a' "$backup_directory")" == "root:${service_user}:750" ]] || { echo "Backup root ownership or mode drifted." >&2; detach_operational_report "$root_preflight_operation" "$root_preflight_phase" failed "$root_preflight_category"; exit 2; }
   fi
 fi
 
@@ -476,9 +807,9 @@ if [[ "$command" == "backup" ]]; then
   if [[ "$focused_test_mode" == 1 ]]; then rm -rf "$operation_backup_directory"; mkdir -p "$operation_backup_directory"; chmod 0700 "$operation_backup_directory"; else rm -rf -- "$operation_backup_directory"; install -d -o "$service_user" -g "$service_user" -m 0700 "$operation_backup_directory"; fi
 elif [[ "$command" == "verify-backup" ]]; then
   operation_backup_directory="$backup_directory/.candidate-${release_attempt_id}"
-  [[ "$manifest_path" == "$operation_backup_directory"/* && "$manifest_path" != *..* ]] || { echo "Unsafe backup manifest path." >&2; exit 2; }
+  [[ "$manifest_path" == "$operation_backup_directory"/* && "$manifest_path" != *..* ]] || { echo "Unsafe backup manifest path." >&2; detach_operational_report backup backup-verify failed backup-candidate; exit 2; }
   manifest_path="$($realpath_command -e -- "$manifest_path")"
-  [[ "$manifest_path" == "$operation_backup_directory"/* && ! -L "$manifest_path" ]] || { echo "Backup manifest is not canonical." >&2; exit 2; }
+  [[ "$manifest_path" == "$operation_backup_directory"/* && ! -L "$manifest_path" ]] || { echo "Backup manifest is not canonical." >&2; detach_operational_report backup backup-verify failed backup-candidate; exit 2; }
 elif [[ "$command" == "promote" ]]; then
   operation_backup_directory="$backup_directory/.candidate-${release_attempt_id}"
 else
@@ -486,50 +817,43 @@ else
 fi
 if [[ "$command" == "promote" ]]; then
   candidate_directory="$backup_directory/.candidate-${release_attempt_id}"
-  [[ "$manifest_path" == "$candidate_directory"/* && "$manifest_path" != *..* ]] || { echo "Unsafe backup manifest path." >&2; exit 2; }
+  [[ "$manifest_path" == "$candidate_directory"/* && "$manifest_path" != *..* ]] || { echo "Unsafe backup manifest path." >&2; detach_operational_report backup backup-promote failed backup-candidate; exit 2; }
   manifest_path="$($realpath_command -e -- "$manifest_path")"
-  [[ "$manifest_path" == "$candidate_directory"/* && ! -L "$manifest_path" ]] || { echo "Backup manifest is not canonical." >&2; exit 2; }
+  [[ "$manifest_path" == "$candidate_directory"/* && ! -L "$manifest_path" ]] || { echo "Backup manifest is not canonical." >&2; detach_operational_report backup backup-promote failed backup-candidate; exit 2; }
 elif [[ "$command" == "restore" ]]; then
-  [[ "$environment" == production ]] || { echo "Production restore operations only." >&2; exit 2; }
-  [[ -n "$manifest_path" && "$manifest_path" == "$backup_directory"/* && "$manifest_path" != *..* ]] || { echo "Unsafe restore manifest path." >&2; exit 2; }
-  manifest_path="$($realpath_command -e -- "$manifest_path")"
-  [[ "$manifest_path" == "$backup_directory"/* && ! -L "$manifest_path" ]] || { echo "Restore manifest is not canonical." >&2; exit 2; }
-  [[ "$(basename -- "$(dirname -- "$manifest_path")")" =~ ^verified-[A-Za-z0-9._-]+$ ]] || { echo "Restore requires a promoted verified snapshot." >&2; exit 2; }
-  [[ "$(basename -- "$manifest_path")" =~ ^[A-Za-z0-9._-]+\.manifest\.json$ ]] || { echo "Restore manifest filename is unsafe." >&2; exit 2; }
+  [[ "$environment" == production ]] || restore_preparation_failure restore-selection-invalid 2
+  [[ -n "$manifest_path" && "$manifest_path" == "$backup_directory"/* && "$manifest_path" != *..* ]] || restore_preparation_failure restore-selection-invalid 2
+  manifest_path="$($realpath_command -e -- "$manifest_path")" || restore_preparation_failure restore-selection-invalid 2
+  [[ "$manifest_path" == "$backup_directory"/* && ! -L "$manifest_path" ]] || restore_preparation_failure restore-selection-invalid 2
+  [[ "$(basename -- "$(dirname -- "$manifest_path")")" =~ ^verified-[A-Za-z0-9._-]+$ ]] || restore_preparation_failure restore-selection-invalid 2
+  [[ "$(basename -- "$manifest_path")" =~ ^[A-Za-z0-9._-]+\.manifest\.json$ ]] || restore_preparation_failure restore-selection-invalid 2
 fi
 restore_workspace=""
 if [[ "$command" == "restore" ]]; then
   restore_workspace="$($mktemp_command -d "$backup_directory/.restore-${release_attempt_id}-XXXXXX")" || {
-    echo "Restore workspace could not be allocated." >&2
-    exit 1
+    restore_preparation_failure restore-preparation-failed 1
   }
   [[ "$restore_workspace" == "$backup_directory/.restore-${release_attempt_id}-"* && "$restore_workspace" != *..* ]] || {
-    echo "Restore workspace identity is unsafe." >&2
-    exit 2
+    restore_preparation_failure restore-preparation-failed 2
   }
   if ! "$install_command" -d -o root -g root -m 0700 "$restore_workspace" >/dev/null 2>&1; then
-    echo "Restore workspace could not be prepared." >&2
-    exit 1
+    restore_preparation_failure restore-preparation-failed 1
   fi
   [[ -d "$restore_workspace" && ! -L "$restore_workspace" ]] || {
-    echo "Restore workspace is not a regular directory." >&2
-    exit 2
+    restore_preparation_failure restore-preparation-failed 2
   }
   [[ "$($realpath_command -e -- "$restore_workspace")" == "$restore_workspace" ]] || {
-    echo "Restore workspace is not canonical." >&2
-    exit 2
+    restore_preparation_failure restore-preparation-failed 2
   }
   if [[ "$focused_test_mode" != 1 ]]; then
     [[ "$(stat -c '%U:%G:%a' "$restore_workspace")" == "root:root:700" ]] || {
-      echo "Restore workspace staging ownership or mode drifted." >&2
-      exit 2
+      restore_preparation_failure restore-preparation-failed 2
     }
   fi
   snapshot_directory="$(dirname -- "$manifest_path")"
   snapshot_id="$(basename -- "$manifest_path" .manifest.json)"
   [[ "$snapshot_id" =~ ^[A-Za-z0-9._-]{1,128}$ ]] || {
-    echo "Restore snapshot identity is unsafe." >&2
-    exit 2
+    restore_preparation_failure restore-selection-invalid 2
   }
   [[ "$(basename -- "$snapshot_directory")" =~ ^verified-[A-Za-z0-9._-]+$ ]] || {
     restore_preparation_failure restore-selection-invalid 2
@@ -555,6 +879,13 @@ if [[ "$command" == "restore" ]]; then
   fi
   manifest_path="$restore_workspace/$(basename -- "$manifest_path")"
 fi
+if ! prepare_operational_report_file; then
+  operational_report_file=""
+fi
+# The maintenance CLI owns its semantic event in the private spool. Its
+# expected nonzero result is collected explicitly below and must not also fire
+# the root ERR fallback.
+trap - ERR
 set +e
 foundation_backup_directory="$operation_backup_directory"
 [[ "$command" == "promote" ]] && foundation_backup_directory="$backup_directory"
@@ -578,7 +909,9 @@ if [[ "$command" == "promote" || "$command" == "restore" ]]; then
   RESTORE_WORKSPACE_DIRECTORY="$restore_workspace" \
   QBT_FOCUSED_TEST_MODE="$focused_test_mode" \
   QBT_FOCUSED_TEST_ROOT="$focused_test_root" \
+  QBT_OPERATIONAL_REPORT_FILE="$operational_report_file" \
   AD_HOC_ENVIRONMENT_ID="$ad_hoc_environment_identity" \
+  GLITCHTIP_DSN="$trusted_glitchtip_dsn" \
   QBT_FOCUSED_FAILURE_PHASE="$focused_failure_phase" \
   QBT_ROOT_PROMOTION="$root_promotion" \
   "$release_dir/quadball-timer" --production-activation "$command" --root-promotion 2>&1)"
@@ -600,8 +933,10 @@ else
   BACKUP_MANIFEST_PATH="$manifest_path" \
   QBT_FOCUSED_TEST_MODE="$focused_test_mode" \
   QBT_FOCUSED_TEST_ROOT="$focused_test_root" \
-  AD_HOC_ENVIRONMENT_ID="$ad_hoc_environment_identity" \
+  QBT_OPERATIONAL_REPORT_FILE="$operational_report_file" \
+  GLITCHTIP_DSN="$trusted_glitchtip_dsn" \
   QBT_FOCUSED_FAILURE_PHASE="$focused_failure_phase" \
+  AD_HOC_ENVIRONMENT_ID="$ad_hoc_environment_identity" \
   QBT_ROOT_PROMOTION="$root_promotion" \
   "$release_dir/quadball-timer" --production-activation "$command"
   rc=$?
@@ -618,6 +953,7 @@ if [[ "$command" == "restore" ]]; then
   fi
   restore_report_emitted=1
 fi
+dispatch_operational_report || true
 if [[ "$command" == "promote" ]]; then
   if (( rc != 0 )); then
     if (( ${#maintenance_output} > 4096 )); then
@@ -628,14 +964,19 @@ if [[ "$command" == "promote" ]]; then
     fi
   else
     if ! promote_verified_backup_as_root "$operation_backup_directory" "$manifest_path" "$release_attempt_id"; then
+      detach_operational_report backup backup-promote failed backup-candidate
       rc=1
     fi
   fi
 fi
 if (( rc == 0 )) && [[ "$command" == "restore" ]]; then
-  if ! "$systemctl_command" restart "$service_name" >/dev/null 2>&1 ||
-    [[ "$($systemctl_command is-active "$service_name" 2>/dev/null || true)" != active ]]
-  then
+  if ! "$systemctl_command" restart "$service_name" >/dev/null 2>&1; then
+    detach_operational_report restore startup failed atomic-install
+    printf '{"restored":false,"outcome":"cutover-completed-readiness-failed","cutoverCompleted":true,"restartVerified":false,"technicalAdminAuth":%s,"authorityResurrectionWarning":"Restoring an older snapshot may resurrect Grants, Grant Sessions, Ad Hoc Controller sessions, or QR-admitting state changed after the snapshot."}\n' "$technical_admin_auth" >&${restore_error_fd}
+    restore_result_emitted=1
+    rc=12
+  elif [[ "$($systemctl_command is-active "$service_name" 2>/dev/null || true)" != active ]]; then
+    detach_operational_report restore readiness failed readiness
     printf '{"restored":false,"outcome":"cutover-completed-readiness-failed","cutoverCompleted":true,"restartVerified":false,"technicalAdminAuth":%s,"authorityResurrectionWarning":"Restoring an older snapshot may resurrect Grants, Grant Sessions, Ad Hoc Controller sessions, or QR-admitting state changed after the snapshot."}\n' "$technical_admin_auth" >&${restore_error_fd}
     restore_result_emitted=1
     rc=12
@@ -647,5 +988,9 @@ if [[ "$command" == restore && "$restore_result_emitted" == 0 ]]; then
 fi
 if (( rc != 0 )) && [[ "$command" == "backup" || "$command" == "verify-backup" || "$command" == "promote" ]]; then
   if [[ "$focused_test_mode" == 1 ]]; then chmod -R u+w "$operation_backup_directory" 2>/dev/null || true; rm -rf "$operation_backup_directory"; else chmod -R u+w -- "$operation_backup_directory" 2>/dev/null || true; rm -rf -- "$operation_backup_directory"; fi
+fi
+trap - ERR
+if (( rc != 0 )) && [[ "$operational_report_dispatched" == 0 ]]; then
+  report_unhandled_root_failure
 fi
 exit "$rc"

--- a/deploy/monitoring.md
+++ b/deploy/monitoring.md
@@ -11,6 +11,26 @@ environment or any server credential. Both values are optional, so a missing or
 failed monitoring transport never changes an application response or authority
 decision.
 
+Deployment, backup, migration, restore, and readiness failures use one
+best-effort operational adapter. Its event is limited to the operation,
+`Environment`, trusted release attempt when available, phase, bounded outcome,
+bounded category, and timestamp. It never carries commands, environment values,
+logs, paths, database/request data, credentials, authority/session data, restore
+details, or WebAuthn details. Delivery is detached and bounded; output records
+only `sent`, `failed`, or `unavailable`, never the event payload.
+
+The activation shell delegates shell-owned failures to the root-owned
+`activation-maintenance-root.sh` seam. That seam selects the Environment-specific
+root-controlled `EnvironmentFile`, reads only `GLITCHTIP_DSN` without sourcing it,
+and invokes the immutable release executable with the manifest release identity.
+If the attempted candidate has not reached the immutable release directory, the
+same seam uses the current installed executable while passing only the validated
+attempt identity; it never executes the rejected staged candidate. A private
+root-owned per-attempt record lets the workflow read only the latest bounded
+delivery status through a five-second SSH boundary.
+Missing DSN is reported as `unavailable`; it never changes activation cleanup,
+rollback, or fail-closed results.
+
 To exercise server delivery, from the Test host run this bounded transient unit.
 It runs as the Test service identity, loads the root-controlled Test
 `EnvironmentFile`, uses the immutable compiled release as its working directory,

--- a/docs/agents/issue-165-pre-merge-handoff.md
+++ b/docs/agents/issue-165-pre-merge-handoff.md
@@ -1,5 +1,10 @@
 # Issue #165 pre-merge activation handoff
 
+> Historical record only. This document pins the pre-#168 privileged wrapper
+> and must not be used as the current installation procedure. The reviewed
+> superseding handoff is `docs/agents/issue-168-pre-merge-handoff.md`, which
+> carries the current wrapper checksum and fish-compatible operator path.
+
 This is the bounded, operator-run host prerequisite for the schema-aware
 activation in Draft PR #222. It is intentionally separate from deployment:
 the agent does not SSH, upload, install, restart, or change the live server.

--- a/docs/agents/issue-168-pre-merge-handoff.md
+++ b/docs/agents/issue-168-pre-merge-handoff.md
@@ -1,0 +1,116 @@
+# Issue #168 privileged wrapper installation handoff
+
+This handoff installs only the reviewed #168 privileged reporter wrapper on
+`jannis.rocks`. It does not deploy a release, restart either service, change a
+unit or sudoers rule, read a DSN, or contact GlitchTip. The previous wrapper is
+retained as `/usr/local/sbin/quadball-timer-activation-maintenance.pre-168` for
+bounded recovery.
+
+The wrapper reads the selected Environment's root-controlled `GLITCHTIP_DSN`
+without printing it, launches the bounded reporter independently from release
+recovery, and stores only `sent`, `failed`, or `unavailable` in root-owned
+`/run/quadball-timer-operational-status` records (`0700` directory, `0600`
+files).
+
+Run each fish block only if the preceding block succeeds. The blocks
+intentionally contain no `exit`, because closing a failed block must not close
+the operator's terminal tab.
+
+## 1. Verify the accepted local candidate
+
+```fish
+set candidate_root (git rev-parse --show-toplevel)
+set accepted_base 260a8b1deba98d6ed982be651928d268f274bb24
+set wrapper_sha c892da10bff3350492ff5f17293e69b161ad33926bd75a7cffd7b231610643eb
+
+cd $candidate_root
+and test (git status --porcelain) = ""
+and git diff --quiet
+and git diff --cached --quiet
+and test (git rev-list --count $accepted_base..HEAD) = 1
+and test (git merge-base $accepted_base HEAD) = $accepted_base
+and test (shasum -a 256 deploy/activation-maintenance-root.sh | awk '{print $1}') = $wrapper_sha
+or begin
+    echo "STOP: the #168 candidate is dirty, has the wrong ancestry, or has the wrong wrapper checksum." >&2
+    false
+end
+```
+
+## 2. Upload the exact reviewed wrapper
+
+```fish
+set candidate_dir (mktemp -d /tmp/quadball-timer-168-candidate.XXXXXX)
+set remote_dir /tmp/quadball-timer-168-final-premerge
+
+chmod 700 $candidate_dir
+and cp deploy/activation-maintenance-root.sh $candidate_dir/activation-maintenance-root.sh
+and test (shasum -a 256 $candidate_dir/activation-maintenance-root.sh | awk '{print $1}') = $wrapper_sha
+and ssh jannis@jannis.rocks "test ! -e $remote_dir && /usr/bin/install -d -m 0700 $remote_dir"
+and scp $candidate_dir/activation-maintenance-root.sh jannis@jannis.rocks:$remote_dir/activation-maintenance-root.sh
+and set remote_wrapper_sha (ssh jannis@jannis.rocks "/usr/bin/sha256sum $remote_dir/activation-maintenance-root.sh | /usr/bin/awk '{print \\$1}'")
+and test $remote_wrapper_sha = $wrapper_sha
+or begin
+    echo "STOP: wrapper staging or upload verification failed; nothing privileged was changed." >&2
+    false
+end
+```
+
+## 3. Install and verify in one privileged session
+
+This replaces one root-owned executable and runs read-only unit/sudoers/service
+checks plus `daemon-reload`. It does not stop or restart a service.
+
+```fish
+set remote_script (string join '; ' \
+    'set -euo pipefail' \
+    "/usr/bin/sha256sum $remote_dir/activation-maintenance-root.sh | /usr/bin/grep -F '$wrapper_sha  $remote_dir/activation-maintenance-root.sh'" \
+    '/usr/bin/sudo -v' \
+    "if /usr/bin/sudo /usr/bin/test -e /usr/local/sbin/quadball-timer-activation-maintenance.pre-168; then /usr/bin/sudo /usr/bin/test -f /usr/local/sbin/quadball-timer-activation-maintenance.pre-168; else /usr/bin/sudo /usr/bin/install -o root -g root -m 0755 /usr/local/sbin/quadball-timer-activation-maintenance /usr/local/sbin/quadball-timer-activation-maintenance.pre-168; fi" \
+    "/usr/bin/sudo /usr/bin/install -o root -g root -m 0755 $remote_dir/activation-maintenance-root.sh /usr/local/sbin/quadball-timer-activation-maintenance.new-168" \
+    "/usr/bin/sudo /usr/bin/sha256sum /usr/local/sbin/quadball-timer-activation-maintenance.new-168 | /usr/bin/grep -F '$wrapper_sha  /usr/local/sbin/quadball-timer-activation-maintenance.new-168'" \
+    '/usr/bin/sudo /usr/bin/mv -T /usr/local/sbin/quadball-timer-activation-maintenance.new-168 /usr/local/sbin/quadball-timer-activation-maintenance' \
+    "/usr/bin/sudo /usr/bin/sha256sum /usr/local/sbin/quadball-timer-activation-maintenance | /usr/bin/grep -F '$wrapper_sha  /usr/local/sbin/quadball-timer-activation-maintenance'" \
+    "/usr/bin/sudo /usr/bin/stat -c '%n %U:%G %a' /usr/local/sbin/quadball-timer-activation-maintenance /usr/local/sbin/quadball-timer-activation-maintenance.pre-168" \
+    '/usr/bin/sudo /usr/sbin/visudo -cf /etc/sudoers.d/deploy-quadball-timer' \
+    '/usr/bin/sudo /usr/sbin/visudo -cf /etc/sudoers.d/deploy-quadball-timer-test' \
+    "/usr/bin/sudo /usr/bin/systemctl show quadball-timer --property=User --property=Group --property=WorkingDirectory --property=EnvironmentFiles --property=StateDirectory --property=ExecStart --no-pager" \
+    "/usr/bin/sudo /usr/bin/systemctl show quadball-timer-test --property=User --property=Group --property=WorkingDirectory --property=EnvironmentFiles --property=StateDirectory --property=ExecStart --no-pager" \
+    '/usr/bin/sudo /usr/bin/systemctl daemon-reload' \
+    '/usr/bin/sudo /usr/bin/systemctl is-active quadball-timer' \
+    '/usr/bin/sudo /usr/bin/systemctl is-active quadball-timer-test' \
+    "/usr/bin/rm -rf -- $remote_dir" \
+    "/usr/bin/test ! -e $remote_dir" \
+    "echo privileged-wrapper-install-ok")
+
+ssh -tt jannis@jannis.rocks "/usr/bin/bash -c "(string escape -- $remote_script)
+or begin
+    echo "STOP: privileged wrapper installation or verification failed. Do not restart either service." >&2
+    false
+end
+```
+
+Expected terminal evidence includes the reviewed checksum for the installed
+wrapper, `root:root 755`, both sudoers files parsing OK, both service contracts,
+two `active` results, and `privileged-wrapper-install-ok`.
+
+## 4. Remove the local staging copy
+
+```fish
+rm -rf -- $candidate_dir
+and test ! -e $candidate_dir
+and echo local-candidate-removed
+```
+
+## Recovery if the installed wrapper itself is defective
+
+Recovery is a separate explicitly chosen action. Before using it, confirm the
+failure is in the installed wrapper rather than the candidate executable. It
+atomically restores only the retained pre-#168 wrapper and does not restart a
+service:
+
+```fish
+ssh -tt jannis@jannis.rocks "/usr/bin/sudo -v && /usr/bin/sudo /usr/bin/test -f /usr/local/sbin/quadball-timer-activation-maintenance.pre-168 && /usr/bin/sudo /usr/bin/install -o root -g root -m 0755 /usr/local/sbin/quadball-timer-activation-maintenance.pre-168 /usr/local/sbin/quadball-timer-activation-maintenance.rollback-168 && /usr/bin/sudo /usr/bin/mv -T /usr/local/sbin/quadball-timer-activation-maintenance.rollback-168 /usr/local/sbin/quadball-timer-activation-maintenance && /usr/bin/sudo /usr/bin/stat -c '%n %U:%G %a' /usr/local/sbin/quadball-timer-activation-maintenance"
+```
+
+GlitchTip Test arrival and tags are a separate bounded operator check after the
+Test DSN is installed. This handoff claims no live delivery result.

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,6 +115,16 @@ import {
   browserMonitoringPublicConfig,
   serializeBrowserMonitoringConfig,
 } from "@/lib/monitoring-redaction";
+import {
+  OPERATIONAL_CATEGORIES,
+  OPERATIONAL_OPERATIONS,
+  OPERATIONAL_OUTCOMES,
+  OPERATIONAL_PHASES,
+  createOperationalMonitoringAdapter,
+  createOperationalMonitoringAdapterForMaintenance,
+  type OperationalFailureInput,
+  type OperationalMonitoringAdapter,
+} from "@/lib/operational-monitoring";
 import { runProductionActivationCli } from "@/lib/production-activation-cli";
 import { createPublicHealthRoute } from "@/lib/public-health";
 
@@ -162,9 +172,27 @@ async function main() {
     return;
   }
 
+  const operationalFailureIndex = process.argv.indexOf("--emit-operational-failure");
+  if (operationalFailureIndex !== -1) {
+    await emitOperationalFailure(process.argv.slice(operationalFailureIndex + 1));
+    return;
+  }
+
   const maintenanceIndex = process.argv.indexOf("--production-activation");
   if (maintenanceIndex !== -1) {
-    process.exitCode = await runProductionActivationCli(process.argv.slice(maintenanceIndex + 1));
+    const operationalReportFile = process.env.QBT_OPERATIONAL_REPORT_FILE?.trim();
+    // The root wrapper supplies a private spool and owns detached delivery.
+    // Direct CLI invocations remain authoritative and must not read release
+    // identity or initialize monitoring before the operation starts.
+    const operationalMonitoring =
+      operationalReportFile === undefined
+        ? createOperationalMonitoringAdapter({ enabled: false })
+        : createOperationalMonitoringAdapterForMaintenance(operationalReportFile);
+    const result = await runProductionActivationCli(
+      process.argv.slice(maintenanceIndex + 1),
+      operationalMonitoring,
+    );
+    process.exitCode = result;
     return;
   }
 
@@ -200,6 +228,11 @@ async function startServer() {
   let grantAuthorityOptions: ReturnType<typeof readGrantAuthorityOptions>;
   let server: Bun.Server<SessionData> | undefined;
   let shutdown: (() => void) | undefined;
+  let monitoringEnvironment: "production" | "test" = "test";
+  let operationalMonitoring: OperationalMonitoringAdapter = createOperationalMonitoringAdapter({
+    enabled: false,
+  });
+  let deferredStartupOperationalFailure: OperationalFailureInput | undefined;
   let monitoring: ServerMonitoring = initializeServerMonitoring({
     environment: "test",
     release: "startup",
@@ -212,6 +245,7 @@ async function startServer() {
     const port = Number(process.env.PORT ?? 3000);
     const { technicalAdmin: technicalAdminConfig, storagePaths } = readRuntimeConfig();
     const { environment } = technicalAdminConfig;
+    monitoringEnvironment = environment;
     const monitoringIdentity = await readTrustedMonitoringIdentity(environment);
     monitoring =
       monitoringIdentity === null
@@ -224,6 +258,7 @@ async function startServer() {
             ...monitoringIdentity,
             dsn: process.env.GLITCHTIP_DSN?.trim() || undefined,
           });
+    operationalMonitoring = createOperationalMonitoringAdapterForServer(monitoring);
     assertProductionStateBoundary(environment, storagePaths);
     grantAuthorityOptions = readGrantAuthorityOptions(environment);
     const adHocDatabasePath =
@@ -309,6 +344,14 @@ async function startServer() {
         startupCleanup.add(() => readyFoundation.close());
         eventCatalogStorage = createFoundationEventCatalogStorage(readyFoundation);
       } else {
+        operationalMonitoring.reportFailure({
+          operation: "readiness",
+          environment,
+          ...(monitoringIdentity === null ? {} : { releaseAttempt: monitoringIdentity.release }),
+          phase: "readiness",
+          outcome: "failed",
+          category: (readiness.evidence?.keys.missingCount ?? 0) > 0 ? "key-version" : "readiness",
+        });
         candidateFoundation.close();
         candidateFoundation = undefined;
         eventCatalogStorage = createUnavailableEventCatalogStorage(
@@ -316,6 +359,22 @@ async function startServer() {
         );
       }
     } catch (error) {
+      const failure: OperationalFailureInput = {
+        operation: "readiness",
+        environment,
+        ...(monitoringIdentity === null ? {} : { releaseAttempt: monitoringIdentity.release }),
+        phase: "readiness",
+        outcome: "failed",
+        category:
+          error instanceof GrantKeyRingCustodyError && error.category === "missing-key-version"
+            ? "key-version"
+            : "readiness",
+      };
+      if (error instanceof GrantKeyRingCustodyError) {
+        deferredStartupOperationalFailure = failure;
+      } else {
+        operationalMonitoring.reportFailure(failure);
+      }
       monitoring.captureException(error, {
         category: "startup",
         component: "foundation-storage",
@@ -2529,14 +2588,77 @@ async function startServer() {
 
     console.log(`Server running at ${server.url}`);
   } catch (error) {
+    const startupFailure =
+      deferredStartupOperationalFailure ??
+      ({
+        operation: "deployment",
+        environment: monitoringEnvironment,
+        phase: "startup",
+        outcome: "failed",
+        category:
+          error instanceof GrantKeyRingCustodyError && error.category === "missing-key-version"
+            ? "key-version"
+            : "atomic-install",
+      } satisfies OperationalFailureInput);
     monitoring.captureException(error, { category: "startup", component: "server" });
     if (shutdown !== undefined) {
       process.removeListener("SIGTERM", shutdown);
       process.removeListener("SIGINT", shutdown);
     }
     cleanup();
+    detachStartupOperationalFailure(startupFailure);
     throw error;
   }
+}
+
+function detachStartupOperationalFailure(failure: OperationalFailureInput): void {
+  const bunExecutable = Bun.which("bun");
+  const command =
+    bunExecutable !== null && process.execPath === bunExecutable
+      ? [process.execPath, "run", import.meta.path]
+      : [process.execPath];
+  try {
+    const reporter = Bun.spawn({
+      cmd: [
+        "/bin/bash",
+        "-c",
+        'exec 9>&-; exec "$@"',
+        "qbt-operational-reporter",
+        ...command,
+        "--emit-operational-failure",
+        "--operation",
+        failure.operation,
+        "--phase",
+        failure.phase,
+        "--outcome",
+        failure.outcome,
+        "--category",
+        failure.category,
+      ],
+      env: process.env,
+      stdin: "ignore",
+      stdout: "ignore",
+      stderr: "ignore",
+    });
+    reporter.unref();
+  } catch {
+    // Startup failure remains authoritative when the reporter cannot start.
+  }
+}
+
+function createOperationalMonitoringAdapterForServer(
+  monitoring: ServerMonitoring,
+): OperationalMonitoringAdapter {
+  return createOperationalMonitoringAdapter({
+    enabled: monitoring.enabled,
+    send: async (event) => {
+      if (!monitoring.captureOperationalFailure(event)) return false;
+      return await monitoring.flush(250);
+    },
+    onDelivery: (delivery) => {
+      console.error(delivery);
+    },
+  });
 }
 
 export async function createHtmlRoute({
@@ -2653,12 +2775,77 @@ async function emitTestMonitoringError(): Promise<void> {
     dsn: process.env.GLITCHTIP_DSN?.trim() || undefined,
   });
   if (!monitoring.enabled) throw new Error("GLITCHTIP_DSN is not configured.");
-  monitoring.captureMessage("Quadball Timer Test monitoring event", {
-    category: "test-monitoring",
-    component: "host-local",
-    operation: "emit-test-error",
+  const operationalMonitoring = createOperationalMonitoringAdapter({
+    enabled: monitoring.enabled,
+    send: async (event) => {
+      if (!monitoring.captureOperationalFailure(event)) return false;
+      return await monitoring.flush(250);
+    },
   });
-  if (!(await monitoring.flush(5_000))) throw new Error("Monitoring event was not delivered.");
+  const delivery = await operationalMonitoring.deliverFailure({
+    operation: "deployment",
+    environment: "test",
+    releaseAttempt: identity.release,
+    phase: "startup",
+    outcome: "failed",
+    category: "readiness",
+  });
+  if (delivery !== "sent") throw new Error("Operational monitoring event was not delivered.");
+}
+
+async function emitOperationalFailure(argv: readonly string[]): Promise<void> {
+  const readOption = (name: string): string | undefined => {
+    const index = argv.indexOf(name);
+    return index === -1 ? undefined : argv[index + 1];
+  };
+  const operation = allowlistedOperationalOption(readOption("--operation"), OPERATIONAL_OPERATIONS);
+  const phase = allowlistedOperationalOption(readOption("--phase"), OPERATIONAL_PHASES);
+  const outcome = allowlistedOperationalOption(readOption("--outcome"), OPERATIONAL_OUTCOMES);
+  const category = allowlistedOperationalOption(readOption("--category"), OPERATIONAL_CATEGORIES);
+  if (
+    operation === undefined ||
+    phase === undefined ||
+    outcome === undefined ||
+    category === undefined
+  ) {
+    throw new Error("Operational failure fields are required.");
+  }
+  const environment = process.env.QUADBALL_ENVIRONMENT === "production" ? "production" : "test";
+  const identity = await readTrustedMonitoringIdentity(environment);
+  const monitoring =
+    identity === null
+      ? initializeServerMonitoring({
+          environment,
+          release: "unavailable",
+          browserCorrelation: "release-unavailable",
+        })
+      : initializeServerMonitoring({
+          ...identity,
+          dsn: process.env.GLITCHTIP_DSN?.trim() || undefined,
+        });
+  const adapter = createOperationalMonitoringAdapter({
+    enabled: monitoring.enabled,
+    send: async (event) => {
+      if (!monitoring.captureOperationalFailure(event)) return false;
+      return await monitoring.flush(250);
+    },
+  });
+  const delivery = await adapter.deliverFailure({
+    operation,
+    environment,
+    releaseAttempt: identity?.release,
+    phase,
+    outcome,
+    category,
+  });
+  console.log(delivery);
+}
+
+function allowlistedOperationalOption<const Values extends readonly string[]>(
+  value: string | undefined,
+  values: Values,
+): Values[number] | undefined {
+  return value !== undefined && values.includes(value) ? value : undefined;
 }
 
 async function runProbeMode(

--- a/src/lib/monitoring-redaction.test.ts
+++ b/src/lib/monitoring-redaction.test.ts
@@ -6,6 +6,7 @@ import {
   sendRedactedEvent,
   serializeBrowserMonitoringConfig,
 } from "@/lib/monitoring-redaction";
+import { redactServerEventForTest } from "@/lib/monitoring-server";
 
 describe("monitoring redaction boundary", () => {
   test("sends only the reviewed event shape to a fake transport", async () => {
@@ -19,6 +20,8 @@ describe("monitoring redaction boundary", () => {
         tags: {
           category: "server",
           operation: "open",
+          environment: "test",
+          releaseAttempt: "sha-safe-release-attempt",
           grantCode: "raw-grant-code",
           userInput: "private team name",
         },
@@ -107,6 +110,8 @@ describe("monitoring redaction boundary", () => {
           Environment: "request-environment",
           Release: "request-release",
           BrowserCorrelation: "request-alias",
+          environment: "production",
+          releaseAttempt: "request-release",
         },
         message: "safe failure",
       },
@@ -129,6 +134,87 @@ describe("monitoring redaction boundary", () => {
         BrowserCorrelation: "release-trusted-alias",
       },
     });
+  });
+
+  test("composes a real operational event through the reviewed server redaction boundary", () => {
+    const redacted = redactServerEventForTest(
+      {
+        timestamp: 123,
+        tags: {
+          operationalEvent: "1",
+          Environment: "test",
+          ReleaseAttempt: "sha-safe-release-attempt",
+          operation: "restore",
+          phase: "staged-restore",
+          outcome: "failed",
+          category: "staged-restore",
+        },
+        request: { url: "https://timer.example/private" },
+        extra: { secret: "never-send" },
+      },
+      {
+        environment: "test",
+        release: "sha-safe-release-attempt",
+        browserCorrelation: "release-safe-alias",
+      },
+    );
+
+    expect(redacted).toMatchObject({
+      timestamp: 123,
+      tags: {
+        Environment: "test",
+        ReleaseAttempt: "sha-safe-release-attempt",
+        operation: "restore",
+        phase: "staged-restore",
+        outcome: "failed",
+        category: "staged-restore",
+      },
+    });
+    expect(redacted).not.toHaveProperty("request");
+    expect(redacted).not.toHaveProperty("extra");
+  });
+
+  test("keeps operational events to the fixed allowlist", () => {
+    const redacted = redactServerEventForTest(
+      {
+        platform: "javascript",
+        logger: "attacker-controlled",
+        message: "secret command /var/lib/private token=secret",
+        tags: {
+          operationalEvent: "1",
+          Environment: "test",
+          ReleaseAttempt: "sha-safe-release-attempt",
+          operation: "restore",
+          phase: "staged-restore",
+          outcome: "failed",
+          category: "technical-admin-auth-sanitization",
+          BrowserCorrelation: "must-not-leave",
+        },
+        request: { url: "https://timer.example/private" },
+        extra: { stdout: "secret" },
+      },
+      {
+        environment: "test",
+        release: "sha-safe-release-attempt",
+        browserCorrelation: "release-safe-alias",
+      },
+    );
+
+    expect(redacted).toEqual({
+      timestamp: undefined,
+      level: "error",
+      message: "Quadball Timer operational failure",
+      tags: {
+        operation: "restore",
+        Environment: "test",
+        ReleaseAttempt: "sha-safe-release-attempt",
+        phase: "staged-restore",
+        outcome: "failed",
+        category: "technical-admin-auth-sanitization",
+      },
+    });
+    expect(JSON.stringify(redacted)).not.toContain("secret");
+    expect(JSON.stringify(redacted)).not.toContain("BrowserCorrelation");
   });
 
   test("redacts Basic credentials and plausible key material before rewrites", () => {

--- a/src/lib/monitoring-redaction.ts
+++ b/src/lib/monitoring-redaction.ts
@@ -1,4 +1,10 @@
 import type { Event, Stacktrace, StackFrame } from "@sentry/core";
+import {
+  OPERATIONAL_CATEGORIES,
+  OPERATIONAL_OPERATIONS,
+  OPERATIONAL_PHASES,
+  OPERATIONAL_OUTCOMES,
+} from "@/lib/operational-monitoring";
 
 type ExceptionValue = NonNullable<NonNullable<Event["exception"]>["values"]>[number];
 
@@ -65,6 +71,9 @@ const SAFE_EXCEPTION_TYPES = new Set([
  * not part of this application's privacy boundary.
  */
 export function redactSentryEvent(event: Event, identity: MonitoringIdentity): Event {
+  if (event.tags?.operationalEvent === "1") {
+    return redactOperationalSentryEvent(event, identity);
+  }
   const exceptionValues = event.exception?.values
     ?.map((value) => redactExceptionValue(value))
     .filter((value): value is ExceptionValue => value !== null);
@@ -84,11 +93,49 @@ export function redactSentryEvent(event: Event, identity: MonitoringIdentity): E
       ReleaseAttempt: identity.release,
       BrowserCorrelation: identity.browserCorrelation,
       ...safeTags(event.tags),
+      ...safeOperationalIdentityTags(event.tags, identity),
     },
     exception:
       exceptionValues === undefined || exceptionValues.length === 0
         ? undefined
         : { values: exceptionValues },
+  };
+}
+
+/** Rebuild operational events using only their reviewed fixed allowlist. */
+export function redactOperationalSentryEvent(event: Event, identity: MonitoringIdentity): Event {
+  const tags = event.tags ?? {};
+  const operation = allowlistedTag(tags.operation, OPERATIONAL_OPERATIONS);
+  const phase = allowlistedTag(tags.phase, OPERATIONAL_PHASES);
+  const outcome = allowlistedTag(tags.outcome, OPERATIONAL_OUTCOMES);
+  const category = allowlistedTag(tags.category, OPERATIONAL_CATEGORIES);
+  const eventEnvironment = tags.Environment ?? tags.environment;
+  const eventRelease = tags.ReleaseAttempt ?? tags.releaseAttempt;
+
+  return {
+    timestamp: Number.isFinite(event.timestamp) ? event.timestamp : undefined,
+    level: "error",
+    message: "Quadball Timer operational failure",
+    tags: {
+      ...(operation === undefined ? {} : { operation }),
+      ...(eventEnvironment === identity.environment ? { Environment: identity.environment } : {}),
+      ...(eventRelease === identity.release ? { ReleaseAttempt: identity.release } : {}),
+      ...(phase === undefined ? {} : { phase }),
+      ...(outcome === undefined ? {} : { outcome }),
+      ...(category === undefined ? {} : { category }),
+    },
+  };
+}
+
+function safeOperationalIdentityTags(
+  tags: Record<string, unknown> | undefined,
+  identity: MonitoringIdentity,
+): Record<string, string> {
+  const environment = tags?.environment;
+  const releaseAttempt = tags?.releaseAttempt;
+  return {
+    ...(environment === identity.environment ? { Environment: identity.environment } : {}),
+    ...(releaseAttempt === identity.release ? { ReleaseAttempt: identity.release } : {}),
   };
 }
 
@@ -166,6 +213,13 @@ function safeTags(tags: Record<string, unknown> | undefined) {
     }
   }
   return output;
+}
+
+function allowlistedTag<const Values extends readonly string[]>(
+  value: unknown,
+  values: Values,
+): Values[number] | undefined {
+  return typeof value === "string" && values.includes(value as Values[number]) ? value : undefined;
 }
 
 function isEventId(value: string | undefined): value is string {

--- a/src/lib/monitoring-server.test.ts
+++ b/src/lib/monitoring-server.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { createBrowserCorrelation, readTrustedMonitoringIdentity } from "@/lib/monitoring-server";
+import {
+  captureOperationalFailureEvent,
+  createBrowserCorrelation,
+  readTrustedMonitoringIdentity,
+} from "@/lib/monitoring-server";
 
 describe("trusted monitoring release identity", () => {
   test("does not fabricate a deployed identity when the immutable manifest is unavailable", async () => {
@@ -26,5 +30,54 @@ describe("trusted monitoring release identity", () => {
       release: "sha-commit-run-123-attempt-1",
       browserCorrelation: createBrowserCorrelation("sha-commit-run-123-attempt-1"),
     });
+  });
+
+  test("returns capture success and preserves only the operational event shape", () => {
+    const captured: unknown[] = [];
+    const event = {
+      operation: "restore",
+      environment: "test",
+      releaseAttempt: "sha-safe-release-attempt",
+      phase: "staged-restore",
+      outcome: "failed",
+      category: "staged-restore",
+      timestampMs: 123_000,
+    } as const;
+    const identity = {
+      environment: "test" as const,
+      release: "sha-safe-release-attempt",
+    };
+
+    expect(captureOperationalFailureEvent(event, identity, (value) => captured.push(value))).toBe(
+      true,
+    );
+    expect(captured).toEqual([
+      {
+        level: "error",
+        message: "Quadball Timer operational failure",
+        timestamp: 123,
+        tags: {
+          operationalEvent: "1",
+          Environment: "test",
+          ReleaseAttempt: "sha-safe-release-attempt",
+          operation: "restore",
+          phase: "staged-restore",
+          outcome: "failed",
+          category: "staged-restore",
+        },
+      },
+    ]);
+    expect(
+      captureOperationalFailureEvent(event, identity, () => {
+        throw new Error("monitoring transport unavailable");
+      }),
+    ).toBe(false);
+    expect(
+      captureOperationalFailureEvent(
+        { ...event, environment: "production" },
+        identity,
+        () => undefined,
+      ),
+    ).toBe(false);
   });
 });

--- a/src/lib/monitoring-server.ts
+++ b/src/lib/monitoring-server.ts
@@ -8,11 +8,13 @@ import {
   type MonitoringContext,
   type MonitoringIdentity,
 } from "@/lib/monitoring-redaction";
+import type { OperationalEvent } from "@/lib/operational-monitoring";
 
 export type ServerMonitoring = {
   enabled: boolean;
   captureException(error: unknown, context?: MonitoringContext): void;
   captureMessage(message: string, context?: MonitoringContext): void;
+  captureOperationalFailure(event: OperationalEvent): boolean;
   flush(timeoutMs?: number): Promise<boolean>;
 };
 
@@ -58,36 +60,92 @@ export function createBrowserCorrelation(release: string): string {
 export function initializeServerMonitoring(options: ServerMonitoringOptions): ServerMonitoring {
   if (options.dsn === undefined || options.dsn.length === 0) return createDisabledMonitoring();
 
-  Sentry.init({
-    dsn: options.dsn,
-    environment: options.environment,
-    release: options.release,
-    defaultIntegrations: false,
-    sendDefaultPii: false,
-    tracesSampleRate: 0,
-    beforeSend(event) {
-      return redactSentryEvent(event, options) as typeof event;
-    },
-  });
+  try {
+    Sentry.init({
+      dsn: options.dsn,
+      environment: options.environment,
+      release: options.release,
+      defaultIntegrations: false,
+      sendDefaultPii: false,
+      tracesSampleRate: 0,
+      beforeSend(event) {
+        return redactSentryEvent(event, options) as typeof event;
+      },
+    });
+  } catch {
+    return createDisabledMonitoring();
+  }
 
   return {
     enabled: true,
     captureException(error, context) {
-      Sentry.withScope((scope) => {
-        scope.setTags(safeMonitoringTags(context));
-        Sentry.captureException(error);
+      safelyCapture(() => {
+        Sentry.withScope((scope) => {
+          scope.setTags(safeMonitoringTags(context));
+          Sentry.captureException(error);
+        });
       });
     },
     captureMessage(message, context) {
-      Sentry.withScope((scope) => {
-        scope.setTags(safeMonitoringTags(context));
-        Sentry.captureMessage(message);
+      safelyCapture(() => {
+        Sentry.withScope((scope) => {
+          scope.setTags(safeMonitoringTags(context));
+          Sentry.captureMessage(message);
+        });
+      });
+    },
+    captureOperationalFailure(event) {
+      return captureOperationalFailureEvent(event, options, (captured) => {
+        Sentry.captureEvent(captured);
       });
     },
     flush(timeoutMs = 2_000) {
       return Sentry.flush(timeoutMs).catch(() => false);
     },
   };
+}
+
+export function captureOperationalFailureEvent(
+  event: OperationalEvent,
+  identity: Pick<MonitoringIdentity, "environment" | "release">,
+  capture: (event: Event) => void,
+): boolean {
+  if (event.environment !== identity.environment) return false;
+  if (event.releaseAttempt !== undefined && event.releaseAttempt !== identity.release) return false;
+  const timestampMs =
+    Number.isSafeInteger(event.timestampMs) && event.timestampMs >= 0
+      ? event.timestampMs
+      : Date.now();
+  return tryCapture(() => {
+    capture({
+      level: "error",
+      message: "Quadball Timer operational failure",
+      timestamp: timestampMs / 1_000,
+      tags: {
+        operationalEvent: "1",
+        Environment: event.environment,
+        ...(event.releaseAttempt === undefined ? {} : { ReleaseAttempt: event.releaseAttempt }),
+        operation: event.operation,
+        phase: event.phase,
+        outcome: event.outcome,
+        category: event.category,
+      },
+    });
+  });
+}
+
+function safelyCapture(capture: () => void): void {
+  tryCapture(capture);
+}
+
+function tryCapture(capture: () => void): boolean {
+  try {
+    capture();
+    return true;
+  } catch {
+    // Monitoring is observational and must never alter application behavior.
+    return false;
+  }
 }
 
 export function redactServerEventForTest(event: Event, identity: MonitoringIdentity): Event {
@@ -99,6 +157,9 @@ function createDisabledMonitoring(): ServerMonitoring {
     enabled: false,
     captureException() {},
     captureMessage() {},
+    captureOperationalFailure() {
+      return false;
+    },
     flush: async () => true,
   };
 }

--- a/src/lib/operational-monitoring.test.ts
+++ b/src/lib/operational-monitoring.test.ts
@@ -1,0 +1,339 @@
+import { describe, expect, test } from "bun:test";
+import {
+  OPERATIONAL_CATEGORIES,
+  OPERATIONAL_PHASES,
+  createOperationalMonitoringAdapter,
+  type OperationalEvent,
+} from "@/lib/operational-monitoring";
+
+describe("operational monitoring adapter", () => {
+  test("emits only fixed operational fields across every phase", async () => {
+    const events: OperationalEvent[] = [];
+    let sendStarted = false;
+    const adapter = createOperationalMonitoringAdapter({
+      enabled: true,
+      now: () => 123,
+      scheduleTimeout: (callback) => callback(),
+      send: (event) => {
+        sendStarted = true;
+        events.push(event);
+      },
+    });
+
+    for (const [index, phase] of OPERATIONAL_PHASES.entries()) {
+      adapter.reportFailure({
+        operation: "deployment",
+        environment: "production",
+        releaseAttempt: "sha-safe-run-1-attempt-1",
+        phase,
+        outcome: "failed",
+        category: OPERATIONAL_CATEGORIES[index % OPERATIONAL_CATEGORIES.length] ?? "readiness",
+        timestampMs: 123,
+        error: "Bearer secret /var/lib/private stdout=do-not-send",
+      } as never);
+    }
+    expect(sendStarted).toBe(false);
+    await Promise.resolve();
+
+    expect(events).toHaveLength(OPERATIONAL_PHASES.length);
+    expect(events[0]).toEqual({
+      operation: "deployment",
+      environment: "production",
+      releaseAttempt: "sha-safe-run-1-attempt-1",
+      phase: "preflight",
+      outcome: "failed",
+      category: "backup-candidate",
+      timestampMs: 123,
+    });
+    expect(JSON.stringify(events)).not.toContain("Bearer");
+    expect(JSON.stringify(events)).not.toContain("/var/lib/private");
+
+    adapter.reportFailure({
+      operation: "deployment Bearer raw-secret" as never,
+      environment: "production",
+      releaseAttempt: "token=private",
+      phase: "/var/lib/private" as never,
+      outcome: "stdout=private" as never,
+      category: "stderr=private" as never,
+    });
+    await Promise.resolve();
+    expect(events.at(-1)).toEqual({
+      operation: "deployment",
+      environment: "production",
+      phase: "readiness",
+      outcome: "failed",
+      category: "readiness",
+      timestampMs: 123,
+    });
+  });
+
+  test("reports an outage without retrying or delaying the operation", async () => {
+    let sends = 0;
+    const deliveries: string[] = [];
+    const adapter = createOperationalMonitoringAdapter({
+      enabled: true,
+      timeoutMs: 10,
+      scheduleTimeout: (callback) => callback(),
+      send: async () => {
+        sends += 1;
+        throw new Error("monitoring outage");
+      },
+      onDelivery: (delivery) => deliveries.push(delivery),
+    });
+
+    adapter.reportFailure({
+      operation: "restore",
+      environment: "production",
+      phase: "staged-restore",
+      outcome: "failed",
+      category: "technical-admin-auth-sanitization",
+    });
+    expect(deliveries).toEqual([]);
+    for (let turn = 0; turn < 5; turn += 1) await Promise.resolve();
+
+    expect(sends).toBe(1);
+    expect(deliveries).toEqual(["failed"]);
+  });
+
+  test("awaits one bounded reporter delivery and returns its truthful status", async () => {
+    let sends = 0;
+    const deliveries: string[] = [];
+    const adapter = createOperationalMonitoringAdapter({
+      enabled: true,
+      scheduleTimeout: () => {},
+      send: async (event) => {
+        sends += 1;
+        expect(event).toEqual({
+          operation: "readiness",
+          environment: "test",
+          releaseAttempt: "sha-readiness-run-1-attempt-1",
+          phase: "readiness",
+          outcome: "failed",
+          category: "key-version",
+          timestampMs: 321,
+        });
+        return true;
+      },
+      onDelivery: (delivery) => deliveries.push(delivery),
+    });
+
+    const delivery = await adapter.deliverFailure({
+      operation: "readiness",
+      environment: "test",
+      releaseAttempt: "sha-readiness-run-1-attempt-1",
+      phase: "readiness",
+      outcome: "failed",
+      category: "key-version",
+      timestampMs: 321,
+      message: "secret-bearing failure /var/lib/private token=secret",
+    } as never);
+
+    expect(delivery).toBe("sent");
+    expect(sends).toBe(1);
+    expect(deliveries).toEqual(["sent"]);
+  });
+
+  test("surfaces a failed reporter attempt without retrying it", async () => {
+    let sends = 0;
+    const adapter = createOperationalMonitoringAdapter({
+      enabled: true,
+      scheduleTimeout: () => {},
+      send: () => {
+        sends += 1;
+        return false;
+      },
+    });
+
+    const delivery = await adapter.deliverFailure({
+      operation: "backup",
+      environment: "production",
+      phase: "backup-verify",
+      outcome: "failed",
+      category: "backup-candidate",
+    });
+    expect(delivery).toBe("failed");
+    expect(sends).toBe(1);
+  });
+
+  test("does not retry the underlying operation when monitoring fails", async () => {
+    let operationRuns = 0;
+    let monitoringCalls = 0;
+    const events: OperationalEvent[] = [];
+    const deliveries: string[] = [];
+    const adapter = createOperationalMonitoringAdapter({
+      enabled: true,
+      scheduleTimeout: (callback) => callback(),
+      send: (event) => {
+        monitoringCalls += 1;
+        events.push(event);
+        throw new Error("secret-bearing operation failure /var/lib/private token=secret");
+      },
+      onDelivery: (delivery) => deliveries.push(delivery),
+    });
+
+    const runOperation = () => {
+      operationRuns += 1;
+      return "failed" as const;
+    };
+    const operations = [
+      [
+        "deployment",
+        "production",
+        "sha-deployment-run-1-attempt-0",
+        "preflight",
+        "atomic-install",
+        "failed",
+      ],
+      [
+        "deployment",
+        "test",
+        "sha-deployment-run-1-attempt-0-test",
+        "quiesce-stop",
+        "atomic-install",
+        "failed",
+      ],
+      [
+        "deployment",
+        "production",
+        "sha-deployment-run-1-attempt-1",
+        "release-switch",
+        "atomic-install",
+        "failed",
+      ],
+      [
+        "backup",
+        "production",
+        "sha-backup-run-1-attempt-1",
+        "backup-create",
+        "backup-candidate",
+        "failed",
+      ],
+      [
+        "backup",
+        "production",
+        "sha-backup-run-1-attempt-2",
+        "backup-verify",
+        "backup-candidate",
+        "failed",
+      ],
+      [
+        "backup",
+        "production",
+        "sha-backup-run-1-attempt-3",
+        "backup-promote",
+        "backup-candidate",
+        "failed",
+      ],
+      [
+        "migration",
+        "production",
+        "sha-migration-run-1-attempt-1",
+        "candidate-validation",
+        "schema-incompatibility",
+        "incompatible",
+      ],
+      [
+        "migration",
+        "test",
+        "sha-migration-run-1-attempt-2",
+        "live-migration",
+        "migration-candidate",
+        "failed",
+      ],
+      [
+        "restore",
+        "production",
+        "sha-restore-run-1-attempt-1",
+        "staged-restore",
+        "technical-admin-auth-sanitization",
+        "failed",
+      ],
+      [
+        "restore",
+        "production",
+        "sha-restore-run-1-attempt-2",
+        "staged-restore",
+        "re-enrollment-required",
+        "degraded",
+      ],
+      ["readiness", "test", "sha-readiness-run-1-attempt-1", "startup", "key-version", "failed"],
+      [
+        "readiness",
+        "production",
+        "sha-readiness-run-1-attempt-2",
+        "readiness",
+        "readiness",
+        "failed",
+      ],
+      [
+        "deployment",
+        "production",
+        "sha-deployment-run-1-attempt-2",
+        "rollback-restart",
+        "binary-rollback",
+        "failed",
+      ],
+      [
+        "deployment",
+        "test",
+        "sha-deployment-run-1-attempt-3",
+        "final-report",
+        "atomic-install",
+        "failed",
+      ],
+    ] as const;
+    const results = operations.map(
+      ([operation, environment, releaseAttempt, phase, category, outcome]) => {
+        const result = runOperation();
+        adapter.reportFailure({
+          operation,
+          environment,
+          releaseAttempt,
+          phase,
+          outcome,
+          category,
+        });
+        return result;
+      },
+    );
+    for (let turn = 0; turn < 5; turn += 1) await Promise.resolve();
+
+    expect(results).toEqual(operations.map(() => "failed"));
+    expect(operationRuns).toBe(operations.length);
+    expect(monitoringCalls).toBe(operations.length);
+    expect(deliveries).toEqual(operations.map(() => "failed"));
+    expect(events).toEqual(
+      operations.map(([operation, environment, releaseAttempt, phase, category, outcome]) => ({
+        operation,
+        environment,
+        releaseAttempt,
+        phase,
+        outcome,
+        category,
+        timestampMs: expect.any(Number),
+      })),
+    );
+    expect(JSON.stringify(events)).not.toContain("secret-bearing");
+    expect(JSON.stringify(events)).not.toContain("/var/lib/private");
+    expect(JSON.stringify(events)).not.toContain("token=secret");
+    expect(new Set(events.map(({ phase }) => phase))).toEqual(new Set(OPERATIONAL_PHASES));
+  });
+
+  test("marks an unavailable transport without invoking an operation", () => {
+    const deliveries: string[] = [];
+    const adapter = createOperationalMonitoringAdapter({
+      enabled: false,
+      onDelivery: (delivery) => deliveries.push(delivery),
+    });
+
+    adapter.reportFailure({
+      operation: "readiness",
+      environment: "test",
+      phase: "readiness",
+      outcome: "unavailable",
+      category: "readiness",
+    });
+
+    expect(deliveries).toEqual(["unavailable"]);
+  });
+});

--- a/src/lib/operational-monitoring.ts
+++ b/src/lib/operational-monitoring.ts
@@ -1,0 +1,175 @@
+import { appendFileSync } from "node:fs";
+
+export const OPERATIONAL_OPERATIONS = [
+  "deployment",
+  "backup",
+  "migration",
+  "restore",
+  "readiness",
+] as const;
+export type OperationalOperation = (typeof OPERATIONAL_OPERATIONS)[number];
+
+export const OPERATIONAL_PHASES = [
+  "preflight",
+  "quiesce-stop",
+  "backup-create",
+  "backup-verify",
+  "backup-promote",
+  "candidate-validation",
+  "live-migration",
+  "staged-restore",
+  "release-switch",
+  "startup",
+  "readiness",
+  "rollback-restart",
+  "final-report",
+] as const;
+export type OperationalPhase = (typeof OPERATIONAL_PHASES)[number];
+
+export const OPERATIONAL_CATEGORIES = [
+  "backup-candidate",
+  "migration-candidate",
+  "schema-incompatibility",
+  "binary-rollback",
+  "staged-restore",
+  "key-version",
+  "technical-admin-auth-sanitization",
+  "re-enrollment-required",
+  "atomic-install",
+  "readiness",
+] as const;
+export type OperationalCategory = (typeof OPERATIONAL_CATEGORIES)[number];
+
+export const OPERATIONAL_OUTCOMES = [
+  "failed",
+  "degraded",
+  "blocked",
+  "incompatible",
+  "rolled-back",
+  "unavailable",
+] as const;
+export type OperationalOutcome = (typeof OPERATIONAL_OUTCOMES)[number];
+
+export type OperationalEvent = {
+  operation: OperationalOperation;
+  environment: "production" | "test";
+  releaseAttempt?: string;
+  phase: OperationalPhase;
+  outcome: OperationalOutcome;
+  category: OperationalCategory;
+  timestampMs: number;
+};
+
+export type OperationalDelivery = "sent" | "failed" | "unavailable";
+
+export type OperationalFailureInput = Omit<OperationalEvent, "timestampMs"> & {
+  timestampMs?: number;
+};
+
+export type OperationalMonitoringAdapter = {
+  /** Queue delivery without allowing monitoring to delay the caller. */
+  reportFailure(input: OperationalFailureInput): void;
+  /** Await one bounded delivery attempt for an explicit reporter boundary. */
+  deliverFailure(input: OperationalFailureInput): Promise<OperationalDelivery>;
+};
+
+export function createOperationalMonitoringAdapter(options: {
+  enabled: boolean;
+  send?: (event: OperationalEvent) => boolean | void | Promise<boolean | void>;
+  now?: () => number;
+  timeoutMs?: number;
+  scheduleTimeout?: (callback: () => void, timeoutMs: number) => void;
+  onDelivery?: (delivery: OperationalDelivery) => void;
+}): OperationalMonitoringAdapter {
+  const now = options.now ?? Date.now;
+  const timeoutMs = Math.max(1, Math.min(1_000, options.timeoutMs ?? 250));
+  const scheduleTimeout =
+    options.scheduleTimeout ??
+    ((callback, delayMs) => {
+      setTimeout(callback, delayMs);
+    });
+  const operations = new Set<string>(OPERATIONAL_OPERATIONS);
+  const phases = new Set<string>(OPERATIONAL_PHASES);
+  const categories = new Set<string>(OPERATIONAL_CATEGORIES);
+  const outcomes = new Set<string>(OPERATIONAL_OUTCOMES);
+
+  const normalizeEvent = (input: OperationalFailureInput): OperationalEvent => ({
+    operation: allowlistedEnum(operations, input.operation, "deployment") as OperationalOperation,
+    environment: input.environment === "production" ? "production" : "test",
+    ...(typeof input.releaseAttempt === "string" &&
+    /^[A-Za-z0-9._-]{1,128}$/u.test(input.releaseAttempt)
+      ? { releaseAttempt: input.releaseAttempt }
+      : {}),
+    phase: allowlistedEnum(phases, input.phase, "readiness") as OperationalPhase,
+    outcome: allowlistedEnum(outcomes, input.outcome, "failed") as OperationalOutcome,
+    category: allowlistedEnum(categories, input.category, "readiness") as OperationalCategory,
+    timestampMs:
+      typeof input.timestampMs === "number" && Number.isSafeInteger(input.timestampMs)
+        ? input.timestampMs
+        : now(),
+  });
+
+  const deliverEvent = (event: OperationalEvent): Promise<OperationalDelivery> => {
+    if (!options.enabled || options.send === undefined) return Promise.resolve("unavailable");
+
+    let pending: boolean | void | Promise<boolean | void>;
+    try {
+      pending = options.send(event);
+    } catch {
+      return Promise.resolve("failed");
+    }
+    if (!(pending instanceof Promise)) {
+      return Promise.resolve(pending === true ? "sent" : "failed");
+    }
+
+    const timeout = new Promise<OperationalDelivery>((resolve) => {
+      scheduleTimeout(() => resolve("failed"), timeoutMs);
+    });
+    return Promise.race([
+      pending.then(
+        (delivered): OperationalDelivery => (delivered === true ? "sent" : "failed"),
+        () => "failed" as const,
+      ),
+      timeout,
+    ]).catch(() => "failed");
+  };
+
+  return {
+    reportFailure(input) {
+      const event = normalizeEvent(input);
+      if (!options.enabled || options.send === undefined) {
+        options.onDelivery?.("unavailable");
+        return;
+      }
+
+      queueMicrotask(() => {
+        void deliverEvent(event).then((delivery) => options.onDelivery?.(delivery));
+      });
+    },
+    async deliverFailure(input) {
+      const delivery = await deliverEvent(normalizeEvent(input));
+      options.onDelivery?.(delivery);
+      return delivery;
+    },
+  };
+}
+
+export function createOperationalMonitoringAdapterForMaintenance(
+  reportFile: string,
+): OperationalMonitoringAdapter {
+  return createOperationalMonitoringAdapter({
+    enabled: true,
+    send: (event) => {
+      appendFileSync(
+        reportFile,
+        `${event.operation}\t${event.environment}\t${event.releaseAttempt ?? ""}\t${event.phase}\t${event.outcome}\t${event.category}\n`,
+        { encoding: "utf8", mode: 0o600 },
+      );
+      return true;
+    },
+  });
+}
+
+function allowlistedEnum(values: Set<string>, value: unknown, fallback: string): string {
+  return typeof value === "string" && values.has(value) ? value : fallback;
+}

--- a/src/lib/production-activation-cli.ts
+++ b/src/lib/production-activation-cli.ts
@@ -9,6 +9,7 @@ import {
   readSqliteFoundationStorageReadiness,
 } from "./foundation-storage-sqlite";
 import { readGrantAuthorityOptions } from "./grant-runtime";
+import { GrantKeyRingCustodyError } from "./grant-key-ring-custody";
 import { readRuntimeConfig } from "./runtime-config";
 import {
   createSqliteTechnicalAdminAuthRepository,
@@ -35,6 +36,12 @@ import {
   writeFile,
 } from "node:fs/promises";
 import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
+import type {
+  OperationalCategory,
+  OperationalMonitoringAdapter,
+  OperationalOperation,
+  OperationalPhase,
+} from "./operational-monitoring";
 
 type MaintenanceCommand =
   | "backup"
@@ -68,7 +75,23 @@ function injectFocusedFailure(phase: FocusedFailurePhase): void {
 }
 
 /** Host-local maintenance entrypoint used by the shipped compiled executable. */
-export async function runProductionActivationCli(argv: readonly string[]): Promise<number> {
+export async function runProductionActivationCli(
+  argv: readonly string[],
+  operationalMonitoring?: OperationalMonitoringAdapter,
+): Promise<number> {
+  const reportFailure = createFailureReporter(operationalMonitoring);
+  try {
+    return await runProductionActivationCliInternal(argv, reportFailure);
+  } catch (error) {
+    reportFailure(classifyFailure(argv[0], error));
+    throw error;
+  }
+}
+
+async function runProductionActivationCliInternal(
+  argv: readonly string[],
+  reportFailure: (failure: OperationalFailure) => void,
+): Promise<number> {
   const command = argv[0] as MaintenanceCommand | undefined;
   const rootPromotionRequested =
     process.env.QBT_ROOT_PROMOTION === "1" || argv.includes("--root-promotion");
@@ -95,6 +118,7 @@ export async function runProductionActivationCli(argv: readonly string[]): Promi
     grant = readGrantAuthorityOptions(technicalAdmin.environment);
   } catch (error) {
     if (command === "restore") {
+      reportFailure(classifyFailure(command, error));
       emitBoundedRestoreFailure(error);
       return 1;
     }
@@ -122,6 +146,12 @@ export async function runProductionActivationCli(argv: readonly string[]): Promi
         migration: readiness.evidence?.migration ?? null,
       }),
     );
+    if (!readiness.ok) {
+      reportFailure({
+        ...classifyFailure("readiness", undefined),
+        category: (readiness.evidence?.keys.missingCount ?? 0) > 0 ? "key-version" : "readiness",
+      });
+    }
     return readiness.ok ? 0 : 1;
   }
   if (command === "authoritative-operation") {
@@ -201,12 +231,33 @@ export async function runProductionActivationCli(argv: readonly string[]): Promi
       console.log(
         JSON.stringify({ compatible, schemaVersion: migration.schemaVersion, migration }),
       );
+      if (!compatible) {
+        const schemaIncompatible = !["ready", "pending", "missing"].includes(migration.status);
+        reportFailure({
+          ...classifyFailure("preflight", undefined),
+          category: schemaIncompatible ? "schema-incompatibility" : "migration-candidate",
+          outcome: schemaIncompatible ? "incompatible" : "failed",
+        });
+      }
       return compatible ? 0 : 1;
     }
     if (command === "validate-migration") {
       injectFocusedFailure("candidate-validation");
       const candidate = await storage.validateCandidate();
       console.log(JSON.stringify({ ready: candidate.ready, migration: candidate.migration }));
+      if (!candidate.ready) {
+        const schemaIncompatible = [
+          "future",
+          "reordered",
+          "changed-checksum",
+          "incomplete",
+        ].includes(candidate.readiness.ok ? "" : candidate.readiness.status);
+        reportFailure({
+          ...classifyFailure("validate-migration", undefined),
+          category: schemaIncompatible ? "schema-incompatibility" : "migration-candidate",
+          outcome: schemaIncompatible ? "incompatible" : "failed",
+        });
+      }
       return candidate.ready ? 0 : 1;
     }
     if (command === "apply-migrations") {
@@ -547,6 +598,13 @@ export async function runProductionActivationCli(argv: readonly string[]): Promi
           authorityResurrectionWarning: restored.authorityResurrectionWarning,
         }),
       );
+      if (restored.technicalAdminAuth.reEnrollmentRequired) {
+        reportFailure({
+          ...classifyFailure("restore", undefined),
+          outcome: "degraded",
+          category: "re-enrollment-required",
+        });
+      }
       return 0;
     }
     const schemaCompatibility = process.env.SCHEMA_COMPATIBILITY;
@@ -602,6 +660,7 @@ export async function runProductionActivationCli(argv: readonly string[]): Promi
     return 0;
   } catch (error) {
     if (command !== "restore") throw error;
+    reportFailure(classifyFailure(command, error));
     emitBoundedRestoreFailure(error);
     return 1;
   } finally {
@@ -909,4 +968,113 @@ function boundedRestoreFailureOutcome(
   if (failure?.phase === "foundation-replacement") return "foundation-replacement-failed";
   if (failure?.phase === "post-cutover-evidence") return "cutover-completed-evidence-failed";
   return "restore-preparation-failed";
+}
+
+type OperationalFailure = {
+  operation: OperationalOperation;
+  environment: "production" | "test";
+  releaseAttempt?: string;
+  phase: OperationalPhase;
+  outcome: "failed" | "degraded" | "blocked" | "incompatible" | "rolled-back" | "unavailable";
+  category: OperationalCategory;
+};
+
+function createFailureReporter(
+  adapter: OperationalMonitoringAdapter | undefined,
+): (failure: OperationalFailure) => void {
+  let reported = false;
+  return (failure) => {
+    if (reported || adapter === undefined) return;
+    reported = true;
+    adapter.reportFailure(failure);
+  };
+}
+
+function classifyFailure(command: string | undefined, error: unknown): OperationalFailure {
+  const releaseAttempt = safeReleaseAttempt(process.env.RELEASE_ATTEMPT_ID);
+  const environment = process.env.QUADBALL_ENVIRONMENT === "production" ? "production" : "test";
+  const message = error instanceof Error ? error.message : "";
+  if (command === "restore") {
+    return {
+      operation: "restore",
+      environment,
+      ...(releaseAttempt === undefined ? {} : { releaseAttempt }),
+      phase: "staged-restore",
+      outcome: "failed",
+      category: classifyRestoreOperationalCategory(error),
+    };
+  }
+  if (error instanceof GrantKeyRingCustodyError && error.category === "missing-key-version") {
+    return {
+      operation: command === "readiness" ? "readiness" : "deployment",
+      environment,
+      ...(releaseAttempt === undefined ? {} : { releaseAttempt }),
+      phase: command === "readiness" ? "readiness" : "startup",
+      outcome: "failed",
+      category: "key-version",
+    };
+  }
+  if (command === "backup" || command === "verify-backup" || command === "promote") {
+    return {
+      operation: "backup",
+      environment,
+      ...(releaseAttempt === undefined ? {} : { releaseAttempt }),
+      phase:
+        command === "backup"
+          ? "backup-create"
+          : command === "verify-backup"
+            ? "backup-verify"
+            : "backup-promote",
+      outcome: "failed",
+      category: "backup-candidate",
+    };
+  }
+  if (command === "validate-migration" || command === "apply-migrations") {
+    return {
+      operation: "migration",
+      environment,
+      ...(releaseAttempt === undefined ? {} : { releaseAttempt }),
+      phase: command === "validate-migration" ? "candidate-validation" : "live-migration",
+      outcome: message.includes("incompatible") ? "incompatible" : "failed",
+      category: message.includes("incompatible") ? "schema-incompatibility" : "migration-candidate",
+    };
+  }
+  if (command === "readiness" || command === "preflight") {
+    return {
+      operation: command === "readiness" ? "readiness" : "deployment",
+      environment,
+      ...(releaseAttempt === undefined ? {} : { releaseAttempt }),
+      phase: command === "readiness" ? "readiness" : "preflight",
+      outcome: "failed",
+      category: "readiness",
+    };
+  }
+  return {
+    operation: "deployment",
+    environment,
+    ...(releaseAttempt === undefined ? {} : { releaseAttempt }),
+    phase: "preflight",
+    outcome: "failed",
+    category: "atomic-install",
+  };
+}
+
+export function classifyRestoreOperationalCategory(error: unknown): OperationalCategory {
+  if (error instanceof GrantKeyRingCustodyError && error.category === "missing-key-version") {
+    return "key-version";
+  }
+  if (error instanceof FoundationRestoreFailure && error.phase === "foundation-replacement") {
+    return "atomic-install";
+  }
+  const technicalAdminOutcome =
+    error instanceof FoundationRestoreFailure ? error.technicalAdminAuth.outcome : null;
+  if (technicalAdminOutcome === "sanitation-failed") {
+    return "technical-admin-auth-sanitization";
+  }
+  if (technicalAdminOutcome === "re-enrollment-required") return "re-enrollment-required";
+  return "staged-restore";
+}
+
+function safeReleaseAttempt(value: string | undefined): string | undefined {
+  return value !== undefined && /^[A-Za-z0-9._-]{1,128}$/u.test(value) ? value : undefined;
 }

--- a/src/lib/production-activation.focused.ts
+++ b/src/lib/production-activation.focused.ts
@@ -136,7 +136,7 @@ describe("disposable activation SQLite integration", () => {
       const runuserStub = join(binDirectory, "runuser");
       await writeFile(
         runuserStub,
-        '#!/bin/sh\nprintf "runuser\\n" >> "$QBT_FOCUSED_RUNUSER_LOG"\nshift 3\nexec "$@"\n',
+        '#!/bin/sh\ncase "$*" in *"--production-activation restore"*) printf "restore-maintenance\\n" >> "$QBT_FOCUSED_RUNUSER_LOG" ;; *"--emit-operational-failure"*) printf "operational-report\\n" >> "$QBT_FOCUSED_RUNUSER_LOG" ;; esac\nshift 3\nexec "$@"\n',
       );
       await chmod(runuserStub, 0o755);
       const flockStub = join(binDirectory, "flock");
@@ -293,7 +293,9 @@ describe("disposable activation SQLite integration", () => {
       );
       expect(wrongSourceOwner.code, wrongSourceOwner.output).not.toBe(0);
       expect(wrongSourceOwner.output).toContain('"outcome":"restore-staging-failed"');
-      expect(await readFile(join(root, "runuser.log"), "utf8")).toBe("");
+      expect(await readFile(join(root, "runuser.log"), "utf8")).not.toContain(
+        "restore-maintenance",
+      );
 
       const wrongDestinationOwner = await run(
         "restore",
@@ -305,7 +307,9 @@ describe("disposable activation SQLite integration", () => {
       );
       expect(wrongDestinationOwner.code, wrongDestinationOwner.output).not.toBe(0);
       expect(wrongDestinationOwner.output).toContain('"outcome":"restore-staging-failed"');
-      expect(await readFile(join(root, "runuser.log"), "utf8")).toBe("");
+      expect(await readFile(join(root, "runuser.log"), "utf8")).not.toContain(
+        "restore-maintenance",
+      );
 
       const restore = await run("restore", canonicalLock, retainedManifestPath);
       expect(restore.code, restore.output).toBe(0);

--- a/src/production-activation-fast.test.ts
+++ b/src/production-activation-fast.test.ts
@@ -62,7 +62,15 @@ async function createRelease(base: string): Promise<string> {
   ];
   const records: Array<{ path: string; sha256: string }> = [];
   for (const member of members) {
-    const contents = `fast fixture ${member}\n`;
+    const contents =
+      member === "quadball-timer"
+        ? `#!/usr/bin/env bash
+if [[ "$1" == "--emit-operational-failure" ]]; then
+  printf 'operational %s %s %s %s %s\\n' "$2" "$3" "$5" "$7" "$9" >>"$QBT_FAST_LOG"
+  [[ "\${QBT_OPERATIONAL_MONITORING_OUTAGE:-}" == 1 ]] && exit 1
+fi
+`
+        : `fast fixture ${member}\n`;
     const path = join(release, member);
     await mkdir(join(path, ".."), { recursive: true });
     await writeFile(path, contents);
@@ -89,29 +97,49 @@ async function createHarness(): Promise<{
   log: string;
   pointer: string;
   probe: string;
+  reportSignal: string;
   root: string;
   state: string;
+  testBase: string;
   testCanary: string;
+  testDatabase: string;
+  testState: string;
   wrapper: string;
 }> {
   const root = await realpath(await mkdtemp(join(tmpdir(), "quadball-activation-fast-")));
   roots.push(root);
   const base = join(root, "srv", "quadball-timer");
+  const testBase = join(root, "srv", "quadball-timer-test");
   const bin = join(root, "bin");
   const state = join(root, "state");
+  const testState = join(root, "test-state");
   const previous = join(base, "releases", previousReleaseId);
+  const testPrevious = join(testBase, "releases", previousReleaseId);
   const database = join(state, "foundation.sqlite");
+  const testDatabase = join(testState, "foundation.sqlite");
   const log = join(state, "operations.log");
   const pointer = join(state, "retained-pointer");
   const probe = join(state, "probe-results");
+  const reportSignal = join(root, "report-signal");
   const testCanary = join(root, "srv", "quadball-timer-test", "canary");
   await Promise.all([
     mkdir(bin, { recursive: true }),
     mkdir(previous, { recursive: true }),
+    mkdir(testPrevious, { recursive: true }),
     mkdir(join(testCanary, ".."), { recursive: true }),
     mkdir(state, { recursive: true }),
+    mkdir(testState, { recursive: true }),
   ]);
+  await executable(
+    join(bin, "realpath"),
+    `#!/usr/bin/env bash
+if [[ "$1" == -e ]]; then shift; fi
+if [[ "$1" == -- ]]; then shift; fi
+exec /bin/realpath "$@"
+`,
+  );
   await createRelease(base);
+  await createRelease(testBase);
   const previousExecutable = "prior executable\n";
   await writeFile(join(previous, "quadball-timer"), previousExecutable);
   await chmod(join(previous, "quadball-timer"), 0o555);
@@ -125,10 +153,24 @@ async function createHarness(): Promise<{
     }),
   );
   await symlink(previous, join(base, "current"));
+  await writeFile(join(testPrevious, "quadball-timer"), previousExecutable);
+  await chmod(join(testPrevious, "quadball-timer"), 0o555);
+  await writeFile(
+    join(testPrevious, "release-manifest.json"),
+    JSON.stringify({
+      releaseAttemptId: previousReleaseId,
+      executableSha256: digest(previousExecutable),
+      schemaCompatibility: "26",
+      supportedFoundationSchemaVersions: ["26"],
+    }),
+  );
+  await symlink(testPrevious, join(testBase, "current"));
   await writeFile(database, "schema-before\n");
+  await writeFile(testDatabase, "schema-before\n");
   await writeFile(pointer, "retained-before\n");
   await writeFile(log, "");
   await writeFile(probe, "");
+  expect(Bun.spawnSync({ cmd: ["mkfifo", reportSignal] }).exitCode).toBe(0);
   await writeFile(testCanary, "test-untouched\n");
 
   await executable(
@@ -140,9 +182,15 @@ if [[ "$1" == show ]]; then
   property=""
   for argument in "$@"; do [[ "$argument" == --property=* ]] && property="\${argument#--property=}"; done
   case "$property" in
-    Environment) echo "QUADBALL_ENVIRONMENT=production FOUNDATION_DATABASE=/var/lib/quadball-timer/foundation.sqlite TECHNICAL_ADMIN_DATABASE=/var/lib/quadball-timer/technical-admin.sqlite GRANT_KEY_RING_FILE=/etc/quadball-timer/production-grant-key-ring.json" ;;
+    Environment)
+      if [[ "\${QBT_FAST_ENVIRONMENT:-production}" == test ]]; then
+        echo "QUADBALL_ENVIRONMENT=test PUBLIC_ORIGIN=https://test.timer.quadball.app FOUNDATION_DATABASE=/var/lib/quadball-timer-test/foundation.sqlite TECHNICAL_ADMIN_DATABASE=/var/lib/quadball-timer-test/technical-admin.sqlite EVENT_GAME_DATABASE=/var/lib/quadball-timer-test/event-game.sqlite GRANT_KEY_RING_FILE=/etc/quadball-timer/test-grant-key-ring.json"
+      else
+        echo "QUADBALL_ENVIRONMENT=production FOUNDATION_DATABASE=/var/lib/quadball-timer/foundation.sqlite TECHNICAL_ADMIN_DATABASE=/var/lib/quadball-timer/technical-admin.sqlite GRANT_KEY_RING_FILE=/etc/quadball-timer/production-grant-key-ring.json"
+      fi
+      ;;
     ExecStart) echo "$QBT_FAST_BASE/current/quadball-timer" ;;
-    StateDirectory) echo "quadball-timer" ;;
+    StateDirectory) [[ "\${QBT_FAST_ENVIRONMENT:-production}" == test ]] && echo "quadball-timer-test" || echo "quadball-timer" ;;
     StateDirectoryMode) echo "0750" ;;
     ActiveState) echo "active" ;;
     SubState) echo "running" ;;
@@ -171,7 +219,13 @@ case "$url" in
     ;;
   */ws) printf 'HTTP/1.1 101 Switching Protocols\\r\\n\\r\\n' ;;
   */api/audience/events|*/internal/healthz) printf '{}\\n' ;;
-  */) printf '<!doctype html>\\n' ;;
+  */)
+    if [[ "\${QBT_FAST_ENVIRONMENT:-production}" == test ]]; then
+      printf 'Test environment — not for live games\\n'
+    else
+      printf '<!doctype html>\\n'
+    fi
+    ;;
 esac
 `,
   );
@@ -182,31 +236,181 @@ esac
 set -euo pipefail
 echo "maintenance $1 $3" >> "$QBT_FAST_LOG"
 operation="$3"
+release_attempt="\${2##*/}"
+fail_if_focused() {
+  local phase="$1" operation_name="$2" category="$3"
+  if [[ "\${QBT_FOCUSED_FAILURE_PHASE:-}" == "$phase" ]]; then
+    echo "Focused activation failure at $phase." >&2
+    printf 'report-operational %s %s %s %s failed %s %s\\n' "\${QBT_FAST_ENVIRONMENT:-production}" "$release_attempt" "$operation_name" "$phase" "$category" "$QBT_OPERATIONAL_MONITORING_OUTAGE" >> "$QBT_FAST_LOG"
+    if [[ -n "\${QBT_FAST_REPORT_SIGNAL:-}" ]]; then printf 'report\\n' > "$QBT_FAST_REPORT_SIGNAL"; fi
+    exit 1
+  fi
+}
 case "$operation" in
-  preflight) printf '{"schemaVersion":26}\\n' ;;
+  preflight)
+    fail_if_focused preflight deployment readiness
+    printf '{"schemaVersion":26}\\n'
+    ;;
+  report-operational|report-operational-attempt)
+    if [[ "$operation" == report-operational-attempt ]]; then release_attempt="$8"; fi
+    printf 'report-operational %s %s %s %s %s %s %s\\n' "$1" "$release_attempt" "$4" "$5" "$6" "$7" "$QBT_OPERATIONAL_MONITORING_OUTAGE" >> "$QBT_FAST_LOG"
+    if [[ -n "\${QBT_FAST_REPORT_SIGNAL:-}" ]]; then printf 'report\\n' > "$QBT_FAST_REPORT_SIGNAL"; fi
+    ;;
   backup)
+    fail_if_focused backup-create backup backup-candidate
     candidate="$QBT_FAST_STATE/backup-candidate"
     mkdir -p "$candidate"
     printf 'snapshot\\n' > "$candidate/foundation.sqlite"
     printf 'manifest\\n' > "$candidate/manifest.json"
     printf '{"manifestPath":"%s"}\\n' "$candidate/manifest.json"
     ;;
-  verify-backup) test -f "$4" ;;
+  verify-backup)
+    fail_if_focused backup-verify backup backup-candidate
+    test -f "$4"
+    ;;
   promote)
+    fail_if_focused backup-promote backup backup-candidate
     test -f "$4"
     printf 'retained-after\\n' > "$QBT_FAST_POINTER.next"
     mv "$QBT_FAST_POINTER.next" "$QBT_FAST_POINTER"
     ;;
-  validate-migration) : ;;
-  apply-migrations) printf 'schema-after\\n' > "$QBT_FAST_DATABASE" ;;
+  validate-migration)
+    fail_if_focused candidate-validation migration migration-candidate
+    ;;
+  apply-migrations)
+    fail_if_focused live-migration migration migration-candidate
+    printf 'schema-after\\n' > "$QBT_FAST_DATABASE"
+    ;;
   *) exit 64 ;;
 esac
 `,
   );
-  return { base, bin, database, log, pointer, probe, root, state, testCanary, wrapper };
+  return {
+    base,
+    bin,
+    database,
+    log,
+    pointer,
+    probe,
+    reportSignal,
+    root,
+    state,
+    testBase,
+    testCanary,
+    testDatabase,
+    testState,
+    wrapper,
+  };
 }
 
 describe("Production activation Fast phase matrix", () => {
+  test("reports a rejected staged bundle through the installed immutable release", async () => {
+    const harness = await createHarness();
+    const release = join(harness.base, "releases", releaseId);
+    const staged = join(harness.base, ".staging", releaseId);
+    Bun.spawnSync({ cmd: ["chmod", "-R", "u+w", release] });
+    await rm(release, { recursive: true, force: true });
+    await mkdir(staged, { recursive: true });
+    await writeFile(join(staged, "private-token"), secretSentinel);
+    const reportReader = Bun.spawn({
+      cmd: ["bash", "-c", 'read -r _ < "$QBT_FAST_REPORT_SIGNAL"'],
+      env: { ...process.env, QBT_FAST_REPORT_SIGNAL: harness.reportSignal },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const child = Bun.spawn({
+      cmd: [
+        "bash",
+        join(repositoryRoot, "deploy/activate-release.sh"),
+        "--base-dir",
+        harness.base,
+        "--staged-dir",
+        staged,
+        "--release",
+        releaseId,
+        "--service",
+        "quadball-timer",
+        "--port",
+        "3099",
+      ],
+      env: {
+        ...process.env,
+        PATH: `${harness.bin}:${process.env.PATH ?? ""}`,
+        QBT_FAST_BASE: harness.base,
+        QBT_FAST_DATABASE: harness.database,
+        QBT_FAST_LOG: harness.log,
+        QBT_FAST_POINTER: harness.pointer,
+        QBT_FAST_RELEASE: releaseId,
+        QBT_FAST_REPORT_SIGNAL: harness.reportSignal,
+        QBT_FAST_STATE: harness.state,
+        QBT_FOCUSED_TEST_MAINTENANCE_WRAPPER: harness.wrapper,
+        QBT_FOCUSED_TEST_MODE: "1",
+        QBT_FOCUSED_TEST_ROOT: harness.root,
+        QBT_OPERATIONAL_MONITORING_OUTAGE: "1",
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(await child.exited).not.toBe(0);
+    expect(await reportReader.exited).toBe(0);
+    const output = `${await new Response(child.stdout).text()}${await new Response(child.stderr).text()}`;
+    expect(output).not.toContain(secretSentinel);
+    const testRelease = join(harness.testBase, "releases", releaseId);
+    const testStaged = join(harness.testBase, ".staging", releaseId);
+    Bun.spawnSync({ cmd: ["chmod", "-R", "u+w", testRelease] });
+    await rm(testRelease, { recursive: true, force: true });
+    await mkdir(testStaged, { recursive: true });
+    await writeFile(join(testStaged, "private-token"), secretSentinel);
+    const testReportReader = Bun.spawn({
+      cmd: ["bash", "-c", 'read -r _ < "$QBT_FAST_REPORT_SIGNAL"'],
+      env: { ...process.env, QBT_FAST_REPORT_SIGNAL: harness.reportSignal },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const testChild = Bun.spawn({
+      cmd: [
+        "bash",
+        join(repositoryRoot, "deploy/activate-test-release.sh"),
+        "--base-dir",
+        harness.testBase,
+        "--staged-dir",
+        testStaged,
+        "--release",
+        releaseId,
+      ],
+      env: {
+        ...process.env,
+        PATH: `${harness.bin}:${process.env.PATH ?? ""}`,
+        QBT_FAST_BASE: harness.testBase,
+        QBT_FAST_DATABASE: harness.testDatabase,
+        QBT_FAST_ENVIRONMENT: "test",
+        QBT_FAST_LOG: harness.log,
+        QBT_FAST_POINTER: harness.pointer,
+        QBT_FAST_RELEASE: releaseId,
+        QBT_FAST_REPORT_SIGNAL: harness.reportSignal,
+        QBT_FAST_STATE: harness.testState,
+        QBT_FOCUSED_TEST_MAINTENANCE_WRAPPER: harness.wrapper,
+        QBT_FOCUSED_TEST_MODE: "1",
+        QBT_FOCUSED_TEST_ROOT: harness.root,
+        QBT_OPERATIONAL_MONITORING_OUTAGE: "1",
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(await testChild.exited).not.toBe(0);
+    expect(await testReportReader.exited).toBe(0);
+    const testOutput = `${await new Response(testChild.stdout).text()}${await new Response(testChild.stderr).text()}`;
+    expect(testOutput).not.toContain(secretSentinel);
+    expect(
+      (await readFile(harness.log, "utf8"))
+        .split("\n")
+        .filter((line) => line.startsWith("report-operational ")),
+    ).toEqual([
+      `report-operational production ${releaseId} deployment preflight failed atomic-install 1`,
+      `report-operational test ${releaseId} deployment preflight failed atomic-install 1`,
+    ]);
+  });
+
   test("injects every shipped orchestration phase without false or cross-Environment success", async () => {
     const cases = [
       ["preflight", "migration", false, false],
@@ -221,8 +425,14 @@ describe("Production activation Fast phase matrix", () => {
       ["rollback-restart", "activation", true, true],
       ["final-report", "activation", true, true],
     ] as const;
-
     const harness = await createHarness();
+    const testActivationSource = await readFile(
+      join(repositoryRoot, "deploy/activate-test-release.sh"),
+      "utf8",
+    );
+    expect(testActivationSource).toContain("report-operational");
+    expect(testActivationSource).toContain("maintenance_wrapper");
+    expect(testActivationSource).toContain("binary-rollback");
     const linkedState = join(harness.root, "state-link");
     await symlink(harness.state, linkedState);
     const command = [
@@ -255,6 +465,7 @@ describe("Production activation Fast phase matrix", () => {
       QBT_FOCUSED_TEST_RELEASE_VERIFIED: "1",
       QBT_FOCUSED_TEST_ROOT: harness.root,
       QBT_SECRET_SENTINEL: secretSentinel,
+      QBT_OPERATIONAL_MONITORING_OUTAGE: "1",
     };
     const batchOnlyRoot = await realpath(
       await mkdtemp(join(tmpdir(), "quadball-activation-batch-only-")),
@@ -387,6 +598,47 @@ describe("Production activation Fast phase matrix", () => {
       expect(await readFile(join(phaseDirectory, "database"), "utf8"), failurePhase).toBe(
         migrationApplied ? "schema-after\n" : "schema-before\n",
       );
+      const reports = operations
+        .split("\n")
+        .filter((line) => line.startsWith("report-operational "));
+      const expectedReports = {
+        preflight: ["deployment preflight failed readiness 1"],
+        "quiesce-stop": ["deployment quiesce-stop failed atomic-install 1"],
+        "backup-create": ["backup backup-create failed backup-candidate 1"],
+        "backup-verify": ["backup backup-verify failed backup-candidate 1"],
+        "backup-promote": ["backup backup-promote failed backup-candidate 1"],
+        "candidate-validation": ["migration candidate-validation failed migration-candidate 1"],
+        "live-migration": ["migration live-migration failed migration-candidate 1"],
+        "release-switch": ["deployment release-switch failed atomic-install 1"],
+        readiness: [
+          "deployment readiness failed readiness 1",
+          "deployment rollback-restart failed binary-rollback 1",
+        ],
+        "rollback-restart": [
+          "deployment startup failed atomic-install 1",
+          "deployment rollback-restart failed binary-rollback 1",
+        ],
+        "final-report": ["deployment final-report failed atomic-install 1"],
+      }[failurePhase].map((report) => `report-operational production ${releaseId} ${report}`);
+      expect([...reports].sort(), failurePhase).toEqual([...expectedReports].sort());
+      const maintenanceCommand = (
+        {
+          preflight: "preflight",
+          "backup-create": "backup",
+          "backup-verify": "verify-backup",
+          "backup-promote": "promote",
+          "candidate-validation": "validate-migration",
+          "live-migration": "apply-migrations",
+        } as Record<string, string | undefined>
+      )[failurePhase];
+      if (maintenanceCommand !== undefined) {
+        expect(
+          operations
+            .split("\n")
+            .filter((line) => line === `maintenance production ${maintenanceCommand}`),
+          failurePhase,
+        ).toHaveLength(1);
+      }
       expect(await readFile(harness.testCanary, "utf8"), failurePhase).toBe("test-untouched\n");
       expect(operations, failurePhase).not.toContain("quadball-timer-test");
       expect(operations.includes("systemctl stop quadball-timer"), failurePhase).toBe(
@@ -409,6 +661,135 @@ describe("Production activation Fast phase matrix", () => {
       );
     }
     expect(await readFile(harness.probe, "utf8")).toBe("0 1 1\n");
+
+    const testCases = {
+      preflight: {
+        reports: ["deployment preflight failed readiness 1"],
+        current: previousReleaseId,
+        database: "schema-before\n",
+      },
+      "candidate-validation": {
+        reports: ["migration candidate-validation failed migration-candidate 1"],
+        current: previousReleaseId,
+        database: "schema-before\n",
+      },
+      "live-migration": {
+        reports: ["migration live-migration failed migration-candidate 1"],
+        current: previousReleaseId,
+        database: "schema-before\n",
+      },
+      "quiesce-stop": {
+        reports: ["deployment quiesce-stop failed atomic-install 1"],
+        current: previousReleaseId,
+        database: "schema-before\n",
+      },
+      "release-switch": {
+        reports: ["deployment release-switch failed atomic-install 1"],
+        current: previousReleaseId,
+        database: "schema-after\n",
+      },
+      readiness: {
+        reports: [
+          "deployment readiness failed readiness 1",
+          "deployment rollback-restart failed binary-rollback 1",
+        ],
+        current: previousReleaseId,
+        database: "schema-after\n",
+      },
+      "rollback-restart": {
+        reports: [
+          "deployment startup failed atomic-install 1",
+          "deployment rollback-restart failed binary-rollback 1",
+        ],
+        current: previousReleaseId,
+        database: "schema-after\n",
+      },
+      "final-report": {
+        reports: ["deployment final-report failed atomic-install 1"],
+        current: releaseId,
+        database: "schema-after\n",
+      },
+    } as const;
+    for (const [failurePhase, testCase] of Object.entries(testCases)) {
+      await rm(join(harness.testBase, "current"), { force: true });
+      await symlink(
+        join(harness.testBase, "releases", previousReleaseId),
+        join(harness.testBase, "current"),
+      );
+      await writeFile(harness.testDatabase, "schema-before\n");
+      await writeFile(harness.log, "");
+      const reportSignalReader = Bun.spawn({
+        cmd: [
+          "bash",
+          "-c",
+          `count=0; while (( count < ${testCase.reports.length} )); do read -r < "$QBT_FAST_REPORT_SIGNAL" || true; count=$((count + 1)); done`,
+        ],
+        env: { ...process.env, QBT_FAST_REPORT_SIGNAL: harness.reportSignal },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const testProcess = Bun.spawnSync({
+        cmd: [
+          "bash",
+          join(repositoryRoot, "deploy/activate-test-release.sh"),
+          "--base-dir",
+          harness.testBase,
+          "--release",
+          releaseId,
+        ],
+        env: {
+          ...process.env,
+          PATH: `${harness.bin}:${process.env.PATH ?? ""}`,
+          QBT_FAST_BASE: harness.testBase,
+          QBT_FAST_DATABASE: harness.testDatabase,
+          QBT_FAST_ENVIRONMENT: "test",
+          QBT_FAST_LOG: harness.log,
+          QBT_FAST_RELEASE: releaseId,
+          QBT_FAST_REPORT_SIGNAL: harness.reportSignal,
+          QBT_FAST_STATE: harness.testState,
+          QBT_FOCUSED_TEST_MAINTENANCE_WRAPPER: harness.wrapper,
+          QBT_FOCUSED_TEST_MODE: "1",
+          QBT_FOCUSED_TEST_RELEASE_VERIFIED: "1",
+          QBT_FOCUSED_TEST_ROOT: harness.root,
+          QBT_FOCUSED_FAILURE_PHASE: failurePhase,
+          QBT_SECRET_SENTINEL: secretSentinel,
+          QBT_OPERATIONAL_MONITORING_OUTAGE: "1",
+        },
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+      const output = `${testProcess.stdout.toString()}${testProcess.stderr.toString()}`;
+      expect(await reportSignalReader.exited).toBe(0);
+      const reports = (await readFile(harness.log, "utf8"))
+        .split("\n")
+        .filter((line) => line.startsWith("report-operational "));
+      expect(testProcess.exitCode, failurePhase).not.toBe(0);
+      expect(output, failurePhase).toContain(`Focused activation failure at ${failurePhase}.`);
+      expect(output, failurePhase).not.toContain(secretSentinel);
+      expect(output, failurePhase).not.toContain("production");
+      expect([...reports].sort(), failurePhase).toEqual(
+        testCase.reports.map((report) => `report-operational test ${releaseId} ${report}`).sort(),
+      );
+      const maintenanceCommand = {
+        preflight: "preflight",
+        "candidate-validation": "validate-migration",
+        "live-migration": "apply-migrations",
+      }[failurePhase];
+      if (maintenanceCommand !== undefined) {
+        expect(
+          (await readFile(harness.log, "utf8"))
+            .split("\n")
+            .filter((line) => line === `maintenance test ${maintenanceCommand}`),
+          failurePhase,
+        ).toHaveLength(1);
+      }
+      expect(
+        await readFile(join(harness.testBase, "current", "release-manifest.json"), "utf8"),
+        failurePhase,
+      ).toContain(`"releaseAttemptId":"${testCase.current}"`);
+      expect(await readFile(harness.testDatabase, "utf8"), failurePhase).toBe(testCase.database);
+      expect(await readFile(harness.testCanary, "utf8"), failurePhase).toBe("test-untouched\n");
+    }
   }, 30_000);
 
   test("uses one bounded semantic Test readiness deadline for delayed and unhealthy services", async () => {

--- a/src/production-deployment.test.ts
+++ b/src/production-deployment.test.ts
@@ -1,7 +1,17 @@
 import { describe, expect, test } from "bun:test";
 import { Database } from "bun:sqlite";
 import { Buffer } from "node:buffer";
-import { readFileSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import {
   chmod,
   lstat,
@@ -18,9 +28,11 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { resolveAdHocEnvironmentIdentity } from "@/lib/ad-hoc-games";
 import {
+  classifyRestoreOperationalCategory,
   copyStableRestoreFile,
   prepareTechnicalAdminStorageForRestore,
 } from "@/lib/production-activation-cli";
+import { FoundationRestoreFailure } from "@/lib/foundation-recovery";
 
 const repositoryRoot = process.cwd();
 
@@ -34,6 +46,21 @@ async function pathExists(path: string): Promise<boolean> {
 }
 
 describe("Production deployment contract", () => {
+  test("classifies Foundation replacement as an atomic restore installation failure", () => {
+    const failure = new FoundationRestoreFailure(
+      new Error("secret path must remain private"),
+      {
+        outcome: "re-enrollment-required",
+        credentialPreserved: false,
+        reEnrollmentRequired: true,
+      },
+      "foundation-replacement",
+      true,
+    );
+
+    expect(classifyRestoreOperationalCategory(failure)).toBe("atomic-install");
+  });
+
   test("gives the service one private persistent state directory", () => {
     const unit = readFileSync(
       join(repositoryRoot, "deploy/systemd/quadball-timer.service"),
@@ -81,6 +108,11 @@ describe("Production deployment contract", () => {
     expect(workflow).toContain('"releaseAttemptId": "${RELEASE_ATTEMPT_ID}"');
     expect(workflow).toContain('"phase": "${TEST_PHASE}"');
     expect(workflow).toContain('"phase": "${PRODUCTION_PHASE}"');
+    expect(workflow).toContain('"monitoringDelivery": "${TEST_MONITORING_DELIVERY}"');
+    expect(workflow).toContain('"monitoringDelivery": "${PRODUCTION_MONITORING_DELIVERY}"');
+    expect(workflow).toContain("timeout --signal=KILL 5s ssh");
+    expect(workflow).toContain("read-operational-delivery");
+    expect(workflow).not.toContain("OPERATIONAL_REPORT=");
     expect(workflow).toContain(
       'if [[ "$TEST_STATUS" != "success" || "$PRODUCTION_STATUS" != "success" ]]; then',
     );
@@ -789,6 +821,446 @@ esac
     expect(handoff.match(/\/usr\/bin\/sudo -v/gu)).toHaveLength(1);
     expect(handoff).toContain("rm -rf -- $remote_dir");
     expect(handoff).toContain("test ! -e $remote_dir");
+  });
+
+  test("keeps activation recovery independent from monitoring delivery", () => {
+    const source = readFileSync(join(repositoryRoot, "src/index.ts"), "utf8");
+    const maintenanceStart = source.indexOf("if (maintenanceIndex !== -1)");
+    const maintenanceEnd = source.indexOf('if (grantKeyRingInvocation.kind === "invalid")');
+    const maintenanceLifecycle = source.slice(maintenanceStart, maintenanceEnd);
+    const adapterStart = source.indexOf("function createOperationalMonitoringAdapterForServer");
+    const adapterEnd = source.indexOf("async function createHtmlRoute", adapterStart);
+    const serverAdapter = source.slice(adapterStart, adapterEnd);
+
+    expect(maintenanceLifecycle).not.toContain("await monitoring.flush");
+    expect(serverAdapter).toContain("send: async (event) =>");
+    expect(serverAdapter).toContain(
+      "if (!monitoring.captureOperationalFailure(event)) return false",
+    );
+    expect(serverAdapter).toContain("return await monitoring.flush(250)");
+    expect(source).toContain("await monitoring.flush(250);");
+    expect(source).toContain("const delivery = await adapter.deliverFailure");
+    expect(source).toContain("console.log(delivery)");
+  });
+
+  test("composes Production and Test reporting through the root-controlled DSN seam", async () => {
+    const root = realpathSync(mkdtempSync(join(tmpdir(), "quadball-monitoring-root-")));
+    try {
+      const releaseId = "sha-root-run-test-attempt-1";
+      const runuser = join(root, "runuser");
+      writeFileSync(
+        runuser,
+        '#!/usr/bin/env bash\nwhile [[ "$1" != "--" ]]; do shift; done\nshift\nexec "$@"\n',
+      );
+      chmodSync(runuser, 0o755);
+      const realpath = join(root, "realpath");
+      writeFileSync(
+        realpath,
+        '#!/usr/bin/env bash\n[[ "$1" == "-e" ]] && shift\n[[ "$1" == "--" ]] && shift\nif [[ -d "$1" ]]; then cd "$1" && pwd -P; else cd "$(dirname "$1")" && printf "%s/%s\\n" "$(pwd -P)" "$(basename "$1")"; fi\n',
+      );
+      chmodSync(realpath, 0o755);
+      const redactionHelper = join(root, "operational-redaction.ts");
+      writeFileSync(
+        redactionHelper,
+        [
+          `import { captureOperationalFailureEvent, redactServerEventForTest } from ${JSON.stringify(join(repositoryRoot, "src/lib/monitoring-server.ts"))};`,
+          "const identity = { environment: process.env.QUADBALL_ENVIRONMENT as 'production' | 'test', release: process.env.RELEASE_ATTEMPT_ID!, browserCorrelation: 'release-test' };",
+          "let redacted: unknown = null;",
+          "captureOperationalFailureEvent({ operation: 'deployment', environment: identity.environment, releaseAttempt: identity.release, phase: 'readiness', outcome: 'failed', category: 'readiness', timestampMs: 123_000 }, identity, (event) => { redacted = redactServerEventForTest({ ...event, request: { url: 'https://timer.example/private' }, extra: { stdout: 'secret command /var/lib/private token=secret' } }, identity); });",
+          "console.log(JSON.stringify(redacted));",
+          "",
+        ].join("\n"),
+      );
+      const bunPath = Bun.which("bun") ?? process.execPath;
+      const executableContents = [
+        "#!/usr/bin/env bash",
+        'if [[ "$1" == "--emit-operational-failure" ]]; then',
+        '  printf "%s %s %s %s\\n" "$QUADBALL_ENVIRONMENT" "$RELEASE_ATTEMPT_ID" "$3" "${GLITCHTIP_DSN:+configured}" > "$0.observed"',
+        `  ${bunPath} ${redactionHelper} > "$0.redacted"`,
+        '  [[ -n "${GLITCHTIP_DSN:-}" ]] && printf "sent\\n" || printf "unavailable\\n"',
+        "fi",
+        "",
+      ].join("\n");
+      for (const environment of ["production", "test"] as const) {
+        const serviceRoot =
+          environment === "production" ? "srv/quadball-timer" : "srv/quadball-timer-test";
+        const release = join(root, serviceRoot, "releases", releaseId);
+        mkdirSync(release, { recursive: true });
+        const executable = join(release, "quadball-timer");
+        writeFileSync(executable, executableContents);
+        chmodSync(executable, 0o755);
+        writeFileSync(
+          join(release, "release-manifest.json"),
+          JSON.stringify({ releaseAttemptId: releaseId, schemaCompatibility: "26" }),
+        );
+      }
+      const installedReleaseId = "sha-root-installed-attempt-1";
+      const installedRelease = join(root, "srv/quadball-timer/releases", installedReleaseId);
+      mkdirSync(installedRelease, { recursive: true });
+      writeFileSync(join(installedRelease, "quadball-timer"), executableContents);
+      chmodSync(join(installedRelease, "quadball-timer"), 0o755);
+      writeFileSync(
+        join(installedRelease, "release-manifest.json"),
+        JSON.stringify({ releaseAttemptId: installedReleaseId, schemaCompatibility: "26" }),
+      );
+      const environmentDirectory = join(root, "etc", "quadball-timer");
+      mkdirSync(environmentDirectory, { recursive: true });
+      writeFileSync(
+        join(environmentDirectory, "production.env"),
+        "GLITCHTIP_DSN=https://prod.example/1\n",
+      );
+      writeFileSync(
+        join(environmentDirectory, "test.env"),
+        "GLITCHTIP_DSN=https://test.example/1\n",
+      );
+      const serviceOwnedState = join(root, "var/lib/quadball-timer");
+      mkdirSync(serviceOwnedState, { recursive: true });
+      writeFileSync(
+        join(serviceOwnedState, `.operational-status-${releaseId}-readiness-readiness`),
+        "failed\n",
+      );
+      const wrapper = join(repositoryRoot, "deploy/activation-maintenance-root.sh");
+      const runReport = (
+        environment: "production" | "test",
+        operation: "deployment" | "restore",
+        phase = "readiness",
+        category = "readiness",
+        reporterReleaseId = releaseId,
+        eventReleaseId = releaseId,
+      ) => {
+        const serviceRoot = environment === "production" ? "quadball-timer" : "quadball-timer-test";
+        const commonEnvironment = {
+          ...process.env,
+          QBT_FOCUSED_TEST_MODE: "1",
+          QBT_FOCUSED_TEST_ROOT: root,
+          QBT_FOCUSED_TEST_RUNUSER: runuser,
+          QBT_FOCUSED_TEST_REALPATH: realpath,
+          SUDO_USER:
+            environment === "production" ? "deploy-quadball-timer" : "deploy-quadball-timer-test",
+          GLITCHTIP_DSN: "https://attacker.example/should-not-be-used",
+        };
+        const result = Bun.spawnSync({
+          cmd: [
+            "bash",
+            wrapper,
+            environment,
+            join(root, "srv", serviceRoot, "releases", reporterReleaseId),
+            reporterReleaseId === eventReleaseId
+              ? "report-operational"
+              : "report-operational-attempt",
+            operation,
+            phase,
+            "failed",
+            category,
+            ...(reporterReleaseId === eventReleaseId ? [] : [eventReleaseId]),
+          ],
+          env: commonEnvironment,
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const status = Bun.spawnSync({
+          cmd: [
+            "bash",
+            wrapper,
+            environment,
+            join(root, "srv", serviceRoot, "releases", reporterReleaseId),
+            "read-operational-delivery",
+            eventReleaseId,
+          ],
+          env: commonEnvironment,
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const executablePath = join(
+          root,
+          "srv",
+          serviceRoot,
+          "releases",
+          reporterReleaseId,
+          "quadball-timer",
+        );
+        const observedPath = `${executablePath}.observed`;
+        const redactedPath = `${executablePath}.redacted`;
+        return {
+          output: status.stdout.toString().trim(),
+          status: result.exitCode,
+          observed: existsSync(observedPath)
+            ? readFileSync(observedPath, "utf8").trim()
+            : `missing:${result.stderr.toString()}`,
+          redacted: existsSync(redactedPath) ? readFileSync(redactedPath, "utf8").trim() : "",
+        };
+      };
+
+      const productionReport = runReport("production", "deployment");
+      expect(productionReport).toMatchObject({
+        output: "sent",
+        status: 0,
+        observed: `production ${releaseId} deployment configured`,
+      });
+      expect(productionReport.redacted).toContain("Quadball Timer operational failure");
+      expect(productionReport.redacted).not.toContain("secret");
+      const statusDirectory = join(root, "run/quadball-timer-operational-status");
+      const statusPath = join(statusDirectory, `status-${releaseId}-readiness-readiness`);
+      expect(statSync(statusDirectory).mode & 0o777).toBe(0o700);
+      expect(statSync(statusPath).mode & 0o777).toBe(0o600);
+      expect(readFileSync(statusPath, "utf8")).toBe("sent\n");
+      const restoreReport = runReport("production", "restore", "staged-restore", "staged-restore");
+      expect(restoreReport).toMatchObject({
+        output: "sent",
+        status: 0,
+        observed: `production ${releaseId} restore configured`,
+      });
+      const preInstallReport = runReport(
+        "production",
+        "deployment",
+        "preflight",
+        "atomic-install",
+        installedReleaseId,
+        releaseId,
+      );
+      expect(preInstallReport).toMatchObject({
+        output: "sent",
+        status: 0,
+        observed: `production ${releaseId} deployment configured`,
+      });
+      const testReport = runReport("test", "deployment");
+      expect(testReport).toMatchObject({
+        output: "sent",
+        status: 0,
+        observed: `test ${releaseId} deployment configured`,
+      });
+      expect(testReport.redacted).toContain('"Environment":"test"');
+      expect(testReport.redacted).not.toContain("/var/lib/private");
+      rmSync(join(environmentDirectory, "test.env"));
+      expect(runReport("test", "deployment")).toEqual({
+        output: "unavailable",
+        status: 0,
+        observed: `test ${releaseId} deployment`,
+        redacted: testReport.redacted,
+      });
+
+      const productionRelease = join(root, "srv/quadball-timer/releases", releaseId);
+      const productionExecutable = join(productionRelease, "quadball-timer");
+      rmSync(`${productionExecutable}.observed`, { force: true });
+      writeFileSync(
+        join(productionRelease, "release-manifest.json"),
+        JSON.stringify({ releaseAttemptId: releaseId }),
+      );
+      const rejectedPreflight = Bun.spawnSync({
+        cmd: ["bash", wrapper, "production", productionRelease, "readiness"],
+        env: {
+          ...process.env,
+          QBT_FOCUSED_TEST_MODE: "1",
+          QBT_FOCUSED_TEST_ROOT: root,
+          QBT_FOCUSED_TEST_RUNUSER: runuser,
+          QBT_FOCUSED_TEST_REALPATH: realpath,
+          SUDO_USER: "deploy-quadball-timer",
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      expect(rejectedPreflight.exitCode).not.toBe(0);
+      for (
+        let attempt = 0;
+        attempt < 50 && !existsSync(`${productionExecutable}.observed`);
+        attempt++
+      ) {
+        await Bun.sleep(10);
+      }
+      expect(readFileSync(`${productionExecutable}.observed`, "utf8")).toContain(
+        `production ${releaseId} deployment configured`,
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("bounds missing activation option values and reports prune failures", () => {
+    for (const scriptName of ["activate-release.sh", "activate-test-release.sh"]) {
+      const script = join(repositoryRoot, "deploy", scriptName);
+      const missingValue = Bun.spawnSync({
+        cmd: ["bash", script, "--release"],
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      expect(missingValue.exitCode).not.toBe(0);
+      expect(missingValue.stderr.toString()).toContain("Missing value for --release.");
+      expect(missingValue.stderr.toString()).toContain("unavailable");
+
+      const source = readFileSync(script, "utf8");
+      expect(source).toContain("if ! prune_releases");
+      expect(source).toContain("report_operational_failure final-report atomic-install");
+      expect(source).toContain("report-operational-attempt");
+      expect(source).not.toContain("OPERATIONAL_REPORT=");
+    }
+
+    const rootWrapper = readFileSync(
+      join(repositoryRoot, "deploy/activation-maintenance-root.sh"),
+      "utf8",
+    );
+    expect(rootWrapper).toContain("fail_root_preflight_validation");
+    expect(rootWrapper).toContain(
+      'operational_status_directory="/run/quadball-timer-operational-status"',
+    );
+    expect(rootWrapper).toContain('expected_owner="0:0:600"');
+  });
+
+  test("detaches CLI-owned reporting from the authoritative maintenance process", async () => {
+    const root = realpathSync(mkdtempSync(join(tmpdir(), "quadball-maintenance-spool-")));
+    try {
+      const releaseId = "sha-spool-run-test-attempt-1";
+      const release = join(root, "srv/quadball-timer/releases", releaseId);
+      const runuser = join(root, "runuser");
+      const realpath = join(root, "realpath");
+      const systemctl = join(root, "systemctl");
+      const flock = join(root, "flock");
+      const reportGate = join(root, "report-gate");
+      const reportStarted = join(root, "report-started");
+      const reportDone = join(root, "report-done");
+      const operationalMonitoringHelper = join(root, "emit-operational.ts");
+      for (const fifo of [reportGate, reportStarted, reportDone]) {
+        expect(Bun.spawnSync({ cmd: ["mkfifo", fifo] }).exitCode).toBe(0);
+      }
+      writeFileSync(
+        runuser,
+        [
+          "#!/usr/bin/env bash",
+          'while [[ "$1" != "--" ]]; do shift; done',
+          "shift",
+          'if [[ "$*" == *"--emit-operational-failure"* ]]; then',
+          '  printf "started\\n" > "$QBT_REPORT_STARTED"',
+          '  read -r _ < "$QBT_REPORT_GATE"',
+          '  "$@"; status=$?',
+          '  printf "done\\n" > "$QBT_REPORT_DONE"',
+          "  exit $status",
+          "fi",
+          'exec "$@"',
+          "",
+        ].join("\n"),
+      );
+      chmodSync(runuser, 0o755);
+      writeFileSync(
+        realpath,
+        '#!/usr/bin/env bash\n[[ "$1" == "-e" ]] && shift\n[[ "$1" == "--" ]] && shift\nif [[ -d "$1" ]]; then cd "$1" && pwd -P; else cd "$(dirname "$1")" && printf "%s/%s\\n" "$(pwd -P)" "$(basename "$1")"; fi\n',
+      );
+      chmodSync(realpath, 0o755);
+      writeFileSync(
+        systemctl,
+        '#!/usr/bin/env bash\nif [[ "$1" == "is-active" ]]; then printf "inactive\\n"; else exit 1; fi\n',
+      );
+      chmodSync(systemctl, 0o755);
+      writeFileSync(flock, "#!/usr/bin/env bash\nexit 1\n");
+      chmodSync(flock, 0o755);
+      writeFileSync(
+        operationalMonitoringHelper,
+        [
+          `import { createOperationalMonitoringAdapterForMaintenance } from ${JSON.stringify(join(repositoryRoot, "src/lib/operational-monitoring.ts"))};`,
+          "const [operation, phase, category] = process.argv.slice(2);",
+          "const adapter = createOperationalMonitoringAdapterForMaintenance(process.env.QBT_OPERATIONAL_REPORT_FILE!);",
+          "adapter.reportFailure({ operation, environment: process.env.QUADBALL_ENVIRONMENT, releaseAttempt: process.env.RELEASE_ATTEMPT_ID, phase, outcome: 'failed', category, error: 'Bearer secret /var/lib/private stdout=do-not-send' } as never);",
+          "await Promise.resolve();",
+          "",
+        ].join("\n"),
+      );
+      const bunPath = Bun.which("bun") ?? process.execPath;
+      const executable = join(release, "quadball-timer");
+      mkdirSync(release, { recursive: true });
+      writeFileSync(
+        executable,
+        [
+          "#!/usr/bin/env bash",
+          'if [[ "$1" == "--production-activation" ]]; then',
+          '  printf "activation %s\\n" "$2" >> "$0.calls"',
+          `  ${bunPath} ${operationalMonitoringHelper} deployment preflight readiness`,
+          "  exit 1",
+          "fi",
+          'if [[ "$1" == "--emit-operational-failure" ]]; then',
+          '  printf "%s %s %s %s %s %s\\n" "$QUADBALL_ENVIRONMENT" "$RELEASE_ATTEMPT_ID" "$3" "$5" "$7" "$9" > "$0.reported.$3.$5"',
+          '  printf "unavailable\\n"',
+          "fi",
+          "",
+        ].join("\n"),
+      );
+      chmodSync(executable, 0o755);
+      writeFileSync(
+        join(release, "release-manifest.json"),
+        JSON.stringify({ releaseAttemptId: releaseId, schemaCompatibility: "26" }),
+      );
+      const wrapper = join(repositoryRoot, "deploy/activation-maintenance-root.sh");
+      const startedReader = Bun.spawn({
+        cmd: ["bash", "-c", 'read -r _ < "$QBT_REPORT_STARTED"'],
+        env: { ...process.env, QBT_REPORT_STARTED: reportStarted },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const activationProcess = Bun.spawn({
+        cmd: ["bash", wrapper, "production", release, "preflight"],
+        env: {
+          ...process.env,
+          QBT_FOCUSED_TEST_MODE: "1",
+          QBT_FOCUSED_TEST_ROOT: root,
+          QBT_FOCUSED_TEST_REALPATH: realpath,
+          QBT_FOCUSED_TEST_RUNUSER: runuser,
+          QBT_FOCUSED_TEST_SYSTEMCTL: systemctl,
+          QBT_FOCUSED_TEST_FLOCK: flock,
+          QBT_FOCUSED_FAILURE_PHASE: "preflight",
+          QBT_REPORT_DONE: reportDone,
+          QBT_REPORT_GATE: reportGate,
+          QBT_REPORT_STARTED: reportStarted,
+          SUDO_USER: "deploy-quadball-timer",
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      expect(await activationProcess.exited).toBe(1);
+      expect(await startedReader.exited).toBe(0);
+      expect(readFileSync(`${executable}.calls`, "utf8")).toBe("activation preflight\n");
+      // The reporter is still blocked on its injected gate. Reading the
+      // authoritative process streams to EOF here proves that the detached
+      // child retained none of the SSH/workflow pipe descriptors.
+      expect(await new Response(activationProcess.stdout).text()).toBe("");
+      expect(await new Response(activationProcess.stderr).text()).not.toContain("Bearer secret");
+      const doneReader = Bun.spawn({
+        cmd: ["bash", "-c", 'read -r _ < "$QBT_REPORT_DONE"'],
+        env: { ...process.env, QBT_REPORT_DONE: reportDone },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      expect(
+        Bun.spawnSync({
+          cmd: ["bash", "-c", 'printf "release\\n" > "$QBT_REPORT_GATE"'],
+          env: { ...process.env, QBT_REPORT_GATE: reportGate },
+        }).exitCode,
+      ).toBe(0);
+      expect(await doneReader.exited).toBe(0);
+      expect(readFileSync(`${executable}.reported.deployment.preflight`, "utf8")).toBe(
+        "production sha-spool-run-test-attempt-1 deployment preflight failed readiness\n",
+      );
+      const delivery = Bun.spawnSync({
+        cmd: [
+          "bash",
+          wrapper,
+          "production",
+          release,
+          "read-operational-status",
+          "preflight",
+          "readiness",
+        ],
+        env: {
+          ...process.env,
+          QBT_FOCUSED_TEST_MODE: "1",
+          QBT_FOCUSED_TEST_ROOT: root,
+          QBT_FOCUSED_TEST_REALPATH: realpath,
+          QBT_FOCUSED_TEST_RUNUSER: runuser,
+          SUDO_USER: "deploy-quadball-timer",
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      expect(delivery.stdout.toString()).toBe("unavailable\n");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   test("includes the canonical Production Ad Hoc database in backup verification", () => {


### PR DESCRIPTION
## Summary

- capture bounded operational failures for deployment, backup, migration, restore, and readiness through the reviewed GlitchTip boundary
- keep delivery detached and best-effort so monitoring cannot delay or change cleanup, rollback, restart, preservation, or fail-closed outcomes
- report Production and Test failures with trusted Environment and immutable release-attempt identity, fixed categories, and no raw operational payload
- compose the accepted #166 restore paths with distinct staged restore, sanitation, re-enrollment, key-version, atomic-install, startup, and readiness diagnostics

## Operator impact

The privileged activation wrapper has a new reviewed checksum and installation handoff. Deployment remains unchanged until an operator installs that reviewed artifact. Monitoring delivery is observable only as `sent`, `failed`, or `unavailable`; an outage does not alter the authoritative operation result.

Issue: #168

Stacked on #277 (`codex/166-production-restore`).

## Validation

- `bun run check`
- targeted #168 Fast operational, deployment, and redaction tests: 48 passed
- focused #166 activation and restore tests: 3 passed
- full ordinary suite: 1005 passed
- final restore-category regression and independent Spec/Standards review
- shell syntax, shellcheck, diff check, exact ancestry, and privileged-wrapper checksum

No Qualification tests were run. No deployment or live GlitchTip verification was performed.
