### PR TITLE
Extend resumable departure to Event Controllers

### DIFF
--- a/scripts/test-ad-hoc-browser.ts
+++ b/scripts/test-ad-hoc-browser.ts
@@ -320,6 +320,50 @@ async function run() {
         await waitForGameRoute(second, gameId);
         await first.getByText("Paused", { exact: true }).waitFor();
 
+        // An Ad Hoc returnable session must use the same shared replacement
+        // confirmation before an Event admission transport is touched.
+        await second.getByRole("button", { name: "Leave", exact: true }).click();
+        await second.getByRole("dialog").getByRole("button", { name: "Leave game" }).click();
+        await second.waitForURL(`${origin}/`);
+        let eventOpenCalls = 0;
+        const eventReplacementOrder: string[] = [];
+        const recordEventOpen = (request: import("playwright").Request) => {
+          if (request.method() === "POST" && new URL(request.url()).pathname.endsWith("/leave"))
+            eventReplacementOrder.push("finalize");
+          if (
+            request.method() === "POST" &&
+            new URL(request.url()).pathname.endsWith("/event-control/open")
+          ) {
+            eventOpenCalls += 1;
+            eventReplacementOrder.push("admit");
+          }
+        };
+        second.on("request", recordEventOpen);
+        await second.goto(`${origin}/event-control`);
+        await second.getByLabel("Active Pitch Slot Control Grant QR").fill("event-replacement");
+        await second.getByRole("button", { name: "Open Event Game Controller" }).click();
+        await second.getByRole("dialog", { name: "Leave the previous game?" }).waitFor();
+        if (eventOpenCalls !== 0)
+          throw new Error("Event admission started before the Ad Hoc replacement confirmation.");
+        await second.getByRole("button", { name: "Cancel" }).click();
+        if (eventOpenCalls !== 0)
+          throw new Error("Cancelling Ad Hoc→Event mutated Event admission.");
+        await second.getByRole("button", { name: "Open Event Game Controller" }).click();
+        const eventAdmissionRequest = second.waitForRequest(
+          (request) =>
+            request.method() === "POST" &&
+            new URL(request.url()).pathname.endsWith("/event-control/open"),
+        );
+        await second.getByRole("button", { name: "Continue" }).click();
+        await eventAdmissionRequest;
+        const eventAdmissionIndex = eventReplacementOrder.indexOf("admit");
+        if (
+          eventAdmissionIndex <= 0 ||
+          eventReplacementOrder.slice(0, eventAdmissionIndex).some((entry) => entry !== "finalize")
+        )
+          throw new Error(`Ad Hoc→Event replacement order was ${eventReplacementOrder.join(",")}.`);
+        second.off("request", recordEventOpen);
+
         const creationContext = await browser!.newContext({
           ignoreHTTPSErrors: true,
           storageState: postLeaveStorageState,

--- a/scripts/test-event-game-controller-browser.ts
+++ b/scripts/test-event-game-controller-browser.ts
@@ -33,6 +33,7 @@ const environment = {
 let server: Bun.Subprocess | null = null;
 let browser: Awaited<ReturnType<typeof chromium.launch>> | null = null;
 let currentProjection = createProjection();
+let openCalls = 0;
 
 try {
   const certificate = Bun.spawnSync([
@@ -71,6 +72,7 @@ try {
     await installControllerApi(context);
     const controller = await context.newPage();
     await completeSuspendReviewResume(controller);
+    await eventDepartureLifecycleEvidence(controller);
 
     const secondContext = await browser.newContext({ ignoreHTTPSErrors: true });
     await installControllerApi(secondContext);
@@ -106,7 +108,8 @@ async function completeSuspendReviewResume(page: Page) {
   await page.goto(`${origin}/event-control`);
   await page.getByLabel("Active Pitch Slot Control Grant QR").fill("disposable-grant");
   await page.getByRole("button", { name: "Open Event Game Controller" }).click();
-  await assertControllerSurface(page);
+  await page.getByText("Controller Device: game-browser-focused").waitFor();
+  await assertControllerSurface(page, "initial");
   await page.getByRole("button", { name: "Start game clock" }).click();
   await page.getByRole("button", { name: "Adjust game clock by plus 10 seconds" }).click();
   await page.getByLabel("Set game clock (milliseconds)").fill("123000");
@@ -146,16 +149,89 @@ async function completeSuspendReviewResume(page: Page) {
   await assertNoDocumentScroll(page);
 }
 
-async function assertControllerSurface(page: Page) {
-  const controls = await page.locator("main button").evaluateAll((buttons) =>
-    buttons.map((button) => ({
-      name: button.getAttribute("aria-label") ?? button.textContent?.trim() ?? "",
-      minHeight: Number.parseFloat(getComputedStyle(button).minHeight),
-    })),
+async function eventDepartureLifecycleEvidence(page: Page) {
+  const initialOpenCalls = openCalls;
+  await page.getByRole("button", { name: "Leave Event Game Controller session" }).click();
+  await page.getByRole("button", { name: "Leave game" }).click();
+  await page.waitForURL((url) => url.pathname === "/");
+  await page.getByRole("button", { name: "Return to game" }).click();
+  await page.waitForURL((url) => url.pathname === "/event-control");
+  await page.getByText("Controller Device: game-browser-focused").waitFor();
+  await assertControllerSurface(page, "returned");
+
+  // Admission into another Event Game must show the shared confirmation before
+  // the Event open transport can mutate authority.
+  await page.getByRole("button", { name: "Leave Event Game Controller session" }).click();
+  await page.getByRole("button", { name: "Leave game" }).click();
+  await page.waitForURL((url) => url.pathname === "/");
+  await page.evaluate(() => {
+    localStorage.removeItem("quadball:event-controller-session");
+    sessionStorage.removeItem("quadball:event-controller-session");
+  });
+  await page.goto(`${origin}/event-control`);
+  await page.getByLabel("Active Pitch Slot Control Grant QR").fill("replacement-grant");
+  await page.getByRole("button", { name: "Open Event Game Controller" }).click();
+  await page.getByRole("dialog", { name: "Leave the previous game?" }).waitFor();
+  assert(openCalls === initialOpenCalls, "confirmation did not precede the Event admission seam");
+  await page.getByRole("button", { name: "Cancel" }).click();
+  assert(openCalls === initialOpenCalls, "cancel mutated Event admission");
+  await page.getByRole("button", { name: "Open Event Game Controller" }).click();
+  await page.getByRole("button", { name: "Continue" }).click();
+  assert(openCalls === initialOpenCalls + 1, "confirmed Event admission did not reach transport");
+  await page.getByText("Controller Device: game-browser-focused").waitFor();
+  await assertControllerSurface(page, "replacement");
+
+  // Event→Ad Hoc replacement must finalize the Event bearer before the new
+  // Ad Hoc creation transport is allowed to run.
+  await page.getByRole("button", { name: "Leave Event Game Controller session" }).click();
+  await page.getByRole("button", { name: "Leave game" }).click();
+  await page.waitForURL((url) => url.pathname === "/");
+  const replacementOrder: string[] = [];
+  const recordReplacementRequest = (request: import("playwright").Request) => {
+    if (request.method() !== "POST") return;
+    const pathname = new URL(request.url()).pathname;
+    if (pathname.endsWith("/leave")) replacementOrder.push("finalize");
+    if (pathname === "/api/games") replacementOrder.push("create");
+  };
+  page.on("request", recordReplacementRequest);
+  const startAdHoc = page.getByRole("button", { name: /Start an Ad Hoc Game/ });
+  await startAdHoc.click();
+  await page.getByRole("dialog", { name: "Leave the previous game?" }).waitFor();
+  assert(
+    replacementOrder.length === 0,
+    "Event finalization started before replacement confirmation",
   );
-  assert(controls.length > 15, "production Controller control inventory was unexpectedly small");
+  await page.getByRole("dialog").getByRole("button", { name: "Cancel" }).click();
+  assert(replacementOrder.length === 0, "Cancelling Event→Ad Hoc mutated transport");
+  await startAdHoc.click();
+  const createRequest = page.waitForRequest(
+    (request) => request.method() === "POST" && new URL(request.url()).pathname === "/api/games",
+  );
+  await page.getByRole("dialog").getByRole("button", { name: "Continue" }).click();
+  await createRequest;
+  const createIndex = replacementOrder.indexOf("create");
+  assert(
+    createIndex > 0 &&
+      replacementOrder.slice(0, createIndex).every((entry) => entry === "finalize"),
+    `Event→Ad Hoc replacement order was ${replacementOrder.join(",")}`,
+  );
+  page.off("request", recordReplacementRequest);
+}
+
+async function assertControllerSurface(page: Page, label = "surface") {
+  const controls = await page.locator("button").evaluateAll((buttons) =>
+    buttons
+      .map((button) => ({
+        name: button.getAttribute("aria-label") ?? button.textContent?.trim() ?? "",
+        minHeight: Number.parseFloat(getComputedStyle(button).minHeight),
+      }))
+      .filter((control) => control.name.length > 0),
+  );
+  assert(
+    controls.length > 15,
+    `production Controller control inventory was unexpectedly small (${controls.length}) at ${page.url()} (${label})`,
+  );
   for (const control of controls) {
-    assert(control.name.length > 0, "production Controller control had no accessible name");
     assert(control.minHeight >= 44, `Controller control was below 44px: ${control.name}`);
   }
   await page.getByRole("region", { name: "Event Game Clock" }).waitFor();
@@ -188,6 +264,7 @@ async function installControllerApi(context: BrowserContext) {
     const url = new URL(route.request().url());
     const body = route.request().postDataJSON() as Record<string, unknown> | null;
     if (url.pathname.endsWith("/open")) {
+      openCalls += 1;
       await route.fulfill({
         contentType: "application/json",
         body: JSON.stringify({
@@ -224,6 +301,13 @@ async function installControllerApi(context: BrowserContext) {
       await route.fulfill({
         contentType: "application/json",
         body: JSON.stringify({ status: "revealed", qrCredential: "focused-revealed-qr" }),
+      });
+      return;
+    }
+    if (url.pathname.endsWith("/leave")) {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({ status: "left" }),
       });
       return;
     }

--- a/src/components/controller-departure.tsx
+++ b/src/components/controller-departure.tsx
@@ -354,6 +354,7 @@ function ControllerReplacementDialog({
 export function controllerDepartureReference(input: {
   workflow: ControllerDepartureReference["workflow"];
   gameId: string;
+  sessionReferenceId?: string;
   homeName: string;
   awayName: string;
   navigationPath?: string;
@@ -362,6 +363,9 @@ export function controllerDepartureReference(input: {
   return {
     workflow: input.workflow,
     gameId: input.gameId,
+    ...(input.sessionReferenceId === undefined
+      ? {}
+      : { sessionReferenceId: input.sessionReferenceId }),
     navigationPath: input.navigationPath ?? `/game/${input.gameId}`,
     identity: {
       title: input.workflow === "ad-hoc" ? "Ad Hoc Game" : "Event Game",

--- a/src/lib/controller-departure.test.ts
+++ b/src/lib/controller-departure.test.ts
@@ -7,14 +7,128 @@ import {
   type ControllerDepartureReference,
 } from "@/lib/controller-departure";
 
-const departure = (gameId: string): ControllerDepartureReference => ({
-  workflow: "ad-hoc",
+const departure = (
+  gameId: string,
+  workflow: ControllerDepartureReference["workflow"] = "ad-hoc",
+  sessionReferenceId?: string,
+): ControllerDepartureReference => ({
+  workflow,
   gameId,
+  ...(workflow === "event"
+    ? { sessionReferenceId: sessionReferenceId ?? `legacy-event-session-${gameId}` }
+    : {}),
   navigationPath: `/game/${gameId}`,
   identity: { title: "Ad Hoc Game", homeName: "Basel", awayName: "Zurich" },
 });
 
 describe("Controller Departure", () => {
+  test("coordinates the Event adapter through the same newest-only Interface", async () => {
+    const finalized: ControllerDepartureReference[] = [];
+    const reconciled: ControllerDepartureReference[] = [];
+    const adapters = createInMemoryControllerDepartureAdapters({
+      finalize: async (reference) => {
+        finalized.push(reference);
+        return "accepted";
+      },
+      reconcile: async (reference) => {
+        reconciled.push(reference);
+        return "available";
+      },
+    });
+    const module = createControllerDeparture(adapters);
+    const event = departure("event-a", "event");
+
+    adapters.setOnline(false);
+    expect(
+      await module.transition({ type: "leave", departure: event, online: false }),
+    ).toMatchObject({ status: "left", projection: { departure: event } });
+    expect(await module.transition({ type: "return", gameId: "event-a", online: false })).toEqual({
+      status: "resumed",
+      mode: "offline",
+    });
+    adapters.setOnline(true);
+    await flushRetries();
+
+    expect(reconciled).toEqual([event]);
+    expect(finalized).toEqual([]);
+    expect(module.project().status).toBe("returned");
+  });
+
+  test("routes Ad Hoc and Event authority and replica work through distinct adapters", async () => {
+    const calls: string[] = [];
+    const adapters = createInMemoryControllerDepartureAdapters({
+      departure: departure("event-a", "event"),
+    });
+    const module = createControllerDeparture({
+      ...adapters,
+      authorities: {
+        adHoc: {
+          finalize: async () => {
+            calls.push("ad-hoc-finalize");
+            return "accepted";
+          },
+          reconcile: async () => "available",
+        },
+        event: {
+          finalize: async () => {
+            calls.push("event-finalize");
+            return "accepted";
+          },
+          reconcile: async () => "available",
+        },
+      },
+    });
+    await module.transition({ type: "expire", online: true, nowMs: CONTROLLER_LEAVE_GRACE_MS });
+    expect(calls).toEqual(["event-finalize"]);
+  });
+
+  test("expires an offline Event departure through its Event adapter without blocking Ad Hoc", async () => {
+    const finalized: string[] = [];
+    const adapters = createInMemoryControllerDepartureAdapters({
+      departure: departure("shared-id", "event"),
+      eventFinalize: async (reference) => {
+        finalized.push(reference.workflow);
+        return "accepted";
+      },
+    });
+    const module = createControllerDeparture(adapters);
+    adapters.setOnline(false);
+    await module.transition({
+      type: "expire",
+      online: false,
+      nowMs: CONTROLLER_LEAVE_GRACE_MS,
+    });
+    expect(controllerDepartureBlocksGame(module.project(), "event", "shared-id")).toBe(true);
+    expect(controllerDepartureBlocksGame(module.project(), "ad-hoc", "shared-id")).toBe(false);
+    expect(finalized).toEqual([]);
+    adapters.setOnline(true);
+    await flushRetries();
+    expect(finalized).toEqual(["event"]);
+  });
+
+  test("blocks only the exact Event session after same-Game finalization", async () => {
+    const adapters = createInMemoryControllerDepartureAdapters({
+      departure: departure("same-game", "event", "session-a"),
+    });
+    const module = createControllerDeparture(adapters);
+    adapters.setOnline(false);
+    await module.transition({ type: "expire", online: false, nowMs: CONTROLLER_LEAVE_GRACE_MS });
+
+    expect(controllerDepartureBlocksGame(module.project(), "event", "same-game", "session-a")).toBe(
+      true,
+    );
+    expect(controllerDepartureBlocksGame(module.project(), "event", "same-game", "session-b")).toBe(
+      false,
+    );
+    expect(
+      await module.transition({
+        type: "request-entry",
+        destination: { kind: "resume-event", gameId: "same-game", sessionReferenceId: "session-b" },
+        online: false,
+      }),
+    ).toMatchObject({ status: "authorized" });
+  });
+
   test("keeps the newest opportunity and blocks every superseded game", async () => {
     const adapters = createInMemoryControllerDepartureAdapters({ nowMs: 100 });
     const module = createControllerDeparture(adapters);
@@ -275,7 +389,10 @@ describe("Controller Departure", () => {
         },
         clear: () => undefined,
       },
-      replica: { clear: (gameId) => cleared.push(gameId), clearAll: () => undefined },
+      replica: {
+        clear: (value) => cleared.push(value.gameId),
+        clearAll: () => undefined,
+      },
       authority: {
         finalize: async (value) => {
           finalized.push(value.gameId);
@@ -313,7 +430,10 @@ describe("Controller Departure", () => {
         write: () => false,
         clear: () => undefined,
       },
-      replica: { clear: (gameId) => cleared.push(gameId), clearAll: () => undefined },
+      replica: {
+        clear: (value) => cleared.push(value.gameId),
+        clearAll: () => undefined,
+      },
       authority: {
         finalize: async (value) => {
           finalized.push(value.gameId);
@@ -552,6 +672,90 @@ describe("Controller Departure", () => {
     } finally {
       globalThis.fetch = originalFetch;
     }
+  });
+
+  test("qualifies identical Ad Hoc and Event IDs without cross-blocking", async () => {
+    const adapters = createInMemoryControllerDepartureAdapters({
+      departure: departure("shared-id", "ad-hoc"),
+    });
+    const module = createControllerDeparture(adapters);
+
+    await module.transition({ type: "expire", online: false, nowMs: CONTROLLER_LEAVE_GRACE_MS });
+
+    expect(controllerDepartureBlocksGame(module.project(), "ad-hoc", "shared-id")).toBe(true);
+    expect(controllerDepartureBlocksGame(module.project(), "event", "shared-id")).toBe(false);
+    const replacement = await module.transition({
+      type: "request-entry",
+      destination: { kind: "resume-event", gameId: "shared-id" },
+      online: false,
+    });
+    expect(replacement.status).toBe("authorized");
+  });
+
+  test("confirms both cross-workflow replacement directions before mutation", async () => {
+    const adapters = createInMemoryControllerDepartureAdapters({
+      departure: departure("shared-id", "event"),
+    });
+    const module = createControllerDeparture(adapters);
+    const adHocRequest = await module.transition({
+      type: "request-entry",
+      destination: { kind: "new-ad-hoc" },
+      online: false,
+    });
+    expect(adHocRequest).toMatchObject({
+      status: "needs-confirmation",
+      departure: { workflow: "event", gameId: "shared-id" },
+    });
+
+    const eventWriter = createInMemoryControllerDepartureAdapters({
+      departure: departure("shared-id", "ad-hoc"),
+    });
+    const other = createControllerDeparture(eventWriter);
+    const eventRequest = await other.transition({
+      type: "request-entry",
+      destination: { kind: "admit-event" },
+      online: false,
+    });
+    expect(eventRequest).toMatchObject({
+      status: "needs-confirmation",
+      departure: { workflow: "ad-hoc", gameId: "shared-id" },
+    });
+  });
+
+  test("migrates raw #268 Ad Hoc blocked IDs while retaining workflow separation", async () => {
+    const adapters = createInMemoryControllerDepartureAdapters({
+      projection: {
+        status: "blocked",
+        revision: 4,
+        gameId: "shared-id",
+        blockedGameIds: ["shared-id"],
+        pendingFinalizations: [],
+        reconciliationPending: [],
+      },
+    });
+    const module = createControllerDeparture(adapters);
+    expect(controllerDepartureBlocksGame(module.project(), "ad-hoc", "shared-id")).toBe(true);
+    expect(controllerDepartureBlocksGame(module.project(), "event", "shared-id")).toBe(false);
+  });
+
+  test("migrates a legacy Event blocked key to its pending exact session", async () => {
+    const adapters = createInMemoryControllerDepartureAdapters({
+      projection: {
+        status: "blocked",
+        revision: 4,
+        gameId: "shared-id",
+        blockedGameIds: ["event:shared-id"],
+        pendingFinalizations: [departure("shared-id", "event", "session-old")],
+        reconciliationPending: [],
+      },
+    });
+    const module = createControllerDeparture(adapters);
+    expect(
+      controllerDepartureBlocksGame(module.project(), "event", "shared-id", "session-old"),
+    ).toBe(true);
+    expect(
+      controllerDepartureBlocksGame(module.project(), "event", "shared-id", "session-new"),
+    ).toBe(false);
   });
 });
 

--- a/src/lib/controller-departure.ts
+++ b/src/lib/controller-departure.ts
@@ -1,22 +1,32 @@
 import { clearAdHocControllerSession } from "@/lib/ad-hoc-controller-session";
+import {
+  createBrowserEventControllerSessionStorage,
+  legacyEventControllerSessionReference,
+} from "@/lib/event-controller-session";
+import { controllerReplicaStorageKey, parseControllerReplica } from "@/lib/controller-reconnect";
 import { validateOpaqueIdentifier } from "@/lib/validation-policy";
 
 export const CONTROLLER_LEAVE_GRACE_MS = 5 * 60_000;
 export const CONTROLLER_DEPARTURE_STORAGE_KEY = "quadball:controller-departure";
-const CONTROLLER_DEPARTURE_VERSION = "controller-departure-v2" as const;
+const CONTROLLER_DEPARTURE_VERSION = "controller-departure-v3" as const;
+const PREVIOUS_CONTROLLER_DEPARTURE_VERSION = "controller-departure-v2" as const;
 const LEGACY_CONTROLLER_DEPARTURE_VERSION = "controller-departure-v1" as const;
 const AD_HOC_CONTROLLER_STORAGE_PREFIX = "quadball:ad-hoc-controller:";
+export { EVENT_CONTROLLER_SESSION_STORAGE_KEY } from "@/lib/event-controller-session";
 
 export type ControllerDepartureWorkflow = "ad-hoc" | "event";
 
 export type ControllerDepartureReference = {
   workflow: ControllerDepartureWorkflow;
   gameId: string;
+  /** Non-secret local reference to the exact Event Grant Session. */
+  sessionReferenceId?: string;
   navigationPath: string;
   identity: { title: string; homeName: string; awayName: string; detail?: string };
 };
 
 type ControllerDepartureStateFields = {
+  /** Values are workflow-qualified (`ad-hoc:<id>` or `event:<id>`). */
   blockedGameIds: string[];
   pendingFinalizations: ControllerDepartureReference[];
   reconciliationPending: ControllerDepartureReference[];
@@ -42,7 +52,9 @@ export type ControllerDepartureProjection = WithRevision<ControllerDepartureStat
 export type ControllerDepartureDestination =
   | { kind: "new-ad-hoc" }
   | { kind: "admit-ad-hoc"; gameId: string }
-  | { kind: "resume-ad-hoc"; gameId: string };
+  | { kind: "resume-ad-hoc"; gameId: string }
+  | { kind: "admit-event" }
+  | { kind: "resume-event"; gameId: string; sessionReferenceId?: string };
 
 export type ControllerDepartureEntryRequest = {
   id: string;
@@ -114,22 +126,34 @@ export type ControllerDepartureAuthority = {
   ): Promise<"available" | "transient" | "unavailable">;
 };
 
+export type ControllerDepartureAuthorityAdapters = {
+  adHoc: ControllerDepartureAuthority;
+  event: ControllerDepartureAuthority;
+};
+
 export type ControllerDepartureConnectivity = {
   isOnline(): boolean;
   onOnline(callback: () => void): () => void;
 };
 
 export type ControllerDepartureReplica = {
-  clear(gameId: string): void;
+  clear(departure: ControllerDepartureReference): void;
   clearAll(): void;
+};
+
+export type ControllerDepartureReplicaAdapters = {
+  adHoc: ControllerDepartureReplica;
+  event: ControllerDepartureReplica;
 };
 
 export type ControllerDepartureAdapters = {
   clock: ControllerDepartureClock;
   persistence: ControllerDeparturePersistence;
-  authority: ControllerDepartureAuthority;
+  authority?: ControllerDepartureAuthority;
+  authorities?: ControllerDepartureAuthorityAdapters;
   connectivity: ControllerDepartureConnectivity;
-  replica: ControllerDepartureReplica;
+  replica?: ControllerDepartureReplica;
+  replicas?: ControllerDepartureReplicaAdapters;
 };
 
 export type ControllerDepartureModule = {
@@ -141,11 +165,31 @@ export type ControllerDepartureModule = {
 
 export function controllerDepartureBlocksGame(
   projection: ControllerDepartureProjection,
+  workflow: ControllerDepartureWorkflow,
   gameId: string,
+  sessionReferenceId?: string,
+): boolean;
+export function controllerDepartureBlocksGame(
+  projection: ControllerDepartureProjection,
+  gameId: string,
+): boolean;
+export function controllerDepartureBlocksGame(
+  projection: ControllerDepartureProjection,
+  workflowOrGameId: string,
+  maybeGameId?: string,
+  sessionReferenceId?: string,
 ): boolean {
+  const key =
+    maybeGameId === undefined
+      ? lifecycleKey("ad-hoc", workflowOrGameId)
+      : lifecycleKey(
+          workflowOrGameId as ControllerDepartureWorkflow,
+          maybeGameId,
+          sessionReferenceId,
+        );
   return (
     projection.status === "failed-closed" ||
-    (projection.status !== "empty" && projection.blockedGameIds.includes(gameId))
+    (projection.status !== "empty" && projection.blockedGameIds.includes(key))
   );
 }
 
@@ -154,9 +198,17 @@ export function createControllerDeparture(
 ): ControllerDepartureModule {
   const clock = adapters.clock ?? createBrowserClock();
   const persistence = adapters.persistence ?? createBrowserPersistence();
-  const authority = adapters.authority ?? createBrowserAuthority();
+  const authorities =
+    adapters.authorities ??
+    (adapters.authority === undefined
+      ? { adHoc: createBrowserAdHocAuthority(), event: createBrowserEventAuthority() }
+      : { adHoc: adapters.authority, event: adapters.authority });
   const connectivity = adapters.connectivity ?? createBrowserConnectivity();
-  const replica = adapters.replica ?? createBrowserReplica();
+  const replicas =
+    adapters.replicas ??
+    (adapters.replica === undefined
+      ? { adHoc: createBrowserAdHocReplica(), event: createBrowserEventReplica() }
+      : { adHoc: adapters.replica, event: adapters.replica });
   let expiryHandle: unknown = null;
   let disposed = false;
   let lifecycleQueue = Promise.resolve();
@@ -211,16 +263,21 @@ export function createControllerDeparture(
     );
     return next;
   };
-  const clearReplica = (gameId: string) => {
+  const authorityFor = (workflow: ControllerDepartureWorkflow) =>
+    authorities[workflow === "event" ? "event" : "adHoc"];
+  const replicaFor = (workflow: ControllerDepartureWorkflow) =>
+    replicas[workflow === "event" ? "event" : "adHoc"];
+  const clearReplica = (departure: ControllerDepartureReference) => {
     try {
-      replica.clear(gameId);
+      replicaFor(departure.workflow).clear(departure);
     } catch {
       // Persisted fail-closed state remains authoritative for this browser.
     }
   };
   const clearAllReplicas = () => {
     try {
-      replica.clearAll();
+      replicas.adHoc.clearAll();
+      replicas.event.clearAll();
     } catch {
       // The failed-closed projection still prevents retained replicas from being used.
     }
@@ -263,11 +320,11 @@ export function createControllerDeparture(
     for (const departure of departures) {
       let result: "accepted" | "deferred" | "unavailable" = "deferred";
       try {
-        result = await authority.finalize(departure);
+        result = await authorityFor(departure.workflow).finalize(departure);
       } catch {
         result = "deferred";
       }
-      results.set(departure.gameId, result);
+      results.set(departureKey(departure), result);
     }
     return results;
   };
@@ -276,11 +333,11 @@ export function createControllerDeparture(
     for (const departure of departures) {
       let result: "available" | "transient" | "unavailable" = "transient";
       try {
-        result = await authority.reconcile(departure);
+        result = await authorityFor(departure.workflow).reconcile(departure);
       } catch {
         result = "transient";
       }
-      results.set(departure.gameId, result);
+      results.set(departureKey(departure), result);
     }
     return results;
   };
@@ -293,21 +350,24 @@ export function createControllerDeparture(
     const fields = projectionFields(latest);
     const pendingFinalizations = fields.pendingFinalizations.filter(
       (departure) =>
-        finalizations.get(departure.gameId) === "deferred" || !finalizations.has(departure.gameId),
+        finalizations.get(departureKey(departure)) === "deferred" ||
+        !finalizations.has(departureKey(departure)),
     );
     const reconciliationPending = fields.reconciliationPending.filter(
       (departure) =>
-        reconciliations.get(departure.gameId) === "transient" ||
-        !reconciliations.has(departure.gameId),
+        reconciliations.get(departureKey(departure)) === "transient" ||
+        !reconciliations.has(departureKey(departure)),
     );
-    const unavailableGameIds = [
-      ...[...finalizations]
-        .filter(([, result]) => result === "unavailable")
-        .map(([gameId]) => gameId),
-      ...[...reconciliations]
-        .filter(([, result]) => result === "unavailable")
-        .map(([gameId]) => gameId),
+    const unavailableDepartureKeys = [
+      ...[...finalizations].filter(([, result]) => result === "unavailable").map(([key]) => key),
+      ...[...reconciliations].filter(([, result]) => result === "unavailable").map(([key]) => key),
     ];
+    const unavailableGameIds = unavailableDepartureKeys.map((key) => {
+      const departure = [...fields.pendingFinalizations, ...fields.reconciliationPending].find(
+        (candidate) => departureKey(candidate) === key,
+      );
+      return departure === undefined ? key : blockedDepartureKey(departure);
+    });
     const blockedGameIds = unique([...fields.blockedGameIds, ...unavailableGameIds]);
     if (
       sameDepartures(pendingFinalizations, fields.pendingFinalizations) &&
@@ -322,7 +382,12 @@ export function createControllerDeparture(
       reconciliationPending,
     } as ControllerDepartureState);
     if (written !== null) {
-      for (const gameId of unavailableGameIds) clearReplica(gameId);
+      for (const key of unavailableDepartureKeys) {
+        const departure = [...fields.pendingFinalizations, ...fields.reconciliationPending].find(
+          (candidate) => departureKey(candidate) === key,
+        );
+        if (departure !== undefined) clearReplica(departure);
+      }
       return written;
     }
     return readStored();
@@ -352,19 +417,19 @@ export function createControllerDeparture(
     const next = writeFrom(current, {
       status: "blocked",
       gameId: current.departure.gameId,
-      blockedGameIds: unique([...current.blockedGameIds, current.departure.gameId]),
+      blockedGameIds: unique([...current.blockedGameIds, blockedDepartureKey(current.departure)]),
       pendingFinalizations,
       reconciliationPending: current.reconciliationPending,
     });
     if (next === null) return { status: "unavailable" };
     cancelExpiry();
-    clearReplica(current.departure.gameId);
+    clearReplica(current.departure);
     if (!online) return { status: "expired", finalization: "deferred" };
     const results = await callFinalizations(pendingFinalizations);
     settleAuthorityResults(results, new Map());
     return {
       status: "expired",
-      finalization: results.get(current.departure.gameId) ?? "deferred",
+      finalization: results.get(departureKey(current.departure)) ?? "deferred",
     };
   };
 
@@ -387,7 +452,7 @@ export function createControllerDeparture(
     const blockedGameIds =
       superseded === null
         ? fields.blockedGameIds
-        : unique([...fields.blockedGameIds, superseded.gameId]);
+        : unique([...fields.blockedGameIds, blockedDepartureKey(superseded)]);
     const next = writeFrom(current, {
       status: "returnable",
       departure: intent.departure,
@@ -397,13 +462,16 @@ export function createControllerDeparture(
       reconciliationPending: fields.reconciliationPending,
     });
     if (next === null) return { status: "unavailable" };
-    if (superseded !== null) clearReplica(superseded.gameId);
+    if (superseded !== null) clearReplica(superseded);
     if ((intent.online ?? connectivity.isOnline()) && pendingFinalizations.length > 0) {
       const results = await callFinalizations(pendingFinalizations);
       settleAuthorityResults(results, new Map());
     }
     const latest = readStored();
-    if (latest.status === "returnable" && latest.departure.gameId === intent.departure.gameId)
+    if (
+      latest.status === "returnable" &&
+      departureKey(latest.departure) === departureKey(intent.departure)
+    )
       scheduleExpiry(latest.expiresAtMs);
     return { status: "left", projection: latest };
   };
@@ -438,18 +506,18 @@ export function createControllerDeparture(
       latest.departure.gameId !== gameId
     )
       return { status: "unavailable" };
-    const result = results.get(gameId) ?? "transient";
+    const result = results.get(departureKey(departure)) ?? "transient";
     if (result === "unavailable") {
       const next = writeFrom(latest, {
         status: "blocked",
         gameId,
-        blockedGameIds: unique([...latest.blockedGameIds, gameId]),
+        blockedGameIds: unique([...latest.blockedGameIds, blockedDepartureKey(departure)]),
         pendingFinalizations: latest.pendingFinalizations,
         reconciliationPending: latest.reconciliationPending,
       });
       if (next === null) return { status: "unavailable" };
       cancelExpiry();
-      clearReplica(gameId);
+      clearReplica(departure);
       return { status: "unavailable" };
     }
     const next = writeFrom(latest, {
@@ -478,17 +546,25 @@ export function createControllerDeparture(
       current = readStored();
     }
     if (current.status === "failed-closed") {
-      return destination.kind === "resume-ad-hoc"
+      return destination.kind === "resume-ad-hoc" || destination.kind === "resume-event"
         ? { status: "unavailable" }
         : issueAuthorization(destination, current.revision);
     }
     const gameId = destinationGameId(destination);
-    if (gameId !== null && controllerDepartureBlocksGame(current, gameId))
+    if (
+      gameId !== null &&
+      controllerDepartureBlocksGame(
+        current,
+        destination.kind === "resume-event" ? "event" : "ad-hoc",
+        gameId,
+        destination.kind === "resume-event" ? destination.sessionReferenceId : undefined,
+      )
+    )
       return { status: "unavailable" };
     if (
-      destination.kind === "resume-ad-hoc" &&
+      (destination.kind === "resume-ad-hoc" || destination.kind === "resume-event") &&
       current.status === "returnable" &&
-      current.departure.gameId === destination.gameId
+      destinationMatchesDeparture(current.departure, destination)
     ) {
       const returned = await returnToGame(destination.gameId, online);
       if (returned.status !== "resumed") return returned;
@@ -523,13 +599,13 @@ export function createControllerDeparture(
     const next = writeFrom(current, {
       status: "blocked",
       gameId: current.departure.gameId,
-      blockedGameIds: unique([...current.blockedGameIds, current.departure.gameId]),
+      blockedGameIds: unique([...current.blockedGameIds, blockedDepartureKey(current.departure)]),
       pendingFinalizations,
       reconciliationPending: current.reconciliationPending,
     });
     if (next === null) return { status: "unavailable" };
     pendingEntries.delete(request.id);
-    clearReplica(current.departure.gameId);
+    clearReplica(current.departure);
     if (online) {
       const results = await callFinalizations(pendingFinalizations);
       settleAuthorityResults(results, new Map());
@@ -557,7 +633,11 @@ export function createControllerDeparture(
       return { status: "unavailable" };
     if (invalidated !== undefined || current.revision !== authorization.revision)
       return requestEntry(authorization.destination, connectivity.isOnline(), clock.now());
-    if (current.status === "failed-closed" && authorization.destination.kind === "resume-ad-hoc")
+    if (
+      current.status === "failed-closed" &&
+      (authorization.destination.kind === "resume-ad-hoc" ||
+        authorization.destination.kind === "resume-event")
+    )
       return { status: "unavailable" };
     const completion = { ...authorization };
     pendingCompletions.set(completion.id, completion);
@@ -651,7 +731,10 @@ export function createControllerDeparture(
         status: "blocked",
         gameId: projection.departure.gameId,
         revision: projection.revision,
-        blockedGameIds: unique([...projection.blockedGameIds, projection.departure.gameId]),
+        blockedGameIds: unique([
+          ...projection.blockedGameIds,
+          blockedDepartureKey(projection.departure),
+        ]),
         pendingFinalizations: uniqueDepartures([
           ...projection.pendingFinalizations,
           projection.departure,
@@ -696,11 +779,14 @@ export function createInMemoryControllerDepartureAdapters(
     projection?: ControllerDepartureProjection;
     finalize?: ControllerDepartureAuthority["finalize"];
     reconcile?: ControllerDepartureAuthority["reconcile"];
+    eventFinalize?: ControllerDepartureAuthority["finalize"];
+    eventReconcile?: ControllerDepartureAuthority["reconcile"];
   } = {},
 ): ControllerDepartureAdapters & {
   advanceTo(nowMs: number): void;
   setOnline(value: boolean): void;
   clearedReplicas: string[];
+  clearedReplicaReferences: ControllerDepartureReference[];
   clearAllCount: number;
 } {
   let nowMs = options.nowMs ?? 0;
@@ -722,6 +808,7 @@ export function createInMemoryControllerDepartureAdapters(
   const onlineListeners = new Set<() => void>();
   const persistenceListeners = new Set<() => void>();
   const clearedReplicas: string[] = [];
+  const clearedReplicaReferences: ControllerDepartureReference[] = [];
   let clearAllCount = 0;
   let nextHandle = 0;
   const adapters = {
@@ -755,6 +842,17 @@ export function createInMemoryControllerDepartureAdapters(
       finalize: options.finalize ?? (async () => "accepted" as const),
       reconcile: options.reconcile ?? (async () => "available" as const),
     },
+    authorities: {
+      adHoc: {
+        finalize: options.finalize ?? (async () => "accepted" as const),
+        reconcile: options.reconcile ?? (async () => "available" as const),
+      },
+      event: {
+        finalize: options.eventFinalize ?? options.finalize ?? (async () => "accepted" as const),
+        reconcile:
+          options.eventReconcile ?? options.reconcile ?? (async () => "available" as const),
+      },
+    },
     connectivity: {
       isOnline: () => online,
       onOnline(callback: () => void) {
@@ -763,10 +861,32 @@ export function createInMemoryControllerDepartureAdapters(
       },
     },
     replica: {
-      clear: (gameId: string) => clearedReplicas.push(gameId),
+      clear: (departure: ControllerDepartureReference) => {
+        clearedReplicas.push(departure.gameId);
+        clearedReplicaReferences.push(departure);
+      },
       clearAll: () => {
         clearAllCount += 1;
         adapters.clearAllCount = clearAllCount;
+      },
+    },
+    replicas: {
+      adHoc: {
+        clear: (departure: ControllerDepartureReference) => {
+          clearedReplicas.push(departure.gameId);
+          clearedReplicaReferences.push(departure);
+        },
+        clearAll: () => {
+          clearAllCount += 1;
+          adapters.clearAllCount = clearAllCount;
+        },
+      },
+      event: {
+        clear: (departure: ControllerDepartureReference) => {
+          clearedReplicas.push(departure.gameId);
+          clearedReplicaReferences.push(departure);
+        },
+        clearAll: () => undefined,
       },
     },
     advanceTo(value: number) {
@@ -782,11 +902,13 @@ export function createInMemoryControllerDepartureAdapters(
       if (becameOnline) for (const callback of onlineListeners) callback();
     },
     clearedReplicas,
+    clearedReplicaReferences,
     clearAllCount,
   } satisfies ControllerDepartureAdapters & {
     advanceTo(nowMs: number): void;
     setOnline(value: boolean): void;
     clearedReplicas: string[];
+    clearedReplicaReferences: ControllerDepartureReference[];
     clearAllCount: number;
   };
   return adapters;
@@ -827,6 +949,8 @@ function createBrowserPersistence(): ControllerDeparturePersistence {
         if (raw === null) return { status: "empty", revision: 0 };
         const value = JSON.parse(raw) as unknown;
         if (isStoredDeparture(value)) return normalizeProjection(value);
+        if (isPreviousStoredDeparture(value))
+          return normalizeProjection({ ...value, revision: value.revision ?? 0 });
         if (isLegacyStoredDeparture(value)) return normalizeProjection({ ...value, revision: 0 });
         return { status: "failed-closed", revision: 0 };
       } catch {
@@ -863,10 +987,9 @@ function createBrowserPersistence(): ControllerDeparturePersistence {
   };
 }
 
-function createBrowserAuthority(): ControllerDepartureAuthority {
+function createBrowserAdHocAuthority(): ControllerDepartureAuthority {
   return {
     async finalize(departure) {
-      if (departure.workflow !== "ad-hoc") return "deferred";
       try {
         const response = await fetch(`/api/games/${encodeURIComponent(departure.gameId)}/leave`, {
           method: "POST",
@@ -884,7 +1007,6 @@ function createBrowserAuthority(): ControllerDepartureAuthority {
       }
     },
     async reconcile(departure) {
-      if (departure.workflow !== "ad-hoc") return "available";
       try {
         const response = await fetch(`/api/games/${encodeURIComponent(departure.gameId)}`, {
           credentials: "same-origin",
@@ -898,15 +1020,110 @@ function createBrowserAuthority(): ControllerDepartureAuthority {
   };
 }
 
-function createBrowserReplica(): ControllerDepartureReplica {
+function createBrowserEventAuthority(): ControllerDepartureAuthority {
+  const sessionStorage = createBrowserEventControllerSessionStorage();
   return {
-    clear: clearAdHocControllerSession,
+    async finalize(departure) {
+      const persisted = sessionStorage.readForGame(departure.gameId, departure.sessionReferenceId);
+      if (persisted === null) return "unavailable";
+      try {
+        const response = await fetch("/api/event-control/leave", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          credentials: "same-origin",
+          body: JSON.stringify({ sessionBearer: persisted.sessionBearer }),
+        });
+        if (response.ok) {
+          sessionStorage.clear(departure.gameId, departure.sessionReferenceId);
+          return "accepted";
+        }
+        if ([401, 403, 404, 410].includes(response.status)) {
+          sessionStorage.clear(departure.gameId, departure.sessionReferenceId);
+          return "unavailable";
+        }
+        return "deferred";
+      } catch {
+        return "deferred";
+      }
+    },
+    async reconcile(departure) {
+      const persisted = sessionStorage.readForGame(departure.gameId, departure.sessionReferenceId);
+      if (persisted === null) return "unavailable";
+      try {
+        const response = await fetch("/api/event-control/refresh", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          credentials: "same-origin",
+          body: JSON.stringify({
+            sessionBearer: persisted.sessionBearer,
+            eventGameId: departure.gameId,
+          }),
+        });
+        if (response.status === 409) {
+          const value = (await response.json()) as { status?: string };
+          return value.status === "switch-required" ? "available" : "transient";
+        }
+        if (response.ok) {
+          const value = (await response.json()) as { status?: string };
+          // Reassignment is a retained authority choice. The Event page
+          // renders the existing retain-or-switch decision after Return.
+          if (value.status === "authorized" || value.status === "switch-required")
+            return "available";
+          return "unavailable";
+        }
+        if ([401, 403, 404, 410].includes(response.status)) {
+          sessionStorage.clear(departure.gameId, departure.sessionReferenceId);
+          return "unavailable";
+        }
+        return "transient";
+      } catch {
+        return "transient";
+      }
+    },
+  };
+}
+
+function createBrowserAdHocReplica(): ControllerDepartureReplica {
+  return {
+    clear(departure) {
+      clearAdHocControllerSession(departure.gameId);
+    },
     clearAll() {
       try {
         const keys: string[] = [];
         for (let index = 0; index < window.localStorage.length; index += 1) {
           const key = window.localStorage.key(index);
           if (key?.startsWith(AD_HOC_CONTROLLER_STORAGE_PREFIX)) keys.push(key);
+        }
+        for (const key of keys) window.localStorage.removeItem(key);
+      } catch {
+        // The failed-closed lifecycle projection still blocks local control.
+      }
+    },
+  };
+}
+
+function createBrowserEventReplica(): ControllerDepartureReplica {
+  return {
+    clear(departure) {
+      if (departure.sessionReferenceId === undefined) return;
+      try {
+        const storageKey = controllerReplicaStorageKey(departure.gameId);
+        const raw = window.localStorage.getItem(storageKey);
+        if (raw === null) return;
+        const state = parseControllerReplica(JSON.parse(raw), departure.gameId);
+        if (state.sessionReferenceId !== departure.sessionReferenceId) return;
+        window.localStorage.removeItem(storageKey);
+      } catch {
+        // The lifecycle projection remains authoritative if replica storage fails.
+      }
+    },
+    clearAll() {
+      try {
+        const keys: string[] = [];
+        for (let index = 0; index < window.localStorage.length; index += 1) {
+          const key = window.localStorage.key(index);
+          if (key?.startsWith(`${controllerReplicaStorageKey()}:`)) keys.push(key);
         }
         for (const key of keys) window.localStorage.removeItem(key);
       } catch {
@@ -939,26 +1156,108 @@ function normalizeProjection(
   const revision = isSafeTimestamp(projection.revision) ? projection.revision : 0;
   if (projection.status === "empty" || projection.status === "failed-closed")
     return { status: projection.status, revision };
+  const departure =
+    projection.status === "returnable"
+      ? normalizeDepartureReference(projection.departure)
+      : undefined;
+  const pendingFinalizations = projection.pendingFinalizations.map(normalizeDepartureReference);
+  const reconciliationPending = projection.reconciliationPending.map(normalizeDepartureReference);
+  const knownDepartures = [
+    ...(departure === undefined ? [] : [departure]),
+    ...pendingFinalizations,
+    ...reconciliationPending,
+  ];
   return {
     ...projection,
     revision,
-    blockedGameIds: unique(projection.blockedGameIds),
-    pendingFinalizations: uniqueDepartures(projection.pendingFinalizations),
-    reconciliationPending: uniqueDepartures(projection.reconciliationPending),
+    ...(departure === undefined ? {} : { departure }),
+    blockedGameIds: unique(
+      projection.blockedGameIds.flatMap((value) => qualifyStoredGameIds(value, knownDepartures)),
+    ),
+    pendingFinalizations: uniqueDepartures(pendingFinalizations),
+    reconciliationPending: uniqueDepartures(reconciliationPending),
   };
 }
 
+function workflowQualifiedGameId(workflow: ControllerDepartureWorkflow, gameId: string) {
+  return `${workflow}:${gameId}`;
+}
+
+function lifecycleKey(
+  workflow: ControllerDepartureWorkflow,
+  gameId: string,
+  sessionReferenceId?: string,
+) {
+  return workflow === "event"
+    ? `${workflowQualifiedGameId(workflow, gameId)}|${sessionReferenceId ?? legacyEventControllerSessionReference(gameId)}`
+    : workflowQualifiedGameId(workflow, gameId);
+}
+
+function departureKey(departure: ControllerDepartureReference) {
+  return lifecycleKey(departure.workflow, departure.gameId, departure.sessionReferenceId);
+}
+
+function blockedDepartureKey(departure: ControllerDepartureReference) {
+  return departureKey(departure);
+}
+
+function normalizeDepartureReference(
+  departure: ControllerDepartureReference,
+): ControllerDepartureReference {
+  return departure.workflow === "event" && departure.sessionReferenceId === undefined
+    ? { ...departure, sessionReferenceId: legacyEventControllerSessionReference(departure.gameId) }
+    : departure;
+}
+
+function qualifyStoredGameIds(
+  value: string,
+  knownDepartures: ControllerDepartureReference[],
+): string[] {
+  if (value.startsWith("ad-hoc:")) return [value];
+  if (value.startsWith("event:")) {
+    if (value.includes("|")) return [value];
+    const gameId = value.slice("event:".length);
+    const exactReferences = knownDepartures
+      .filter((departure) => departure.workflow === "event" && departure.gameId === gameId)
+      .map(departureKey);
+    return exactReferences.length > 0 ? exactReferences : [lifecycleKey("event", gameId)];
+  }
+  return [workflowQualifiedGameId("ad-hoc", value)];
+}
+
 function destinationGameId(destination: ControllerDepartureDestination) {
-  return destination.kind === "new-ad-hoc" ? null : destination.gameId;
+  return destination.kind === "new-ad-hoc" || destination.kind === "admit-event"
+    ? null
+    : destination.gameId;
 }
 
 function destinationMatches(
   left: ControllerDepartureDestination,
   right: ControllerDepartureDestination,
 ) {
+  if (left.kind !== right.kind) return false;
+  if (left.kind === "new-ad-hoc" || left.kind === "admit-event") return true;
+  if (left.kind === "resume-event" && right.kind === "resume-event") {
+    return left.gameId === right.gameId && left.sessionReferenceId === right.sessionReferenceId;
+  }
   return (
-    left.kind === right.kind &&
-    (left.kind === "new-ad-hoc" || right.kind === "new-ad-hoc" || left.gameId === right.gameId)
+    (left.kind === "resume-ad-hoc" || left.kind === "admit-ad-hoc") &&
+    (right.kind === "resume-ad-hoc" || right.kind === "admit-ad-hoc") &&
+    left.gameId === right.gameId
+  );
+}
+
+function destinationMatchesDeparture(
+  departure: ControllerDepartureReference,
+  destination: ControllerDepartureDestination,
+) {
+  return (
+    (destination.kind === "resume-ad-hoc" || destination.kind === "resume-event") &&
+    departure.workflow === (destination.kind === "resume-event" ? "event" : "ad-hoc") &&
+    departure.gameId === destination.gameId &&
+    (destination.kind !== "resume-event" ||
+      lifecycleKey("event", departure.gameId, departure.sessionReferenceId) ===
+        lifecycleKey("event", destination.gameId, destination.sessionReferenceId))
   );
 }
 
@@ -967,9 +1266,9 @@ function unique(values: string[]) {
 }
 
 function uniqueDepartures(values: ControllerDepartureReference[]) {
-  const byGameId = new Map<string, ControllerDepartureReference>();
-  for (const departure of values) byGameId.set(departure.gameId, departure);
-  return [...byGameId.values()];
+  const byWorkflowGame = new Map<string, ControllerDepartureReference>();
+  for (const departure of values) byWorkflowGame.set(departureKey(departure), departure);
+  return [...byWorkflowGame.values()];
 }
 
 function sameStrings(left: string[], right: string[]) {
@@ -980,10 +1279,7 @@ function sameDepartures(
   left: ControllerDepartureReference[],
   right: ControllerDepartureReference[],
 ) {
-  return sameStrings(
-    left.map((departure) => departure.gameId),
-    right.map((departure) => departure.gameId),
-  );
+  return sameStrings(left.map(departureKey), right.map(departureKey));
 }
 
 function isStoredDeparture(value: unknown): value is ControllerDepartureProjection & {
@@ -993,7 +1289,7 @@ function isStoredDeparture(value: unknown): value is ControllerDepartureProjecti
     isRecord(value) &&
     value.version === CONTROLLER_DEPARTURE_VERSION &&
     isSafeTimestamp(value.revision) &&
-    isProjectionBody(value)
+    isProjectionBody(value, true)
   );
 }
 
@@ -1006,28 +1302,48 @@ function isLegacyStoredDeparture(value: unknown): value is Exclude<
   return (
     isRecord(value) &&
     value.version === LEGACY_CONTROLLER_DEPARTURE_VERSION &&
-    isProjectionBody(value) &&
+    isProjectionBody(value, false) &&
     value.status !== "failed-closed"
   );
 }
 
-function isProjectionBody(value: Record<string, any>) {
+function isPreviousStoredDeparture(value: unknown): value is ControllerDepartureProjection & {
+  version: typeof PREVIOUS_CONTROLLER_DEPARTURE_VERSION;
+} {
+  return (
+    isRecord(value) &&
+    value.version === PREVIOUS_CONTROLLER_DEPARTURE_VERSION &&
+    isSafeTimestamp(value.revision) &&
+    isProjectionBody(value, false)
+  );
+}
+
+function isProjectionBody(value: Record<string, any>, qualifiedIds: boolean) {
   if (value.status === "empty" || value.status === "failed-closed") return true;
-  if (value.status === "returned") return isStateFields(value);
+  if (value.status === "returned") return isStateFields(value, qualifiedIds);
   if (value.status === "blocked")
-    return validateOpaqueIdentifier(value.gameId, "gameId").ok && isStateFields(value);
+    return (
+      validateOpaqueIdentifier(value.gameId, "gameId").ok && isStateFields(value, qualifiedIds)
+    );
   return (
     value.status === "returnable" &&
     isSafeTimestamp(value.expiresAtMs) &&
     isDeparture(value.departure) &&
-    isStateFields(value)
+    isStateFields(value, qualifiedIds)
   );
 }
 
-function isStateFields(value: Record<string, any>) {
+function isStateFields(value: Record<string, any>, qualifiedIds = true) {
   return (
     Array.isArray(value.blockedGameIds) &&
-    value.blockedGameIds.every((id: unknown) => validateOpaqueIdentifier(id, "gameId").ok) &&
+    value.blockedGameIds.every(
+      (id: unknown) =>
+        typeof id === "string" &&
+        (qualifiedIds
+          ? /^(?:ad-hoc|event):.+/u.test(id) &&
+            validateOpaqueIdentifier(id.slice(id.indexOf(":") + 1), "gameId").ok
+          : validateOpaqueIdentifier(id, "gameId").ok),
+    ) &&
     Array.isArray(value.pendingFinalizations) &&
     value.pendingFinalizations.every(isDeparture) &&
     Array.isArray(value.reconciliationPending) &&
@@ -1048,7 +1364,11 @@ function isDeparture(value: unknown): value is ControllerDepartureReference {
     typeof value.identity.title === "string" &&
     typeof value.identity.homeName === "string" &&
     typeof value.identity.awayName === "string" &&
-    (value.identity.detail === undefined || typeof value.identity.detail === "string")
+    (value.identity.detail === undefined || typeof value.identity.detail === "string") &&
+    (value.sessionReferenceId === undefined ||
+      (value.workflow === "event" &&
+        typeof value.sessionReferenceId === "string" &&
+        validateOpaqueIdentifier(value.sessionReferenceId, "sessionReferenceId").ok))
   );
 }
 

--- a/src/lib/controller-reconnect.ts
+++ b/src/lib/controller-reconnect.ts
@@ -101,6 +101,8 @@ export type ControllerReplicaState = {
   version: typeof CONTROLLER_REPLICA_VERSION;
   workflow?: "event";
   eventGameId: string;
+  /** Non-secret local reference to the exact Event Grant Session owner. */
+  sessionReferenceId?: string;
   authoritativeProjection: ControllerProjection;
   projection: ControllerProjection;
   pendingActions: readonly PendingControllerAction[];
@@ -166,6 +168,7 @@ export function createControllerReplica(input: {
   projection: ControllerProjection;
   grantSessionId: string;
   grantVersion: string;
+  sessionReferenceId?: string;
   deviceId?: string;
   replicaGeneration?: string;
 }): ControllerReplicaState {
@@ -179,6 +182,9 @@ export function createControllerReplica(input: {
     version: CONTROLLER_REPLICA_VERSION,
     workflow: "event",
     eventGameId,
+    ...(input.sessionReferenceId === undefined
+      ? {}
+      : { sessionReferenceId: requireIdentifier(input.sessionReferenceId, "sessionReferenceId") }),
     authoritativeProjection: cloneProjection(input.projection),
     projection: cloneProjection(input.projection),
     pendingActions: [],
@@ -455,12 +461,14 @@ export function rebindControllerReplica(
   state: ControllerReplicaState,
   session: ControllerSessionAttachment,
   projection: ControllerProjection | null,
+  sessionReferenceId = state.sessionReferenceId,
 ): ControllerReplicaState {
   if (session.eventGameId !== state.eventGameId) {
     throw new Error("Controller session belongs to another Event Game.");
   }
   return reapplyPendingOptimisticActions({
     ...state,
+    ...(sessionReferenceId === undefined ? {} : { sessionReferenceId }),
     authoritativeProjection:
       projection === null ? state.authoritativeProjection : cloneProjection(projection),
     session: structuredClone(session),
@@ -524,6 +532,10 @@ export function parseControllerReplica(
   if (value.workflow !== undefined && value.workflow !== "event")
     throw new Error("Controller replica workflow is invalid.");
   const eventGameId = requireIdentifier(value.eventGameId, "eventGameId");
+  const sessionReferenceId =
+    value.sessionReferenceId === undefined
+      ? undefined
+      : requireIdentifier(value.sessionReferenceId, "sessionReferenceId");
   if (expectedEventGameId !== undefined && eventGameId !== expectedEventGameId) {
     throw new Error("Controller replica belongs to another Event Game.");
   }
@@ -557,6 +569,7 @@ export function parseControllerReplica(
     version: CONTROLLER_REPLICA_VERSION,
     workflow: "event",
     eventGameId,
+    ...(sessionReferenceId === undefined ? {} : { sessionReferenceId }),
     authoritativeProjection,
     projection,
     pendingActions,
@@ -643,6 +656,8 @@ export function validateControllerReplica(state: ControllerReplicaState): void {
   if (state.workflow !== undefined && state.workflow !== "event")
     throw new Error("Controller replica workflow is invalid.");
   requireIdentifier(state.eventGameId, "eventGameId");
+  if (state.sessionReferenceId !== undefined)
+    requireIdentifier(state.sessionReferenceId, "sessionReferenceId");
   parseProjection(state.authoritativeProjection);
   parseProjection(state.projection);
   if (

--- a/src/lib/event-controller-session.test.ts
+++ b/src/lib/event-controller-session.test.ts
@@ -1,0 +1,222 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { Window } from "happy-dom";
+import { CONTROLLER_LEAVE_GRACE_MS, createControllerDeparture } from "@/lib/controller-departure";
+import {
+  createBrowserEventControllerSessionStorage,
+  readBrowserEventControllerSession,
+} from "@/lib/event-controller-session";
+
+describe("Event Controller credential store", () => {
+  const originalWindow = globalThis.window;
+  const originalLocalStorage = globalThis.localStorage;
+  const originalSessionStorage = globalThis.sessionStorage;
+  let testWindow: Window;
+
+  beforeEach(() => {
+    testWindow = new Window({ url: "http://timer.quadball.app/event-control" });
+    Object.assign(globalThis, {
+      window: testWindow,
+      localStorage: testWindow.localStorage,
+      sessionStorage: testWindow.sessionStorage,
+    });
+  });
+
+  afterEach(() => {
+    testWindow.close();
+    Object.assign(globalThis, {
+      window: originalWindow,
+      localStorage: originalLocalStorage,
+      sessionStorage: originalSessionStorage,
+    });
+  });
+
+  test("retains Event A while Event B is current for deferred finalization", () => {
+    const storage = createBrowserEventControllerSessionStorage();
+    expect(
+      storage.write({
+        eventGameId: "event-a",
+        sessionBearer: "bearer-a",
+        sessionReferenceId: "session-a",
+      }),
+    ).toBe(true);
+    expect(
+      storage.write({
+        eventGameId: "event-b",
+        sessionBearer: "bearer-b",
+        sessionReferenceId: "session-b",
+      }),
+    ).toBe(true);
+
+    expect(readBrowserEventControllerSession()).toEqual({
+      eventGameId: "event-b",
+      sessionBearer: "bearer-b",
+      sessionReferenceId: "session-b",
+    });
+    expect(storage.readForGame("event-a")).toEqual({
+      eventGameId: "event-a",
+      sessionBearer: "bearer-a",
+      sessionReferenceId: "session-a",
+    });
+    storage.clear("event-a");
+    expect(storage.readForGame("event-a")).toBeNull();
+    expect(storage.readForGame("event-b")).toEqual({
+      eventGameId: "event-b",
+      sessionBearer: "bearer-b",
+      sessionReferenceId: "session-b",
+    });
+  });
+
+  test("retains same-Game old and new Grant Sessions for exact deferred finalization", async () => {
+    const storage = createBrowserEventControllerSessionStorage();
+    storage.write({
+      eventGameId: "event-a",
+      sessionBearer: "bearer-old",
+      sessionReferenceId: "session-old",
+    });
+    const departureModule = createControllerDeparture();
+    const departure = {
+      workflow: "event" as const,
+      gameId: "event-a",
+      sessionReferenceId: "session-old",
+      navigationPath: "/event-control",
+      identity: { title: "Event Game", homeName: "Basel", awayName: "Zurich" },
+    };
+    Object.defineProperty(testWindow.navigator, "onLine", { configurable: true, value: false });
+    await departureModule.transition({ type: "leave", departure, online: false, nowMs: 0 });
+    await departureModule.transition({
+      type: "expire",
+      online: false,
+      nowMs: CONTROLLER_LEAVE_GRACE_MS,
+    });
+    storage.write({
+      eventGameId: "event-a",
+      sessionBearer: "bearer-new",
+      sessionReferenceId: "session-new",
+    });
+    expect(storage.read()).toEqual({
+      eventGameId: "event-a",
+      sessionBearer: "bearer-new",
+      sessionReferenceId: "session-new",
+    });
+    expect(createBrowserEventControllerSessionStorage().read()).toEqual({
+      eventGameId: "event-a",
+      sessionBearer: "bearer-new",
+      sessionReferenceId: "session-new",
+    });
+
+    const originalFetch = globalThis.fetch;
+    const bodies: Record<string, unknown>[] = [];
+    globalThis.fetch = (async (_input, init) => {
+      bodies.push(JSON.parse(typeof init?.body === "string" ? init.body : "{}"));
+      return new Response(JSON.stringify({ status: "left" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as typeof fetch;
+    try {
+      Object.defineProperty(testWindow.navigator, "onLine", { configurable: true, value: true });
+      testWindow.dispatchEvent(new testWindow.Event("online"));
+      for (let index = 0; index < 8; index += 1) await Promise.resolve();
+      expect(bodies).toEqual([{ sessionBearer: "bearer-old" }]);
+      expect(storage.readForGame("event-a", "session-new")).toMatchObject({
+        sessionBearer: "bearer-new",
+      });
+    } finally {
+      departureModule.dispose();
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("treats a production-shaped HTTP 409 switch-required refresh as available", async () => {
+    const storage = createBrowserEventControllerSessionStorage();
+    storage.write({
+      eventGameId: "event-conflict",
+      sessionBearer: "bearer-conflict",
+      sessionReferenceId: "session-conflict",
+    });
+    const departureModule = createControllerDeparture();
+    const departure = {
+      workflow: "event" as const,
+      gameId: "event-conflict",
+      sessionReferenceId: "session-conflict",
+      navigationPath: "/event-control",
+      identity: { title: "Event Game", homeName: "Basel", awayName: "Zurich" },
+    };
+    await departureModule.transition({ type: "leave", departure, online: false, nowMs: 0 });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ status: "switch-required" }), {
+        status: 409,
+        headers: { "content-type": "application/json" },
+      })) as unknown as typeof fetch;
+    try {
+      const result = await departureModule.transition({
+        type: "return",
+        gameId: "event-conflict",
+        online: true,
+      });
+      expect(result).toEqual({ status: "resumed", mode: "online" });
+      expect(departureModule.project()).toMatchObject({ status: "returned" });
+    } finally {
+      departureModule.dispose();
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("fails closed on a partial write and on divergent storage copies", () => {
+    const storage = createBrowserEventControllerSessionStorage();
+    const sessionSetItem = testWindow.sessionStorage.setItem.bind(testWindow.sessionStorage);
+    Object.defineProperty(testWindow.sessionStorage, "setItem", {
+      configurable: true,
+      value: () => {
+        throw new Error("session quota");
+      },
+    });
+    expect(storage.write({ eventGameId: "event-a", sessionBearer: "bearer-a" })).toBe(false);
+    expect(readBrowserEventControllerSession()).toBeNull();
+
+    Object.defineProperty(testWindow.sessionStorage, "setItem", {
+      configurable: true,
+      value: sessionSetItem,
+    });
+    testWindow.localStorage.setItem(
+      "quadball:event-controller-session",
+      JSON.stringify({ sessionBearer: "bearer-a", eventGameId: "event-a" }),
+    );
+    testWindow.sessionStorage.setItem(
+      "quadball:event-controller-session",
+      JSON.stringify({ sessionBearer: "bearer-b", eventGameId: "event-b" }),
+    );
+    expect(readBrowserEventControllerSession()).toBeNull();
+  });
+
+  test("migrates the single #268 credential without changing its identity", () => {
+    const legacy = JSON.stringify({ sessionBearer: "bearer-a", eventGameId: "event-a" });
+    testWindow.localStorage.setItem("quadball:event-controller-session", legacy);
+    testWindow.sessionStorage.setItem("quadball:event-controller-session", legacy);
+    expect(readBrowserEventControllerSession()).toEqual({
+      eventGameId: "event-a",
+      sessionBearer: "bearer-a",
+      sessionReferenceId: "legacy-event-session-event-a",
+    });
+  });
+
+  test("migrates a v3 same-Game document to its newest current session", () => {
+    const legacy = JSON.stringify({
+      version: "event-controller-session-v3",
+      currentEventGameId: "event-a",
+      sessions: [
+        { eventGameId: "event-a", sessionBearer: "bearer-old", sessionReferenceId: "session-old" },
+        { eventGameId: "event-a", sessionBearer: "bearer-new", sessionReferenceId: "session-new" },
+      ],
+    });
+    testWindow.localStorage.setItem("quadball:event-controller-session", legacy);
+    testWindow.sessionStorage.setItem("quadball:event-controller-session", legacy);
+
+    expect(readBrowserEventControllerSession()).toEqual({
+      eventGameId: "event-a",
+      sessionBearer: "bearer-new",
+      sessionReferenceId: "session-new",
+    });
+  });
+});

--- a/src/lib/event-controller-session.ts
+++ b/src/lib/event-controller-session.ts
@@ -1,0 +1,297 @@
+import { validateOpaqueIdentifier } from "@/lib/validation-policy";
+
+export const EVENT_CONTROLLER_SESSION_STORAGE_KEY = "quadball:event-controller-session";
+const EVENT_CONTROLLER_SESSION_VERSION = "event-controller-session-v4" as const;
+const PREVIOUS_EVENT_CONTROLLER_SESSION_VERSION = "event-controller-session-v3" as const;
+const LEGACY_EVENT_CONTROLLER_SESSION_VERSION = "event-controller-session-v2" as const;
+
+export type PersistedEventControllerSession = {
+  sessionBearer: string;
+  eventGameId: string;
+  sessionReferenceId: string;
+};
+
+export type EventControllerSessionInput = Omit<
+  PersistedEventControllerSession,
+  "sessionReferenceId"
+> & { sessionReferenceId?: string };
+
+type PersistedEventControllerSessionDocument = {
+  version: typeof EVENT_CONTROLLER_SESSION_VERSION;
+  currentEventGameId: string;
+  currentSessionReferenceId: string;
+  sessions: PersistedEventControllerSession[];
+};
+
+export type EventControllerSessionStorage = {
+  read(): PersistedEventControllerSession | null;
+  readForGame(
+    eventGameId: string,
+    sessionReferenceId?: string,
+  ): PersistedEventControllerSession | null;
+  write(session: EventControllerSessionInput): boolean;
+  clear(gameId?: string, sessionReferenceId?: string): void;
+};
+
+export function createBrowserEventControllerSessionStorage(): EventControllerSessionStorage {
+  return {
+    read: readBrowserEventControllerSession,
+    readForGame: readBrowserEventControllerSessionForGame,
+    write(session) {
+      const current = readBrowserEventControllerSessionDocument();
+      const normalized = {
+        ...session,
+        sessionReferenceId: session.sessionReferenceId ?? createEventControllerSessionReference(),
+      };
+      const sessions =
+        current?.sessions.filter(
+          (candidate) => candidate.sessionReferenceId !== normalized.sessionReferenceId,
+        ) ?? [];
+      sessions.push(normalized);
+      return writeBrowserEventControllerSessionDocument({
+        version: EVENT_CONTROLLER_SESSION_VERSION,
+        currentEventGameId: normalized.eventGameId,
+        currentSessionReferenceId: normalized.sessionReferenceId,
+        sessions,
+      });
+    },
+    clear(gameId, sessionReferenceId) {
+      const current = readBrowserEventControllerSessionDocument();
+      if (current === null) return;
+      const sessions =
+        gameId === undefined
+          ? []
+          : current.sessions.filter(
+              (candidate) =>
+                candidate.eventGameId !== gameId ||
+                (sessionReferenceId !== undefined &&
+                  candidate.sessionReferenceId !== sessionReferenceId),
+            );
+      if (sessions.length === 0) {
+        removeBrowserEventControllerSessionDocument();
+        return;
+      }
+      const currentSession =
+        sessions.find(
+          (candidate) => candidate.sessionReferenceId === current.currentSessionReferenceId,
+        ) ?? sessions.at(-1)!;
+      writeBrowserEventControllerSessionDocument({
+        version: EVENT_CONTROLLER_SESSION_VERSION,
+        currentEventGameId: currentSession.eventGameId,
+        currentSessionReferenceId: currentSession.sessionReferenceId,
+        sessions,
+      });
+    },
+  };
+}
+
+export function readBrowserEventControllerSession(): PersistedEventControllerSession | null {
+  const document = readBrowserEventControllerSessionDocument();
+  if (document === null) return null;
+  return (
+    document.sessions.find(
+      (session) => session.sessionReferenceId === document.currentSessionReferenceId,
+    ) ??
+    document.sessions.at(-1) ??
+    null
+  );
+}
+
+export function readBrowserEventControllerSessionForGame(
+  eventGameId: string,
+  sessionReferenceId?: string,
+): PersistedEventControllerSession | null {
+  return (() => {
+    const document = readBrowserEventControllerSessionDocument();
+    if (document === null) return null;
+    if (sessionReferenceId !== undefined)
+      return (
+        document.sessions.find(
+          (session) =>
+            session.eventGameId === eventGameId &&
+            session.sessionReferenceId === sessionReferenceId,
+        ) ?? null
+      );
+    return (
+      document.sessions.find(
+        (session) =>
+          session.eventGameId === eventGameId &&
+          session.sessionReferenceId === document.currentSessionReferenceId,
+      ) ??
+      document.sessions.find((session) => session.eventGameId === eventGameId) ??
+      null
+    );
+  })();
+}
+
+export function parseEventControllerSession(raw: string): PersistedEventControllerSession | null {
+  const document = parseEventControllerSessionDocument(raw);
+  return (
+    document?.sessions.find(
+      (session) => session.sessionReferenceId === document.currentSessionReferenceId,
+    ) ??
+    document?.sessions.at(-1) ??
+    null
+  );
+}
+
+function readBrowserEventControllerSessionDocument(): PersistedEventControllerSessionDocument | null {
+  const copies: string[] = [];
+  try {
+    const local = window.localStorage.getItem(EVENT_CONTROLLER_SESSION_STORAGE_KEY);
+    if (local !== null) copies.push(local);
+  } catch {
+    return null;
+  }
+  try {
+    const session = window.sessionStorage.getItem(EVENT_CONTROLLER_SESSION_STORAGE_KEY);
+    if (session !== null) copies.push(session);
+  } catch {
+    // A readable durable local copy remains usable when the mirror is blocked.
+  }
+  if (copies.length === 0) return null;
+  const documents = copies.map(parseEventControllerSessionDocument);
+  if (documents.some((document) => document === null)) return null;
+  const [first, ...rest] = documents as PersistedEventControllerSessionDocument[];
+  // localStorage is durable and sessionStorage is its mirror. A mismatch is
+  // a failed-closed partial write, never a reason to choose a stale copy.
+  if (rest.some((document) => JSON.stringify(document) !== JSON.stringify(first))) return null;
+  return first ?? null;
+}
+
+function writeBrowserEventControllerSessionDocument(
+  document: PersistedEventControllerSessionDocument,
+): boolean {
+  const value = JSON.stringify(document);
+  let localWritten = false;
+  let sessionWritten = false;
+  try {
+    window.localStorage.setItem(EVENT_CONTROLLER_SESSION_STORAGE_KEY, value);
+    localWritten = window.localStorage.getItem(EVENT_CONTROLLER_SESSION_STORAGE_KEY) === value;
+  } catch {
+    // Durable storage is required for recovery; a session-only write is not enough.
+  }
+  try {
+    window.sessionStorage.setItem(EVENT_CONTROLLER_SESSION_STORAGE_KEY, value);
+    sessionWritten = window.sessionStorage.getItem(EVENT_CONTROLLER_SESSION_STORAGE_KEY) === value;
+  } catch {
+    // The caller receives a durability warning.
+  }
+  if (localWritten && sessionWritten) return true;
+  removeBrowserEventControllerSessionDocument();
+  return false;
+}
+
+function removeBrowserEventControllerSessionDocument() {
+  try {
+    window.localStorage.removeItem(EVENT_CONTROLLER_SESSION_STORAGE_KEY);
+  } catch {
+    // Best effort; lifecycle state remains authoritative.
+  }
+  try {
+    window.sessionStorage.removeItem(EVENT_CONTROLLER_SESSION_STORAGE_KEY);
+  } catch {
+    // Best effort; lifecycle state remains authoritative.
+  }
+}
+
+function parseEventControllerSessionDocument(
+  raw: string,
+): PersistedEventControllerSessionDocument | null {
+  try {
+    const value = JSON.parse(raw) as Record<string, unknown>;
+    if (
+      value.version === EVENT_CONTROLLER_SESSION_VERSION ||
+      value.version === PREVIOUS_EVENT_CONTROLLER_SESSION_VERSION ||
+      value.version === LEGACY_EVENT_CONTROLLER_SESSION_VERSION
+    ) {
+      if (typeof value.currentEventGameId !== "string" || !Array.isArray(value.sessions))
+        return null;
+      const sessions = value.sessions
+        .filter(isPersistedEventControllerSessionShape)
+        .map((session) => normalizeEventControllerSession(session, true));
+      if (sessions.length !== value.sessions.length || sessions.length === 0) return null;
+      if (!sessions.some((session) => session.eventGameId === value.currentEventGameId))
+        return null;
+      const currentSessionReferenceId =
+        typeof value.currentSessionReferenceId === "string" &&
+        sessions.some((session) => session.sessionReferenceId === value.currentSessionReferenceId)
+          ? value.currentSessionReferenceId
+          : [...sessions]
+              .reverse()
+              .find((session) => session.eventGameId === value.currentEventGameId)!
+              .sessionReferenceId;
+      return {
+        version: EVENT_CONTROLLER_SESSION_VERSION,
+        currentEventGameId: value.currentEventGameId,
+        currentSessionReferenceId,
+        sessions,
+      };
+    }
+    // #268 stored one current credential. Preserve it as the first v2 entry.
+    if (isPersistedEventControllerSession(value)) {
+      return {
+        version: EVENT_CONTROLLER_SESSION_VERSION,
+        currentEventGameId: value.eventGameId,
+        currentSessionReferenceId: normalizeEventControllerSession(value, true).sessionReferenceId,
+        sessions: [normalizeEventControllerSession(value, true)],
+      };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function isPersistedEventControllerSessionShape(value: unknown): value is Omit<
+  PersistedEventControllerSession,
+  "sessionReferenceId"
+> & {
+  sessionReferenceId?: unknown;
+} {
+  if (typeof value !== "object" || value === null) return false;
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.sessionBearer === "string" &&
+    typeof candidate.eventGameId === "string" &&
+    validateOpaqueIdentifier(candidate.sessionBearer, "sessionBearer").ok &&
+    validateOpaqueIdentifier(candidate.eventGameId, "eventGameId").ok &&
+    (candidate.sessionReferenceId === undefined ||
+      (typeof candidate.sessionReferenceId === "string" &&
+        validateOpaqueIdentifier(candidate.sessionReferenceId, "sessionReferenceId").ok))
+  );
+}
+
+function isPersistedEventControllerSession(
+  value: unknown,
+): value is Omit<PersistedEventControllerSession, "sessionReferenceId"> {
+  return isPersistedEventControllerSessionShape(value);
+}
+
+function normalizeEventControllerSession(
+  session:
+    | EventControllerSessionInput
+    | (Omit<PersistedEventControllerSession, "sessionReferenceId"> & {
+        sessionReferenceId?: unknown;
+      }),
+  legacy = false,
+): PersistedEventControllerSession {
+  const sessionReferenceId =
+    typeof session.sessionReferenceId === "string" &&
+    validateOpaqueIdentifier(session.sessionReferenceId, "sessionReferenceId").ok
+      ? session.sessionReferenceId
+      : legacy
+        ? legacyEventControllerSessionReference(session.eventGameId)
+        : createEventControllerSessionReference();
+  return { ...session, sessionReferenceId };
+}
+
+export function createEventControllerSessionReference(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function")
+    return crypto.randomUUID();
+  return `event-session-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
+export function legacyEventControllerSessionReference(eventGameId: string): string {
+  return `legacy-event-session-${eventGameId}`;
+}

--- a/src/pages/event-game-controller-page.test.tsx
+++ b/src/pages/event-game-controller-page.test.tsx
@@ -12,6 +12,14 @@ import {
 import type { ControllerProjection } from "@/lib/live-event-game-control";
 import { createInitialClockBaseline, projectClockBaseline } from "@/lib/clock-authority";
 import { deriveLivePenaltyProjection } from "@/lib/live-event-penalties";
+import {
+  CONTROLLER_LEAVE_GRACE_MS,
+  getBrowserControllerDeparture,
+} from "@/lib/controller-departure";
+import {
+  createBrowserEventControllerSessionStorage,
+  readBrowserEventControllerSession,
+} from "@/lib/event-controller-session";
 
 describe("Event Game Controller reconnect browser seam", () => {
   const originalWindow = globalThis.window;
@@ -31,6 +39,7 @@ describe("Event Game Controller reconnect browser seam", () => {
   let openBodies: Record<string, unknown>[];
   let replayCalls: number;
   let refreshCalls: number;
+  let leaveBodies: Record<string, unknown>[];
   let deferredRefresh: ((response: Response) => void) | null;
   let deferredRefreshResponse: Response | null;
   let replayBodies: Record<string, any>[];
@@ -42,6 +51,9 @@ describe("Event Game Controller reconnect browser seam", () => {
   let openProjection: ControllerProjection | null;
   let refreshProjection: ControllerProjection | null;
   let refreshRejected: boolean;
+  let restoreRejected: boolean;
+  let leaveUnavailable: boolean;
+  let refreshConflict: boolean;
   let switchRequested: boolean;
   let deferredReplay: ((response: Response) => void) | null;
   let deferredReplayResponse: Response | null;
@@ -54,6 +66,7 @@ describe("Event Game Controller reconnect browser seam", () => {
     openBodies = [];
     replayCalls = 0;
     refreshCalls = 0;
+    leaveBodies = [];
     deferredRefresh = null;
     deferredRefreshResponse = null;
     replayBodies = [];
@@ -65,6 +78,9 @@ describe("Event Game Controller reconnect browser seam", () => {
     openProjection = null;
     refreshProjection = projection();
     refreshRejected = false;
+    restoreRejected = false;
+    leaveUnavailable = false;
+    refreshConflict = false;
     switchRequested = false;
     deferredReplay = null;
     deferredReplayResponse = null;
@@ -142,6 +158,11 @@ describe("Event Game Controller reconnect browser seam", () => {
         }
         if (url.endsWith("/api/event-control/refresh")) {
           refreshCalls += 1;
+          if (restoreRejected)
+            return new Response(
+              JSON.stringify({ status: "rejected", message: "Grant Session rejected" }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            );
           if (refreshRejected) return new Response("rejected", { status: 401 });
           if (switchRequested) {
             return new Response(
@@ -150,7 +171,10 @@ describe("Event Game Controller reconnect browser seam", () => {
                 previousEventGameId: "game-browser",
                 currentEventGameId: "game-b",
               }),
-              { status: 200, headers: { "content-type": "application/json" } },
+              {
+                status: refreshConflict ? 409 : 200,
+                headers: { "content-type": "application/json" },
+              },
             );
           }
           const refreshResponse = new Response(
@@ -200,6 +224,12 @@ describe("Event Game Controller reconnect browser seam", () => {
           });
         }
         if (url.endsWith("/api/event-control/leave")) {
+          leaveBodies.push(JSON.parse(typeof init?.body === "string" ? init.body : "{}"));
+          if (leaveUnavailable)
+            return new Response(JSON.stringify({ status: "rejected" }), {
+              status: 401,
+              headers: { "content-type": "application/json" },
+            });
           return new Response(JSON.stringify({ status: "left" }), {
             status: 200,
             headers: { "content-type": "application/json" },
@@ -261,9 +291,23 @@ describe("Event Game Controller reconnect browser seam", () => {
       await Promise.resolve();
       await Promise.resolve();
       await Promise.resolve();
-      await Promise.resolve();
-      await Promise.resolve();
     });
+    let continueButton: HTMLButtonElement | undefined;
+    for (let attempt = 0; attempt < 32 && continueButton === undefined; attempt += 1) {
+      continueButton = Array.from(container.getElementsByTagName("button")).find((button) =>
+        button.textContent?.includes("Continue"),
+      );
+      if (continueButton === undefined) await Promise.resolve();
+    }
+    if (continueButton !== undefined) {
+      await act(async () => {
+        continueButton.click();
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+    }
   }
 
   function installControllerIntervalProbe() {
@@ -1351,6 +1395,423 @@ describe("Event Game Controller reconnect browser seam", () => {
     expect(container.textContent).not.toContain("retained for reconnect replay");
   });
 
+  test("restores a persisted Event session only after Controller Departure authorizes Return", async () => {
+    const departureModule = getBrowserControllerDeparture();
+    await departureModule.transition({
+      type: "leave",
+      departure: {
+        workflow: "event",
+        gameId: "game-browser",
+        navigationPath: "/event-control",
+        identity: { title: "Event Game", homeName: "Basel", awayName: "Zurich" },
+      },
+      online: false,
+      nowMs: Date.now(),
+    });
+    testWindow.localStorage.setItem(
+      "quadball:event-controller-session",
+      JSON.stringify({ sessionBearer: "bearer", eventGameId: "game-browser" }),
+    );
+    testWindow.localStorage.setItem(
+      controllerReplicaStorageKey("game-browser"),
+      JSON.stringify(
+        createControllerReplica({
+          eventGameId: "game-browser",
+          projection: projection(),
+          grantSessionId: "session",
+          grantVersion: "version",
+        }),
+      ),
+    );
+
+    await act(async () => {
+      root.render(<EventGameControllerPage />);
+      for (let index = 0; index < 12; index += 1) await Promise.resolve();
+    });
+
+    expect(openBodies).toEqual([]);
+    expect(refreshCalls).toBeGreaterThanOrEqual(2);
+    expect(container.textContent).toContain("Controller Device: game-browser");
+  });
+
+  test("restores a retained Event replica offline and converges after reconnect", async () => {
+    const departureModule = getBrowserControllerDeparture();
+    await departureModule.transition({
+      type: "leave",
+      departure: {
+        workflow: "event",
+        gameId: "game-browser",
+        sessionReferenceId: "legacy-event-session-game-browser",
+        navigationPath: "/event-control",
+        identity: { title: "Event Game", homeName: "Basel", awayName: "Zurich" },
+      },
+      online: false,
+      nowMs: Date.now(),
+    });
+    createBrowserEventControllerSessionStorage().write({
+      sessionBearer: "bearer",
+      eventGameId: "game-browser",
+      sessionReferenceId: "legacy-event-session-game-browser",
+    });
+    testWindow.localStorage.setItem(
+      controllerReplicaStorageKey("game-browser"),
+      JSON.stringify(
+        createControllerReplica({
+          eventGameId: "game-browser",
+          projection: refreshProjection ?? projection(),
+          grantSessionId: "session",
+          grantVersion: "version",
+        }),
+      ),
+    );
+    Object.defineProperty(testWindow.navigator, "onLine", { configurable: true, value: false });
+
+    await act(async () => {
+      root.render(<EventGameControllerPage />);
+      for (let index = 0; index < 12; index += 1) await Promise.resolve();
+    });
+
+    expect(refreshCalls).toBe(0);
+    expect(container.textContent).toContain("Controller Device: game-browser");
+    Object.defineProperty(testWindow.navigator, "onLine", { configurable: true, value: true });
+    await act(async () => {
+      testWindow.dispatchEvent(new testWindow.Event("online"));
+      for (let index = 0; index < 12; index += 1) await Promise.resolve();
+    });
+    expect(refreshCalls).toBeGreaterThan(0);
+    expect(container.textContent).toContain("Controller Device: game-browser");
+  });
+
+  test("renders unavailable when an authorized restore has no retained Event replica", async () => {
+    const departureModule = getBrowserControllerDeparture();
+    await departureModule.transition({
+      type: "leave",
+      departure: {
+        workflow: "event",
+        gameId: "game-browser",
+        sessionReferenceId: "restore-missing",
+        navigationPath: "/event-control",
+        identity: { title: "Event Game", homeName: "Basel", awayName: "Zurich" },
+      },
+      online: false,
+      nowMs: Date.now(),
+    });
+    createBrowserEventControllerSessionStorage().write({
+      sessionBearer: "bearer",
+      eventGameId: "game-browser",
+      sessionReferenceId: "restore-missing",
+    });
+    expect(readBrowserEventControllerSession()).toMatchObject({
+      eventGameId: "game-browser",
+      sessionReferenceId: "restore-missing",
+    });
+
+    await act(async () => {
+      root.render(<EventGameControllerPage />);
+      for (let index = 0; index < 12; index += 1) await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain("Event Game Controller unavailable.");
+    expect(container.textContent).not.toContain("Controller Device: game-browser");
+  });
+
+  test("renders unavailable when an authorized restore has a corrupt Event replica", async () => {
+    const departureModule = getBrowserControllerDeparture();
+    await departureModule.transition({
+      type: "leave",
+      departure: {
+        workflow: "event",
+        gameId: "game-browser",
+        sessionReferenceId: "restore-corrupt",
+        navigationPath: "/event-control",
+        identity: { title: "Event Game", homeName: "Basel", awayName: "Zurich" },
+      },
+      online: false,
+      nowMs: Date.now(),
+    });
+    createBrowserEventControllerSessionStorage().write({
+      sessionBearer: "bearer",
+      eventGameId: "game-browser",
+      sessionReferenceId: "restore-corrupt",
+    });
+    testWindow.localStorage.setItem(controllerReplicaStorageKey("game-browser"), "not-json");
+
+    await act(async () => {
+      root.render(<EventGameControllerPage />);
+      for (let index = 0; index < 12; index += 1) await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain("Event Game Controller unavailable.");
+    expect(container.textContent).not.toContain("Controller Device: game-browser");
+  });
+
+  test("rejected restore clears only its exact Event credential", async () => {
+    const storage = createBrowserEventControllerSessionStorage();
+    storage.write({
+      sessionBearer: "bearer-b",
+      eventGameId: "game-browser",
+      sessionReferenceId: "session-b",
+    });
+    storage.write({
+      sessionBearer: "bearer-a",
+      eventGameId: "game-browser",
+      sessionReferenceId: "session-a",
+    });
+    expect(storage.read()).toMatchObject({
+      sessionBearer: "bearer-a",
+      sessionReferenceId: "session-a",
+    });
+    restoreRejected = true;
+
+    await act(async () => {
+      root.render(<EventGameControllerPage />);
+      for (let index = 0; index < 12; index += 1) await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain("Event Game Controller unavailable.");
+    expect(storage.readForGame("game-browser", "session-a")).toBeNull();
+    expect(storage.readForGame("game-browser", "session-b")).toMatchObject({
+      sessionBearer: "bearer-b",
+    });
+  });
+
+  test("restores the newest same-Game Event session while an older one remains pending", async () => {
+    const departureModule = getBrowserControllerDeparture();
+    const storage = createBrowserEventControllerSessionStorage();
+    storage.write({
+      sessionBearer: "bearer-a",
+      eventGameId: "game-browser",
+      sessionReferenceId: "session-a",
+    });
+    await departureModule.transition({
+      type: "leave",
+      departure: {
+        workflow: "event",
+        gameId: "game-browser",
+        sessionReferenceId: "session-a",
+        navigationPath: "/event-control",
+        identity: { title: "Event Game", homeName: "Basel", awayName: "Zurich" },
+      },
+      online: false,
+      nowMs: 0,
+    });
+    await departureModule.transition({
+      type: "expire",
+      online: false,
+      nowMs: CONTROLLER_LEAVE_GRACE_MS,
+    });
+    storage.write({
+      sessionBearer: "bearer-b",
+      eventGameId: "game-browser",
+      sessionReferenceId: "session-b",
+    });
+    testWindow.localStorage.setItem(
+      controllerReplicaStorageKey("game-browser"),
+      JSON.stringify(
+        createControllerReplica({
+          eventGameId: "game-browser",
+          projection: projection(),
+          grantSessionId: "session-b",
+          grantVersion: "version-b",
+          sessionReferenceId: "session-b",
+        }),
+      ),
+    );
+
+    expect(storage.read()).toMatchObject({
+      sessionBearer: "bearer-b",
+      sessionReferenceId: "session-b",
+    });
+    expect(departureModule.project()).toMatchObject({
+      pendingFinalizations: [{ sessionReferenceId: "session-a" }],
+    });
+    Object.defineProperty(testWindow.navigator, "onLine", { configurable: true, value: false });
+
+    await act(async () => {
+      root.render(<EventGameControllerPage />);
+      for (let index = 0; index < 16; index += 1) await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain("Controller Device: game-browser");
+    expect(storage.read()).toMatchObject({
+      sessionBearer: "bearer-b",
+      sessionReferenceId: "session-b",
+    });
+    expect(departureModule.project()).toMatchObject({
+      pendingFinalizations: [{ sessionReferenceId: "session-a" }],
+    });
+    leaveUnavailable = true;
+    Object.defineProperty(testWindow.navigator, "onLine", { configurable: true, value: true });
+    await act(async () => {
+      testWindow.dispatchEvent(new testWindow.Event("online"));
+      for (let index = 0; index < 16; index += 1) await Promise.resolve();
+    });
+    expect(leaveBodies).toEqual([{ sessionBearer: "bearer-a" }]);
+    expect(
+      testWindow.localStorage.getItem(controllerReplicaStorageKey("game-browser")),
+    ).not.toBeNull();
+    expect(container.textContent).toContain("Controller Device: game-browser");
+  });
+
+  test("restores a production-shaped HTTP 409 switch-required response", async () => {
+    const departureModule = getBrowserControllerDeparture();
+    await departureModule.transition({
+      type: "leave",
+      departure: {
+        workflow: "event",
+        gameId: "game-browser",
+        sessionReferenceId: "restore-conflict",
+        navigationPath: "/event-control",
+        identity: { title: "Event Game", homeName: "Basel", awayName: "Zurich" },
+      },
+      online: false,
+      nowMs: Date.now(),
+    });
+    createBrowserEventControllerSessionStorage().write({
+      sessionBearer: "bearer",
+      eventGameId: "game-browser",
+      sessionReferenceId: "restore-conflict",
+    });
+    testWindow.localStorage.setItem(
+      controllerReplicaStorageKey("game-browser"),
+      JSON.stringify(
+        createControllerReplica({
+          eventGameId: "game-browser",
+          projection: projection(),
+          grantSessionId: "session",
+          grantVersion: "version",
+        }),
+      ),
+    );
+    switchRequested = true;
+    refreshConflict = true;
+
+    await act(async () => {
+      root.render(<EventGameControllerPage />);
+      for (let index = 0; index < 16; index += 1) await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain("Pitch Slot assignment changed.");
+    expect(container.textContent).toContain("Controller Device: game-browser");
+  });
+
+  test("removes an Event replica when its exact departing session owns it", async () => {
+    const departureModule = getBrowserControllerDeparture();
+    const storage = createBrowserEventControllerSessionStorage();
+    storage.write({
+      sessionBearer: "bearer-a",
+      eventGameId: "game-browser",
+      sessionReferenceId: "session-a",
+    });
+    testWindow.localStorage.setItem(
+      controllerReplicaStorageKey("game-browser"),
+      JSON.stringify(
+        createControllerReplica({
+          eventGameId: "game-browser",
+          projection: projection(),
+          grantSessionId: "session-a",
+          grantVersion: "version-a",
+          sessionReferenceId: "session-a",
+        }),
+      ),
+    );
+    Object.defineProperty(testWindow.navigator, "onLine", { configurable: true, value: false });
+    await departureModule.transition({
+      type: "leave",
+      departure: {
+        workflow: "event",
+        gameId: "game-browser",
+        sessionReferenceId: "session-a",
+        navigationPath: "/event-control",
+        identity: { title: "Event Game", homeName: "Basel", awayName: "Zurich" },
+      },
+      online: false,
+      nowMs: 0,
+    });
+    await departureModule.transition({
+      type: "expire",
+      online: false,
+      nowMs: CONTROLLER_LEAVE_GRACE_MS,
+    });
+    leaveUnavailable = true;
+    Object.defineProperty(testWindow.navigator, "onLine", { configurable: true, value: true });
+    await act(async () => {
+      testWindow.dispatchEvent(new testWindow.Event("online"));
+      for (let index = 0; index < 12; index += 1) await Promise.resolve();
+    });
+
+    expect(leaveBodies).toEqual([{ sessionBearer: "bearer-a" }]);
+    expect(testWindow.localStorage.getItem(controllerReplicaStorageKey("game-browser"))).toBeNull();
+  });
+
+  test("mounted Event Controller terminates only after its workflow-qualified lifecycle invalidation", async () => {
+    await enterAndOpen();
+    const departureModule = getBrowserControllerDeparture();
+    const sessionReferenceId =
+      createBrowserEventControllerSessionStorage().readForGame("game-browser")?.sessionReferenceId;
+    await act(async () => {
+      await departureModule.transition({
+        type: "leave",
+        departure: {
+          workflow: "event",
+          gameId: "game-browser",
+          sessionReferenceId,
+          navigationPath: "/event-control",
+          identity: { title: "Event Game", homeName: "Basel", awayName: "Zurich" },
+        },
+        online: false,
+        nowMs: 0,
+      });
+      await departureModule.transition({
+        type: "expire",
+        online: false,
+        nowMs: CONTROLLER_LEAVE_GRACE_MS,
+      });
+    });
+    await act(async () => {
+      for (let index = 0; index < 8; index += 1) await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain("Event Game Controller unavailable.");
+    expect(container.textContent).not.toContain("Controller Device: game-browser");
+    expect(testWindow.localStorage.getItem(controllerReplicaStorageKey("game-browser"))).toBeNull();
+  });
+
+  test("mounted Event expiry retains the bearer until deferred finalization retries", async () => {
+    await enterAndOpen();
+    const departureModule = getBrowserControllerDeparture();
+    const sessionReferenceId =
+      createBrowserEventControllerSessionStorage().readForGame("game-browser")?.sessionReferenceId;
+    Object.defineProperty(testWindow.navigator, "onLine", { configurable: true, value: false });
+    await act(async () => {
+      await departureModule.transition({
+        type: "leave",
+        departure: {
+          workflow: "event",
+          gameId: "game-browser",
+          sessionReferenceId,
+          navigationPath: "/event-control",
+          identity: { title: "Event Game", homeName: "Basel", awayName: "Zurich" },
+        },
+        online: false,
+        nowMs: 0,
+      });
+      await departureModule.transition({
+        type: "expire",
+        online: false,
+        nowMs: CONTROLLER_LEAVE_GRACE_MS,
+      });
+    });
+    expect(leaveBodies).toEqual([]);
+    expect(container.textContent).toContain("Event Game Controller unavailable.");
+    Object.defineProperty(testWindow.navigator, "onLine", { configurable: true, value: true });
+    await act(async () => {
+      testWindow.dispatchEvent(new testWindow.Event("online"));
+      for (let index = 0; index < 12; index += 1) await Promise.resolve();
+    });
+    expect(leaveBodies).toEqual([{ sessionBearer: "bearer" }]);
+  });
+
   test("fresh same-Game scan replays retained work with original evidence", async () => {
     replayMode = "lost";
     await enterAndOpen();
@@ -1369,6 +1830,12 @@ describe("Event Game Controller reconnect browser seam", () => {
     await act(async () => {
       Array.from(container.getElementsByTagName("button"))
         .find((button) => button.textContent?.includes("Leave Controller Session"))
+        ?.click();
+      await Promise.resolve();
+    });
+    await act(async () => {
+      Array.from(container.getElementsByTagName("button"))
+        .find((button) => button.textContent?.includes("Leave game"))
         ?.click();
       await Promise.resolve();
       await Promise.resolve();
@@ -1607,6 +2074,12 @@ describe("Event Game Controller reconnect browser seam", () => {
     await act(async () => {
       Array.from(container.getElementsByTagName("button"))
         .find((button) => button.textContent?.includes("Leave Controller Session"))
+        ?.click();
+      await Promise.resolve();
+    });
+    await act(async () => {
+      Array.from(container.getElementsByTagName("button"))
+        .find((button) => button.textContent?.includes("Leave game"))
         ?.click();
       await Promise.resolve();
       await Promise.resolve();

--- a/src/pages/event-game-controller-page.tsx
+++ b/src/pages/event-game-controller-page.tsx
@@ -53,8 +53,23 @@ import {
   type ControllerReplayBatchResponse,
   type ControllerReplicaStorage,
 } from "@/lib/controller-reconnect";
+import {
+  ControllerLeaveDialog,
+  controllerDepartureReference,
+  useControllerDepartureEntry,
+} from "@/components/controller-departure";
+import {
+  controllerDepartureBlocksGame,
+  getBrowserControllerDeparture,
+} from "@/lib/controller-departure";
+import {
+  createBrowserEventControllerSessionStorage,
+  createEventControllerSessionReference,
+  readBrowserEventControllerSession,
+  type PersistedEventControllerSession,
+} from "@/lib/event-controller-session";
 
-type PersistedControllerSession = { sessionBearer: string; eventGameId: string };
+type PersistedControllerSession = PersistedEventControllerSession;
 type ControllerOpenResponse = {
   status: "opened";
   eventGameId: string;
@@ -117,15 +132,13 @@ type ClockReceiptAnchor = {
 };
 
 export function EventGameControllerPage() {
-  const persisted = readPersistedControllerSession();
+  const persisted = readBrowserEventControllerSession();
   const [qrCredential, setQrCredential] = useState("");
   const [grantCode, setGrantCode] = useState("");
   const qrCredentialInputRef = useRef<HTMLInputElement>(null);
   const grantCodeInputRef = useRef<HTMLInputElement>(null);
-  const [sessionBearer, setSessionBearer] = useState<string | null>(
-    persisted?.sessionBearer ?? null,
-  );
-  const [eventGameId, setEventGameId] = useState<string | null>(persisted?.eventGameId ?? null);
+  const [sessionBearer, setSessionBearer] = useState<string | null>(null);
+  const [eventGameId, setEventGameId] = useState<string | null>(null);
   const [projection, setProjection] = useState<ControllerProjection | null>(null);
   const [projectionStatus, setProjectionStatus] = useState<"available" | "unavailable">(
     "unavailable",
@@ -163,11 +176,12 @@ export function EventGameControllerPage() {
   const [pendingFlagCatchBoundaryOverride, setPendingFlagCatchBoundaryOverride] =
     useState<PendingFlagCatchBoundaryOverride | null>(null);
   const [persistedReplicaLoad] = useState<ControllerReplicaLoad>(() =>
-    readPersistedControllerReplica(persisted?.eventGameId),
+    readPersistedControllerReplica(undefined),
   );
   const [replica, setReplica] = useState<ControllerReplicaState | null>(persistedReplicaLoad.state);
   const replicaRef = useRef<ControllerReplicaState | null>(replica);
   const bearerGenerationRef = useRef(0);
+  const lifecycleGenerationRef = useRef(0);
   const installedReplayAuthorityRef = useRef<ReplayAuthority | null>(null);
   const activeReplayRef = useRef<ActiveReplay | null>(null);
   const queuedReplayRef = useRef<ReplayRequest | null>(null);
@@ -177,9 +191,75 @@ export function EventGameControllerPage() {
   const [durabilityWarning, setDurabilityWarning] = useState<string | null>(
     persistedReplicaLoad.warning,
   );
+  const [leaveDialogOpen, setLeaveDialogOpen] = useState(false);
+  const [restorePending, setRestorePending] = useState(persisted !== null);
+  const [controllerUnavailable, setControllerUnavailable] = useState(false);
   const [browserContext] = useState(() => readControllerDeviceContext());
   const qrTriggerRef = useRef<HTMLButtonElement>(null);
   const qrDialogRef = useRef<HTMLDivElement>(null);
+  const leaveTriggerRef = useRef<HTMLButtonElement>(null);
+  const entryTriggerRef = useRef<HTMLButtonElement>(null);
+  const switchTriggerRef = useRef<HTMLButtonElement>(null);
+  const restoreTriggerRef = useRef<HTMLButtonElement>(null);
+  const persistedSessionRef = useRef<PersistedControllerSession | null>(persisted);
+  const sessionReferenceIdRef = useRef<string | null>(persisted?.sessionReferenceId ?? null);
+  const restoreStartedRef = useRef(false);
+  const departureModule = getBrowserControllerDeparture();
+
+  const eventEntry = useControllerDepartureEntry({
+    destination: { kind: "admit-event" },
+    triggerRef: entryTriggerRef,
+    onCommitted: openController,
+    onUnavailable: () => setMessage("Unable to open Controller experience."),
+    onCancelled: () => setMessage("Entry cancelled. Your Controller return is still available."),
+  });
+  const switchEntry = useControllerDepartureEntry({
+    destination: {
+      kind: "resume-event",
+      gameId: switchTarget ?? "event-game-switch-pending",
+      sessionReferenceId: sessionReferenceIdRef.current ?? undefined,
+    },
+    triggerRef: switchTriggerRef,
+    onCommitted: switchController,
+    onUnavailable: () => setMessage("Unable to switch Controller Device."),
+    onCancelled: () => setMessage("Switch cancelled. Your Controller return is still available."),
+  });
+
+  const restoreEntry = useControllerDepartureEntry({
+    destination: {
+      kind: "resume-event",
+      gameId: persisted?.eventGameId ?? "event-restore-pending",
+      sessionReferenceId: persisted?.sessionReferenceId,
+    },
+    triggerRef: restoreTriggerRef,
+    onCommitted: restoreController,
+    onUnavailable: () => {
+      setRestorePending(false);
+      setControllerUnavailable(true);
+      setMessage("Event Game Controller is unavailable.");
+    },
+    onCancelled: () => {
+      setRestorePending(false);
+      setMessage("Restore cancelled. Your Controller return is still available.");
+    },
+  });
+
+  useEffect(() => {
+    return departureModule.subscribe(() => {
+      const currentEventGameId = eventGameId;
+      if (
+        currentEventGameId !== null &&
+        controllerDepartureBlocksGame(
+          departureModule.project(),
+          "event",
+          currentEventGameId,
+          sessionReferenceIdRef.current ?? undefined,
+        )
+      ) {
+        terminateMountedController();
+      }
+    });
+  }, [departureModule, eventGameId]);
 
   useEffect(() => {
     const timer = window.setInterval(() => {
@@ -249,13 +329,26 @@ export function EventGameControllerPage() {
 
   useEffect(() => {
     if (sessionBearer === null || eventGameId === null) {
-      window.sessionStorage.removeItem("quadball:event-controller-session");
       return;
     }
-    window.sessionStorage.setItem(
-      "quadball:event-controller-session",
-      JSON.stringify({ sessionBearer, eventGameId } satisfies PersistedControllerSession),
-    );
+    const sessionStorage = createBrowserEventControllerSessionStorage();
+    if (
+      !sessionStorage.write({
+        sessionBearer,
+        eventGameId,
+        ...(sessionReferenceIdRef.current === null
+          ? {}
+          : { sessionReferenceId: sessionReferenceIdRef.current }),
+      })
+    ) {
+      setDurabilityWarning(
+        "Controller recovery storage is full or unavailable; changes remain in memory.",
+      );
+    } else {
+      const current = sessionStorage.read();
+      sessionReferenceIdRef.current =
+        current?.eventGameId === eventGameId ? current.sessionReferenceId : null;
+    }
   }, [eventGameId, sessionBearer]);
 
   useEffect(() => {
@@ -271,8 +364,12 @@ export function EventGameControllerPage() {
   }, [replica]);
 
   useEffect(() => {
-    if (persisted !== null) void refreshController(true);
-    // Persisted authority is deliberately revalidated after browser restore.
+    if (persisted !== null && !restoreStartedRef.current) {
+      restoreStartedRef.current = true;
+      void restoreEntry.begin();
+    } else {
+      setRestorePending(false);
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -307,15 +404,95 @@ export function EventGameControllerPage() {
     return clockProjection?.gameTimeMs ?? projection?.clock.gameTimeMs ?? 0;
   }
 
-  async function openController() {
+  async function restoreController(): Promise<boolean> {
+    const saved = persistedSessionRef.current;
+    if (saved === null) return false;
+    setBusy(true);
+    sessionReferenceIdRef.current = saved.sessionReferenceId;
+    try {
+      if (navigator.onLine === false) {
+        const restored = restoreLocalController(saved);
+        if (!restored) setControllerUnavailable(true);
+        return restored;
+      }
+      const response = await postJson<ControllerRefreshResponse>(
+        "/api/event-control/refresh",
+        { sessionBearer: saved.sessionBearer, eventGameId: saved.eventGameId },
+        { allowConflict: true },
+      );
+      if (response.status === "switch-required") {
+        const restoredLoad = loadControllerReplica(
+          browserReplicaStorage(saved.eventGameId),
+          saved.eventGameId,
+        );
+        if (restoredLoad.warning !== null) setDurabilityWarning(restoredLoad.warning);
+        if (restoredLoad.state === null) {
+          setControllerUnavailable(true);
+          return false;
+        }
+        setSessionBearer(saved.sessionBearer);
+        setEventGameId(saved.eventGameId);
+        setControllerUnavailable(false);
+        setSwitchTarget(response.currentEventGameId);
+        commitReplica(restoredLoad.state);
+        return true;
+      }
+      if (response.status === "rejected") {
+        clearSession({ eventSession: saved });
+        setControllerUnavailable(true);
+        return false;
+      }
+      setSwitchTarget(null);
+      const restoredLoad = loadControllerReplica(
+        browserReplicaStorage(saved.eventGameId),
+        saved.eventGameId,
+      );
+      if (restoredLoad.warning !== null) setDurabilityWarning(restoredLoad.warning);
+      if (restoredLoad.state === null) {
+        setControllerUnavailable(true);
+        return false;
+      }
+      setSessionBearer(saved.sessionBearer);
+      setEventGameId(saved.eventGameId);
+      setControllerUnavailable(false);
+      receiveProjection(response.projection, { resynchronized: true });
+      const nextReplica = rebindControllerReplica(
+        restoredLoad.state,
+        {
+          eventGameId: saved.eventGameId,
+          grantSessionId: response.session.grantSessionId,
+          grantVersion: response.session.grantVersion,
+        },
+        response.projection,
+        sessionReferenceIdRef.current ?? undefined,
+      );
+      commitReplica(nextReplica);
+      await flushReplica(nextReplica, saved.sessionBearer);
+      return true;
+    } catch {
+      // A retained Event replica is an offline Return, not an authority loss.
+      // Keep the credential for the Event adapter's pending finalization and
+      // let the foreground/online seam reconcile it later.
+      if (restoreLocalController(saved)) return true;
+      setControllerUnavailable(true);
+      return false;
+    } finally {
+      setRestorePending(false);
+      setBusy(false);
+    }
+  }
+
+  async function openController(): Promise<boolean> {
     const hasQrCredential = qrCredential.length > 0;
     const hasGrantCode = grantCode.length > 0;
     if (hasQrCredential === hasGrantCode) {
       setMessage("Enter exactly one Controller QR credential or Grant Code.");
-      return;
+      return false;
     }
     setBusy(true);
     setMessage(null);
+    setControllerUnavailable(false);
+    sessionReferenceIdRef.current = null;
     clearReplayAuthority();
     if (replicaRef.current !== null) {
       const invalidated = invalidateControllerReplica(replicaRef.current);
@@ -328,6 +505,7 @@ export function EventGameControllerPage() {
         browserContext,
       });
       if (response.status !== "opened") throw new Error("open failed");
+      sessionReferenceIdRef.current = createEventControllerSessionReference();
       setQrCredential("");
       setGrantCode("");
       if (qrCredentialInputRef.current !== null) qrCredentialInputRef.current.value = "";
@@ -355,20 +533,24 @@ export function EventGameControllerPage() {
                 grantVersion: response.session.grantVersion,
               },
               response.projection,
+              sessionReferenceIdRef.current ?? undefined,
             )
           : createControllerReplica({
               eventGameId: response.eventGameId,
               projection: response.projection ?? emptyProjection(response.eventGameId),
               grantSessionId: response.session.grantSessionId,
               grantVersion: response.session.grantVersion,
+              sessionReferenceId: sessionReferenceIdRef.current ?? undefined,
             });
       commitReplica(nextReplica);
       await flushReplica(nextReplica, response.session.sessionBearer);
+      return true;
     } catch {
       clearSession();
       setMessage(
         "Unable to open Controller experience. A fresh device cannot reconstruct Clock Authority during a server outage; use manual timing.",
       );
+      return false;
     } finally {
       setBusy(false);
     }
@@ -376,13 +558,16 @@ export function EventGameControllerPage() {
 
   async function refreshController(silent = false): Promise<boolean> {
     if (sessionBearer === null || eventGameId === null) return false;
+    const requestGeneration = lifecycleGenerationRef.current;
     projectClockImmediately();
     if (!silent) setBusy(true);
     try {
-      const response = await postJson<ControllerRefreshResponse>("/api/event-control/refresh", {
-        sessionBearer,
-        eventGameId,
-      });
+      const response = await postJson<ControllerRefreshResponse>(
+        "/api/event-control/refresh",
+        { sessionBearer, eventGameId },
+        { allowConflict: true },
+      );
+      if (requestGeneration !== lifecycleGenerationRef.current) return false;
       if (response.status === "switch-required") {
         setSwitchTarget(
           stayedOnAssignment === response.currentEventGameId ? null : response.currentEventGameId,
@@ -405,12 +590,18 @@ export function EventGameControllerPage() {
         currentReplica.session.grantVersion === response.session.grantVersion
           ? acknowledgeControllerProjection(currentReplica, response.projection)
           : currentReplica?.eventGameId === response.session.eventGameId
-            ? rebindControllerReplica(currentReplica, refreshedSession, response.projection)
+            ? rebindControllerReplica(
+                currentReplica,
+                refreshedSession,
+                response.projection,
+                sessionReferenceIdRef.current ?? undefined,
+              )
             : createControllerReplica({
                 eventGameId: response.session.eventGameId,
                 projection: response.projection ?? emptyProjection(response.session.eventGameId),
                 grantSessionId: response.session.grantSessionId,
                 grantVersion: response.session.grantVersion,
+                sessionReferenceId: sessionReferenceIdRef.current ?? undefined,
               });
       commitReplica(nextReplica);
       await flushReplica(nextReplica, sessionBearer);
@@ -423,8 +614,9 @@ export function EventGameControllerPage() {
     }
   }
 
-  async function switchController() {
-    if (sessionBearer === null) return;
+  async function switchController(): Promise<boolean> {
+    if (sessionBearer === null) return false;
+    const requestGeneration = lifecycleGenerationRef.current;
     setBusy(true);
     clearReplayAuthority();
     const current = replicaRef.current;
@@ -437,6 +629,7 @@ export function EventGameControllerPage() {
       const response = await postJson<ControllerRefreshResponse>("/api/event-control/switch", {
         sessionBearer,
       });
+      if (requestGeneration !== lifecycleGenerationRef.current) return false;
       if (response.status !== "authorized") throw new Error("switch failed");
       setEventGameId(response.session.eventGameId);
       receiveProjection(response.projection);
@@ -453,6 +646,7 @@ export function EventGameControllerPage() {
               projection: response.projection ?? emptyProjection(response.session.eventGameId),
               grantSessionId: response.session.grantSessionId,
               grantVersion: response.session.grantVersion,
+              sessionReferenceId: sessionReferenceIdRef.current ?? undefined,
             })
           : rebindControllerReplica(
               restored,
@@ -462,14 +656,17 @@ export function EventGameControllerPage() {
                 grantVersion: response.session.grantVersion,
               },
               response.projection,
+              sessionReferenceIdRef.current ?? undefined,
             );
       commitReplica(nextReplica);
       await flushReplica(nextReplica, sessionBearer);
       setSwitchTarget(null);
       setStayedOnAssignment(null);
       setMessage("Controller Device switched to the newly assigned Event Game.");
+      return true;
     } catch {
       setMessage("Unable to switch Controller Device.");
+      return false;
     } finally {
       setBusy(false);
     }
@@ -497,6 +694,7 @@ export function EventGameControllerPage() {
             grantVersion: response.session.grantVersion,
           },
           response.projection,
+          sessionReferenceIdRef.current ?? undefined,
         );
         commitReplica(nextReplica);
         await flushReplica(nextReplica, sessionBearer);
@@ -528,20 +726,32 @@ export function EventGameControllerPage() {
   }
 
   async function leaveController() {
-    if (sessionBearer === null) return;
+    if (sessionBearer === null || eventGameId === null) return;
     setBusy(true);
-    try {
-      const response = await postJson<{ status: "left" }>("/api/event-control/leave", {
-        sessionBearer,
-      });
-      if (response.status !== "left") throw new Error("leave failed");
-      clearSession();
-      setMessage("Controller Session left. Pending evidence remains on the Event Game Record.");
-    } catch {
+    const sessionReferenceId =
+      sessionReferenceIdRef.current ??
+      createBrowserEventControllerSessionStorage().readForGame(eventGameId)?.sessionReferenceId;
+    const outcome = await departureModule.transition({
+      type: "leave",
+      departure: controllerDepartureReference({
+        workflow: "event",
+        gameId: eventGameId,
+        sessionReferenceId,
+        homeName: eventTeamName(projection, 0),
+        awayName: eventTeamName(projection, 1),
+        navigationPath: "/event-control",
+        detail: `Event Game ${eventGameId}`,
+      }),
+      online: navigator.onLine !== false,
+    });
+    if (outcome.status === "left") {
+      clearSession({ preserveEventSession: true });
+      setLeaveDialogOpen(false);
+      navigateTo("/");
+    } else {
       setMessage("Unable to leave Controller session.");
-    } finally {
-      setBusy(false);
     }
+    setBusy(false);
   }
 
   function recordGoal(gameSideId: string) {
@@ -1185,6 +1395,43 @@ export function EventGameControllerPage() {
   function clearReplayAuthority() {
     installedReplayAuthorityRef.current = null;
     queuedReplayRef.current = null;
+    bearerGenerationRef.current += 1;
+  }
+
+  function terminateMountedController() {
+    lifecycleGenerationRef.current += 1;
+    clearReplayAuthority();
+    activeReplayRef.current = null;
+    if (resynchronizationTimerRef.current !== null) {
+      window.clearTimeout(resynchronizationTimerRef.current);
+      resynchronizationTimerRef.current = null;
+    }
+    // Controller Departure owns the finalization decision. Keep this Event
+    // credential until its distinct authority adapter accepts or rejects the
+    // deferred /leave, while the mounted UI and replica become unusable now.
+    clearSession({ preserveEventSession: true, discardReplica: true });
+    setControllerUnavailable(true);
+    setMessage("Event Game Controller is unavailable.");
+  }
+
+  function restoreLocalController(saved: PersistedControllerSession): boolean {
+    const restoredLoad = loadControllerReplica(
+      browserReplicaStorage(saved.eventGameId),
+      saved.eventGameId,
+    );
+    if (restoredLoad.warning !== null) setDurabilityWarning(restoredLoad.warning);
+    if (restoredLoad.state === null) return false;
+    sessionReferenceIdRef.current = saved.sessionReferenceId;
+    setSessionBearer(saved.sessionBearer);
+    setEventGameId(saved.eventGameId);
+    setSwitchTarget(null);
+    setControllerUnavailable(false);
+    commitReplica(restoredLoad.state);
+    receiveProjection(restoredLoad.state.projection, { markSynchronized: false });
+    controllerConnectionStatusRef.current = "disconnected";
+    setControllerConnectionStatus("disconnected");
+    setMessage("Controller restored offline; reconnecting when connectivity returns.");
+    return true;
   }
 
   function commitReplica(state: ControllerReplicaState) {
@@ -1402,12 +1649,14 @@ export function EventGameControllerPage() {
     bearer: string,
     currentEventGameId: string,
   ) {
+    const requestGeneration = lifecycleGenerationRef.current;
     try {
       const response = await postJson<LiveEventGameControlResult>("/api/event-control/intent", {
         sessionBearer: bearer,
         eventGameId: currentEventGameId,
         intent,
       });
+      if (requestGeneration !== lifecycleGenerationRef.current) return;
       if (response.status !== "accepted" && response.status !== "duplicate-accepted") {
         setMessage("The online Controller action was not accepted.");
         return;
@@ -1435,9 +1684,32 @@ export function EventGameControllerPage() {
     }
   }
 
-  function clearSession() {
+  function clearSession(
+    options: {
+      preserveEventSession?: boolean;
+      discardReplica?: boolean;
+      eventSession?: Pick<PersistedControllerSession, "eventGameId" | "sessionReferenceId">;
+    } = {},
+  ) {
+    const currentEventGameId = eventGameId;
+    const currentSessionReferenceId = sessionReferenceIdRef.current;
+    const eventSessionToClear =
+      options.eventSession ??
+      (currentEventGameId === null
+        ? null
+        : { eventGameId: currentEventGameId, sessionReferenceId: currentSessionReferenceId });
     clearReplayAuthority();
-    if (replicaRef.current !== null) {
+    if (options.discardReplica) {
+      replicaRef.current = null;
+      setReplica(null);
+      if (currentEventGameId !== null) {
+        try {
+          window.localStorage.removeItem(controllerReplicaStorageKey(currentEventGameId));
+        } catch {
+          // The mounted UI is still terminated; the lifecycle projection remains authoritative.
+        }
+      }
+    } else if (replicaRef.current !== null) {
       const invalidated = invalidateControllerReplica(replicaRef.current);
       replicaRef.current = invalidated;
       setReplica(invalidated);
@@ -1456,6 +1728,17 @@ export function EventGameControllerPage() {
     setQrDialogOpen(false);
     setSwitchTarget(null);
     setStayedOnAssignment(null);
+    if (!options.preserveEventSession) {
+      if (eventSessionToClear !== null) {
+        createBrowserEventControllerSessionStorage().clear(
+          eventSessionToClear.eventGameId,
+          eventSessionToClear.sessionReferenceId ?? undefined,
+        );
+        if (currentSessionReferenceId === eventSessionToClear.sessionReferenceId) {
+          sessionReferenceIdRef.current = null;
+        }
+      }
+    }
   }
 
   useEffect(() => {
@@ -1510,7 +1793,26 @@ export function EventGameControllerPage() {
           </CardDescription>
         </CardHeader>
         <CardContent className="flex min-h-0 flex-1 flex-col overflow-hidden px-3 pb-3 sm:px-6">
-          {sessionBearer === null ? (
+          {restorePending ? (
+            <div className="space-y-3 rounded-lg border bg-muted/30 p-4" role="status">
+              <p className="font-medium">Restoring Event Game Controller…</p>
+              <p className="text-sm text-muted-foreground">
+                The saved Event authority is being confirmed before this device reconnects.
+              </p>
+              <button ref={restoreTriggerRef} className="sr-only" tabIndex={-1} />
+            </div>
+          ) : controllerUnavailable ? (
+            <div
+              className="space-y-3 rounded-lg border border-rose-300 bg-rose-50 p-4"
+              role="alert"
+            >
+              <p className="font-medium text-rose-950">Event Game Controller unavailable.</p>
+              <p className="text-sm text-rose-900">
+                This Event authority or Game is no longer valid. Start a fresh Controller admission
+                to continue.
+              </p>
+            </div>
+          ) : sessionBearer === null ? (
             <>
               <div className="space-y-2">
                 <Label htmlFor="control-grant">Active Pitch Slot Control Grant QR</Label>
@@ -1540,10 +1842,11 @@ export function EventGameControllerPage() {
                 />
               </div>
               <Button
+                ref={entryTriggerRef}
                 className="min-h-11 w-full"
                 aria-label="Open Event Game Controller"
-                onClick={() => void openController()}
-                disabled={busy}
+                onClick={() => void eventEntry.begin()}
+                disabled={busy || eventEntry.busy}
               >
                 Open Controller Device
               </Button>
@@ -1601,7 +1904,8 @@ export function EventGameControllerPage() {
                 <Button
                   variant="outline"
                   aria-label="Leave Event Game Controller session"
-                  onClick={() => void leaveController()}
+                  ref={leaveTriggerRef}
+                  onClick={() => setLeaveDialogOpen(true)}
                   disabled={busy}
                 >
                   Leave Controller Session
@@ -1615,9 +1919,10 @@ export function EventGameControllerPage() {
                   </p>
                   <div className="mt-3 flex flex-wrap gap-2">
                     <Button
+                      ref={switchTriggerRef}
                       aria-label={`Switch to Event Game ${switchTarget}`}
-                      onClick={() => void switchController()}
-                      disabled={busy}
+                      onClick={() => void switchEntry.begin()}
+                      disabled={busy || switchEntry.busy}
                     >
                       Switch Event Game
                     </Button>
@@ -2519,6 +2824,17 @@ export function EventGameControllerPage() {
           </div>
         </div>
       ) : null}
+      {leaveDialogOpen ? (
+        <ControllerLeaveDialog
+          triggerRef={leaveTriggerRef}
+          busy={busy}
+          onCancel={() => setLeaveDialogOpen(false)}
+          onConfirm={() => void leaveController()}
+        />
+      ) : null}
+      {eventEntry.dialog}
+      {switchEntry.dialog}
+      {restoreEntry.dialog}
     </main>
   );
 }
@@ -2585,14 +2901,29 @@ function readMonotonicNow(): number {
   return typeof performance === "undefined" ? 0 : performance.now();
 }
 
-async function postJson<T>(path: string, body: unknown): Promise<T> {
+function eventTeamName(projection: ControllerProjection | null, sideIndex: number): string {
+  const assignment = projection?.teamAssignments?.[sideIndex];
+  return assignment?.eventTeamName ?? `Game Side ${assignment?.gameSideId ?? sideIndex + 1}`;
+}
+
+function navigateTo(path: string) {
+  window.history.pushState(null, "", path);
+  window.dispatchEvent(new window.Event("popstate"));
+}
+
+async function postJson<T>(
+  path: string,
+  body: unknown,
+  options: { allowConflict?: boolean } = {},
+): Promise<T> {
   const response = await fetch(path, {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify(body),
   });
   const result = (await response.json()) as T;
-  if (!response.ok) throw new Error("request failed");
+  if (!response.ok && !(options.allowConflict === true && response.status === 409))
+    throw new Error("request failed");
   return result;
 }
 
@@ -2606,19 +2937,6 @@ function replicaMatchesAuthority(
     state.session.grantSessionId === authority.grantSessionId &&
     state.session.grantVersion === authority.grantVersion
   );
-}
-
-function readPersistedControllerSession(): PersistedControllerSession | null {
-  try {
-    const raw = window.sessionStorage.getItem("quadball:event-controller-session");
-    if (raw === null) return null;
-    const value = JSON.parse(raw) as Partial<PersistedControllerSession>;
-    return typeof value.sessionBearer === "string" && typeof value.eventGameId === "string"
-      ? { sessionBearer: value.sessionBearer, eventGameId: value.eventGameId }
-      : null;
-  } catch {
-    return null;
-  }
 }
 
 function readPersistedControllerReplica(eventGameId: string | undefined): ControllerReplicaLoad {

--- a/src/pages/game-page.tsx
+++ b/src/pages/game-page.tsx
@@ -123,7 +123,7 @@ export function GamePage({ gameId, role }: { gameId: string; role: ControllerRol
 
   const departureProjection = departureModule.project();
   const departureBlocked =
-    role === "controller" && controllerDepartureBlocksGame(departureProjection, gameId);
+    role === "controller" && controllerDepartureBlocksGame(departureProjection, "ad-hoc", gameId);
 
   const {
     baseState,
@@ -172,7 +172,7 @@ export function GamePage({ gameId, role }: { gameId: string; role: ControllerRol
     () =>
       departureModule.subscribe(() => {
         const projection = departureModule.project();
-        if (controllerDepartureBlocksGame(projection, gameId)) {
+        if (controllerDepartureBlocksGame(projection, "ad-hoc", gameId)) {
           setEntryReady(false);
           setEntryError("Ad Hoc Game unavailable.");
         }


### PR DESCRIPTION
## What

- extend the shared Controller Departure module to Event Game Controllers
- add confirmed Event Leave, countdown-free Home Return, offline/restart restore, and exact Event Grant Session finalization
- preserve Event-specific Grant, Game Lock, Pitch Slot, reassignment, credential, replica, and authority boundaries behind separate adapters
- enforce newest-only replacement across Event and Ad Hoc entry paths, including same-Game multi-session isolation

## Why

Event Controllers need the same recoverable five-minute departure experience as Ad Hoc Controllers without conflating their authority models. Exact session and replica ownership ensures deferred finalization cannot revoke or erase a newer Controller session for the same Event Game.

## User impact

Controllers now confirm before leaving an Event Game, can return from Home for five minutes online or offline, and receive the existing retain-or-switch choice after reassignment. Entering another Event or Ad Hoc Game confirms and finalizes the previous opportunity before the new admission mutates state.

## Validation

- `bun run check`
- 32 Controller Departure and Event session deep tests
- 45 Event Controller page tests
- `bun run test:focused:event-game-controller-browser` (Chromium and WebKit)
- `bun run test:focused:adhoc-browser`
- `bun run build`
- `git diff --check`
- independent specification and standards reviews: clean

No Qualification Test was added or run.

Stacked on #276.

Closes #269
