### PR TITLE
Keep the Ad Hoc action bar at the bottom

### DIFF
--- a/src/components/controller-action-sheet.tsx
+++ b/src/components/controller-action-sheet.tsx
@@ -41,7 +41,7 @@ export function ControllerActionSheet({
   return (
     <div
       data-controller-action-sheet="true"
-      className="pointer-events-none fixed inset-x-0 bottom-0 top-[clamp(16rem,38dvh,22rem)] z-20 mx-auto flex w-full max-w-[460px] flex-col gap-0"
+      className="pointer-events-none fixed inset-x-0 bottom-0 top-[clamp(16rem,38dvh,22rem)] z-20 mx-auto flex w-full max-w-[460px] flex-col justify-end gap-0"
       style={topOffsetPx === undefined ? undefined : { top: `${topOffsetPx + 8}px` }}
     >
       {activePanel === null ? null : (


### PR DESCRIPTION
## What changed

- bottom-align the fixed Ad Hoc Controller action-sheet layer so its navigation stays at the viewport’s safe bottom edge

## Why

The viewport anchoring correction in #293 fixed the containing layer but left its flex children laid out from the layer’s top edge. With no panel selected, the Cards/Timeout/Game end bar therefore appeared in the middle of the screen. Bottom justification keeps the bar at the bottom and keeps an open panel directly above it.

## Validation

- `bun run check`
- `bun run test:focused:adhoc-browser`
- `git diff --check`
