### PR TITLE
Protect Event mutations from CSRF

### DIFF
--- a/src/index-event-admin-headers.focused.ts
+++ b/src/index-event-admin-headers.focused.ts
@@ -5,6 +5,21 @@ import { tmpdir } from "node:os";
 import { writeFileSync } from "node:fs";
 import { createGrantKeyRingDocument, writeGrantKeyRingFile } from "@/lib/grant-key-ring-custody";
 import { SHARED_LIMITS } from "@/lib/validation-policy";
+import { openSqliteFoundationStorage } from "@/lib/foundation-storage-sqlite";
+import { createEventCatalog, createFoundationEventCatalogStorage } from "@/lib/event-catalog";
+import { createGrantAuthority } from "@/lib/grant-authority";
+import { readGrantAuthorityOptions } from "@/lib/grant-runtime";
+import { createEventAdministration } from "@/lib/event-administration";
+import {
+  createTechnicalAdminAuth,
+  MemoryTechnicalAdminAuthRepository,
+} from "@/lib/technical-admin-auth";
+import {
+  deriveGrantSessionCsrfToken,
+  EVENT_ADMIN_CSRF_HEADER,
+  PITCH_MANAGER_CSRF_HEADER,
+  type GrantSessionCsrfRole,
+} from "@/lib/grant-session-csrf";
 
 const OVERSIZED_CREDENTIAL = "credential-must-not-be-echoed";
 
@@ -133,6 +148,181 @@ describe("Event Admin admission response headers", () => {
   });
 });
 
