### PR TITLE
Ship the compact shared Controller header

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test:focused:event-admin-browser-webkit": "bun scripts/test-event-admin-webkit.ts",
     "test:focused:public-event-browser": "bun scripts/test-public-event-browser.ts",
     "test:focused:event-game-controller-browser": "bun scripts/test-event-game-controller-browser.ts",
+    "test:focused:controller-header-mobile": "bun scripts/test-controller-header-mobile-focused.ts",
     "test:focused:event-game-routes": "bun test --isolate ./src/lib/live-event-game-transport.focused.ts",
     "test:focused:technical-admin": "bun test --isolate ./src/lib/technical-admin-auth-sqlite.focused.ts",
     "test:focused:technical-admin-bootstrap": "bun test --isolate ./src/lib/technical-admin-bootstrap.focused.ts",

--- a/scripts/test-ad-hoc-browser.ts
+++ b/scripts/test-ad-hoc-browser.ts
@@ -98,7 +98,7 @@ async function run() {
         second.setDefaultTimeout(15_000);
 
         await first.addInitScript(() => {
-          const evidence = { sawBusy: false, sawOffline: false };
+          const evidence = { sawBusy: false, sawOffline: false, sawInitialQrFocus: false };
           const inspect = () => {
             const text = document.body?.textContent ?? "";
             evidence.sawBusy ||= /Ad Hoc connection busy/u.test(text);
@@ -113,6 +113,14 @@ async function run() {
             });
             inspect();
           };
+          document.addEventListener("focusin", (event) => {
+            if (
+              event.target instanceof HTMLElement &&
+              event.target.getAttribute("aria-label") === "Show Ad Hoc Control QR"
+            ) {
+              evidence.sawInitialQrFocus = true;
+            }
+          });
           if (document.body === null) {
             document.addEventListener("DOMContentLoaded", install, { once: true });
           } else {
@@ -127,13 +135,14 @@ async function run() {
         await first.goto(origin);
         await first.getByRole("button", { name: /Start an Ad Hoc Game/ }).click();
         await first.waitForURL(/\/game\/adhoc-/u);
-        await first.getByText("Live", { exact: true }).waitFor();
+        await waitForHealthyControllerHeader(first);
         const initialConnectionEvidence = await first.evaluate(() => {
           const evidence = (
             window as typeof window & {
               __quadballTimerInitialAdHocConnectionEvidence?: {
                 sawBusy: boolean;
                 sawOffline: boolean;
+                sawInitialQrFocus: boolean;
               };
             }
           ).__quadballTimerInitialAdHocConnectionEvidence;
@@ -143,6 +152,9 @@ async function run() {
         });
         if (initialConnectionEvidence.sawBusy || initialConnectionEvidence.sawOffline) {
           throw new Error("Newly created Test-shaped Ad Hoc Game did not reach Live cleanly.");
+        }
+        if (initialConnectionEvidence.sawInitialQrFocus) {
+          throw new Error("Ad Hoc Control QR trigger received focus during initial page load.");
         }
         await assertAccessibleQr(first, "creator");
 
@@ -226,15 +238,19 @@ async function run() {
         await stopServer();
         await second.getByRole("button", { name: "Pause game" }).click();
         await second.getByRole("button", { name: "Start game" }).click();
-        await second.getByText(/Offline 2/u).waitFor();
+        await second.getByText(/Offline · 2 queued actions/u).waitFor();
         await startServer();
-        await second.getByText("Live", { exact: true }).waitFor();
+        await waitForHealthyControllerHeader(second);
         await first.getByText("Running", { exact: true }).waitFor();
         await second.getByRole("button", { name: "Pause game" }).click();
         await second.getByRole("button", { name: "Game end" }).click();
         await second.getByRole("button", { name: "Double forfeit" }).click();
         await second.getByText("Finished", { exact: true }).waitFor();
-        await first.getByText("new admission is paused.", { exact: false }).waitFor();
+        await first.waitForFunction(
+          () =>
+            document.querySelector('button[aria-label="Show Ad Hoc Control QR"]') === null &&
+            !document.body.textContent?.includes("Share Ad Hoc Control"),
+        );
         await second.getByRole("button", { name: "Correct back to unfinished" }).click();
         await waitForUnfinishedGame(second, gameId);
 
@@ -266,7 +282,7 @@ async function run() {
         await stopServer();
         await secondContext.setOffline(true);
         await second.getByRole("button", { name: "Start game" }).click();
-        await second.getByText(/Offline 1/u).waitFor();
+        await second.getByText(/Offline · 1 queued action/u).waitFor();
         replaceAdHocDatabaseFromSnapshot(recoverySnapshotPath);
         await startServer();
         await first.reload();
@@ -286,11 +302,11 @@ async function run() {
         if (restoredServerState.game?.state?.isRunning !== false) {
           throw new Error("Restored server state was silently overwritten by newer local state.");
         }
-        await second.getByText(/Offline 1/u).waitFor();
+        await second.getByText(/Offline · 1 queued action/u).waitFor();
         await secondContext.setOffline(false);
         await second.reload();
         await waitForGameRoute(second, gameId);
-        await second.getByText("Live", { exact: true }).waitFor();
+        await waitForHealthyControllerHeader(second);
         await first.getByText("Running", { exact: true }).waitFor();
         await second.getByRole("button", { name: "Pause game" }).click();
         await first.getByText("Paused", { exact: true }).waitFor();
@@ -298,7 +314,7 @@ async function run() {
         await second.getByRole("button", { name: "Start game" }).click();
         await first.getByText("Running", { exact: true }).waitFor();
         await second.getByRole("button", { name: "Pause game" }).click();
-        const leaveButton = second.getByRole("button", { name: "Leave", exact: true });
+        const leaveButton = second.getByRole("button", { name: "Leave Ad Hoc Game Controller" });
         await leaveButton.click();
         await second.getByRole("dialog").waitFor();
         await second.getByRole("dialog").press("Escape");
@@ -322,7 +338,7 @@ async function run() {
 
         // An Ad Hoc returnable session must use the same shared replacement
         // confirmation before an Event admission transport is touched.
-        await second.getByRole("button", { name: "Leave", exact: true }).click();
+        await second.getByRole("button", { name: "Leave Ad Hoc Game Controller" }).click();
         await second.getByRole("dialog").getByRole("button", { name: "Leave game" }).click();
         await second.waitForURL(`${origin}/`);
         let eventOpenCalls = 0;
@@ -404,7 +420,7 @@ async function run() {
           creationOrder.slice(0, creationIndex).some((entry) => entry !== "finalize")
         )
           throw new Error(`Ad Hoc creation order was ${creationOrder.join(",")}.`);
-        await creationPage.getByRole("button", { name: "Leave", exact: true }).click();
+        await creationPage.getByRole("button", { name: "Leave Ad Hoc Game Controller" }).click();
         await creationPage.getByRole("dialog").getByRole("button", { name: "Leave game" }).click();
         await creationPage.waitForURL(`${origin}/`);
         const admissionStorageState = await creationContext.storageState();
@@ -457,7 +473,7 @@ async function run() {
         await startServer();
         await first.reload();
         await waitForGameRoute(first, gameId);
-        await first.getByText("Live", { exact: true }).waitFor();
+        await waitForHealthyControllerHeader(first);
         await first.waitForTimeout(250);
         const retryContext = await browser!.newContext({
           ignoreHTTPSErrors: true,
@@ -467,16 +483,34 @@ async function run() {
         retryPage.setDefaultTimeout(15_000);
         await retryPage.goto(handoffUrl);
         await waitForGameRoute(retryPage, gameId);
-        await retryPage.getByText(/Ad Hoc connection busy/u).waitFor();
+        const busyWarning = retryPage.locator('[data-controller-warning="true"]');
+        await busyWarning.waitFor();
+        const busyWarningText = (await busyWarning.textContent()) ?? "";
+        if (
+          !busyWarningText.includes("Offline") ||
+          !busyWarningText.includes("Ad Hoc connection busy")
+        ) {
+          throw new Error(
+            `Busy retry was not composed into the shared warning: ${busyWarningText}`,
+          );
+        }
+        if (
+          (await retryPage
+            .locator('p[role="status"]')
+            .filter({ hasText: /Ad Hoc connection busy/u })
+            .count()) !== 0
+        ) {
+          throw new Error("Busy retry rendered a duplicate Ad Hoc connection status.");
+        }
         await first.close();
-        await retryPage.getByText("Live", { exact: true }).waitFor();
+        await waitForHealthyControllerHeader(retryPage);
 
         await stopServer();
         rmSync(databasePath, { force: true });
         await startServer();
         await retryPage.reload();
         await waitForGameRoute(retryPage, gameId);
-        await retryPage.getByText("Local", { exact: true }).waitFor();
+        await retryPage.locator('[data-controller-warning="true"]').waitFor();
         await retryPage
           .getByText("Server does not know this game", { exact: false })
           .first()
@@ -517,7 +551,7 @@ async function run() {
         victim.setDefaultTimeout(15_000);
         await victim.goto(`${origin}/game/${victimGameId}`);
         await waitForGameRoute(victim, victimGameId);
-        await victim.getByText("Local", { exact: true }).waitFor();
+        await victim.locator('[data-controller-warning="true"]').waitFor();
         await victim
           .getByText("Server does not know this game", { exact: false })
           .first()
@@ -531,7 +565,7 @@ async function run() {
         }
         await victim.reload();
         await waitForGameRoute(victim, victimGameId);
-        await victim.getByText("Local", { exact: true }).waitFor();
+        await victim.locator('[data-controller-warning="true"]').waitFor();
         await victim
           .getByText("Server does not know this game", { exact: false })
           .first()
@@ -726,9 +760,28 @@ async function waitForGameRoute(page: Page, gameId: string) {
   if (page.url() !== `${origin}/game/${gameId}`) await page.waitForURL(`${origin}/game/${gameId}`);
 }
 
+async function waitForHealthyControllerHeader(page: Page) {
+  const header = page.getByRole("region", { name: "Controller header" });
+  await header.waitFor();
+  await page.waitForFunction(() => document.querySelector("[data-controller-warning]") === null);
+}
+
 async function assertAccessibleQr(page: Page, stage: string) {
   try {
+    const viewport = stage.includes("second")
+      ? { width: 412, height: 915 }
+      : { width: 390, height: 844 };
+    await page.setViewportSize(viewport);
     const trigger = page.getByRole("button", { name: "Show Ad Hoc Control QR" });
+    const leave = page.getByRole("button", { name: "Leave Ad Hoc Game Controller" });
+    const triggerBox = await trigger.boundingBox();
+    const leaveBox = await leave.boundingBox();
+    if (triggerBox === null || leaveBox === null)
+      throw new Error("header controls were not laid out");
+    if (triggerBox.width < 44 || triggerBox.height < 44) throw new Error("QR target was too small");
+    if (leaveBox.width < 44 || leaveBox.height < 44) throw new Error("Leave target was too small");
+    if (Math.abs(triggerBox.x + triggerBox.width - leaveBox.x) < 8)
+      throw new Error("QR and Leave controls were directly adjacent");
     await trigger.click();
     const dialog = page.getByRole("dialog", { name: "Ad Hoc Control QR dialog" });
     if ((await dialog.getAttribute("aria-modal")) !== "true")
@@ -746,7 +799,7 @@ async function assertAccessibleQr(page: Page, stage: string) {
     await page.waitForFunction(
       () =>
         document.activeElement?.tagName === "BUTTON" &&
-        document.activeElement?.textContent?.trim() === "Show Ad Hoc Control QR",
+        document.activeElement?.getAttribute("aria-label") === "Show Ad Hoc Control QR",
     );
     if (!(await trigger.evaluate((element) => element === document.activeElement))) {
       throw new Error("Escape did not restore focus to the QR trigger");
@@ -758,7 +811,7 @@ async function assertAccessibleQr(page: Page, stage: string) {
     await page.waitForFunction(
       () =>
         document.activeElement?.tagName === "BUTTON" &&
-        document.activeElement?.textContent?.trim() === "Show Ad Hoc Control QR",
+        document.activeElement?.getAttribute("aria-label") === "Show Ad Hoc Control QR",
     );
     if (!(await trigger.evaluate((element) => element === document.activeElement))) {
       throw new Error("Close did not restore focus to the QR trigger");

--- a/scripts/test-controller-header-mobile-focused.ts
+++ b/scripts/test-controller-header-mobile-focused.ts
@@ -1,0 +1,30 @@
+#!/usr/bin/env bun
+
+const journeys = [
+  {
+    name: "Ad Hoc production Controller header",
+    command: "scripts/test-ad-hoc-browser.ts",
+  },
+  {
+    name: "Event production Controller header",
+    command: "scripts/test-event-game-controller-browser.ts",
+  },
+] as const;
+
+for (const journey of journeys) {
+  console.log(`Focused Integration journey: ${journey.name}`);
+  const child = Bun.spawn(["bun", journey.command], {
+    cwd: process.cwd(),
+    stdin: "inherit",
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+  const exitCode = await child.exited;
+  if (exitCode !== 0) {
+    throw new Error(`${journey.name} failed with exit code ${exitCode}.`);
+  }
+}
+
+console.log(
+  "Shared mobile Controller Focused Integration passed: Ad Hoc and Event headers at 390x844 and 412x915.",
+);

--- a/scripts/test-event-game-controller-browser.ts
+++ b/scripts/test-event-game-controller-browser.ts
@@ -83,7 +83,7 @@ try {
   }
 
   console.log(
-    "Focused Integration Test passed: Chromium/WebKit 360x640 Controller interactions and suspend/review/resume.",
+    "Focused Integration Test passed: Chromium/WebKit 390x844 and 412x915 Controller interactions and suspend/review/resume.",
   );
 } catch (error) {
   console.error(error instanceof Error ? error.message : String(error));
@@ -104,12 +104,13 @@ try {
 
 async function completeSuspendReviewResume(page: Page) {
   page.setDefaultTimeout(5_000);
-  await page.setViewportSize({ width: 360, height: 640 });
+  await page.setViewportSize({ width: 390, height: 844 });
   await page.goto(`${origin}/event-control`);
   await page.getByLabel("Active Pitch Slot Control Grant QR").fill("disposable-grant");
   await page.getByRole("button", { name: "Open Event Game Controller" }).click();
   await page.getByText("Controller Device: game-browser-focused").waitFor();
   await assertControllerSurface(page, "initial");
+  await assertControllerHeaderGeometry(page, "initial");
   await page.getByRole("button", { name: "Start game clock" }).click();
   await page.getByRole("button", { name: "Adjust game clock by plus 10 seconds" }).click();
   await page.getByLabel("Set game clock (milliseconds)").fill("123000");
@@ -219,6 +220,22 @@ async function eventDepartureLifecycleEvidence(page: Page) {
 }
 
 async function assertControllerSurface(page: Page, label = "surface") {
+  const header = page.getByRole("region", { name: "Controller header" });
+  await header.waitFor();
+  const headerText = await header.innerText();
+  const normalizedHeaderText = headerText.toLowerCase();
+  assert(
+    normalizedHeaderText.includes("pitch 2 · qf-07"),
+    `${label} lost Event identity: ${headerText}`,
+  );
+  assert(
+    normalizedHeaderText.includes("championship"),
+    `${label} lost Game Designation: ${headerText}`,
+  );
+  assert(
+    !(await header.innerText()).includes("Controller connection"),
+    `${label} exposed healthy status`,
+  );
   const controls = await page.locator("button").evaluateAll((buttons) =>
     buttons
       .map((button) => ({
@@ -239,10 +256,11 @@ async function assertControllerSurface(page: Page, label = "surface") {
 }
 
 async function reviewAndResume(page: Page) {
-  await page.setViewportSize({ width: 360, height: 640 });
+  await page.setViewportSize({ width: 412, height: 915 });
   await page.goto(`${origin}/event-control`);
   await page.getByLabel("Active Pitch Slot Control Grant QR").fill("disposable-grant");
   await page.getByRole("button", { name: "Open Event Game Controller" }).click();
+  await assertControllerHeaderGeometry(page, "review");
   await page.locator('[data-suspension-snapshot="effective"]').waitFor();
   const snapshotText = await page.locator('[data-suspension-snapshot="effective"]').innerText();
   assert(snapshotText.includes("Volleyball: side-a"), "volleyball recovery was not shown");
@@ -257,6 +275,25 @@ async function reviewAndResume(page: Page) {
   };
   assert(resumed.projection?.suspension?.status === "none", "resume did not clear suspension");
   await assertNoDocumentScroll(page);
+}
+
+async function assertControllerHeaderGeometry(page: Page, stage: string) {
+  const qr = page.getByRole("button", { name: /Grant QR/u });
+  const leave = page.getByRole("button", { name: "Leave Event Game Controller session" });
+  const qrBox = await qr.boundingBox();
+  const leaveBox = await leave.boundingBox();
+  assert(
+    qrBox !== null && qrBox.width >= 44 && qrBox.height >= 44,
+    `${stage} QR target was too small`,
+  );
+  assert(
+    leaveBox !== null && leaveBox.width >= 44 && leaveBox.height >= 44,
+    `${stage} Leave target was too small`,
+  );
+  assert(
+    qrBox !== null && leaveBox !== null && Math.abs(qrBox.x + qrBox.width - leaveBox.x) >= 8,
+    `${stage} QR and Leave controls were directly adjacent`,
+  );
 }
 
 async function installControllerApi(context: BrowserContext) {
@@ -442,6 +479,7 @@ function createProjection(): ControllerProjection {
   baseline.authorityGeneration = 1;
   return {
     eventGameId: "game-browser-focused",
+    identity: { pitchName: "Pitch 2", gameCode: "QF-07", gameDesignation: "Championship" },
     phase: "in-progress",
     scoreByGameSide: { "side-a": 0, "side-b": 0 },
     goalCount: 0,
@@ -474,6 +512,20 @@ function createProjection(): ControllerProjection {
       provisionalElapsedMs: 0,
     },
     clock: projectClockBaseline(baseline, 0),
+    teamAssignments: [
+      {
+        gameSideId: "side-a",
+        eventTeamId: "team-a",
+        eventTeamName: "Basilisks",
+        teamInterpretationRef: "ref-a",
+      },
+      {
+        gameSideId: "side-b",
+        eventTeamId: "team-b",
+        eventTeamName: "Thunderbirds",
+        teamInterpretationRef: "ref-b",
+      },
+    ],
     presentation: {
       gameSideIds: ["side-a", "side-b"],
       pitchOrientation: "side-a-left",

--- a/src/components/controller-header.test.tsx
+++ b/src/components/controller-header.test.tsx
@@ -1,0 +1,164 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { Window } from "happy-dom";
+import { ControllerHeader } from "@/components/controller-header";
+import { eventControllerHeaderIdentity } from "@/lib/controller-header-identity";
+
+describe("shared Controller header", () => {
+  const originalWindow = globalThis.window;
+  const originalDocument = globalThis.document;
+  let testWindow: Window;
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    testWindow = new Window({ url: "http://timer.quadball.app/game/controller" });
+    Object.assign(globalThis, {
+      window: testWindow,
+      document: testWindow.document,
+      IS_REACT_ACT_ENVIRONMENT: true,
+    });
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+      await Promise.resolve();
+    });
+    container.remove();
+    testWindow.close();
+    Object.assign(globalThis, { window: originalWindow, document: originalDocument });
+  });
+
+  test("keeps healthy state quiet and wires compact accessible QR and Leave controls", async () => {
+    let qrClicks = 0;
+    let leaveClicks = 0;
+    await act(async () => {
+      root.render(
+        <ControllerHeader
+          identity={{ eyebrow: "Ad Hoc Game", title: "Basel Basilisks vs Thunderbirds" }}
+          warning={null}
+          qr={{
+            label: "Show Ad Hoc Control QR",
+            expanded: false,
+            controls: "qr-dialog",
+            onClick: () => {
+              qrClicks += 1;
+            },
+          }}
+          onLeave={() => {
+            leaveClicks += 1;
+          }}
+          leaveLabel="Leave Ad Hoc Game Controller"
+        />,
+      );
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain("Ad Hoc Game");
+    expect(container.textContent).toContain("Basel Basilisks vs Thunderbirds");
+    expect(container.textContent).not.toContain("Live");
+    const qr = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Show Ad Hoc Control QR"]',
+    );
+    expect(qr?.getAttribute("aria-expanded")).toBe("false");
+    expect(qr?.getAttribute("aria-controls")).toBe("qr-dialog");
+    expect(qr?.className).toContain("size-11");
+    qr?.click();
+    container
+      .querySelector<HTMLButtonElement>('button[aria-label="Leave Ad Hoc Game Controller"]')
+      ?.click();
+    expect(qrClicks).toBe(1);
+    expect(leaveClicks).toBe(1);
+  });
+
+  test("projects Offline without a zero queued-action clause", async () => {
+    await act(async () => {
+      root.render(
+        <ControllerHeader
+          identity={{ eyebrow: "Pitch 2 · QF-07", title: "Game Designation" }}
+          warning={{ kind: "offline", queuedActions: 0, retryDetail: "Reconnect to reconcile." }}
+        />,
+      );
+      await Promise.resolve();
+    });
+    const warning = container.querySelector("[data-controller-warning]");
+    expect(warning?.textContent).toBe("Offline. Reconnect to reconcile.");
+    expect(container.querySelectorAll("[data-controller-warning]")).toHaveLength(1);
+    expect(container.textContent).not.toContain("Connection is healthy");
+  });
+
+  test("projects one queued action in the concise Offline warning", async () => {
+    await act(async () => {
+      root.render(
+        <ControllerHeader
+          identity={{ eyebrow: "Pitch 2 · QF-07", title: "Game Designation" }}
+          warning={{ kind: "offline", queuedActions: 1 }}
+        />,
+      );
+      await Promise.resolve();
+    });
+
+    expect(container.querySelector("[data-controller-warning]")?.textContent).toBe(
+      "Offline · 1 queued action.",
+    );
+  });
+
+  test("projects many queued actions in the concise Offline warning", async () => {
+    await act(async () => {
+      root.render(
+        <ControllerHeader
+          identity={{ eyebrow: "Pitch 2 · QF-07", title: "Game Designation" }}
+          warning={{ kind: "offline", queuedActions: 2 }}
+        />,
+      );
+      await Promise.resolve();
+    });
+
+    expect(container.querySelector("[data-controller-warning]")?.textContent).toBe(
+      "Offline · 2 queued actions.",
+    );
+  });
+
+  test("projects stale connectivity without mislabeling it Offline", async () => {
+    await act(async () => {
+      root.render(
+        <ControllerHeader
+          identity={{ eyebrow: "Pitch 2 · QF-07", title: "Game Designation" }}
+          warning={{ kind: "stale", queuedActions: 0, retryDetail: "Reconnect to reconcile." }}
+        />,
+      );
+      await Promise.resolve();
+    });
+
+    expect(container.querySelector("[data-controller-warning]")?.textContent).toBe(
+      "Connection stale. Reconnect to reconcile.",
+    );
+    expect(container.textContent).not.toContain("Offline");
+  });
+
+  test("formats Event identity without empty separators and falls back to teams", () => {
+    expect(
+      eventControllerHeaderIdentity({
+        identity: { pitchName: "Pitch 2", gameCode: null, gameDesignation: "Final" },
+        teamAssignments: [
+          { eventTeamName: "Basilisks", gameSideId: "side-a" },
+          { eventTeamName: "Thunderbirds", gameSideId: "side-b" },
+        ],
+      }),
+    ).toEqual({ eyebrow: "Pitch 2", title: "Final" });
+    expect(
+      eventControllerHeaderIdentity({
+        identity: { pitchName: null, gameCode: "QF-07", gameDesignation: null },
+        teamAssignments: [
+          { eventTeamName: "Basilisks", gameSideId: "side-a" },
+          { eventTeamName: "Thunderbirds", gameSideId: "side-b" },
+        ],
+      }),
+    ).toEqual({ eyebrow: "QF-07", title: "Basilisks vs Thunderbirds" });
+  });
+});

--- a/src/components/controller-header.tsx
+++ b/src/components/controller-header.tsx
@@ -1,0 +1,119 @@
+import type { ReactNode } from "react";
+import type { RefObject } from "react";
+import { LogOut, QrCode, WifiOff } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+export type ControllerHeaderIdentity = {
+  eyebrow: string;
+  title: string;
+};
+
+type ControllerHeaderWarningBase = {
+  queuedActions: number;
+  retryDetail?: string;
+};
+
+export type ControllerHeaderWarning =
+  | (ControllerHeaderWarningBase & { kind: "offline" })
+  | (ControllerHeaderWarningBase & { kind: "stale" });
+
+export type ControllerHeaderQr = {
+  onClick: () => void;
+  expanded: boolean;
+  controls: string;
+  label: string;
+  disabled?: boolean;
+  triggerRef?: RefObject<HTMLButtonElement | null>;
+};
+
+export function ControllerHeader({
+  identity,
+  warning,
+  qr,
+  onLeave,
+  leaveTriggerRef,
+  leaveLabel = "Leave",
+  leaveDisabled = false,
+  children,
+}: {
+  identity: ControllerHeaderIdentity;
+  warning: ControllerHeaderWarning | null;
+  qr?: ControllerHeaderQr;
+  onLeave?: () => void;
+  leaveTriggerRef?: RefObject<HTMLButtonElement | null>;
+  leaveLabel?: string;
+  leaveDisabled?: boolean;
+  children?: ReactNode;
+}) {
+  return (
+    <section
+      aria-label="Controller header"
+      className={cn(
+        "rounded-2xl border bg-white px-3 py-2 shadow-[0_8px_18px_rgba(15,23,42,0.08)]",
+        warning === null ? "border-slate-300" : "border-amber-300",
+      )}
+    >
+      <div className="grid min-h-10 grid-cols-[minmax(0,1fr)_auto] items-center gap-3">
+        <div className="flex min-w-0 items-center gap-2">
+          {qr === undefined ? null : (
+            <Button
+              type="button"
+              variant="outline"
+              size="icon"
+              className="size-11 shrink-0 rounded-xl border-slate-300 bg-white text-slate-800 hover:bg-slate-100"
+              ref={qr.triggerRef}
+              aria-label={qr.label}
+              aria-expanded={qr.expanded}
+              aria-controls={qr.controls}
+              onClick={qr.onClick}
+              disabled={qr.disabled}
+            >
+              <QrCode className="size-4" aria-hidden="true" />
+            </Button>
+          )}
+          <div className="min-w-0">
+            <p className="truncate text-[10px] font-semibold tracking-[0.15em] text-slate-500 uppercase">
+              {identity.eyebrow}
+            </p>
+            <p className="truncate text-xs font-bold text-slate-950">{identity.title}</p>
+          </div>
+        </div>
+        {onLeave === undefined ? null : (
+          <Button
+            type="button"
+            ref={leaveTriggerRef}
+            variant="ghost"
+            size="sm"
+            className="h-11 shrink-0 px-2 text-[11px] font-semibold text-rose-700 hover:bg-rose-50 hover:text-rose-800"
+            aria-label={leaveLabel}
+            onClick={onLeave}
+            disabled={leaveDisabled}
+          >
+            <LogOut className="size-3.5" aria-hidden="true" />
+            Leave
+            <span className="sr-only"> Controller Session</span>
+          </Button>
+        )}
+      </div>
+      {warning === null ? null : (
+        <div
+          role="status"
+          aria-live="polite"
+          data-controller-warning="true"
+          className="mt-2 flex items-start gap-1.5 rounded-xl border border-amber-300 bg-amber-50 px-2 py-1.5 text-[10px] text-amber-950"
+        >
+          <WifiOff className="mt-0.5 size-3 shrink-0" aria-hidden="true" />
+          <span>
+            {warning.kind === "stale" ? "Connection stale" : "Offline"}
+            {warning.queuedActions > 0
+              ? ` · ${warning.queuedActions} queued action${warning.queuedActions === 1 ? "" : "s"}`
+              : ""}
+            .{warning.retryDetail === undefined ? null : ` ${warning.retryDetail}`}
+          </span>
+        </div>
+      )}
+      {children}
+    </section>
+  );
+}

--- a/src/lib/controller-header-identity.ts
+++ b/src/lib/controller-header-identity.ts
@@ -1,0 +1,26 @@
+export type EventControllerHeaderProjection = {
+  identity?: {
+    pitchName: string | null;
+    gameCode: string | null;
+    gameDesignation: string | null;
+  };
+  teamAssignments?: readonly { eventTeamName?: string; gameSideId: string }[];
+} | null;
+
+export function eventControllerHeaderIdentity(projection: EventControllerHeaderProjection) {
+  const pitch = projection?.identity?.pitchName?.trim() ?? "";
+  const gameCode = projection?.identity?.gameCode?.trim() ?? "";
+  const designation = projection?.identity?.gameDesignation?.trim() ?? "";
+  return {
+    eyebrow: [pitch, gameCode].filter((value) => value.length > 0).join(" · ") || "Event Game",
+    title:
+      designation.length > 0
+        ? designation
+        : `${eventTeamName(projection, 0)} vs ${eventTeamName(projection, 1)}`,
+  };
+}
+
+function eventTeamName(projection: EventControllerHeaderProjection, sideIndex: number): string {
+  const assignment = projection?.teamAssignments?.[sideIndex];
+  return assignment?.eventTeamName ?? `Game Side ${assignment?.gameSideId ?? sideIndex + 1}`;
+}

--- a/src/lib/controller-reconnect.test.ts
+++ b/src/lib/controller-reconnect.test.ts
@@ -503,6 +503,50 @@ describe("Controller reconnect replica", () => {
     );
   });
 
+  test("round-trips and strictly validates projected Event header identity", () => {
+    const state = createReplica();
+    state.authoritativeProjection.identity = {
+      pitchName: "Pitch 2",
+      gameCode: "QF-07",
+      gameDesignation: "Championship",
+    };
+    state.projection.identity = state.authoritativeProjection.identity;
+
+    const restored = parseControllerReplica(
+      JSON.parse(serializeControllerReplica(state)),
+      "game-1",
+    );
+    expect(restored.authoritativeProjection.identity).toEqual({
+      pitchName: "Pitch 2",
+      gameCode: "QF-07",
+      gameDesignation: "Championship",
+    });
+    expect(restored.projection.identity).toEqual(restored.authoritativeProjection.identity);
+
+    const missingField = JSON.parse(serializeControllerReplica(state)) as Record<string, any>;
+    delete missingField.projection.identity.gameCode;
+    expect(() => parseControllerReplica(missingField, "game-1")).toThrow(
+      "projection.identity.gameCode",
+    );
+    const invalidField = JSON.parse(serializeControllerReplica(state)) as Record<string, any>;
+    invalidField.projection.identity.gameCode = 7;
+    expect(() => parseControllerReplica(invalidField, "game-1")).toThrow(
+      "projection.identity.gameCode",
+    );
+
+    const absentIdentity = JSON.parse(serializeControllerReplica(state)) as Record<string, any>;
+    delete absentIdentity.projection.identity;
+    expect(() => parseControllerReplica(absentIdentity, "game-1")).toThrow(
+      "optimistic projection is inconsistent",
+    );
+
+    const differentIdentity = JSON.parse(serializeControllerReplica(state)) as Record<string, any>;
+    differentIdentity.projection.identity.pitchName = "Pitch 9";
+    expect(() => parseControllerReplica(differentIdentity, "game-1")).toThrow(
+      "optimistic projection is inconsistent",
+    );
+  });
+
   test("rejects malformed, duplicate, and unknown causal predecessors without weakening the action", () => {
     const state = createReplica();
     const candidate = goal("goal-a", "fact-a");

--- a/src/lib/controller-reconnect.ts
+++ b/src/lib/controller-reconnect.ts
@@ -26,8 +26,11 @@ import {
 } from "@/lib/live-event-game-control";
 import {
   SHARED_LIMITS,
+  validateGameCode,
+  validateGameDesignation,
   validateIntegerInRange,
   validateOpaqueIdentifier,
+  validateTeamOrPitchName,
 } from "@/lib/validation-policy";
 import {
   projectControllerReplayRetry,
@@ -1073,6 +1076,7 @@ function sameProjection(left: ControllerProjection, right: ControllerProjection)
   ]);
   return (
     left.eventGameId === right.eventGameId &&
+    sameProjectionIdentity(left.identity, right.identity) &&
     left.phase === right.phase &&
     left.goalCount === right.goalCount &&
     left.commencement.status === right.commencement.status &&
@@ -1087,6 +1091,18 @@ function sameProjection(left: ControllerProjection, right: ControllerProjection)
       ([side, score], index) =>
         rightScores[index]?.[0] === side && rightScores[index]?.[1] === score,
     )
+  );
+}
+
+function sameProjectionIdentity(
+  left: ControllerProjection["identity"],
+  right: ControllerProjection["identity"],
+): boolean {
+  if (left === undefined || right === undefined) return left === right;
+  return (
+    left.pitchName === right.pitchName &&
+    left.gameCode === right.gameCode &&
+    left.gameDesignation === right.gameDesignation
   );
 }
 
@@ -1176,6 +1192,7 @@ function parsePendingAction(
 function parseProjection(value: unknown): ControllerProjection {
   if (!isRecord(value)) throw new Error("Controller projection is invalid.");
   const eventGameId = requireIdentifier(value.eventGameId, "projection.eventGameId");
+  const identity = parseProjectionIdentity(value.identity);
   const phase = value.phase;
   if (
     phase !== "scheduled" &&
@@ -1241,6 +1258,7 @@ function parseProjection(value: unknown): ControllerProjection {
         );
   return {
     eventGameId,
+    ...(identity === undefined ? {} : { identity }),
     phase,
     scoreByGameSide: scores,
     goalCount: goalCount.value,
@@ -1265,6 +1283,39 @@ function parseProjection(value: unknown): ControllerProjection {
       provisionalElapsedMs: elapsed.value,
     },
   };
+}
+
+function parseProjectionIdentity(value: unknown): ControllerProjection["identity"] | undefined {
+  if (value === undefined) return undefined;
+  if (!isRecord(value)) throw new Error("Projection identity is invalid.");
+  return {
+    pitchName: parseNullableProjectionText(
+      value.pitchName,
+      "projection.identity.pitchName",
+      validateTeamOrPitchName,
+    ),
+    gameCode: parseNullableProjectionText(
+      value.gameCode,
+      "projection.identity.gameCode",
+      validateGameCode,
+    ),
+    gameDesignation: parseNullableProjectionText(
+      value.gameDesignation,
+      "projection.identity.gameDesignation",
+      validateGameDesignation,
+    ),
+  };
+}
+
+function parseNullableProjectionText(
+  value: unknown,
+  field: string,
+  validate: (value: unknown) => { ok: true; value: string } | { ok: false; error: string },
+): string | null {
+  if (value === null) return null;
+  const parsed = validate(value);
+  if (!parsed.ok) throw new Error(`${field}: ${parsed.error}`);
+  return parsed.value;
 }
 
 function parseBoolean(value: unknown, field: string): boolean {

--- a/src/lib/live-event-game-control.ts
+++ b/src/lib/live-event-game-control.ts
@@ -490,6 +490,11 @@ export type LiveEventGuardrailExplanation = {
 
 export type ControllerProjection = {
   eventGameId: string;
+  identity?: {
+    pitchName: string | null;
+    gameCode: string | null;
+    gameDesignation: string | null;
+  };
   phase: EventGameLifecyclePhase;
   scoreByGameSide: Readonly<Record<string, number>>;
   goalCount: number;
@@ -631,6 +636,9 @@ export type LiveEventGameControlOptions = {
     eventId: string,
     eventTeamId: string,
   ) => string | null | Promise<string | null>;
+  resolveEventGameIdentity?: (
+    root: EventGameRecordRoot,
+  ) => ControllerProjection["identity"] | null | Promise<ControllerProjection["identity"] | null>;
   /** Production composition seam backed by the Event Admin catalog snapshot. */
   readHeatStoppageConfiguration?: (
     scope: HeatStoppageConfigurationScope,
@@ -3256,6 +3264,7 @@ export function createLiveEventGameControl(options: LiveEventGameControlOptions)
         root.lifecycle.commencedAtMs === null ? latestRunningClockStart(derived.gameFacts) : null;
       const controllerProjection: ControllerProjection = {
         eventGameId: root.eventGameId,
+        identity: (await options.resolveEventGameIdentity?.(root)) ?? undefined,
         phase: derived.phase,
         scoreByGameSide: structuredClone(derived.scoreByGameSide),
         goalCount: derived.goalCount,

--- a/src/lib/live-event-game-runtime.ts
+++ b/src/lib/live-event-game-runtime.ts
@@ -293,6 +293,20 @@ export async function openLiveEventGameRuntime(input: {
           const team = transaction.findEventTeam(eventTeamId);
           return team?.eventId === eventId ? team.name : null;
         }),
+      resolveEventGameIdentity: async (root) =>
+        storage.transaction((transaction) => {
+          const game = transaction.findEventGame?.(root.eventGameId);
+          const pitchSlot = transaction.findPitchSlot?.(root.externalScope.pitchSlotId);
+          const pitch =
+            pitchSlot === null || pitchSlot === undefined
+              ? null
+              : transaction.findPitch?.(pitchSlot.pitchId);
+          return {
+            pitchName: pitch?.name ?? null,
+            gameCode: game?.gameCode ?? null,
+            gameDesignation: game?.gameDesignation ?? null,
+          };
+        }),
       acceptance,
       grantAuthority: authority,
       clock,

--- a/src/pages/event-game-controller-page.test.tsx
+++ b/src/pages/event-game-controller-page.test.tsx
@@ -1473,6 +1473,9 @@ describe("Event Game Controller reconnect browser seam", () => {
 
     expect(refreshCalls).toBe(0);
     expect(container.textContent).toContain("Controller Device: game-browser");
+    const restoredHeader = container.querySelector('[aria-label="Controller header"]');
+    expect(restoredHeader?.textContent).toContain("Pitch 2 · QF-07");
+    expect(restoredHeader?.textContent).toContain("Championship");
     Object.defineProperty(testWindow.navigator, "onLine", { configurable: true, value: true });
     await act(async () => {
       testWindow.dispatchEvent(new testWindow.Event("online"));
@@ -1884,26 +1887,33 @@ describe("Event Game Controller reconnect browser seam", () => {
   test("observes the literal 5,000 ms status boundary before foreground reconciliation", async () => {
     const probe = installControllerIntervalProbe();
     await enterAndOpen();
-    const status = container.querySelector<HTMLElement>("[data-controller-freshness]");
-    expect(status?.getAttribute("role")).toBe("status");
-    expect(status?.getAttribute("aria-live")).toBe("polite");
+    expect(container.querySelector("[data-controller-freshness]")).toBeNull();
     expect(CONTROLLER_STALE_DISCONNECTED_AFTER_MS).toBe(5_000);
     monotonicNow = 4_999;
     await act(async () => probe.tick());
-    expect(status?.textContent).toContain("fresh");
+    expect(container.querySelector("[data-controller-warning]")).toBeNull();
     monotonicNow = 5_000;
     await act(async () => probe.tick());
-    expect(status?.textContent).toContain("stale");
+    expect(container.querySelector("[data-controller-warning]")?.textContent).toContain(
+      "Connection stale",
+    );
+    expect(container.querySelector("[data-controller-warning]")?.textContent).not.toContain(
+      "Offline",
+    );
     monotonicNow = 5_001;
     await act(async () => probe.tick());
-    expect(status?.textContent).toContain("stale");
+    expect(container.querySelector("[data-controller-warning]")?.textContent).toContain(
+      "Connection stale",
+    );
     refreshMode = "deferred";
     await act(async () => {
       document.dispatchEvent(new testWindow.Event("visibilitychange") as unknown as Event);
       await Promise.resolve();
     });
     expect(refreshCalls).toBe(1);
-    expect(status?.textContent).toContain("stale");
+    expect(container.querySelector("[data-controller-warning]")?.textContent).toContain(
+      "Connection stale",
+    );
     const pendingRefresh = deferredRefresh;
     const pendingResponse = deferredRefreshResponse;
     expect(pendingRefresh).not.toBeNull();
@@ -1913,7 +1923,7 @@ describe("Event Game Controller reconnect browser seam", () => {
       await Promise.resolve();
       await Promise.resolve();
     });
-    expect(status?.textContent).toContain("fresh");
+    expect(container.querySelector("[data-controller-warning]")).toBeNull();
     await act(async () => {
       root.unmount();
       await Promise.resolve();
@@ -1934,10 +1944,12 @@ describe("Event Game Controller reconnect browser seam", () => {
     Object.defineProperty(testWindow.navigator, "onLine", { configurable: true, value: true });
     monotonicNow = 4_999;
     await act(async () => probe.tick());
-    expect(container.querySelector("[data-controller-freshness]")?.textContent).toContain("fresh");
+    expect(container.querySelector("[data-controller-warning]")).toBeNull();
     monotonicNow = 5_000;
     await act(async () => probe.tick());
-    expect(container.querySelector("[data-controller-freshness]")?.textContent).toContain("stale");
+    expect(container.querySelector("[data-controller-warning]")?.textContent).toContain(
+      "Connection stale",
+    );
     await act(async () => {
       root.unmount();
       await Promise.resolve();
@@ -2306,6 +2318,11 @@ function projection(
   if (defaultProjection) baseline.gameTimeMs = 12_000;
   return {
     eventGameId,
+    identity: {
+      pitchName: "Pitch 2",
+      gameCode: "QF-07",
+      gameDesignation: "Championship",
+    },
     phase: defaultProjection || options.commenced !== false ? "in-progress" : "scheduled",
     scoreByGameSide: defaultProjection
       ? { "side-a": 10, "side-b": 0 }

--- a/src/pages/event-game-controller-page.tsx
+++ b/src/pages/event-game-controller-page.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
+import { ControllerHeader } from "@/components/controller-header";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -68,6 +69,7 @@ import {
   readBrowserEventControllerSession,
   type PersistedEventControllerSession,
 } from "@/lib/event-controller-session";
+import { eventControllerHeaderIdentity } from "@/lib/controller-header-identity";
 
 type PersistedControllerSession = PersistedEventControllerSession;
 type ControllerOpenResponse = {
@@ -1853,20 +1855,38 @@ export function EventGameControllerPage() {
             </>
           ) : (
             <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain [&_button]:min-h-11">
-              <div className="rounded-lg border bg-muted/30 p-3 text-sm">
+              <ControllerHeader
+                identity={eventControllerHeaderIdentity(projection)}
+                warning={
+                  controllerConnectionStatus === "fresh"
+                    ? null
+                    : {
+                        queuedActions: replica?.pendingActions.length ?? 0,
+                        kind: controllerConnectionStatus === "stale" ? "stale" : "offline",
+                        retryDetail:
+                          controllerConnectionStatus === "stale"
+                            ? "Reconnect to reconcile."
+                            : "Reconnect to sync.",
+                      }
+                }
+                qr={{
+                  triggerRef: qrTriggerRef,
+                  label: revealedQr === null ? "Reveal active Grant QR" : "Show active Grant QR",
+                  expanded: qrDialogOpen,
+                  controls: "active-grant-qr-dialog",
+                  onClick: () => {
+                    if (revealedQr === null) void revealQr();
+                    else setQrDialogOpen(true);
+                  },
+                  disabled: busy,
+                }}
+                onLeave={() => setLeaveDialogOpen(true)}
+                leaveTriggerRef={leaveTriggerRef}
+                leaveLabel="Leave Event Game Controller session"
+                leaveDisabled={busy}
+              />
+              <div className="mt-2 rounded-lg border bg-muted/30 p-3 text-sm">
                 <p className="font-medium">Controller Device: {eventGameId}</p>
-                <p
-                  role="status"
-                  aria-live="polite"
-                  data-controller-freshness="true"
-                  className="mt-1 text-muted-foreground"
-                >
-                  {controllerConnectionStatus === "fresh"
-                    ? "Controller connection: fresh"
-                    : controllerConnectionStatus === "stale"
-                      ? "Controller connection: stale; reconnect to reconcile"
-                      : "Controller connection: disconnected; reconnect to reconcile"}
-                </p>
                 <p className="mt-1 text-muted-foreground">
                   {projection?.commencement.status === "commenced"
                     ? "Game Commencement is irreversible."
@@ -1878,37 +1898,12 @@ export function EventGameControllerPage() {
               </div>
               <div className="flex shrink-0 flex-wrap gap-2">
                 <Button
-                  ref={qrTriggerRef}
-                  variant="outline"
-                  aria-label={
-                    revealedQr === null ? "Reveal active Grant QR" : "Show active Grant QR"
-                  }
-                  aria-expanded={qrDialogOpen}
-                  aria-controls="active-grant-qr-dialog"
-                  onClick={() => {
-                    if (revealedQr === null) void revealQr();
-                    else setQrDialogOpen(true);
-                  }}
-                  disabled={busy}
-                >
-                  {revealedQr === null ? "Reveal active Grant QR" : "Show active Grant QR"}
-                </Button>
-                <Button
                   variant="outline"
                   aria-label="Refresh Event Game assignment"
                   onClick={() => void refreshController()}
                   disabled={busy}
                 >
                   Refresh assignment
-                </Button>
-                <Button
-                  variant="outline"
-                  aria-label="Leave Event Game Controller session"
-                  ref={leaveTriggerRef}
-                  onClick={() => setLeaveDialogOpen(true)}
-                  disabled={busy}
-                >
-                  Leave Controller Session
                 </Button>
               </div>
               {switchTarget === null ? null : (

--- a/src/pages/game-page.tsx
+++ b/src/pages/game-page.tsx
@@ -1,17 +1,25 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type RefObject,
+} from "react";
 import QRCode from "qrcode/lib/browser";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { CloudOff, Eye, OctagonX, Shield, TriangleAlert, UserX, Wifi, WifiOff } from "lucide-react";
+import { Eye, OctagonX, Shield, TriangleAlert, UserX } from "lucide-react";
 import { projectGameView } from "@/lib/game-engine";
 import type { CardType, ControllerRole, GameCommand, TeamId } from "@/lib/game-types";
 import { GameControllerActionPanels } from "@/components/game-controller-action-panels";
 import { ControllerTopSection, PenaltyColumnsSection } from "@/components/game-controller-sections";
+import { ControllerHeader } from "@/components/controller-header";
 import {
   FLAG_RELEASE_MS,
   FLAG_STATUS_HIDE_AFTER_MS,
   FLAG_STATUS_SHOW_FROM_MS,
-  LOCAL_ONLY_MESSAGE,
   ONE_MINUTE_MS,
   SEEKER_RELEASE_MS,
   SEEKER_STATUS_HIDE_AFTER_MS,
@@ -93,6 +101,7 @@ export function GamePage({ gameId, role }: { gameId: string; role: ControllerRol
     useState<PendingWinConfirmation | null>(null);
   const [leaveDialogOpen, setLeaveDialogOpen] = useState(false);
   const [leavePending, setLeavePending] = useState(false);
+  const [adHocQrOpen, setAdHocQrOpen] = useState(false);
   const [entryReady, setEntryReady] = useState(role !== "controller");
   const [entryError, setEntryError] = useState<string | null>(null);
   const [scorePulse, setScorePulse] = useState<{ home: -1 | 0 | 1; away: -1 | 0 | 1 }>({
@@ -115,6 +124,7 @@ export function GamePage({ gameId, role }: { gameId: string; role: ControllerRol
   const rightTeamNameButtonRef = useRef<HTMLButtonElement | null>(null);
   const [displayTeamNameHeightPx, setDisplayTeamNameHeightPx] = useState<number | null>(null);
   const leaveTriggerRef = useRef<HTMLButtonElement | null>(null);
+  const adHocQrTriggerRef = useRef<HTMLButtonElement | null>(null);
   const entryTriggerRef = useRef<HTMLButtonElement | null>(null);
   const entryStartedForRef = useRef<string | null>(null);
   const departureModule = getBrowserControllerDeparture();
@@ -139,6 +149,11 @@ export function GamePage({ gameId, role }: { gameId: string; role: ControllerRol
     role,
     blocked: departureBlocked || !entryReady,
   });
+  const controllerWarningRetryDetail = localOnlyMode
+    ? "Server does not know this game; retry when the server returns."
+    : error !== null && /busy|retry|reconnect|reach server/iu.test(error)
+      ? error
+      : undefined;
   const [leaveMessage, setLeaveMessage] = useState<string | null>(null);
   const entry = useControllerDepartureEntry({
     destination: { kind: "resume-ad-hoc", gameId },
@@ -881,87 +896,57 @@ export function GamePage({ gameId, role }: { gameId: string; role: ControllerRol
         />
       ) : null}
       <div className="mx-auto grid h-full w-full max-w-[460px] grid-rows-[auto_auto_minmax(0,1fr)_auto_auto] gap-2">
-        <section className="rounded-2xl border border-slate-300 bg-white px-3 py-2 shadow-[0_8px_18px_rgba(15,23,42,0.08)]">
-          <div className="flex items-start justify-between gap-2">
-            <div className="min-w-0">
-              <p className="truncate text-xs font-semibold tracking-wide text-slate-900">
-                {state.homeName} vs {state.awayName}
-              </p>
-              <p className="text-[10px] text-slate-500">{role}</p>
-            </div>
-            <div className="flex items-center gap-1.5">
-              {controller ? (
-                localOnlyMode ? (
-                  <span className="inline-flex items-center gap-1 rounded bg-amber-100 px-2 py-1 text-[10px] font-semibold text-amber-800">
-                    <CloudOff className="h-3 w-3" />
-                    Local
-                  </span>
-                ) : connectionState !== "online" ? (
-                  <span className="inline-flex items-center gap-1 rounded bg-amber-100 px-2 py-1 text-[10px] font-semibold text-amber-800">
-                    <WifiOff className="h-3 w-3" />
-                    Offline {pendingCommands}
-                  </span>
-                ) : (
-                  <span className="inline-flex items-center gap-1 rounded bg-emerald-100 px-2 py-1 text-[10px] font-semibold text-emerald-800">
-                    <Wifi className="h-3 w-3" />
-                    Live
-                  </span>
-                )
-              ) : (
-                <span className="inline-flex items-center gap-1 rounded bg-sky-100 px-2 py-1 text-[10px] font-semibold text-sky-800">
-                  <Eye className="h-3 w-3" />
-                  Read only
-                </span>
-              )}
-              <Button
-                variant="outline"
-                size="sm"
-                className="h-7 border-slate-300 bg-white px-2 text-[11px] text-slate-800 hover:bg-slate-100"
-                onClick={() => navigateTo("/")}
-              >
-                Games
-              </Button>
-              {controller ? (
-                <Button
-                  ref={leaveTriggerRef}
-                  variant="outline"
-                  size="sm"
-                  className="h-7 border-slate-300 bg-white px-2 text-[11px] text-slate-800 hover:bg-slate-100"
-                  onClick={() => setLeaveDialogOpen(true)}
-                >
-                  Leave
-                </Button>
-              ) : null}
-            </div>
-          </div>
+        <ControllerHeader
+          identity={{
+            eyebrow: "Ad Hoc Game",
+            title: `${state.homeName} vs ${state.awayName}`,
+          }}
+          warning={
+            controller && connectionState !== "online"
+              ? {
+                  kind: "offline",
+                  queuedActions: pendingCommands,
+                  retryDetail: controllerWarningRetryDetail,
+                }
+              : null
+          }
+          qr={
+            controller && controlQr !== null && !state.isFinished
+              ? {
+                  label: "Show Ad Hoc Control QR",
+                  expanded: adHocQrOpen,
+                  controls: "ad-hoc-control-qr-dialog",
+                  triggerRef: adHocQrTriggerRef,
+                  onClick: () => setAdHocQrOpen(true),
+                }
+              : undefined
+          }
+          onLeave={controller ? () => setLeaveDialogOpen(true) : undefined}
+          leaveTriggerRef={controller ? leaveTriggerRef : undefined}
+          leaveLabel="Leave Ad Hoc Game Controller"
+        >
           {leaveMessage ? (
             <p className="mt-1 text-[10px] font-medium text-rose-700">{leaveMessage}</p>
           ) : null}
-          {error !== null ? (
-            <p
-              className="mt-1 text-[10px] font-medium text-amber-700"
-              role="status"
-              aria-live="polite"
-            >
+          {!controller && error === null ? (
+            <p className="mt-1 inline-flex items-center gap-1 text-[10px] text-slate-500">
+              <Eye className="size-3" aria-hidden="true" /> Read only
+            </p>
+          ) : null}
+          {controller && error !== null && connectionState === "online" ? (
+            <p className="mt-1 text-[10px] font-medium text-amber-700" role="status">
               {error}
             </p>
           ) : null}
-          {controller ? (
-            localOnlyMode ? (
-              <p className="mt-1 text-[10px] font-medium text-amber-700">{LOCAL_ONLY_MESSAGE}</p>
-            ) : connectionState !== "online" ? (
-              <p className="mt-1 text-[10px] font-medium text-amber-700">
-                Offline mode active. {pendingCommands} local change(s) queued.
-              </p>
-            ) : null
-          ) : null}
-        </section>
+        </ControllerHeader>
 
         {controller ? (
           <AdHocControlHandoff
             gameId={gameId}
             controlQr={controlQr}
-            isFinished={state.isFinished}
+            qrOpen={adHocQrOpen}
+            triggerRef={adHocQrTriggerRef}
+            onClose={() => setAdHocQrOpen(false)}
           />
         ) : null}
 
@@ -1159,24 +1144,22 @@ export function GamePage({ gameId, role }: { gameId: string; role: ControllerRol
 function AdHocControlHandoff({
   gameId,
   controlQr,
-  isFinished,
+  qrOpen,
+  triggerRef,
+  onClose,
 }: {
   gameId: string;
   controlQr: string | null;
-  isFinished: boolean;
+  qrOpen: boolean;
+  triggerRef: RefObject<HTMLButtonElement | null>;
+  onClose: () => void;
 }) {
   const [qrDataUrl, setQrDataUrl] = useState<string | null>(null);
   const [qrError, setQrError] = useState(false);
-  const [qrOpen, setQrOpen] = useState(false);
   const dialogRef = useRef<HTMLDivElement | null>(null);
   const closeQrButtonRef = useRef<HTMLButtonElement | null>(null);
-  const showQrButtonRef = useRef<HTMLButtonElement | null>(null);
+  const dialogWasOpenRef = useRef(false);
   const payload = controlQr === null ? null : buildAdHocControlQrPayload(gameId, controlQr);
-
-  const closeQr = useCallback(() => {
-    setQrOpen(false);
-    window.setTimeout(() => showQrButtonRef.current?.focus(), 0);
-  }, []);
 
   useEffect(() => {
     if (!qrOpen) return;
@@ -1187,7 +1170,7 @@ function AdHocControlHandoff({
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
         event.preventDefault();
-        closeQr();
+        onClose();
         return;
       }
       if (event.key !== "Tab") return;
@@ -1213,7 +1196,17 @@ function AdHocControlHandoff({
 
     dialog.addEventListener("keydown", onKeyDown);
     return () => dialog.removeEventListener("keydown", onKeyDown);
-  }, [closeQr, qrOpen]);
+  }, [onClose, qrOpen]);
+
+  useEffect(() => {
+    if (qrOpen) {
+      dialogWasOpenRef.current = true;
+      return;
+    }
+    if (!dialogWasOpenRef.current) return;
+    dialogWasOpenRef.current = false;
+    window.setTimeout(() => triggerRef.current?.focus(), 0);
+  }, [qrOpen, triggerRef]);
 
   useEffect(() => {
     if (payload === null) {
@@ -1240,62 +1233,44 @@ function AdHocControlHandoff({
     };
   }, [payload]);
 
+  if (!qrOpen) return null;
   return (
-    <section
-      aria-label="Ad Hoc Controller handoff"
-      className="rounded-2xl border border-slate-300 bg-white p-3 shadow-[0_8px_18px_rgba(15,23,42,0.08)]"
+    <div
+      id="ad-hoc-control-qr-dialog"
+      aria-label="Ad Hoc Control QR dialog"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/50 p-4"
+      aria-modal="true"
+      ref={dialogRef}
+      role="dialog"
+      onClick={(event) => {
+        if (event.target === event.currentTarget) onClose();
+      }}
     >
-      <p className="text-xs font-semibold tracking-wide text-slate-900">Share Ad Hoc Control</p>
-      {isFinished ? (
-        <p className="mt-1 text-[11px] text-slate-600">
-          This Game is finished. Existing Controllers can still make Corrections; new admission is
-          paused.
-        </p>
-      ) : qrOpen ? (
-        <div
-          aria-label="Ad Hoc Control QR dialog"
-          className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/50 p-4"
-          aria-modal="true"
-          ref={dialogRef}
-          role="dialog"
-        >
-          <div className="w-full max-w-sm space-y-3 rounded-2xl bg-white p-4 shadow-xl">
-            <div className="flex items-center justify-between gap-2">
-              <p className="text-sm font-semibold text-slate-900">Ad Hoc Control QR</p>
-              <Button ref={closeQrButtonRef} size="sm" variant="outline" onClick={closeQr}>
-                Close Control QR
-              </Button>
-            </div>
-            {qrError ? (
-              <p className="text-[11px] text-rose-700">Unable to display the Control QR.</p>
-            ) : qrDataUrl !== null ? (
-              <>
-                <img
-                  alt="Ad Hoc Control QR code"
-                  className="mx-auto size-64 max-w-full rounded border border-slate-200"
-                  src={qrDataUrl}
-                />
-                <p className="text-center text-[11px] text-slate-600">
-                  Scan this QR on another device to join directly as an equal Controller.
-                </p>
-              </>
-            ) : (
-              <p className="text-[11px] text-slate-600">Preparing the reusable Control QR…</p>
-            )}
-          </div>
+      <div className="w-full max-w-sm space-y-3 rounded-2xl bg-white p-4 shadow-xl">
+        <div className="flex items-center justify-between gap-2">
+          <p className="text-sm font-semibold text-slate-900">Ad Hoc Control QR</p>
+          <Button ref={closeQrButtonRef} size="sm" variant="outline" onClick={onClose}>
+            Close Control QR
+          </Button>
         </div>
-      ) : (
-        <Button
-          ref={showQrButtonRef}
-          size="sm"
-          variant="outline"
-          className="mt-2"
-          onClick={() => setQrOpen(true)}
-        >
-          Show Ad Hoc Control QR
-        </Button>
-      )}
-    </section>
+        {qrError ? (
+          <p className="text-[11px] text-rose-700">Unable to display the Control QR.</p>
+        ) : qrDataUrl !== null ? (
+          <>
+            <img
+              alt="Ad Hoc Control QR code"
+              className="mx-auto size-64 max-w-full rounded border border-slate-200"
+              src={qrDataUrl}
+            />
+            <p className="text-center text-[11px] text-slate-600">
+              Scan this QR on another device to join directly as an equal Controller.
+            </p>
+          </>
+        ) : (
+          <p className="text-[11px] text-slate-600">Preparing the reusable Control QR…</p>
+        )}
+      </div>
+    </div>
   );
 }
 


### PR DESCRIPTION
## What

- add one shared compact Controller header for Ad Hoc and Event Games
- render identity-led Event and Ad Hoc context while keeping healthy connectivity quiet
- replace the permanent Ad Hoc sharing card with an accessible QR icon action separated from the quieter Leave control
- preserve exact Event header identity through retained offline Controller replicas
- add the shared mobile Controller focused journey for iPhone 13 Pro and representative Android portrait sizes

## Why

The Controller header was consuming too much vertical space and duplicated navigation and sharing controls. Both Controller experiences now use the selected compact composition while preserving QR authority, resumable departure, and offline recovery.

## User impact

Controllers get more room for the Game clock and score controls. Normal online play shows a compact identity header; concise warning detail appears only when connectivity is stale or offline. Ad Hoc and Event Games now behave consistently.

## Validation

- bun run check
- 73 targeted Controller reconnect, header, and Event page Fast Tests
- bun run build
- bun run test:focused:controller-header-mobile
- git diff --check origin/main...HEAD
- independent specification and standards reviews: clean

Stack continuation after merged #282.

Closes #270