### PR TITLE
Gate Production activation behind Test validation and approval

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,4 +1,4 @@
-name: Deploy environments
+name: Deploy Test environment
 
 on:
   push:
@@ -227,146 +227,17 @@ jobs:
             echo "failureCategory=$failure_category"
           } >> "$GITHUB_OUTPUT"
 
-  deploy-production:
-    if: github.ref == 'refs/heads/main'
-    needs: build
-    outputs:
-      status: ${{ steps.deployment-outcome.outputs.status }}
-      phase: ${{ steps.deployment-outcome.outputs.phase }}
-      releaseAttemptId: ${{ steps.deployment-outcome.outputs.releaseAttemptId }}
-      failureCategory: ${{ steps.deployment-outcome.outputs.failureCategory }}
-    runs-on: ubuntu-latest
-    environment:
-      name: production
-      url: https://timer.quadball.app
-    steps:
-      - name: Download shared release artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
-        with:
-          name: ${{ needs.build.outputs.release-artifact }}
-          path: .
-
-      - name: Safely extract and verify release bundle modes
-        run: |
-          set -euo pipefail
-          echo "DEPLOYMENT_PHASE=artifact-verification" >> "$GITHUB_ENV"
-          archive="release-bundle.tar.gz"
-          install -d -m 700 release
-          while IFS= read -r member; do
-            case "$member" in
-              ./) ;;
-              ./*)
-                relative="${member#./}"
-                case "$relative" in
-                  ""|/*|../*|*/../*|*/..) echo "Unsafe archive member: ${member}" >&2; exit 1 ;;
-                esac
-                ;;
-              *) echo "Unsafe archive member: ${member}" >&2; exit 1 ;;
-            esac
-          done < <(tar --list --gzip --file="$archive")
-          tar --extract --gzip --file="$archive" --directory=release --no-same-owner
-          ! find release -type l -print -quit | grep -q .
-          test -x release/quadball-timer
-          test -x release/deploy/activate-test-release.sh
-          test -x release/deploy/activate-release.sh
-          test "$(stat -c '%a' release/quadball-timer)" = 555
-          test "$(stat -c '%a' release/deploy/activate-test-release.sh)" = 555
-          test "$(stat -c '%a' release/deploy/activate-release.sh)" = 555
-
-      - name: Configure temporary Production SSH material
-        env:
-          PROD_SSH_KEY: ${{ secrets.PROD_SSH_KEY }}
-          PROD_KNOWN_HOSTS: ${{ secrets.PROD_KNOWN_HOSTS }}
-        run: |
-          set -euo pipefail
-          : "${PROD_SSH_KEY:?Missing PROD_SSH_KEY secret}"
-          : "${PROD_KNOWN_HOSTS:?Missing PROD_KNOWN_HOSTS secret}"
-          ssh_dir="${RUNNER_TEMP}/quadball-production-ssh-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          install -m 700 -d "$ssh_dir"
-          printf '%s\n' "$PROD_SSH_KEY" > "$ssh_dir/id_ed25519"
-          chmod 600 "$ssh_dir/id_ed25519"
-          printf '%s\n' "$PROD_KNOWN_HOSTS" > "$ssh_dir/known_hosts"
-          chmod 644 "$ssh_dir/known_hosts"
-          echo "SSH_DIR=$ssh_dir" >> "$GITHUB_ENV"
-
-      - name: Transfer and activate Production release
-        env:
-          DEPLOY_HOST: ${{ secrets.PROD_HOST }}
-          DEPLOY_USER: ${{ secrets.PROD_USER }}
-          DEPLOY_BASE: ${{ vars.PROD_DEPLOY_BASE }}
-          PROD_SERVICE_NAME: ${{ vars.PROD_SERVICE_NAME }}
-          PROD_APP_PORT: ${{ vars.PROD_APP_PORT }}
-        run: |
-          set -euo pipefail
-          echo "DEPLOYMENT_PHASE=staging-and-activation" >> "$GITHUB_ENV"
-          : "${DEPLOY_HOST:?Missing PROD_HOST secret}"
-          : "${DEPLOY_USER:?Missing PROD_USER secret}"
-          base_dir="${DEPLOY_BASE:-/srv/quadball-timer}"
-          service_name="${PROD_SERVICE_NAME:-quadball-timer}"
-          app_port="${PROD_APP_PORT:-3000}"
-          release_id="${RELEASE_ATTEMPT_ID}"
-          stage_dir="${base_dir}/.staging/${release_id}"
-          ssh_opts="-i ${SSH_DIR}/id_ed25519 -o StrictHostKeyChecking=yes -o UserKnownHostsFile=${SSH_DIR}/known_hosts"
-          cleanup_remote_stage() {
-            ssh $ssh_opts "${DEPLOY_USER}@${DEPLOY_HOST}" "chmod -R u+w -- '${stage_dir}' 2>/dev/null || true; rm -rf -- '${stage_dir}'" || true
-            rm -rf -- "$SSH_DIR"
-          }
-          trap cleanup_remote_stage EXIT
-          ssh $ssh_opts "${DEPLOY_USER}@${DEPLOY_HOST}" "test ! -e '${stage_dir}' && install -d -m 750 '${stage_dir}'"
-          rsync -a -e "ssh ${ssh_opts}" release/ "${DEPLOY_USER}@${DEPLOY_HOST}:${stage_dir}/"
-          set +e
-          ssh $ssh_opts "${DEPLOY_USER}@${DEPLOY_HOST}" "'${stage_dir}/deploy/activate-release.sh' --base-dir '${base_dir}' --staged-dir '${stage_dir}' --release '${release_id}' --service '${service_name}' --port '${app_port}'" 2>&1 | tee "$RUNNER_TEMP/quadball-production-deployment.log"
-          activation_status=${PIPESTATUS[0]}
-          set -e
-          phase="$(sed -n 's/^ACTIVATION_PHASE=//p' "$RUNNER_TEMP/quadball-production-deployment.log" | tail -n 1)"
-          echo "DEPLOYMENT_PHASE=${phase:-activation}" >> "$GITHUB_ENV"
-          if (( activation_status != 0 )); then exit "$activation_status"; fi
-          curl --fail --silent --show-error --max-time 10 https://timer.quadball.app/ | grep -qi "<!doctype html"
-
-      - name: Record Production deployment outcome
-        id: deployment-outcome
-        if: always()
-        env:
-          JOB_STATUS: ${{ job.status }}
-          RELEASE_ATTEMPT: ${{ env.RELEASE_ATTEMPT_ID }}
-          FAILED_PHASE: ${{ env.DEPLOYMENT_PHASE }}
-        run: |
-          set -euo pipefail
-          case "$JOB_STATUS" in
-            success)
-              phase="verified"
-              failure_category="none"
-              ;;
-            cancelled)
-              phase="${FAILED_PHASE:-deployment}"
-              failure_category="cancelled"
-              ;;
-            *)
-              phase="${FAILED_PHASE:-deployment}"
-              failure_category="${phase}-failed"
-              ;;
-          esac
-          {
-            echo "status=$JOB_STATUS"
-            echo "phase=$phase"
-            echo "releaseAttemptId=$RELEASE_ATTEMPT"
-            echo "failureCategory=$failure_category"
-          } >> "$GITHUB_OUTPUT"
-
   report:
     if: always() && github.ref == 'refs/heads/main'
