### PR TITLE
Bound HTTP JSON request bodies

### DIFF
--- a/src/index-event-admin-headers.focused.ts
+++ b/src/index-event-admin-headers.focused.ts
@@ -4,6 +4,9 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { writeFileSync } from "node:fs";
 import { createGrantKeyRingDocument, writeGrantKeyRingFile } from "@/lib/grant-key-ring-custody";
+import { SHARED_LIMITS } from "@/lib/validation-policy";
+
+const OVERSIZED_CREDENTIAL = "credential-must-not-be-echoed";
 
 describe("Event Hub early response headers", () => {
   test("marks unauthenticated and unavailable early responses as sensitive", async () => {
@@ -63,6 +66,18 @@ describe("Pitch Manager early response headers", () => {
       await expectSensitiveFailure(unavailableLeave, 503, { error: "Authentication failed." });
     });
   });
+
+  test("rejects an oversized admission body without echoing credentials", async () => {
+    await withServer({}, async (serverUrl) => {
+      const response = await fetch(new URL("/api/pitch-manager/admit", serverUrl), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: credentialBodyWithByteLength(SHARED_LIMITS.transport.httpJsonBodyBytes + 1),
+      });
+
+      await expectOversizedCredentialFailure(response);
+    });
+  });
 });
 
 describe("Event Admin admission response headers", () => {
@@ -94,7 +109,42 @@ describe("Event Admin admission response headers", () => {
       await expectSensitiveFailure(unavailable, 503, { error: "Authentication failed." });
     });
   });
+
+  test("accepts the exact body limit and rejects limit plus one without echoing credentials", async () => {
+    await withServer({}, async (serverUrl) => {
+      const exactLimit = await fetch(new URL("/api/event-admin/admit", serverUrl), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: credentialBodyWithByteLength(SHARED_LIMITS.transport.httpJsonBodyBytes),
+      });
+      expect(exactLimit.status).toBe(401);
+      expect(exactLimit.headers.get("cache-control")).toBe("no-store");
+      expect(exactLimit.headers.get("referrer-policy")).toBe("no-referrer");
+      expect(await exactLimit.text()).not.toContain(OVERSIZED_CREDENTIAL);
+
+      const oversized = await fetch(new URL("/api/event-admin/admit", serverUrl), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: credentialBodyWithByteLength(SHARED_LIMITS.transport.httpJsonBodyBytes + 1),
+      });
+
+      await expectOversizedCredentialFailure(oversized);
+    });
+  });
 });
+
+async function expectOversizedCredentialFailure(response: Response) {
+  expect(response.status).toBe(413);
+  expect(await response.text()).not.toContain(OVERSIZED_CREDENTIAL);
+}
+
+function credentialBodyWithByteLength(byteLength: number): string {
+  const prefix = `{"qrCredential":"${OVERSIZED_CREDENTIAL}","padding":"`;
+  const suffix = '"}';
+  const body = `${prefix}${"x".repeat(byteLength - prefix.length - suffix.length)}${suffix}`;
+  expect(new TextEncoder().encode(body).byteLength).toBe(byteLength);
+  return body;
+}
 
 async function expectSensitiveFailure(
   response: Response,

--- a/src/index.ts
+++ b/src/index.ts
@@ -636,6 +636,7 @@ async function startServer() {
     server = serve<SessionData>({
       hostname: process.env.HOST ?? "127.0.0.1",
       port,
+      maxRequestBodySize: SHARED_LIMITS.transport.httpJsonBodyBytes,
       error(error) {
         monitoring.captureException(error, { category: "server", component: "http" });
         return json({ error: "Internal server error." }, 500);
@@ -3226,12 +3227,8 @@ function sensitiveJson(
 }
 
 async function readJsonRecord(req: Request): Promise<Record<string, unknown> | null> {
-  try {
-    const value: unknown = await req.json();
-    return isRecord(value) ? value : null;
-  } catch {
-    return null;
-  }
+  const result = await readJsonBodyWithinLimit(req);
+  return result.ok && isRecord(result.body) ? result.body : null;
 }
 
 async function readCeremonyBody(


### PR DESCRIPTION
## Summary

- enforce the shared 64 KiB JSON limit at the Bun server boundary
- route server JSON records through the bounded body reader
- cover oversized unauthenticated Event Admin and Pitch Manager admissions

## Verification

- `bun test --isolate ./src/lib/http-body.test.ts` (6 passed)
- `bun test --isolate ./src/index-event-admin-headers.focused.ts` (10 passed on the complete stack)
- complete-stack `bun run check`, `bun run test`, and `bun run build`
- complete-stack terminal security review found no actionable findings

Fixes #299

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
