### PR TITLE
Collapse Controller action panels

### DIFF
--- a/scripts/controller-action-sheet-browser-assertions.ts
+++ b/scripts/controller-action-sheet-browser-assertions.ts
@@ -1,0 +1,224 @@
+import type { Locator, Page } from "playwright";
+
+export async function assertControllerActionSheet(page: Page, stage: string) {
+  for (const viewport of [
+    { width: 390, height: 844 },
+    { width: 412, height: 915 },
+  ]) {
+    await page.setViewportSize(viewport);
+    const navigation = page.locator('[data-controller-action-navigation="true"]');
+    await navigation.waitFor();
+    assert(
+      (await page.locator('[data-controller-action-panel="true"]').count()) === 0,
+      `${stage} opened with an action panel selected at ${viewport.width}x${viewport.height}`,
+    );
+    const navigationBox = await navigation.boundingBox();
+    assert(navigationBox !== null, `${stage} action navigation was not laid out`);
+    assert(
+      navigationBox.y + navigationBox.height <= viewport.height + 1,
+      `${stage} action navigation crossed the safe viewport edge`,
+    );
+
+    const cards = page.getByRole("button", { name: "Cards", exact: true });
+    const timeout = page.getByRole("button", { name: "Timeout", exact: true });
+    const gameEnd = page.getByRole("button", { name: "Game end", exact: true });
+    if (
+      viewport.width === 390 &&
+      (await page.locator('button[aria-label="Start game"]').count()) > 0
+    ) {
+      await assertAdHocCompletionJourney(page, cards, timeout, stage);
+    }
+    await cards.click();
+    await assertOpenPanel(page, "Cards", cards, navigation, stage, viewport);
+    await cards.click();
+    assert(
+      (await page.locator('[data-controller-action-panel="true"]').count()) === 0,
+      `${stage} same-action close did not close Cards`,
+    );
+    assert(
+      (await page.evaluate(() => document.activeElement?.textContent?.trim())) === "Cards",
+      `${stage} closing Cards did not restore focus to its disclosure button`,
+    );
+    await timeout.click();
+    await assertOpenPanel(page, "Timeout", timeout, navigation, stage, viewport);
+    await gameEnd.click();
+    await assertOpenPanel(page, "Game end", gameEnd, navigation, stage, viewport);
+    await gameEnd.click();
+    assert(
+      (await page.locator('[data-controller-action-panel="true"]').count()) === 0,
+      `${stage} selected Game end action did not close`,
+    );
+    assert(
+      (await page.evaluate(() => document.activeElement?.textContent?.trim())) === "Game end",
+      `${stage} closing Game end did not restore focus to its disclosure button`,
+    );
+
+    const clock = page.locator(
+      'button[aria-label="Start game"], button[aria-label="Start game clock"], button[aria-label="Pause game"], button[aria-label="Pause game clock"]',
+    );
+    const scoreControls = page.locator('button[data-primary-score="up"]');
+    const scoreDownControls = page.locator('button[data-primary-score="down"]');
+    assert(
+      (await scoreControls.count()) >= 2,
+      `${stage} did not render both primary score controls`,
+    );
+    await cards.click();
+    const panel = page.locator('[data-controller-action-panel="true"]');
+    await panel.waitFor();
+    await assertPrimaryControlsDoNotIntersect(
+      panel,
+      navigation,
+      clock,
+      scoreControls,
+      scoreDownControls,
+      stage,
+      viewport,
+    );
+    if ((await clock.count()) > 0) {
+      await clock.first().click();
+      await page.locator('[data-controller-action-panel="true"]').waitFor();
+    }
+    for (let index = 0; index < (await scoreControls.count()); index += 1) {
+      await scoreControls.nth(index).click();
+      await page.locator('[data-controller-action-panel="true"]').waitFor();
+    }
+    for (let index = 0; index < (await scoreDownControls.count()); index += 1) {
+      await scoreDownControls.nth(index).click();
+      await page.locator('[data-controller-action-panel="true"]').waitFor();
+    }
+    assert(
+      (await page.locator('[data-controller-action-panel="true"]').count()) === 1,
+      `${stage} primary controls cleared the open action draft`,
+    );
+    if ((await clock.count()) > 0) {
+      const runningClock = page.locator(
+        'button[aria-label="Pause game"], button[aria-label="Pause game clock"]',
+      );
+      if ((await runningClock.count()) > 0) await runningClock.first().click();
+      await page.locator('[data-controller-action-panel="true"]').waitFor();
+    }
+    await cards.click();
+  }
+}
+
+async function assertAdHocCompletionJourney(
+  page: Page,
+  cards: Locator,
+  timeout: Locator,
+  stage: string,
+) {
+  await cards.click();
+  const panel = page.locator('[data-controller-action-panel="true"]');
+  const ok = panel.getByRole("button", { name: "OK", exact: true });
+  assert(
+    (await panel.getByRole("alert").count()) > 0,
+    `${stage} invalid Ad Hoc card was not retained`,
+  );
+  const blue = panel.getByRole("button", { name: "Blue", exact: true });
+  await blue.scrollIntoViewIfNeeded();
+  await blue.click();
+  const home = panel.getByRole("button", { name: "Home", exact: true });
+  await home.scrollIntoViewIfNeeded();
+  await home.click();
+  await ok.scrollIntoViewIfNeeded();
+  await ok.click();
+  assert(
+    (await page.locator('[data-controller-action-panel="true"]').count()) === 0,
+    `${stage} accepted Ad Hoc card did not close its panel`,
+  );
+  assert(
+    (await page.evaluate(() => document.activeElement?.textContent?.trim())) === "Cards",
+    `${stage} accepted Ad Hoc card did not restore Cards focus`,
+  );
+
+  await timeout.click();
+  const homeTimeout = page.getByRole("button", { name: "Home timeout", exact: true });
+  await homeTimeout.scrollIntoViewIfNeeded();
+  await homeTimeout.click();
+  assert(
+    (await page.locator('[data-controller-action-panel="true"]').count()) === 1,
+    `${stage} incomplete Ad Hoc timeout stoppage closed its panel`,
+  );
+  const startTimeout = page.getByRole("button", { name: "Start", exact: true });
+  await startTimeout.scrollIntoViewIfNeeded();
+  await startTimeout.click();
+  assert(
+    (await page.locator('[data-controller-action-panel="true"]').count()) === 0,
+    `${stage} accepted Ad Hoc timeout start did not close its panel`,
+  );
+  assert(
+    (await page.evaluate(() => document.activeElement?.textContent?.trim())) === "Timeout",
+    `${stage} accepted Ad Hoc timeout did not restore Timeout focus`,
+  );
+}
+
+async function assertOpenPanel(
+  page: Page,
+  label: string,
+  action: Locator,
+  navigation: Locator,
+  stage: string,
+  viewport: { width: number; height: number },
+) {
+  const panel = page.locator('[data-controller-action-panel="true"]');
+  await panel.waitFor();
+  assert(
+    (await action.getAttribute("aria-expanded")) === "true",
+    `${stage} ${label} action was not expanded`,
+  );
+  const panelBox = await panel.boundingBox();
+  const navigationBox = await navigation.boundingBox();
+  assert(panelBox !== null && navigationBox !== null, `${stage} ${label} panel was not laid out`);
+  assert(
+    panelBox.y + panelBox.height <= navigationBox.y + 1,
+    `${stage} ${label} panel overlapped navigation at ${viewport.width}x${viewport.height}`,
+  );
+}
+
+async function assertPrimaryControlsDoNotIntersect(
+  panel: Locator,
+  navigation: Locator,
+  clock: Locator,
+  scoreControls: Locator,
+  scoreDownControls: Locator,
+  stage: string,
+  viewport: { width: number; height: number },
+) {
+  const covered = [panel, navigation];
+  const controls = [
+    clock.first(),
+    scoreControls.nth(0),
+    scoreControls.nth(1),
+    scoreDownControls.nth(0),
+    scoreDownControls.nth(1),
+  ];
+  for (const [controlIndex, control] of controls.entries()) {
+    if ((await control.count()) === 0) continue;
+    const controlBox = await control.boundingBox();
+    assert(controlBox !== null, `${stage} primary control ${controlIndex} was not laid out`);
+    for (const [coveredIndex, coveredLocator] of covered.entries()) {
+      const coveredBox = await coveredLocator.boundingBox();
+      assert(coveredBox !== null, `${stage} covered region ${coveredIndex} was not laid out`);
+      assert(
+        !intersects(controlBox, coveredBox),
+        `${stage} primary control ${controlIndex} intersected region ${coveredIndex} at ${viewport.width}x${viewport.height}: control=${JSON.stringify(controlBox)} covered=${JSON.stringify(coveredBox)}`,
+      );
+    }
+  }
+}
+
+function intersects(
+  first: { x: number; y: number; width: number; height: number },
+  second: { x: number; y: number; width: number; height: number },
+) {
+  return !(
+    first.x + first.width <= second.x ||
+    second.x + second.width <= first.x ||
+    first.y + first.height <= second.y ||
+    second.y + second.height <= first.y
+  );
+}
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}

--- a/scripts/test-ad-hoc-browser.ts
+++ b/scripts/test-ad-hoc-browser.ts
@@ -10,6 +10,7 @@ import {
   openSqliteAdHocStore,
 } from "@/lib/ad-hoc-games";
 import { createGrantKeyRingDocument, writeGrantKeyRingFile } from "@/lib/grant-key-ring-custody";
+import { assertControllerActionSheet } from "./controller-action-sheet-browser-assertions";
 
 let directory = "";
 let certificatePath = "";