-    needs: [deploy-test, deploy-production]
+    needs: [deploy-test]
     runs-on: ubuntu-latest
     steps:
-      - name: Report both independent environment outcomes
+      - name: Report Test environment outcome
         env:
           RELEASE_ATTEMPT_ID: ${{ env.RELEASE_ATTEMPT_ID }}
           TEST_STATUS: ${{ needs.deploy-test.outputs.status || needs.deploy-test.result }}
           TEST_PHASE: ${{ needs.deploy-test.outputs.phase || 'deployment' }}
           TEST_FAILURE_CATEGORY: ${{ needs.deploy-test.outputs.failureCategory || 'job-skipped' }}
-          PRODUCTION_STATUS: ${{ needs.deploy-production.outputs.status || needs.deploy-production.result }}
-          PRODUCTION_PHASE: ${{ needs.deploy-production.outputs.phase || 'deployment' }}
-          PRODUCTION_FAILURE_CATEGORY: ${{ needs.deploy-production.outputs.failureCategory || 'job-skipped' }}
         run: |
           set -euo pipefail
           cat > deployment-report.json <<EOF
@@ -376,15 +247,10 @@ jobs:
               "status": "${TEST_STATUS}",
               "phase": "${TEST_PHASE}",
               "failureCategory": "${TEST_FAILURE_CATEGORY}"
