### PR TITLE
Compact the Ad Hoc Controller action panel

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -329,6 +329,10 @@ _Avoid_: Game from scratch, unassigned game
 A participant admitted through an unfinished Ad Hoc Game's Control QR. All Ad Hoc Controllers for the Game have equal authority; its creator is not an owner or primary Controller, and an admitted browser retains its authority across ordinary browser and server restarts until its Controller Leave Grace Period expires or capacity cleanup removes the Game.
 _Avoid_: Ad Hoc Game owner, creator role, primary Controller
 
+**Ad Hoc Penalty**:
+A penalty card fact recorded for an Ad Hoc Game Side at an original Game Clock time. Its card type and affected Game Side remain associated with that original entry even when a Controller later assigns or corrects its optional player number or changes its card details.
+_Avoid_: mutable penalty timer, latest card, player-only penalty
+
 **Controller Leave Grace Period**:
 The five-minute interval after a Controller leaves an Ad Hoc Game or Event Game during which the departing browser can resume its most recently left control authority from Home, subject to the Game's current authority rules. The opportunity survives an ordinary browser restart, replaces any earlier Leave Grace Period for that browser, and makes the departure final only when it expires.
 _Avoid_: Undo leave, logout timeout, session expiry

--- a/docs/adr/0003-ad-hoc-controller-penalty-entry.md
+++ b/docs/adr/0003-ad-hoc-controller-penalty-entry.md
@@ -1,0 +1,26 @@
+# Ad Hoc Controller penalty entry is staged
+
+- Status: accepted
+- Date: 2026-08-16
+
+## Decision
+
+Ad Hoc Controller action panels use a compact, viewport-aware bottom surface. The surface is attached directly to its Cards/Timeout/Game end navigation, keeps the clock and score controls available whenever the viewport permits, and scrolls only its content when the available height is insufficient. This change is Ad Hoc-only; Event Controller UI and Event card semantics remain unchanged.
+
+Ad Hoc Card entry is delivered in two stacked implementation layers:
+
+1. The first layer is backend-neutral. It makes the Card panel a short wizard (`Card type → Game Side → player number`) and retains the existing final `add-card` command, so a penalty is recorded only after a valid number is entered. `Undo` navigates to the previous uncommitted step; closing the panel discards only the uncommitted draft.
+2. The second layer extends Ad Hoc durable state. Selecting type and Game Side records an Ad Hoc Penalty immediately with no player number. The resulting fact keeps its original Game Clock time. A Controller may then assign or correct its player number, card type, or Game Side by selecting the exact visible penalty; `Back` leaves the committed fact intact. Number entry with `OK` may intentionally leave the number absent.
+
+Both layers use the same exact penalty fact identity for later edits. No edit may infer the latest penalty or change the original entry time.
+
+## Context
+
+The existing all-at-once Card form consumes most of a phone viewport and makes the action surface compete with the clock and score controls. A two-layer rollout keeps the first visual/interaction improvement independently deployable while reserving durable correction semantics for a separately reviewable change.
+
+## Consequences
+
+- Ad Hoc Controllers can complete ordinary numbered-card entry without a backend protocol change in the first layer.
+- The second layer supports unknown-number penalties and later correction without losing elapsed-time semantics.
+- `Undo` is only pre-commit navigation. A committed penalty has no destructive remove action; `Back` returns to the sheet without removing it.
+- Event Controller layout and card behavior are deliberately outside this decision.

