### PR TITLE
Show SQM 2026 in Current Events

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -325,6 +325,14 @@ _Avoid_: Official game record, mutable Game State, Official Score Sheet
 A controller-only, disposable game created without an account or Event Grant for a friendly or spontaneous session. Its current state and control authority survive ordinary restarts and return as ordinary data after a full restore, but it has neither a spectator experience, a Game Lock, nor a durable Control Audit Trail; it cannot be manually removed and remains retained until capacity cleanup prunes it. Its rate-limit state and resource budget are separate from Event operations: exhausting an Ad Hoc limit may affect only Ad Hoc work and never throttles, rejects, disconnects, or otherwise degrades an ongoing Event operation.
 _Avoid_: Game from scratch, unassigned game
 
+**Protected Fixture Ad Hoc Game**:
+An Ad Hoc Game temporarily bound to a named public fixture slot, whose state and spectator view remain durable beyond ordinary Ad Hoc cleanup and whose public access is allowlisted by that fixture's Event and slot. It remains an Ad Hoc Game for authority, operation, and audit purposes rather than becoming an Event Game.
+_Avoid_: Fake Event Game, permanent Ad Hoc Game, public Ad Hoc Game
+
+**SQM Fixture Event**:
+The temporary Published Event projection for Schweizer Quadball Meisterschaft 2026 on 16 August 2026 in Europe/Zurich. It supplies a public schedule for four Protected Fixture Ad Hoc Games without creating ordinary Event Catalog records.
+_Avoid_: SQM tournament record, seeded Event, production Event
+
 **Ad Hoc Controller**:
 A participant admitted through an unfinished Ad Hoc Game's Control QR. All Ad Hoc Controllers for the Game have equal authority; its creator is not an owner or primary Controller, and an admitted browser retains its authority across ordinary browser and server restarts until its Controller Leave Grace Period expires or capacity cleanup removes the Game.
 _Avoid_: Ad Hoc Game owner, creator role, primary Controller

--- a/docs/adr/0004-sqm-fixture-event-boundary.md
+++ b/docs/adr/0004-sqm-fixture-event-boundary.md
@@ -1,0 +1,8 @@
+# Keep the SQM presentation fixture outside the Event Catalog
+
+- Status: accepted
+- Date: 2026-08-16
+
+For the Schweizer Quadball Meisterschaft 2026 live screen, expose a temporary SQM Fixture Event through the public Audience Projection instead of seeding Event Catalog records. Its four scheduled rows resolve to Protected Fixture Ad Hoc Games keyed by `secret1`–`secret4`; those protected records are durable, excluded from the ordinary 50-game capacity and cleanup, and publicly readable only through the allowlisted SQM Event paths. Secret-key activation is accepted only on 16 August 2026 in the Event's Europe/Zurich timezone, while created records and spectator views remain available afterward.
+
+This keeps the time-critical presentation path separate from Event administration, Event Game authority, and audit semantics while allowing the existing Ad Hoc Controller workflow to operate the games.

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1186,7 +1186,7 @@ describe("App", () => {
     expect(previews).toHaveLength(100);
   });
 