-            },
-            "production": {
-              "status": "${PRODUCTION_STATUS}",
-              "phase": "${PRODUCTION_PHASE}",
-              "failureCategory": "${PRODUCTION_FAILURE_CATEGORY}"
             }
           }
           EOF
           cat deployment-report.json
-          if [[ "$TEST_STATUS" != "success" || "$PRODUCTION_STATUS" != "success" ]]; then
+          if [[ "$TEST_STATUS" != "success" ]]; then
             exit 1
           fi

--- a/.github/workflows/promote-production.yml
+++ b/.github/workflows/promote-production.yml
@@ -1,0 +1,187 @@
+name: Promote Production release
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_run_id:
+        description: Successful Deploy Test environment workflow run to promote
+        required: true
+        type: string
+      source_run_attempt:
+        description: Attempt number of that workflow run
+        required: true
+        type: string
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: timer-production-promotion
+  cancel-in-progress: false
+
+jobs:
+  validate-source-run:
+    runs-on: ubuntu-latest
+    outputs:
+      source-sha: ${{ steps.source.outputs.source-sha }}
+      release-attempt-id: ${{ steps.source.outputs.release-attempt-id }}
+      artifact-name: ${{ steps.source.outputs.artifact-name }}
+    steps:
+      - name: Validate the Test-validated source run
+        id: source
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          SOURCE_RUN_ID: ${{ inputs.source_run_id }}
+          SOURCE_RUN_ATTEMPT: ${{ inputs.source_run_attempt }}
+        run: |
+          set -euo pipefail
+          [[ "$SOURCE_RUN_ID" =~ ^[0-9]+$ ]]
+          [[ "$SOURCE_RUN_ATTEMPT" =~ ^[0-9]+$ ]]
+          api="https://api.github.com/repos/${GITHUB_REPOSITORY}"
+          auth_header="Authorization: Bearer ${GITHUB_TOKEN}"
+          run_json="$(curl --fail --silent --show-error \
+            --header "$auth_header" \
+            --header 'Accept: application/vnd.github+json' \
+            "${api}/actions/runs/${SOURCE_RUN_ID}")"
+          test "$(jq -r '.path' <<<"$run_json")" = ".github/workflows/deploy-production.yml"
+          test "$(jq -r '.head_branch' <<<"$run_json")" = "main"
+          test "$(jq -r '.status' <<<"$run_json")" = "completed"
+          test "$(jq -r '.conclusion' <<<"$run_json")" = "success"
+          test "$(jq -r '.run_attempt|tostring' <<<"$run_json")" = "$SOURCE_RUN_ATTEMPT"
+          source_sha="$(jq -r '.head_sha' <<<"$run_json")"
+          [[ "$source_sha" =~ ^[0-9a-f]{40}$ ]]
+          jobs_json="$(curl --fail --silent --show-error \
+            --header "$auth_header" \
+            --header 'Accept: application/vnd.github+json' \
+            "${api}/actions/runs/${SOURCE_RUN_ID}/jobs?per_page=100")"
+          jq -e '[.jobs[] | select(.name == "deploy-test" and .conclusion == "success")] | length == 1' \
+            <<<"$jobs_json" >/dev/null
+          artifact_name="release-${SOURCE_RUN_ID}-${SOURCE_RUN_ATTEMPT}"
+          release_attempt_id="sha-${source_sha}-run-${SOURCE_RUN_ID}-attempt-${SOURCE_RUN_ATTEMPT}"
+          {
+            echo "source-sha=${source_sha}"
+            echo "release-attempt-id=${release_attempt_id}"
+            echo "artifact-name=${artifact_name}"
+          } >> "$GITHUB_OUTPUT"
+
+  deploy-production:
+    needs: validate-source-run
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+      url: https://timer.quadball.app
+    steps:
+      - name: Download the exact Test-validated release bundle
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: ${{ needs.validate-source-run.outputs.artifact-name }}
+          path: .
+          run-id: ${{ inputs.source_run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Safely extract and verify release bundle modes
+        run: |
+          set -euo pipefail
+          echo "DEPLOYMENT_PHASE=artifact-verification" >> "$GITHUB_ENV"
+          archive="release-bundle.tar.gz"
+          install -d -m 700 release
+          while IFS= read -r member; do
+            case "$member" in
+              ./) ;;
+              ./*)
+                relative="${member#./}"
+                case "$relative" in
+                  ""|/*|../*|*/../*|*/..) echo "Unsafe archive member: ${member}" >&2; exit 1 ;;
+                esac
+                ;;
+              *) echo "Unsafe archive member: ${member}" >&2; exit 1 ;;
+            esac
+          done < <(tar --list --gzip --file="$archive")
+          tar --extract --gzip --file="$archive" --directory=release --no-same-owner
+          ! find release -type l -print -quit | grep -q .
+          test -x release/quadball-timer
+          test -x release/deploy/activate-test-release.sh
+          test -x release/deploy/activate-release.sh
+          test "$(stat -c '%a' release/quadball-timer)" = 555
+          test "$(stat -c '%a' release/deploy/activate-test-release.sh)" = 555
+          test "$(stat -c '%a' release/deploy/activate-release.sh)" = 555
+
+      - name: Configure temporary Production SSH material
+        env:
+          PROD_SSH_KEY: ${{ secrets.PROD_SSH_KEY }}
+          PROD_KNOWN_HOSTS: ${{ secrets.PROD_KNOWN_HOSTS }}
+        run: |
+          set -euo pipefail
+          : "${PROD_SSH_KEY:?Missing PROD_SSH_KEY secret}"
+          : "${PROD_KNOWN_HOSTS:?Missing PROD_KNOWN_HOSTS secret}"
+          ssh_dir="${RUNNER_TEMP}/quadball-production-ssh-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          install -m 700 -d "$ssh_dir"
+          printf '%s\n' "$PROD_SSH_KEY" > "$ssh_dir/id_ed25519"
+          chmod 600 "$ssh_dir/id_ed25519"
+          printf '%s\n' "$PROD_KNOWN_HOSTS" > "$ssh_dir/known_hosts"
+          chmod 644 "$ssh_dir/known_hosts"
+          echo "SSH_DIR=$ssh_dir" >> "$GITHUB_ENV"
+
+      - name: Transfer and activate the approved Production release
+        env:
+          DEPLOY_HOST: ${{ secrets.PROD_HOST }}
+          DEPLOY_USER: ${{ secrets.PROD_USER }}
+          DEPLOY_BASE: ${{ vars.PROD_DEPLOY_BASE }}
+          PROD_SERVICE_NAME: ${{ vars.PROD_SERVICE_NAME }}
+          PROD_APP_PORT: ${{ vars.PROD_APP_PORT }}
+          RELEASE_ATTEMPT_ID: ${{ needs.validate-source-run.outputs.release-attempt-id }}
+        run: |
+          set -euo pipefail
+          echo "DEPLOYMENT_PHASE=staging-and-activation" >> "$GITHUB_ENV"
+          : "${DEPLOY_HOST:?Missing PROD_HOST secret}"
+          : "${DEPLOY_USER:?Missing PROD_USER secret}"
+          base_dir="${DEPLOY_BASE:-/srv/quadball-timer}"
+          service_name="${PROD_SERVICE_NAME:-quadball-timer}"
+          app_port="${PROD_APP_PORT:-3000}"
+          release_id="${RELEASE_ATTEMPT_ID}"
+          stage_dir="${base_dir}/.staging/${release_id}"
+          ssh_opts="-i ${SSH_DIR}/id_ed25519 -o StrictHostKeyChecking=yes -o UserKnownHostsFile=${SSH_DIR}/known_hosts"
+          cleanup_remote_stage() {
+            ssh $ssh_opts "${DEPLOY_USER}@${DEPLOY_HOST}" "chmod -R u+w -- '${stage_dir}' 2>/dev/null || true; rm -rf -- '${stage_dir}'" || true
+            rm -rf -- "$SSH_DIR"
+          }
+          trap cleanup_remote_stage EXIT
+          ssh $ssh_opts "${DEPLOY_USER}@${DEPLOY_HOST}" "test ! -e '${stage_dir}' && install -d -m 750 '${stage_dir}'"
+          rsync -a -e "ssh ${ssh_opts}" release/ "${DEPLOY_USER}@${DEPLOY_HOST}:${stage_dir}/"
+          set +e
+          ssh $ssh_opts "${DEPLOY_USER}@${DEPLOY_HOST}" "'${stage_dir}/deploy/activate-release.sh' --base-dir '${base_dir}' --staged-dir '${stage_dir}' --release '${release_id}' --service '${service_name}' --port '${app_port}'" 2>&1 | tee "$RUNNER_TEMP/quadball-production-deployment.log"
+          activation_status=${PIPESTATUS[0]}
+          set -e
+          phase="$(sed -n 's/^ACTIVATION_PHASE=//p' "$RUNNER_TEMP/quadball-production-deployment.log" | tail -n 1)"
+          echo "DEPLOYMENT_PHASE=${phase:-activation}" >> "$GITHUB_ENV"
+          if (( activation_status != 0 )); then exit "$activation_status"; fi
+          curl --fail --silent --show-error --max-time 10 https://timer.quadball.app/ | grep -qi "<!doctype html"
+
+      - name: Record Production promotion outcome
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          RELEASE_ATTEMPT: ${{ needs.validate-source-run.outputs.release-attempt-id }}
+          FAILED_PHASE: ${{ env.DEPLOYMENT_PHASE }}
+        run: |
+          set -euo pipefail
+          case "$JOB_STATUS" in
+            success)
+              phase="verified"
+              failure_category="none"
+              ;;
+            cancelled)
+              phase="${FAILED_PHASE:-promotion}"
+              failure_category="cancelled"
+              ;;
+            *)
+              phase="${FAILED_PHASE:-promotion}"
+              failure_category="${phase}-failed"
+              ;;
+          esac
+          printf '%s\n' \
+            "releaseAttemptId=${RELEASE_ATTEMPT}" \
+            "status=${JOB_STATUS}" \
+            "phase=${phase}" \
+            "failureCategory=${failure_category}"

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -372,3 +372,25 @@ _Avoid_: Finalization, inactivity timeout
 **Official Score Sheet**:
 The paper record signed by referees after a game and treated as authoritative for the event. The app's Game Timeline and Control Audit Trail support live operations but do not replace it.
 _Avoid_: Game Timeline, Control Audit Trail
