### PR TITLE
Hardcode the first SQM result

### DIFF
--- a/src/lib/audience-projection.test.ts
+++ b/src/lib/audience-projection.test.ts
@@ -792,15 +792,19 @@ describe("Audience Publication Projection", () => {
             {
               eventGameId: "secret1",
               gameDesignation: "9:30",
+              scheduleStatus: "past",
               sideA: {
                 name: "Basel Basilisks / Luzern",
                 color: "#16a34a",
+                score: 40,
               },
               sideB: {
                 name: "Berner Boggarts",
                 color: "#7f1d1d",
+                score: 140,
               },
-              spectatorAvailable: false,
+              clock: { gameTimeMs: 1_360_000 },
+              spectatorAvailable: true,
             },
             {
               eventGameId: "secret2",
@@ -835,7 +839,7 @@ describe("Audience Publication Projection", () => {
     expect(pastResult).toMatchObject({ status: "accepted", value: { lifecycle: "past" } });
   });
 
-  test("publishes only created SQM fixture games and keeps uncreated rows anonymous", async () => {
+  test("publishes the hardcoded first SQM game and only created tracked games", async () => {
     const storage = {
       snapshot: async () => ({ listEvents: () => [] }),
     } as unknown as EventCatalogFoundationStorage;
@@ -862,6 +866,17 @@ describe("Audience Publication Projection", () => {
       },
     });
 
+    const hardcoded = await audience.readGame("sqm-2026", "secret1");
+    expect(hardcoded).toMatchObject({
+      status: "accepted",
+      value: {
+        eventGameId: "secret1",
+        scheduleStatus: "past",
+        sideA: { score: 40 },
+        sideB: { score: 140 },
+        clock: { gameTimeMs: 1_360_000 },
+      },
+    });
     const accepted = await audience.readGame("sqm-2026", "secret2");
     expect(accepted).toMatchObject({
       status: "accepted",
@@ -872,7 +887,7 @@ describe("Audience Publication Projection", () => {
         sideB: { name: "Berner Boggarts", color: "#7f1d1d" },
       },
     });
-    expect(await audience.readGame("sqm-2026", "secret1")).toEqual({ status: "unavailable" });
+    expect(await audience.readGame("sqm-2026", "secret3")).toEqual({ status: "unavailable" });
   });
 
   test("lists only Published Events and classifies them in each Event timezone", async () => {

--- a/src/lib/sqm-fixture.ts
+++ b/src/lib/sqm-fixture.ts
@@ -11,6 +11,9 @@ export const SQM_FIXTURE_EVENT_ID = "sqm-2026" as const;
 export const SQM_FIXTURE_EVENT_NAME = "Schweizer Quadball Meisterschaft 2026" as const;
 export const SQM_FIXTURE_TIME_ZONE = "Europe/Zurich" as const;
 export const SQM_FIXTURE_GAME_DAY = "2026-08-16" as const;
+const SQM_FIRST_GAME_HOME_SCORE = 40;
+const SQM_FIRST_GAME_AWAY_SCORE = 140;
+const SQM_FIRST_GAME_TIME_MS = 22 * 60_000 + 40_000;
 
 export type SqmFixtureKey = "secret1" | "secret2" | "secret3" | "secret4";
 
@@ -104,8 +107,9 @@ export function createSqmFixtureGameProjection(
   gameId: string | null,
   nowMs: number,
 ): PublicAudienceGameProjection {
-  const state = game?.state;
-  const isFinished = state?.isFinished === true;
+  const isHardcodedFirstGame = definition.key === "secret1";
+  const state = isHardcodedFirstGame ? undefined : game?.state;
+  const isFinished = isHardcodedFirstGame || state?.isFinished === true;
   const isSuspended = state?.isSuspended === true;
   const isRunning = state?.isRunning === true;
   const operationalProjection = isSuspended
@@ -118,15 +122,27 @@ export function createSqmFixtureGameProjection(
             : ("scheduled" as const),
         gameSuspension: "none" as const,
       };
-  const scheduleStatus = isFinished
+  const scheduleStatus = isHardcodedFirstGame
     ? ("past" as const)
-    : isRunning || isSuspended
-      ? ("running" as const)
-      : definition.scheduledStartMs <= nowMs
-        ? ("awaiting-start" as const)
-        : ("future" as const);
-  const clock = state === undefined ? null : projectFixtureClock(state, nowMs);
-  const winner = state?.winner === "home" ? "side-a" : state?.winner === "away" ? "side-b" : null;
+    : isFinished
+      ? ("past" as const)
+      : isRunning || isSuspended
+        ? ("running" as const)
+        : definition.scheduledStartMs <= nowMs
+          ? ("awaiting-start" as const)
+          : ("future" as const);
+  const clock = isHardcodedFirstGame
+    ? projectFixtureClockValue(SQM_FIRST_GAME_TIME_MS, nowMs)
+    : state === undefined
+      ? null
+      : projectFixtureClock(state, nowMs);
+  const winner = isHardcodedFirstGame
+    ? "side-b"
+    : state?.winner === "home"
+      ? "side-a"
+      : state?.winner === "away"
+        ? "side-b"
+        : null;
   const catchingSide =
     state?.flagCatch?.team === "home"
       ? "side-a"
@@ -151,12 +167,12 @@ export function createSqmFixtureGameProjection(
     sideA: {
       name: state?.homeName ?? definition.homeName,
       color: state?.homeColor ?? definition.homeColor,
-      score: state?.score.home ?? null,
+      score: isHardcodedFirstGame ? SQM_FIRST_GAME_HOME_SCORE : (state?.score.home ?? null),
     },
     sideB: {
       name: state?.awayName ?? definition.awayName,
       color: state?.awayColor ?? definition.awayColor,
-      score: state?.score.away ?? null,
+      score: isHardcodedFirstGame ? SQM_FIRST_GAME_AWAY_SCORE : (state?.score.away ?? null),
     },
     overtimeTarget: null,
     clock,
@@ -197,7 +213,7 @@ export function createSqmFixtureGameProjection(
     },
     canonicalPath: `/events/${encodeURIComponent(SQM_FIXTURE_EVENT_ID)}/games/${encodeURIComponent(definition.key)}`,
     timeline: [],
-    spectatorAvailable: gameId !== null,
+    spectatorAvailable: isHardcodedFirstGame || gameId !== null,
   };
 }
 
@@ -246,12 +262,16 @@ function emptySqmSchedule(nowMs: number): PublicAudienceScheduleProjection {
 }
 
 function projectFixtureClock(state: GameView["state"], nowMs: number) {
+  return projectFixtureClockValue(state.gameClockMs, nowMs, state.updatedAtMs);
+}
+
+function projectFixtureClockValue(gameTimeMs: number, nowMs: number, updatedAtMs = nowMs) {
   const baseline = {
     ...createInitialClockBaseline(),
-    gameTimeMs: state.gameClockMs,
+    gameTimeMs,
     running: false,
-    establishedAtMs: state.updatedAtMs,
-    lastAcceptedAtMs: state.updatedAtMs,
+    establishedAtMs: updatedAtMs,
+    lastAcceptedAtMs: updatedAtMs,
   };
   return projectClockBaseline(baseline, nowMs);
 }


### PR DESCRIPTION
## Summary

- hardcode the first SQM game as a completed public result of 40–140 at 22:40 game time
- keep the first game's public projection fixed even if an old `secret1` record exists
- continue tracking only the second through fourth games through their persisted Ad Hoc fixture records

## Test plan

- `bun test --timeout=10000`
- `bun run check`

Both pass. The repository check reports only pre-existing lint warnings.
