### PR TITLE
Anchor the Ad Hoc action sheet to the viewport

### DIFF
--- a/src/components/controller-action-sheet.tsx
+++ b/src/components/controller-action-sheet.tsx
@@ -41,7 +41,7 @@ export function ControllerActionSheet({
   return (
     <div
       data-controller-action-sheet="true"
-      className="pointer-events-none absolute inset-x-0 bottom-0 top-[clamp(16rem,38dvh,22rem)] z-20 flex flex-col gap-0"
+      className="pointer-events-none fixed inset-x-0 bottom-0 top-[clamp(16rem,38dvh,22rem)] z-20 mx-auto flex w-full max-w-[460px] flex-col gap-0"
       style={topOffsetPx === undefined ? undefined : { top: `${topOffsetPx + 8}px` }}
     >
       {activePanel === null ? null : (

--- a/src/pages/game-page.tsx
+++ b/src/pages/game-page.tsx
@@ -130,7 +130,7 @@ export function GamePage({ gameId, role }: { gameId: string; role: ControllerRol
   const rightTeamNameButtonRef = useRef<HTMLButtonElement | null>(null);
   const controllerTopSectionRef = useRef<HTMLDivElement | null>(null);
   const [displayTeamNameHeightPx, setDisplayTeamNameHeightPx] = useState<number | null>(null);
-  const [controllerTopSectionHeightPx, setControllerTopSectionHeightPx] = useState<number | null>(
+  const [controllerTopSectionBottomPx, setControllerTopSectionBottomPx] = useState<number | null>(
     null,
   );
   const leaveTriggerRef = useRef<HTMLButtonElement | null>(null);
@@ -598,9 +598,10 @@ export function GamePage({ gameId, role }: { gameId: string; role: ControllerRol
     }
 
     const observer = new ResizeObserver(([entry]) => {
-      const nextHeight = entry === undefined ? null : Math.ceil(entry.contentRect.height);
-      setControllerTopSectionHeightPx((previous) =>
-        previous === nextHeight ? previous : nextHeight,
+      const nextBottom =
+        entry === undefined ? null : Math.ceil(element.getBoundingClientRect().bottom);
+      setControllerTopSectionBottomPx((previous) =>
+        previous === nextBottom ? previous : nextBottom,
       );
     });
     observer.observe(element);
@@ -1078,7 +1079,7 @@ export function GamePage({ gameId, role }: { gameId: string; role: ControllerRol
           <GameControllerActionPanels
             activePanel={activePanel}
             setActivePanel={handleActionPanelChange}
-            topOffsetPx={controllerTopSectionHeightPx ?? undefined}
+            topOffsetPx={controllerTopSectionBottomPx ?? undefined}
             controller={controller}
             state={state}
             gameView={{


### PR DESCRIPTION
## What changed

- anchor the Ad Hoc Controller action sheet to the viewport instead of the inner game grid
- keep the bottom navigation flush with the device viewport bottom
- measure the Controller top section’s actual viewport position so the sheet starts below the core clock/score area

## Why

The merged action-sheet layout used `position: absolute` inside the game grid. On phone-sized screens, its bottom edge therefore stopped at the grid’s bottom rather than the viewport bottom, leaving the navigation stranded below the clock and penalty area. The sheet now owns a viewport-fixed layer while retaining the compact game-width constraint.

## Validation

- `bun run check`
- `bun run build`
- `bun run test:focused:adhoc-browser`
- `git diff --check`