+
+## Deployment Language
+
+**Release Bundle**:
+An immutable deployable candidate whose bytes and provenance are fixed as one unit. A Release Bundle is identified by its exact source and attempt provenance.
+_Avoid_: build, deployment package, latest artifact
+
+**Test Activation**:
+The automatic validation of a Release Bundle in the disposable Test Environment after an eligible merge to `main`.
+_Avoid_: Test promotion, Test deployment candidate
+
+**Promotion Source Run**:
+The successful validation record whose Test Activation certified the Release Bundle selected for Production Promotion.
+_Avoid_: latest run, source build, production run
+
+**Production Promotion**:
+The manual transfer and activation of the exact Release Bundle validated by a Promotion Source Run, after the required Production Approval.
+_Avoid_: Production deploy, rebuild-and-deploy, hotfix push
+
+**Production Approval**:
+The explicit human review granted before a Production Promotion may activate its selected Release Bundle.
+_Avoid_: automatic approval, deployment confirmation

--- a/README.md
+++ b/README.md
@@ -78,8 +78,13 @@ release when the installed unit does not provide this state contract.
 
 The permanent Test Environment is deployed independently at
 `https://test.timer.quadball.app` by the Test job in
-`.github/workflows/deploy-production.yml`. The workflow builds one immutable
-release attempt and gives Production and Test independent activation jobs. Test uses
+`.github/workflows/deploy-production.yml`. Every eligible merge to `main` builds
+one immutable Release Bundle and performs Test Activation only. Production is
+activated separately through `.github/workflows/promote-production.yml`: manually
+select the successful Promotion Source Run, then approve the `production`
+Environment. That workflow downloads the exact Test-validated bundle and never
+rebuilds it. Follow `deploy/production-promotion.md` for the operator steps.
+Test uses
 the separate `quadball-timer-test` service on `127.0.0.1:3001`, release root
 `/srv/quadball-timer-test`, and state directory `/var/lib/quadball-timer-test`.
 Its root-controlled key file is `/etc/quadball-timer/test.env`; Test keys must