-  test("lists public Events with the Ad Hoc handoff between upcoming and past content", async () => {
+  test("lists public Events without an unscheduled section", async () => {
     testWindow.history.replaceState(null, "", "/events");
     (globalThis.fetch as typeof fetch) = (async (input: string | URL | Request) => {
       const url =
@@ -1269,7 +1269,7 @@ describe("App", () => {
     const text = container.textContent ?? "";
     expect(text).toContain("Current Event");
     expect(text).toContain("Future Event");
-    expect(text).toContain("Unscheduled Events");
+    expect(text).not.toContain("Unscheduled Events");
     expect(text).toContain("Start Ad Hoc Game");
     expect(text).toContain("Past Event");
     expect(text.indexOf("Future Event")).toBeLessThan(text.indexOf("Start Ad Hoc Game"));

--- a/src/lib/audience-projection.test.ts
+++ b/src/lib/audience-projection.test.ts
@@ -760,10 +760,40 @@ describe("Audience Publication Projection", () => {
     );
 
     const result = await audience.list();
-    expect(result).toMatchObject({
-      status: "accepted",
-      value: { events: [{ name: "Unscheduled", lifecycle: "unscheduled" }] },
+    expect(result.status).toBe("accepted");
+    if (result.status !== "accepted") return;
+    expect(result.value.events).toContainEqual(
+      expect.objectContaining({ name: "Unscheduled", lifecycle: "unscheduled" }),
+    );
+  });
+
+  test("projects the temporary SQM fixture as current on its Game Day and past afterward", async () => {
+    const storage = {
+      snapshot: async () => ({
+        listEvents: () => [],
+      }),
+    } as unknown as EventCatalogFoundationStorage;
+    const current = createAudienceProjection(storage, {
+      now: () => Date.parse("2026-08-16T10:00:00.000Z"),
     });
+    const currentResult = await current.read("sqm-2026");
+    expect(currentResult).toMatchObject({
+      status: "accepted",
+      value: {
+        eventId: "sqm-2026",
+        name: "Schweizer Quadball Meisterschaft 2026",
+        timeZone: "Europe/Zurich",
+        gameDays: ["2026-08-16"],
+        lifecycle: "current",
+        schedule: { scheduleGames: [] },
+      },
+    });
+
+    const past = createAudienceProjection(storage, {
+      now: () => Date.parse("2026-08-17T10:00:00.000Z"),
+    });
+    const pastResult = await past.read("sqm-2026");
+    expect(pastResult).toMatchObject({ status: "accepted", value: { lifecycle: "past" } });
   });
 
   test("lists only Published Events and classifies them in each Event timezone", async () => {
@@ -798,6 +828,7 @@ describe("Audience Publication Projection", () => {
     expect(result.value.events.map((event) => [event.name, event.lifecycle])).toEqual([
       ["Current", "current"],
       ["Future", "future"],
+      ["Schweizer Quadball Meisterschaft 2026", "future"],
       ["Past", "past"],
     ]);
     expect(result.value.events[0]).toMatchObject({
@@ -877,7 +908,10 @@ describe("Audience Publication Projection", () => {
 
     const list = await audience.list();
     if (list.status !== "accepted") throw new Error("Expected discovery list.");
-    expect(list.value.events.map((event) => event.name)).toEqual(["Visible Event"]);
+    expect(list.value.events.map((event) => event.name)).toEqual([
+      "Visible Event",
+      "Schweizer Quadball Meisterschaft 2026",
+    ]);
 
     const sitemap = await readAudienceSitemap(
       new Request("https://timer.example/sitemap.xml"),

--- a/src/lib/audience-projection.ts
+++ b/src/lib/audience-projection.ts
@@ -18,6 +18,7 @@ import {
 } from "@/lib/live-event-game-control";
 import type { ClockProjection } from "@/lib/clock-authority";
 import type { GamePresentation } from "@/lib/game-presentation";
+import { createSqmFixtureEvent, SQM_FIXTURE_EVENT_ID } from "@/lib/sqm-fixture";
 
 export type PublicAudienceEventLifecycle = "unscheduled" | "current" | "future" | "past";
 
@@ -239,6 +240,9 @@ export function createAudienceProjection(
     async read(eventId: unknown): Promise<AudienceProjectionOutcome> {
       if (typeof eventId !== "string" || eventId.trim().length === 0)
         return { status: "unavailable" };
+      if (eventId === SQM_FIXTURE_EVENT_ID) {
+        return { status: "accepted", value: createSqmFixtureEvent(now()) };
+      }
       try {
         const snapshot = await storage.snapshot();
         const event = snapshot.findEvent(eventId);
@@ -294,12 +298,15 @@ export function createAudienceProjection(
       try {
         const snapshot = await storage.snapshot();
         const nowMs = now();
-        const events = await Promise.all(
+        const catalogEvents = await Promise.all(
           snapshot
             .listEvents()
             .filter((event) => event.publicationStatus === "published")
             .map((event) => projectPublicEvent(snapshot, event, nowMs, options.gameInput)),
         );
+        const events = catalogEvents.some((event) => event.eventId === SQM_FIXTURE_EVENT_ID)
+          ? catalogEvents
+          : [...catalogEvents, createSqmFixtureEvent(nowMs)];
         return {
           status: "accepted",
           value: { events: sortPublicEvents(events) },

--- a/src/lib/sqm-fixture.ts
+++ b/src/lib/sqm-fixture.ts
@@ -1,0 +1,47 @@
+import type { PublicAudienceEventProjection } from "@/lib/audience-projection";
+
+export const SQM_FIXTURE_EVENT_ID = "sqm-2026" as const;
+export const SQM_FIXTURE_EVENT_NAME = "Schweizer Quadball Meisterschaft 2026" as const;
+export const SQM_FIXTURE_TIME_ZONE = "Europe/Zurich" as const;
+export const SQM_FIXTURE_GAME_DAY = "2026-08-16" as const;
+
+export function createSqmFixtureEvent(nowMs: number): PublicAudienceEventProjection {
+  return {
+    eventId: SQM_FIXTURE_EVENT_ID,
+    name: SQM_FIXTURE_EVENT_NAME,
+    timeZone: SQM_FIXTURE_TIME_ZONE,
+    publicationStatus: "published",
+    gameDays: [SQM_FIXTURE_GAME_DAY],
+    lifecycle: classifySqmFixtureLifecycle(nowMs),
+    canonicalPath: `/events/${encodeURIComponent(SQM_FIXTURE_EVENT_ID)}`,
+    teams: [],
+    pitches: [],
+    schedule: {
+      asOfMs: nowMs,
+      runningGames: [],
+      upcomingGames: [],
+      scheduleGames: [],
+      focusIndex: null,
+    },
+  };
+}
+
+function classifySqmFixtureLifecycle(nowMs: number): PublicAudienceEventProjection["lifecycle"] {
+  const today = localDate(nowMs, SQM_FIXTURE_TIME_ZONE);
+  return today < SQM_FIXTURE_GAME_DAY
+    ? "future"
+    : today === SQM_FIXTURE_GAME_DAY
+      ? "current"
+      : "past";
+}
+
+function localDate(nowMs: number, timeZone: string): string {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(new Date(nowMs));
+  const values = new Map(parts.map((part) => [part.type, part.value]));
+  return `${values.get("year")}-${values.get("month")}-${values.get("day")}`;
+}

--- a/src/pages/public-event-page.tsx
+++ b/src/pages/public-event-page.tsx
@@ -1038,18 +1038,12 @@ function clockStatusLabel(
 function EventDiscovery({ events }: { events: readonly PublicAudienceEventProjection[] }) {
   const current = events.filter((event) => event.lifecycle === "current");
   const future = events.filter((event) => event.lifecycle === "future");
-  const unscheduled = events.filter((event) => event.lifecycle === "unscheduled");
   const past = events.filter((event) => event.lifecycle === "past");
 
   return (
     <div className="space-y-6">
       <EventGroup title="Current Events" events={current} empty="No Event is current today." />
       <EventGroup title="Upcoming Events" events={future} empty="No upcoming Published Events." />
-      <EventGroup
-        title="Unscheduled Events"
-        events={unscheduled}
-        empty="No unscheduled Published Events."
-      />
       <StartAdHocGame />
       <EventGroup title="Past Events" events={past} empty="No past Published Events." />
     </div>


### PR DESCRIPTION
## Summary

- add the temporary Schweizer Quadball Meisterschaft 2026 Published Event fixture to public discovery
- classify it by its Europe/Zurich Game Day so it is current on 16 August 2026 and past afterward
- remove the public Unscheduled Events section from the Home screen
- document the temporary Audience Projection boundary for the follow-up protected Ad Hoc games

## Validation

- `bun test --timeout=10000 --isolate ./src/lib/audience-projection.test.ts`
- `bun test --timeout=10000 --isolate ./src/App.test.tsx`
- `bun run check`