@@ -160,6 +161,15 @@ async function run() {
 
         const gameId = new URL(first.url()).pathname.split("/").at(-1);
         if (gameId === undefined) throw new Error("Game route did not contain a Game ID.");
+        const actionSheetContext = await browser!.newContext({ ignoreHTTPSErrors: true });
+        const actionSheetPage = await actionSheetContext.newPage();
+        actionSheetPage.setDefaultTimeout(15_000);
+        await actionSheetPage.goto(origin);
+        await actionSheetPage.getByRole("button", { name: /Start an Ad Hoc Game/ }).click();
+        await actionSheetPage.waitForURL(/\/game\/adhoc-/u);
+        await waitForHealthyControllerHeader(actionSheetPage);
+        await assertControllerActionSheet(actionSheetPage, "Ad Hoc initial Controller");
+        await actionSheetContext.close();
         for (let index = 0; index < 4; index += 1) {
           await first.goto(origin);
           await first.getByRole("button", { name: /Start an Ad Hoc Game/ }).click();
@@ -233,7 +243,8 @@ async function run() {
         await waitForGameRoute(second, gameId);
         await assertAccessibleQr(second, "second browser");
 
-        await second.getByRole("button", { name: "Start game" }).click();
+        const startGame = second.getByRole("button", { name: "Start game" });
+        if ((await startGame.count()) > 0) await startGame.click();
         await first.getByText("Running", { exact: true }).waitFor();
         await stopServer();
         await second.getByRole("button", { name: "Pause game" }).click();
@@ -243,7 +254,7 @@ async function run() {
         await waitForHealthyControllerHeader(second);
         await first.getByText("Running", { exact: true }).waitFor();
         await second.getByRole("button", { name: "Pause game" }).click();
-        await second.getByRole("button", { name: "Game end" }).click();
+        await second.getByRole("button", { name: "Game end", exact: true }).click();
         await second.getByRole("button", { name: "Double forfeit" }).click();
         await second.getByText("Finished", { exact: true }).waitFor();
         await first.waitForFunction(
@@ -251,6 +262,7 @@ async function run() {
             document.querySelector('button[aria-label="Show Ad Hoc Control QR"]') === null &&
             !document.body.textContent?.includes("Share Ad Hoc Control"),
         );
+        await second.getByRole("button", { name: "Game end", exact: true }).click();
         await second.getByRole("button", { name: "Correct back to unfinished" }).click();
         await waitForUnfinishedGame(second, gameId);
 
@@ -484,7 +496,7 @@ async function run() {
         await retryPage.goto(handoffUrl);
         await waitForGameRoute(retryPage, gameId);
         const busyWarning = retryPage.locator('[data-controller-warning="true"]');
-        await busyWarning.waitFor();
+        await busyWarning.filter({ hasText: /Ad Hoc connection busy/u }).waitFor();
         const busyWarningText = (await busyWarning.textContent()) ?? "";
         if (
           !busyWarningText.includes("Offline") ||

--- a/scripts/test-event-game-controller-browser.ts
+++ b/scripts/test-event-game-controller-browser.ts
@@ -1,12 +1,13 @@
 #!/usr/bin/env bun
 import { chromium, webkit, type BrowserContext, type Page } from "playwright";
-import { mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { createGrantKeyRingDocument, writeGrantKeyRingFile } from "@/lib/grant-key-ring-custody";
 import { createInitialClockBaseline, projectClockBaseline } from "@/lib/clock-authority";
 import type { ControllerProjection, LiveSuspensionSnapshot } from "@/lib/live-event-game-control";
 import type { LivePenaltyProjection } from "@/lib/live-event-penalties";
+import { assertControllerActionSheet } from "./controller-action-sheet-browser-assertions";
 
 const directory = mkdtempSync(join(tmpdir(), "quadball-timer-controller-browser-"));
 const certificatePath = join(directory, "localhost.crt");
@@ -34,75 +35,95 @@ let server: Bun.Subprocess | null = null;
 let browser: Awaited<ReturnType<typeof chromium.launch>> | null = null;
 let currentProjection = createProjection();
 let openCalls = 0;
+const lifecycleController = new AbortController();
+const lifecycleTimer = setTimeout(() => lifecycleController.abort(), 52_000);
+let primaryError: Error | null = null;
+let cleanupError: Error | null = null;
+let serverDiagnostics = "";
+
+lifecycleController.signal.addEventListener(
+  "abort",
+  () => {
+    void browser?.close().catch(() => undefined);
+  },
+  { once: true },
+);
 
 try {
-  const certificate = Bun.spawnSync([
-    "openssl",
-    "req",
-    "-x509",
-    "-newkey",
-    "rsa:2048",
-    "-nodes",
-    "-subj",
-    "/CN=localhost",
-    "-addext",
-    "subjectAltName=DNS:localhost",
-    "-days",
-    "1",
-    "-keyout",
-    keyPath,
-    "-out",
-    certificatePath,
-  ]);
-  if (certificate.exitCode !== 0)
-    throw new Error("openssl could not create a temporary certificate.");
-  writeGrantKeyRingFile(grantKeyRingPath, createGrantKeyRingDocument("test"));
-  server = Bun.spawn(["bun", "run", "src/index.ts"], {
-    cwd: process.cwd(),
-    env: environment,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  await waitForServer(`${origin}/internal/healthz`);
+  await raceWithDeadline(
+    (async () => {
+      const certificate = Bun.spawnSync([
+        "openssl",
+        "req",
+        "-x509",
+        "-newkey",
+        "rsa:2048",
+        "-nodes",
+        "-subj",
+        "/CN=localhost",
+        "-addext",
+        "subjectAltName=DNS:localhost",
+        "-days",
+        "1",
+        "-keyout",
+        keyPath,
+        "-out",
+        certificatePath,
+      ]);
+      if (certificate.exitCode !== 0)
+        throw new Error("openssl could not create a temporary certificate.");
+      writeGrantKeyRingFile(grantKeyRingPath, createGrantKeyRingDocument("test"));
+      server = Bun.spawn(["bun", "run", "src/index.ts"], {
+        cwd: process.cwd(),
+        env: environment,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      await waitForServer(`${origin}/internal/healthz`);
 
-  for (const browserType of [chromium, webkit]) {
-    currentProjection = createProjection();
-    browser = await browserType.launch({ headless: true });
-    const context = await browser.newContext({ ignoreHTTPSErrors: true });
-    await installControllerApi(context);
-    const controller = await context.newPage();
-    await completeSuspendReviewResume(controller);
-    await eventDepartureLifecycleEvidence(controller);
+      for (const browserType of [chromium, webkit]) {
+        assertLifecycleActive();
+        currentProjection = createProjection();
+        browser = await browserType.launch({ headless: true });
+        const context = await browser.newContext({ ignoreHTTPSErrors: true });
+        await installControllerApi(context);
+        const controller = await context.newPage();
+        await completeSuspendReviewResume(controller);
+        await eventDepartureLifecycleEvidence(controller);
 
-    const secondContext = await browser.newContext({ ignoreHTTPSErrors: true });
-    await installControllerApi(secondContext);
-    const reviewingController = await secondContext.newPage();
-    await reviewAndResume(reviewingController);
-    await browser.close();
-    browser = null;
-  }
+        const secondContext = await browser.newContext({ ignoreHTTPSErrors: true });
+        await installControllerApi(secondContext);
+        const reviewingController = await secondContext.newPage();
+        await reviewAndResume(reviewingController);
+        await browser.close();
+        browser = null;
+        assertLifecycleActive();
+      }
 
-  console.log(
-    "Focused Integration Test passed: Chromium/WebKit 390x844 and 412x915 Controller interactions and suspend/review/resume.",
+      console.log(
+        "Focused Integration Test passed: Chromium/WebKit 390x844 and 412x915 Controller interactions and suspend/review/resume.",
+      );
+    })(),
+    lifecycleController.signal,
   );
 } catch (error) {
-  console.error(error instanceof Error ? error.message : String(error));
-  if (server !== null) {
-    server.kill("SIGTERM");
-    const stderr = await new Response(server.stderr as unknown as BodyInit).text();
-    if (stderr.trim() !== "") console.error(stderr.slice(-2_000));
-  }
-  process.exitCode = 1;
+  primaryError = error instanceof Error ? error : new Error(String(error));
 } finally {
-  await browser?.close();
-  if (server !== null) {
-    server.kill("SIGTERM");
-    await server.exited;
-  }
-  rmSync(directory, { recursive: true, force: true });
+  clearTimeout(lifecycleTimer);
+  cleanupError = await cleanupEventLifecycle();
 }
 
+if (primaryError !== null) {
+  console.error(`Focused Integration primary failure: ${primaryError.message}`);
+  if (serverDiagnostics.trim() !== "") console.error(serverDiagnostics);
+}
+if (cleanupError !== null) {
+  console.error(`Focused Integration cleanup failure: ${cleanupError.message}`);
+}
+if (primaryError !== null || cleanupError !== null) process.exitCode = 1;
+
 async function completeSuspendReviewResume(page: Page) {
+  assertLifecycleActive();
   page.setDefaultTimeout(5_000);
   await page.setViewportSize({ width: 390, height: 844 });
   await page.goto(`${origin}/event-control`);
@@ -110,17 +131,29 @@ async function completeSuspendReviewResume(page: Page) {
   await page.getByRole("button", { name: "Open Event Game Controller" }).click();
   await page.getByText("Controller Device: game-browser-focused").waitFor();
   await assertControllerSurface(page, "initial");
+  await assertControllerActionSheet(page, "Event initial Controller");
   await assertControllerHeaderGeometry(page, "initial");
-  await page.getByRole("button", { name: "Start game clock" }).click();
+  const startClock = page.getByRole("button", { name: "Start game clock" });
+  if ((await startClock.count()) > 0) await startClock.click();
   await page.getByRole("button", { name: "Adjust game clock by plus 10 seconds" }).click();
   await page.getByLabel("Set game clock (milliseconds)").fill("123000");
   await page.getByRole("button", { name: "Correct Event Game clock" }).click();
+  await page.getByRole("button", { name: "Cards", exact: true }).click();
   await page.locator("#penalty-game-side").selectOption("side-a");
   await page
     .getByRole("button", { name: "Accept penalty card for the selected Game Side" })
     .click();
+  await page.getByRole("button", { name: "Timeout", exact: true }).click();
   await page.getByRole("button", { name: "Timeout stoppage: side-a" }).click();
-  await page.getByRole("button", { name: "Record 10-point goal for Game Side side-a" }).click();
+  await page.getByRole("button", { name: "Start timeout minute: side-a" }).click();
+  assert(
+    (await page.locator('[data-controller-action-panel="true"]').count()) === 0,
+    "Event timeout completion did not close the action sheet",
+  );
+  await page
+    .getByRole("button", { name: "Record 10-point goal for Game Side side-a" })
+    .first()
+    .click();
   await page.getByRole("button", { name: "Flip Event Game physical ends" }).click();
   await page.getByRole("button", { name: "Reveal active Grant QR" }).click();
   await page.getByRole("dialog", { name: "Active Grant QR" }).waitFor();
@@ -132,7 +165,21 @@ async function completeSuspendReviewResume(page: Page) {
       "Show active Grant QR",
     "QR outside-pointer dismissal did not return focus",
   );
-  await page.getByRole("button", { name: "Record final Event Game result" }).click();
+  await page.getByRole("button", { name: "Game end", exact: true }).click();
+  assert(
+    (await page.locator('[data-controller-action-panel="true"]').count()) === 1,
+    "Event Game end action did not open",
+  );
+  const gameEndPanel = page.locator('[data-controller-action-panel="true"]');
+  await gameEndPanel.evaluate((element) => {
+    element.scrollTop = element.scrollHeight;
+  });
+  const reviewResult = gameEndPanel.locator("button").filter({ hasText: "Review final result" });
+  await reviewResult.scrollIntoViewIfNeeded();
+  await reviewResult.click();
+  const confirmResult = gameEndPanel.locator("button").filter({ hasText: "Confirm game end" });
+  await confirmResult.scrollIntoViewIfNeeded();
+  await confirmResult.click();
   await page.getByRole("button", { name: "Review suspension recovery" }).click();
   await page.locator("#volleyball-possession").selectOption("side-a");
   await page.locator("#dodgeball-possession-ball-1").selectOption("side-b");
@@ -151,6 +198,7 @@ async function completeSuspendReviewResume(page: Page) {
 }
 
 async function eventDepartureLifecycleEvidence(page: Page) {
+  assertLifecycleActive();
   const initialOpenCalls = openCalls;
   await page.getByRole("button", { name: "Leave Event Game Controller session" }).click();
   await page.getByRole("button", { name: "Leave game" }).click();
@@ -256,6 +304,7 @@ async function assertControllerSurface(page: Page, label = "surface") {
 }
 
 async function reviewAndResume(page: Page) {
+  assertLifecycleActive();
   await page.setViewportSize({ width: 412, height: 915 });
   await page.goto(`${origin}/event-control`);
   await page.getByLabel("Active Pitch Slot Control Grant QR").fill("disposable-grant");
@@ -454,6 +503,33 @@ function applyIntent(intent: Record<string, unknown>) {
   if (intent.type === "substantive" && intent.trigger === "result") {
     currentProjection = { ...currentProjection, phase: "finished" };
   }
+  if (
+    intent.type === "substantive" &&
+    intent.trigger === "timeout" &&
+    typeof intent.timeoutGameSideId === "string" &&
+    (intent.timeoutAction === "stoppage" || intent.timeoutAction === "start")
+  ) {
+    currentProjection = {
+      ...currentProjection,
+      timeout:
+        intent.timeoutAction === "stoppage"
+          ? {
+              ...currentProjection.timeout,
+              factId: "fact-focused-timeout-stoppage",
+              status: "stoppage",
+              gameSideId: intent.timeoutGameSideId,
+              remainingMs: 60_000,
+            }
+          : {
+              ...currentProjection.timeout,
+              factId: "fact-focused-timeout-start",
+              status: "started",
+              gameSideId: intent.timeoutGameSideId,
+              startedAtMs: 0,
+              remainingMs: 60_000,
+            },
+    };
+  }
 }
 
 async function assertNoDocumentScroll(page: Page) {
@@ -470,6 +546,7 @@ async function assertNoDocumentScroll(page: Page) {
     metrics.scrollHeight <= metrics.clientHeight,
     `document overflowed the viewport (${JSON.stringify(metrics)})`,
   );
+  assertLifecycleActive();
 }
 
 function createProjection(): ControllerProjection {
@@ -542,6 +619,132 @@ async function waitForServer(url: string) {
     await Bun.sleep(50);
   }
   throw new Error("Focused browser server did not become ready.");
+}
+
+async function raceWithDeadline<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) throw new Error("Focused Integration lifecycle deadline exceeded.");
+  let rejectDeadline: (() => void) | null = null;
+  const deadline = new Promise<never>((_, reject) => {
+    const onAbort = () => reject(new Error("Focused Integration lifecycle deadline exceeded."));
+    rejectDeadline = onAbort;
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+  try {
+    return await Promise.race([promise, deadline]);
+  } finally {
+    if (rejectDeadline !== null) signal.removeEventListener("abort", rejectDeadline);
+  }
+}
+
+function assertLifecycleActive() {
+  if (lifecycleController.signal.aborted) {
+    throw new Error("Focused Integration work deadline exceeded.");
+  }
+}
+
+async function cleanupEventLifecycle(): Promise<Error | null> {
+  const failures: string[] = [];
+  const cleanupBrowser = browser as Awaited<ReturnType<typeof chromium.launch>> | null;
+  if (cleanupBrowser !== null) {
+    try {
+      await withTimeout(cleanupBrowser.close(), 1_500, "browser close");
+      browser = null;
+    } catch (error) {
+      failures.push(error instanceof Error ? error.message : String(error));
+    }
+  }
+
+  const cleanupServer = server as Bun.Subprocess | null;
+  if (cleanupServer !== null) {
+    try {
+      cleanupServer.kill("SIGTERM");
+      let exitCode = await waitForSubprocessExit(cleanupServer, 1_000);
+      if (exitCode === null) {
+        cleanupServer.kill("SIGKILL");
+        exitCode = await waitForSubprocessExit(cleanupServer, 1_000);
+      }
+      if (exitCode === null) throw new Error("server did not exit after TERM/KILL");
+      await withTimeout(cleanupServer.exited, 500, "server reap");
+      const stderr = cleanupServer.stderr;
+      serverDiagnostics = await readBoundedDiagnostics(
+        stderr !== undefined && typeof stderr !== "number" ? stderr : null,
+        4_000,
+        500,
+      );
+      server = null;
+    } catch (error) {
+      failures.push(error instanceof Error ? error.message : String(error));
+    }
+  }
+
+  if (failures.length > 0) {
+    return new Error(failures.join("; "));
+  }
+  try {
+    rmSync(directory, { recursive: true, force: true });
+    if (existsSync(directory)) throw new Error("temporary directory remained after cleanup");
+  } catch (error) {
+    return error instanceof Error ? error : new Error(String(error));
+  }
+  return null;
+}
+
+async function waitForSubprocessExit(child: Bun.Subprocess, timeoutMs: number) {
+  return await Promise.race([child.exited, Bun.sleep(timeoutMs).then(() => null)]);
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(`${label} exceeded ${timeoutMs} ms`)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
+async function readBoundedDiagnostics<T extends Uint8Array>(
+  stream: ReadableStream<T> | null,
+  limit: number,
+  timeoutMs: number,
+) {
+  if (stream === null) return "";
+  return await withTimeout(
+    (async () => {
+      const reader = stream.getReader();
+      const chunks: Uint8Array[] = [];
+      let length = 0;
+      try {
+        while (length < limit) {
+          const result = await reader.read();
+          if (result.done) break;
+          const remaining = limit - length;
+          const chunk = result.value.subarray(0, remaining);
+          chunks.push(chunk);
+          length += chunk.length;
+          if (chunk.length < result.value.length) break;
+        }
+      } finally {
+        reader.releaseLock();
+      }
+      const combined = new Uint8Array(length);
+      let offset = 0;
+      for (const chunk of chunks) {
+        combined.set(chunk, offset);
+        offset += chunk.length;
+      }
+      return new TextDecoder().decode(combined).trim();
+    })(),
+    timeoutMs,
+    "diagnostics read",
+  ).catch(
+    (error) =>
+      `[diagnostics unavailable: ${error instanceof Error ? error.message : String(error)}]`,
+  );
 }
 
 function assert(condition: boolean, message: string): asserts condition {

--- a/src/components/controller-action-sheet.tsx
+++ b/src/components/controller-action-sheet.tsx
@@ -1,0 +1,143 @@
+import { useEffect, useRef, type CSSProperties, type ReactNode } from "react";
+import { Clock3, Flag, Trophy } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  toggleControllerActionPanel,
+  type ControllerActionPanel,
+} from "@/lib/controller-action-sheet";
+
+type TabTheme = { activeStyle?: CSSProperties };
+
+export function ControllerActionSheet({
+  activePanel,
+  onPanelChange,
+  panel,
+  tabThemes,
+}: {
+  activePanel: ControllerActionPanel | null;
+  onPanelChange: (panel: ControllerActionPanel | null) => void;
+  panel: ReactNode;
+  tabThemes?: Partial<Record<ControllerActionPanel, TabTheme>>;
+}) {
+  const previousPanelRef = useRef<ControllerActionPanel | null>(null);
+  const actionButtonRefs = useRef<Partial<Record<ControllerActionPanel, HTMLButtonElement | null>>>(
+    {},
+  );
+
+  useEffect(() => {
+    const previousPanel = previousPanelRef.current;
+    previousPanelRef.current = activePanel;
+    if (previousPanel !== null && activePanel === null) {
+      actionButtonRefs.current[previousPanel]?.focus();
+    }
+  }, [activePanel]);
+
+  const select = (requestedPanel: ControllerActionPanel) => {
+    onPanelChange(toggleControllerActionPanel(activePanel, requestedPanel));
+  };
+
+  return (
+    <div
+      data-controller-action-sheet="true"
+      className="pointer-events-none absolute inset-x-0 bottom-0 z-20 flex flex-col gap-2"
+    >
+      {activePanel === null ? null : (
+        <section
+          id="controller-action-panel"
+          data-controller-action-panel="true"
+          role="region"
+          aria-label={`${panelLabel(activePanel)} actions`}
+          className="pointer-events-auto max-h-[min(15dvh,12rem)] overflow-y-auto overscroll-contain rounded-2xl border border-slate-300 bg-white/95 p-2 shadow-[0_12px_30px_rgba(15,23,42,0.2)] backdrop-blur-sm [&_button]:min-h-11"
+        >
+          {panel}
+        </section>
+      )}
+      <nav
+        data-controller-action-navigation="true"
+        aria-label="Controller actions"
+        className="pointer-events-auto rounded-2xl border border-slate-300 bg-white p-1 pb-[max(0.25rem,env(safe-area-inset-bottom))] shadow-[0_8px_20px_rgba(15,23,42,0.16)]"
+      >
+        <div className="grid grid-cols-3 gap-1">
+          <ActionTab
+            panel="card"
+            activePanel={activePanel}
+            theme={tabThemes?.card}
+            onSelect={select}
+            buttonRef={(button) => {
+              actionButtonRefs.current.card = button;
+            }}
+            icon={<Flag className="size-4" aria-hidden="true" />}
+          >
+            Cards
+          </ActionTab>
+          <ActionTab
+            panel="timeout"
+            activePanel={activePanel}
+            theme={tabThemes?.timeout}
+            onSelect={select}
+            buttonRef={(button) => {
+              actionButtonRefs.current.timeout = button;
+            }}
+            icon={<Clock3 className="size-4" aria-hidden="true" />}
+          >
+            Timeout
+          </ActionTab>
+          <ActionTab
+            panel="game"
+            activePanel={activePanel}
+            theme={tabThemes?.game}
+            onSelect={select}
+            buttonRef={(button) => {
+              actionButtonRefs.current.game = button;
+            }}
+            icon={<Trophy className="size-4" aria-hidden="true" />}
+          >
+            Game end
+          </ActionTab>
+        </div>
+      </nav>
+    </div>
+  );
+}
+
+function ActionTab({
+  panel,
+  activePanel,
+  theme,
+  onSelect,
+  buttonRef,
+  icon,
+  children,
+}: {
+  panel: ControllerActionPanel;
+  activePanel: ControllerActionPanel | null;
+  theme?: TabTheme;
+  onSelect: (panel: ControllerActionPanel) => void;
+  buttonRef: (button: HTMLButtonElement | null) => void;
+  icon: ReactNode;
+  children: ReactNode;
+}) {
+  const selected = activePanel === panel;
+  return (
+    <Button
+      type="button"
+      ref={buttonRef}
+      variant="ghost"
+      size="sm"
+      aria-expanded={selected}
+      aria-controls={selected ? "controller-action-panel" : undefined}
+      className={`h-11 min-h-11 gap-1 rounded-xl px-1 text-[11px] transition-all ${
+        selected ? "" : "bg-slate-100 text-slate-700"
+      }`}
+      style={selected ? theme?.activeStyle : undefined}
+      onClick={() => onSelect(panel)}
+    >
+      {icon}
+      {children}
+    </Button>
+  );
+}
+
+function panelLabel(panel: ControllerActionPanel) {
+  return panel === "card" ? "Cards" : panel === "timeout" ? "Timeout" : "Game end";
+}

--- a/src/components/game-controller-action-panels.test.tsx
+++ b/src/components/game-controller-action-panels.test.tsx
@@ -1,0 +1,259 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { act, useState } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { Window } from "happy-dom";
+import { GameControllerActionPanels } from "@/components/game-controller-action-panels";
+import { applyGameCommand, createInitialGameState } from "@/lib/game-engine";
+import type { CardType, GameCommand, TeamId } from "@/lib/game-types";
+
+describe("Ad Hoc Controller action UI", () => {
+  const originalWindow = globalThis.window;
+  const originalDocument = globalThis.document;
+  let testWindow: Window;
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    testWindow = new Window({ url: "http://timer.quadball.app/game/adhoc-ui" });
+    Object.assign(globalThis, {
+      window: testWindow,
+      document: testWindow.document,
+      IS_REACT_ACT_ENVIRONMENT: true,
+    });
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+      await Promise.resolve();
+    });
+    container.remove();
+    testWindow.close();
+    Object.assign(globalThis, { window: originalWindow, document: originalDocument });
+  });
+
+  test("covers Ad Hoc validation, draft reset, local completion, timeout sequencing, focus, and core coexistence", async () => {
+    await act(async () => {
+      root.render(<AdHocActionHarness />);
+      await Promise.resolve();
+    });
+
+    const cards = actionButton("Cards");
+    const timeout = actionButton("Timeout");
+    const gameEnd = actionButton("Game end");
+    expect(container.querySelector('[data-controller-action-panel="true"]')).toBeNull();
+    expect(document.activeElement).not.toBe(cards);
+
+    await click(cards);
+    expect(container.querySelector('[data-controller-action-panel="true"]')).not.toBeNull();
+    expect(container.querySelector('[role="alert"]')).not.toBeNull();
+    await click(actionButton("Timeout"));
+    await click(cards);
+    expect(container.querySelector('[role="alert"]')).not.toBeNull();
+    expect(container.textContent).toContain("Remaining on add: --");
+
+    await click(cards);
+    await click(cards);
+    await click(panelButton("Blue"));
+    await click(panelButton("Home"));
+    await click(panelButton("OK"));
+    expect(container.querySelector('[data-controller-action-panel="true"]')).toBeNull();
+    expect(document.activeElement).toBe(cards);
+
+    await click(timeout);
+    await click(panelButton("Home timeout"));
+    expect(container.querySelector('[data-controller-action-panel="true"]')).not.toBeNull();
+    expect(document.activeElement).not.toBe(timeout);
+    await click(panelButton("Start"));
+    expect(container.querySelector('[data-controller-action-panel="true"]')).toBeNull();
+    expect(document.activeElement).toBe(timeout);
+
+    await click(gameEnd);
+    await click(panelButton("Home forfeit"));
+    await click(panelButton("Confirm"));
+    expect(container.querySelector('[data-controller-action-panel="true"]')).toBeNull();
+    expect(document.activeElement).toBe(gameEnd);
+
+    await click(cards);
+    await click(panelButton("Blue"));
+    await click(container.querySelector<HTMLButtonElement>('button[aria-label="Play/pause game"]'));
+    await click(
+      container.querySelector<HTMLButtonElement>('button[aria-label="Increase Home score"]'),
+    );
+    await click(
+      container.querySelector<HTMLButtonElement>('button[aria-label="Decrease Home score"]'),
+    );
+    expect(container.querySelector('[data-controller-action-panel="true"]')).not.toBeNull();
+    expect(container.textContent).toContain("blue");
+  });
+
+  function actionButton(label: string) {
+    const button = Array.from(container.getElementsByTagName("button")).find(
+      (candidate) => candidate.textContent?.trim() === label,
+    );
+    if (button === undefined) throw new Error(`Missing action button: ${label}`);
+    return button;
+  }
+
+  function panelButton(label: string) {
+    const panel = container.querySelector('[data-controller-action-panel="true"]');
+    if (panel === null) throw new Error(`Missing action panel for: ${label}`);
+    const button = Array.from(panel.getElementsByTagName("button")).find(
+      (candidate) => candidate.textContent?.trim() === label,
+    );
+    if (button === undefined) throw new Error(`Missing panel button: ${label}`);
+    return button;
+  }
+
+  async function click(button: HTMLButtonElement | null) {
+    if (button === null) throw new Error("Expected a button to click.");
+    await act(async () => {
+      button.click();
+      await Promise.resolve();
+    });
+  }
+});
+
+function AdHocActionHarness() {
+  const [activePanel, setActivePanel] = useState<"card" | "timeout" | "game" | null>(null);
+  const [state, setState] = useState(() => createInitialGameState({ id: "adhoc-ui", nowMs: 0 }));
+  const [cardDraft, setCardDraft] = useState({
+    cardType: null as CardType | null,
+    team: null as TeamId | null,
+    digits: "",
+    startedGameClockMs: null as number | null,
+  });
+  const [pendingWinConfirmation, setPendingWinConfirmation] = useState<{ label: string } | null>(
+    null,
+  );
+
+  const dispatch = (command: GameCommand) => {
+    setState((current) =>
+      applyGameCommand({ state: current, command, nowMs: 1_000, idGenerator: () => "ui-action" }),
+    );
+  };
+  const resetDraft = () =>
+    setCardDraft({ cardType: null, team: null, digits: "", startedGameClockMs: null });
+
+  return (
+    <>
+      <button aria-label="Play/pause game" onClick={() => undefined}>
+        Play/pause
+      </button>
+      <button
+        aria-label="Increase Home score"
+        onClick={() => dispatch({ type: "change-score", team: "home", delta: 10, reason: "goal" })}
+      >
+        Home +10
+      </button>
+      <button
+        aria-label="Decrease Home score"
+        onClick={() => dispatch({ type: "undo-last-score", team: "home" })}
+      >
+        Home −10
+      </button>
+      <GameControllerActionPanels
+        activePanel={activePanel}
+        setActivePanel={(panel) => {
+          resetDraft();
+          setPendingWinConfirmation(null);
+          setActivePanel(panel);
+        }}
+        controller
+        state={state}
+        gameView={{ timeoutFinalCountdown: false, timeoutWarningActive: false }}
+        displayTeamOrder={["home", "away"]}
+        displayTeamName={(team) => (team === "home" ? "Home" : "Away")}
+        tabThemes={{
+          card: { activeStyle: {} },
+          timeout: { activeStyle: {} },
+          game: { activeStyle: {} },
+        }}
+        cardTypeOptions={[
+          { type: "blue", label: "Blue", icon: EmptyIcon, activeClassName: "", idleClassName: "" },
+          {
+            type: "yellow",
+            label: "Yellow",
+            icon: EmptyIcon,
+            activeClassName: "",
+            idleClassName: "",
+          },
+          { type: "red", label: "Red", icon: EmptyIcon, activeClassName: "", idleClassName: "" },
+          {
+            type: "ejection",
+            label: "Ejection",
+            icon: EmptyIcon,
+            activeClassName: "",
+            idleClassName: "",
+          },
+        ]}
+        cardDraft={cardDraft}
+        setCardDraft={setCardDraft}
+        canSelectCardType
+        canSelectCardTeam={cardDraft.cardType !== null}
+        cardPlayerLabel="no player"
+        cardEntryStarted={cardDraft.cardType !== null}
+        cardAddStatusText={
+          cardDraft.cardType === null || cardDraft.team === null ? "Remaining on add: --" : "Ready"
+        }
+        canEditCardDigits={cardDraft.cardType !== null && cardDraft.team !== null}
+        appendCardDigit={(digit) =>
+          setCardDraft((current) => ({ ...current, digits: current.digits + digit }))
+        }
+        canSubmitCard={cardDraft.cardType !== null && cardDraft.team !== null}
+        submitCard={() => {
+          dispatch({
+            type: "add-card",
+            team: cardDraft.team ?? "home",
+            cardType: cardDraft.cardType ?? "blue",
+            playerNumber: null,
+            startedGameClockMs: 0,
+          });
+          resetDraft();
+          setActivePanel(null);
+        }}
+        activeTimeout={state.timeouts.active}
+        formatRemaining={(ms) => `${ms}ms`}
+        pendingWinConfirmation={pendingWinConfirmation}
+        confirmWinAction={() => {
+          setPendingWinConfirmation(null);
+          setActivePanel(null);
+        }}
+        clearPendingWinConfirmation={() => setPendingWinConfirmation(null)}
+        finishSummary={null}
+        canResumeGame={false}
+        canSuspendGame={false}
+        canUseEndingActions
+        canRecordFlagCatch={false}
+        startTimeout={(team) => dispatch({ type: "start-timeout", team })}
+        setTimeoutRunning={(running) => {
+          dispatch({ type: "set-timeout-running", running });
+          setActivePanel(null);
+        }}
+        undoTimeoutStart={() => {
+          dispatch({ type: "undo-timeout-start" });
+          setActivePanel(null);
+        }}
+        cancelTimeout={() => {
+          dispatch({ type: "cancel-timeout" });
+          setActivePanel(null);
+        }}
+        resumeGame={() => undefined}
+        suspendGame={() => undefined}
+        requestForfeitWin={() => setPendingWinConfirmation({ label: "Home wins by forfeit" })}
+        recordDoubleForfeit={() => setActivePanel(null)}
+        correctBackToUnfinished={() => undefined}
+        requestTargetScoreWin={() => undefined}
+        requestConcedeWin={() => undefined}
+        recordOrConfirmFlagCatch={() => undefined}
+      />
+    </>
+  );
+}
+
+function EmptyIcon({ className }: { className?: string }) {
+  return <span className={className} aria-hidden="true" />;
+}

--- a/src/components/game-controller-action-panels.tsx
+++ b/src/components/game-controller-action-panels.tsx
@@ -1,10 +1,12 @@
 import type { CSSProperties, ComponentType, Dispatch, SetStateAction } from "react";
-import { Check, Clock3, Delete, Flag, Trophy } from "lucide-react";
+import { Check, Delete } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import { ControllerActionSheet } from "@/components/controller-action-sheet";
+import type { ControllerActionPanel } from "@/lib/controller-action-sheet";
 import type { CardType, GameState, TeamId } from "@/lib/game-types";
 
-type ActivePanel = "card" | "timeout" | "game";
+type ActivePanel = ControllerActionPanel | null;
 
 type CardDraft = {
   cardType: CardType | null;
@@ -124,419 +126,388 @@ export function GameControllerActionPanels({
   recordOrConfirmFlagCatch: (team: TeamId) => void;
 }) {
   return (
-    <>
-      <Card className="relative min-h-0 overflow-hidden rounded-[1.5rem] border border-slate-300 bg-white py-1 shadow-[0_12px_26px_rgba(15,23,42,0.1)]">
-        <CardContent className="overflow-hidden px-2">
-          <div
-            className={`flex min-h-0 flex-col gap-1.5 rounded-2xl border border-slate-200 bg-slate-50 p-2 ${
-              activePanel === "card" ? "animate-in fade-in-0 slide-in-from-bottom-2" : "hidden"
-            }`}
-          >
-            <div className="grid grid-cols-2 gap-1">
-              {cardTypeOptions.map((option) => {
-                const Icon = option.icon;
-                const active = cardDraft.cardType === option.type;
+    <ControllerActionSheet
+      activePanel={activePanel}
+      onPanelChange={setActivePanel}
+      tabThemes={tabThemes}
+      panel={
+        <Card className="relative min-h-0 overflow-hidden rounded-[1.5rem] border-0 bg-transparent py-0 shadow-none">
+          <CardContent className="overflow-hidden px-2">
+            <div
+              className={`flex min-h-0 flex-col gap-1.5 rounded-2xl border border-slate-200 bg-slate-50 p-2 ${
+                activePanel === "card" ? "animate-in fade-in-0 slide-in-from-bottom-2" : "hidden"
+              }`}
+            >
+              <div className="grid grid-cols-2 gap-1">
+                {cardTypeOptions.map((option) => {
+                  const Icon = option.icon;
+                  const active = cardDraft.cardType === option.type;
 
-                return (
-                  <Button
-                    key={option.type}
-                    size="sm"
-                    variant="outline"
-                    className={`h-7 justify-start gap-1.5 rounded-xl px-2 text-[10px] ${
-                      active ? option.activeClassName : option.idleClassName
-                    }`}
-                    onClick={() =>
-                      setCardDraft((previous) => ({
-                        ...previous,
-                        cardType: option.type,
-                        startedGameClockMs:
-                          previous.startedGameClockMs === null
-                            ? state.gameClockMs
-                            : previous.startedGameClockMs,
-                      }))
-                    }
-                    disabled={!canSelectCardType}
-                  >
-                    <Icon className="h-3.5 w-3.5" />
-                    {option.label}
-                  </Button>
-                );
-              })}
-            </div>
-            <div className="grid grid-cols-2 gap-1">
-              {displayTeamOrder.map((team) => (
-                <Button
-                  key={team}
-                  size="sm"
-                  variant={cardDraft.team === team ? "default" : "outline"}
-                  className="h-7 rounded-xl text-[10px]"
-                  onClick={() =>
-                    setCardDraft((previous) => ({
-                      ...previous,
-                      team,
-                    }))
-                  }
-                  disabled={!canSelectCardTeam}
-                >
-                  {displayTeamName(team)}
-                </Button>
-              ))}
-            </div>
-            <div className="grid grid-cols-[auto_1fr_auto] items-center gap-2 rounded-xl border border-slate-300 bg-white px-2 py-1 text-[10px] font-medium">
-              {cardDraft.cardType === null ? (
-                <span className="text-slate-500">Card?</span>
-              ) : (
-                <>
-                  <span className="uppercase">{cardDraft.cardType}</span>
-                  <span className="truncate text-slate-600">
-                    {cardDraft.team === null
-                      ? "team?"
-                      : cardDraft.team === "home"
-                        ? state.homeName
-                        : state.awayName}{" "}
-                    • {cardPlayerLabel}
-                  </span>
-                </>
-              )}
-              <Button
-                size="sm"
-                variant="ghost"
-                className="h-5 px-1.5 text-[10px] text-slate-700"
-                onClick={() =>
-                  setCardDraft({
-                    cardType: null,
-                    team: null,
-                    digits: "",
-                    startedGameClockMs: null,
-                  })
-                }
-                disabled={!controller || !cardEntryStarted}
-              >
-                Reset
-              </Button>
-            </div>
-            <p className="h-4 text-[10px] text-slate-600">{cardAddStatusText}</p>
-            <div className="grid grid-cols-3 gap-1">
-              {["1", "2", "3", "4", "5", "6", "7", "8", "9"].map((digit) => (
-                <Button
-                  key={digit}
-                  size="sm"
-                  variant="outline"
-                  className="h-7 rounded-xl border-slate-300 bg-white text-sm text-slate-900"
-                  onClick={() => appendCardDigit(digit)}
-                  disabled={!canEditCardDigits}
-                >
-                  {digit}
-                </Button>
-              ))}
-              <Button
-                size="sm"
-                variant="outline"
-                className="h-7 rounded-xl border-slate-300 bg-white text-slate-900"
-                onClick={() =>
-                  setCardDraft((previous) => ({
-                    ...previous,
-                    digits: previous.digits.slice(0, -1),
-                  }))
-                }
-                disabled={!canEditCardDigits || cardDraft.digits.length === 0}
-              >
-                <Delete className="h-4 w-4" />
-              </Button>
-              <Button
-                size="sm"
-                variant="outline"
-                className="h-7 rounded-xl border-slate-300 bg-white text-sm text-slate-900"
-                onClick={() => appendCardDigit("0")}
-                disabled={!canEditCardDigits}
-              >
-                0
-              </Button>
-              <Button
-                size="sm"
-                className="h-7 gap-1 rounded-xl bg-emerald-600 text-white hover:bg-emerald-500"
-                onClick={submitCard}
-                disabled={!canSubmitCard}
-              >
-                <Check className="h-4 w-4" />
-                OK
-              </Button>
-            </div>
-          </div>
-
-          <div
-            className={`flex min-h-0 flex-col gap-1.5 rounded-2xl border border-slate-200 bg-slate-50 p-2 ${
-              activePanel === "timeout" ? "animate-in fade-in-0 slide-in-from-bottom-2" : "hidden"
-            }`}
-          >
-            {activeTimeout === null ? (
-              <div className="grid gap-1">
+                  return (
+                    <Button
+                      key={option.type}
+                      size="sm"
+                      variant="outline"
+                      className={`h-7 justify-start gap-1.5 rounded-xl px-2 text-[10px] ${
+                        active ? option.activeClassName : option.idleClassName
+                      }`}
+                      onClick={() =>
+                        setCardDraft((previous) => ({
+                          ...previous,
+                          cardType: option.type,
+                          startedGameClockMs:
+                            previous.startedGameClockMs === null
+                              ? state.gameClockMs
+                              : previous.startedGameClockMs,
+                        }))
+                      }
+                      disabled={!canSelectCardType}
+                    >
+                      <Icon className="h-3.5 w-3.5" />
+                      {option.label}
+                    </Button>
+                  );
+                })}
+              </div>
+              <div className="grid grid-cols-2 gap-1">
                 {displayTeamOrder.map((team) => (
                   <Button
                     key={team}
-                    variant="outline"
                     size="sm"
-                    className="h-9 rounded-xl border-slate-300 bg-white text-slate-900"
-                    onClick={() => startTimeout(team)}
-                    disabled={
-                      !controller ||
-                      state.isRunning ||
-                      state.isSuspended ||
-                      state.timeouts[team].used ||
-                      state.isFinished
+                    variant={cardDraft.team === team ? "default" : "outline"}
+                    className="h-7 rounded-xl text-[10px]"
+                    onClick={() =>
+                      setCardDraft((previous) => ({
+                        ...previous,
+                        team,
+                      }))
                     }
+                    disabled={!canSelectCardTeam}
                   >
-                    {displayTeamName(team)} timeout
+                    {displayTeamName(team)}
                   </Button>
                 ))}
               </div>
-            ) : (
-              <>
-                <p
-                  className={`text-center text-3xl font-semibold tabular-nums ${
-                    gameView.timeoutFinalCountdown
-                      ? "text-red-700"
-                      : gameView.timeoutWarningActive
-                        ? "text-red-600"
-                        : "text-slate-900"
-                  }`}
-                >
-                  {formatRemaining(activeTimeout.remainingMs)}
-                </p>
-                {!activeTimeout.running ? (
-                  <div className="grid grid-cols-2 gap-1">
-                    <Button
-                      size="sm"
-                      className="h-9 rounded-xl bg-emerald-600 text-white hover:bg-emerald-500"
-                      onClick={() => setTimeoutRunning(true)}
-                      disabled={!controller}
-                    >
-                      Start
-                    </Button>
-                    <Button
-                      size="sm"
-                      variant="outline"
-                      className="h-9 rounded-xl border-slate-300 bg-white text-slate-900"
-                      onClick={undoTimeoutStart}
-                      disabled={!controller}
-                    >
-                      Undo
-                    </Button>
-                  </div>
+              <div className="grid grid-cols-[auto_1fr_auto] items-center gap-2 rounded-xl border border-slate-300 bg-white px-2 py-1 text-[10px] font-medium">
+                {cardDraft.cardType === null ? (
+                  <span className="text-slate-500">Card?</span>
                 ) : (
-                  <div className="grid grid-cols-2 gap-1">
-                    <Button
-                      size="sm"
-                      variant="outline"
-                      className="h-9 rounded-xl border-slate-300 bg-white text-slate-900"
-                      onClick={cancelTimeout}
-                      disabled={!controller}
-                    >
-                      End early
-                    </Button>
-                    <Button
-                      size="sm"
-                      variant="outline"
-                      className="h-9 rounded-xl border-slate-300 bg-white text-slate-900"
-                      onClick={undoTimeoutStart}
-                      disabled={!controller}
-                    >
-                      Undo
-                    </Button>
-                  </div>
+                  <>
+                    <span className="uppercase">{cardDraft.cardType}</span>
+                    <span className="truncate text-slate-600">
+                      {cardDraft.team === null
+                        ? "team?"
+                        : cardDraft.team === "home"
+                          ? state.homeName
+                          : state.awayName}{" "}
+                      • {cardPlayerLabel}
+                    </span>
+                  </>
                 )}
-              </>
-            )}
-          </div>
-
-          <div
-            className={`flex min-h-0 flex-col gap-1.5 rounded-2xl border border-slate-200 bg-slate-50 p-2 ${
-              activePanel === "game" ? "animate-in fade-in-0 slide-in-from-bottom-2" : "hidden"
-            }`}
-          >
-            {pendingWinConfirmation !== null ? (
-              <div className="mb-1 rounded-xl border border-amber-300 bg-amber-100 p-2 text-[10px] text-amber-900">
-                <p className="font-semibold">Confirm result</p>
-                <p className="mt-0.5">{pendingWinConfirmation.label}</p>
-                <div className="mt-2 grid grid-cols-2 gap-1">
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="h-5 px-1.5 text-[10px] text-slate-700"
+                  onClick={() =>
+                    setCardDraft({
+                      cardType: null,
+                      team: null,
+                      digits: "",
+                      startedGameClockMs: null,
+                    })
+                  }
+                  disabled={!controller || !cardEntryStarted}
+                >
+                  Reset
+                </Button>
+              </div>
+              <p
+                role={canSubmitCard ? "status" : "alert"}
+                className="h-4 text-[10px] text-slate-600"
+              >
+                {cardAddStatusText}
+              </p>
+              <div className="grid grid-cols-3 gap-1">
+                {["1", "2", "3", "4", "5", "6", "7", "8", "9"].map((digit) => (
                   <Button
-                    size="sm"
-                    className="h-7 rounded-xl"
-                    onClick={confirmWinAction}
-                    disabled={!controller}
-                  >
-                    Confirm
-                  </Button>
-                  <Button
+                    key={digit}
                     size="sm"
                     variant="outline"
-                    className="h-7 rounded-xl border-slate-300 bg-white text-slate-900"
-                    onClick={clearPendingWinConfirmation}
-                    disabled={!controller}
+                    className="h-7 rounded-xl border-slate-300 bg-white text-sm text-slate-900"
+                    onClick={() => appendCardDigit(digit)}
+                    disabled={!canEditCardDigits}
                   >
-                    Cancel
+                    {digit}
                   </Button>
-                </div>
+                ))}
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="h-7 rounded-xl border-slate-300 bg-white text-slate-900"
+                  onClick={() =>
+                    setCardDraft((previous) => ({
+                      ...previous,
+                      digits: previous.digits.slice(0, -1),
+                    }))
+                  }
+                  disabled={!canEditCardDigits || cardDraft.digits.length === 0}
+                >
+                  <Delete className="h-4 w-4" />
+                </Button>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="h-7 rounded-xl border-slate-300 bg-white text-sm text-slate-900"
+                  onClick={() => appendCardDigit("0")}
+                  disabled={!canEditCardDigits}
+                >
+                  0
+                </Button>
+                <Button
+                  size="sm"
+                  className="h-7 gap-1 rounded-xl bg-emerald-600 text-white hover:bg-emerald-500"
+                  onClick={submitCard}
+                  disabled={!canSubmitCard}
+                >
+                  <Check className="h-4 w-4" />
+                  OK
+                </Button>
               </div>
-            ) : null}
-            {state.isFinished ? (
-              <>
-                <p className="text-[11px] text-slate-600">{finishSummary ?? "Game finished."}</p>
-                <Button
-                  size="sm"
-                  variant="outline"
-                  className="h-8 rounded-xl border-slate-300 bg-white text-slate-900"
-                  onClick={correctBackToUnfinished}
-                  disabled={!controller}
-                >
-                  Correct back to unfinished
-                </Button>
-              </>
-            ) : state.isSuspended ? (
-              <>
-                <p className="text-[11px] text-slate-600">
-                  Game suspended. Resume when continuing this game.
-                </p>
-                <Button
-                  size="sm"
-                  variant="outline"
-                  className="h-8 rounded-xl border-slate-300 bg-white text-slate-900"
-                  onClick={resumeGame}
-                  disabled={!canResumeGame}
-                >
-                  Resume game
-                </Button>
-              </>
-            ) : (
-              <>
-                <Button
-                  size="sm"
-                  variant="outline"
-                  className="h-8 rounded-xl border-slate-300 bg-white text-slate-900"
-                  onClick={suspendGame}
-                  disabled={!canSuspendGame}
-                >
-                  Suspend game
-                </Button>
-                <div className="grid grid-cols-2 gap-1">
+            </div>
+
+            <div
+              className={`flex min-h-0 flex-col gap-1.5 rounded-2xl border border-slate-200 bg-slate-50 p-2 ${
+                activePanel === "timeout" ? "animate-in fade-in-0 slide-in-from-bottom-2" : "hidden"
+              }`}
+            >
+              {activeTimeout === null ? (
+                <div className="grid gap-1">
                   {displayTeamOrder.map((team) => (
                     <Button
-                      key={`forfeit-${team}`}
-                      size="sm"
+                      key={team}
                       variant="outline"
-                      className="h-8 rounded-xl border-slate-300 bg-white text-slate-900"
-                      onClick={() => requestForfeitWin(team)}
-                      disabled={!canUseEndingActions}
+                      size="sm"
+                      className="h-9 rounded-xl border-slate-300 bg-white text-slate-900"
+                      onClick={() => startTimeout(team)}
+                      disabled={
+                        !controller ||
+                        state.isRunning ||
+                        state.isSuspended ||
+                        state.timeouts[team].used ||
+                        state.isFinished
+                      }
                     >
-                      {displayTeamName(team)} forfeit
+                      {displayTeamName(team)} timeout
                     </Button>
                   ))}
                 </div>
-                <Button
-                  size="sm"
-                  variant="outline"
-                  className="h-8 rounded-xl border-slate-300 bg-white text-slate-900"
-                  onClick={recordDoubleForfeit}
-                  disabled={!canUseEndingActions}
-                >
-                  Double forfeit
-                </Button>
+              ) : (
+                <>
+                  <p
+                    className={`text-center text-3xl font-semibold tabular-nums ${
+                      gameView.timeoutFinalCountdown
+                        ? "text-red-700"
+                        : gameView.timeoutWarningActive
+                          ? "text-red-600"
+                          : "text-slate-900"
+                    }`}
+                  >
+                    {formatRemaining(activeTimeout.remainingMs)}
+                  </p>
+                  {!activeTimeout.running ? (
+                    <div className="grid grid-cols-2 gap-1">
+                      <Button
+                        size="sm"
+                        className="h-9 rounded-xl bg-emerald-600 text-white hover:bg-emerald-500"
+                        onClick={() => setTimeoutRunning(true)}
+                        disabled={!controller}
+                      >
+                        Start
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        className="h-9 rounded-xl border-slate-300 bg-white text-slate-900"
+                        onClick={undoTimeoutStart}
+                        disabled={!controller}
+                      >
+                        Undo
+                      </Button>
+                    </div>
+                  ) : (
+                    <div className="grid grid-cols-2 gap-1">
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        className="h-9 rounded-xl border-slate-300 bg-white text-slate-900"
+                        onClick={cancelTimeout}
+                        disabled={!controller}
+                      >
+                        End early
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        className="h-9 rounded-xl border-slate-300 bg-white text-slate-900"
+                        onClick={undoTimeoutStart}
+                        disabled={!controller}
+                      >
+                        Undo
+                      </Button>
+                    </div>
+                  )}
+                </>
+              )}
+            </div>
 
-                {state.isOvertime ? (
-                  <>
-                    <div className="grid grid-cols-2 gap-1">
-                      {displayTeamOrder.map((team) => (
-                        <Button
-                          key={`target-${team}`}
-                          size="sm"
-                          className="h-8 rounded-xl"
-                          onClick={() => requestTargetScoreWin(team)}
-                          disabled={!canUseEndingActions}
-                        >
-                          {displayTeamName(team)} reached target
-                        </Button>
-                      ))}
-                    </div>
-                    <div className="grid grid-cols-2 gap-1">
-                      {displayTeamOrder.map((team) => (
-                        <Button
-                          key={`concede-${team}`}
-                          size="sm"
-                          variant="outline"
-                          className="h-8 rounded-xl border-slate-300 bg-white text-slate-900"
-                          onClick={() => requestConcedeWin(team)}
-                          disabled={!canUseEndingActions}
-                        >
-                          {displayTeamName(team)} concedes
-                        </Button>
-                      ))}
-                    </div>
-                  </>
-                ) : canRecordFlagCatch ? (
+            <div
+              className={`flex min-h-0 flex-col gap-1.5 rounded-2xl border border-slate-200 bg-slate-50 p-2 ${
+                activePanel === "game" ? "animate-in fade-in-0 slide-in-from-bottom-2" : "hidden"
+              }`}
+            >
+              {pendingWinConfirmation !== null ? (
+                <div className="mb-1 rounded-xl border border-amber-300 bg-amber-100 p-2 text-[10px] text-amber-900">
+                  <p className="font-semibold">Confirm result</p>
+                  <p className="mt-0.5">{pendingWinConfirmation.label}</p>
+                  <div className="mt-2 grid grid-cols-2 gap-1">
+                    <Button
+                      size="sm"
+                      className="h-7 rounded-xl"
+                      onClick={confirmWinAction}
+                      disabled={!controller}
+                    >
+                      Confirm
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      className="h-7 rounded-xl border-slate-300 bg-white text-slate-900"
+                      onClick={clearPendingWinConfirmation}
+                      disabled={!controller}
+                    >
+                      Cancel
+                    </Button>
+                  </div>
+                </div>
+              ) : null}
+              {state.isFinished ? (
+                <>
+                  <p className="text-[11px] text-slate-600">{finishSummary ?? "Game finished."}</p>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="h-8 rounded-xl border-slate-300 bg-white text-slate-900"
+                    onClick={correctBackToUnfinished}
+                    disabled={!controller}
+                  >
+                    Correct back to unfinished
+                  </Button>
+                </>
+              ) : state.isSuspended ? (
+                <>
+                  <p className="text-[11px] text-slate-600">
+                    Game suspended. Resume when continuing this game.
+                  </p>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="h-8 rounded-xl border-slate-300 bg-white text-slate-900"
+                    onClick={resumeGame}
+                    disabled={!canResumeGame}
+                  >
+                    Resume game
+                  </Button>
+                </>
+              ) : (
+                <>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="h-8 rounded-xl border-slate-300 bg-white text-slate-900"
+                    onClick={suspendGame}
+                    disabled={!canSuspendGame}
+                  >
+                    Suspend game
+                  </Button>
                   <div className="grid grid-cols-2 gap-1">
                     {displayTeamOrder.map((team) => (
                       <Button
-                        key={`flag-catch-${team}`}
+                        key={`forfeit-${team}`}
                         size="sm"
-                        className="h-8 rounded-xl"
-                        onClick={() => recordOrConfirmFlagCatch(team)}
+                        variant="outline"
+                        className="h-8 rounded-xl border-slate-300 bg-white text-slate-900"
+                        onClick={() => requestForfeitWin(team)}
                         disabled={!canUseEndingActions}
                       >
-                        {displayTeamName(team)} flag +30
+                        {displayTeamName(team)} forfeit
                       </Button>
                     ))}
                   </div>
-                ) : (
-                  <p className="text-[11px] text-slate-600">
-                    Flag catch appears after seeker release while play is paused.
-                  </p>
-                )}
-              </>
-            )}
-          </div>
-        </CardContent>
-      </Card>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="h-8 rounded-xl border-slate-300 bg-white text-slate-900"
+                    onClick={recordDoubleForfeit}
+                    disabled={!canUseEndingActions}
+                  >
+                    Double forfeit
+                  </Button>
 
-      <section className="rounded-2xl border border-slate-300 bg-white p-1 shadow-[0_8px_20px_rgba(15,23,42,0.1)]">
-        <div className="grid grid-cols-3 gap-1">
-          <Button
-            variant="ghost"
-            size="sm"
-            className={`h-10 gap-1 rounded-xl px-1 text-[11px] transition-all ${
-              activePanel === "card" ? "" : "bg-slate-100 text-slate-700"
-            }`}
-            style={activePanel === "card" ? tabThemes.card.activeStyle : undefined}
-            onClick={() => setActivePanel("card")}
-          >
-            <Flag className={`h-3.5 w-3.5 ${activePanel === "card" ? "animate-pulse" : ""}`} />
-            Cards
-          </Button>
-          <Button
-            variant="ghost"
-            size="sm"
-            className={`h-10 gap-1 rounded-xl px-1 text-[11px] transition-all ${
-              activePanel === "timeout" ? "" : "bg-slate-100 text-slate-700"
-            }`}
-            style={activePanel === "timeout" ? tabThemes.timeout.activeStyle : undefined}
-            onClick={() => setActivePanel("timeout")}
-          >
-            <Clock3 className={`h-3.5 w-3.5 ${activePanel === "timeout" ? "animate-pulse" : ""}`} />
-            Timeout
-          </Button>
-          <Button
-            variant="ghost"
-            size="sm"
-            className={`h-10 gap-1 rounded-xl px-1 text-[11px] transition-all ${
-              activePanel === "game" ? "" : "bg-slate-100 text-slate-700"
-            }`}
-            style={activePanel === "game" ? tabThemes.game.activeStyle : undefined}
-            onClick={() => setActivePanel("game")}
-          >
-            <Trophy className={`h-3.5 w-3.5 ${activePanel === "game" ? "animate-pulse" : ""}`} />
-            Game end
-          </Button>
-        </div>
-      </section>
-    </>
+                  {state.isOvertime ? (
+                    <>
+                      <div className="grid grid-cols-2 gap-1">
+                        {displayTeamOrder.map((team) => (
+                          <Button
+                            key={`target-${team}`}
+                            size="sm"
+                            className="h-8 rounded-xl"
+                            onClick={() => requestTargetScoreWin(team)}
+                            disabled={!canUseEndingActions}
+                          >
+                            {displayTeamName(team)} reached target
+                          </Button>
+                        ))}
+                      </div>
+                      <div className="grid grid-cols-2 gap-1">
+                        {displayTeamOrder.map((team) => (
+                          <Button
+                            key={`concede-${team}`}
+                            size="sm"
+                            variant="outline"
+                            className="h-8 rounded-xl border-slate-300 bg-white text-slate-900"
+                            onClick={() => requestConcedeWin(team)}
+                            disabled={!canUseEndingActions}
+                          >
+                            {displayTeamName(team)} concedes
+                          </Button>
+                        ))}
+                      </div>
+                    </>
+                  ) : canRecordFlagCatch ? (
+                    <div className="grid grid-cols-2 gap-1">
+                      {displayTeamOrder.map((team) => (
+                        <Button
+                          key={`flag-catch-${team}`}
+                          size="sm"
+                          className="h-8 rounded-xl"
+                          onClick={() => recordOrConfirmFlagCatch(team)}
+                          disabled={!canUseEndingActions}
+                        >
+                          {displayTeamName(team)} flag +30
+                        </Button>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="text-[11px] text-slate-600">
+                      Flag catch appears after seeker release while play is paused.
+                    </p>
+                  )}
+                </>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      }
+    />
   );
 }

--- a/src/components/game-controller-sections.tsx
+++ b/src/components/game-controller-sections.tsx
@@ -361,6 +361,8 @@ function TeamScoreColumn({
       <Button
         size="sm"
         className="h-8 w-full rounded-2xl border shadow-sm"
+        data-primary-score="up"
+        aria-label={`Increase ${column.name} score`}
         style={column.scoreBoxStyle}
         onClick={() => onAddScore(column.team)}
         disabled={scoreUpDisabled}
@@ -387,6 +389,8 @@ function TeamScoreColumn({
         size="sm"
         variant="outline"
         className="h-8 w-full rounded-2xl bg-white"
+        data-primary-score="down"
+        aria-label={`Decrease ${column.name} score`}
         style={column.scoreDownButtonStyle}
         onClick={() => onUndoScore(column.team)}
         disabled={scoreDownDisabled}

--- a/src/lib/controller-action-sheet.test.ts
+++ b/src/lib/controller-action-sheet.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+import { toggleControllerActionPanel } from "@/lib/controller-action-sheet";
+
+describe("Controller action-sheet selection", () => {
+  test("opens from a nullable selection", () => {
+    expect(toggleControllerActionPanel(null, "card")).toBe("card");
+  });
+
+  test("selecting the same action closes it", () => {
+    expect(toggleControllerActionPanel("card", "card")).toBeNull();
+  });
+
+  test("switching categories selects the new action", () => {
+    expect(toggleControllerActionPanel("card", "timeout")).toBe("timeout");
+  });
+});

--- a/src/lib/controller-action-sheet.ts
+++ b/src/lib/controller-action-sheet.ts
@@ -1,0 +1,9 @@
+export type ControllerActionPanel = "card" | "timeout" | "game";
+
+/** Selecting the open action closes it; selecting another action switches panels. */
+export function toggleControllerActionPanel(
+  activePanel: ControllerActionPanel | null,
+  requestedPanel: ControllerActionPanel,
+): ControllerActionPanel | null {
+  return activePanel === requestedPanel ? null : requestedPanel;
+}

--- a/src/pages/event-game-controller-page.test.tsx
+++ b/src/pages/event-game-controller-page.test.tsx
@@ -310,6 +310,15 @@ describe("Event Game Controller reconnect browser seam", () => {
     }
   }
 
+  async function openActionPanel(label: "Cards" | "Timeout" | "Game end") {
+    await act(async () => {
+      Array.from(container.getElementsByTagName("button"))
+        .find((button) => button.textContent?.trim() === label)
+        ?.click();
+      await Promise.resolve();
+    });
+  }
+
   function installControllerIntervalProbe() {
     let tick: (() => void) | null = null;
     const cleared: number[] = [];
@@ -367,7 +376,7 @@ describe("Event Game Controller reconnect browser seam", () => {
     expect(activeSurface).not.toBeNull();
     expect(activeSurface?.className).toContain("[&_button]:min-h-11");
     const buttons = Array.from(activeSurface?.querySelectorAll<HTMLButtonElement>("button") ?? []);
-    expect(buttons.length).toBeGreaterThan(15);
+    expect(buttons.length).toBeGreaterThan(14);
     for (const button of buttons) {
       expect(button.getAttribute("aria-label") ?? button.textContent?.trim()).not.toBe("");
     }
@@ -385,6 +394,97 @@ describe("Event Game Controller reconnect browser seam", () => {
       await Promise.resolve();
     });
     expect(testWindow.document.activeElement?.getAttribute("aria-label")).toBe("Pause game clock");
+  });
+
+  test("renders nullable sheet actions, clears drafts on switch, and keeps core controls usable", async () => {
+    await enterAndOpen();
+    const cardsButton = Array.from(container.getElementsByTagName("button")).find(
+      (button) => button.textContent?.trim() === "Cards",
+    );
+    const timeoutButton = Array.from(container.getElementsByTagName("button")).find(
+      (button) => button.textContent?.trim() === "Timeout",
+    );
+    const gameButton = Array.from(container.getElementsByTagName("button")).find(
+      (button) => button.textContent?.trim() === "Game end",
+    );
+    expect(cardsButton?.getAttribute("aria-expanded")).toBe("false");
+    expect(container.querySelector('[data-controller-action-panel="true"]')).toBeNull();
+    await act(async () => {
+      cardsButton?.click();
+      await Promise.resolve();
+    });
+    expect(cardsButton?.getAttribute("aria-expanded")).toBe("true");
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>(
+          'button[aria-label="Accept penalty card for the selected Game Side"]',
+        )
+        ?.click();
+      await Promise.resolve();
+    });
+    expect(container.querySelector('[data-controller-action-panel="true"]')).not.toBeNull();
+    const sideSelect = container.querySelector<HTMLSelectElement>("#penalty-game-side");
+    const cardTypeSelect = container.querySelector<HTMLSelectElement>("#penalty-card-type");
+    if (sideSelect === null || cardTypeSelect === null)
+      throw new Error("Card sheet did not render.");
+    await act(async () => {
+      sideSelect.value = "side-a";
+      sideSelect.dispatchEvent(
+        new testWindow.Event("change", { bubbles: true }) as unknown as Event,
+      );
+      cardTypeSelect.value = "yellow";
+      cardTypeSelect.dispatchEvent(
+        new testWindow.Event("change", { bubbles: true }) as unknown as Event,
+      );
+      await Promise.resolve();
+    });
+    await act(async () => {
+      timeoutButton?.click();
+      await Promise.resolve();
+    });
+    await act(async () => {
+      Array.from(container.getElementsByTagName("button"))
+        .find((button) => button.textContent?.includes("Timeout stoppage: side-a"))
+        ?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(container.querySelector('[data-controller-action-panel="true"]')).not.toBeNull();
+    await act(async () => {
+      cardsButton?.click();
+      await Promise.resolve();
+    });
+    expect(container.querySelector<HTMLSelectElement>("#penalty-game-side")?.value).toBe("");
+    expect(container.querySelector<HTMLSelectElement>("#penalty-card-type")?.value).toBe("blue");
+    await act(async () => {
+      cardsButton?.click();
+      await Promise.resolve();
+    });
+    expect(container.querySelector('[data-controller-action-panel="true"]')).toBeNull();
+    await act(async () => {
+      cardsButton?.click();
+      await Promise.resolve();
+      container.querySelector<HTMLButtonElement>('button[aria-label="Start game clock"]')?.click();
+      container.querySelector<HTMLButtonElement>('button[data-primary-score="up"]')?.click();
+      container.querySelectorAll<HTMLButtonElement>('button[data-primary-score="up"]')[1]?.click();
+      await Promise.resolve();
+    });
+    expect(container.querySelector('[data-controller-action-panel="true"]')).not.toBeNull();
+    await act(async () => {
+      gameButton?.click();
+      await Promise.resolve();
+    });
+    await act(async () => {
+      Array.from(container.getElementsByTagName("button"))
+        .find((button) => button.textContent?.trim() === "Review final result")
+        ?.click();
+      await Promise.resolve();
+      Array.from(container.getElementsByTagName("button"))
+        .find((button) => button.textContent?.trim() === "Confirm game end")
+        ?.click();
+      await Promise.resolve();
+    });
+    expect(container.querySelector('[data-controller-action-panel="true"]')).toBeNull();
   });
 
   test("acknowledges only the current corrected Event Team identity before team actions", async () => {
@@ -494,8 +594,8 @@ describe("Event Game Controller reconnect browser seam", () => {
       await Promise.resolve();
       await Promise.resolve();
     });
-    const goalButton = Array.from(container.getElementsByTagName("button")).find((button) =>
-      button.textContent?.includes("Record 10-point goal"),
+    const goalButton = Array.from(container.getElementsByTagName("button")).find(
+      (button) => button.getAttribute("aria-label")?.startsWith("Record 10-point goal") === true,
     );
     expect(goalButton).not.toBeNull();
     await act(async () => {
@@ -615,8 +715,8 @@ describe("Event Game Controller reconnect browser seam", () => {
     });
     expect(container.textContent).toContain("SEEKER RELEASED at 20:00");
 
-    const goalButton = Array.from(container.getElementsByTagName("button")).find((button) =>
-      button.textContent?.includes("Record 10-point goal"),
+    const goalButton = Array.from(container.getElementsByTagName("button")).find(
+      (button) => button.getAttribute("aria-label")?.startsWith("Record 10-point goal") === true,
     );
     await act(async () => {
       goalButton?.click();
@@ -641,6 +741,7 @@ describe("Event Game Controller reconnect browser seam", () => {
     });
     replayMode = "lost";
     await enterAndOpen();
+    await openActionPanel("Cards");
     Object.defineProperty(testWindow.navigator, "onLine", { configurable: true, value: false });
     const sideSelect = container.querySelector("select#penalty-game-side") as HTMLSelectElement;
     await act(async () => {
@@ -657,6 +758,17 @@ describe("Event Game Controller reconnect browser seam", () => {
     await act(async () => {
       acceptCard()?.click();
       await Promise.resolve();
+      await Promise.resolve();
+    });
+    await openActionPanel("Cards");
+    const reopenedSideSelect = container.querySelector(
+      "select#penalty-game-side",
+    ) as HTMLSelectElement;
+    await act(async () => {
+      reopenedSideSelect.value = "side-b";
+      reopenedSideSelect.dispatchEvent(
+        new testWindow.Event("change", { bubbles: true }) as unknown as Event,
+      );
       await Promise.resolve();
     });
     const seekerLabel = Array.from(container.getElementsByTagName("label")).find((label) =>
@@ -692,6 +804,7 @@ describe("Event Game Controller reconnect browser seam", () => {
   test("disables foul-before-score for ejection cards and omits it from offline intent", async () => {
     replayMode = "lost";
     await enterAndOpen();
+    await openActionPanel("Cards");
     Object.defineProperty(testWindow.navigator, "onLine", { configurable: true, value: false });
     const sideSelect = container.querySelector("select#penalty-game-side") as HTMLSelectElement;
     const cardTypeSelect = container.querySelector("select#penalty-card-type") as HTMLSelectElement;
@@ -727,6 +840,7 @@ describe("Event Game Controller reconnect browser seam", () => {
   test("projects offline card and reason taps, then converges after reconnect", async () => {
     replayMode = "lost";
     await enterAndOpen();
+    await openActionPanel("Cards");
     Object.defineProperty(testWindow.navigator, "onLine", { configurable: true, value: false });
 
     const sideSelect = container.querySelector("select#penalty-game-side") as HTMLSelectElement;
@@ -868,8 +982,8 @@ describe("Event Game Controller reconnect browser seam", () => {
     replayMode = "lost";
     await enterAndOpen();
     Object.defineProperty(testWindow.navigator, "onLine", { configurable: true, value: false });
-    const goalButton = Array.from(container.getElementsByTagName("button")).find((button) =>
-      button.textContent?.includes("Record 10-point goal"),
+    const goalButton = Array.from(container.getElementsByTagName("button")).find(
+      (button) => button.getAttribute("aria-label")?.startsWith("Record 10-point goal") === true,
     );
     await act(async () => {
       goalButton?.click();
@@ -1011,6 +1125,7 @@ describe("Event Game Controller reconnect browser seam", () => {
 
   test("uses a contextual Head Referee choice for close-play catch ordering", async () => {
     await enterAndOpen();
+    await openActionPanel("Game end");
     const catchButtons = Array.from(container.getElementsByTagName("button")).filter((button) =>
       button.textContent?.includes("Record flag catch"),
     );
@@ -1042,6 +1157,7 @@ describe("Event Game Controller reconnect browser seam", () => {
       await Promise.resolve();
       await Promise.resolve();
     });
+    expect(container.querySelector('[data-controller-action-panel="true"]')).toBeNull();
     const selected = replayBodies
       .flatMap((body) => body.actions ?? [])
       .find((action) => action.intent.type === "record-flag-catch");
@@ -1071,6 +1187,55 @@ describe("Event Game Controller reconnect browser seam", () => {
     });
   });
 
+  test("preserves an unrelated Card draft after accepting close-play goal ordering", async () => {
+    const initial = projection();
+    const existingFlagCatch = initial.gameFacts?.[0];
+    if (existingFlagCatch === undefined) throw new Error("Expected a close-play fixture.");
+    openProjection = {
+      ...initial,
+      gameFacts: [{ ...existingFlagCatch, factId: "fact-flag-catch", factType: "flag-catch" }],
+    };
+    await enterAndOpen();
+    await openActionPanel("Cards");
+    const sideSelect = container.querySelector<HTMLSelectElement>("#penalty-game-side");
+    const cardTypeSelect = container.querySelector<HTMLSelectElement>("#penalty-card-type");
+    if (sideSelect === null || cardTypeSelect === null)
+      throw new Error("Card sheet did not render.");
+    await act(async () => {
+      sideSelect.value = "side-a";
+      sideSelect.dispatchEvent(
+        new testWindow.Event("change", { bubbles: true }) as unknown as Event,
+      );
+      cardTypeSelect.value = "yellow";
+      cardTypeSelect.dispatchEvent(
+        new testWindow.Event("change", { bubbles: true }) as unknown as Event,
+      );
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      Array.from(container.getElementsByTagName("button"))
+        .find(
+          (button) =>
+            button.getAttribute("aria-label")?.startsWith("Record 10-point goal") === true,
+        )
+        ?.click();
+      await Promise.resolve();
+    });
+    expect(container.querySelector('[data-close-play-adjudication="true"]')).not.toBeNull();
+    await act(async () => {
+      Array.from(container.getElementsByTagName("button"))
+        .find((button) => button.textContent?.includes("Goal before catch"))
+        ?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(container.querySelector('[data-controller-action-panel="true"]')).not.toBeNull();
+    expect(container.querySelector<HTMLSelectElement>("#penalty-game-side")?.value).toBe("side-a");
+    expect(container.querySelector<HTMLSelectElement>("#penalty-card-type")?.value).toBe("yellow");
+  });
+
   test("causally retains a close-play fact behind its optimistic paired predecessor", async () => {
     replayMode = "retryable";
     const initial = projection();
@@ -1081,10 +1246,14 @@ describe("Event Game Controller reconnect browser seam", () => {
       gameFacts: [],
     };
     await enterAndOpen();
+    await openActionPanel("Game end");
 
     await act(async () => {
       Array.from(container.getElementsByTagName("button"))
-        .find((button) => button.textContent?.includes("Record 10-point goal"))
+        .find(
+          (button) =>
+            button.getAttribute("aria-label")?.startsWith("Record 10-point goal") === true,
+        )
         ?.click();
       await Promise.resolve();
       await Promise.resolve();
@@ -1125,6 +1294,7 @@ describe("Event Game Controller reconnect browser seam", () => {
     openProjection = { ...initial, gameFacts: [] };
     refreshProjection = openProjection;
     await enterAndOpen();
+    await openActionPanel("Game end");
     await act(async () => {
       Array.from(container.getElementsByTagName("button"))
         .find((button) => button.textContent?.includes("Record flag catch"))
@@ -1139,6 +1309,7 @@ describe("Event Game Controller reconnect browser seam", () => {
       await Promise.resolve();
       await Promise.resolve();
     });
+    expect(container.querySelector('[data-controller-action-panel="true"]')).toBeNull();
     const selected = replayBodies
       .flatMap((body) => body.actions ?? [])
       .find((action) => action.intent.type === "record-flag-catch");
@@ -1173,6 +1344,7 @@ describe("Event Game Controller reconnect browser seam", () => {
       ],
     };
     await enterAndOpen();
+    await openActionPanel("Game end");
     await act(async () => {
       Array.from(container.getElementsByTagName("button"))
         .find((button) => button.textContent?.includes("Record flag catch"))
@@ -1229,6 +1401,7 @@ describe("Event Game Controller reconnect browser seam", () => {
       })),
     };
     await enterAndOpen();
+    await openActionPanel("Game end");
     await act(async () => {
       Array.from(container.getElementsByTagName("button"))
         .find((button) => button.textContent?.includes("Record flag catch"))
@@ -1282,6 +1455,7 @@ describe("Event Game Controller reconnect browser seam", () => {
       })),
     };
     await enterAndOpen();
+    await openActionPanel("Game end");
     expect(container.textContent).not.toContain("Concede");
     await act(async () => {
       Array.from(container.getElementsByTagName("button"))
@@ -1315,6 +1489,7 @@ describe("Event Game Controller reconnect browser seam", () => {
 
   test("shows overtime concession and communicates winner or double-forfeit results", async () => {
     await enterAndOpen();
+    await openActionPanel("Game end");
     const current = projection();
     refreshProjection = {
       ...current,
@@ -1382,8 +1557,8 @@ describe("Event Game Controller reconnect browser seam", () => {
       await Promise.resolve();
       await Promise.resolve();
     });
-    const goalButton = Array.from(container.getElementsByTagName("button")).find((button) =>
-      button.textContent?.includes("Record 10-point goal"),
+    const goalButton = Array.from(container.getElementsByTagName("button")).find(
+      (button) => button.getAttribute("aria-label")?.startsWith("Record 10-point goal") === true,
     );
     await act(async () => {
       goalButton?.click();
@@ -1818,9 +1993,16 @@ describe("Event Game Controller reconnect browser seam", () => {
   test("fresh same-Game scan replays retained work with original evidence", async () => {
     replayMode = "lost";
     await enterAndOpen();
+    await openActionPanel("Cards");
+    const draftSide = container.querySelector<HTMLSelectElement>("#penalty-game-side");
+    if (draftSide === null)
+      throw new Error("Expected Event Card draft controls before session clear.");
+    draftSide.value = "side-a";
+    draftSide.dispatchEvent(new testWindow.Event("change", { bubbles: true }) as unknown as Event);
+    expect(container.querySelector('[data-controller-action-panel="true"]')).not.toBeNull();
     Object.defineProperty(testWindow.navigator, "onLine", { configurable: true, value: false });
-    const goalButton = Array.from(container.getElementsByTagName("button")).find((button) =>
-      button.textContent?.includes("Record 10-point goal"),
+    const goalButton = Array.from(container.getElementsByTagName("button")).find(
+      (button) => button.getAttribute("aria-label")?.startsWith("Record 10-point goal") === true,
     );
     await act(async () => {
       goalButton?.click();
@@ -1843,6 +2025,8 @@ describe("Event Game Controller reconnect browser seam", () => {
       await Promise.resolve();
       await Promise.resolve();
     });
+    expect(container.querySelector('[data-controller-action-panel="true"]')).toBeNull();
+    expect(container.querySelector("#penalty-game-side")).toBeNull();
     openGrantSessionId = "session-fresh";
     openGrantVersion = "version-fresh";
     replayMode = "success";
@@ -1862,8 +2046,8 @@ describe("Event Game Controller reconnect browser seam", () => {
     replayMode = "lost";
     await enterAndOpen();
     Object.defineProperty(testWindow.navigator, "onLine", { configurable: true, value: false });
-    const goalButton = Array.from(container.getElementsByTagName("button")).find((button) =>
-      button.textContent?.includes("Record 10-point goal"),
+    const goalButton = Array.from(container.getElementsByTagName("button")).find(
+      (button) => button.getAttribute("aria-label")?.startsWith("Record 10-point goal") === true,
     );
     await act(async () => {
       goalButton?.click();
@@ -1962,8 +2146,8 @@ describe("Event Game Controller reconnect browser seam", () => {
     replayMode = "lost";
     await enterAndOpen();
     Object.defineProperty(testWindow.navigator, "onLine", { configurable: true, value: false });
-    const goalButton = Array.from(container.getElementsByTagName("button")).find((button) =>
-      button.textContent?.includes("Record 10-point goal"),
+    const goalButton = Array.from(container.getElementsByTagName("button")).find(
+      (button) => button.getAttribute("aria-label")?.startsWith("Record 10-point goal") === true,
     );
     await act(async () => {
       goalButton?.click();
@@ -1993,7 +2177,10 @@ describe("Event Game Controller reconnect browser seam", () => {
     Object.defineProperty(testWindow.navigator, "onLine", { configurable: true, value: false });
     await act(async () => {
       Array.from(container.getElementsByTagName("button"))
-        .find((button) => button.textContent?.includes("Record 10-point goal"))
+        .find(
+          (button) =>
+            button.getAttribute("aria-label")?.startsWith("Record 10-point goal") === true,
+        )
         ?.click();
       await Promise.resolve();
       await Promise.resolve();
@@ -2072,8 +2259,8 @@ describe("Event Game Controller reconnect browser seam", () => {
   test("fresh authority supersedes an in-flight replay and starts exactly one newest-bearer replay", async () => {
     replayMode = "deferred";
     await enterAndOpen();
-    const goalButton = Array.from(container.getElementsByTagName("button")).find((button) =>
-      button.textContent?.includes("Record 10-point goal"),
+    const goalButton = Array.from(container.getElementsByTagName("button")).find(
+      (button) => button.getAttribute("aria-label")?.startsWith("Record 10-point goal") === true,
     );
     await act(async () => {
       goalButton?.click();
@@ -2195,8 +2382,8 @@ describe("Event Game Controller reconnect browser seam", () => {
     });
     await enterAndOpen();
     expect(container.querySelector('[role="alert"]')?.textContent).toContain("full or unavailable");
-    const goalButton = Array.from(container.getElementsByTagName("button")).find((button) =>
-      button.textContent?.includes("Record 10-point goal"),
+    const goalButton = Array.from(container.getElementsByTagName("button")).find(
+      (button) => button.getAttribute("aria-label")?.startsWith("Record 10-point goal") === true,
     );
     await act(async () => {
       goalButton?.click();
@@ -2224,8 +2411,8 @@ describe("Event Game Controller reconnect browser seam", () => {
       await Promise.resolve();
       await Promise.resolve();
     });
-    const goalButton = Array.from(container.getElementsByTagName("button")).find((button) =>
-      button.textContent?.includes("Record 10-point goal"),
+    const goalButton = Array.from(container.getElementsByTagName("button")).find(
+      (button) => button.getAttribute("aria-label")?.startsWith("Record 10-point goal") === true,
     );
     await act(async () => {
       goalButton?.click();
@@ -2261,8 +2448,14 @@ describe("Event Game Controller reconnect browser seam", () => {
       await Promise.resolve();
       await Promise.resolve();
     });
-    const goalButton = Array.from(container.getElementsByTagName("button")).find((button) =>
-      button.textContent?.includes("Record 10-point goal"),
+    await openActionPanel("Cards");
+    const draftSide = container.querySelector<HTMLSelectElement>("#penalty-game-side");
+    if (draftSide === null)
+      throw new Error("Expected Event Card draft controls before Game switch.");
+    draftSide.value = "side-a";
+    draftSide.dispatchEvent(new testWindow.Event("change", { bubbles: true }) as unknown as Event);
+    const goalButton = Array.from(container.getElementsByTagName("button")).find(
+      (button) => button.getAttribute("aria-label")?.startsWith("Record 10-point goal") === true,
     );
     await act(async () => {
       goalButton?.click();
@@ -2291,6 +2484,8 @@ describe("Event Game Controller reconnect browser seam", () => {
       await Promise.resolve();
     });
     expect(container.textContent).toContain("Controller Device: game-b");
+    expect(container.querySelector('[data-controller-action-panel="true"]')).toBeNull();
+    expect(container.querySelector("#penalty-game-side")).toBeNull();
     const oldGame = JSON.parse(
       testWindow.localStorage.getItem(controllerReplicaStorageKey("game-browser")) ?? "null",
     ) as { pendingActions?: unknown[] };

--- a/src/pages/event-game-controller-page.tsx
+++ b/src/pages/event-game-controller-page.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { ControllerHeader } from "@/components/controller-header";
+import { ControllerActionSheet } from "@/components/controller-action-sheet";
+import type { ControllerActionPanel } from "@/lib/controller-action-sheet";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -177,6 +179,8 @@ export function EventGameControllerPage() {
     useState<PendingClosePlayAdjudication | null>(null);
   const [pendingFlagCatchBoundaryOverride, setPendingFlagCatchBoundaryOverride] =
     useState<PendingFlagCatchBoundaryOverride | null>(null);
+  const [activeActionPanel, setActiveActionPanel] = useState<ControllerActionPanel | null>(null);
+  const [pendingEventResultConfirmation, setPendingEventResultConfirmation] = useState(false);
   const [persistedReplicaLoad] = useState<ControllerReplicaLoad>(() =>
     readPersistedControllerReplica(undefined),
   );
@@ -207,6 +211,22 @@ export function EventGameControllerPage() {
   const sessionReferenceIdRef = useRef<string | null>(persisted?.sessionReferenceId ?? null);
   const restoreStartedRef = useRef(false);
   const departureModule = getBrowserControllerDeparture();
+
+  function changeActionPanel(panel: ControllerActionPanel | null) {
+    resetActionSheetDrafts();
+    setActiveActionPanel(panel);
+  }
+
+  function resetActionSheetDrafts() {
+    setCardGameSideId("");
+    setCardPlayerNumber("");
+    setCardType("blue");
+    setCardFoulBeforeScore(false);
+    setCardSeekerPenaltyConfirmed(false);
+    setPendingEventResultConfirmation(false);
+    setPendingClosePlayAdjudication(null);
+    setPendingFlagCatchBoundaryOverride(null);
+  }
 
   const eventEntry = useControllerDepartureEntry({
     destination: { kind: "admit-event" },
@@ -618,6 +638,8 @@ export function EventGameControllerPage() {
 
   async function switchController(): Promise<boolean> {
     if (sessionBearer === null) return false;
+    resetActionSheetDrafts();
+    setActiveActionPanel(null);
     const requestGeneration = lifecycleGenerationRef.current;
     setBusy(true);
     clearReplayAuthority();
@@ -757,16 +779,16 @@ export function EventGameControllerPage() {
   }
 
   function recordGoal(gameSideId: string) {
-    recordScoringFact("record-goal", gameSideId);
+    return recordScoringFact("record-goal", gameSideId);
   }
 
   function recordFlagCatch(gameSideId: string) {
-    recordScoringFact("record-flag-catch", gameSideId);
+    return recordScoringFact("record-flag-catch", gameSideId);
   }
 
   function recordScoringFact(intentType: "record-goal" | "record-flag-catch", gameSideId: string) {
     const gameTimeMs = currentSportingTimeMs();
-    if (gameTimeMs === null) return;
+    if (gameTimeMs === null) return false;
     const running = clockProjection?.running ?? projection?.clock.running ?? false;
     const flagCatchBoundaryRunning =
       intentType === "record-flag-catch" && (gameTimeMs < SEEKER_RELEASE_MS || running)
@@ -793,16 +815,16 @@ export function EventGameControllerPage() {
         })),
       });
       setMessage("Head Referee adjudication is required to order this close goal and flag catch.");
-      return;
+      return false;
     }
     if (flagCatchBoundaryRunning !== null) {
       setPendingFlagCatchBoundaryOverride({ gameSideId, gameTimeMs, running });
       setMessage(
         "Head Referee confirmation is required for a flag catch before seeker release or while play is running.",
       );
-      return;
+      return false;
     }
-    queueIntent({
+    return queueIntent({
       version: LIVE_EVENT_CONTROL_INTENT_VERSION,
       type: intentType,
       operationId: crypto.randomUUID(),
@@ -816,9 +838,9 @@ export function EventGameControllerPage() {
 
   function submitClosePlayAdjudication(order: "before" | "after", relatedFactId: string) {
     const pending = pendingClosePlayAdjudication;
-    if (pending === null) return;
+    if (pending === null) return false;
     const relatedFact = pending.relatedFacts.find((fact) => fact.factId === relatedFactId);
-    if (relatedFact === undefined) return;
+    if (relatedFact === undefined) return false;
     const override: OfficialOverrideMetadata = {
       guardrail: "sporting-order-adjudication",
       direction: "head-referee-adjudicated-sporting-order",
@@ -851,9 +873,9 @@ export function EventGameControllerPage() {
       setMessage(
         "Sporting Order recorded. Separately confirm the flag-catch boundary override before submission.",
       );
-      return;
+      return false;
     }
-    queueIntent({
+    const accepted = queueIntent({
       version: LIVE_EVENT_CONTROL_INTENT_VERSION,
       type: pending.intentType,
       operationId: crypto.randomUUID(),
@@ -867,13 +889,15 @@ export function EventGameControllerPage() {
       override,
       occurrence: { clientOriginAtMs: Date.now() },
     });
-    setPendingClosePlayAdjudication(null);
+    if (!accepted) return false;
+    if (pending.intentType === "record-flag-catch") changeActionPanel(null);
+    return true;
   }
 
   function submitFlagCatchBoundaryOverride() {
     const pending = pendingFlagCatchBoundaryOverride;
-    if (pending === null) return;
-    queueIntent({
+    if (pending === null) return false;
+    const accepted = queueIntent({
       version: LIVE_EVENT_CONTROL_INTENT_VERSION,
       type: "record-flag-catch",
       operationId: crypto.randomUUID(),
@@ -889,13 +913,15 @@ export function EventGameControllerPage() {
           }),
       occurrence: { clientOriginAtMs: Date.now() },
     });
-    setPendingFlagCatchBoundaryOverride(null);
+    if (!accepted) return false;
+    changeActionPanel(null);
+    return true;
   }
 
   function recordConcession(gameSideId: string) {
     const gameTimeMs = currentSportingTimeMs();
-    if (gameTimeMs === null) return;
-    queueIntent({
+    if (gameTimeMs === null) return false;
+    return queueIntent({
       version: LIVE_EVENT_CONTROL_INTENT_VERSION,
       type: "record-concession",
       operationId: crypto.randomUUID(),
@@ -909,8 +935,8 @@ export function EventGameControllerPage() {
 
   function recordForfeit(gameSideId: string) {
     const gameTimeMs = currentSportingTimeMs();
-    if (gameTimeMs === null) return;
-    queueIntent({
+    if (gameTimeMs === null) return false;
+    return queueIntent({
       version: LIVE_EVENT_CONTROL_INTENT_VERSION,
       type: "record-forfeit",
       operationId: crypto.randomUUID(),
@@ -924,8 +950,11 @@ export function EventGameControllerPage() {
 
   function recordDoubleForfeit() {
     const gameTimeMs = currentSportingTimeMs();
-    if (gameTimeMs === null) return;
-    queueIntent({
+    if (gameTimeMs === null) {
+      setMessage("Game Clock time is unavailable; action remains open.");
+      return false;
+    }
+    return queueIntent({
       version: LIVE_EVENT_CONTROL_INTENT_VERSION,
       type: "record-double-forfeit",
       operationId: crypto.randomUUID(),
@@ -937,10 +966,16 @@ export function EventGameControllerPage() {
   }
 
   function recordCard() {
-    if (cardGameSideId === "") return;
+    if (cardGameSideId === "") {
+      setMessage("Choose a Game Side before accepting the card.");
+      return false;
+    }
     const parsedPlayerNumber = cardPlayerNumber === "" ? null : Number(cardPlayerNumber);
-    if (parsedPlayerNumber !== null && !Number.isSafeInteger(parsedPlayerNumber)) return;
-    queueIntent({
+    if (parsedPlayerNumber !== null && !Number.isSafeInteger(parsedPlayerNumber)) {
+      setMessage("Player number must be a whole number.");
+      return false;
+    }
+    const queued = queueIntent({
       version: LIVE_EVENT_CONTROL_INTENT_VERSION,
       type: "record-card",
       operationId: crypto.randomUUID(),
@@ -955,6 +990,7 @@ export function EventGameControllerPage() {
       gameTimeMs: controllerGameTimeMs(),
       occurrence: { clientOriginAtMs: Date.now() },
     });
+    return queued;
   }
 
   function flipPitchOrientation() {
@@ -1062,21 +1098,24 @@ export function EventGameControllerPage() {
       suspensionAction?: "start" | "resume";
       resumesSuspensionFactId?: string;
     } = {},
-  ) {
+  ): boolean {
     const gameTimeMs = currentSportingTimeMs();
-    if (gameTimeMs === null) return;
+    if (gameTimeMs === null) {
+      setMessage("Game Clock time is unavailable; action remains open.");
+      return false;
+    }
     if (type === "suspension" && options.suspensionAction !== "resume") {
       if (projection === null || projection.penalties === undefined) {
         setMessage("A current authoritative projection is required before suspending.");
-        return;
+        return false;
       }
       if (volleyballPossession === "") {
         setMessage("Confirm volleyball possession before suspending.");
-        return;
+        return false;
       }
       if ((projection.knownDodgeballIds ?? []).some((ballId) => !(ballId in dodgeballPossession))) {
         setMessage("Confirm every known dodgeball possession before suspending.");
-        return;
+        return false;
       }
     }
     const suspensionSnapshot =
@@ -1090,7 +1129,7 @@ export function EventGameControllerPage() {
             dodgeballPossession,
           }
         : undefined;
-    queueIntent({
+    return queueIntent({
       version: LIVE_EVENT_CONTROL_INTENT_VERSION,
       type: "substantive",
       trigger: type,
@@ -1207,9 +1246,9 @@ export function EventGameControllerPage() {
   function queueIntent(
     candidate: LiveEventControllerIntent,
     options: { causalPredecessorIds?: readonly string[] } = {},
-  ) {
+  ): boolean {
     const current = replicaRef.current;
-    if (current === null) return;
+    if (current === null) return false;
     try {
       const relatedFactId = candidate.sportingOrderAdjudication?.relatedFactId;
       const relatedPendingOperationId =
@@ -1241,8 +1280,10 @@ export function EventGameControllerPage() {
       setProjection(dispatched.state.projection);
       setProjectionStatus("available");
       void flushReplica(dispatched.state);
+      return true;
     } catch {
       setMessage("The Controller action could not be retained safely.");
+      return false;
     }
   }
 
@@ -1693,6 +1734,8 @@ export function EventGameControllerPage() {
       eventSession?: Pick<PersistedControllerSession, "eventGameId" | "sessionReferenceId">;
     } = {},
   ) {
+    resetActionSheetDrafts();
+    setActiveActionPanel(null);
     const currentEventGameId = eventGameId;
     const currentSessionReferenceId = sessionReferenceIdRef.current;
     const eventSessionToClear =
@@ -1854,936 +1897,862 @@ export function EventGameControllerPage() {
               </Button>
             </>
           ) : (
-            <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain [&_button]:min-h-11">
-              <ControllerHeader
-                identity={eventControllerHeaderIdentity(projection)}
-                warning={
-                  controllerConnectionStatus === "fresh"
-                    ? null
-                    : {
-                        queuedActions: replica?.pendingActions.length ?? 0,
-                        kind: controllerConnectionStatus === "stale" ? "stale" : "offline",
-                        retryDetail:
-                          controllerConnectionStatus === "stale"
-                            ? "Reconnect to reconcile."
-                            : "Reconnect to sync.",
-                      }
-                }
-                qr={{
-                  triggerRef: qrTriggerRef,
-                  label: revealedQr === null ? "Reveal active Grant QR" : "Show active Grant QR",
-                  expanded: qrDialogOpen,
-                  controls: "active-grant-qr-dialog",
-                  onClick: () => {
-                    if (revealedQr === null) void revealQr();
-                    else setQrDialogOpen(true);
-                  },
-                  disabled: busy,
-                }}
-                onLeave={() => setLeaveDialogOpen(true)}
-                leaveTriggerRef={leaveTriggerRef}
-                leaveLabel="Leave Event Game Controller session"
-                leaveDisabled={busy}
-              />
-              <div className="mt-2 rounded-lg border bg-muted/30 p-3 text-sm">
-                <p className="font-medium">Controller Device: {eventGameId}</p>
-                <p className="mt-1 text-muted-foreground">
-                  {projection?.commencement.status === "commenced"
-                    ? "Game Commencement is irreversible."
-                    : "Game remains provisional until genuine play is recognized."}
-                </p>
-                {projectionStatus === "unavailable" ? (
-                  <p className="mt-1 text-muted-foreground">Projection temporarily unavailable.</p>
-                ) : null}
-              </div>
-              <div className="flex shrink-0 flex-wrap gap-2">
-                <Button
-                  variant="outline"
-                  aria-label="Refresh Event Game assignment"
-                  onClick={() => void refreshController()}
-                  disabled={busy}
-                >
-                  Refresh assignment
-                </Button>
-              </div>
-              {switchTarget === null ? null : (
-                <div className="rounded-lg border border-amber-500/50 bg-amber-50 p-3 text-sm">
-                  <p className="font-medium">Pitch Slot assignment changed.</p>
-                  <p className="mt-1">
-                    Switch to {switchTarget}, or stay on {eventGameId}.
+            <div className="relative min-h-0 flex-1 overflow-hidden">
+              <div className="h-full min-h-0 overflow-y-auto overscroll-contain pb-40 [&_button]:min-h-11">
+                <ControllerHeader
+                  identity={eventControllerHeaderIdentity(projection)}
+                  warning={
+                    controllerConnectionStatus === "fresh"
+                      ? null
+                      : {
+                          queuedActions: replica?.pendingActions.length ?? 0,
+                          kind: controllerConnectionStatus === "stale" ? "stale" : "offline",
+                          retryDetail:
+                            controllerConnectionStatus === "stale"
+                              ? "Reconnect to reconcile."
+                              : "Reconnect to sync.",
+                        }
+                  }
+                  qr={{
+                    triggerRef: qrTriggerRef,
+                    label: revealedQr === null ? "Reveal active Grant QR" : "Show active Grant QR",
+                    expanded: qrDialogOpen,
+                    controls: "active-grant-qr-dialog",
+                    onClick: () => {
+                      if (revealedQr === null) void revealQr();
+                      else setQrDialogOpen(true);
+                    },
+                    disabled: busy,
+                  }}
+                  onLeave={() => setLeaveDialogOpen(true)}
+                  leaveTriggerRef={leaveTriggerRef}
+                  leaveLabel="Leave Event Game Controller session"
+                  leaveDisabled={busy}
+                />
+                <div className="mt-2 rounded-lg border bg-muted/30 p-3 text-sm">
+                  <p className="font-medium">Controller Device: {eventGameId}</p>
+                  <p className="mt-1 text-muted-foreground">
+                    {projection?.commencement.status === "commenced"
+                      ? "Game Commencement is irreversible."
+                      : "Game remains provisional until genuine play is recognized."}
                   </p>
-                  <div className="mt-3 flex flex-wrap gap-2">
-                    <Button
-                      ref={switchTriggerRef}
-                      aria-label={`Switch to Event Game ${switchTarget}`}
-                      onClick={() => void switchEntry.begin()}
-                      disabled={busy || switchEntry.busy}
-                    >
-                      Switch Event Game
-                    </Button>
-                    <Button
-                      variant="outline"
-                      aria-label={`Stay on Event Game ${eventGameId}`}
-                      onClick={stayOnCurrentAssignment}
-                      disabled={busy}
-                    >
-                      Stay here
-                    </Button>
-                  </div>
-                </div>
-              )}
-              <div
-                className="sticky top-0 z-10 flex shrink-0 items-center justify-between gap-2 rounded-lg border bg-slate-950 p-3 text-white"
-                role="region"
-                aria-label="Event Game Clock"
-                aria-live="polite"
-              >
-                <div className="min-w-0 text-center">
-                  <p className="text-xs uppercase tracking-[0.2em] text-slate-300">Game Clock</p>
-                  <p className="mt-1 text-4xl font-semibold tabular-nums">
-                    {clockProjection === null || clockProjection.synchronization === "unavailable"
-                      ? "--:--"
-                      : formatClock(clockProjection.gameTimeMs)}
-                  </p>
-                  <p className="mt-1 text-xs text-slate-300">
-                    {clockProjection?.running ? "Play" : "Paused"} · Controller projection
-                  </p>
-                  <p className="mt-2 text-xs text-slate-300" data-clock-freshness="true">
-                    {clockProjection === null
-                      ? "Unavailable · manual timing required"
-                      : `${clockProjection.synchronization} · last synchronization: ${formatSynchronizationTime(clockProjection.lastSynchronizedAtMs)}`}
-                  </p>
-                </div>
-                <Button
-                  aria-label={clockRunning ? "Pause game clock" : "Start game clock"}
-                  aria-pressed={clockRunning}
-                  onClick={toggleClock}
-                  disabled={busy}
-                >
-                  {clockRunning ? "Pause clock" : "Start clock"}
-                </Button>
-              </div>
-              {clockProjection === null ? null : (
-                <div className="space-y-1 rounded-lg border border-amber-500/50 bg-amber-50 p-3 text-sm text-amber-950">
-                  <p data-clock-cue="flag-runner">
-                    {clockProjection.cues.flagRunnerEntry === "pending"
-                      ? "Flag-runner entry pending at 19:00"
-                      : clockProjection.cues.flagRunnerEntry === "due"
-                        ? "FLAG-RUNNER ENTRY NOW"
-                        : "Flag-runner entry complete"}
-                  </p>
-                  <p data-clock-cue="seeker-warning">
-                    {clockProjection.cues.seekerWarning === "pending"
-                      ? "Seeker warning pending"
-                      : clockProjection.cues.seekerWarning === "due"
-                        ? "SEEKER WARNING: release countdown active"
-                        : "Seeker warning complete"}
-                  </p>
-                  <p data-clock-cue="seeker-countdown">
-                    {clockProjection.cues.seekerCountdownMs === null
-                      ? "Seeker countdown: complete"
-                      : `SEEKER COUNTDOWN: ${formatClock(clockProjection.cues.seekerCountdownMs)}`}
-                  </p>
-                  <p data-clock-cue="seeker-release">
-                    {clockProjection.cues.seekerRelease === "released"
-                      ? "SEEKER RELEASED at 20:00"
-                      : "Seeker release pending at 20:00"}
-                  </p>
-                </div>
-              )}
-              {displayedHeat === undefined ? null : (
-                <div className="space-y-3 rounded-lg border border-orange-500/50 bg-orange-50 p-3 text-sm text-orange-950">
-                  <div className="flex flex-wrap items-center justify-between gap-2">
-                    <div>
-                      <p className="font-medium">Heat Stoppage Controller workflow</p>
-                      <p>
-                        Mode: {displayedHeat.mode ?? "disabled"} · status: {displayedHeat.status}
-                      </p>
-                    </div>
-                    <div className="flex gap-2">
-                      <Button
-                        size="sm"
-                        variant="outline"
-                        onClick={() => submitHeatAction("enable")}
-                        disabled={busy || displayedHeat.mode === "enabled"}
-                      >
-                        Enable mode
-                      </Button>
-                      <Button
-                        size="sm"
-                        variant="outline"
-                        onClick={() => submitHeatAction("disable")}
-                        disabled={busy || displayedHeat.mode !== "enabled"}
-                      >
-                        Disable mode
-                      </Button>
-                    </div>
-                  </div>
-                  <p>
-                    {displayedHeat.pendingTrigger === null ||
-                    displayedHeat.pendingTrigger === undefined
-                      ? "No Heat Stoppage cue is pending."
-                      : `Pending cue at ${formatClock(displayedHeat.pendingTrigger.gameTimeMs)} · the Game Clock remains running until a Controller decision.`}
-                  </p>
-                  {displayedHeat.status === "started" || displayedHeat.status === "extended" ? (
-                    <div className="rounded border bg-white/70 p-2">
-                      <p>
-                        Timer: {formatClock(displayedHeat.actualDurationMs ?? 0)} elapsed · nominal{" "}
-                        {formatClock(displayedHeat.nominalDurationMs ?? 0)} · allowed{" "}
-                        {formatClock(
-                          displayedHeat.allowedDurationMs ?? displayedHeat.nominalDurationMs ?? 0,
-                        )}
-                      </p>
-                      <p className="text-xs">
-                        Start game time: {formatClock(displayedHeat.startedAtGameTimeMs ?? 0)}
-                      </p>
-                    </div>
-                  ) : null}
-                  {displayedHeat.status === "ended" && displayedHeat.completedAtAllowed === true ? (
-                    <div className="rounded border bg-white/70 p-2">
-                      <p>
-                        Heat Stoppage complete at the allowed duration; the Game Clock remains
-                        stopped.
-                      </p>
-                      <Button size="sm" onClick={() => submitHeatAction("end")} disabled={busy}>
-                        Acknowledge completion
-                      </Button>
-                    </div>
-                  ) : null}
-                  <label className="flex items-center gap-2">
-                    <input
-                      type="checkbox"
-                      checked={heatOverrideConfirmed}
-                      onChange={(event) => setHeatOverrideConfirmed(event.target.checked)}
-                    />
-                    Head Referee Official Override confirmed
-                  </label>
-                  {displayedHeat.pendingTriggerId === null ? null : (
-                    <div className="flex flex-wrap gap-2">
-                      {(
-                        [
-                          ["end-of-drive", "End of drive"],
-                          ["dead-volleyball", "Dead volleyball"],
-                          ["other-stoppage", "Other stoppage"],
-                          ["skip-required", "Required skip"],
-                          ["start", "Start Heat Stoppage"],
-                        ] as const
-                      ).map(([action, label]) => (
-                        <Button
-                          key={action}
-                          size="sm"
-                          variant="outline"
-                          onClick={() => submitHeatAction(action)}
-                          disabled={busy}
-                        >
-                          {label}
-                        </Button>
-                      ))}
-                      <Button
-                        size="sm"
-                        variant="outline"
-                        onClick={() => submitHeatAction("skip")}
-                        disabled={busy || !heatOverrideConfirmed}
-                      >
-                        Skip (Official Override)
-                      </Button>
-                      <Button
-                        size="sm"
-                        variant="outline"
-                        onClick={() => submitHeatAction("suppress")}
-                        disabled={busy || !heatOverrideConfirmed}
-                      >
-                        Suppress cue (override)
-                      </Button>
-                    </div>
-                  )}
-                  {displayedHeat.status === "started" || displayedHeat.status === "extended" ? (
-                    <div className="flex flex-wrap gap-2">
-                      <Button size="sm" onClick={() => submitHeatAction("end")} disabled={busy}>
-                        End Heat Stoppage
-                      </Button>
-                      {displayedHeat.permittedExtensionTriggerId ===
-                      displayedHeat.activeTriggerId ? (
-                        <Button
-                          size="sm"
-                          variant="outline"
-                          onClick={() => submitHeatAction("extend-permitted")}
-                          disabled={busy}
-                        >
-                          Permitted extension
-                        </Button>
-                      ) : null}
-                      <Button
-                        size="sm"
-                        variant="outline"
-                        onClick={() => submitHeatAction("extend")}
-                        disabled={busy || !heatOverrideConfirmed}
-                      >
-                        Extend (override)
-                      </Button>
-                    </div>
+                  {projectionStatus === "unavailable" ? (
+                    <p className="mt-1 text-muted-foreground">
+                      Projection temporarily unavailable.
+                    </p>
                   ) : null}
                 </div>
-              )}
-              {projection === null ? null : (
-                <div className="flex flex-wrap items-center gap-2 rounded-lg border p-3">
+                <div className="flex shrink-0 flex-wrap gap-2">
                   <Button
                     variant="outline"
-                    aria-label="Flip Event Game physical ends"
-                    onClick={flipPitchOrientation}
+                    aria-label="Refresh Event Game assignment"
+                    onClick={() => void refreshController()}
                     disabled={busy}
                   >
-                    Flip physical ends
+                    Refresh assignment
                   </Button>
-                  <span className="text-sm text-muted-foreground">
-                    Game Side{" "}
-                    {projection.presentation?.pitchOrientation === "side-b-left"
-                      ? "side-b"
-                      : "side-a"}{" "}
-                    left
-                  </span>
-                  {Object.keys(projection.scoreByGameSide).map((gameSideId) => (
-                    <label key={gameSideId} className="flex items-center gap-2 text-sm">
-                      <input
-                        type="color"
-                        aria-label={`Game Side ${gameSideId} displayed team color`}
-                        value={
-                          projection.presentation?.displayedTeamColors[gameSideId] ?? "#00afe8"
-                        }
-                        onInput={(event) =>
-                          changeDisplayedTeamColor(
-                            gameSideId,
-                            (event.target as HTMLInputElement).value,
-                          )
-                        }
+                </div>
+                {switchTarget === null ? null : (
+                  <div className="rounded-lg border border-amber-500/50 bg-amber-50 p-3 text-sm">
+                    <p className="font-medium">Pitch Slot assignment changed.</p>
+                    <p className="mt-1">
+                      Switch to {switchTarget}, or stay on {eventGameId}.
+                    </p>
+                    <div className="mt-3 flex flex-wrap gap-2">
+                      <Button
+                        ref={switchTriggerRef}
+                        aria-label={`Switch to Event Game ${switchTarget}`}
+                        onClick={() => void switchEntry.begin()}
+                        disabled={busy || switchEntry.busy}
+                      >
+                        Switch Event Game
+                      </Button>
+                      <Button
+                        variant="outline"
+                        aria-label={`Stay on Event Game ${eventGameId}`}
+                        onClick={stayOnCurrentAssignment}
                         disabled={busy}
-                        className="h-11 w-11 cursor-pointer rounded border border-slate-300 bg-white p-1"
-                      />
-                      {gameSideId}
-                    </label>
-                  ))}
-                </div>
-              )}
-              {projection?.teamAssignmentCorrections?.map((correction) =>
-                acknowledgedTeamCorrections[correction.gameSideId] ===
-                correction.operationId ? null : (
-                  <div
-                    key={correction.operationId}
-                    className="flex items-center justify-between gap-3 rounded border border-amber-300 bg-amber-50 p-2 text-sm"
-                  >
-                    <span>
-                      Game Side {correction.gameSideId} now uses {correction.eventTeamName} (Event
-                      Team {correction.eventTeamId}). Acknowledge the corrected identity before
-                      recording another team action.
-                    </span>
-                    <Button
-                      variant="outline"
-                      onClick={() => acknowledgeTeamAssignment(correction)}
-                      disabled={busy}
-                    >
-                      Acknowledge identity
-                    </Button>
-                  </div>
-                ),
-              )}
-              <div className="flex flex-wrap gap-2">
-                {[-60_000, -10_000, 10_000, 60_000].map((adjustmentMs) => (
-                  <Button
-                    key={adjustmentMs}
-                    variant="outline"
-                    aria-label={`Adjust game clock by ${adjustmentMs < 0 ? "minus" : "plus"} ${Math.abs(adjustmentMs) / 1000} seconds`}
-                    onClick={() => adjustClock(adjustmentMs)}
-                    disabled={busy}
-                  >
-                    {adjustmentMs < 0 ? "−" : "+"}
-                    {Math.abs(adjustmentMs) / 1000}s
-                  </Button>
-                ))}
-                <div className="flex w-full flex-wrap items-end gap-2 rounded border p-2 text-left">
-                  <div className="min-w-48 flex-1 space-y-1">
-                    <Label htmlFor="clock-correction">Set game clock (milliseconds)</Label>
-                    <Input
-                      id="clock-correction"
-                      inputMode="numeric"
-                      value={clockCorrectionInput}
-                      onChange={(event) => setClockCorrectionInput(event.target.value)}
-                      placeholder="0–7200000"
-                      disabled={busy}
-                    />
-                  </div>
-                  <Button
-                    variant="outline"
-                    aria-label="Correct Event Game clock"
-                    data-clock-correction="true"
-                    onClick={correctClock}
-                    disabled={busy}
-                  >
-                    Correct clock
-                  </Button>
-                </div>
-                <div className="flex w-full flex-wrap items-end gap-2 rounded border border-amber-500/50 p-2 text-left">
-                  <div className="min-w-48 flex-1 space-y-1">
-                    <Label htmlFor="clock-takeover-adjustment">
-                      Emergency takeover adjustment (ms)
-                    </Label>
-                    <Input
-                      id="clock-takeover-adjustment"
-                      inputMode="numeric"
-                      value={takeoverAdjustmentInput}
-                      onChange={(event) => setTakeoverAdjustmentInput(event.target.value)}
-                      placeholder="optional, e.g. -1000"
-                      disabled={busy}
-                    />
-                  </div>
-                  <Button
-                    variant="outline"
-                    aria-label="Apply emergency Event Game clock takeover"
-                    data-clock-takeover="true"
-                    onClick={emergencyClockTakeover}
-                    disabled={busy}
-                  >
-                    Emergency clock takeover
-                  </Button>
-                </div>
-                <div className="flex w-full flex-wrap items-end gap-2 rounded border p-2 text-left">
-                  <div className="min-w-32 flex-1 space-y-1">
-                    <Label htmlFor="penalty-game-side">Penalized Game Side</Label>
-                    <select
-                      id="penalty-game-side"
-                      className="h-10 w-full rounded-md border bg-background px-3 text-sm"
-                      value={cardGameSideId}
-                      onChange={(event) => setCardGameSideId(event.target.value)}
-                      disabled={busy}
-                    >
-                      <option value="">Choose side</option>
-                      {Object.keys(projection?.scoreByGameSide ?? {}).map((sideId) => (
-                        <option key={sideId} value={sideId}>
-                          {sideId}
-                        </option>
-                      ))}
-                    </select>
-                  </div>
-                  <div className="w-24 space-y-1">
-                    <Label htmlFor="penalty-player-number">Player #</Label>
-                    <Input
-                      id="penalty-player-number"
-                      inputMode="numeric"
-                      value={cardPlayerNumber}
-                      onChange={(event) => setCardPlayerNumber(event.target.value)}
-                      placeholder="optional"
-                      disabled={busy}
-                    />
-                  </div>
-                  <div className="min-w-24 space-y-1">
-                    <Label htmlFor="penalty-card-type">Card</Label>
-                    <select
-                      id="penalty-card-type"
-                      className="h-10 w-full rounded-md border bg-background px-3 text-sm"
-                      value={cardType}
-                      onChange={(event) => {
-                        const nextCardType = event.target.value as LiveCardType;
-                        setCardType(nextCardType);
-                        if (nextCardType === "red" || nextCardType === "ejection") {
-                          setCardFoulBeforeScore(false);
-                        }
-                      }}
-                      disabled={busy}
-                    >
-                      <option value="blue">Blue</option>
-                      <option value="yellow">Yellow</option>
-                      <option value="red">Red</option>
-                      <option value="ejection">Ejection</option>
-                    </select>
-                  </div>
-                  <p className="max-w-52 self-center text-xs text-muted-foreground">
-                    Timing follows the live Game Clock: pregame cards begin at sticks up and
-                    confirmed seeker penalties during the seeker floor begin at 20:00.
-                  </p>
-                  <Button
-                    variant="outline"
-                    aria-label="Accept penalty card for the selected Game Side"
-                    onClick={recordCard}
-                    disabled={busy || cardGameSideId === ""}
-                  >
-                    Accept card
-                  </Button>
-                  <label className="flex items-center gap-2 text-xs">
-                    <input
-                      type="checkbox"
-                      checked={cardFoulBeforeScore}
-                      onChange={(event) => setCardFoulBeforeScore(event.target.checked)}
-                      disabled={busy || cardType === "red" || cardType === "ejection"}
-                    />
-                    Foul before score
-                  </label>
-                  <label className="flex items-center gap-2 text-xs">
-                    <input
-                      type="checkbox"
-                      checked={cardSeekerPenaltyConfirmed}
-                      onChange={(event) => setCardSeekerPenaltyConfirmed(event.target.checked)}
-                      disabled={busy}
-                    />
-                    Penalized player is the seeker (Head Referee confirmed)
-                  </label>
-                </div>
-                {projection === null
-                  ? null
-                  : Object.keys(projection.scoreByGameSide).map((gameSideId) => {
-                      const timeout = projection.timeout;
-                      const isStoppageForSide =
-                        timeout?.status === "stoppage" && timeout.gameSideId === gameSideId;
-                      const used = timeout?.usedGameSideIds?.includes(gameSideId) === true;
-                      const anotherSideActive =
-                        (timeout?.status === "stoppage" || timeout?.status === "started") &&
-                        timeout.gameSideId !== gameSideId;
-                      return (
-                        <Button
-                          key={gameSideId}
-                          variant="outline"
-                          onClick={() =>
-                            trigger("timeout", {
-                              timeoutAction: isStoppageForSide ? "start" : "stoppage",
-                              timeoutGameSideId: gameSideId,
-                            })
-                          }
-                          disabled={busy || anotherSideActive || (used && !isStoppageForSide)}
-                        >
-                          {isStoppageForSide
-                            ? `Start timeout minute: ${gameSideId}`
-                            : used
-                              ? `Timeout used: ${gameSideId}`
-                              : `Timeout stoppage: ${gameSideId}`}
-                        </Button>
-                      );
-                    })}
-                <Button
-                  variant="outline"
-                  onClick={() => setShowSuspensionRecovery(true)}
-                  disabled={busy}
-                >
-                  Review suspension recovery
-                </Button>
-                {showSuspensionRecovery || projection?.suspension?.status === "suspended" ? (
-                  <div className="w-full space-y-2 rounded-lg border p-3 text-left">
-                    <p className="text-sm font-medium">Suspension recovery review</p>
-                    <p className="text-xs text-muted-foreground">
-                      Verify the effective snapshot with another Controller before resuming.
-                    </p>
-                    {projection?.suspension?.snapshot === null ||
-                    projection?.suspension?.snapshot === undefined ? (
-                      <div className="grid gap-2 sm:grid-cols-2">
-                        <div className="space-y-1">
-                          <Label htmlFor="volleyball-possession">Volleyball possession</Label>
-                          <select
-                            id="volleyball-possession"
-                            className="h-9 w-full rounded-md border bg-background px-3 text-sm"
-                            value={volleyballPossession}
-                            onChange={(event) => setVolleyballPossession(event.target.value)}
-                            disabled={busy}
-                          >
-                            <option value="">Select Game Side</option>
-                            {Object.keys(projection?.scoreByGameSide ?? {}).map((sideId) => (
-                              <option key={sideId} value={sideId}>
-                                {sideId}
-                              </option>
-                            ))}
-                          </select>
-                        </div>
-                        <div className="space-y-1">
-                          <p className="text-sm font-medium">Dodgeball possession</p>
-                          {(projection?.knownDodgeballIds ?? []).map((ballId) => (
-                            <div key={ballId} className="space-y-1">
-                              <Label htmlFor={`dodgeball-possession-${ballId}`}>{ballId}</Label>
-                              <select
-                                id={`dodgeball-possession-${ballId}`}
-                                className="h-9 w-full rounded-md border bg-background px-3 text-sm"
-                                value={dodgeballPossession[ballId] ?? ""}
-                                onChange={(event) =>
-                                  setDodgeballPossession((current) => ({
-                                    ...current,
-                                    [ballId]: event.target.value || null,
-                                  }))
-                                }
-                                disabled={busy}
-                              >
-                                <option value="">No confirmed side</option>
-                                {Object.keys(projection?.scoreByGameSide ?? {}).map((sideId) => (
-                                  <option key={sideId} value={sideId}>
-                                    {sideId}
-                                  </option>
-                                ))}
-                              </select>
-                            </div>
-                          ))}
-                        </div>
-                        <Button
-                          variant="outline"
-                          onClick={() => trigger("suspension", { suspensionAction: "start" })}
-                          disabled={busy}
-                        >
-                          Suspend with verified snapshot
-                        </Button>
-                      </div>
-                    ) : (
-                      <div className="space-y-2">
-                        <div
-                          data-suspension-snapshot="effective"
-                          className="rounded-md bg-muted p-2 text-xs"
-                        >
-                          <p>Volleyball: {projection.suspension.snapshot.volleyballPossession}</p>
-                          {Object.entries(projection.suspension.snapshot.dodgeballPossession).map(
-                            ([ballId, gameSideId]) => (
-                              <p key={ballId} data-dodgeball-id={ballId}>
-                                {ballId}={gameSideId ?? "unconfirmed"}
-                              </p>
-                            ),
-                          )}
-                          <p>
-                            Penalty segments:{" "}
-                            {projection.suspension.snapshot.penalties.segments.length}
-                          </p>
-                        </div>
-                        <Button
-                          variant="outline"
-                          onClick={() =>
-                            trigger("suspension", {
-                              suspensionAction: "resume",
-                              resumesSuspensionFactId: projection.suspension?.factId ?? undefined,
-                            })
-                          }
-                          disabled={busy || projection.suspension?.factId === null}
-                        >
-                          Resume verified suspension
-                        </Button>
-                      </div>
-                    )}
-                  </div>
-                ) : null}
-                <Button
-                  variant="outline"
-                  aria-label="Record final Event Game result"
-                  onClick={() => trigger("result")}
-                  disabled={busy}
-                >
-                  Record result
-                </Button>
-              </div>
-              {projection === null ? null : (
-                <div className="space-y-3">
-                  <p className="text-sm text-muted-foreground">
-                    Phase: {projection.phase} · Goals: {projection.goalCount}
-                    {projection.overtime ? " · Overtime" : ""}
-                  </p>
-                  {projection.overtime ? (
-                    <p data-overtime-target="true" className="text-sm font-semibold">
-                      Overtime target: {projection.overtimeTarget ?? projection.targetScore ?? "—"}
-                    </p>
-                  ) : null}
-                  {pendingClosePlayAdjudication === null ? null : (
-                    <div
-                      data-close-play-adjudication="true"
-                      className="space-y-2 rounded-lg border border-amber-500/60 bg-amber-50 p-3 text-sm text-amber-950"
-                    >
-                      <p className="font-medium">Head Referee close goal/catch ordering</p>
-                      <p>
-                        The{" "}
-                        {pendingClosePlayAdjudication.intentType === "record-goal"
-                          ? "goal"
-                          : "flag catch"}{" "}
-                        has {pendingClosePlayAdjudication.relatedFacts.length} opposing close-play
-                        candidate
-                        {pendingClosePlayAdjudication.relatedFacts.length === 1 ? "" : "s"}. Choose
-                        the exact paired fact and adjudicated sporting order without changing either
-                        Game Clock time.
-                      </p>
-                      {pendingClosePlayAdjudication.relatedFacts.map((relatedFact) => (
-                        <div
-                          key={relatedFact.factId}
-                          data-close-play-related-fact-id={relatedFact.factId}
-                          className="space-y-1"
-                        >
-                          <p>
-                            Existing {relatedFact.factType} at {relatedFact.gameTimeMs}
-                          </p>
-                          <div className="flex flex-wrap gap-2">
-                            <Button
-                              variant="outline"
-                              onClick={() =>
-                                submitClosePlayAdjudication("before", relatedFact.factId)
-                              }
-                              disabled={busy}
-                            >
-                              {pendingClosePlayAdjudication.intentType === "record-goal"
-                                ? "Goal before catch"
-                                : "Catch before goal"}
-                            </Button>
-                            <Button
-                              variant="outline"
-                              onClick={() =>
-                                submitClosePlayAdjudication("after", relatedFact.factId)
-                              }
-                              disabled={busy}
-                            >
-                              {pendingClosePlayAdjudication.intentType === "record-goal"
-                                ? "Goal after catch"
-                                : "Catch after goal"}
-                            </Button>
-                          </div>
-                        </div>
-                      ))}
-                      <div>
-                        <Button
-                          variant="ghost"
-                          aria-label="Cancel close-play adjudication"
-                          onClick={() => setPendingClosePlayAdjudication(null)}
-                          disabled={busy}
-                        >
-                          Cancel
-                        </Button>
-                      </div>
+                      >
+                        Stay here
+                      </Button>
                     </div>
-                  )}
-                  {pendingFlagCatchBoundaryOverride === null ? null : (
-                    <div
-                      data-flag-catch-boundary-override="true"
-                      className="space-y-2 rounded-lg border border-amber-500/60 bg-amber-50 p-3 text-sm text-amber-950"
-                    >
-                      <p className="font-medium">Head Referee flag-catch boundary override</p>
-                      <p>
-                        Confirm the catch despite unreleased seekers or running play. This records
-                        the affected guardrail separately from any Sporting Order decision.
-                      </p>
-                      <div className="flex flex-wrap gap-2">
-                        <Button onClick={submitFlagCatchBoundaryOverride} disabled={busy}>
-                          Confirm boundary override
-                        </Button>
-                        <Button
-                          variant="ghost"
-                          aria-label="Cancel flag-catch boundary override"
-                          onClick={() => setPendingFlagCatchBoundaryOverride(null)}
-                          disabled={busy}
-                        >
-                          Cancel
-                        </Button>
-                      </div>
-                    </div>
-                  )}
-                  <p className="text-xs text-muted-foreground">
-                    Timeout: {projection.timeout?.status ?? "inactive"} · Stoppage:{" "}
-                    {projection.stoppage?.status ?? "none"} · Heat:{" "}
-                    {projection.heat?.status ?? "inactive"}
-                    {projection.result === null || projection.result === undefined
-                      ? ""
-                      : projection.winnerGameSideId !== null &&
-                          projection.winnerGameSideId !== undefined
-                        ? ` · Winner: Game Side ${projection.winnerGameSideId}`
-                        : isDoubleForfeitResult(projection.result)
-                          ? " · Double-forfeit: no winner"
-                          : " · Result recorded"}
-                  </p>
-                  {Object.entries(projection.scoreByGameSide).map(([gameSideId, score]) => (
-                    <div key={gameSideId} className="flex items-center justify-between gap-3">
-                      <span className="font-medium">Game Side {gameSideId}</span>
-                      <div className="flex items-center gap-3">
+                  </div>
+                )}
+                <div
+                  className="sticky top-0 z-10 flex shrink-0 items-center justify-between gap-2 rounded-lg border bg-slate-950 p-3 text-white"
+                  role="region"
+                  aria-label="Event Game Clock"
+                  aria-live="polite"
+                >
+                  <div className="min-w-0 text-center">
+                    <p className="text-xs uppercase tracking-[0.2em] text-slate-300">Game Clock</p>
+                    <p className="mt-1 text-4xl font-semibold tabular-nums">
+                      {clockProjection === null || clockProjection.synchronization === "unavailable"
+                        ? "--:--"
+                        : formatClock(clockProjection.gameTimeMs)}
+                    </p>
+                    <p className="mt-1 text-xs text-slate-300">
+                      {clockProjection?.running ? "Play" : "Paused"} · Controller projection
+                    </p>
+                    <p className="mt-2 text-xs text-slate-300" data-clock-freshness="true">
+                      {clockProjection === null
+                        ? "Unavailable · manual timing required"
+                        : `${clockProjection.synchronization} · last synchronization: ${formatSynchronizationTime(clockProjection.lastSynchronizedAtMs)}`}
+                    </p>
+                  </div>
+                  <Button
+                    aria-label={clockRunning ? "Pause game clock" : "Start game clock"}
+                    aria-pressed={clockRunning}
+                    onClick={toggleClock}
+                    disabled={busy}
+                  >
+                    {clockRunning ? "Pause clock" : "Start clock"}
+                  </Button>
+                </div>
+                {projection === null ? null : (
+                  <section
+                    aria-label="Event Game Score"
+                    className="mt-2 grid grid-cols-2 gap-2 rounded-lg border bg-white p-2"
+                  >
+                    {Object.entries(projection.scoreByGameSide).map(([gameSideId, score]) => (
+                      <div
+                        key={gameSideId}
+                        className="grid gap-1 rounded-lg border p-2 text-center"
+                      >
+                        <span className="text-xs font-medium">Game Side {gameSideId}</span>
                         <span className="text-2xl font-semibold tabular-nums">{score}</span>
                         <Button
+                          data-primary-score="up"
                           aria-label={`Record 10-point goal for Game Side ${gameSideId}`}
                           onClick={() => recordGoal(gameSideId)}
                           disabled={busy}
                         >
-                          Record 10-point goal
+                          +10 goal
+                        </Button>
+                      </div>
+                    ))}
+                  </section>
+                )}
+                {clockProjection === null ? null : (
+                  <div className="space-y-1 rounded-lg border border-amber-500/50 bg-amber-50 p-3 text-sm text-amber-950">
+                    <p data-clock-cue="flag-runner">
+                      {clockProjection.cues.flagRunnerEntry === "pending"
+                        ? "Flag-runner entry pending at 19:00"
+                        : clockProjection.cues.flagRunnerEntry === "due"
+                          ? "FLAG-RUNNER ENTRY NOW"
+                          : "Flag-runner entry complete"}
+                    </p>
+                    <p data-clock-cue="seeker-warning">
+                      {clockProjection.cues.seekerWarning === "pending"
+                        ? "Seeker warning pending"
+                        : clockProjection.cues.seekerWarning === "due"
+                          ? "SEEKER WARNING: release countdown active"
+                          : "Seeker warning complete"}
+                    </p>
+                    <p data-clock-cue="seeker-countdown">
+                      {clockProjection.cues.seekerCountdownMs === null
+                        ? "Seeker countdown: complete"
+                        : `SEEKER COUNTDOWN: ${formatClock(clockProjection.cues.seekerCountdownMs)}`}
+                    </p>
+                    <p data-clock-cue="seeker-release">
+                      {clockProjection.cues.seekerRelease === "released"
+                        ? "SEEKER RELEASED at 20:00"
+                        : "Seeker release pending at 20:00"}
+                    </p>
+                  </div>
+                )}
+                {displayedHeat === undefined ? null : (
+                  <div className="space-y-3 rounded-lg border border-orange-500/50 bg-orange-50 p-3 text-sm text-orange-950">
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                      <div>
+                        <p className="font-medium">Heat Stoppage Controller workflow</p>
+                        <p>
+                          Mode: {displayedHeat.mode ?? "disabled"} · status: {displayedHeat.status}
+                        </p>
+                      </div>
+                      <div className="flex gap-2">
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() => submitHeatAction("enable")}
+                          disabled={busy || displayedHeat.mode === "enabled"}
+                        >
+                          Enable mode
                         </Button>
                         <Button
+                          size="sm"
                           variant="outline"
-                          aria-label={`Record flag catch for Game Side ${gameSideId}`}
-                          onClick={() => recordFlagCatch(gameSideId)}
-                          disabled={busy}
+                          onClick={() => submitHeatAction("disable")}
+                          disabled={busy || displayedHeat.mode !== "enabled"}
                         >
-                          Record flag catch
-                        </Button>
-                        {projection.overtime &&
-                        projection.phase !== "finished" &&
-                        projection.winnerGameSideId === null ? (
-                          <Button
-                            variant="outline"
-                            aria-label={`Concede Event Game for Game Side ${gameSideId}`}
-                            onClick={() => recordConcession(gameSideId)}
-                            disabled={busy}
-                          >
-                            Concede
-                          </Button>
-                        ) : null}
-                        <Button
-                          variant="outline"
-                          aria-label={`Record directed forfeit for Game Side ${gameSideId}`}
-                          onClick={() => recordForfeit(gameSideId)}
-                          disabled={busy}
-                        >
-                          Directed forfeit
+                          Disable mode
                         </Button>
                       </div>
                     </div>
-                  ))}
-                  <Button
-                    variant="outline"
-                    aria-label="Record directed double-forfeit"
-                    onClick={recordDoubleForfeit}
-                    disabled={busy}
-                  >
-                    Record double-forfeit
-                  </Button>
-                  <div className="space-y-3 rounded-lg border p-3">
-                    <p className="text-sm font-medium">Penalties</p>
-                    {(livePenalties?.players ?? []).length === 0 ? (
-                      <p className="text-sm text-muted-foreground">No active penalties.</p>
-                    ) : (
-                      (livePenalties?.players ?? []).map((player) => (
-                        <div
-                          key={player.playerKey}
-                          className="flex items-center justify-between gap-3 text-sm"
-                        >
-                          <span>{formatPenaltyPlayerLabel(player.playerKey, livePenalties)}</span>
-                          <span className="tabular-nums">
-                            {formatClock(
-                              player.segments.reduce(
-                                (sum, segment) => sum + segment.remainingMs,
-                                0,
-                              ),
-                            )}
-                          </span>
-                        </div>
-                      ))
-                    )}
-                    {(livePenalties?.pendingExpirations ?? []).map((pending) => (
-                      <div
-                        key={pending.id}
-                        className="space-y-2 rounded border border-amber-500/50 bg-amber-50 p-2 text-sm"
-                      >
+                    <p>
+                      {displayedHeat.pendingTrigger === null ||
+                      displayedHeat.pendingTrigger === undefined
+                        ? "No Heat Stoppage cue is pending."
+                        : `Pending cue at ${formatClock(displayedHeat.pendingTrigger.gameTimeMs)} · the Game Clock remains running until a Controller decision.`}
+                    </p>
+                    {displayedHeat.status === "started" || displayedHeat.status === "extended" ? (
+                      <div className="rounded border bg-white/70 p-2">
                         <p>
-                          Goal release: choose a penalty ({formatClock(pending.serviceDurationMs)}).
-                          {pending.requiresOfficialChoice
-                            ? " Complete tie requires official choice."
-                            : ""}
+                          Timer: {formatClock(displayedHeat.actualDurationMs ?? 0)} elapsed ·
+                          nominal {formatClock(displayedHeat.nominalDurationMs ?? 0)} · allowed{" "}
+                          {formatClock(
+                            displayedHeat.allowedDurationMs ?? displayedHeat.nominalDurationMs ?? 0,
+                          )}
                         </p>
-                        <div className="flex flex-wrap gap-2">
-                          {pending.candidatePlayerKeys.map((playerKey) => (
-                            <Button
-                              key={playerKey}
-                              size="sm"
-                              variant="outline"
-                              onClick={() =>
-                                resolvePenaltyExpiration(pending.id, pending.scoreFactId, playerKey)
-                              }
-                              disabled={busy}
-                            >
-                              Release {formatPenaltyPlayerLabel(playerKey, livePenalties)}
-                            </Button>
-                          ))}
-                        </div>
+                        <p className="text-xs">
+                          Start game time: {formatClock(displayedHeat.startedAtGameTimeMs ?? 0)}
+                        </p>
                       </div>
-                    ))}
-                    {(livePenalties?.releases ?? []).map((release) => (
-                      <p key={release.id} className="text-xs text-emerald-700">
-                        Released {formatPenaltyPlayerLabel(release.playerKey, livePenalties)} after
-                        {release.releaseCause === "foul-before-score"
-                          ? " foul-before-score"
-                          : " opposing score"}{" "}
-                        at {formatClock(release.releasedMs)}.
-                      </p>
-                    ))}
-                    {(livePenalties?.cards ?? []).map((card) => (
-                      <div key={card.factId} className="flex flex-wrap items-center gap-2 text-xs">
-                        <span>
-                          {card.cardType} ·{" "}
-                          {formatPenaltyPlayerLabel(card.playerKey, livePenalties, {
-                            gameSideId: card.gameSideId,
-                            playerNumber: card.playerNumber,
-                          })}
-                        </span>
-                        <span>
-                          {card.reason === null
-                            ? skippedPenaltyReasonCardIds.has(card.factId)
-                              ? "reason skipped; add later"
-                              : "reason later/skipped"
-                            : `reason: ${card.reason}`}
-                        </span>
-                        {card.reason === null ? (
-                          <>
-                            {(
-                              [
-                                ["contact-safety", "Contact/Safety"],
-                                ["ball-interaction", "Ball Interaction"],
-                                ["position-boundary", "Position/Boundary"],
-                                ["procedure-substitution", "Procedure/Substitution"],
-                                ["conduct", "Conduct"],
-                                ["skip", "Skip"],
-                              ] as const
-                            ).map(([reason, label]) => (
-                              <Button
-                                key={reason}
-                                size="sm"
-                                variant="ghost"
-                                onClick={() =>
-                                  reason === "skip"
-                                    ? skipPenaltyReason(card.factId)
-                                    : recordPenaltyReason(card.factId, reason as LivePenaltyReason)
-                                }
-                                disabled={busy}
-                              >
-                                {label}
-                              </Button>
-                            ))}
-                          </>
-                        ) : null}
+                    ) : null}
+                    {displayedHeat.status === "ended" &&
+                    displayedHeat.completedAtAllowed === true ? (
+                      <div className="rounded border bg-white/70 p-2">
+                        <p>
+                          Heat Stoppage complete at the allowed duration; the Game Clock remains
+                          stopped.
+                        </p>
+                        <Button size="sm" onClick={() => submitHeatAction("end")} disabled={busy}>
+                          Acknowledge completion
+                        </Button>
                       </div>
-                    ))}
-                  </div>
-                  <div className="space-y-2 rounded-lg border p-3">
-                    <p className="text-sm font-medium">Game Facts</p>
-                    {(projection.gameFacts ?? []).length === 0 ? (
-                      <p className="text-sm text-muted-foreground">No Game Facts recorded.</p>
-                    ) : (
-                      (projection.gameFacts ?? []).map((fact) => (
-                        <div
-                          key={fact.factId}
-                          data-game-fact-id={fact.factId}
-                          className="flex items-center justify-between gap-3 text-sm"
+                    ) : null}
+                    <label className="flex items-center gap-2">
+                      <input
+                        type="checkbox"
+                        checked={heatOverrideConfirmed}
+                        onChange={(event) => setHeatOverrideConfirmed(event.target.checked)}
+                      />
+                      Head Referee Official Override confirmed
+                    </label>
+                    {displayedHeat.pendingTriggerId === null ? null : (
+                      <div className="flex flex-wrap gap-2">
+                        {(
+                          [
+                            ["end-of-drive", "End of drive"],
+                            ["dead-volleyball", "Dead volleyball"],
+                            ["other-stoppage", "Other stoppage"],
+                            ["skip-required", "Required skip"],
+                            ["start", "Start Heat Stoppage"],
+                          ] as const
+                        ).map(([action, label]) => (
+                          <Button
+                            key={action}
+                            size="sm"
+                            variant="outline"
+                            onClick={() => submitHeatAction(action)}
+                            disabled={busy}
+                          >
+                            {label}
+                          </Button>
+                        ))}
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() => submitHeatAction("skip")}
+                          disabled={busy || !heatOverrideConfirmed}
                         >
-                          <span className="min-w-0">
-                            <span className="font-medium">{fact.factType}</span>
-                            <code className="ml-2 text-xs text-muted-foreground">
-                              {fact.factId}
-                            </code>
-                            <span className="ml-2 text-xs text-muted-foreground">
-                              sporting {fact.sportingOrder} · sync {fact.synchronizationOrder}
-                            </span>
-                          </span>
+                          Skip (Official Override)
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() => submitHeatAction("suppress")}
+                          disabled={busy || !heatOverrideConfirmed}
+                        >
+                          Suppress cue (override)
+                        </Button>
+                      </div>
+                    )}
+                    {displayedHeat.status === "started" || displayedHeat.status === "extended" ? (
+                      <div className="flex flex-wrap gap-2">
+                        <Button size="sm" onClick={() => submitHeatAction("end")} disabled={busy}>
+                          End Heat Stoppage
+                        </Button>
+                        {displayedHeat.permittedExtensionTriggerId ===
+                        displayedHeat.activeTriggerId ? (
                           <Button
                             size="sm"
                             variant="outline"
-                            aria-label={`${fact.effective ? "Correct" : "Reinstate"} Game Fact ${fact.factId}`}
-                            onClick={() => correctFact(fact.factId, !fact.effective)}
+                            onClick={() => submitHeatAction("extend-permitted")}
                             disabled={busy}
                           >
-                            {fact.effective ? "Correct" : "Reinstate"}
+                            Permitted extension
+                          </Button>
+                        ) : null}
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() => submitHeatAction("extend")}
+                          disabled={busy || !heatOverrideConfirmed}
+                        >
+                          Extend (override)
+                        </Button>
+                      </div>
+                    ) : null}
+                  </div>
+                )}
+                {projection === null ? null : (
+                  <div className="flex flex-wrap items-center gap-2 rounded-lg border p-3">
+                    <Button
+                      variant="outline"
+                      aria-label="Flip Event Game physical ends"
+                      onClick={flipPitchOrientation}
+                      disabled={busy}
+                    >
+                      Flip physical ends
+                    </Button>
+                    <span className="text-sm text-muted-foreground">
+                      Game Side{" "}
+                      {projection.presentation?.pitchOrientation === "side-b-left"
+                        ? "side-b"
+                        : "side-a"}{" "}
+                      left
+                    </span>
+                    {Object.keys(projection.scoreByGameSide).map((gameSideId) => (
+                      <label key={gameSideId} className="flex items-center gap-2 text-sm">
+                        <input
+                          type="color"
+                          aria-label={`Game Side ${gameSideId} displayed team color`}
+                          value={
+                            projection.presentation?.displayedTeamColors[gameSideId] ?? "#00afe8"
+                          }
+                          onInput={(event) =>
+                            changeDisplayedTeamColor(
+                              gameSideId,
+                              (event.target as HTMLInputElement).value,
+                            )
+                          }
+                          disabled={busy}
+                          className="h-11 w-11 cursor-pointer rounded border border-slate-300 bg-white p-1"
+                        />
+                        {gameSideId}
+                      </label>
+                    ))}
+                  </div>
+                )}
+                {projection?.teamAssignmentCorrections?.map((correction) =>
+                  acknowledgedTeamCorrections[correction.gameSideId] ===
+                  correction.operationId ? null : (
+                    <div
+                      key={correction.operationId}
+                      className="flex items-center justify-between gap-3 rounded border border-amber-300 bg-amber-50 p-2 text-sm"
+                    >
+                      <span>
+                        Game Side {correction.gameSideId} now uses {correction.eventTeamName} (Event
+                        Team {correction.eventTeamId}). Acknowledge the corrected identity before
+                        recording another team action.
+                      </span>
+                      <Button
+                        variant="outline"
+                        onClick={() => acknowledgeTeamAssignment(correction)}
+                        disabled={busy}
+                      >
+                        Acknowledge identity
+                      </Button>
+                    </div>
+                  ),
+                )}
+                <div className="flex flex-wrap gap-2">
+                  {[-60_000, -10_000, 10_000, 60_000].map((adjustmentMs) => (
+                    <Button
+                      key={adjustmentMs}
+                      variant="outline"
+                      aria-label={`Adjust game clock by ${adjustmentMs < 0 ? "minus" : "plus"} ${Math.abs(adjustmentMs) / 1000} seconds`}
+                      onClick={() => adjustClock(adjustmentMs)}
+                      disabled={busy}
+                    >
+                      {adjustmentMs < 0 ? "−" : "+"}
+                      {Math.abs(adjustmentMs) / 1000}s
+                    </Button>
+                  ))}
+                  <div className="flex w-full flex-wrap items-end gap-2 rounded border p-2 text-left">
+                    <div className="min-w-48 flex-1 space-y-1">
+                      <Label htmlFor="clock-correction">Set game clock (milliseconds)</Label>
+                      <Input
+                        id="clock-correction"
+                        inputMode="numeric"
+                        value={clockCorrectionInput}
+                        onChange={(event) => setClockCorrectionInput(event.target.value)}
+                        placeholder="0–7200000"
+                        disabled={busy}
+                      />
+                    </div>
+                    <Button
+                      variant="outline"
+                      aria-label="Correct Event Game clock"
+                      data-clock-correction="true"
+                      onClick={correctClock}
+                      disabled={busy}
+                    >
+                      Correct clock
+                    </Button>
+                  </div>
+                  <div className="flex w-full flex-wrap items-end gap-2 rounded border border-amber-500/50 p-2 text-left">
+                    <div className="min-w-48 flex-1 space-y-1">
+                      <Label htmlFor="clock-takeover-adjustment">
+                        Emergency takeover adjustment (ms)
+                      </Label>
+                      <Input
+                        id="clock-takeover-adjustment"
+                        inputMode="numeric"
+                        value={takeoverAdjustmentInput}
+                        onChange={(event) => setTakeoverAdjustmentInput(event.target.value)}
+                        placeholder="optional, e.g. -1000"
+                        disabled={busy}
+                      />
+                    </div>
+                    <Button
+                      variant="outline"
+                      aria-label="Apply emergency Event Game clock takeover"
+                      data-clock-takeover="true"
+                      onClick={emergencyClockTakeover}
+                      disabled={busy}
+                    >
+                      Emergency clock takeover
+                    </Button>
+                  </div>
+                  <Button
+                    variant="outline"
+                    onClick={() => setShowSuspensionRecovery(true)}
+                    disabled={busy}
+                  >
+                    Review suspension recovery
+                  </Button>
+                  {showSuspensionRecovery || projection?.suspension?.status === "suspended" ? (
+                    <div className="w-full space-y-2 rounded-lg border p-3 text-left">
+                      <p className="text-sm font-medium">Suspension recovery review</p>
+                      <p className="text-xs text-muted-foreground">
+                        Verify the effective snapshot with another Controller before resuming.
+                      </p>
+                      {projection?.suspension?.snapshot === null ||
+                      projection?.suspension?.snapshot === undefined ? (
+                        <div className="grid gap-2 sm:grid-cols-2">
+                          <div className="space-y-1">
+                            <Label htmlFor="volleyball-possession">Volleyball possession</Label>
+                            <select
+                              id="volleyball-possession"
+                              className="h-9 w-full rounded-md border bg-background px-3 text-sm"
+                              value={volleyballPossession}
+                              onChange={(event) => setVolleyballPossession(event.target.value)}
+                              disabled={busy}
+                            >
+                              <option value="">Select Game Side</option>
+                              {Object.keys(projection?.scoreByGameSide ?? {}).map((sideId) => (
+                                <option key={sideId} value={sideId}>
+                                  {sideId}
+                                </option>
+                              ))}
+                            </select>
+                          </div>
+                          <div className="space-y-1">
+                            <p className="text-sm font-medium">Dodgeball possession</p>
+                            {(projection?.knownDodgeballIds ?? []).map((ballId) => (
+                              <div key={ballId} className="space-y-1">
+                                <Label htmlFor={`dodgeball-possession-${ballId}`}>{ballId}</Label>
+                                <select
+                                  id={`dodgeball-possession-${ballId}`}
+                                  className="h-9 w-full rounded-md border bg-background px-3 text-sm"
+                                  value={dodgeballPossession[ballId] ?? ""}
+                                  onChange={(event) =>
+                                    setDodgeballPossession((current) => ({
+                                      ...current,
+                                      [ballId]: event.target.value || null,
+                                    }))
+                                  }
+                                  disabled={busy}
+                                >
+                                  <option value="">No confirmed side</option>
+                                  {Object.keys(projection?.scoreByGameSide ?? {}).map((sideId) => (
+                                    <option key={sideId} value={sideId}>
+                                      {sideId}
+                                    </option>
+                                  ))}
+                                </select>
+                              </div>
+                            ))}
+                          </div>
+                          <Button
+                            variant="outline"
+                            onClick={() => trigger("suspension", { suspensionAction: "start" })}
+                            disabled={busy}
+                          >
+                            Suspend with verified snapshot
                           </Button>
                         </div>
-                      ))
-                    )}
-                  </div>
+                      ) : (
+                        <div className="space-y-2">
+                          <div
+                            data-suspension-snapshot="effective"
+                            className="rounded-md bg-muted p-2 text-xs"
+                          >
+                            <p>Volleyball: {projection.suspension.snapshot.volleyballPossession}</p>
+                            {Object.entries(projection.suspension.snapshot.dodgeballPossession).map(
+                              ([ballId, gameSideId]) => (
+                                <p key={ballId} data-dodgeball-id={ballId}>
+                                  {ballId}={gameSideId ?? "unconfirmed"}
+                                </p>
+                              ),
+                            )}
+                            <p>
+                              Penalty segments:{" "}
+                              {projection.suspension.snapshot.penalties.segments.length}
+                            </p>
+                          </div>
+                          <Button
+                            variant="outline"
+                            onClick={() =>
+                              trigger("suspension", {
+                                suspensionAction: "resume",
+                                resumesSuspensionFactId: projection.suspension?.factId ?? undefined,
+                              })
+                            }
+                            disabled={busy || projection.suspension?.factId === null}
+                          >
+                            Resume verified suspension
+                          </Button>
+                        </div>
+                      )}
+                    </div>
+                  ) : null}
                 </div>
-              )}
-              {replica !== null && replica.pendingActions.length > 0 ? (
-                <p className="text-sm text-amber-700">
-                  {replica.pendingActions.length} Controller action(s) retained for reconnect
-                  replay.
-                </p>
-              ) : null}
-              {durabilityWarning === null ? null : (
-                <p role="alert" className="text-sm font-medium text-amber-700">
-                  {durabilityWarning}
-                </p>
-              )}
+                {projection === null ? null : (
+                  <div className="space-y-3">
+                    <p className="text-sm text-muted-foreground">
+                      Phase: {projection.phase} · Goals: {projection.goalCount}
+                      {projection.overtime ? " · Overtime" : ""}
+                    </p>
+                    {projection.overtime ? (
+                      <p data-overtime-target="true" className="text-sm font-semibold">
+                        Overtime target:{" "}
+                        {projection.overtimeTarget ?? projection.targetScore ?? "—"}
+                      </p>
+                    ) : null}
+                    {pendingClosePlayAdjudication === null ? null : (
+                      <div
+                        data-close-play-adjudication="true"
+                        className="space-y-2 rounded-lg border border-amber-500/60 bg-amber-50 p-3 text-sm text-amber-950"
+                      >
+                        <p className="font-medium">Head Referee close goal/catch ordering</p>
+                        <p>
+                          The{" "}
+                          {pendingClosePlayAdjudication.intentType === "record-goal"
+                            ? "goal"
+                            : "flag catch"}{" "}
+                          has {pendingClosePlayAdjudication.relatedFacts.length} opposing close-play
+                          candidate
+                          {pendingClosePlayAdjudication.relatedFacts.length === 1 ? "" : "s"}.
+                          Choose the exact paired fact and adjudicated sporting order without
+                          changing either Game Clock time.
+                        </p>
+                        {pendingClosePlayAdjudication.relatedFacts.map((relatedFact) => (
+                          <div
+                            key={relatedFact.factId}
+                            data-close-play-related-fact-id={relatedFact.factId}
+                            className="space-y-1"
+                          >
+                            <p>
+                              Existing {relatedFact.factType} at {relatedFact.gameTimeMs}
+                            </p>
+                            <div className="flex flex-wrap gap-2">
+                              <Button
+                                variant="outline"
+                                onClick={() =>
+                                  submitClosePlayAdjudication("before", relatedFact.factId)
+                                }
+                                disabled={busy}
+                              >
+                                {pendingClosePlayAdjudication.intentType === "record-goal"
+                                  ? "Goal before catch"
+                                  : "Catch before goal"}
+                              </Button>
+                              <Button
+                                variant="outline"
+                                onClick={() =>
+                                  submitClosePlayAdjudication("after", relatedFact.factId)
+                                }
+                                disabled={busy}
+                              >
+                                {pendingClosePlayAdjudication.intentType === "record-goal"
+                                  ? "Goal after catch"
+                                  : "Catch after goal"}
+                              </Button>
+                            </div>
+                          </div>
+                        ))}
+                        <div>
+                          <Button
+                            variant="ghost"
+                            aria-label="Cancel close-play adjudication"
+                            onClick={() => setPendingClosePlayAdjudication(null)}
+                            disabled={busy}
+                          >
+                            Cancel
+                          </Button>
+                        </div>
+                      </div>
+                    )}
+                    {pendingFlagCatchBoundaryOverride === null ? null : (
+                      <div
+                        data-flag-catch-boundary-override="true"
+                        className="space-y-2 rounded-lg border border-amber-500/60 bg-amber-50 p-3 text-sm text-amber-950"
+                      >
+                        <p className="font-medium">Head Referee flag-catch boundary override</p>
+                        <p>
+                          Confirm the catch despite unreleased seekers or running play. This records
+                          the affected guardrail separately from any Sporting Order decision.
+                        </p>
+                        <div className="flex flex-wrap gap-2">
+                          <Button onClick={submitFlagCatchBoundaryOverride} disabled={busy}>
+                            Confirm boundary override
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            aria-label="Cancel flag-catch boundary override"
+                            onClick={() => setPendingFlagCatchBoundaryOverride(null)}
+                            disabled={busy}
+                          >
+                            Cancel
+                          </Button>
+                        </div>
+                      </div>
+                    )}
+                    <p className="text-xs text-muted-foreground">
+                      Timeout: {projection.timeout?.status ?? "inactive"} · Stoppage:{" "}
+                      {projection.stoppage?.status ?? "none"} · Heat:{" "}
+                      {projection.heat?.status ?? "inactive"}
+                      {projection.result === null || projection.result === undefined
+                        ? ""
+                        : projection.winnerGameSideId !== null &&
+                            projection.winnerGameSideId !== undefined
+                          ? ` · Winner: Game Side ${projection.winnerGameSideId}`
+                          : isDoubleForfeitResult(projection.result)
+                            ? " · Double-forfeit: no winner"
+                            : " · Result recorded"}
+                    </p>
+                    {Object.entries(projection.scoreByGameSide).map(([gameSideId, score]) => (
+                      <div key={gameSideId} className="flex items-center justify-between gap-3">
+                        <span className="font-medium">Game Side {gameSideId}</span>
+                        <span className="text-2xl font-semibold tabular-nums">{score}</span>
+                      </div>
+                    ))}
+                    <div className="space-y-3 rounded-lg border p-3">
+                      <p className="text-sm font-medium">Penalties</p>
+                      {(livePenalties?.players ?? []).length === 0 ? (
+                        <p className="text-sm text-muted-foreground">No active penalties.</p>
+                      ) : (
+                        (livePenalties?.players ?? []).map((player) => (
+                          <div
+                            key={player.playerKey}
+                            className="flex items-center justify-between gap-3 text-sm"
+                          >
+                            <span>{formatPenaltyPlayerLabel(player.playerKey, livePenalties)}</span>
+                            <span className="tabular-nums">
+                              {formatClock(
+                                player.segments.reduce(
+                                  (sum, segment) => sum + segment.remainingMs,
+                                  0,
+                                ),
+                              )}
+                            </span>
+                          </div>
+                        ))
+                      )}
+                      {(livePenalties?.pendingExpirations ?? []).map((pending) => (
+                        <div
+                          key={pending.id}
+                          className="space-y-2 rounded border border-amber-500/50 bg-amber-50 p-2 text-sm"
+                        >
+                          <p>
+                            Goal release: choose a penalty ({formatClock(pending.serviceDurationMs)}
+                            ).
+                            {pending.requiresOfficialChoice
+                              ? " Complete tie requires official choice."
+                              : ""}
+                          </p>
+                          <div className="flex flex-wrap gap-2">
+                            {pending.candidatePlayerKeys.map((playerKey) => (
+                              <Button
+                                key={playerKey}
+                                size="sm"
+                                variant="outline"
+                                onClick={() =>
+                                  resolvePenaltyExpiration(
+                                    pending.id,
+                                    pending.scoreFactId,
+                                    playerKey,
+                                  )
+                                }
+                                disabled={busy}
+                              >
+                                Release {formatPenaltyPlayerLabel(playerKey, livePenalties)}
+                              </Button>
+                            ))}
+                          </div>
+                        </div>
+                      ))}
+                      {(livePenalties?.releases ?? []).map((release) => (
+                        <p key={release.id} className="text-xs text-emerald-700">
+                          Released {formatPenaltyPlayerLabel(release.playerKey, livePenalties)}{" "}
+                          after
+                          {release.releaseCause === "foul-before-score"
+                            ? " foul-before-score"
+                            : " opposing score"}{" "}
+                          at {formatClock(release.releasedMs)}.
+                        </p>
+                      ))}
+                      {(livePenalties?.cards ?? []).map((card) => (
+                        <div
+                          key={card.factId}
+                          className="flex flex-wrap items-center gap-2 text-xs"
+                        >
+                          <span>
+                            {card.cardType} ·{" "}
+                            {formatPenaltyPlayerLabel(card.playerKey, livePenalties, {
+                              gameSideId: card.gameSideId,
+                              playerNumber: card.playerNumber,
+                            })}
+                          </span>
+                          <span>
+                            {card.reason === null
+                              ? skippedPenaltyReasonCardIds.has(card.factId)
+                                ? "reason skipped; add later"
+                                : "reason later/skipped"
+                              : `reason: ${card.reason}`}
+                          </span>
+                          {card.reason === null ? (
+                            <>
+                              {(
+                                [
+                                  ["contact-safety", "Contact/Safety"],
+                                  ["ball-interaction", "Ball Interaction"],
+                                  ["position-boundary", "Position/Boundary"],
+                                  ["procedure-substitution", "Procedure/Substitution"],
+                                  ["conduct", "Conduct"],
+                                  ["skip", "Skip"],
+                                ] as const
+                              ).map(([reason, label]) => (
+                                <Button
+                                  key={reason}
+                                  size="sm"
+                                  variant="ghost"
+                                  onClick={() =>
+                                    reason === "skip"
+                                      ? skipPenaltyReason(card.factId)
+                                      : recordPenaltyReason(
+                                          card.factId,
+                                          reason as LivePenaltyReason,
+                                        )
+                                  }
+                                  disabled={busy}
+                                >
+                                  {label}
+                                </Button>
+                              ))}
+                            </>
+                          ) : null}
+                        </div>
+                      ))}
+                    </div>
+                    <div className="space-y-2 rounded-lg border p-3">
+                      <p className="text-sm font-medium">Game Facts</p>
+                      {(projection.gameFacts ?? []).length === 0 ? (
+                        <p className="text-sm text-muted-foreground">No Game Facts recorded.</p>
+                      ) : (
+                        (projection.gameFacts ?? []).map((fact) => (
+                          <div
+                            key={fact.factId}
+                            data-game-fact-id={fact.factId}
+                            className="flex items-center justify-between gap-3 text-sm"
+                          >
+                            <span className="min-w-0">
+                              <span className="font-medium">{fact.factType}</span>
+                              <code className="ml-2 text-xs text-muted-foreground">
+                                {fact.factId}
+                              </code>
+                              <span className="ml-2 text-xs text-muted-foreground">
+                                sporting {fact.sportingOrder} · sync {fact.synchronizationOrder}
+                              </span>
+                            </span>
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              aria-label={`${fact.effective ? "Correct" : "Reinstate"} Game Fact ${fact.factId}`}
+                              onClick={() => correctFact(fact.factId, !fact.effective)}
+                              disabled={busy}
+                            >
+                              {fact.effective ? "Correct" : "Reinstate"}
+                            </Button>
+                          </div>
+                        ))
+                      )}
+                    </div>
+                  </div>
+                )}
+                {replica !== null && replica.pendingActions.length > 0 ? (
+                  <p className="text-sm text-amber-700">
+                    {replica.pendingActions.length} Controller action(s) retained for reconnect
+                    replay.
+                  </p>
+                ) : null}
+                {durabilityWarning === null ? null : (
+                  <p role="alert" className="text-sm font-medium text-amber-700">
+                    {durabilityWarning}
+                  </p>
+                )}
+              </div>
+              <ControllerActionSheet
+                activePanel={activeActionPanel}
+                onPanelChange={changeActionPanel}
+                tabThemes={{
+                  card: { activeStyle: { backgroundColor: "#0284c7", color: "white" } },
+                  timeout: { activeStyle: { backgroundColor: "#0f766e", color: "white" } },
+                  game: { activeStyle: { backgroundColor: "#7c3aed", color: "white" } },
+                }}
+                panel={
+                  <EventControllerActionPanel
+                    activePanel={activeActionPanel}
+                    busy={busy}
+                    projection={projection}
+                    cardGameSideId={cardGameSideId}
+                    setCardGameSideId={setCardGameSideId}
+                    cardPlayerNumber={cardPlayerNumber}
+                    setCardPlayerNumber={setCardPlayerNumber}
+                    cardType={cardType}
+                    setCardType={setCardType}
+                    cardFoulBeforeScore={cardFoulBeforeScore}
+                    setCardFoulBeforeScore={setCardFoulBeforeScore}
+                    cardSeekerPenaltyConfirmed={cardSeekerPenaltyConfirmed}
+                    setCardSeekerPenaltyConfirmed={setCardSeekerPenaltyConfirmed}
+                    recordCard={() => {
+                      const accepted = recordCard();
+                      if (accepted) changeActionPanel(null);
+                      return accepted;
+                    }}
+                    trigger={trigger}
+                    recordFlagCatch={recordFlagCatch}
+                    recordConcession={recordConcession}
+                    recordForfeit={recordForfeit}
+                    recordDoubleForfeit={() => {
+                      const accepted = recordDoubleForfeit();
+                      if (accepted) changeActionPanel(null);
+                      return accepted;
+                    }}
+                    onAccepted={() => changeActionPanel(null)}
+                    pendingResultConfirmation={pendingEventResultConfirmation}
+                    setPendingResultConfirmation={setPendingEventResultConfirmation}
+                    recordResult={() => {
+                      const accepted = trigger("result");
+                      if (accepted) changeActionPanel(null);
+                      return accepted;
+                    }}
+                  />
+                }
+              />
             </div>
           )}
           {message === null ? null : (
@@ -2831,6 +2800,274 @@ export function EventGameControllerPage() {
       {switchEntry.dialog}
       {restoreEntry.dialog}
     </main>
+  );
+}
+
+function EventControllerActionPanel({
+  activePanel,
+  busy,
+  projection,
+  cardGameSideId,
+  setCardGameSideId,
+  cardPlayerNumber,
+  setCardPlayerNumber,
+  cardType,
+  setCardType,
+  cardFoulBeforeScore,
+  setCardFoulBeforeScore,
+  cardSeekerPenaltyConfirmed,
+  setCardSeekerPenaltyConfirmed,
+  recordCard,
+  trigger,
+  recordDoubleForfeit,
+  recordFlagCatch,
+  recordConcession,
+  recordForfeit,
+  onAccepted,
+  pendingResultConfirmation,
+  setPendingResultConfirmation,
+  recordResult,
+}: {
+  activePanel: ControllerActionPanel | null;
+  busy: boolean;
+  projection: ControllerProjection | null;
+  cardGameSideId: string;
+  setCardGameSideId: (value: string) => void;
+  cardPlayerNumber: string;
+  setCardPlayerNumber: (value: string) => void;
+  cardType: LiveCardType;
+  setCardType: (value: LiveCardType) => void;
+  cardFoulBeforeScore: boolean;
+  setCardFoulBeforeScore: (value: boolean) => void;
+  cardSeekerPenaltyConfirmed: boolean;
+  setCardSeekerPenaltyConfirmed: (value: boolean) => void;
+  recordCard: () => boolean;
+  trigger: (
+    type: "card" | "timeout" | "suspension" | "result",
+    options?: {
+      timeoutAction?: "stoppage" | "start" | "complete";
+      timeoutGameSideId?: string;
+    },
+  ) => boolean;
+  recordDoubleForfeit: () => boolean;
+  recordFlagCatch: (gameSideId: string) => boolean;
+  recordConcession: (gameSideId: string) => boolean;
+  recordForfeit: (gameSideId: string) => boolean;
+  onAccepted: () => void;
+  pendingResultConfirmation: boolean;
+  setPendingResultConfirmation: (value: boolean) => void;
+  recordResult: () => boolean;
+}) {
+  const sideIds = Object.keys(projection?.scoreByGameSide ?? {});
+  if (activePanel === "card") {
+    return (
+      <div className="grid gap-2">
+        <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_8rem_minmax(0,1fr)]">
+          <label className="grid gap-1 text-xs font-medium">
+            Penalized Game Side
+            <select
+              id="penalty-game-side"
+              aria-label="Penalized Game Side"
+              className="h-11 rounded-md border bg-white px-3 text-sm"
+              value={cardGameSideId}
+              onChange={(event) => setCardGameSideId(event.target.value)}
+              disabled={busy}
+            >
+              <option value="">Choose side</option>
+              {sideIds.map((sideId) => (
+                <option key={sideId} value={sideId}>
+                  {sideId}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="grid gap-1 text-xs font-medium">
+            Player #
+            <input
+              id="penalty-player-number"
+              aria-label="Player number"
+              className="h-11 rounded-md border bg-white px-3 text-sm"
+              inputMode="numeric"
+              value={cardPlayerNumber}
+              onChange={(event) => setCardPlayerNumber(event.target.value)}
+              placeholder="optional"
+              disabled={busy}
+            />
+          </label>
+          <label className="grid gap-1 text-xs font-medium">
+            Card
+            <select
+              id="penalty-card-type"
+              aria-label="Card type"
+              className="h-11 rounded-md border bg-white px-3 text-sm"
+              value={cardType}
+              onChange={(event) => setCardType(event.target.value as LiveCardType)}
+              disabled={busy}
+            >
+              <option value="blue">Blue</option>
+              <option value="yellow">Yellow</option>
+              <option value="red">Red</option>
+              <option value="ejection">Ejection</option>
+            </select>
+          </label>
+        </div>
+        <label className="flex min-h-11 items-center gap-2 text-xs">
+          <input
+            type="checkbox"
+            checked={cardFoulBeforeScore}
+            onChange={(event) => setCardFoulBeforeScore(event.target.checked)}
+            disabled={busy || cardType === "red" || cardType === "ejection"}
+          />
+          Foul before score
+        </label>
+        <label className="flex min-h-11 items-center gap-2 text-xs">
+          <input
+            type="checkbox"
+            checked={cardSeekerPenaltyConfirmed}
+            onChange={(event) => setCardSeekerPenaltyConfirmed(event.target.checked)}
+            disabled={busy}
+          />
+          Penalized player is the seeker (Head Referee confirmed)
+        </label>
+        {cardGameSideId === "" ? (
+          <p role="alert" className="text-xs text-amber-800">
+            Choose a Game Side before accepting the card.
+          </p>
+        ) : null}
+        <Button
+          variant="outline"
+          aria-label="Accept penalty card for the selected Game Side"
+          onClick={recordCard}
+          disabled={busy}
+        >
+          Accept card
+        </Button>
+      </div>
+    );
+  }
+
+  if (activePanel === "timeout") {
+    return (
+      <div className="grid gap-2">
+        <p className="text-xs text-slate-600">
+          Choose a Game Side, then start or complete its timeout.
+        </p>
+        {sideIds.map((sideId) => {
+          const timeout = projection?.timeout;
+          const isStoppageForSide = timeout?.status === "stoppage" && timeout.gameSideId === sideId;
+          const used = timeout?.usedGameSideIds?.includes(sideId) === true;
+          const anotherSideActive =
+            (timeout?.status === "stoppage" || timeout?.status === "started") &&
+            timeout.gameSideId !== sideId;
+          return (
+            <Button
+              key={sideId}
+              variant="outline"
+              onClick={() => {
+                const accepted = trigger("timeout", {
+                  timeoutAction: isStoppageForSide ? "start" : "stoppage",
+                  timeoutGameSideId: sideId,
+                });
+                if (accepted && isStoppageForSide) {
+                  // A locally retained timeout is complete enough to return to the core.
+                  onAccepted();
+                }
+              }}
+              disabled={busy || anotherSideActive || (used && !isStoppageForSide)}
+            >
+              {isStoppageForSide
+                ? `Start timeout minute: ${sideId}`
+                : used
+                  ? `Timeout used: ${sideId}`
+                  : `Timeout stoppage: ${sideId}`}
+            </Button>
+          );
+        })}
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid gap-2">
+      <p className="text-xs text-slate-600">
+        Game-end actions require local acceptance before the sheet closes.
+      </p>
+      <div className="grid gap-2 sm:grid-cols-2">
+        {sideIds.map((sideId) => (
+          <div key={sideId} className="grid gap-2 rounded-xl border p-2">
+            <p className="text-xs font-semibold">Game Side {sideId}</p>
+            <Button
+              variant="outline"
+              aria-label={`Record flag catch for Game Side ${sideId}`}
+              onClick={() => {
+                if (recordFlagCatch(sideId)) onAccepted();
+              }}
+              disabled={busy}
+            >
+              Record flag catch
+            </Button>
+            {projection?.overtime &&
+            projection.phase !== "finished" &&
+            projection.winnerGameSideId === null ? (
+              <Button
+                variant="outline"
+                aria-label={`Concede Event Game for Game Side ${sideId}`}
+                onClick={() => {
+                  if (recordConcession(sideId)) onAccepted();
+                }}
+                disabled={busy}
+              >
+                Concede
+              </Button>
+            ) : null}
+            <Button
+              variant="outline"
+              aria-label={`Record directed forfeit for Game Side ${sideId}`}
+              onClick={() => {
+                if (recordForfeit(sideId)) onAccepted();
+              }}
+              disabled={busy}
+            >
+              Directed forfeit
+            </Button>
+          </div>
+        ))}
+      </div>
+      {!pendingResultConfirmation ? (
+        <Button
+          variant="outline"
+          aria-label="Record final Event Game result"
+          onClick={() => setPendingResultConfirmation(true)}
+          disabled={busy}
+        >
+          Review final result
+        </Button>
+      ) : (
+        <div className="grid gap-2 rounded-xl border border-amber-300 bg-amber-50 p-2 text-sm text-amber-950">
+          <p className="font-medium">Confirm final Event Game result?</p>
+          <div className="grid grid-cols-2 gap-2">
+            <Button onClick={recordResult} disabled={busy}>
+              Confirm game end
+            </Button>
+            <Button
+              variant="outline"
+              onClick={() => setPendingResultConfirmation(false)}
+              disabled={busy}
+            >
+              Cancel
+            </Button>
+          </div>
+        </div>
+      )}
+      <Button
+        variant="outline"
+        aria-label="Record directed double-forfeit"
+        onClick={recordDoubleForfeit}
+        disabled={busy}
+      >
+        Record directed double-forfeit
+      </Button>
+    </div>
   );
 }
 

--- a/src/pages/game-page.tsx
+++ b/src/pages/game-page.tsx
@@ -16,6 +16,7 @@ import type { CardType, ControllerRole, GameCommand, TeamId } from "@/lib/game-t
 import { GameControllerActionPanels } from "@/components/game-controller-action-panels";
 import { ControllerTopSection, PenaltyColumnsSection } from "@/components/game-controller-sections";
 import { ControllerHeader } from "@/components/controller-header";
+import type { ControllerActionPanel } from "@/lib/controller-action-sheet";
 import {
   FLAG_RELEASE_MS,
   FLAG_STATUS_HIDE_AFTER_MS,
@@ -79,7 +80,7 @@ type PendingWinConfirmation = {
 
 export function GamePage({ gameId, role }: { gameId: string; role: ControllerRole }) {
   const controller = role === "controller";
-  const [activePanel, setActivePanel] = useState<"card" | "timeout" | "game">("card");
+  const [activePanel, setActivePanel] = useState<ControllerActionPanel | null>(null);
   const [homeName, setHomeName] = useState("Home");
   const [awayName, setAwayName] = useState("Away");
   const [homeColor, setHomeColor] = useState(DEFAULT_HOME_TEAM_COLOR);
@@ -99,6 +100,11 @@ export function GamePage({ gameId, role }: { gameId: string; role: ControllerRol
   const [renamingTeam, setRenamingTeam] = useState<TeamId | null>(null);
   const [pendingWinConfirmation, setPendingWinConfirmation] =
     useState<PendingWinConfirmation | null>(null);
+  const handleActionPanelChange = useCallback((panel: ControllerActionPanel | null) => {
+    setCardDraft({ cardType: null, team: null, digits: "", startedGameClockMs: null });
+    setPendingWinConfirmation(null);
+    setActivePanel(panel);
+  }, []);
   const [leaveDialogOpen, setLeaveDialogOpen] = useState(false);
   const [leavePending, setLeavePending] = useState(false);
   const [adHocQrOpen, setAdHocQrOpen] = useState(false);
@@ -293,7 +299,7 @@ export function GamePage({ gameId, role }: { gameId: string; role: ControllerRol
       cardDraft.team === null ||
       liveState === null
     ) {
-      return;
+      return false;
     }
 
     const playerNumber = cardDraft.digits.length === 0 ? null : Number(cardDraft.digits);
@@ -311,6 +317,7 @@ export function GamePage({ gameId, role }: { gameId: string; role: ControllerRol
       digits: "",
       startedGameClockMs: null,
     });
+    return true;
   }, [cardDraft, controller, dispatchCommand, liveState]);
 
   const adjustGameClock = useCallback(
@@ -883,7 +890,7 @@ export function GamePage({ gameId, role }: { gameId: string; role: ControllerRol
     : null;
 
   return (
-    <div className="h-[100dvh] overflow-hidden bg-slate-100 p-2 text-slate-900">
+    <div className="relative h-[100dvh] overflow-hidden bg-slate-100 p-2 text-slate-900">
       {entry.dialog}
       {leaveDialogOpen ? (
         <ControllerLeaveDialog
@@ -895,7 +902,7 @@ export function GamePage({ gameId, role }: { gameId: string; role: ControllerRol
           onConfirm={() => void leaveAdHocGame()}
         />
       ) : null}
-      <div className="mx-auto grid h-full w-full max-w-[460px] grid-rows-[auto_auto_minmax(0,1fr)_auto_auto] gap-2">
+      <div className="mx-auto grid h-full w-full max-w-[460px] grid-rows-[auto_minmax(0,1fr)] gap-2">
         <ControllerHeader
           identity={{
             eyebrow: "Ad Hoc Game",
@@ -940,202 +947,231 @@ export function GamePage({ gameId, role }: { gameId: string; role: ControllerRol
           ) : null}
         </ControllerHeader>
 
-        {controller ? (
-          <AdHocControlHandoff
-            gameId={gameId}
-            controlQr={controlQr}
-            qrOpen={adHocQrOpen}
-            triggerRef={adHocQrTriggerRef}
-            onClose={() => setAdHocQrOpen(false)}
-          />
-        ) : null}
+        <div className="relative min-h-0 grid grid-rows-[auto_minmax(0,1fr)] gap-2">
+          {controller ? (
+            <AdHocControlHandoff
+              gameId={gameId}
+              controlQr={controlQr}
+              qrOpen={adHocQrOpen}
+              triggerRef={adHocQrTriggerRef}
+              onClose={() => setAdHocQrOpen(false)}
+            />
+          ) : null}
 
-        <ControllerTopSection
-          controller={controller}
-          stateIsRunning={state.isRunning}
-          stateIsFinished={state.isFinished}
-          stateIsSuspended={state.isSuspended}
-          statusLabel={statusLabel}
-          gameClockText={formatClock(gameView.state.gameClockMs)}
-          leftScoreColumn={homeScoreColumn}
-          rightScoreColumn={awayScoreColumn}
-          scorePulse={scorePulse}
-          teamNameEditor={{
-            controller,
-            renamingTeam,
-            homeName,
-            awayName,
-            homeColor,
-            awayColor,
-            activeTeamRenameInputRef,
-            leftTeamNameButtonRef,
-            rightTeamNameButtonRef,
-            displayTeamNameHeightPx,
-            onOpenRename: (team) => {
-              if (!controller) {
+          <ControllerTopSection
+            controller={controller}
+            stateIsRunning={state.isRunning}
+            stateIsFinished={state.isFinished}
+            stateIsSuspended={state.isSuspended}
+            statusLabel={statusLabel}
+            gameClockText={formatClock(gameView.state.gameClockMs)}
+            leftScoreColumn={homeScoreColumn}
+            rightScoreColumn={awayScoreColumn}
+            scorePulse={scorePulse}
+            teamNameEditor={{
+              controller,
+              renamingTeam,
+              homeName,
+              awayName,
+              homeColor,
+              awayColor,
+              activeTeamRenameInputRef,
+              leftTeamNameButtonRef,
+              rightTeamNameButtonRef,
+              displayTeamNameHeightPx,
+              onOpenRename: (team) => {
+                if (!controller) {
+                  return;
+                }
+
+                setHomeName(state.homeName);
+                setAwayName(state.awayName);
+                setHomeColor(state.homeColor);
+                setAwayColor(state.awayColor);
+                setRenamingTeam(team);
+              },
+              onRenameInputChange: (team, value) => {
+                if (team === "home") {
+                  setHomeName(value);
+                } else {
+                  setAwayName(value);
+                }
+              },
+              onRenameColorChange: (team, value) => {
+                if (team === "home") {
+                  setHomeColor(value);
+                } else {
+                  setAwayColor(value);
+                }
+              },
+              onRenameInputKeyDown: handleTeamRenameInputKeyDown,
+              onSaveRename: saveTeamRename,
+              onSwapDisplayedTeamSides: swapDisplayedTeamSides,
+            }}
+            onAddScore={(team) =>
+              dispatchCommand({
+                type: "change-score",
+                team,
+                delta: 10,
+                reason: "goal",
+              })
+            }
+            onUndoScore={(team) => dispatchCommand({ type: "undo-last-score", team })}
+            onToggleClockAdjust={() => setClockAdjustOpen((previous) => !previous)}
+            onToggleRunning={() =>
+              dispatchCommand({
+                type: "set-running",
+                running: !state.isRunning,
+              })
+            }
+            clockAdjustOpen={clockAdjustOpen}
+            onAdjustGameClock={adjustGameClock}
+            finishSummary={finishSummary}
+            timeoutReminder={timeoutReminder}
+            flagStatus={flagStatus}
+            seekersStatus={seekersStatus}
+            clockTheme={clockTheme}
+          />
+
+          <PenaltyColumnsSection
+            penaltyColumns={penaltyColumns}
+            displayTeamName={displayTeamName}
+            pendingReleaseByPlayer={pendingReleaseByPlayer}
+            controller={controller}
+            onConfirmPenaltyExpiration={(pendingId, playerKey) =>
+              dispatchCommand({
+                type: "confirm-penalty-expiration",
+                pendingId,
+                playerKey,
+              })
+            }
+            getPendingReleaseActionLabel={(action, playerKey) =>
+              formatPendingReleaseActionLabel(action, state.players[playerKey] ?? null)
+            }
+          />
+
+          <GameControllerActionPanels
+            activePanel={activePanel}
+            setActivePanel={handleActionPanelChange}
+            controller={controller}
+            state={state}
+            gameView={{
+              timeoutFinalCountdown: gameView.timeoutFinalCountdown,
+              timeoutWarningActive: gameView.timeoutWarningActive,
+            }}
+            displayTeamOrder={displayTeamOrder}
+            displayTeamName={displayTeamName}
+            tabThemes={{
+              card: homeTabTheme,
+              timeout: awayTabTheme,
+              game: {
+                activeStyle: buildActionPanelTabStyle(
+                  "game",
+                  teamColorsByTeam.home,
+                  teamColorsByTeam.away,
+                ),
+              },
+            }}
+            cardTypeOptions={cardTypeOptions}
+            cardDraft={cardDraft}
+            setCardDraft={setCardDraft}
+            canSelectCardType={canSelectCardType}
+            canSelectCardTeam={canSelectCardTeam}
+            cardPlayerLabel={cardPlayerLabel}
+            cardEntryStarted={cardEntryStarted}
+            cardAddStatusText={cardAddStatusText}
+            canEditCardDigits={canEditCardDigits}
+            appendCardDigit={appendCardDigit}
+            canSubmitCard={canSubmitCard}
+            submitCard={() => {
+              if (submitCard()) handleActionPanelChange(null);
+            }}
+            activeTimeout={activeTimeout}
+            formatRemaining={formatRemaining}
+            pendingWinConfirmation={
+              pendingWinConfirmation === null ? null : { label: pendingWinConfirmation.label }
+            }
+            confirmWinAction={() => {
+              confirmWinAction();
+              handleActionPanelChange(null);
+            }}
+            clearPendingWinConfirmation={() => setPendingWinConfirmation(null)}
+            finishSummary={finishSummary}
+            canResumeGame={canResumeGame}
+            canSuspendGame={canSuspendGame}
+            canUseEndingActions={canUseEndingActions}
+            canRecordFlagCatch={canRecordFlagCatch}
+            startTimeout={(team) => {
+              dispatchCommand({ type: "start-timeout", team });
+            }}
+            setTimeoutRunning={(running) => {
+              dispatchCommand({
+                type: "set-timeout-running",
+                running,
+              });
+              handleActionPanelChange(null);
+            }}
+            undoTimeoutStart={() => {
+              dispatchCommand({ type: "undo-timeout-start" });
+              handleActionPanelChange(null);
+            }}
+            cancelTimeout={() => {
+              dispatchCommand({ type: "cancel-timeout" });
+              handleActionPanelChange(null);
+            }}
+            resumeGame={() => {
+              dispatchCommand({ type: "resume-game" });
+              handleActionPanelChange(null);
+            }}
+            suspendGame={() => {
+              dispatchCommand({ type: "suspend-game" });
+              handleActionPanelChange(null);
+            }}
+            requestForfeitWin={(team) => {
+              const winner = team === "home" ? "away" : "home";
+              requestWinConfirmation(`${displayTeamName(winner)} wins by forfeit penalty.`, {
+                type: "record-forfeit",
+                team,
+              });
+            }}
+            recordDoubleForfeit={() => {
+              dispatchCommand({ type: "record-double-forfeit" });
+              handleActionPanelChange(null);
+            }}
+            correctBackToUnfinished={() => {
+              dispatchCommand({ type: "correct-to-unfinished" });
+              handleActionPanelChange(null);
+            }}
+            requestTargetScoreWin={(team) =>
+              requestWinConfirmation(`${displayTeamName(team)} reached target score and wins.`, {
+                type: "record-target-score",
+                team,
+              })
+            }
+            requestConcedeWin={(team) => {
+              const winner = team === "home" ? "away" : "home";
+              requestWinConfirmation(
+                `${displayTeamName(team)} conceded. ${displayTeamName(winner)} wins.`,
+                {
+                  type: "record-concede",
+                  team,
+                },
+              );
+            }}
+            recordOrConfirmFlagCatch={(team) => {
+              if (willFlagCatchWin(state, team)) {
+                requestWinConfirmation(`${displayTeamName(team)} wins on flag catch.`, {
+                  type: "record-flag-catch",
+                  team,
+                });
                 return;
               }
 
-              setHomeName(state.homeName);
-              setAwayName(state.awayName);
-              setHomeColor(state.homeColor);
-              setAwayColor(state.awayColor);
-              setRenamingTeam(team);
-            },
-            onRenameInputChange: (team, value) => {
-              if (team === "home") {
-                setHomeName(value);
-              } else {
-                setAwayName(value);
-              }
-            },
-            onRenameColorChange: (team, value) => {
-              if (team === "home") {
-                setHomeColor(value);
-              } else {
-                setAwayColor(value);
-              }
-            },
-            onRenameInputKeyDown: handleTeamRenameInputKeyDown,
-            onSaveRename: saveTeamRename,
-            onSwapDisplayedTeamSides: swapDisplayedTeamSides,
-          }}
-          onAddScore={(team) =>
-            dispatchCommand({
-              type: "change-score",
-              team,
-              delta: 10,
-              reason: "goal",
-            })
-          }
-          onUndoScore={(team) => dispatchCommand({ type: "undo-last-score", team })}
-          onToggleClockAdjust={() => setClockAdjustOpen((previous) => !previous)}
-          onToggleRunning={() =>
-            dispatchCommand({
-              type: "set-running",
-              running: !state.isRunning,
-            })
-          }
-          clockAdjustOpen={clockAdjustOpen}
-          onAdjustGameClock={adjustGameClock}
-          finishSummary={finishSummary}
-          timeoutReminder={timeoutReminder}
-          flagStatus={flagStatus}
-          seekersStatus={seekersStatus}
-          clockTheme={clockTheme}
-        />
-
-        <PenaltyColumnsSection
-          penaltyColumns={penaltyColumns}
-          displayTeamName={displayTeamName}
-          pendingReleaseByPlayer={pendingReleaseByPlayer}
-          controller={controller}
-          onConfirmPenaltyExpiration={(pendingId, playerKey) =>
-            dispatchCommand({
-              type: "confirm-penalty-expiration",
-              pendingId,
-              playerKey,
-            })
-          }
-          getPendingReleaseActionLabel={(action, playerKey) =>
-            formatPendingReleaseActionLabel(action, state.players[playerKey] ?? null)
-          }
-        />
-
-        <GameControllerActionPanels
-          activePanel={activePanel}
-          setActivePanel={setActivePanel}
-          controller={controller}
-          state={state}
-          gameView={{
-            timeoutFinalCountdown: gameView.timeoutFinalCountdown,
-            timeoutWarningActive: gameView.timeoutWarningActive,
-          }}
-          displayTeamOrder={displayTeamOrder}
-          displayTeamName={displayTeamName}
-          tabThemes={{
-            card: homeTabTheme,
-            timeout: awayTabTheme,
-            game: {
-              activeStyle: buildActionPanelTabStyle(
-                "game",
-                teamColorsByTeam.home,
-                teamColorsByTeam.away,
-              ),
-            },
-          }}
-          cardTypeOptions={cardTypeOptions}
-          cardDraft={cardDraft}
-          setCardDraft={setCardDraft}
-          canSelectCardType={canSelectCardType}
-          canSelectCardTeam={canSelectCardTeam}
-          cardPlayerLabel={cardPlayerLabel}
-          cardEntryStarted={cardEntryStarted}
-          cardAddStatusText={cardAddStatusText}
-          canEditCardDigits={canEditCardDigits}
-          appendCardDigit={appendCardDigit}
-          canSubmitCard={canSubmitCard}
-          submitCard={submitCard}
-          activeTimeout={activeTimeout}
-          formatRemaining={formatRemaining}
-          pendingWinConfirmation={
-            pendingWinConfirmation === null ? null : { label: pendingWinConfirmation.label }
-          }
-          confirmWinAction={confirmWinAction}
-          clearPendingWinConfirmation={() => setPendingWinConfirmation(null)}
-          finishSummary={finishSummary}
-          canResumeGame={canResumeGame}
-          canSuspendGame={canSuspendGame}
-          canUseEndingActions={canUseEndingActions}
-          canRecordFlagCatch={canRecordFlagCatch}
-          startTimeout={(team) => dispatchCommand({ type: "start-timeout", team })}
-          setTimeoutRunning={(running) =>
-            dispatchCommand({
-              type: "set-timeout-running",
-              running,
-            })
-          }
-          undoTimeoutStart={() => dispatchCommand({ type: "undo-timeout-start" })}
-          cancelTimeout={() => dispatchCommand({ type: "cancel-timeout" })}
-          resumeGame={() => dispatchCommand({ type: "resume-game" })}
-          suspendGame={() => dispatchCommand({ type: "suspend-game" })}
-          requestForfeitWin={(team) => {
-            const winner = team === "home" ? "away" : "home";
-            requestWinConfirmation(`${displayTeamName(winner)} wins by forfeit penalty.`, {
-              type: "record-forfeit",
-              team,
-            });
-          }}
-          recordDoubleForfeit={() => dispatchCommand({ type: "record-double-forfeit" })}
-          correctBackToUnfinished={() => dispatchCommand({ type: "correct-to-unfinished" })}
-          requestTargetScoreWin={(team) =>
-            requestWinConfirmation(`${displayTeamName(team)} reached target score and wins.`, {
-              type: "record-target-score",
-              team,
-            })
-          }
-          requestConcedeWin={(team) => {
-            const winner = team === "home" ? "away" : "home";
-            requestWinConfirmation(
-              `${displayTeamName(team)} conceded. ${displayTeamName(winner)} wins.`,
-              {
-                type: "record-concede",
-                team,
-              },
-            );
-          }}
-          recordOrConfirmFlagCatch={(team) => {
-            if (willFlagCatchWin(state, team)) {
-              requestWinConfirmation(`${displayTeamName(team)} wins on flag catch.`, {
-                type: "record-flag-catch",
-                team,
-              });
-              return;
-            }
-
-            dispatchCommand({ type: "record-flag-catch", team });
-          }}
-        />
+              dispatchCommand({ type: "record-flag-catch", team });
+              handleActionPanelChange(null);
+            }}
+          />
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## What

- move Ad Hoc and Event Cards, Timeout, and Game end controls into one shared nullable bottom action sheet
- keep the sheet collapsed initially, toggle the selected action closed, clear drafts on switches and authority transitions, and restore focus after completion
- preserve multi-step timeout semantics and locally accepted offline closure
- protect the primary clock and score controls with explicit overlay geometry and safe-area navigation
- migrate Event flag-catch and close-play confirmation flows without duplicating legacy mutating controls
- add observable Ad Hoc/Event Fast Tests and bounded mobile Focused Integration coverage

## Why

The Controller action controls previously consumed the game surface, duplicated Event workflows, and could compress or obscure the clock and score controls on portrait devices. This establishes one consistent interaction boundary for both Controller experiences while retaining existing rule and synchronization behavior.

## User impact

Controllers open directly to the unobstructed game core. Cards, Timeout, and Game end open only when selected, can be dismissed by tapping the selected action, and return focus predictably after completion. The core clock and both score directions remain reachable while a nonmodal action is open.

## Validation

- bun run check
- 57 targeted Controller action/header/Event Fast Tests
- bun run build
- bun run test:focused:controller-header-mobile at 390x844 and 412x915
- git diff --check origin/main...HEAD
- independent specification and standards reviews: clean
- no Qualification Test added or run

Closes #271