@@ -90,11 +95,11 @@ standing backup or availability guarantee. See
 The Test Environment Technical Admin verification checklist is in
 `deploy/technical-admin-bootstrap-test-checklist.md`.
 
-Pushes to `main` skip CI and deployment when every changed path is limited to
+Pushes to `main` skip CI and Test Activation when every changed path is limited to
 `AGENTS.md`, `CONTEXT.md`, `README.md`, `docs/`, or `.github/dependabot.yml`.
 Files under `docs/` are also excluded from formatting, linting, and type-aware
-validation. Manually dispatch the workflow to force CI; production deployment
-still occurs only when the selected ref is `main`.
+validation. Manually dispatch the Test workflow to force CI/Test Activation; use
+the separate Production promotion workflow for a reviewed Production Approval.
 
 ## Quality checks
 

--- a/deploy/production-promotion.md
+++ b/deploy/production-promotion.md
@@ -1,0 +1,22 @@
+# Production Promotion
+
+The merge workflow deploys and verifies Test only. Production is activated only
+by promoting the exact Release Bundle that passed Test.
+
+1. Open the successful `Deploy Test environment` run for the desired merge to
+   `main`. Record its run ID and attempt number. The Test job must be green.
+2. In Actions, choose `Promote Production release` → `Run workflow` on `main`.
+   Enter that run ID and attempt number exactly; do not use a different run or
+   rebuild locally.
+3. The workflow verifies the source run, its `deploy-test` success, its
+   immutable artifact, and its release identity before it can reach the
+   Production job.
+4. Approve the pending `production` Environment deployment as `netzhuffle`.
+   Approval is required even after manually dispatching the workflow; there is
+   no timeout-based promotion and administrators cannot bypass the gate.
+5. Confirm the Production job's bounded activation and public smoke check are
+   green. If source validation, artifact download, activation, or verification
+   fails, do not retry with a rebuilt artifact; investigate the exact source run.
+
+The promotion workflow uses a non-cancelling Production concurrency group. A
+second promotion waits for the first rather than cancelling or overlapping it.

