### PR TITLE
Enable Ad Hoc card fact editing

### DIFF
--- a/scripts/controller-action-sheet-browser-assertions.ts
+++ b/scripts/controller-action-sheet-browser-assertions.ts
@@ -117,10 +117,9 @@ async function assertAdHocCompletionJourney(
   await home.scrollIntoViewIfNeeded();
   await home.click();
   assert(
-    (await panel.getByRole("alert").count()) > 0,
-    `${stage} missing Ad Hoc player number was not retained`,
+    await panel.getByRole("button", { name: "OK", exact: true }).isEnabled(),
+    `${stage} Ad Hoc card without a number was not immediately committed`,
   );
-  await panel.getByRole("button", { name: "7", exact: true }).click();
   await ok.scrollIntoViewIfNeeded();
   await ok.click();
   assert(
@@ -130,6 +129,24 @@ async function assertAdHocCompletionJourney(
   assert(
     (await page.evaluate(() => document.activeElement?.textContent?.trim())) === "Cards",
     `${stage} accepted Ad Hoc card did not restore Cards focus`,
+  );
+
+  const visiblePenalty = page.locator("[data-penalty-card-id]").first();
+  await visiblePenalty.waitFor();
+  await visiblePenalty.focus();
+  await visiblePenalty.press("Enter");
+  const editor = page.locator('[data-controller-action-panel="true"]');
+  await editor.waitFor();
+  const editorStep = await editor
+    .locator("[data-card-wizard-step]")
+    .getAttribute("data-card-wizard-step");
+  if (editorStep !== "number")
+    throw new Error(`${stage} penalty edit opened at ${editorStep ?? "unknown"} step`);
+  await editor.getByRole("button", { name: "8", exact: true }).click();
+  await editor.getByRole("button", { name: "OK", exact: true }).click();
+  assert(
+    (await page.locator('[data-controller-action-panel="true"]').count()) === 0,
+    `${stage} Ad Hoc card number edit did not close its panel`,
   );
 
   await timeout.click();

--- a/src/components/game-controller-action-panels.test.tsx
+++ b/src/components/game-controller-action-panels.test.tsx
@@ -61,10 +61,6 @@ describe("Ad Hoc Controller action UI", () => {
     await click(panelButton("Home"));
     expect(container.querySelector('[data-card-wizard-step="number"]')).not.toBeNull();
     await click(panelButton("OK"));
-    expect(container.querySelector('[data-controller-action-panel="true"]')).not.toBeNull();
-    expect(container.querySelector('[role="alert"]')).not.toBeNull();
-    await click(panelButton("7"));
-    await click(panelButton("OK"));
     expect(container.querySelector('[data-controller-action-panel="true"]')).toBeNull();
     expect(document.activeElement).toBe(cards);
 
@@ -130,6 +126,8 @@ function AdHocActionHarness() {
     team: null as TeamId | null,
     digits: "",
     startedGameClockMs: null as number | null,
+    editingCardId: null as string | null,
+    wizardStep: "type" as "type" | "team" | "number",
   });
   const [pendingWinConfirmation, setPendingWinConfirmation] = useState<{ label: string } | null>(
     null,
@@ -141,7 +139,14 @@ function AdHocActionHarness() {
     );
   };
   const resetDraft = () =>
-    setCardDraft({ cardType: null, team: null, digits: "", startedGameClockMs: null });
+    setCardDraft({
+      cardType: null,
+      team: null,
+      digits: "",
+      startedGameClockMs: null,
+      editingCardId: null,
+      wizardStep: "type",
+    });
 
   return (
     <>
@@ -208,11 +213,22 @@ function AdHocActionHarness() {
               : "Ready"
         }
         canEditCardDigits={cardDraft.cardType !== null && cardDraft.team !== null}
+        cardCreationPending={false}
+        commitCardWithoutNumber={(team) =>
+          setCardDraft((current) => ({
+            ...current,
+            team,
+            editingCardId: "ui-action",
+            wizardStep: "number",
+          }))
+        }
         appendCardDigit={(digit) =>
           setCardDraft((current) => ({ ...current, digits: current.digits + digit }))
         }
         canSubmitCard={
-          cardDraft.cardType !== null && cardDraft.team !== null && cardDraft.digits.length > 0
+          cardDraft.cardType !== null &&
+          cardDraft.team !== null &&
+          (cardDraft.editingCardId !== null || cardDraft.digits.length > 0)
         }
         submitCard={() => {
           dispatch({

--- a/src/components/game-controller-action-panels.tsx
+++ b/src/components/game-controller-action-panels.tsx
@@ -13,6 +13,8 @@ type CardDraft = {
   team: TeamId | null;
   digits: string;
   startedGameClockMs: number | null;
+  editingCardId: string | null;
+  wizardStep: "type" | "team" | "number";
 };
 
 type CardTypeOption = {
@@ -49,6 +51,8 @@ export function GameControllerActionPanels({
   cardPlayerLabel,
   cardAddStatusText,
   canEditCardDigits,
+  cardCreationPending,
+  commitCardWithoutNumber,
   appendCardDigit,
   canSubmitCard,
   submitCard,
@@ -99,6 +103,8 @@ export function GameControllerActionPanels({
   cardPlayerLabel: string;
   cardAddStatusText: string;
   canEditCardDigits: boolean;
+  cardCreationPending: boolean;
+  commitCardWithoutNumber: (team: TeamId) => void;
   appendCardDigit: (digit: string) => void;
   canSubmitCard: boolean;
   submitCard: () => void;
@@ -148,6 +154,8 @@ export function GameControllerActionPanels({
               cardPlayerLabel={cardPlayerLabel}
               cardAddStatusText={cardAddStatusText}
               canEditCardDigits={canEditCardDigits}
+              cardCreationPending={cardCreationPending}
+              commitCardWithoutNumber={commitCardWithoutNumber}
               appendCardDigit={appendCardDigit}
               canSubmitCard={canSubmitCard}
               submitCard={submitCard}
@@ -405,6 +413,8 @@ function CardWizard({
   cardPlayerLabel,
   cardAddStatusText,
   canEditCardDigits,
+  cardCreationPending,
+  commitCardWithoutNumber,
   appendCardDigit,
   canSubmitCard,
   submitCard,
@@ -423,12 +433,14 @@ function CardWizard({
   cardPlayerLabel: string;
   cardAddStatusText: string;
   canEditCardDigits: boolean;
+  cardCreationPending: boolean;
+  commitCardWithoutNumber: (team: TeamId) => void;
   appendCardDigit: (digit: string) => void;
   canSubmitCard: boolean;
   submitCard: () => void;
   closePanel: () => void;
 }) {
-  const step = cardDraft.cardType === null ? "type" : cardDraft.team === null ? "team" : "number";
+  const step = cardDraft.wizardStep;
 
   if (!active) {
     return null;
@@ -436,14 +448,21 @@ function CardWizard({
 
   const undo = () => {
     if (step === "number") {
-      setCardDraft((previous) => ({ ...previous, team: null, digits: "" }));
+      setCardDraft((previous) => ({ ...previous, wizardStep: "team" }));
       return;
     }
     if (step === "team") {
-      setCardDraft({ cardType: null, team: null, digits: "", startedGameClockMs: null });
+      setCardDraft((previous) => ({ ...previous, team: null, digits: "", wizardStep: "type" }));
       return;
     }
-    setCardDraft({ cardType: null, team: null, digits: "", startedGameClockMs: null });
+    setCardDraft({
+      cardType: null,
+      team: null,
+      digits: "",
+      startedGameClockMs: null,
+      editingCardId: null,
+      wizardStep: "type",
+    });
     closePanel();
   };
 
@@ -477,7 +496,9 @@ function CardWizard({
                     cardType: option.type,
                     team: null,
                     digits: "",
-                    startedGameClockMs: state.gameClockMs,
+                    startedGameClockMs: cardDraft.startedGameClockMs ?? state.gameClockMs,
+                    editingCardId: cardDraft.editingCardId,
+                    wizardStep: "team",
                   })
                 }
                 disabled={!canSelectCardType}
@@ -498,7 +519,13 @@ function CardWizard({
               size="sm"
               variant="outline"
               className="h-10 rounded-xl border-slate-300 bg-white text-slate-900"
-              onClick={() => setCardDraft((previous) => ({ ...previous, team }))}
+              onClick={() => {
+                if (cardDraft.editingCardId === null) {
+                  commitCardWithoutNumber(team);
+                } else {
+                  setCardDraft((previous) => ({ ...previous, team, wizardStep: "number" }));
+                }
+              }}
               disabled={!canSelectCardTeam}
             >
               {displayTeamName(team)}
@@ -529,7 +556,7 @@ function CardWizard({
                 variant="outline"
                 className="h-9 rounded-xl border-slate-300 bg-white text-sm text-slate-900"
                 onClick={() => appendCardDigit(digit)}
-                disabled={!canEditCardDigits}
+                disabled={!canEditCardDigits || cardCreationPending}
               >
                 {digit}
               </Button>
@@ -541,7 +568,7 @@ function CardWizard({
               onClick={() =>
                 setCardDraft((previous) => ({ ...previous, digits: previous.digits.slice(0, -1) }))
               }
-              disabled={!canEditCardDigits || cardDraft.digits.length === 0}
+              disabled={!canEditCardDigits || cardCreationPending || cardDraft.digits.length === 0}
             >
               <Delete className="h-4 w-4" />
             </Button>
@@ -550,7 +577,7 @@ function CardWizard({
               variant="outline"
               className="h-9 rounded-xl border-slate-300 bg-white text-sm text-slate-900"
               onClick={() => appendCardDigit("0")}
-              disabled={!canEditCardDigits}
+              disabled={!canEditCardDigits || cardCreationPending}
             >
               0
             </Button>
@@ -558,7 +585,7 @@ function CardWizard({
               size="sm"
               className="h-9 gap-1 rounded-xl bg-emerald-600 text-white hover:bg-emerald-500"
               onClick={submitCard}
-              disabled={!canSubmitCard}
+              disabled={!canSubmitCard || cardCreationPending}
             >
               <Check className="h-4 w-4" />
               OK
@@ -574,7 +601,7 @@ function CardWizard({
         onClick={undo}
         disabled={!controller}
       >
-        Undo
+        {cardDraft.editingCardId === null ? "Undo" : "Back"}
       </Button>
     </div>
   );

--- a/src/components/game-controller-sections.tsx
+++ b/src/components/game-controller-sections.tsx
@@ -3,7 +3,7 @@ import { ArrowLeftRight, ChevronDown, ChevronUp } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
-import type { TeamId } from "@/lib/game-types";
+import type { CardType, TeamId } from "@/lib/game-types";
 
 type ScoreColumnView = {
   team: TeamId;
@@ -30,6 +30,10 @@ type TimeoutReminderView = null | {
 
 type PenaltyEntryView = {
   playerKey: string;
+  cardEventId: string | null;
+  cardType: CardType | null;
+  team: TeamId;
+  playerNumber: number | null;
   label: string;
   remaining: string;
   highlight: boolean;
@@ -418,6 +422,7 @@ export function PenaltyColumnsSection({
   pendingReleaseByPlayer,
   controller,
   onConfirmPenaltyExpiration,
+  onEditPenalty,
   getPendingReleaseActionLabel,
 }: {
   penaltyColumns: PenaltyColumnView[];
@@ -425,6 +430,7 @@ export function PenaltyColumnsSection({
   pendingReleaseByPlayer: Record<string, PendingReleaseActionView[]>;
   controller: boolean;
   onConfirmPenaltyExpiration: (pendingId: string, playerKey: string) => void;
+  onEditPenalty: (cardEventId: string) => void;
   getPendingReleaseActionLabel: (action: PendingReleaseActionView, playerKey: string) => string;
 }) {
   return (
@@ -457,18 +463,35 @@ export function PenaltyColumnsSection({
                   return (
                     <div
                       key={entry.playerKey}
+                      data-penalty-card-id={entry.cardEventId ?? undefined}
+                      role={controller && entry.cardEventId !== null ? "button" : undefined}
+                      tabIndex={controller && entry.cardEventId !== null ? 0 : undefined}
                       className={`rounded-xl border px-2 py-1 text-[10px] ${
                         releaseActions.length > 0
                           ? "animate-pulse border-red-300 bg-red-100 text-red-900"
                           : entry.highlight
                             ? "border-amber-300 bg-amber-100 text-amber-900"
                             : ""
-                      }`}
+                      } ${controller && entry.cardEventId !== null ? "cursor-pointer" : ""}`}
                       style={
                         releaseActions.length > 0 || entry.highlight
                           ? undefined
                           : column.neutralChipStyle
                       }
+                      onClick={() => {
+                        if (controller && entry.cardEventId !== null)
+                          onEditPenalty(entry.cardEventId);
+                      }}
+                      onKeyDown={(event) => {
+                        if (
+                          controller &&
+                          entry.cardEventId !== null &&
+                          (event.key === "Enter" || event.key === " ")
+                        ) {
+                          event.preventDefault();
+                          onEditPenalty(entry.cardEventId);
+                        }
+                      }}
                     >
                       <div className="flex items-center justify-between gap-1">
                         <span>{entry.label}</span>
@@ -481,9 +504,10 @@ export function PenaltyColumnsSection({
                               key={action.pendingId}
                               size="sm"
                               className="h-6 justify-start rounded-lg bg-red-500 px-1.5 text-[10px] text-white hover:bg-red-600"
-                              onClick={() =>
-                                onConfirmPenaltyExpiration(action.pendingId, entry.playerKey)
-                              }
+                              onClick={(event) => {
+                                event.stopPropagation();
+                                onConfirmPenaltyExpiration(action.pendingId, entry.playerKey);
+                              }}
                               disabled={!controller}
                             >
                               {getPendingReleaseActionLabel(action, entry.playerKey)}

--- a/src/lib/ad-hoc-card-facts.test.ts
+++ b/src/lib/ad-hoc-card-facts.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test } from "bun:test";
+import { applyAdHocCardMutation } from "@/lib/ad-hoc-card-facts";
+import { createInitialGameState } from "@/lib/game-engine";
+
+function ids() {
+  let next = 0;
+  return () => `card-fact-${++next}`;
+}
+
+describe("Ad Hoc card facts", () => {
+  test("records an unknown-number card at its original Game Clock time", () => {
+    const state = createInitialGameState({ id: "adhoc-facts", nowMs: 0 });
+    state.gameClockMs = 45_000;
+
+    expect(
+      applyAdHocCardMutation({
+        state,
+        mutation: {
+          type: "add-card",
+          team: "home",
+          cardType: "blue",
+          playerNumber: null,
+          startedGameClockMs: 30_000,
+        },
+        nowMs: 50_000,
+        idGenerator: ids(),
+      }),
+    ).toBe(true);
+
+    const event = state.cardEvents[0];
+    expect(event?.gameClockMs).toBe(30_000);
+    expect(event?.playerNumber).toBeNull();
+    expect(event?.id).toBe("card-fact-1");
+    expect(Object.values(state.players)[0]?.segments[0]?.remainingMs).toBe(45_000);
+  });
+
+  test("updates one exact card while preserving its entry time", () => {
+    const state = createInitialGameState({ id: "adhoc-facts", nowMs: 0 });
+    const makeId = ids();
+    applyAdHocCardMutation({
+      state,
+      mutation: { type: "add-card", team: "home", cardType: "blue", playerNumber: 7 },
+      nowMs: 1_000,
+      idGenerator: makeId,
+    });
+    applyAdHocCardMutation({
+      state,
+      mutation: { type: "add-card", team: "away", cardType: "yellow", playerNumber: 8 },
+      nowMs: 2_000,
+      idGenerator: makeId,
+    });
+    state.gameClockMs = 20_000;
+    const first = state.cardEvents[0];
+    const second = state.cardEvents[1];
+    if (first === undefined || second === undefined) throw new Error("Expected two cards.");
+
+    expect(
+      applyAdHocCardMutation({
+        state,
+        mutation: {
+          type: "update-card",
+          cardId: first.id,
+          team: "away",
+          cardType: "red",
+          playerNumber: null,
+        },
+        nowMs: 21_000,
+        idGenerator: makeId,
+      }),
+    ).toBe(true);
+
+    expect(state.cardEvents[0]).toMatchObject({
+      id: first.id,
+      createdAtMs: first.createdAtMs,
+      gameClockMs: first.gameClockMs,
+      team: "away",
+      cardType: "red",
+      playerNumber: null,
+    });
+    expect(state.cardEvents[1]).toEqual(second);
+    expect(Object.values(state.players).flatMap((player) => player.segments)).toHaveLength(3);
+    const segments = Object.values(state.players).flatMap((player) => player.segments);
+    expect(segments.filter((segment) => segment.cardEventId === first.id)).toHaveLength(2);
+    expect(segments.filter((segment) => segment.cardEventId === second.id)).toHaveLength(1);
+  });
+
+  test("rejects an update for an unknown or legacy penalty without mutation", () => {
+    const state = createInitialGameState({ id: "adhoc-facts", nowMs: 0 });
+    state.cardEvents.push({
+      id: "legacy-card",
+      team: "home",
+      playerKey: "home:7",
+      playerNumber: 7,
+      cardType: "blue",
+      createdAtMs: 1,
+      gameClockMs: 0,
+    });
+    const before = structuredClone(state);
+
+    expect(
+      applyAdHocCardMutation({
+        state,
+        mutation: {
+          type: "update-card",
+          cardId: "legacy-card",
+          team: "away",
+          cardType: "yellow",
+          playerNumber: 9,
+        },
+        nowMs: 2,
+        idGenerator: ids(),
+      }),
+    ).toBe(false);
+    expect(state).toEqual(before);
+  });
+});

--- a/src/lib/ad-hoc-card-facts.ts
+++ b/src/lib/ad-hoc-card-facts.ts
@@ -1,0 +1,176 @@
+import type { CardEvent, CardType, GameState, PenaltySegment, TeamId } from "@/lib/game-types";
+import { validateGameClockMs, validatePlayerNumber } from "@/lib/validation-policy";
+
+const ONE_MINUTE_MS = 60_000;
+
+export type AdHocCardMutation =
+  | {
+      type: "add-card";
+      team: TeamId;
+      playerNumber: number | null;
+      cardType: CardType;
+      startedGameClockMs?: number;
+    }
+  | {
+      type: "update-card";
+      cardId: string;
+      team: TeamId;
+      playerNumber: number | null;
+      cardType: CardType;
+    };
+
+/**
+ * The Ad Hoc card-fact seam owns card identity, original Game Clock time, and
+ * the player segments derived from each card. Callers never need to infer a
+ * "latest" card or manipulate player penalty state directly.
+ */
+export function applyAdHocCardMutation({
+  state,
+  mutation,
+  nowMs,
+  idGenerator,
+}: {
+  state: GameState;
+  mutation: AdHocCardMutation;
+  nowMs: number;
+  idGenerator: () => string;
+}): boolean {
+  if (mutation.type === "add-card") {
+    const gameClockMs = mutation.startedGameClockMs ?? state.gameClockMs;
+    if (!validCardInput(mutation.team, mutation.playerNumber, mutation.cardType, gameClockMs)) {
+      return false;
+    }
+
+    const cardId = idGenerator();
+    const event: CardEvent = {
+      id: cardId,
+      team: mutation.team,
+      playerKey: null,
+      playerNumber: mutation.playerNumber,
+      cardType: mutation.cardType,
+      createdAtMs: nowMs,
+      gameClockMs,
+    };
+    addSegmentsForCard(state, event, idGenerator, nowMs);
+    state.cardEvents.push(event);
+    return true;
+  }
+
+  if (!validCardInput(mutation.team, mutation.playerNumber, mutation.cardType, state.gameClockMs)) {
+    return false;
+  }
+  const event = state.cardEvents.find((candidate) => candidate.id === mutation.cardId);
+  if (event === undefined) return false;
+  const hasLinkedSegments = Object.values(state.players).some((player) =>
+    player.segments.some((segment) => segment.cardEventId === event.id),
+  );
+  if (event.cardType !== "ejection" && !hasLinkedSegments) return false;
+
+  removeSegmentsForCard(state, event.id);
+  event.team = mutation.team;
+  event.playerNumber = mutation.playerNumber;
+  event.cardType = mutation.cardType;
+  event.playerKey = null;
+  addSegmentsForCard(state, event, idGenerator, nowMs);
+  return true;
+}
+
+function validCardInput(
+  team: TeamId,
+  playerNumber: number | null,
+  cardType: CardType,
+  gameClockMs: number,
+) {
+  return (
+    (team === "home" || team === "away") &&
+    (cardType === "blue" ||
+      cardType === "yellow" ||
+      cardType === "red" ||
+      cardType === "ejection") &&
+    (playerNumber === null || validatePlayerNumber(playerNumber).ok) &&
+    validateGameClockMs(gameClockMs).ok
+  );
+}
+
+function addSegmentsForCard(
+  state: GameState,
+  event: CardEvent,
+  idGenerator: () => string,
+  nowMs: number,
+) {
+  if (event.cardType === "ejection") {
+    event.playerKey = event.playerNumber === null ? null : `${event.team}:${event.playerNumber}`;
+    return;
+  }
+
+  const playerKey =
+    event.playerNumber === null
+      ? `${event.team}:unknown:${state.nextUnknownPlayerId[event.team]++}`
+      : `${event.team}:${event.playerNumber}`;
+  event.playerKey = playerKey;
+  const player = (state.players[playerKey] ??= {
+    key: playerKey,
+    team: event.team,
+    playerNumber: event.playerNumber,
+    segments: [],
+  });
+  const hadExistingSegments = player.segments.some((segment) => segment.remainingMs > 0);
+  const segments: PenaltySegment[] = [];
+  if (event.cardType === "red") {
+    segments.push(
+      createSegment(idGenerator, "red", false, event.id),
+      createSegment(idGenerator, "red", false, event.id),
+    );
+  } else {
+    segments.push(createSegment(idGenerator, event.cardType, true, event.id));
+  }
+
+  if (!hadExistingSegments) {
+    const elapsedSinceEntryMs = Math.max(0, state.gameClockMs - event.gameClockMs);
+    consumeSegments(segments, elapsedSinceEntryMs);
+  }
+  player.segments.push(...segments.filter((segment) => segment.remainingMs > 0));
+  if (player.segments.length === 0) {
+    state.recentReleases.push({
+      id: idGenerator(),
+      team: event.team,
+      playerKey,
+      playerNumber: event.playerNumber,
+      releasedAtMs: nowMs,
+      reason: "served",
+    });
+    delete state.players[playerKey];
+  }
+}
+
+function removeSegmentsForCard(state: GameState, cardId: string) {
+  for (const [playerKey, player] of Object.entries(state.players)) {
+    player.segments = player.segments.filter((segment) => segment.cardEventId !== cardId);
+    if (player.segments.length === 0) delete state.players[playerKey];
+  }
+}
+
+function createSegment(
+  idGenerator: () => string,
+  cardType: "blue" | "yellow" | "red",
+  expirableByScore: boolean,
+  cardEventId: string,
+): PenaltySegment {
+  return {
+    id: idGenerator(),
+    cardType,
+    remainingMs: ONE_MINUTE_MS,
+    expirableByScore,
+    cardEventId,
+  };
+}
+
+function consumeSegments(segments: PenaltySegment[], elapsedMs: number) {
+  let remaining = elapsedMs;
+  for (const segment of segments) {
+    if (remaining <= 0) break;
+    const consumed = Math.min(segment.remainingMs, remaining);
+    segment.remainingMs -= consumed;
+    remaining -= consumed;
+  }
+}

--- a/src/lib/ad-hoc-controller-session.ts
+++ b/src/lib/ad-hoc-controller-session.ts
@@ -280,7 +280,9 @@ function isValidGameState(value: unknown, expectedId: string): value is GameStat
         !validateOpaqueIdentifier(segment.id, "segmentId").ok ||
         !isSafeNumber(segment.remainingMs) ||
         segment.remainingMs < 0 ||
-        typeof segment.expirableByScore !== "boolean"
+        typeof segment.expirableByScore !== "boolean" ||
+        (segment.cardEventId !== undefined &&
+          !validateOpaqueIdentifier(segment.cardEventId, "cardEventId").ok)
       )
         return false;
     }
@@ -314,7 +316,8 @@ function isPersistedCardEvent(value: unknown): boolean {
     (value.playerKey === null || validateOpaqueIdentifier(value.playerKey, "playerKey").ok) &&
     (value.playerNumber === null || isScore(value.playerNumber)) &&
     ["blue", "yellow", "red", "ejection"].includes(value.cardType) &&
-    isSafeNumber(value.createdAtMs)
+    isSafeNumber(value.createdAtMs) &&
+    (value.gameClockMs === undefined || isSafeNumber(value.gameClockMs))
   );
 }
 function isPersistedPending(value: unknown): boolean {

--- a/src/lib/ad-hoc-games.ts
+++ b/src/lib/ad-hoc-games.ts
@@ -2176,6 +2176,8 @@ function validateGameState(value: unknown, expectedId: string): asserts value is
     if (!["blue", "yellow", "red", "ejection"].includes(event.cardType))
       throw new Error("Stored card type is invalid.");
     requireSafeNonNegative(event.createdAtMs, "card event createdAtMs");
+    if (event.gameClockMs !== undefined)
+      requireInteger(event.gameClockMs, 0, SHARED_LIMITS.clock.maxMs, "card event gameClockMs");
   }
   if (!isRecord(value.players)) throw new Error("Stored players are invalid.");
   for (const [key, player] of Object.entries(value.players)) {
@@ -2192,6 +2194,7 @@ function validateGameState(value: unknown, expectedId: string): asserts value is
       requireInteger(segment.remainingMs, 0, SHARED_LIMITS.clock.maxMs, "penalty remainingMs");
       if (typeof segment.expirableByScore !== "boolean")
         throw new Error("Stored penalty expiration flag is invalid.");
+      if (segment.cardEventId !== undefined) requireOpaque(segment.cardEventId, "cardEventId");
     }
   }
   for (const pending of value.pendingExpirations) {

--- a/src/lib/game-engine.ts
+++ b/src/lib/game-engine.ts
@@ -1,5 +1,4 @@
 import type {
-  CardType,
   GameFinishReason,
   GameCommand,
   GameState,
@@ -11,6 +10,7 @@ import type {
   ScoreEvent,
   TeamId,
 } from "@/lib/game-types";
+import { applyAdHocCardMutation } from "@/lib/ad-hoc-card-facts";
 import {
   DEFAULT_AWAY_TEAM_COLOR,
   DEFAULT_HOME_TEAM_COLOR,
@@ -22,7 +22,6 @@ import {
   validateClockAdjustmentMs,
   validateGameClockMs,
   validateIntegerInRange,
-  validatePlayerNumber,
 } from "@/lib/validation-policy";
 
 const ONE_MINUTE_MS = 60_000;
@@ -120,6 +119,11 @@ export function cloneGameState(state: GameState): GameState {
   }
   cloned.homeColor = normalizeTeamColor(cloned.homeColor, DEFAULT_HOME_TEAM_COLOR);
   cloned.awayColor = normalizeTeamColor(cloned.awayColor, DEFAULT_AWAY_TEAM_COLOR);
+  for (const event of cloned.cardEvents) {
+    if (!Number.isSafeInteger(event.gameClockMs) || event.gameClockMs < 0) {
+      event.gameClockMs = 0;
+    }
+  }
   if (cloned.winner !== "home" && cloned.winner !== "away" && cloned.winner !== null) {
     cloned.winner = null;
   }
@@ -314,12 +318,19 @@ export function applyGameCommand({
     }
 
     case "add-card": {
-      addCardToPlayer({
+      applyAdHocCardMutation({
         state: next,
-        cardType: command.cardType,
-        team: command.team,
-        playerNumber: command.playerNumber,
-        startedGameClockMs: command.startedGameClockMs,
+        mutation: command,
+        nowMs,
+        idGenerator: makeId,
+      });
+      return next;
+    }
+
+    case "update-card": {
+      applyAdHocCardMutation({
+        state: next,
+        mutation: command,
         nowMs,
         idGenerator: makeId,
       });
@@ -652,129 +663,6 @@ function undoLastScoreForTeam(state: GameState, team: TeamId, nowMs: number) {
       );
     }
   }
-}
-
-function addCardToPlayer({
-  state,
-  team,
-  playerNumber,
-  cardType,
-  startedGameClockMs,
-  nowMs,
-  idGenerator,
-}: {
-  state: GameState;
-  team: TeamId;
-  playerNumber: number | null;
-  cardType: CardType;
-  startedGameClockMs?: number;
-  nowMs: number;
-  idGenerator: IdGenerator;
-}) {
-  if (playerNumber !== null && !validatePlayerNumber(playerNumber).ok) {
-    return;
-  }
-  if (startedGameClockMs !== undefined && !validateGameClockMs(startedGameClockMs).ok) {
-    return;
-  }
-
-  let playerKey: string | null = null;
-
-  if (cardType !== "ejection") {
-    playerKey = getPlayerKey(state, team, playerNumber);
-    const existingPlayer = state.players[playerKey];
-    const hadExistingSegments =
-      existingPlayer !== undefined &&
-      existingPlayer.segments.some((segment) => segment.remainingMs > 0);
-    const player = getOrCreatePlayer(state, team, playerNumber, playerKey);
-    const newSegments: PlayerPenaltyState["segments"] = [];
-
-    if (cardType === "red") {
-      newSegments.push(
-        createPenaltySegment({ idGenerator, cardType: "red", expirableByScore: false }),
-        createPenaltySegment({ idGenerator, cardType: "red", expirableByScore: false }),
-      );
-    }
-
-    if (cardType === "blue" || cardType === "yellow") {
-      newSegments.push(createPenaltySegment({ idGenerator, cardType, expirableByScore: true }));
-    }
-
-    const normalizedStartedClockMs = startedGameClockMs ?? state.gameClockMs;
-    const elapsedSinceEntryStartMs = Math.max(0, state.gameClockMs - normalizedStartedClockMs);
-
-    if (!hadExistingSegments && elapsedSinceEntryStartMs > 0) {
-      consumePenaltySegments(newSegments, elapsedSinceEntryStartMs);
-    }
-
-    player.segments.push(...newSegments.filter((segment) => segment.remainingMs > 0));
-
-    if (player.segments.length === 0) {
-      recordReleasedPenalty({
-        state,
-        player,
-        nowMs,
-        reason: "served",
-      });
-      delete state.players[player.key];
-    }
-  } else if (playerNumber !== null) {
-    playerKey = `${team}:${playerNumber}`;
-  }
-
-  state.cardEvents.push({
-    id: idGenerator(),
-    team,
-    playerKey,
-    playerNumber,
-    cardType,
-    createdAtMs: nowMs,
-  });
-}
-
-function createPenaltySegment({
-  idGenerator,
-  cardType,
-  expirableByScore,
-}: {
-  idGenerator: IdGenerator;
-  cardType: "blue" | "yellow" | "red";
-  expirableByScore: boolean;
-}) {
-  return {
-    id: idGenerator(),
-    cardType,
-    remainingMs: ONE_MINUTE_MS,
-    expirableByScore,
-  };
-}
-
-function getPlayerKey(state: GameState, team: TeamId, playerNumber: number | null): string {
-  if (playerNumber !== null) {
-    return `${team}:${playerNumber}`;
-  }
-
-  const unknownIndex = state.nextUnknownPlayerId[team];
-  state.nextUnknownPlayerId[team] += 1;
-  return `${team}:unknown:${unknownIndex}`;
-}
-
-function getOrCreatePlayer(
-  state: GameState,
-  team: TeamId,
-  playerNumber: number | null,
-  key: string,
-): PlayerPenaltyState {
-  if (state.players[key] === undefined) {
-    state.players[key] = {
-      key,
-      team,
-      playerNumber,
-      segments: [],
-    };
-  }
-
-  return state.players[key];
 }
 
 function tickPenaltyClock(state: GameState, deltaMs: number, nowMs: number) {

--- a/src/lib/game-page-support.ts
+++ b/src/lib/game-page-support.ts
@@ -7,6 +7,7 @@ import {
 } from "@/lib/ad-hoc-controller-session";
 import { applyGameCommand } from "@/lib/game-engine";
 import type {
+  CardType,
   ControllerRole,
   GameCommand,
   GameState,
@@ -538,6 +539,10 @@ export function formatPenaltySlice(ms: number) {
 
 export type PlayerPenaltyView = {
   playerKey: string;
+  cardEventId: string | null;
+  cardType: CardType | null;
+  team: TeamId;
+  playerNumber: number | null;
   label: string;
   remaining: string;
   remainingMs: number;
@@ -559,23 +564,50 @@ export function getTeamPenalties(
     return [];
   }
 
-  return Object.values(state.players)
-    .filter((player) => player.team === team)
-    .map((player) => {
-      const remainingMs = player.segments.reduce(
-        (total, segment) => total + segment.remainingMs,
-        0,
+  const linkedRows: PlayerPenaltyView[] = state.cardEvents
+    .filter((event) => event.team === team)
+    .map((event): PlayerPenaltyView | null => {
+      const player = event.playerKey === null ? null : state.players[event.playerKey];
+      const segments = Object.values(state.players).flatMap((candidate) =>
+        candidate.segments.filter((segment) => segment.cardEventId === event.id),
       );
-
+      if (segments.length === 0) return null;
+      const remainingMs = segments.reduce((total, segment) => total + segment.remainingMs, 0);
       return {
-        playerKey: player.key,
+        playerKey: event.playerKey ?? `${event.team}:card:${event.id}`,
+        cardEventId: event.id,
+        cardType: event.cardType,
+        team: event.team,
+        playerNumber: event.playerNumber,
         label: formatPlayerLabel(player),
         remaining: formatRemaining(remainingMs),
         remainingMs,
         highlight: remainingMs > 0 && remainingMs <= 10_000,
       };
     })
-    .sort((a, b) => a.remainingMs - b.remainingMs || a.label.localeCompare(b.label));
+    .filter((entry): entry is PlayerPenaltyView => entry !== null);
+  const legacyRows = Object.values(state.players)
+    .filter((player) => player.team === team)
+    .map((player): PlayerPenaltyView | null => {
+      const segments = player.segments.filter((segment) => segment.cardEventId === undefined);
+      if (segments.length === 0) return null;
+      const remainingMs = segments.reduce((total, segment) => total + segment.remainingMs, 0);
+      return {
+        playerKey: player.key,
+        cardEventId: null,
+        cardType: null,
+        team: player.team,
+        playerNumber: player.playerNumber,
+        label: formatPlayerLabel(player),
+        remaining: formatRemaining(remainingMs),
+        remainingMs,
+        highlight: remainingMs > 0 && remainingMs <= 10_000,
+      };
+    })
+    .filter((entry): entry is PlayerPenaltyView => entry !== null);
+  return [...linkedRows, ...legacyRows].sort(
+    (a, b) => a.remainingMs - b.remainingMs || a.label.localeCompare(b.label),
+  );
 }
 
 export function selectVisiblePenalties(

--- a/src/lib/game-types.ts
+++ b/src/lib/game-types.ts
@@ -18,6 +18,7 @@ export type PenaltySegment = {
   cardType: Exclude<CardType, "ejection">;
   remainingMs: number;
   expirableByScore: boolean;
+  cardEventId?: string;
 };
 
 export type PlayerPenaltyState = {
@@ -56,6 +57,7 @@ export type CardEvent = {
   playerNumber: number | null;
   cardType: CardType;
   createdAtMs: number;
+  gameClockMs: number;
 };
 
 export type TeamTimeoutState = {
@@ -165,6 +167,13 @@ export type GameCommand =
       playerNumber: number | null;
       cardType: CardType;
       startedGameClockMs?: number;
+    }
+  | {
+      type: "update-card";
+      cardId: string;
+      team: TeamId;
+      playerNumber: number | null;
+      cardType: CardType;
     }
   | {
       type: "confirm-penalty-expiration";

--- a/src/lib/ws-protocol.test.ts
+++ b/src/lib/ws-protocol.test.ts
@@ -575,6 +575,38 @@ describe("ws-protocol", () => {
     expect(parsed.message.commands[0].command.awayColor).toBe("fedcba");
   });
 
+  test("parses an Ad Hoc exact-card update with an optional number", () => {
+    const parsed = parseClientWsMessage(
+      JSON.stringify({
+        type: "apply-commands",
+        gameId: "game-123",
+        commands: [
+          {
+            id: "cmd-update-card",
+            clientSentAtMs: 42,
+            command: {
+              type: "update-card",
+              cardId: "card-123",
+              team: "away",
+              cardType: "yellow",
+              playerNumber: null,
+            },
+          },
+        ],
+      }),
+    );
+
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok || parsed.message.type !== "apply-commands") return;
+    expect(parsed.message.commands[0]?.command).toEqual({
+      type: "update-card",
+      cardId: "card-123",
+      team: "away",
+      cardType: "yellow",
+      playerNumber: null,
+    });
+  });
+
   test("rejects rename-teams with invalid color", () => {
     const parsed = parseClientWsMessage(
       JSON.stringify({

--- a/src/lib/ws-protocol.ts
+++ b/src/lib/ws-protocol.ts
@@ -501,6 +501,32 @@ export function parseGameCommand(payload: Record<string, unknown>):
     };
   }
 
+  if (payload.type === "update-card") {
+    const cardId = validateOpaqueIdentifier(payload.cardId, "cardId");
+    if (!cardId.ok) return { ok: false, error: `update-card ${cardId.error}` };
+    if (!isTeam(payload.team) || !isCardType(payload.cardType)) {
+      return { ok: false, error: "update-card requires cardId, team, and cardType." };
+    }
+    if (payload.playerNumber !== null && typeof payload.playerNumber !== "number") {
+      return { ok: false, error: "update-card playerNumber must be number or null." };
+    }
+    const playerNumber =
+      payload.playerNumber === null ? null : validatePlayerNumber(payload.playerNumber);
+    if (playerNumber !== null && !playerNumber.ok) {
+      return { ok: false, error: playerNumber.error };
+    }
+    return {
+      ok: true,
+      command: {
+        type: "update-card",
+        cardId: cardId.value,
+        team: payload.team,
+        playerNumber: playerNumber === null ? null : playerNumber.value,
+        cardType: payload.cardType,
+      },
+    };
+  }
+
   if (payload.type === "confirm-penalty-expiration") {
     const pendingId = validateOpaqueIdentifier(payload.pendingId, "pendingId");
     if (!pendingId.ok) {

--- a/src/pages/game-page.tsx
+++ b/src/pages/game-page.tsx
@@ -90,18 +90,33 @@ export function GamePage({ gameId, role }: { gameId: string; role: ControllerRol
     team: TeamId | null;
     digits: string;
     startedGameClockMs: number | null;
+    editingCardId: string | null;
+    wizardStep: "type" | "team" | "number";
   }>({
     cardType: null,
     team: null,
     digits: "",
     startedGameClockMs: null,
+    editingCardId: null,
+    wizardStep: "type",
   });
+  const [cardCreationPending, setCardCreationPending] = useState(false);
+  const pendingCardCreationIdsRef = useRef<Set<string> | null>(null);
   const [clockAdjustOpen, setClockAdjustOpen] = useState(false);
   const [renamingTeam, setRenamingTeam] = useState<TeamId | null>(null);
   const [pendingWinConfirmation, setPendingWinConfirmation] =
     useState<PendingWinConfirmation | null>(null);
   const handleActionPanelChange = useCallback((panel: ControllerActionPanel | null) => {
-    setCardDraft({ cardType: null, team: null, digits: "", startedGameClockMs: null });
+    setCardDraft({
+      cardType: null,
+      team: null,
+      digits: "",
+      startedGameClockMs: null,
+      editingCardId: null,
+      wizardStep: "type",
+    });
+    setCardCreationPending(false);
+    pendingCardCreationIdsRef.current = null;
     setPendingWinConfirmation(null);
     setActivePanel(panel);
   }, []);
@@ -307,22 +322,91 @@ export function GamePage({ gameId, role }: { gameId: string; role: ControllerRol
     }
 
     const playerNumber = cardDraft.digits.length === 0 ? null : Number(cardDraft.digits);
-    dispatchCommand({
-      type: "add-card",
-      team: cardDraft.team,
-      cardType: cardDraft.cardType,
-      playerNumber,
-      startedGameClockMs: cardDraft.startedGameClockMs ?? liveState.gameClockMs,
-    });
+    dispatchCommand(
+      cardDraft.editingCardId === null
+        ? {
+            type: "add-card",
+            team: cardDraft.team,
+            cardType: cardDraft.cardType,
+            playerNumber,
+            startedGameClockMs: cardDraft.startedGameClockMs ?? liveState.gameClockMs,
+          }
+        : {
+            type: "update-card",
+            cardId: cardDraft.editingCardId,
+            team: cardDraft.team,
+            cardType: cardDraft.cardType,
+            playerNumber,
+          },
+    );
 
     setCardDraft({
       cardType: null,
       team: null,
       digits: "",
       startedGameClockMs: null,
+      editingCardId: null,
+      wizardStep: "type",
     });
+    setCardCreationPending(false);
+    pendingCardCreationIdsRef.current = null;
     return true;
   }, [cardDraft, controller, dispatchCommand, liveState]);
+
+  const commitCardWithoutNumber = useCallback(
+    (team: TeamId) => {
+      if (!controller || liveState === null || cardDraft.cardType === null) return;
+      pendingCardCreationIdsRef.current = new Set(liveState.cardEvents.map((event) => event.id));
+      dispatchCommand({
+        type: "add-card",
+        team,
+        cardType: cardDraft.cardType,
+        playerNumber: null,
+        startedGameClockMs: cardDraft.startedGameClockMs ?? liveState.gameClockMs,
+      });
+      setCardDraft((previous) => ({ ...previous, team, digits: "" }));
+      setCardCreationPending(true);
+    },
+    [cardDraft.cardType, cardDraft.startedGameClockMs, controller, dispatchCommand, liveState],
+  );
+
+  useEffect(() => {
+    const previousIds = pendingCardCreationIdsRef.current;
+    if (!cardCreationPending || previousIds === null || liveState === null) return;
+    const created = [...liveState.cardEvents].reverse().find((event) => !previousIds.has(event.id));
+    if (created === undefined) return;
+    setCardDraft((previous) => ({
+      ...previous,
+      cardType: created.cardType,
+      team: created.team,
+      editingCardId: created.id,
+      digits: created.playerNumber === null ? "" : String(created.playerNumber),
+      wizardStep: "number",
+    }));
+    setCardCreationPending(false);
+    pendingCardCreationIdsRef.current = null;
+  }, [cardCreationPending, liveState]);
+
+  const openCardEditor = useCallback(
+    (cardEventId: string) => {
+      if (!controller || liveState === null) return;
+      const event = liveState.cardEvents.find((candidate) => candidate.id === cardEventId);
+      if (event === undefined) return;
+      setCardDraft({
+        cardType: event.cardType,
+        team: event.team,
+        digits: event.playerNumber === null ? "" : String(event.playerNumber),
+        startedGameClockMs: event.gameClockMs,
+        editingCardId: event.id,
+        wizardStep: "number",
+      });
+      setCardCreationPending(false);
+      pendingCardCreationIdsRef.current = null;
+      setPendingWinConfirmation(null);
+      setActivePanel("card");
+    },
+    [controller, liveState],
+  );
 
   const adjustGameClock = useCallback(
     (deltaMs: number) => {
@@ -707,7 +791,8 @@ export function GamePage({ gameId, role }: { gameId: string; role: ControllerRol
     !state.isSuspended &&
     cardDraft.cardType !== null &&
     cardDraft.team !== null &&
-    cardDraft.digits.length > 0;
+    (cardDraft.editingCardId !== null || cardDraft.digits.length > 0) &&
+    !cardCreationPending;
   const cardPlayerLabel = cardDraft.digits.length > 0 ? `#${cardDraft.digits}` : "No #";
   const cardBasePenaltyMs =
     cardDraft.cardType === "red"
@@ -734,7 +819,9 @@ export function GamePage({ gameId, role }: { gameId: string; role: ControllerRol
     cardDraft.cardType === null || cardDraft.team === null
       ? "Choose a card type and team."
       : cardDraft.digits.length === 0
-        ? "Enter a player number to record this card."
+        ? cardDraft.editingCardId === null
+          ? "Waiting for the card to be committed."
+          : "No player number — OK keeps this card unknown."
         : cardDraft.cardType === "ejection"
           ? "Remaining on add: n/a"
           : selectedCardPlayerServingPenalty
@@ -1073,6 +1160,7 @@ export function GamePage({ gameId, role }: { gameId: string; role: ControllerRol
             getPendingReleaseActionLabel={(action, playerKey) =>
               formatPendingReleaseActionLabel(action, state.players[playerKey] ?? null)
             }
+            onEditPenalty={openCardEditor}
           />
 
           <GameControllerActionPanels
@@ -1106,6 +1194,8 @@ export function GamePage({ gameId, role }: { gameId: string; role: ControllerRol
             cardPlayerLabel={cardPlayerLabel}
             cardAddStatusText={cardAddStatusText}
             canEditCardDigits={canEditCardDigits}
+            cardCreationPending={cardCreationPending}
+            commitCardWithoutNumber={commitCardWithoutNumber}
             appendCardDigit={appendCardDigit}
             canSubmitCard={canSubmitCard}
             submitCard={() => {


### PR DESCRIPTION
## What changed

- add a deep Ad Hoc card-fact module with stable card identity and original Game Clock time
- commit a card as soon as its type and team are selected, allowing the player number to remain unknown
- make each visible Ad Hoc penalty row open an exact-card editor for number, team, and card-type corrections
- preserve the original card entry time when recalculating penalty segments after an edit
- retain legacy persisted cards and unlinked penalty segments without exposing them as editable facts

## Why

The compact wizard in #290 still required a player number before a card could exist. During live play, Controllers often have the type and team immediately but identify the player later. This change records that fact first and provides an explicit, exact-row editing path without guessing at the latest penalty or changing Event Games.

## Validation

- `bun run check`
- `bun run build`
- `bun run test` (1,069 tests)
- `bun run test:focused:adhoc-browser`
- targeted card-fact, action-panel, and WebSocket protocol tests