--- a/scripts/controller-action-sheet-browser-assertions.ts
+++ b/scripts/controller-action-sheet-browser-assertions.ts
@@ -110,16 +110,17 @@ async function assertAdHocCompletionJourney(
   await cards.click();
   const panel = page.locator('[data-controller-action-panel="true"]');
   const ok = panel.getByRole("button", { name: "OK", exact: true });
-  assert(
-    (await panel.getByRole("alert").count()) > 0,
-    `${stage} invalid Ad Hoc card was not retained`,
-  );
   const blue = panel.getByRole("button", { name: "Blue", exact: true });
   await blue.scrollIntoViewIfNeeded();
   await blue.click();
   const home = panel.getByRole("button", { name: "Home", exact: true });
   await home.scrollIntoViewIfNeeded();
   await home.click();
+  assert(
+    (await panel.getByRole("alert").count()) > 0,
+    `${stage} missing Ad Hoc player number was not retained`,
+  );
+  await panel.getByRole("button", { name: "7", exact: true }).click();
   await ok.scrollIntoViewIfNeeded();
   await ok.click();
   assert(

--- a/src/components/controller-action-sheet.tsx
+++ b/src/components/controller-action-sheet.tsx
@@ -13,11 +13,13 @@ export function ControllerActionSheet({
   onPanelChange,
   panel,
   tabThemes,
+  topOffsetPx,
 }: {
   activePanel: ControllerActionPanel | null;
   onPanelChange: (panel: ControllerActionPanel | null) => void;
   panel: ReactNode;
   tabThemes?: Partial<Record<ControllerActionPanel, TabTheme>>;
+  topOffsetPx?: number;
 }) {
   const previousPanelRef = useRef<ControllerActionPanel | null>(null);
   const actionButtonRefs = useRef<Partial<Record<ControllerActionPanel, HTMLButtonElement | null>>>(
@@ -39,7 +41,8 @@ export function ControllerActionSheet({
   return (
     <div
       data-controller-action-sheet="true"
-      className="pointer-events-none absolute inset-x-0 bottom-0 z-20 flex flex-col gap-2"
+      className="pointer-events-none absolute inset-x-0 bottom-0 top-[clamp(16rem,38dvh,22rem)] z-20 flex flex-col gap-0"
+      style={topOffsetPx === undefined ? undefined : { top: `${topOffsetPx + 8}px` }}
     >
       {activePanel === null ? null : (
         <section
@@ -47,7 +50,7 @@ export function ControllerActionSheet({
           data-controller-action-panel="true"
           role="region"
           aria-label={`${panelLabel(activePanel)} actions`}
-          className="pointer-events-auto max-h-[min(15dvh,12rem)] overflow-y-auto overscroll-contain rounded-2xl border border-slate-300 bg-white/95 p-2 shadow-[0_12px_30px_rgba(15,23,42,0.2)] backdrop-blur-sm [&_button]:min-h-11"
+          className="pointer-events-auto min-h-0 max-h-[calc(100%_-_4rem)] overflow-y-auto overscroll-contain rounded-t-2xl border border-b-0 border-slate-300 bg-white/95 p-2 shadow-[0_12px_30px_rgba(15,23,42,0.2)] backdrop-blur-sm [&_button]:min-h-11"
         >
           {panel}
         </section>
@@ -55,7 +58,7 @@ export function ControllerActionSheet({
       <nav
         data-controller-action-navigation="true"
         aria-label="Controller actions"
-        className="pointer-events-auto rounded-2xl border border-slate-300 bg-white p-1 pb-[max(0.25rem,env(safe-area-inset-bottom))] shadow-[0_8px_20px_rgba(15,23,42,0.16)]"
+        className="pointer-events-auto rounded-b-2xl border border-slate-300 bg-white p-1 pb-[max(0.25rem,env(safe-area-inset-bottom))] shadow-[0_8px_20px_rgba(15,23,42,0.16)]"
       >
         <div className="grid grid-cols-3 gap-1">
           <ActionTab

--- a/src/components/game-controller-action-panels.test.tsx
+++ b/src/components/game-controller-action-panels.test.tsx
@@ -49,16 +49,21 @@ describe("Ad Hoc Controller action UI", () => {
 
     await click(cards);
     expect(container.querySelector('[data-controller-action-panel="true"]')).not.toBeNull();
-    expect(container.querySelector('[role="alert"]')).not.toBeNull();
+    expect(container.querySelector('[data-card-wizard-step="type"]')).not.toBeNull();
     await click(actionButton("Timeout"));
     await click(cards);
-    expect(container.querySelector('[role="alert"]')).not.toBeNull();
-    expect(container.textContent).toContain("Remaining on add: --");
+    expect(container.querySelector('[data-card-wizard-step="type"]')).not.toBeNull();
 
     await click(cards);
     await click(cards);
     await click(panelButton("Blue"));
+    expect(container.querySelector('[data-card-wizard-step="team"]')).not.toBeNull();
     await click(panelButton("Home"));
+    expect(container.querySelector('[data-card-wizard-step="number"]')).not.toBeNull();
+    await click(panelButton("OK"));
+    expect(container.querySelector('[data-controller-action-panel="true"]')).not.toBeNull();
+    expect(container.querySelector('[role="alert"]')).not.toBeNull();
+    await click(panelButton("7"));
     await click(panelButton("OK"));
     expect(container.querySelector('[data-controller-action-panel="true"]')).toBeNull();
     expect(document.activeElement).toBe(cards);
@@ -195,21 +200,26 @@ function AdHocActionHarness() {
         canSelectCardType
         canSelectCardTeam={cardDraft.cardType !== null}
         cardPlayerLabel="no player"
-        cardEntryStarted={cardDraft.cardType !== null}
         cardAddStatusText={
-          cardDraft.cardType === null || cardDraft.team === null ? "Remaining on add: --" : "Ready"
+          cardDraft.cardType === null || cardDraft.team === null
+            ? "Choose a card type and team."
+            : cardDraft.digits.length === 0
+              ? "Enter a player number to record this card."
+              : "Ready"
         }
         canEditCardDigits={cardDraft.cardType !== null && cardDraft.team !== null}
         appendCardDigit={(digit) =>
           setCardDraft((current) => ({ ...current, digits: current.digits + digit }))
         }
-        canSubmitCard={cardDraft.cardType !== null && cardDraft.team !== null}
+        canSubmitCard={
+          cardDraft.cardType !== null && cardDraft.team !== null && cardDraft.digits.length > 0
+        }
         submitCard={() => {
           dispatch({
             type: "add-card",
             team: cardDraft.team ?? "home",
             cardType: cardDraft.cardType ?? "blue",
-            playerNumber: null,
+            playerNumber: cardDraft.digits.length === 0 ? null : Number(cardDraft.digits),
             startedGameClockMs: 0,
           });
           resetDraft();

--- a/src/components/game-controller-action-panels.tsx
+++ b/src/components/game-controller-action-panels.tsx
@@ -34,6 +34,7 @@ type PanelTabTheme = {
 export function GameControllerActionPanels({
   activePanel,
   setActivePanel,
+  topOffsetPx,
   controller,
   state,
   gameView,
@@ -46,7 +47,6 @@ export function GameControllerActionPanels({
   canSelectCardType,
   canSelectCardTeam,
   cardPlayerLabel,
-  cardEntryStarted,
   cardAddStatusText,
   canEditCardDigits,
   appendCardDigit,
@@ -77,6 +77,7 @@ export function GameControllerActionPanels({
 }: {
   activePanel: ActivePanel;
   setActivePanel: (panel: ActivePanel) => void;
+  topOffsetPx?: number;
   controller: boolean;
   state: GameState;
   gameView: {
@@ -96,7 +97,6 @@ export function GameControllerActionPanels({
   canSelectCardType: boolean;
   canSelectCardTeam: boolean;
   cardPlayerLabel: string;
-  cardEntryStarted: boolean;
   cardAddStatusText: string;
   canEditCardDigits: boolean;
   appendCardDigit: (digit: string) => void;
@@ -130,150 +130,29 @@ export function GameControllerActionPanels({
       activePanel={activePanel}
       onPanelChange={setActivePanel}
       tabThemes={tabThemes}
+      topOffsetPx={topOffsetPx}
       panel={
         <Card className="relative min-h-0 overflow-hidden rounded-[1.5rem] border-0 bg-transparent py-0 shadow-none">
           <CardContent className="overflow-hidden px-2">
-            <div
-              className={`flex min-h-0 flex-col gap-1.5 rounded-2xl border border-slate-200 bg-slate-50 p-2 ${
-                activePanel === "card" ? "animate-in fade-in-0 slide-in-from-bottom-2" : "hidden"
-              }`}
-            >
-              <div className="grid grid-cols-2 gap-1">
-                {cardTypeOptions.map((option) => {
-                  const Icon = option.icon;
-                  const active = cardDraft.cardType === option.type;
-
-                  return (
-                    <Button
-                      key={option.type}
-                      size="sm"
-                      variant="outline"
-                      className={`h-7 justify-start gap-1.5 rounded-xl px-2 text-[10px] ${
-                        active ? option.activeClassName : option.idleClassName
-                      }`}
-                      onClick={() =>
-                        setCardDraft((previous) => ({
-                          ...previous,
-                          cardType: option.type,
-                          startedGameClockMs:
-                            previous.startedGameClockMs === null
-                              ? state.gameClockMs
-                              : previous.startedGameClockMs,
-                        }))
-                      }
-                      disabled={!canSelectCardType}
-                    >
-                      <Icon className="h-3.5 w-3.5" />
-                      {option.label}
-                    </Button>
-                  );
-                })}
-              </div>
-              <div className="grid grid-cols-2 gap-1">
-                {displayTeamOrder.map((team) => (
-                  <Button
-                    key={team}
-                    size="sm"
-                    variant={cardDraft.team === team ? "default" : "outline"}
-                    className="h-7 rounded-xl text-[10px]"
-                    onClick={() =>
-                      setCardDraft((previous) => ({
-                        ...previous,
-                        team,
-                      }))
-                    }
-                    disabled={!canSelectCardTeam}
-                  >
-                    {displayTeamName(team)}
-                  </Button>
-                ))}
-              </div>
-              <div className="grid grid-cols-[auto_1fr_auto] items-center gap-2 rounded-xl border border-slate-300 bg-white px-2 py-1 text-[10px] font-medium">
-                {cardDraft.cardType === null ? (
-                  <span className="text-slate-500">Card?</span>
-                ) : (
-                  <>
-                    <span className="uppercase">{cardDraft.cardType}</span>
-                    <span className="truncate text-slate-600">
-                      {cardDraft.team === null
-                        ? "team?"
-                        : cardDraft.team === "home"
-                          ? state.homeName
-                          : state.awayName}{" "}
-                      • {cardPlayerLabel}
-                    </span>
-                  </>
-                )}
-                <Button
-                  size="sm"
-                  variant="ghost"
-                  className="h-5 px-1.5 text-[10px] text-slate-700"
-                  onClick={() =>
-                    setCardDraft({
-                      cardType: null,
-                      team: null,
-                      digits: "",
-                      startedGameClockMs: null,
-                    })
-                  }
-                  disabled={!controller || !cardEntryStarted}
-                >
-                  Reset
-                </Button>
-              </div>
-              <p
-                role={canSubmitCard ? "status" : "alert"}
-                className="h-4 text-[10px] text-slate-600"
-              >
-                {cardAddStatusText}
-              </p>
-              <div className="grid grid-cols-3 gap-1">
-                {["1", "2", "3", "4", "5", "6", "7", "8", "9"].map((digit) => (
-                  <Button
-                    key={digit}
-                    size="sm"
-                    variant="outline"
-                    className="h-7 rounded-xl border-slate-300 bg-white text-sm text-slate-900"
-                    onClick={() => appendCardDigit(digit)}
-                    disabled={!canEditCardDigits}
-                  >
-                    {digit}
-                  </Button>
-                ))}
-                <Button
-                  size="sm"
-                  variant="outline"
-                  className="h-7 rounded-xl border-slate-300 bg-white text-slate-900"
-                  onClick={() =>
-                    setCardDraft((previous) => ({
-                      ...previous,
-                      digits: previous.digits.slice(0, -1),
-                    }))
-                  }
-                  disabled={!canEditCardDigits || cardDraft.digits.length === 0}
-                >
-                  <Delete className="h-4 w-4" />
-                </Button>
-                <Button
-                  size="sm"
-                  variant="outline"
-                  className="h-7 rounded-xl border-slate-300 bg-white text-sm text-slate-900"
-                  onClick={() => appendCardDigit("0")}
-                  disabled={!canEditCardDigits}
-                >
-                  0
-                </Button>
-                <Button
-                  size="sm"
-                  className="h-7 gap-1 rounded-xl bg-emerald-600 text-white hover:bg-emerald-500"
-                  onClick={submitCard}
-                  disabled={!canSubmitCard}
-                >
-                  <Check className="h-4 w-4" />
-                  OK
-                </Button>
-              </div>
-            </div>
+            <CardWizard
+              active={activePanel === "card"}
+              controller={controller}
+              state={state}
+              displayTeamOrder={displayTeamOrder}
+              displayTeamName={displayTeamName}
+              cardTypeOptions={cardTypeOptions}
+              cardDraft={cardDraft}
+              setCardDraft={setCardDraft}
+              canSelectCardType={canSelectCardType}
+              canSelectCardTeam={canSelectCardTeam}
+              cardPlayerLabel={cardPlayerLabel}
+              cardAddStatusText={cardAddStatusText}
+              canEditCardDigits={canEditCardDigits}
+              appendCardDigit={appendCardDigit}
+              canSubmitCard={canSubmitCard}
+              submitCard={submitCard}
+              closePanel={() => setActivePanel(null)}
+            />
 
             <div
               className={`flex min-h-0 flex-col gap-1.5 rounded-2xl border border-slate-200 bg-slate-50 p-2 ${
@@ -509,5 +388,194 @@ export function GameControllerActionPanels({
         </Card>
       }
     />
+  );
+}
+
+function CardWizard({
+  active,
+  controller,
+  state,
+  displayTeamOrder,
+  displayTeamName,
+  cardTypeOptions,
+  cardDraft,
+  setCardDraft,
+  canSelectCardType,
+  canSelectCardTeam,
+  cardPlayerLabel,
+  cardAddStatusText,
+  canEditCardDigits,
+  appendCardDigit,
+  canSubmitCard,
+  submitCard,
+  closePanel,
+}: {
+  active: boolean;
+  controller: boolean;
+  state: GameState;
+  displayTeamOrder: [TeamId, TeamId];
+  displayTeamName: (team: TeamId) => string;
+  cardTypeOptions: CardTypeOption[];
+  cardDraft: CardDraft;
+  setCardDraft: Dispatch<SetStateAction<CardDraft>>;
+  canSelectCardType: boolean;
+  canSelectCardTeam: boolean;
+  cardPlayerLabel: string;
+  cardAddStatusText: string;
+  canEditCardDigits: boolean;
+  appendCardDigit: (digit: string) => void;
+  canSubmitCard: boolean;
+  submitCard: () => void;
+  closePanel: () => void;
+}) {
+  const step = cardDraft.cardType === null ? "type" : cardDraft.team === null ? "team" : "number";
+
+  if (!active) {
+    return null;
+  }
+
+  const undo = () => {
+    if (step === "number") {
+      setCardDraft((previous) => ({ ...previous, team: null, digits: "" }));
+      return;
+    }
+    if (step === "team") {
+      setCardDraft({ cardType: null, team: null, digits: "", startedGameClockMs: null });
+      return;
+    }
+    setCardDraft({ cardType: null, team: null, digits: "", startedGameClockMs: null });
+    closePanel();
+  };
+
+  return (
+    <div
+      data-card-wizard-step={step}
+      className="flex min-h-0 flex-col gap-1.5 rounded-2xl border border-slate-200 bg-slate-50 p-2 animate-in fade-in-0 slide-in-from-bottom-2"
+    >
+      <div className="flex items-center justify-between gap-2 text-[10px] font-semibold uppercase tracking-[0.16em] text-slate-500">
+        <span>{step === "type" ? "Card type" : step === "team" ? "Team" : "Player number"}</span>
+        {step !== "type" ? (
+          <span className="truncate text-right normal-case tracking-normal text-slate-600">
+            {cardDraft.cardType}{" "}
+            {cardDraft.team === null ? "" : `· ${displayTeamName(cardDraft.team)}`}
+          </span>
+        ) : null}
+      </div>
+
+      {step === "type" ? (
+        <div className="grid grid-cols-2 gap-1">
+          {cardTypeOptions.map((option) => {
+            const Icon = option.icon;
+            return (
+              <Button
+                key={option.type}
+                size="sm"
+                variant="outline"
+                className={`h-9 justify-start gap-1.5 rounded-xl px-2 text-[10px] ${option.idleClassName}`}
+                onClick={() =>
+                  setCardDraft({
+                    cardType: option.type,
+                    team: null,
+                    digits: "",
+                    startedGameClockMs: state.gameClockMs,
+                  })
+                }
+                disabled={!canSelectCardType}
+              >
+                <Icon className="h-3.5 w-3.5" />
+                {option.label}
+              </Button>
+            );
+          })}
+        </div>
+      ) : null}
+
+      {step === "team" ? (
+        <div className="grid grid-cols-2 gap-1">
+          {displayTeamOrder.map((team) => (
+            <Button
+              key={team}
+              size="sm"
+              variant="outline"
+              className="h-10 rounded-xl border-slate-300 bg-white text-slate-900"
+              onClick={() => setCardDraft((previous) => ({ ...previous, team }))}
+              disabled={!canSelectCardTeam}
+            >
+              {displayTeamName(team)}
+            </Button>
+          ))}
+        </div>
+      ) : null}
+
+      {step === "number" ? (
+        <>
+          <div className="grid grid-cols-[auto_1fr] items-center gap-2 rounded-xl border border-slate-300 bg-white px-2 py-1 text-[10px] font-medium">
+            <span className="uppercase">{cardDraft.cardType}</span>
+            <span className="truncate text-slate-600">
+              {cardDraft.team === "home" ? state.homeName : state.awayName} • {cardPlayerLabel}
+            </span>
+          </div>
+          <p
+            role={canSubmitCard ? "status" : "alert"}
+            className="min-h-4 text-[10px] text-slate-600"
+          >
+            {cardAddStatusText}
+          </p>
+          <div className="grid grid-cols-3 gap-1">
+            {["1", "2", "3", "4", "5", "6", "7", "8", "9"].map((digit) => (
+              <Button
+                key={digit}
+                size="sm"
+                variant="outline"
+                className="h-9 rounded-xl border-slate-300 bg-white text-sm text-slate-900"
+                onClick={() => appendCardDigit(digit)}
+                disabled={!canEditCardDigits}
+              >
+                {digit}
+              </Button>
+            ))}
+            <Button
+              size="sm"
+              variant="outline"
+              className="h-9 rounded-xl border-slate-300 bg-white text-slate-900"
+              onClick={() =>
+                setCardDraft((previous) => ({ ...previous, digits: previous.digits.slice(0, -1) }))
+              }
+              disabled={!canEditCardDigits || cardDraft.digits.length === 0}
+            >
+              <Delete className="h-4 w-4" />
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              className="h-9 rounded-xl border-slate-300 bg-white text-sm text-slate-900"
+              onClick={() => appendCardDigit("0")}
+              disabled={!canEditCardDigits}
+            >
+              0
+            </Button>
+            <Button
+              size="sm"
+              className="h-9 gap-1 rounded-xl bg-emerald-600 text-white hover:bg-emerald-500"
+              onClick={submitCard}
+              disabled={!canSubmitCard}
+            >
+              <Check className="h-4 w-4" />
+              OK
+            </Button>
+          </div>
+        </>
+      ) : null}
+
+      <Button
+        size="sm"
+        variant="ghost"
+        className="h-8 rounded-xl text-slate-700"
+        onClick={undo}
+        disabled={!controller}
+      >
+        Undo
+      </Button>
+    </div>
   );
 }

--- a/src/pages/game-page.tsx
+++ b/src/pages/game-page.tsx
@@ -128,7 +128,11 @@ export function GamePage({ gameId, role }: { gameId: string; role: ControllerRol
   } | null>(null);
   const leftTeamNameButtonRef = useRef<HTMLButtonElement | null>(null);
   const rightTeamNameButtonRef = useRef<HTMLButtonElement | null>(null);
+  const controllerTopSectionRef = useRef<HTMLDivElement | null>(null);
   const [displayTeamNameHeightPx, setDisplayTeamNameHeightPx] = useState<number | null>(null);
+  const [controllerTopSectionHeightPx, setControllerTopSectionHeightPx] = useState<number | null>(
+    null,
+  );
   const leaveTriggerRef = useRef<HTMLButtonElement | null>(null);
   const adHocQrTriggerRef = useRef<HTMLButtonElement | null>(null);
   const entryTriggerRef = useRef<HTMLButtonElement | null>(null);
@@ -587,6 +591,22 @@ export function GamePage({ gameId, role }: { gameId: string; role: ControllerRol
     };
   }, [liveState?.awayName, liveState?.displaySidesSwapped, liveState?.homeName, renamingTeam]);
 
+  useEffect(() => {
+    const element = controllerTopSectionRef.current;
+    if (element === null || typeof ResizeObserver === "undefined") {
+      return;
+    }
+
+    const observer = new ResizeObserver(([entry]) => {
+      const nextHeight = entry === undefined ? null : Math.ceil(entry.contentRect.height);
+      setControllerTopSectionHeightPx((previous) =>
+        previous === nextHeight ? previous : nextHeight,
+      );
+    });
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [liveState?.homeName, liveState?.awayName, liveState?.displaySidesSwapped]);
+
   const appendCardDigit = useCallback((digit: string) => {
     setCardDraft((previous) => {
       if (previous.digits.length >= 2) {
@@ -686,7 +706,8 @@ export function GamePage({ gameId, role }: { gameId: string; role: ControllerRol
     !state.isFinished &&
     !state.isSuspended &&
     cardDraft.cardType !== null &&
-    cardDraft.team !== null;
+    cardDraft.team !== null &&
+    cardDraft.digits.length > 0;
   const cardPlayerLabel = cardDraft.digits.length > 0 ? `#${cardDraft.digits}` : "No #";
   const cardBasePenaltyMs =
     cardDraft.cardType === "red"
@@ -711,12 +732,14 @@ export function GamePage({ gameId, role }: { gameId: string; role: ControllerRol
   const selectedCardPlayerServingPenalty = hasServingPenalty(selectedCardPlayer);
   const cardAddStatusText =
     cardDraft.cardType === null || cardDraft.team === null
-      ? "Remaining on add: --"
-      : cardDraft.cardType === "ejection"
-        ? "Remaining on add: n/a"
-        : selectedCardPlayerServingPenalty
-          ? `Adds on confirm: +${formatPenaltySlice(cardBasePenaltyMs ?? ONE_MINUTE_MS)}`
-          : `Remaining on add: ${formatRemaining(predictedCardRemainingMs ?? ONE_MINUTE_MS)}${state.isRunning ? " (live)" : ""}`;
+      ? "Choose a card type and team."
+      : cardDraft.digits.length === 0
+        ? "Enter a player number to record this card."
+        : cardDraft.cardType === "ejection"
+          ? "Remaining on add: n/a"
+          : selectedCardPlayerServingPenalty
+            ? `Adds on confirm: +${formatPenaltySlice(cardBasePenaltyMs ?? ONE_MINUTE_MS)}`
+            : `Remaining on add: ${formatRemaining(predictedCardRemainingMs ?? ONE_MINUTE_MS)}${state.isRunning ? " (live)" : ""}`;
   const cardTypeOptions: Array<{
     type: CardType;
     label: string;
@@ -958,80 +981,82 @@ export function GamePage({ gameId, role }: { gameId: string; role: ControllerRol
             />
           ) : null}
 
-          <ControllerTopSection
-            controller={controller}
-            stateIsRunning={state.isRunning}
-            stateIsFinished={state.isFinished}
-            stateIsSuspended={state.isSuspended}
-            statusLabel={statusLabel}
-            gameClockText={formatClock(gameView.state.gameClockMs)}
-            leftScoreColumn={homeScoreColumn}
-            rightScoreColumn={awayScoreColumn}
-            scorePulse={scorePulse}
-            teamNameEditor={{
-              controller,
-              renamingTeam,
-              homeName,
-              awayName,
-              homeColor,
-              awayColor,
-              activeTeamRenameInputRef,
-              leftTeamNameButtonRef,
-              rightTeamNameButtonRef,
-              displayTeamNameHeightPx,
-              onOpenRename: (team) => {
-                if (!controller) {
-                  return;
-                }
+          <div ref={controllerTopSectionRef} className="min-h-0">
+            <ControllerTopSection
+              controller={controller}
+              stateIsRunning={state.isRunning}
+              stateIsFinished={state.isFinished}
+              stateIsSuspended={state.isSuspended}
+              statusLabel={statusLabel}
+              gameClockText={formatClock(gameView.state.gameClockMs)}
+              leftScoreColumn={homeScoreColumn}
+              rightScoreColumn={awayScoreColumn}
+              scorePulse={scorePulse}
+              teamNameEditor={{
+                controller,
+                renamingTeam,
+                homeName,
+                awayName,
+                homeColor,
+                awayColor,
+                activeTeamRenameInputRef,
+                leftTeamNameButtonRef,
+                rightTeamNameButtonRef,
+                displayTeamNameHeightPx,
+                onOpenRename: (team) => {
+                  if (!controller) {
+                    return;
+                  }
 
-                setHomeName(state.homeName);
-                setAwayName(state.awayName);
-                setHomeColor(state.homeColor);
-                setAwayColor(state.awayColor);
-                setRenamingTeam(team);
-              },
-              onRenameInputChange: (team, value) => {
-                if (team === "home") {
-                  setHomeName(value);
-                } else {
-                  setAwayName(value);
-                }
-              },
-              onRenameColorChange: (team, value) => {
-                if (team === "home") {
-                  setHomeColor(value);
-                } else {
-                  setAwayColor(value);
-                }
-              },
-              onRenameInputKeyDown: handleTeamRenameInputKeyDown,
-              onSaveRename: saveTeamRename,
-              onSwapDisplayedTeamSides: swapDisplayedTeamSides,
-            }}
-            onAddScore={(team) =>
-              dispatchCommand({
-                type: "change-score",
-                team,
-                delta: 10,
-                reason: "goal",
-              })
-            }
-            onUndoScore={(team) => dispatchCommand({ type: "undo-last-score", team })}
-            onToggleClockAdjust={() => setClockAdjustOpen((previous) => !previous)}
-            onToggleRunning={() =>
-              dispatchCommand({
-                type: "set-running",
-                running: !state.isRunning,
-              })
-            }
-            clockAdjustOpen={clockAdjustOpen}
-            onAdjustGameClock={adjustGameClock}
-            finishSummary={finishSummary}
-            timeoutReminder={timeoutReminder}
-            flagStatus={flagStatus}
-            seekersStatus={seekersStatus}
-            clockTheme={clockTheme}
-          />
+                  setHomeName(state.homeName);
+                  setAwayName(state.awayName);
+                  setHomeColor(state.homeColor);
+                  setAwayColor(state.awayColor);
+                  setRenamingTeam(team);
+                },
+                onRenameInputChange: (team, value) => {
+                  if (team === "home") {
+                    setHomeName(value);
+                  } else {
+                    setAwayName(value);
+                  }
+                },
+                onRenameColorChange: (team, value) => {
+                  if (team === "home") {
+                    setHomeColor(value);
+                  } else {
+                    setAwayColor(value);
+                  }
+                },
+                onRenameInputKeyDown: handleTeamRenameInputKeyDown,
+                onSaveRename: saveTeamRename,
+                onSwapDisplayedTeamSides: swapDisplayedTeamSides,
+              }}
+              onAddScore={(team) =>
+                dispatchCommand({
+                  type: "change-score",
+                  team,
+                  delta: 10,
+                  reason: "goal",
+                })
+              }
+              onUndoScore={(team) => dispatchCommand({ type: "undo-last-score", team })}
+              onToggleClockAdjust={() => setClockAdjustOpen((previous) => !previous)}
+              onToggleRunning={() =>
+                dispatchCommand({
+                  type: "set-running",
+                  running: !state.isRunning,
+                })
+              }
+              clockAdjustOpen={clockAdjustOpen}
+              onAdjustGameClock={adjustGameClock}
+              finishSummary={finishSummary}
+              timeoutReminder={timeoutReminder}
+              flagStatus={flagStatus}
+              seekersStatus={seekersStatus}
+              clockTheme={clockTheme}
+            />
+          </div>
 
           <PenaltyColumnsSection
             penaltyColumns={penaltyColumns}
@@ -1053,6 +1078,7 @@ export function GamePage({ gameId, role }: { gameId: string; role: ControllerRol
           <GameControllerActionPanels
             activePanel={activePanel}
             setActivePanel={handleActionPanelChange}
+            topOffsetPx={controllerTopSectionHeightPx ?? undefined}
             controller={controller}
             state={state}
             gameView={{
@@ -1078,7 +1104,6 @@ export function GamePage({ gameId, role }: { gameId: string; role: ControllerRol
             canSelectCardType={canSelectCardType}
             canSelectCardTeam={canSelectCardTeam}
             cardPlayerLabel={cardPlayerLabel}
-            cardEntryStarted={cardEntryStarted}
             cardAddStatusText={cardAddStatusText}
             canEditCardDigits={canEditCardDigits}
             appendCardDigit={appendCardDigit}


### PR DESCRIPTION
## What changed

- compact the Ad Hoc Controller action surface into a viewport-aware bottom sheet
- keep the Cards, Timeout, and Game end navigation attached to the sheet with no visual gap
- turn Ad Hoc card entry into a type → team → player-number wizard with an explicit Undo path
- keep the clock and score controls available while the sheet is open

## Why

The previous Ad Hoc panel consumed too much vertical space on phone screens, introduced a gap above the navigation bar, and exposed the full card form at once. This layout keeps the core game controls reachable and makes the first card-entry step quick to understand without changing Event Games.

## Validation

- `bun run check`
- `bun run build`
- `bun run test:focused:adhoc-browser`
- targeted Ad Hoc action-panel tests