--- a/docs/adr/0003-test-first-production-promotion.md
+++ b/docs/adr/0003-test-first-production-promotion.md
@@ -1,0 +1,5 @@
+# Activate Test automatically and promote Production manually
+
+After an eligible merge to `main`, GitHub Actions builds one immutable Release Bundle and performs Test Activation only. Production is handled by a separately dispatched workflow that accepts only a successful `main` Promotion Source Run whose Test Activation succeeded, downloads that exact artifact without rebuilding, and pauses for the required `production` Environment Production Approval; this keeps ordinary merges green while preventing an unreviewed restart of the SQM Production service.
+
+The Production promotion workflow is non-cancelling and fails closed when the source run, Test outcome, release identity, or artifact is invalid or unavailable. The single-operator SQM setup allows `netzhuffle` to approve its own promotion; no timeout promotes an unapproved release.

--- a/docs/research/production-deployment-operational-audit.md
+++ b/docs/research/production-deployment-operational-audit.md
@@ -6,16 +6,20 @@ Audit date: 12 July 2026
 
 The current deployment is a good process-availability baseline, but it is not yet safe for SQM game state. GitHub Actions builds and tests the exact compiled Bun executable, deploys through a narrow SSH path, switches a `current` symlink, checks localhost health, attempts rollback, and verifies the public page. Caddy terminates TLS, proxies only to loopback, supplies appropriate security headers, and hides the internal health endpoint.
 
