### PR TITLE
Show live SQM fixture games

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -360,10 +360,15 @@ async function startServer() {
                 : await liveEventRuntime.readAudienceProjectionGameInput(eventGameId);
             },
           };
-    const audienceProjection = createAudienceProjection(
-      eventCatalogStorage,
-      liveAudienceGameInput === undefined ? {} : { gameInput: liveAudienceGameInput },
-    );
+    const audienceProjection = createAudienceProjection(eventCatalogStorage, {
+      ...(liveAudienceGameInput === undefined ? {} : { gameInput: liveAudienceGameInput }),
+      sqmFixtureGame: {
+        async read(fixtureKey) {
+          const result = await adHocService.readFixture({ fixtureKey });
+          return result.status === "accepted" ? { gameId: result.gameId, game: result.game } : null;
+        },
+      },
+    });
     const publicEventStream = createPublicAudienceEventStream(audienceProjection);
     let reconcilePublicSpectators = () => {};
     const publicEventWebSocketHub = createPublicAudienceEventWebSocketHub({

--- a/src/lib/ad-hoc-games.focused.ts
+++ b/src/lib/ad-hoc-games.focused.ts
@@ -32,6 +32,53 @@ import {
 } from "@/lib/ad-hoc-games";
 
 describe("Ad Hoc SQLite focused integration", () => {
+  test("persists a protected SQM fixture game and its public lookup across restart", async () => {
+    const root = await mkdtemp(join(tmpdir(), "quadball-timer-adhoc-sqm-restart-"));
+    const databasePath = join(root, "ad-hoc.sqlite");
+    const nowMs = Date.parse("2026-08-16T10:00:00.000Z");
+    try {
+      const store = openSqliteAdHocStore(databasePath, "sqm-test");
+      const games = createAdHocGamesService({
+        store,
+        environmentIdentity: "sqm-test",
+        now: () => nowMs,
+      });
+      const created = await games.create({
+        homeName: "secret4",
+        awayName: "ignored",
+        homeColor: "ignored",
+        awayColor: "ignored",
+      });
+      expect(created).toMatchObject({ status: "accepted" });
+      if (created.status !== "accepted") return;
+      games.close();
+
+      const reopenedStore = openSqliteAdHocStore(databasePath, "sqm-test");
+      const reopened = createAdHocGamesService({
+        store: reopenedStore,
+        environmentIdentity: "sqm-test",
+        now: () => nowMs + 24 * 60 * 60_000,
+      });
+      const publicRead = await reopened.readFixture({ fixtureKey: "secret4" });
+      expect(publicRead).toMatchObject({
+        status: "accepted",
+        gameId: created.gameId,
+        fixtureKey: "secret4",
+        game: {
+          state: {
+            homeName: "Friendlies",
+            awayName: "Kidditch",
+          },
+        },
+      });
+      expect(reopenedStore.listGames()).toHaveLength(1);
+      expect(reopenedStore.listGames()[0]?.fixtureKey).toBe("secret4");
+      reopened.close();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   test("migrates accepted history as a replay baseline and preserves duplicate/conflict outcomes after restart", async () => {
     const root = await mkdtemp(join(tmpdir(), "quadball-timer-adhoc-migration-focused-"));
     const databasePath = join(root, "ad-hoc.sqlite");

--- a/src/lib/ad-hoc-games.test.ts
+++ b/src/lib/ad-hoc-games.test.ts
@@ -22,6 +22,50 @@ function service(): AdHocGamesService {
 }
 
 describe("Ad Hoc Games service", () => {
+  test("creates and reuses date-gated protected SQM fixture games with canonical values", async () => {
+    let nowMs = Date.parse("2026-08-16T10:00:00.000Z");
+    const store = createInMemoryAdHocStore();
+    const games = createAdHocGamesService({ store, now: () => nowMs });
+
+    const first = await games.create({
+      homeName: "secret1",
+      awayName: null,
+      homeColor: "not-a-color",
+      awayColor: { ignored: true },
+      browserId: "browser-1",
+    });
+    expect(first).toMatchObject({ status: "accepted" });
+    if (first.status !== "accepted") return;
+    expect(first.game.state).toMatchObject({
+      homeName: "Basel Basilisks / Luzern",
+      awayName: "Berner Boggarts",
+      homeColor: "#16a34a",
+      awayColor: "#7f1d1d",
+    });
+
+    const second = await games.create({
+      homeName: "secret1",
+      awayName: "ignored",
+      homeColor: "ignored",
+      awayColor: "ignored",
+      browserId: "browser-2",
+    });
+    expect(second).toMatchObject({ status: "accepted", gameId: first.gameId });
+    if (second.status === "accepted") {
+      expect(
+        await games.read({ gameId: second.gameId, sessionId: second.sessionId }),
+      ).toMatchObject({
+        status: "accepted",
+      });
+    }
+    expect(store.listGames()).toHaveLength(1);
+    expect(store.listGames()[0]?.fixtureKey).toBe("secret1");
+
+    nowMs += 24 * 60 * 60_000;
+    const publicRead = await games.readFixture({ fixtureKey: "secret1" });
+    expect(publicRead).toMatchObject({ status: "accepted", gameId: first.gameId });
+  });
+
   test("derives multiple offline operations once from the authoritative base and rebases on reconciliation", () => {
     const authoritative = createInitialGameState({ id: "adhoc-optimistic", nowMs: 1_000 });
     const pending: AdHocPendingOperation[] = [
@@ -508,6 +552,67 @@ describe("Ad Hoc Games service", () => {
     expect(replacement.status).toBe("accepted");
     expect(store.listGames()).toHaveLength(50);
     expect(store.readGame(created[0]!.gameId)).toBeNull();
+  });
+
+  test("keeps the four protected SQM games in addition to the fifty-game Ad Hoc capacity", async () => {
+    let nowMs = Date.parse("2026-08-16T00:00:00.000Z");
+    const store = createInMemoryAdHocStore();
+    const games = createAdHocGamesService({ store, now: () => nowMs });
+    let firstOrdinary: { gameId: string; sessionId: string } | undefined;
+
+    for (const fixtureKey of ["secret1", "secret2", "secret3", "secret4"] as const) {
+      const result = await games.create({ homeName: fixtureKey, awayName: "ignored", nowMs });
+      expect(result.status).toBe("accepted");
+    }
+    for (let index = 0; index < 50; index += 1) {
+      nowMs += 60 * 60_000;
+      const result = await games.create({
+        homeName: `Home ${index}`,
+        awayName: "Away",
+        sourceKey: `ordinary-source-${index}`,
+        nowMs,
+      });
+      if (result.status !== "accepted") throw new Error("ordinary capacity setup failed");
+      firstOrdinary ??= result;
+      await games.setConnection({
+        gameId: result.gameId,
+        sessionId: result.sessionId,
+        connected: true,
+        nowMs,
+      });
+    }
+
+    const protectedIds = store
+      .listGames()
+      .filter((game) => game.fixtureKey !== undefined)
+      .map((game) => game.gameId);
+    expect(store.listGames()).toHaveLength(54);
+    expect(protectedIds).toHaveLength(4);
+
+    if (firstOrdinary === undefined) throw new Error("Expected an ordinary game.");
+    expect(
+      await games.setConnection({
+        gameId: firstOrdinary.gameId,
+        sessionId: firstOrdinary.sessionId,
+        connected: false,
+        nowMs,
+      }),
+    ).toBe(true);
+    nowMs += AD_HOC_DISCONNECTED_GRACE_MS;
+    const replacement = await games.create({
+      homeName: "Replacement",
+      awayName: "Game",
+      sourceKey: "replacement-source",
+      nowMs,
+    });
+    expect(replacement.status).toBe("accepted");
+    expect(store.listGames()).toHaveLength(54);
+    expect(
+      store
+        .listGames()
+        .filter((game) => game.fixtureKey !== undefined)
+        .map((game) => game.gameId),
+    ).toEqual(expect.arrayContaining(protectedIds));
   });
 
   test("protects newly admitted sessions and enforces the exact five-minute boundary", async () => {

--- a/src/lib/ad-hoc-games.ts
+++ b/src/lib/ad-hoc-games.ts
@@ -7,6 +7,12 @@ import type { GameCommand, GameState, GameView } from "@/lib/game-types";
 import { parseGameCommand } from "@/lib/ws-protocol";
 import { DEFAULT_IQA_SPORTING_RULES, type IqaSportingRules } from "@/lib/iqa-game-rules";
 import {
+  getSqmFixtureGame,
+  isSqmFixtureActivationDate,
+  isSqmFixtureKey,
+  type SqmFixtureKey,
+} from "@/lib/sqm-fixture";
+import {
   orderControllerOperations,
   createControllerReplayAcknowledgement,
   resolveControllerBatch,
@@ -52,7 +58,7 @@ export const AD_HOC_MAX_CREATIONS_PER_HOUR = 30;
 export const AD_HOC_MAX_OPERATIONS_PER_SECOND_PER_CONTROLLER = AD_HOC_CONTROLLER_BURST;
 export const AD_HOC_MAX_OPERATIONS_PER_SECOND_PER_GAME = AD_HOC_GAME_BURST;
 
-const SCHEMA_VERSION = 4;
+const SCHEMA_VERSION = 5;
 const GENERIC_UNAVAILABLE = "Ad Hoc Game unavailable.";
 const GENERIC_CAPACITY = "Ad Hoc capacity is currently full; no game was changed.";
 
@@ -115,6 +121,10 @@ export type AdHocAccessResult =
   | { status: "accepted"; game: AdHocGameView }
   | { status: "unavailable"; detail: string };
 
+export type AdHocFixtureAccessResult =
+  | { status: "accepted"; gameId: string; fixtureKey: SqmFixtureKey; game: GameView }
+  | { status: "unavailable" };
+
 export type AdHocSubscriptionResult =
   | AdHocAccessResult
   | { status: "capacity"; retryAfterMs: number };
@@ -141,6 +151,7 @@ export type StoredAdHocGame = {
   gameId: string;
   environmentIdentity: string;
   createdAtMs: number;
+  fixtureKey?: SqmFixtureKey;
   state: GameState;
   initialState?: GameState;
   replayBaselineOperationIds?: readonly string[];
@@ -574,18 +585,6 @@ export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) 
 
   return {
     async create(input: AdHocCreationInput): Promise<AdHocCreateResult> {
-      const home = normalizeTeamInput(input.homeName, "homeName");
-      const away = normalizeTeamInput(input.awayName, "awayName");
-      if (!home.ok) return { status: "rejected", reason: "invalid-input", detail: home.error };
-      if (!away.ok) return { status: "rejected", reason: "invalid-input", detail: away.error };
-
-      const homeColor = validateColor(input.homeColor, DEFAULT_HOME_TEAM_COLOR, "homeColor");
-      const awayColor = validateColor(input.awayColor, DEFAULT_AWAY_TEAM_COLOR, "awayColor");
-      if (!homeColor.ok)
-        return { status: "rejected", reason: "invalid-input", detail: homeColor.error };
-      if (!awayColor.ok)
-        return { status: "rejected", reason: "invalid-input", detail: awayColor.error };
-
       const nowMs = input.nowMs ?? now();
       if (!Number.isSafeInteger(nowMs) || nowMs < 0) {
         return {
@@ -595,9 +594,89 @@ export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) 
         };
       }
 
+      const fixture = isSqmFixtureActivationDate(nowMs) ? getSqmFixtureGame(input.homeName) : null;
+      const home =
+        fixture === null
+          ? normalizeTeamInput(input.homeName, "homeName")
+          : { ok: true as const, value: fixture.homeName };
+      const away =
+        fixture === null
+          ? normalizeTeamInput(input.awayName, "awayName")
+          : { ok: true as const, value: fixture.awayName };
+      if (!home.ok) return { status: "rejected", reason: "invalid-input", detail: home.error };
+      if (!away.ok) return { status: "rejected", reason: "invalid-input", detail: away.error };
+
+      const homeColor =
+        fixture === null
+          ? validateColor(input.homeColor, DEFAULT_HOME_TEAM_COLOR, "homeColor")
+          : { ok: true as const, value: fixture.homeColor };
+      const awayColor =
+        fixture === null
+          ? validateColor(input.awayColor, DEFAULT_AWAY_TEAM_COLOR, "awayColor")
+          : { ok: true as const, value: fixture.awayColor };
+      if (!homeColor.ok)
+        return { status: "rejected", reason: "invalid-input", detail: homeColor.error };
+      if (!awayColor.ok)
+        return { status: "rejected", reason: "invalid-input", detail: awayColor.error };
+
       const sourceKey =
         typeof input.sourceKey === "string" ? input.sourceKey.trim() : "anonymous-browser";
       const browserId = validateBrowserId(input.browserId);
+      if (fixture !== null) {
+        let existing: StoredAdHocGame | undefined;
+        try {
+          existing = store
+            .listGames()
+            .find(
+              (candidate) =>
+                candidate.environmentIdentity === environmentIdentity &&
+                candidate.fixtureKey === fixture.key,
+            );
+        } catch {
+          return { status: "rejected", reason: "unavailable" };
+        }
+        if (existing !== undefined) {
+          const sessionId = random();
+          let joined: boolean | null;
+          try {
+            joined = store.mutateGame(existing.gameId, (game) => {
+              if (
+                game.environmentIdentity !== environmentIdentity ||
+                game.fixtureKey !== fixture.key
+              )
+                return false;
+              game.sessions = game.sessions.filter(
+                (session) => browserId === null || session.browserId !== browserId,
+              );
+              game.sessions.push({
+                sessionHash: digest(sessionId),
+                browserId,
+                connected: false,
+                lastConnectedAtMs: nowMs,
+                lastDisconnectedAtMs: null,
+              });
+              return true;
+            });
+          } catch {
+            return { status: "rejected", reason: "unavailable" };
+          }
+          if (joined !== true) return { status: "rejected", reason: "unavailable" };
+          let game: StoredAdHocGame | null;
+          try {
+            game = store.readGame(existing.gameId);
+          } catch {
+            return { status: "rejected", reason: "unavailable" };
+          }
+          if (game === null) return { status: "rejected", reason: "unavailable" };
+          return {
+            status: "accepted",
+            gameId: game.gameId,
+            sessionId,
+            controlQr: game.controlQr,
+            game: projectAuthorizedGame(game, sessionId, game.controlQr, nowMs, iqaRules),
+          };
+        }
+      }
       const sourceHash = digest(sourceKey || "anonymous-browser");
       const gameId = `adhoc-${random()}`;
       const sessionId = random();
@@ -614,6 +693,7 @@ export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) 
         gameId,
         environmentIdentity,
         createdAtMs: nowMs,
+        ...(fixture === null ? {} : { fixtureKey: fixture.key }),
         state,
         initialState: structuredClone(state),
         replayBaselineOperationIds: [],
@@ -699,6 +779,32 @@ export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) 
       return {
         status: "accepted",
         game: projectAuthorizedGame(game, sessionId, null, input.nowMs ?? now(), iqaRules),
+      };
+    },
+
+    async readFixture(input: {
+      fixtureKey: unknown;
+      nowMs?: number;
+    }): Promise<AdHocFixtureAccessResult> {
+      if (!isSqmFixtureKey(input.fixtureKey)) return { status: "unavailable" };
+      let game: StoredAdHocGame | undefined;
+      try {
+        game = store
+          .listGames()
+          .find(
+            (candidate) =>
+              candidate.environmentIdentity === environmentIdentity &&
+              candidate.fixtureKey === input.fixtureKey,
+          );
+      } catch {
+        return { status: "unavailable" };
+      }
+      if (game === undefined) return { status: "unavailable" };
+      return {
+        status: "accepted",
+        gameId: game.gameId,
+        fixtureKey: input.fixtureKey,
+        game: iqaRules.project(game.state, input.nowMs ?? now()),
       };
     },
 
@@ -1405,12 +1511,15 @@ export function createInMemoryAdHocStore(): AdHocStore {
         };
       }
       let removedGameId: string | null = null;
-      const retainedCount = games.size;
+      const retainedCount = [...games.values()].filter(
+        (candidate) => candidate.fixtureKey === undefined,
+      ).length;
       if (retainedCount >= AD_HOC_MAX_RETAINED_GAMES) {
         const victim = [...games.values()]
           .filter(
             (candidate) =>
               candidate.environmentIdentity === game.environmentIdentity &&
+              candidate.fixtureKey === undefined &&
               candidate.sessions.every((session) => isCleanupEligible(session, nowMs)),
           )
           .sort((a, b) => a.createdAtMs - b.createdAtMs || a.gameId.localeCompare(b.gameId))[0];
@@ -1572,6 +1681,7 @@ export function openSqliteAdHocStore(
     game_id TEXT PRIMARY KEY,
     environment_identity TEXT NOT NULL DEFAULT '',
     created_at_ms INTEGER NOT NULL,
+    fixture_key TEXT,
     state_json TEXT NOT NULL,
     initial_state_json TEXT NOT NULL,
     replay_baseline_operation_ids_json TEXT NOT NULL DEFAULT '[]',
@@ -1583,6 +1693,9 @@ export function openSqliteAdHocStore(
   const columns = db.query("PRAGMA table_info(adhoc_games)").all() as { name?: string }[];
   if (!columns.some((column) => column.name === "environment_identity")) {
     db.run("ALTER TABLE adhoc_games ADD COLUMN environment_identity TEXT NOT NULL DEFAULT ''");
+  }
+  if (!columns.some((column) => column.name === "fixture_key")) {
+    db.run("ALTER TABLE adhoc_games ADD COLUMN fixture_key TEXT");
   }
   const legacyStateColumnWasMissing = !columns.some(
     (column) => column.name === "initial_state_json",
@@ -1612,6 +1725,9 @@ export function openSqliteAdHocStore(
     });
     migrate();
   }
+  db.run(
+    "CREATE UNIQUE INDEX IF NOT EXISTS adhoc_games_fixture_key_unique ON adhoc_games(environment_identity, fixture_key) WHERE fixture_key IS NOT NULL",
+  );
   db.run(
     "CREATE TABLE IF NOT EXISTS adhoc_creation_events (source_hash TEXT NOT NULL, successful INTEGER NOT NULL, occurred_at_ms INTEGER NOT NULL, retry_until_ms INTEGER)",
   );
@@ -1736,14 +1852,16 @@ export function openSqliteAdHocStore(
             retryAfterMs,
           } as const;
         }
-        const countRow = db.query("SELECT COUNT(*) AS count FROM adhoc_games").get() as {
+        const countRow = db
+          .query("SELECT COUNT(*) AS count FROM adhoc_games WHERE fixture_key IS NULL")
+          .get() as {
           count?: number | string;
         } | null;
         const count = Number(countRow?.count ?? 0);
         let removedGameId: string | null = null;
         if (count >= AD_HOC_MAX_RETAINED_GAMES) {
           const victim = db
-            .query(`SELECT game_id FROM adhoc_games WHERE environment_identity = ? AND NOT EXISTS (
+            .query(`SELECT game_id FROM adhoc_games WHERE environment_identity = ? AND fixture_key IS NULL AND NOT EXISTS (
             SELECT 1 FROM json_each(sessions_json) AS session
             WHERE json_extract(session.value, '$.connected') = 1
                OR COALESCE(
@@ -1766,11 +1884,12 @@ export function openSqliteAdHocStore(
           nowMs - AD_HOC_CREATION_GLOBAL_WINDOW_MS,
         ]);
         db.run(
-          "INSERT INTO adhoc_games (game_id, environment_identity, created_at_ms, state_json, initial_state_json, replay_baseline_operation_ids_json, control_qr, control_qr_hash, sessions_json, operations_json) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+          "INSERT INTO adhoc_games (game_id, environment_identity, created_at_ms, fixture_key, state_json, initial_state_json, replay_baseline_operation_ids_json, control_qr, control_qr_hash, sessions_json, operations_json) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
           [
             game.gameId,
             game.environmentIdentity,
             game.createdAtMs,
+            game.fixtureKey ?? null,
             JSON.stringify(game.state),
             JSON.stringify(game.initialState ?? game.state),
             JSON.stringify(game.replayBaselineOperationIds ?? []),
@@ -1830,6 +1949,9 @@ function parseStoredRow(row: Record<string, string | number>): StoredAdHocGame {
     gameId: String(row.game_id),
     environmentIdentity: String(row.environment_identity ?? ""),
     createdAtMs: Number(row.created_at_ms),
+    ...(row.fixture_key === null || row.fixture_key === undefined
+      ? {}
+      : { fixtureKey: String(row.fixture_key) as SqmFixtureKey }),
     state: JSON.parse(String(row.state_json)) as GameState,
     initialState: JSON.parse(String(row.initial_state_json ?? row.state_json)) as GameState,
     replayBaselineOperationIds: JSON.parse(
@@ -1957,6 +2079,7 @@ function inspectAdHocRecoveryDatabaseHandle(
       JSON.stringify({
         gameId: game.gameId,
         createdAtMs: game.createdAtMs,
+        fixtureKey: game.fixtureKey ?? null,
         sessions: game.sessions,
       }),
     );
@@ -2025,6 +2148,8 @@ function validateStoredGame(game: StoredAdHocGame): StoredAdHocGame {
   if (typeof game.environmentIdentity !== "string" || game.environmentIdentity.length === 0)
     throw new Error("Stored Ad Hoc environment identity is invalid.");
   requireSafeNonNegative(game.createdAtMs, "createdAtMs");
+  if (game.fixtureKey !== undefined && !isSqmFixtureKey(game.fixtureKey))
+    throw new Error("Stored Ad Hoc fixture key is invalid.");
   validateGameState(game.state, game.gameId);
   if (game.initialState !== undefined) validateGameState(game.initialState, game.gameId);
   if (!Array.isArray(game.replayBaselineOperationIds))

--- a/src/lib/audience-projection.test.ts
+++ b/src/lib/audience-projection.test.ts
@@ -36,6 +36,8 @@ import {
 import { createInitialClockBaseline, projectClockBaseline } from "@/lib/clock-authority";
 import type { ClockProjection } from "@/lib/clock-authority";
 import { createInitialGamePresentation } from "@/lib/game-presentation-projection";
+import { createInitialGameState } from "@/lib/game-engine";
+import type { GameView } from "@/lib/game-types";
 
 const authority = createTechnicalAdminAuth(
   { environment: "test", origin: "https://timer.example", rpId: "timer.example" },
@@ -785,7 +787,44 @@ describe("Audience Publication Projection", () => {
         timeZone: "Europe/Zurich",
         gameDays: ["2026-08-16"],
         lifecycle: "current",
-        schedule: { scheduleGames: [] },
+        schedule: {
+          scheduleGames: [
+            {
+              eventGameId: "secret1",
+              gameDesignation: "9:30",
+              sideA: {
+                name: "Basel Basilisks / Luzern",
+                color: "#16a34a",
+              },
+              sideB: {
+                name: "Berner Boggarts",
+                color: "#7f1d1d",
+              },
+              spectatorAvailable: false,
+            },
+            {
+              eventGameId: "secret2",
+              gameDesignation: "10:30",
+              sideA: { name: "Turicum Thunderbirds", color: "#facc15" },
+              sideB: { name: "Berner Boggarts", color: "#7f1d1d" },
+              spectatorAvailable: false,
+            },
+            {
+              eventGameId: "secret3",
+              gameDesignation: "11:30",
+              sideA: { name: "Turicum Thunderbirds", color: "#facc15" },
+              sideB: { name: "Basel Basilisks / Luzern", color: "#16a34a" },
+              spectatorAvailable: false,
+            },
+            {
+              eventGameId: "secret4",
+              gameDesignation: "13:00",
+              sideA: { name: "Friendlies", color: "#00afe8" },
+              sideB: { name: "Kidditch", color: "#ff4d35" },
+              spectatorAvailable: false,
+            },
+          ],
+        },
       },
     });
 
@@ -794,6 +833,46 @@ describe("Audience Publication Projection", () => {
     });
     const pastResult = await past.read("sqm-2026");
     expect(pastResult).toMatchObject({ status: "accepted", value: { lifecycle: "past" } });
+  });
+
+  test("publishes only created SQM fixture games and keeps uncreated rows anonymous", async () => {
+    const storage = {
+      snapshot: async () => ({ listEvents: () => [] }),
+    } as unknown as EventCatalogFoundationStorage;
+    const game: GameView = {
+      state: createInitialGameState({
+        id: "adhoc-secret2",
+        nowMs: Date.parse("2026-08-16T08:30:00.000Z"),
+        homeName: "Turicum Thunderbirds",
+        awayName: "Berner Boggarts",
+        homeColor: "#facc15",
+        awayColor: "#7f1d1d",
+      }),
+      seekerReleaseCountdownMs: null,
+      seekerReleased: false,
+      timeoutReminderActive: false,
+      timeoutWarningActive: false,
+      timeoutFinalCountdown: false,
+    };
+    const audience = createAudienceProjection(storage, {
+      now: () => Date.parse("2026-08-16T10:00:00.000Z"),
+      sqmFixtureGame: {
+        read: async (fixtureKey) =>
+          fixtureKey === "secret2" ? { gameId: "adhoc-secret2", game } : null,
+      },
+    });
+
+    const accepted = await audience.readGame("sqm-2026", "secret2");
+    expect(accepted).toMatchObject({
+      status: "accepted",
+      value: {
+        eventGameId: "secret2",
+        spectatorAvailable: true,
+        sideA: { name: "Turicum Thunderbirds", color: "#facc15" },
+        sideB: { name: "Berner Boggarts", color: "#7f1d1d" },
+      },
+    });
+    expect(await audience.readGame("sqm-2026", "secret1")).toEqual({ status: "unavailable" });
   });
 
   test("lists only Published Events and classifies them in each Event timezone", async () => {

--- a/src/lib/audience-projection.ts
+++ b/src/lib/audience-projection.ts
@@ -18,7 +18,15 @@ import {
 } from "@/lib/live-event-game-control";
 import type { ClockProjection } from "@/lib/clock-authority";
 import type { GamePresentation } from "@/lib/game-presentation";
-import { createSqmFixtureEvent, SQM_FIXTURE_EVENT_ID } from "@/lib/sqm-fixture";
+import type { GameView } from "@/lib/game-types";
+import {
+  createSqmFixtureEvent,
+  createSqmFixtureGameProjection,
+  createSqmFixtureSchedule,
+  SQM_FIXTURE_EVENT_ID,
+  SQM_FIXTURE_GAMES,
+  type SqmFixtureKey,
+} from "@/lib/sqm-fixture";
 
 export type PublicAudienceEventLifecycle = "unscheduled" | "current" | "future" | "past";
 
@@ -129,6 +137,7 @@ export type PublicAudienceGameProjection = PublicAudienceGameOperationalProjecti
     displayedTeamColors: { sideA: string | null; sideB: string | null };
   };
   canonicalPath: string;
+  spectatorAvailable?: boolean;
   timeline: readonly PublicAudienceTimelineEntry[];
   /** Temporary neutral notice; correction evidence and provenance stay private. */
   teamAssignmentNotice?: "event-team-assignment-corrected";
@@ -208,6 +217,9 @@ export type AudienceProjectionListOutcome =
 export type AudienceProjectionOptions = {
   now?: () => number;
   gameInput?: AudienceProjectionGameInputReader;
+  sqmFixtureGame?: {
+    read(fixtureKey: SqmFixtureKey): Promise<{ gameId: string; game: GameView } | null>;
+  };
 };
 
 export type AudienceProjectionReader = {
@@ -241,7 +253,10 @@ export function createAudienceProjection(
       if (typeof eventId !== "string" || eventId.trim().length === 0)
         return { status: "unavailable" };
       if (eventId === SQM_FIXTURE_EVENT_ID) {
-        return { status: "accepted", value: createSqmFixtureEvent(now()) };
+        return {
+          status: "accepted",
+          value: await projectSqmFixtureEvent(now(), options.sqmFixtureGame),
+        };
       }
       try {
         const snapshot = await storage.snapshot();
@@ -266,6 +281,15 @@ export function createAudienceProjection(
       )
         return { status: "unavailable" };
       try {
+        if (eventId === SQM_FIXTURE_EVENT_ID) {
+          const event = await projectSqmFixtureEvent(now(), options.sqmFixtureGame);
+          const game = event.schedule.scheduleGames.find(
+            (candidate) => candidate.eventGameId === eventGameId,
+          );
+          return game?.spectatorAvailable === true
+            ? { status: "accepted", value: game }
+            : { status: "unavailable" };
+        }
         const snapshot = await storage.snapshot();
         const event = snapshot.findEvent(eventId);
         const game = snapshot.findEventGame(eventGameId);
@@ -306,7 +330,7 @@ export function createAudienceProjection(
         );
         const events = catalogEvents.some((event) => event.eventId === SQM_FIXTURE_EVENT_ID)
           ? catalogEvents
-          : [...catalogEvents, createSqmFixtureEvent(nowMs)];
+          : [...catalogEvents, await projectSqmFixtureEvent(nowMs, options.sqmFixtureGame)];
         return {
           status: "accepted",
           value: { events: sortPublicEvents(events) },
@@ -316,6 +340,24 @@ export function createAudienceProjection(
       }
     },
   };
+}
+
+async function projectSqmFixtureEvent(
+  nowMs: number,
+  reader: AudienceProjectionOptions["sqmFixtureGame"],
+): Promise<PublicAudienceEventProjection> {
+  const games = await Promise.all(
+    SQM_FIXTURE_GAMES.map(async (definition) => {
+      const current = reader === undefined ? null : await reader.read(definition.key);
+      return createSqmFixtureGameProjection(
+        definition,
+        current?.game ?? null,
+        current?.gameId ?? null,
+        nowMs,
+      );
+    }),
+  );
+  return createSqmFixtureEvent(nowMs, createSqmFixtureSchedule(games, nowMs));
 }
 
 async function projectPublicEvent(

--- a/src/lib/sqm-fixture.ts
+++ b/src/lib/sqm-fixture.ts
@@ -1,11 +1,89 @@
-import type { PublicAudienceEventProjection } from "@/lib/audience-projection";
+import { createInitialClockBaseline, projectClockBaseline } from "@/lib/clock-authority";
+import type { GameView } from "@/lib/game-types";
+import type {
+  PublicAudienceEventProjection,
+  PublicAudienceGameProjection,
+  PublicAudienceScheduleProjection,
+} from "@/lib/audience-projection";
+import { DEFAULT_AWAY_TEAM_COLOR, DEFAULT_HOME_TEAM_COLOR } from "@/lib/team-colors";
 
 export const SQM_FIXTURE_EVENT_ID = "sqm-2026" as const;
 export const SQM_FIXTURE_EVENT_NAME = "Schweizer Quadball Meisterschaft 2026" as const;
 export const SQM_FIXTURE_TIME_ZONE = "Europe/Zurich" as const;
 export const SQM_FIXTURE_GAME_DAY = "2026-08-16" as const;
 
-export function createSqmFixtureEvent(nowMs: number): PublicAudienceEventProjection {
+export type SqmFixtureKey = "secret1" | "secret2" | "secret3" | "secret4";
+
+export type SqmFixtureGameDefinition = {
+  key: SqmFixtureKey;
+  scheduledStartMs: number;
+  gameDesignation: string;
+  homeName: string;
+  awayName: string;
+  homeColor: string;
+  awayColor: string;
+};
+
+export const SQM_FIXTURE_GAMES: readonly SqmFixtureGameDefinition[] = [
+  {
+    key: "secret1",
+    scheduledStartMs: Date.parse("2026-08-16T07:30:00.000Z"),
+    gameDesignation: "9:30",
+    homeName: "Basel Basilisks / Luzern",
+    awayName: "Berner Boggarts",
+    homeColor: "#16a34a",
+    awayColor: "#7f1d1d",
+  },
+  {
+    key: "secret2",
+    scheduledStartMs: Date.parse("2026-08-16T08:30:00.000Z"),
+    gameDesignation: "10:30",
+    homeName: "Turicum Thunderbirds",
+    awayName: "Berner Boggarts",
+    homeColor: "#facc15",
+    awayColor: "#7f1d1d",
+  },
+  {
+    key: "secret3",
+    scheduledStartMs: Date.parse("2026-08-16T09:30:00.000Z"),
+    gameDesignation: "11:30",
+    homeName: "Turicum Thunderbirds",
+    awayName: "Basel Basilisks / Luzern",
+    homeColor: "#facc15",
+    awayColor: "#16a34a",
+  },
+  {
+    key: "secret4",
+    scheduledStartMs: Date.parse("2026-08-16T11:00:00.000Z"),
+    gameDesignation: "13:00",
+    homeName: "Friendlies",
+    awayName: "Kidditch",
+    homeColor: DEFAULT_HOME_TEAM_COLOR,
+    awayColor: DEFAULT_AWAY_TEAM_COLOR,
+  },
+];
+
+export function getSqmFixtureGame(key: unknown): SqmFixtureGameDefinition | null {
+  return SQM_FIXTURE_GAMES.find((game) => game.key === key) ?? null;
+}
+
+export function isSqmFixtureKey(value: unknown): value is SqmFixtureKey {
+  return getSqmFixtureGame(value) !== null;
+}
+
+export function isSqmFixtureActivationDate(nowMs: number): boolean {
+  return localDate(nowMs, SQM_FIXTURE_TIME_ZONE) === SQM_FIXTURE_GAME_DAY;
+}
+
+export function createSqmFixtureEvent(
+  nowMs: number,
+  schedule: PublicAudienceScheduleProjection = emptySqmSchedule(nowMs),
+): PublicAudienceEventProjection {
+  const teams = new Map<string, string>();
+  for (const game of SQM_FIXTURE_GAMES) {
+    teams.set(game.homeName, game.homeColor);
+    teams.set(game.awayName, game.awayColor);
+  }
   return {
     eventId: SQM_FIXTURE_EVENT_ID,
     name: SQM_FIXTURE_EVENT_NAME,
@@ -14,16 +92,168 @@ export function createSqmFixtureEvent(nowMs: number): PublicAudienceEventProject
     gameDays: [SQM_FIXTURE_GAME_DAY],
     lifecycle: classifySqmFixtureLifecycle(nowMs),
     canonicalPath: `/events/${encodeURIComponent(SQM_FIXTURE_EVENT_ID)}`,
-    teams: [],
+    teams: [...teams].map(([name, color]) => ({ name, color })),
     pitches: [],
-    schedule: {
-      asOfMs: nowMs,
-      runningGames: [],
-      upcomingGames: [],
-      scheduleGames: [],
-      focusIndex: null,
-    },
+    schedule,
   };
+}
+
+export function createSqmFixtureGameProjection(
+  definition: SqmFixtureGameDefinition,
+  game: GameView | null,
+  gameId: string | null,
+  nowMs: number,
+): PublicAudienceGameProjection {
+  const state = game?.state;
+  const isFinished = state?.isFinished === true;
+  const isSuspended = state?.isSuspended === true;
+  const isRunning = state?.isRunning === true;
+  const operationalProjection = isSuspended
+    ? { operationalStatus: "suspended" as const, gameSuspension: "suspended" as const }
+    : {
+        operationalStatus: isFinished
+          ? ("finished" as const)
+          : isRunning
+            ? ("running" as const)
+            : ("scheduled" as const),
+        gameSuspension: "none" as const,
+      };
+  const scheduleStatus = isFinished
+    ? ("past" as const)
+    : isRunning || isSuspended
+      ? ("running" as const)
+      : definition.scheduledStartMs <= nowMs
+        ? ("awaiting-start" as const)
+        : ("future" as const);
+  const clock = state === undefined ? null : projectFixtureClock(state, nowMs);
+  const winner = state?.winner === "home" ? "side-a" : state?.winner === "away" ? "side-b" : null;
+  const catchingSide =
+    state?.flagCatch?.team === "home"
+      ? "side-a"
+      : state?.flagCatch?.team === "away"
+        ? "side-b"
+        : null;
+  return {
+    eventId: SQM_FIXTURE_EVENT_ID,
+    eventGameId: definition.key,
+    gameCode: null,
+    gameDesignation: definition.gameDesignation,
+    scheduledStartMs: definition.scheduledStartMs,
+    expectedStartMs: definition.scheduledStartMs,
+    scheduleStatus,
+    phase:
+      state?.isOvertime === true
+        ? "overtime"
+        : game?.seekerReleased === true
+          ? "seekers-released"
+          : "seeker-floor",
+    pitch: null,
+    sideA: {
+      name: state?.homeName ?? definition.homeName,
+      color: state?.homeColor ?? definition.homeColor,
+      score: state?.score.home ?? null,
+    },
+    sideB: {
+      name: state?.awayName ?? definition.awayName,
+      color: state?.awayColor ?? definition.awayColor,
+      score: state?.score.away ?? null,
+    },
+    overtimeTarget: null,
+    clock,
+    teamTimeout: {
+      status:
+        state?.timeouts.active === null || state?.timeouts.active === undefined
+          ? "inactive"
+          : "started",
+      side:
+        state?.timeouts.active?.team === "home"
+          ? "side-a"
+          : state?.timeouts.active?.team === "away"
+            ? "side-b"
+            : null,
+      remainingMs: state?.timeouts.active?.remainingMs ?? null,
+    },
+    heatStoppage: {
+      status: "inactive",
+      mode: "disabled",
+      pending: false,
+      allowedDurationMs: null,
+      actualDurationMs: null,
+      remainingMs: null,
+    },
+    flagState: { catchingSide },
+    result: {
+      status: isFinished ? "finished" : "unfinished",
+      winner,
+      locked: false,
+    },
+    ...operationalProjection,
+    presentation: {
+      pitchOrientation: state?.displaySidesSwapped === true ? "side-b-left" : "side-a-left",
+      displayedTeamColors: {
+        sideA: state?.homeColor ?? definition.homeColor,
+        sideB: state?.awayColor ?? definition.awayColor,
+      },
+    },
+    canonicalPath: `/events/${encodeURIComponent(SQM_FIXTURE_EVENT_ID)}/games/${encodeURIComponent(definition.key)}`,
+    timeline: [],
+    spectatorAvailable: gameId !== null,
+  };
+}
+
+export function createSqmFixtureSchedule(
+  games: readonly PublicAudienceGameProjection[],
+  nowMs: number,
+): PublicAudienceScheduleProjection {
+  const scheduleGames = [...games].sort(
+    (left, right) => left.expectedStartMs - right.expectedStartMs,
+  );
+  const runningGames = scheduleGames.filter((game) => game.scheduleStatus === "running");
+  const upcomingGames = scheduleGames.filter(
+    (game) =>
+      game.scheduleStatus === "future" &&
+      game.expectedStartMs >= nowMs &&
+      game.expectedStartMs < nowMs + 60 * 60 * 1000,
+  );
+  const activeIndex = scheduleGames.findIndex(
+    (game) => game.scheduleStatus === "running" || game.scheduleStatus === "awaiting-start",
+  );
+  const futureIndex = scheduleGames.findIndex((game) => game.scheduleStatus === "future");
+  return {
+    asOfMs: nowMs,
+    runningGames,
+    upcomingGames,
+    scheduleGames,
+    focusIndex:
+      scheduleGames.length === 0
+        ? null
+        : activeIndex >= 0
+          ? activeIndex
+          : futureIndex >= 0
+            ? futureIndex
+            : scheduleGames.length - 1,
+  };
+}
+
+function emptySqmSchedule(nowMs: number): PublicAudienceScheduleProjection {
+  return {
+    asOfMs: nowMs,
+    runningGames: [],
+    upcomingGames: [],
+    scheduleGames: [],
+    focusIndex: null,
+  };
+}
+
+function projectFixtureClock(state: GameView["state"], nowMs: number) {
+  const baseline = {
+    ...createInitialClockBaseline(),
+    gameTimeMs: state.gameClockMs,
+    running: false,
+    establishedAtMs: state.updatedAtMs,
+    lastAcceptedAtMs: state.updatedAtMs,
+  };
+  return projectClockBaseline(baseline, nowMs);
 }
 
 function classifySqmFixtureLifecycle(nowMs: number): PublicAudienceEventProjection["lifecycle"] {

--- a/src/pages/public-event-page.tsx
+++ b/src/pages/public-event-page.tsx
@@ -354,7 +354,7 @@ export function PublicEventGamePage({
   }, [game]);
 
   if (unavailable) return <GameUnavailablePanel eventId={eventId} />;
-  if (game === null) {
+  if (game === null || game.spectatorAvailable === false) {
     if (event !== null) return <GameUnavailablePanel eventId={eventId} />;
     return (
       <PublicShell title="Live spectator Game" description="Loading public Game information…">
@@ -800,25 +800,29 @@ function GameCard({
         <div className="flex flex-wrap items-start justify-between gap-2">
           <div>
             <h3 className={compact ? "text-base font-semibold" : "text-lg font-semibold"}>
-              <a
-                href={game.canonicalPath}
-                className="rounded-sm underline-offset-4 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                onClick={(click) => {
-                  if (
-                    click.button !== 0 ||
-                    click.metaKey ||
-                    click.ctrlKey ||
-                    click.shiftKey ||
-                    click.altKey
-                  )
-                    return;
-                  click.preventDefault();
-                  navigateTo(game.canonicalPath);
-                }}
-              >
-                {game.gameDesignation ?? game.gameCode ?? "Scheduled Game"}
-                <span className="sr-only"> Open spectator Game</span>
-              </a>
+              {game.spectatorAvailable === false ? (
+                <span>{game.gameDesignation ?? game.gameCode ?? "Scheduled Game"}</span>
+              ) : (
+                <a
+                  href={game.canonicalPath}
+                  className="rounded-sm underline-offset-4 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                  onClick={(click) => {
+                    if (
+                      click.button !== 0 ||
+                      click.metaKey ||
+                      click.ctrlKey ||
+                      click.shiftKey ||
+                      click.altKey
+                    )
+                      return;
+                    click.preventDefault();
+                    navigateTo(game.canonicalPath);
+                  }}
+                >
+                  {game.gameDesignation ?? game.gameCode ?? "Scheduled Game"}
+                  <span className="sr-only"> Open spectator Game</span>
+                </a>
+              )}
             </h3>
             {game.gameDesignation !== null && game.gameCode !== null ? (
               <CardDescription>Game {game.gameCode}</CardDescription>


### PR DESCRIPTION
## Summary

- add the four scheduled SQM fixture games with the requested teams, colors, and CEST start times
- turn `secret1` through `secret4` Home names into date-gated canonical Ad Hoc games that reuse the existing game and grant a Controller session on repeat admission
- persist protected fixture records, exclude them from ordinary cleanup and capacity, and expose only created fixture games through the public spectator projection

## Test plan

- `bun test --timeout=10000`
- `bun run check`

Both pass. The repository check reports only pre-existing lint warnings.