+describe("Event mutation request binding and CSRF", () => {
+  test("admission issues role-separated readable CSRF companions beside HttpOnly bearers", async () => {
+    await withServer({ seedGrants: true }, async (serverUrl, credentials) => {
+      if (credentials === null) throw new Error("Expected seeded Grant credentials.");
+      for (const role of ["event-admin", "pitch-manager"] as const) {
+        const response = await fetch(new URL(`/api/${role}/admit`, serverUrl), {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ qrCredential: credentials[role] }),
+        });
+        expect(response.status).toBe(200);
+        const cookies = response.headers.getAll("set-cookie");
+        const bearer = cookies.find((cookie) => cookie.startsWith(`__Host-${role}-session=`));
+        const csrf = cookies.find((cookie) => cookie.startsWith(`__Host-${role}-csrf=`));
+        expect(bearer).toContain("HttpOnly");
+        expect(csrf).not.toContain("HttpOnly");
+        expect(csrf).toContain("Path=/");
+        expect(csrf).toContain("Secure");
+        expect(csrf).toContain("SameSite=Strict");
+        const bearerValue = bearer?.split(";", 1)[0]?.split("=").slice(1).join("=");
+        expect(csrf).not.toContain(bearerValue ?? "missing-bearer");
+      }
+    });
+  });
+
+  for (const role of ["event-admin", "pitch-manager"] as const) {
+    test(`${role} mutations fail closed for missing or sibling Origin and invalid CSRF`, async () => {
+      await withServer({}, async (serverUrl) => {
+        const bearer = `${role}-session-a`;
+        const validToken = deriveGrantSessionCsrfToken(role, bearer);
+        const validHeaders = mutationHeaders(role, bearer, validToken);
+
+        await expectGenericMutationFailure(
+          await fetch(mutationUrl(serverUrl, role), {
+            method: "POST",
+            headers: withoutHeader(validHeaders, "origin"),
+          }),
+        );
+        await expectGenericMutationFailure(
+          await fetch(mutationUrl(serverUrl, role), {
+            method: "POST",
+            headers: { ...validHeaders, origin: "https://test.localhost" },
+          }),
+        );
+        await expectGenericMutationFailure(
+          await fetch(mutationUrl(serverUrl, role), {
+            method: "POST",
+            headers: withoutHeader(validHeaders, csrfHeader(role)),
+          }),
+        );
+        await expectGenericMutationFailure(
+          await fetch(mutationUrl(serverUrl, role), {
+            method: "POST",
+            headers: {
+              ...validHeaders,
+              [csrfHeader(role)]: deriveGrantSessionCsrfToken(role, `${role}-session-b`),
+            },
+          }),
+        );
+        await expectGenericMutationFailure(
+          await fetch(mutationUrl(serverUrl, role), {
+            method: "POST",
+            headers: {
+              ...validHeaders,
+              [csrfHeader(role)]: deriveGrantSessionCsrfToken(otherRole(role), bearer),
+            },
+          }),
+        );
+
+        const authorityLayer = await fetch(mutationUrl(serverUrl, role), {
+          method: "POST",
+          headers: validHeaders,
+        });
+        expect(authorityLayer.status).toBe(404);
+        expect(await authorityLayer.json()).toMatchObject({
+          status: "rejected",
+          reason: "not-found",
+        });
+
+        const readResponse = await fetch(readUrl(serverUrl, role), {
+          headers: { cookie: `__Host-${role}-session=${bearer}` },
+        });
+        expect(await readResponse.json()).not.toEqual({ error: "Authentication failed." });
+      });
+    });
+  }
+
+  test("a weak Technical Admin fallback cannot use a valid Grant Session proof", async () => {
+    await withServer({}, async (serverUrl) => {
+      const bearer = "event-admin-session";
+      await expectGenericMutationFailure(
+        await fetch(mutationUrl(serverUrl, "event-admin"), {
+          method: "POST",
+          headers: {
+            ...mutationHeaders(
+              "event-admin",
+              bearer,
+              deriveGrantSessionCsrfToken("event-admin", bearer),
+            ),
+            cookie: `__Host-technical-admin=invalid-technical-session; __Host-event-admin-session=${bearer}`,
+          },
+        }),
+      );
+    });
+  });
+
+  test("Leave clears bearer and CSRF cookies together after the request boundary", async () => {
+    await withServer({}, async (serverUrl) => {
+      for (const role of ["event-admin", "pitch-manager"] as const) {
+        const bearer = `${role}-session`;
+        const response = await fetch(new URL(`/api/${role}/leave`, serverUrl), {
+          method: "POST",
+          headers: mutationHeaders(role, bearer, deriveGrantSessionCsrfToken(role, bearer)),
+        });
+        expect(response.status).toBe(401);
+        const cookies = response.headers.getAll("set-cookie");
+        expect(cookies).toHaveLength(2);
+        expect(cookies.every((cookie) => cookie.includes("Path=/"))).toBe(true);
+        expect(cookies.every((cookie) => cookie.includes("Max-Age=0"))).toBe(true);
+        expect(cookies.every((cookie) => cookie.includes("Secure"))).toBe(true);
+        expect(cookies.every((cookie) => cookie.includes("SameSite=Strict"))).toBe(true);
+        expect(cookies.some((cookie) => cookie.includes(`__Host-${role}-session=`))).toBe(true);
+        expect(cookies.some((cookie) => cookie.includes(`__Host-${role}-csrf=`))).toBe(true);
+      }
+    });
+  });
+});
+
+function mutationUrl(serverUrl: URL, role: GrantSessionCsrfRole): URL {
+  return new URL(
+    role === "event-admin"
+      ? "/api/event-admin/events/event/game-days/day/pitches/pitch/pitch-manager-grant"
+      : "/api/pitch-manager/events/event/game-days/day/pitches/pitch/pitch-slots/slot/control-grant",
+    serverUrl,
+  );
+}
+
+function readUrl(serverUrl: URL, role: GrantSessionCsrfRole): URL {
+  return new URL(
+    role === "event-admin"
+      ? "/api/event-admin/hub?eventId=event"
+      : "/api/pitch-manager/view?eventId=event&gameDayId=day&pitchId=pitch",
+    serverUrl,
+  );
+}
+
+function mutationHeaders(
+  role: GrantSessionCsrfRole,
+  bearer: string,
+  csrfToken: string,
+): Record<string, string> {
+  return {
+    host: "localhost",
+    origin: "https://localhost",
+    cookie: `__Host-${role}-session=${bearer}`,
+    [csrfHeader(role)]: csrfToken,
+  };
+}
+
+function csrfHeader(role: GrantSessionCsrfRole): string {
+  return role === "event-admin" ? EVENT_ADMIN_CSRF_HEADER : PITCH_MANAGER_CSRF_HEADER;
+}
+
+function otherRole(role: GrantSessionCsrfRole): GrantSessionCsrfRole {
+  return role === "event-admin" ? "pitch-manager" : "event-admin";
+}
+
+function withoutHeader(headers: Record<string, string>, omitted: string): Record<string, string> {
+  return Object.fromEntries(Object.entries(headers).filter(([name]) => name !== omitted));
+}
+
+async function expectGenericMutationFailure(response: Response) {
+  await expectSensitiveFailure(response, 401, { error: "Authentication failed." });
+}
+
 async function expectOversizedCredentialFailure(response: Response) {
   expect(response.status).toBe(413);
   expect(await response.text()).not.toContain(OVERSIZED_CREDENTIAL);
@@ -158,8 +348,11 @@ async function expectSensitiveFailure(
 }
 
 async function withServer(
-  options: { incompleteGrantKeys?: boolean },
-  work: (serverUrl: URL) => Promise<void>,
+  options: { incompleteGrantKeys?: boolean; seedGrants?: boolean },
+  work: (
+    serverUrl: URL,
+    credentials: { "event-admin": string; "pitch-manager": string } | null,
+  ) => Promise<void>,
 ): Promise<void> {
   const directory = mkdtempSync(join(tmpdir(), "quadball-event-admin-headers-"));
   const environment = Object.fromEntries(
@@ -182,7 +375,10 @@ async function withServer(
   } else {
     writeGrantKeyRingFile(grantKeyRingPath, createGrantKeyRingDocument("test"));
   }
-  delete environment.FOUNDATION_DATABASE;
+  const credentials = options.seedGrants
+    ? await seedGrantCredentials(directory, environment)
+    : null;
+  if (!options.seedGrants) delete environment.FOUNDATION_DATABASE;
   delete environment.GRANT_LOOKUP_KEY;
   delete environment.GRANT_AUDIT_KEY;
   delete environment.GRANT_ENCRYPTION_KEY;
@@ -202,12 +398,64 @@ async function withServer(
       expect(exitCode).not.toBe(0);
       return;
     }
-    const serverUrl = await readServerUrl(server.stdout);
-    await work(serverUrl);
+    const serverUrl = await readServerUrl(server.stdout).catch(async (error) => {
+      const stderr = await new Response(server.stderr).text();
+      throw new Error(`${String(error)}\n${stderr}`);
+    });
+    await work(serverUrl, credentials);
   } finally {
     server.kill();
     await server.exited;
     rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+async function seedGrantCredentials(
+  directory: string,
+  environment: Record<string, string>,
+): Promise<{ "event-admin": string; "pitch-manager": string }> {
+  const databasePath = join(directory, "foundation.sqlite");
+  environment.FOUNDATION_DATABASE = databasePath;
+  const grantOptions = readGrantAuthorityOptions("test", environment);
+  const storage = openSqliteFoundationStorage(databasePath, {
+    grantKeyRing: grantOptions.keyRing,
+  });
+  try {
+    await storage.applyMigrations({ requireCandidate: false });
+    const technicalAdminAuth = createTechnicalAdminAuth(
+      { environment: "test", origin: "https://localhost", rpId: "localhost" },
+      new MemoryTechnicalAdminAuthRepository(),
+    );
+    const technical = technicalAdminAuth.resolveHostLocalAuthority();
+    const catalog = createEventCatalog(createFoundationEventCatalogStorage(storage), {});
+    const grants = createGrantAuthority(storage, grantOptions);
+    const administration = createEventAdministration({ storage, grants, catalog });
+    const event = await catalog.createEvent({ name: "CSRF fixture", timeZone: "UTC" }, technical);
+    if (event.status !== "accepted") throw new Error("Expected seeded Event.");
+    const day = await catalog.addGameDay(event.value.eventId, { date: "2026-08-24" }, technical);
+    const pitch = await catalog.createPitch(event.value.eventId, { name: "Pitch" }, technical);
+    if (day.status !== "accepted" || pitch.status !== "accepted")
+      throw new Error("Expected seeded Event structure.");
+    const eventAdmin = await administration.createEventAdminGrant(event.value.eventId, technical);
+    const pitchManager = await administration.createPitchManagerGrant(
+      event.value.eventId,
+      day.value.gameDayId,
+      pitch.value.pitchId,
+      technical,
+    );
+    if (eventAdmin.status !== "accepted" || pitchManager.status !== "accepted")
+      throw new Error("Expected seeded Grants.");
+    const eventAdminSecret = await grants.revealGrant(eventAdmin.value.grantId, technical);
+    const pitchManagerSecret = await grants.revealGrant(pitchManager.value.grantId, technical);
+    if (eventAdminSecret.status !== "revealed" || pitchManagerSecret.status !== "revealed")
+      throw new Error("Expected seeded Grant credentials.");
+    technicalAdminAuth.close();
+    return {
+      "event-admin": eventAdminSecret.qrCredential,
+      "pitch-manager": pitchManagerSecret.qrCredential,
+    };
+  } finally {
+    storage.close();
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,15 @@ import { createHash, randomBytes } from "node:crypto";
 import { dirname } from "node:path";
 import index from "./index.html";
 import { readJsonBodyWithinLimit } from "@/lib/http-body";
+import {
+  deriveGrantSessionCsrfToken,
+  EVENT_ADMIN_CSRF_COOKIE,
+  EVENT_ADMIN_CSRF_HEADER,
+  PITCH_MANAGER_CSRF_COOKIE,
+  PITCH_MANAGER_CSRF_HEADER,
+  verifyGrantSessionCsrfToken,
+  type GrantSessionCsrfRole,
+} from "@/lib/grant-session-csrf";
 import { collectHtmlBundleAssetPaths } from "@/lib/html-bundle-assets";
 import { isInternalHealthHost } from "@/lib/internal-health";
 import { SHARED_LIMITS } from "@/lib/validation-policy";
@@ -467,7 +476,7 @@ async function startServer() {
         | "reactivatePitchManagerGrant",
     ) => {
       if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
-      const authority = resolveEventAdministrationAuthority(req, technicalAdminAuth);
+      const authority = resolveEventAdministrationMutationAuthority(req, technicalAdminAuth);
       const path = new URL(req.url).pathname.split("/");
       if (authority === null) return sensitiveGenericAuthFailure(401);
       const result =
@@ -557,7 +566,10 @@ async function startServer() {
       operation: "inspect" | "create" | "replace" | "disable",
     ) => {
       if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
-      const authority = resolveEventAdministrationAuthority(req, technicalAdminAuth);
+      const authority =
+        operation === "inspect"
+          ? resolveEventAdministrationAuthority(req, technicalAdminAuth)
+          : resolveEventAdministrationMutationAuthority(req, technicalAdminAuth);
       const path = new URL(req.url).pathname.split("/");
       if (authority === null) return sensitiveGenericAuthFailure(401);
       const common = [path[4] ?? "", path[6] ?? "", path[8] ?? ""] as const;
@@ -585,9 +597,13 @@ async function startServer() {
     ) => {
       if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
       const authority =
-        audience === "pitch-manager"
-          ? resolvePitchManagerAuthority(req, technicalAdminAuth)
-          : resolveEventAdministrationAuthority(req, technicalAdminAuth);
+        operation === "inspect"
+          ? audience === "pitch-manager"
+            ? resolvePitchManagerAuthority(req, technicalAdminAuth)
+            : resolveEventAdministrationAuthority(req, technicalAdminAuth)
+          : audience === "pitch-manager"
+            ? resolvePitchManagerMutationAuthority(req, technicalAdminAuth)
+            : resolveEventAdministrationMutationAuthority(req, technicalAdminAuth);
       const path = new URL(req.url).pathname.split("/");
       if (authority === null) return sensitiveGenericAuthFailure(401);
       const common = [path[4] ?? "", path[6] ?? "", path[8] ?? "", path[10] ?? ""] as const;
@@ -1301,10 +1317,16 @@ async function startServer() {
               ["set-cookie", eventAdminContextCookie(context)],
             ];
             if (typeof result.sessionExpiresAtMs === "number")
-              sessionHeaders.push([
-                "set-cookie",
-                eventAdminSessionCookie(result.sessionBearer, result.sessionExpiresAtMs),
-              ]);
+              sessionHeaders.push(
+                [
+                  "set-cookie",
+                  eventAdminSessionCookie(result.sessionBearer, result.sessionExpiresAtMs),
+                ],
+                [
+                  "set-cookie",
+                  eventAdminCsrfCookie(result.sessionBearer, result.sessionExpiresAtMs),
+                ],
+              );
             return sensitiveJson(
               {
                 status: "admitted",
@@ -1324,7 +1346,10 @@ async function startServer() {
           {
             async POST(req: Request) {
               if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
-              const authority = resolveEventAdministrationAuthority(req, technicalAdminAuth);
+              const authority = resolveEventAdministrationMutationAuthority(
+                req,
+                technicalAdminAuth,
+              );
               if (authority === null) return sensitiveGenericAuthFailure(401);
               const body = await readJsonRecord(req);
               if (body === null) return sensitiveEventAdministrationResponse(invalidEventBody());
@@ -1348,7 +1373,10 @@ async function startServer() {
           {
             async POST(req: Request) {
               if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
-              const authority = resolveEventAdministrationAuthority(req, technicalAdminAuth);
+              const authority = resolveEventAdministrationMutationAuthority(
+                req,
+                technicalAdminAuth,
+              );
               if (authority === null) return sensitiveGenericAuthFailure(401);
               const body = await readJsonRecord(req);
               if (body === null) return sensitiveEventAdministrationResponse(invalidEventBody());
@@ -1366,7 +1394,7 @@ async function startServer() {
         "/api/event-admin/events/:eventId/game-days/:gameDayId/event-games/:eventGameId/reopen": {
           async POST(req: Request) {
             if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
-            const authority = resolveEventAdministrationAuthority(req, technicalAdminAuth);
+            const authority = resolveEventAdministrationMutationAuthority(req, technicalAdminAuth);
             if (authority === null) return sensitiveGenericAuthFailure(401);
             const body = await readJsonRecord(req);
             if (body === null) return sensitiveEventAdministrationResponse(invalidEventBody());
@@ -1385,7 +1413,10 @@ async function startServer() {
           {
             async POST(req: Request) {
               if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
-              const authority = resolveEventAdministrationAuthority(req, technicalAdminAuth);
+              const authority = resolveEventAdministrationMutationAuthority(
+                req,
+                technicalAdminAuth,
+              );
               if (authority === null) return sensitiveGenericAuthFailure(401);
               const body = await readJsonRecord(req);
               if (body === null) return sensitiveEventAdministrationResponse(invalidEventBody());
@@ -1418,7 +1449,10 @@ async function startServer() {
             },
             async POST(req: Request) {
               if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
-              const authority = resolveEventAdministrationAuthority(req, technicalAdminAuth);
+              const authority = resolveEventAdministrationMutationAuthority(
+                req,
+                technicalAdminAuth,
+              );
               const path = new URL(req.url).pathname.split("/");
               if (authority === null) return sensitiveGenericAuthFailure(401);
               return sensitiveEventAdministrationMutationResponse(
@@ -1481,7 +1515,10 @@ async function startServer() {
             },
             async POST(req: Request) {
               if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
-              const authority = resolveEventAdministrationAuthority(req, technicalAdminAuth);
+              const authority = resolveEventAdministrationMutationAuthority(
+                req,
+                technicalAdminAuth,
+              );
               const path = new URL(req.url).pathname.split("/");
               if (authority === null) return sensitiveGenericAuthFailure(401);
               return sensitiveEventAdministrationMutationResponse(
@@ -1502,7 +1539,8 @@ async function startServer() {
             POST: (req: Request) =>
               controlGrantMutation(
                 req,
-                (request) => resolveEventAdministrationAuthority(request, technicalAdminAuth),
+                (request) =>
+                  resolveEventAdministrationMutationAuthority(request, technicalAdminAuth),
                 "reveal",
               ),
           },
@@ -1520,7 +1558,8 @@ async function startServer() {
             POST: (req: Request) =>
               controlGrantMutation(
                 req,
-                (request) => resolveEventAdministrationAuthority(request, technicalAdminAuth),
+                (request) =>
+                  resolveEventAdministrationMutationAuthority(request, technicalAdminAuth),
                 "rotate",
               ),
           },
@@ -1547,7 +1586,8 @@ async function startServer() {
             POST: (req: Request) =>
               controlGrantMutation(
                 req,
-                (request) => resolveEventAdministrationAuthority(request, technicalAdminAuth),
+                (request) =>
+                  resolveEventAdministrationMutationAuthority(request, technicalAdminAuth),
                 "revoke-session",
               ),
           },
@@ -1582,10 +1622,16 @@ async function startServer() {
               ["set-cookie", pitchManagerContextCookie(context)],
             ];
             if (typeof result.sessionExpiresAtMs === "number")
-              sessionHeaders.push([
-                "set-cookie",
-                pitchManagerSessionCookie(result.sessionBearer, result.sessionExpiresAtMs),
-              ]);
+              sessionHeaders.push(
+                [
+                  "set-cookie",
+                  pitchManagerSessionCookie(result.sessionBearer, result.sessionExpiresAtMs),
+                ],
+                [
+                  "set-cookie",
+                  pitchManagerCsrfCookie(result.sessionBearer, result.sessionExpiresAtMs),
+                ],
+              );
             return sensitiveJson(
               {
                 status: "admitted",
@@ -1648,7 +1694,7 @@ async function startServer() {
             },
             async POST(req: Request) {
               if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
-              const authority = resolvePitchManagerAuthority(req, technicalAdminAuth);
+              const authority = resolvePitchManagerMutationAuthority(req, technicalAdminAuth);
               const path = new URL(req.url).pathname.split("/");
               if (authority === null) return sensitiveGenericAuthFailure(401);
               return sensitiveEventAdministrationMutationResponse(
@@ -1670,7 +1716,7 @@ async function startServer() {
             POST: (req: Request) =>
               controlGrantMutation(
                 req,
-                (request) => resolvePitchManagerAuthority(request, technicalAdminAuth),
+                (request) => resolvePitchManagerMutationAuthority(request, technicalAdminAuth),
                 "reveal",
                 "pitch-manager",
               ),
@@ -1680,7 +1726,7 @@ async function startServer() {
             POST: (req: Request) =>
               controlGrantMutation(
                 req,
-                (request) => resolvePitchManagerAuthority(request, technicalAdminAuth),
+                (request) => resolvePitchManagerMutationAuthority(request, technicalAdminAuth),
                 "rotate",
                 "pitch-manager",
               ),
@@ -1708,7 +1754,7 @@ async function startServer() {
             POST: (req: Request) =>
               controlGrantMutation(
                 req,
-                (request) => resolvePitchManagerAuthority(request, technicalAdminAuth),
+                (request) => resolvePitchManagerMutationAuthority(request, technicalAdminAuth),
                 "revoke-session",
                 "pitch-manager",
               ),
@@ -1716,11 +1762,14 @@ async function startServer() {
         "/api/pitch-manager/leave": {
           async POST(req: Request) {
             if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
-            const sessionBearer = readPitchManagerSession(req.headers.get("cookie"));
-            if (sessionBearer === null) return sensitiveGenericAuthFailure(401);
-            const result = await eventAdministration.leavePitchManagerSession(sessionBearer);
+            const authority = resolvePitchManagerMutationAuthority(req, technicalAdminAuth);
+            if (authority?.kind !== "grant-session") return sensitiveGenericAuthFailure(401);
+            const result = await eventAdministration.leavePitchManagerSession(
+              authority.sessionBearer,
+            );
             return sensitiveJson(result, result.status === "updated" ? 200 : 401, [
               ["set-cookie", clearPitchManagerSessionCookie()],
+              ["set-cookie", clearPitchManagerCsrfCookie()],
             ]);
           },
         },
@@ -1784,7 +1833,7 @@ async function startServer() {
         "/api/event-admin/events/:eventId/access-sheets": {
           async POST(req: Request) {
             if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
-            const authority = resolveEventAdministrationAuthority(req, technicalAdminAuth);
+            const authority = resolveEventAdministrationMutationAuthority(req, technicalAdminAuth);
             const body = await readJsonRecord(req);
             const eventId = new URL(req.url).pathname.split("/").at(-2) ?? "";
             if (authority === null || body === null) return sensitiveGenericAuthFailure(401);
@@ -1805,7 +1854,7 @@ async function startServer() {
         "/api/event-admin/events/:eventId/publication-status": {
           async POST(req: Request) {
             if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
-            const authority = resolveEventAdministrationAuthority(req, technicalAdminAuth);
+            const authority = resolveEventAdministrationMutationAuthority(req, technicalAdminAuth);
             const body = await readJsonRecord(req);
             const eventId = new URL(req.url).pathname.split("/").at(-2) ?? "";
             if (authority === null || body === null) return sensitiveGenericAuthFailure(401);
@@ -1821,7 +1870,7 @@ async function startServer() {
         "/api/event-admin/events/:eventId/catalog-removal/preview": {
           async POST(req: Request) {
             if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
-            const authority = resolveEventAdministrationAuthority(req, technicalAdminAuth);
+            const authority = resolveEventAdministrationMutationAuthority(req, technicalAdminAuth);
             const body = await readJsonRecord(req);
             const eventId = new URL(req.url).pathname.split("/").at(-3) ?? "";
             if (authority === null) return sensitiveGenericAuthFailure(401);
@@ -1837,7 +1886,7 @@ async function startServer() {
         "/api/event-admin/events/:eventId/catalog-removal": {
           async DELETE(req: Request) {
             if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
-            const authority = resolveEventAdministrationAuthority(req, technicalAdminAuth);
+            const authority = resolveEventAdministrationMutationAuthority(req, technicalAdminAuth);
             const body = await readJsonRecord(req);
             const eventId = new URL(req.url).pathname.split("/").at(-2) ?? "";
             if (authority === null) return sensitiveGenericAuthFailure(401);
@@ -1859,7 +1908,7 @@ async function startServer() {
         "/api/event-admin/events/:eventId/teams": {
           async POST(req: Request) {
             if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
-            const authority = resolveEventAdministrationAuthority(req, technicalAdminAuth);
+            const authority = resolveEventAdministrationMutationAuthority(req, technicalAdminAuth);
             const body = await readJsonRecord(req);
             const eventId = new URL(req.url).pathname.split("/").at(-2) ?? "";
             if (authority === null || body === null) return sensitiveGenericAuthFailure(401);
@@ -1877,7 +1926,7 @@ async function startServer() {
         "/api/event-admin/events/:eventId/teams/:eventTeamId": {
           async PATCH(req: Request) {
             if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
-            const authority = resolveEventAdministrationAuthority(req, technicalAdminAuth);
+            const authority = resolveEventAdministrationMutationAuthority(req, technicalAdminAuth);
             const body = await readJsonRecord(req);
             const path = new URL(req.url).pathname.split("/");
             if (authority === null || body === null) return sensitiveGenericAuthFailure(401);
@@ -1895,7 +1944,7 @@ async function startServer() {
         "/api/event-admin/events/:eventId/teams/:eventTeamId/roster": {
           async PUT(req: Request) {
             if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
-            const authority = resolveEventAdministrationAuthority(req, technicalAdminAuth);
+            const authority = resolveEventAdministrationMutationAuthority(req, technicalAdminAuth);
             const body = await readJsonRecord(req);
             const path = new URL(req.url).pathname.split("/");
             if (authority === null || body === null) return sensitiveGenericAuthFailure(401);
@@ -1913,7 +1962,7 @@ async function startServer() {
         "/api/event-admin/events/:eventId/pitches": {
           async POST(req: Request) {
             if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
-            const authority = resolveEventAdministrationAuthority(req, technicalAdminAuth);
+            const authority = resolveEventAdministrationMutationAuthority(req, technicalAdminAuth);
             const body = await readJsonRecord(req);
             const eventId = new URL(req.url).pathname.split("/").at(-2) ?? "";
             if (authority === null || body === null) return sensitiveGenericAuthFailure(401);
@@ -1927,7 +1976,7 @@ async function startServer() {
         "/api/event-admin/events/:eventId/pitches/:pitchId": {
           async PATCH(req: Request) {
             if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
-            const authority = resolveEventAdministrationAuthority(req, technicalAdminAuth);
+            const authority = resolveEventAdministrationMutationAuthority(req, technicalAdminAuth);
             const body = await readJsonRecord(req);
             const path = new URL(req.url).pathname.split("/");
             if (authority === null || body === null) return sensitiveGenericAuthFailure(401);
@@ -1945,7 +1994,7 @@ async function startServer() {
         "/api/event-admin/events/:eventId/game-days/:gameDayId/gameplay-slots": {
           async POST(req: Request) {
             if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
-            const authority = resolveEventAdministrationAuthority(req, technicalAdminAuth);
+            const authority = resolveEventAdministrationMutationAuthority(req, technicalAdminAuth);
             const body = await readJsonRecord(req);
             const path = new URL(req.url).pathname.split("/");
             if (authority === null || body === null) return sensitiveGenericAuthFailure(401);
@@ -1967,7 +2016,7 @@ async function startServer() {
         "/api/event-admin/events/:eventId/game-days/:gameDayId/heat-stoppage-configuration": {
           async PATCH(req: Request) {
             if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
-            const authority = resolveEventAdministrationAuthority(req, technicalAdminAuth);
+            const authority = resolveEventAdministrationMutationAuthority(req, technicalAdminAuth);
             const body = await readJsonRecord(req);
             const path = new URL(req.url).pathname.split("/");
             if (authority === null || body === null) return sensitiveGenericAuthFailure(401);
@@ -1985,7 +2034,7 @@ async function startServer() {
         "/api/event-admin/events/:eventId/game-days/:gameDayId/event-games": {
           async POST(req: Request) {
             if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
-            const authority = resolveEventAdministrationAuthority(req, technicalAdminAuth);
+            const authority = resolveEventAdministrationMutationAuthority(req, technicalAdminAuth);
             const body = await readJsonRecord(req);
             const path = new URL(req.url).pathname.split("/");
             if (authority === null || body === null) return sensitiveGenericAuthFailure(401);
@@ -2012,7 +2061,10 @@ async function startServer() {
           {
             async POST(req: Request) {
               if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
-              const authority = resolveEventAdministrationAuthority(req, technicalAdminAuth);
+              const authority = resolveEventAdministrationMutationAuthority(
+                req,
+                technicalAdminAuth,
+              );
               const body = await readJsonRecord(req);
               const path = new URL(req.url).pathname.split("/");
               if (authority === null || body === null) return sensitiveGenericAuthFailure(401);
@@ -2032,7 +2084,10 @@ async function startServer() {
           {
             async POST(req: Request) {
               if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
-              const authority = resolveEventAdministrationAuthority(req, technicalAdminAuth);
+              const authority = resolveEventAdministrationMutationAuthority(
+                req,
+                technicalAdminAuth,
+              );
               const body = await readJsonRecord(req);
               const path = new URL(req.url).pathname.split("/");
               if (authority === null || body === null) return sensitiveGenericAuthFailure(401);
@@ -2052,7 +2107,10 @@ async function startServer() {
           {
             async POST(req: Request) {
               if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
-              const authority = resolveEventAdministrationAuthority(req, technicalAdminAuth);
+              const authority = resolveEventAdministrationMutationAuthority(
+                req,
+                technicalAdminAuth,
+              );
               const body = await readJsonRecord(req);
               const path = new URL(req.url).pathname.split("/");
               if (authority === null || body === null) return sensitiveGenericAuthFailure(401);
@@ -2071,7 +2129,10 @@ async function startServer() {
           {
             async POST(req: Request) {
               if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
-              const authority = resolveEventAdministrationAuthority(req, technicalAdminAuth);
+              const authority = resolveEventAdministrationMutationAuthority(
+                req,
+                technicalAdminAuth,
+              );
               const body = await readJsonRecord(req);
               const path = new URL(req.url).pathname.split("/");
               if (authority === null || body === null) return sensitiveGenericAuthFailure(401);
@@ -2091,7 +2152,10 @@ async function startServer() {
           {
             async POST(req: Request) {
               if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
-              const authority = resolveEventAdministrationAuthority(req, technicalAdminAuth);
+              const authority = resolveEventAdministrationMutationAuthority(
+                req,
+                technicalAdminAuth,
+              );
               const body = await readJsonRecord(req);
               const path = new URL(req.url).pathname.split("/");
               if (authority === null || body === null) return sensitiveGenericAuthFailure(401);
@@ -2109,7 +2173,7 @@ async function startServer() {
         "/api/event-admin/events/:eventId/game-days/:gameDayId/event-games/:eventGameId/reassign": {
           async POST(req: Request) {
             if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
-            const authority = resolveEventAdministrationAuthority(req, technicalAdminAuth);
+            const authority = resolveEventAdministrationMutationAuthority(req, technicalAdminAuth);
             const body = await readJsonRecord(req);
             const path = new URL(req.url).pathname.split("/");
             if (authority === null || body === null) return sensitiveGenericAuthFailure(401);
@@ -2128,7 +2192,7 @@ async function startServer() {
         "/api/event-admin/events/:eventId/game-days/:gameDayId/event-games/:eventGameId/identity": {
           async POST(req: Request) {
             if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
-            const authority = resolveEventAdministrationAuthority(req, technicalAdminAuth);
+            const authority = resolveEventAdministrationMutationAuthority(req, technicalAdminAuth);
             const body = await readJsonRecord(req);
             const path = new URL(req.url).pathname.split("/");
             if (authority === null || body === null) return sensitiveGenericAuthFailure(401);
@@ -2153,7 +2217,7 @@ async function startServer() {
         "/api/event-admin/events/:eventId/event-games/:eventGameId/presentation": {
           async POST(req: Request) {
             if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
-            const authority = resolveEventAdministrationAuthority(req, technicalAdminAuth);
+            const authority = resolveEventAdministrationMutationAuthority(req, technicalAdminAuth);
             const body = await readJsonRecord(req);
             const path = new URL(req.url).pathname.split("/");
             if (authority === null || body === null) return sensitiveGenericAuthFailure(401);
@@ -2206,12 +2270,15 @@ async function startServer() {
         },
         "/api/event-admin/leave": {
           async POST(req: Request) {
-            if (eventAdministration === null) return genericAuthFailure(503);
-            const sessionBearer = readEventAdminSession(req.headers.get("cookie"));
-            if (sessionBearer === null) return genericAuthFailure(401);
-            const result = await eventAdministration.leaveEventAdminSession(sessionBearer);
+            if (eventAdministration === null) return sensitiveGenericAuthFailure(503);
+            const authority = resolveEventAdministrationMutationAuthority(req, technicalAdminAuth);
+            if (authority?.kind !== "grant-session") return sensitiveGenericAuthFailure(401);
+            const result = await eventAdministration.leaveEventAdminSession(
+              authority.sessionBearer,
+            );
             return sensitiveJson(result, result.status === "updated" ? 200 : 401, [
               ["set-cookie", clearEventAdminSessionCookie()],
+              ["set-cookie", clearEventAdminCsrfCookie()],
             ]);
           },
         },
@@ -3227,6 +3294,8 @@ function sensitiveJson(
 }
 
 async function readJsonRecord(req: Request): Promise<Record<string, unknown> | null> {
+  const contentType = req.headers.get("content-type")?.split(";", 1)[0]?.trim().toLowerCase();
+  if (contentType !== "application/json") return null;
   const result = await readJsonBodyWithinLimit(req);
   return result.ok && isRecord(result.body) ? result.body : null;
 }
@@ -3419,6 +3488,12 @@ function sensitiveEventAdministrationMutationResponse<T>(
               ? pitchManagerSessionCookie(authority.sessionBearer, result.sessionExpiresAtMs)
               : eventAdminSessionCookie(authority.sessionBearer, result.sessionExpiresAtMs),
           ],
+          [
+            "set-cookie",
+            audience === "pitch-manager"
+              ? pitchManagerCsrfCookie(authority.sessionBearer, result.sessionExpiresAtMs)
+              : eventAdminCsrfCookie(authority.sessionBearer, result.sessionExpiresAtMs),
+          ],
         ]
       : [];
   return sensitiveEventAdministrationResponse(result, acceptedStatus, refreshHeaders);
@@ -3455,6 +3530,42 @@ function resolvePitchManagerAuthority(
   if (technical !== null) return technical;
   const sessionBearer = readPitchManagerSession(req.headers.get("cookie"));
   return sessionBearer === null ? null : { kind: "grant-session", sessionBearer };
+}
+
+function resolveEventAdministrationMutationAuthority(
+  req: Request,
+  technicalAdminAuth: ReturnType<typeof createTechnicalAdminAuth>,
+): EventAdministrationAuthority | null {
+  return resolveMutationAuthority(req, technicalAdminAuth, "event-admin");
+}
+
+function resolvePitchManagerMutationAuthority(
+  req: Request,
+  technicalAdminAuth: ReturnType<typeof createTechnicalAdminAuth>,
+): EventAdministrationAuthority | null {
+  return resolveMutationAuthority(req, technicalAdminAuth, "pitch-manager");
+}
+
+function resolveMutationAuthority(
+  req: Request,
+  technicalAdminAuth: ReturnType<typeof createTechnicalAdminAuth>,
+  role: GrantSessionCsrfRole,
+): EventAdministrationAuthority | null {
+  if (!technicalAdminAuth.isExpectedBinding(requestBinding(req))) return null;
+  const cookieHeader = req.headers.get("cookie");
+  if (readTechnicalAdminCookie(cookieHeader) !== null) {
+    return requireTechnicalAdminMutationToken(req, technicalAdminAuth);
+  }
+  const sessionBearer =
+    role === "event-admin"
+      ? readEventAdminSession(cookieHeader)
+      : readPitchManagerSession(cookieHeader);
+  const csrfToken = req.headers.get(
+    role === "event-admin" ? EVENT_ADMIN_CSRF_HEADER : PITCH_MANAGER_CSRF_HEADER,
+  );
+  if (sessionBearer === null || !verifyGrantSessionCsrfToken(role, sessionBearer, csrfToken))
+    return null;
+  return { kind: "grant-session", sessionBearer };
 }
 
 function readEventAdminContext(header: string | null): string | null {
@@ -3494,6 +3605,10 @@ function eventAdminSessionCookie(value: string, expiresAtMs: number): string {
   return `__Host-event-admin-session=${encodeURIComponent(value)}; Path=/; Max-Age=${maxAgeSeconds}; HttpOnly; Secure; SameSite=Strict`;
 }
 
+function eventAdminCsrfCookie(sessionBearer: string, expiresAtMs: number): string {
+  return grantSessionCsrfCookie("event-admin", sessionBearer, expiresAtMs);
+}
+
 function pitchManagerContextCookie(value: string): string {
   return `__Host-pitch-manager-context=${encodeURIComponent(value)}; Path=/; HttpOnly; Secure; SameSite=Strict`;
 }
@@ -3503,12 +3618,39 @@ function pitchManagerSessionCookie(value: string, expiresAtMs: number): string {
   return `__Host-pitch-manager-session=${encodeURIComponent(value)}; Path=/; Max-Age=${maxAgeSeconds}; HttpOnly; Secure; SameSite=Strict`;
 }
 
+function pitchManagerCsrfCookie(sessionBearer: string, expiresAtMs: number): string {
+  return grantSessionCsrfCookie("pitch-manager", sessionBearer, expiresAtMs);
+}
+
+function grantSessionCsrfCookie(
+  role: GrantSessionCsrfRole,
+  sessionBearer: string,
+  expiresAtMs: number,
+): string {
+  const maxAgeSeconds = Math.max(
+    0,
+    role === "event-admin"
+      ? Math.min(2_592_000, Math.ceil((expiresAtMs - Date.now()) / 1_000))
+      : Math.ceil((expiresAtMs - Date.now()) / 1_000),
+  );
+  const name = role === "event-admin" ? EVENT_ADMIN_CSRF_COOKIE : PITCH_MANAGER_CSRF_COOKIE;
+  return `${name}=${deriveGrantSessionCsrfToken(role, sessionBearer)}; Path=/; Max-Age=${maxAgeSeconds}; Secure; SameSite=Strict`;
+}
+
 function clearEventAdminSessionCookie(): string {
   return "__Host-event-admin-session=; Path=/; Max-Age=0; HttpOnly; Secure; SameSite=Strict";
 }
 
+function clearEventAdminCsrfCookie(): string {
+  return `${EVENT_ADMIN_CSRF_COOKIE}=; Path=/; Max-Age=0; Secure; SameSite=Strict`;
+}
+
 function clearPitchManagerSessionCookie(): string {
   return "__Host-pitch-manager-session=; Path=/; Max-Age=0; HttpOnly; Secure; SameSite=Strict";
+}
+
+function clearPitchManagerCsrfCookie(): string {
+  return `${PITCH_MANAGER_CSRF_COOKIE}=; Path=/; Max-Age=0; Secure; SameSite=Strict`;
 }
 
 function readRuntimeCapacity(value: string | undefined, fallback: number): number {

--- a/src/lib/grant-session-csrf.test.ts
+++ b/src/lib/grant-session-csrf.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import { deriveGrantSessionCsrfToken, verifyGrantSessionCsrfToken } from "@/lib/grant-session-csrf";
+
+describe("Grant Session CSRF", () => {
+  test("derives deterministic opaque tokens separated by session and role", () => {
+    const bearer = "event-admin-session-bearer";
+    const first = deriveGrantSessionCsrfToken("event-admin", bearer);
+
+    expect(deriveGrantSessionCsrfToken("event-admin", bearer)).toBe(first);
+    expect(deriveGrantSessionCsrfToken("event-admin", "another-session-bearer")).not.toBe(first);
+    expect(deriveGrantSessionCsrfToken("pitch-manager", bearer)).not.toBe(first);
+    expect(first).not.toContain(bearer);
+  });
+
+  test("rejects missing, malformed, wrong-session, and wrong-role proofs", () => {
+    const token = deriveGrantSessionCsrfToken("event-admin", "session-a");
+
+    expect(verifyGrantSessionCsrfToken("event-admin", "session-a", token)).toBe(true);
+    expect(verifyGrantSessionCsrfToken("event-admin", "session-b", token)).toBe(false);
+    expect(verifyGrantSessionCsrfToken("pitch-manager", "session-a", token)).toBe(false);
+    expect(verifyGrantSessionCsrfToken("event-admin", "session-a", null)).toBe(false);
+    expect(verifyGrantSessionCsrfToken("event-admin", "session-a", "not-base64url")).toBe(false);
+    expect(verifyGrantSessionCsrfToken("event-admin", null, token)).toBe(false);
+    expect(verifyGrantSessionCsrfToken("event-admin", "", token)).toBe(false);
+    expect(() => deriveGrantSessionCsrfToken("event-admin", "")).toThrow();
+  });
+});

--- a/src/lib/grant-session-csrf.ts
+++ b/src/lib/grant-session-csrf.ts
@@ -1,0 +1,40 @@
+import { createHash, timingSafeEqual } from "node:crypto";
+
+export type GrantSessionCsrfRole = "event-admin" | "pitch-manager";
+
+export const EVENT_ADMIN_CSRF_COOKIE = "__Host-event-admin-csrf";
+export const EVENT_ADMIN_CSRF_HEADER = "x-event-admin-csrf";
+export const PITCH_MANAGER_CSRF_COOKIE = "__Host-pitch-manager-csrf";
+export const PITCH_MANAGER_CSRF_HEADER = "x-pitch-manager-csrf";
+
+const TOKEN_PATTERN = /^[A-Za-z0-9_-]{43}$/u;
+const INVALID_TOKEN_BYTES = Buffer.alloc(32);
+
+export function deriveGrantSessionCsrfToken(
+  role: GrantSessionCsrfRole,
+  sessionBearer: string,
+): string {
+  if (sessionBearer.length === 0) throw new Error("A Grant Session bearer is required.");
+  return csrfDigest(role, sessionBearer).toString("base64url");
+}
+
+export function verifyGrantSessionCsrfToken(
+  role: GrantSessionCsrfRole,
+  sessionBearer: string | null,
+  token: string | null,
+): boolean {
+  if (sessionBearer === null || sessionBearer.length === 0) return false;
+  const expected = csrfDigest(role, sessionBearer);
+  const wellFormed = token !== null && TOKEN_PATTERN.test(token);
+  const supplied = wellFormed ? Buffer.from(token, "base64url") : INVALID_TOKEN_BYTES;
+  return timingSafeEqual(expected, supplied) && wellFormed;
+}
+
+function csrfDigest(role: GrantSessionCsrfRole, sessionBearer: string): Buffer {
+  return createHash("sha256")
+    .update("quadball-timer:grant-session-csrf:v1\0", "utf8")
+    .update(role, "utf8")
+    .update("\0", "utf8")
+    .update(sessionBearer, "utf8")
+    .digest();
+}

--- a/src/pages/event-admin-page.tsx
+++ b/src/pages/event-admin-page.tsx
@@ -293,6 +293,7 @@ export function EventAdminPage({
 }: {
   qrRenderer?: GrantQrRenderer;
 } = {}) {
+  const fetch = eventAdminFetch;
   const queryEventId = new URLSearchParams(window.location.search).get("eventId") ?? "";
   const [eventId, setEventId] = useState(queryEventId);
   const [credential, setCredential] = useState("");
@@ -3397,6 +3398,36 @@ export function EventAdminPage({
       </Card>
     </main>
   );
+}
+
+async function eventAdminFetch(input: RequestInfo | URL, init: RequestInit = {}) {
+  const method = (init.method ?? (input instanceof Request ? input.method : "GET")).toUpperCase();
+  const headers = new Headers(init.headers);
+  if (method !== "GET" && !requestPath(input).endsWith("/api/event-admin/admit")) {
+    const technicalAdminCsrf = readBrowserCookie("__Host-technical-admin-csrf");
+    const eventAdminCsrf = readBrowserCookie("__Host-event-admin-csrf");
+    if (technicalAdminCsrf !== null) {
+      headers.set("x-technical-admin-csrf", technicalAdminCsrf);
+    } else if (eventAdminCsrf !== null) {
+      headers.set("x-event-admin-csrf", eventAdminCsrf);
+    }
+  }
+  return globalThis.fetch(input, { ...init, headers });
+}
+
+function requestPath(input: RequestInfo | URL): string {
+  const value =
+    typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+  return new URL(value, window.location.href).pathname;
+}
+
+function readBrowserCookie(name: string): string | null {
+  const prefix = `${name}=`;
+  const value = document.cookie
+    .split(";")
+    .map((part) => part.trim())
+    .find((part) => part.startsWith(prefix));
+  return value === undefined ? null : value.slice(prefix.length);
 }
 
 function DelayPreviewView({

--- a/src/pages/grant-secret-lifecycle.test.tsx
+++ b/src/pages/grant-secret-lifecycle.test.tsx
@@ -190,14 +190,35 @@ describe("Grant secret UI lifecycle", () => {
   let fetchHandler: (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
 
   beforeEach(() => {
-    testWindow = new Window({ url: "http://timer.quadball.app/event-admin?eventId=event" });
+    testWindow = new Window({ url: "https://timer.quadball.app/event-admin?eventId=event" });
     Object.assign(globalThis, {
       window: testWindow,
       document: testWindow.document,
       navigator: testWindow.navigator,
-      fetch: (input: string | URL | Request, init?: RequestInit) => fetchHandler(input, init),
+      fetch: (input: string | URL | Request, init?: RequestInit) => {
+        const url =
+          typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+        const method = (init?.method ?? (input instanceof Request ? input.method : "GET"))
+          .toUpperCase()
+          .trim();
+        const headers = new Headers(init?.headers);
+        if (method !== "GET" && url.includes("/api/event-admin/")) {
+          expect(headers.get("x-event-admin-csrf")).toBe(
+            url.endsWith("/api/event-admin/admit") ? null : "event-admin-proof",
+          );
+        }
+        if (method !== "GET" && url.includes("/api/pitch-manager/")) {
+          expect(headers.get("x-pitch-manager-csrf")).toBe(
+            url.endsWith("/api/pitch-manager/admit") ? null : "pitch-manager-proof",
+          );
+        }
+        return fetchHandler(input, init);
+      },
     });
     (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    document.cookie = "__Host-event-admin-csrf=event-admin-proof; Path=/; Secure; SameSite=Strict";
+    document.cookie =
+      "__Host-pitch-manager-csrf=pitch-manager-proof; Path=/; Secure; SameSite=Strict";
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
@@ -211,8 +232,10 @@ describe("Grant secret UI lifecycle", () => {
       const url =
         typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       const method = init?.method ?? "GET";
-      if (url.endsWith("/api/event-admin/admit"))
+      if (url.endsWith("/api/event-admin/admit")) {
+        expect(new Headers(init?.headers).has("x-event-admin-csrf")).toBe(false);
         return json({ status: "admitted", sessionExpiresAtMs: 123_000 });
+      }
       if (url.includes("/api/event-admin/hub")) {
         hubCalls += 1;
         if (hubCalls === 1) return json({ status: "rejected" }, 401);
@@ -230,6 +253,7 @@ describe("Grant secret UI lifecycle", () => {
         });
       }
       if (url.includes("/heat-stoppage-configuration") && method === "PATCH") {
+        expect(new Headers(init?.headers).get("x-event-admin-csrf")).toBe("event-admin-proof");
         configurationUpdates += 1;
         const rawBody = typeof init?.body === "string" ? init.body : "";
         const body = JSON.parse(rawBody) as { configuration: typeof configuration };
@@ -829,8 +853,14 @@ describe("Grant secret UI lifecycle", () => {
           ? json({ status: "rejected", message: "Authentication failed." }, 401)
           : json({ status: "accepted", value: pitchManagerView });
       }
-      if (url.endsWith("/api/pitch-manager/admit")) return json({ status: "admitted" });
-      if (url.endsWith("/api/pitch-manager/leave")) return json({ status: "left" });
+      if (url.endsWith("/api/pitch-manager/admit")) {
+        expect(new Headers(init?.headers).has("x-pitch-manager-csrf")).toBe(false);
+        return json({ status: "admitted" });
+      }
+      if (url.endsWith("/api/pitch-manager/leave")) {
+        expect(new Headers(init?.headers).get("x-pitch-manager-csrf")).toBe("pitch-manager-proof");
+        return json({ status: "left" });
+      }
       if (url.endsWith("/control-grant") && method === "GET") {
         controlLookupCalls += 1;
         return controlLookupCalls === 1
@@ -855,7 +885,8 @@ describe("Grant secret UI lifecycle", () => {
             formatVersion: 1,
           },
         });
-      if (url.endsWith("/control-grant/rotate") && method === "POST")
+      if (url.endsWith("/control-grant/rotate") && method === "POST") {
+        expect(new Headers(init?.headers).get("x-pitch-manager-csrf")).toBe("pitch-manager-proof");
         return json({
           status: "accepted",
           value: {
@@ -864,6 +895,7 @@ describe("Grant secret UI lifecycle", () => {
             affectedSessionCount: 3,
           },
         });
+      }
       if (url.endsWith("/control-grant/sessions"))
         return json({ status: "retryable-failure" }, 503);
       throw new Error(`Unexpected request: ${method} ${url}`);

--- a/src/pages/pitch-manager-page.tsx
+++ b/src/pages/pitch-manager-page.tsx
@@ -70,6 +70,7 @@ export function PitchManagerPage({
 }: {
   qrRenderer?: GrantQrRenderer;
 } = {}) {
+  const fetch = pitchManagerFetch;
   const [credential, setCredential] = useState("");
   const [grantCode, setGrantCode] = useState("");
   const [scope, setScope] = useState<Scope | null>(null);
@@ -709,4 +710,34 @@ export function PitchManagerPage({
       </Card>
     </main>
   );
+}
+
+async function pitchManagerFetch(input: RequestInfo | URL, init: RequestInit = {}) {
+  const method = (init.method ?? (input instanceof Request ? input.method : "GET")).toUpperCase();
+  const headers = new Headers(init.headers);
+  if (method !== "GET" && !requestPath(input).endsWith("/api/pitch-manager/admit")) {
+    const technicalAdminCsrf = readBrowserCookie("__Host-technical-admin-csrf");
+    const pitchManagerCsrf = readBrowserCookie("__Host-pitch-manager-csrf");
+    if (technicalAdminCsrf !== null) {
+      headers.set("x-technical-admin-csrf", technicalAdminCsrf);
+    } else if (pitchManagerCsrf !== null) {
+      headers.set("x-pitch-manager-csrf", pitchManagerCsrf);
+    }
+  }
+  return globalThis.fetch(input, { ...init, headers });
+}
+
+function requestPath(input: RequestInfo | URL): string {
+  const value =
+    typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+  return new URL(value, window.location.href).pathname;
+}
+
+function readBrowserCookie(name: string): string | null {
+  const prefix = `${name}=`;
+  const value = document.cookie
+    .split(";")
+    .map((part) => part.trim())
+    .find((part) => part.startsWith(prefix));
+  return value === undefined ? null : value.slice(prefix.length);
 }


### PR DESCRIPTION
## Summary

- require exact Origin/Host binding for Event Admin and Pitch Manager mutations
- add role- and session-bound CSRF companion tokens while keeping bearer cookies `HttpOnly`
- require the full Technical Admin session and CSRF contract for fallback authority
- centralize privileged browser mutation headers and preserve read-only authority behavior

## Stack

Depends on #308.

## Verification

- `bun test --isolate ./src/lib/grant-session-csrf.test.ts` (2 passed)
- `bun test --isolate ./src/index-event-admin-headers.focused.ts` (10 passed)
- `bun test --isolate ./src/pages/grant-secret-lifecycle.test.tsx` (40 passed)
- complete-stack `bun run check`, `bun run test`, and `bun run build`
- complete-stack terminal security review found no actionable findings

Fixes #300

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