+## Current SQM promotion policy
+
+The deployment boundary now separates **Test Activation** from **Production Promotion**. An eligible merge to `main` runs `.github/workflows/deploy-production.yml`, which builds one immutable Release Bundle and activates Test only. `.github/workflows/promote-production.yml` is manually dispatched with the exact successful Promotion Source Run and attempt; it validates that the run is on `main`, that its Test Activation job succeeded, downloads the same artifact without rebuilding, and waits for the required `production` Environment Production Approval before activating Production. The promotion concurrency group is non-cancelling, and invalid, missing, or unavailable source runs fail closed.
+
 Two deployment properties are nevertheless production blockers:
 
 1. Every activation restarts a server whose complete game registry exists only in memory. A deploy, crash, host reboot, or rollback therefore loses every server-side game and command-id record. Rollback restores an executable, not game state. This violates the accepted server-outage recovery drill and makes deployment during an active Event unsafe.
 2. A release directory is named only by Git commit SHA. Re-running or re-dispatching a deployment for the same commit uploads into that same directory with `rsync --delete`. If it is the current release, the workflow mutates the active rollback target before activation; an interrupted upload or failed activation cannot reliably return to the previous bytes.
 
-The remaining gaps are production controls and evidence: production has no approval rule, live release identity is not observable, smoke coverage is too shallow, the systemd/Caddy installation can drift from source, secret rotation and artifact-audit procedures are undocumented, and neither rollback nor server-loss recovery has a recorded rehearsal.
+The remaining gaps are production controls and evidence: the audit snapshot had no approval rule, live release identity is not observable, smoke coverage is too shallow, the systemd/Caddy installation can drift from source, secret rotation and artifact-audit procedures are undocumented, and neither rollback nor server-loss recovery has a recorded rehearsal.
 
 ## Evidence inspected
 
-- `.github/workflows/deploy-production.yml`, `deploy/activate-release.sh`, `deploy/systemd/quadball-timer.service`, `package.json`, `src/index.ts`, and the internal-health implementation and tests.
+- `.github/workflows/deploy-production.yml`, `.github/workflows/promote-production.yml`, `deploy/activate-release.sh`, `deploy/systemd/quadball-timer.service`, `package.json`, `src/index.ts`, and the internal-health implementation and tests.
 - The production GitHub environment, Actions variables and secret names, and recent deployment runs. Secret values were not accessed.
 - The source-of-truth Caddy route and documented server state in `infra-caddy`.
 - The accepted SQM production acceptance and rehearsal plan.
@@ -46,7 +50,7 @@ The remaining gaps are production controls and evidence: production has no appro
 
 ### 2. Separate production promotion from ordinary `main` pushes
 
-- Keep CI on every push, but require an explicit production promotion of the accepted release candidate after feature completion on the afternoon of 13 August and before the joint go/no-go decision on the evening of 14 August. Use required reviewers on the GitHub `production` environment or an equivalent manual promotion gate if environment reviewers are unavailable.
+- Keep CI and Test Activation on every eligible push, but require the separate manual Production Promotion of the exact Test-validated Release Bundle. Use a required reviewer on the GitHub `production` Environment; the single-operator SQM setup permits `netzhuffle` self-approval and never promotes on timeout.
 - Preserve the non-cancelling production concurrency group.
 - Record the exact approved commit, artifact digest, deployment run, and live release identity in the durable acceptance record.
 - From feature freeze through SQM, do not deploy merely because documentation or unrelated code lands on `main`. No event-day deployment is planned; an exceptional event-day deploy or rollback remains the repository maintainer's onsite judgment.
@@ -122,7 +126,7 @@ These checks require the deployed server and, where noted, a deliberate outage. 
 On 12 July 2026:
 
 - the latest production workflow run for commit `92f49ace0a3f1b1084dd9ba4f325664bfe5e1580` completed successfully;
-- the production environment had no protection rules;
+- the production environment had no protection rules at audit time; the current SQM policy is recorded above;
 - repository Actions variables matched `/srv/quadball-timer`, `quadball-timer`, and port `3000`, and the four expected deploy secret names existed;
 - the public root returned `200` with the expected security headers;
 - `/internal/healthz` returned public `404`;

--- a/src/production-deployment.test.ts
+++ b/src/production-deployment.test.ts
@@ -57,7 +57,7 @@ describe("Production deployment contract", () => {
     expect(monitoring).toContain("`root:quadball-timer-test`");
   });
 
-  test("builds one shared immutable artifact for independent environment jobs", () => {
+  test("builds one shared immutable artifact and automatically activates only Test", () => {
     const workflow = readFileSync(
       join(repositoryRoot, ".github/workflows/deploy-production.yml"),
       "utf8",
@@ -67,26 +67,45 @@ describe("Production deployment contract", () => {
     expect(workflow).toContain("bun scripts/create-release-bundle.ts");
     expect(workflow).toContain("Upload one shared release artifact");
     expect(workflow).toContain("deploy-test:");
-    expect(workflow).toContain("deploy-production:");
-    expect(workflow).toContain("needs: [deploy-test, deploy-production]");
+    expect(workflow).not.toContain("deploy-production:");
+    expect(workflow).toContain("needs: [deploy-test]");
+    expect(workflow).not.toContain("name: production");
   });
 
-  test("reports each environment outcome with release identity and bounded phase", () => {
+  test("reports the automatic Test outcome with release identity and bounded phase", () => {
     const workflow = readFileSync(
       join(repositoryRoot, ".github/workflows/deploy-production.yml"),
       "utf8",
     );
 
     expect(workflow).toContain("Record Test deployment outcome");
-    expect(workflow).toContain("Record Production deployment outcome");
     expect(workflow).toContain('echo "releaseAttemptId=$RELEASE_ATTEMPT"');
     expect(workflow).toContain('echo "failureCategory=$failure_category"');
     expect(workflow).toContain('"releaseAttemptId": "${RELEASE_ATTEMPT_ID}"');
     expect(workflow).toContain('"phase": "${TEST_PHASE}"');
-    expect(workflow).toContain('"phase": "${PRODUCTION_PHASE}"');
-    expect(workflow).toContain(
-      'if [[ "$TEST_STATUS" != "success" || "$PRODUCTION_STATUS" != "success" ]]; then',
+    expect(workflow).not.toContain("PRODUCTION_STATUS");
+    expect(workflow).toContain('if [[ "$TEST_STATUS" != "success" ]]; then');
+  });
+
+  test("promotes only an exact successful Test-validated run", () => {
+    const workflow = readFileSync(
+      join(repositoryRoot, ".github/workflows/promote-production.yml"),
+      "utf8",
     );
+
+    expect(workflow).toContain("workflow_dispatch:");
+    expect(workflow).toContain("source_run_id:");
+    expect(workflow).toContain("source_run_attempt:");
+    expect(workflow).toContain(".github/workflows/deploy-production.yml");
+    expect(workflow).toContain('test "$(jq -r \'.head_branch\' <<<"$run_json")" = "main"');
+    expect(workflow).toContain('test "$(jq -r \'.conclusion\' <<<"$run_json")" = "success"');
+    expect(workflow).toContain('select(.name == "deploy-test" and .conclusion == "success")');
+    expect(workflow).toContain("run-id: ${{ inputs.source_run_id }}");
+    expect(workflow).toContain("name: production");
+    expect(workflow).toContain(
+      'release_attempt_id="sha-${source_sha}-run-${SOURCE_RUN_ID}-attempt-${SOURCE_RUN_ATTEMPT}"',
+    );
+    expect(workflow).not.toContain("bun run build:executable");
   });
 
   test("preserves executable modes across the GitHub artifact boundary", () => {


### PR DESCRIPTION
## Summary

- keep the merge-triggered deployment workflow green by activating and verifying Test only
- add a manual Production promotion workflow that validates an exact successful `main` Test run and downloads its immutable artifact without rebuilding
- require the `production` Environment approval before Production activation, with a non-cancelling promotion concurrency group
- document the Release Bundle, Test Activation, Promotion Source Run, Production Promotion, and Production Approval vocabulary and policy

## Why

Production previously activated automatically alongside Test after every eligible `main` merge. The SQM policy is now Test-first: every eligible merge still reaches the Test environment, while Production requires an explicit approval of the exact artifact that passed Test.

## Verification

- `bun test --isolate src/production-deployment.test.ts` (20 passed, 136 assertions)
- `bun run check` (passes with existing lint warnings)
- Ruby YAML parse for both workflows
- `git diff --check`
- the normal `bun run test` suite reached 1,058 passing tests but reproduced one pre-existing timing failure in the live-controller test; that test passes alone with a 30-second budget

## Operator impact

Run `Promote Production release` manually from `main`, enter the successful Test workflow run ID and attempt, then approve the pending `production` Environment deployment. The GitHub `production` Environment is configured with `netzhuffle` as required reviewer, self-approval allowed, no wait timer, and administrator bypass disabled.
