### PR TITLE
Bound rejected Ad Hoc replay work

### DIFF
--- a/src/lib/ad-hoc-games.test.ts
+++ b/src/lib/ad-hoc-games.test.ts
@@ -6,6 +6,7 @@ import {
   type AdHocStore,
   type AdHocGamesService,
 } from "@/lib/ad-hoc-games";
+import { AD_HOC_MAX_RETAINED_REJECTED_OPERATIONS_PER_GAME } from "@/lib/ad-hoc-resource-budgets";
 import { applyGameCommand, createInitialGameState } from "@/lib/game-engine";
 import { deriveAdHocOptimisticState } from "@/lib/game-page-support";
 import type { AdHocPendingOperation } from "@/lib/ad-hoc-controller-session";
@@ -253,6 +254,158 @@ describe("Ad Hoc Games service", () => {
     expect(duplicate.status).toBe("duplicate");
     expect(
       (await games.read({ gameId: created.gameId, sessionId: created.sessionId })).status,
+    ).toBe("accepted");
+  });
+
+  test("returns duplicate acknowledgements without rewriting unchanged Game state", async () => {
+    const base = createInMemoryAdHocStore();
+    let mutationWrites = 0;
+    const store: AdHocStore = {
+      close: () => base.close(),
+      listGames: () => base.listGames(),
+      readGame: (gameId) => base.readGame(gameId),
+      createGame: (input) => base.createGame(input),
+      mutateGame: (gameId, mutation) =>
+        base.mutateGame(gameId, (game) => {
+          const result = mutation(game);
+          const rollsBack =
+            result !== null &&
+            typeof result === "object" &&
+            "rollback" in result &&
+            result.rollback === true;
+          if (result !== null && result !== false && !rollsBack) mutationWrites += 1;
+          return result;
+        }),
+    };
+    const games = createAdHocGamesService({ store, now: () => 1_000 });
+    const created = await games.create({ homeName: "Home", awayName: "Away" });
+    if (created.status !== "accepted") throw new Error("creation failed");
+    const operation = {
+      id: "no-write-duplicate",
+      clientSentAtMs: 1_000,
+      command: { type: "set-running", running: true } as const,
+    };
+    const accepted = await games.apply({
+      gameId: created.gameId,
+      sessionId: created.sessionId,
+      operations: [operation],
+    });
+    expect(accepted.status).toBe("accepted");
+    const beforeDuplicate = store.readGame(created.gameId);
+    const writesBeforeDuplicate = mutationWrites;
+
+    const duplicate = await games.apply({
+      gameId: created.gameId,
+      sessionId: created.sessionId,
+      operations: [operation],
+    });
+
+    expect(duplicate).toMatchObject({
+      status: "duplicate",
+      ackedOperationIds: [operation.id],
+      outcomes: [{ operationId: operation.id, status: "duplicate", workflow: "ad-hoc" }],
+    });
+    expect(mutationWrites).toBe(writesBeforeDuplicate);
+    expect(store.readGame(created.gameId)).toEqual(beforeDuplicate);
+    if (duplicate.status === "duplicate" && beforeDuplicate !== null)
+      expect(duplicate.game.state.updatedAtMs).toBe(beforeDuplicate.state.updatedAtMs);
+  });
+
+  test("bounds retained rejected evidence atomically without blocking accepted replay", async () => {
+    let nowMs = 1_000;
+    const games = createAdHocGamesService({ now: () => nowMs });
+    const created = await games.create({ homeName: "Home", awayName: "Away" });
+    if (created.status !== "accepted") throw new Error("creation failed");
+    const reject = (id: string, predecessorId: string) => ({
+      id,
+      clientSentAtMs: nowMs,
+      causalPredecessorIds: [predecessorId],
+      command: { type: "set-running", running: true } as const,
+    });
+    for (let offset = 0; offset < AD_HOC_MAX_RETAINED_REJECTED_OPERATIONS_PER_GAME; offset += 8) {
+      const operations = Array.from({ length: 8 }, (_, index) => {
+        const operationId = `retained-rejection-${offset + index}`;
+        if (offset === 8 && index === 1)
+          return {
+            id: operationId,
+            clientSentAtMs: nowMs,
+            causalPredecessorIds: ["retained-rejection-8"],
+            command: { type: "set-running", running: true } as const,
+          };
+        return reject(operationId, `missing-${offset + index}`);
+      });
+      const result = await games.apply({
+        gameId: created.gameId,
+        sessionId: created.sessionId,
+        operations,
+      });
+      expect(result.status).toBe("accepted");
+      nowMs += 1_000;
+    }
+    const atLimit = games.store.readGame(created.gameId);
+    expect(
+      Object.values(atLimit?.operations ?? {}).filter(
+        (operation) => operation.status !== "accepted",
+      ),
+    ).toHaveLength(AD_HOC_MAX_RETAINED_REJECTED_OPERATIONS_PER_GAME);
+    expect(atLimit?.operations["retained-rejection-9"]?.status).toBe("causally-blocked");
+
+    const overLimit = await games.apply({
+      gameId: created.gameId,
+      sessionId: created.sessionId,
+      operations: [reject("over-limit", "missing-over-limit")],
+    });
+    expect(overLimit).toMatchObject({ status: "rejected", reason: "rate-limited" });
+    expect(games.store.readGame(created.gameId)).toEqual(atLimit);
+
+    nowMs += 1_000;
+    const duplicateAtLimit = await games.apply({
+      gameId: created.gameId,
+      sessionId: created.sessionId,
+      operations: [
+        {
+          ...reject("retained-rejection-0", "missing-0"),
+          clientSentAtMs: 1_000,
+        },
+      ],
+    });
+    expect(duplicateAtLimit).toMatchObject({
+      status: "duplicate",
+      outcomes: [{ operationId: "retained-rejection-0", status: "rejected" }],
+    });
+
+    nowMs += 1_000;
+    const mixedBefore = games.store.readGame(created.gameId);
+    const mixed = await games.apply({
+      gameId: created.gameId,
+      sessionId: created.sessionId,
+      operations: [
+        {
+          id: "accepted-in-rejected-mix",
+          clientSentAtMs: nowMs,
+          command: { type: "set-running", running: true },
+        },
+        reject("rejected-in-mix", "missing-in-mix"),
+      ],
+    });
+    expect(mixed).toMatchObject({ status: "rejected", reason: "rate-limited" });
+    expect(games.store.readGame(created.gameId)).toEqual(mixedBefore);
+
+    nowMs += 1_000;
+    const accepted = await games.apply({
+      gameId: created.gameId,
+      sessionId: created.sessionId,
+      operations: [
+        {
+          id: "accepted-at-rejected-limit",
+          clientSentAtMs: nowMs,
+          command: { type: "set-running", running: true },
+        },
+      ],
+    });
+    expect(accepted).toMatchObject({ status: "accepted" });
+    expect(
+      games.store.readGame(created.gameId)?.operations["accepted-at-rejected-limit"]?.status,
     ).toBe("accepted");
   });
 

--- a/src/lib/ad-hoc-games.ts
+++ b/src/lib/ad-hoc-games.ts
@@ -38,6 +38,7 @@ import {
   AD_HOC_EVENT_RESERVED_CONNECTION_CAPACITY,
   AD_HOC_EVENT_TOTAL_CONNECTION_CAPACITY,
   AD_HOC_MAX_CONNECTED_CONTROLLERS,
+  AD_HOC_MAX_RETAINED_REJECTED_OPERATIONS_PER_GAME,
   AD_HOC_REPLAY_BURST,
   AD_HOC_REPLAY_MAX_OPERATIONS_PER_BATCH,
   AD_HOC_REPLAY_SUSTAINED_PER_SECOND,
@@ -165,11 +166,12 @@ type AdHocApplyMutationResult =
   | false
   | { invalid: true; rollback: true }
   | { conflict: true; operationId: string }
-  | { rateLimited: true; retryAfterMs: number }
+  | { rateLimited: true; retryAfterMs: number; rollback?: true }
   | {
       acknowledged: string[];
       duplicate: boolean;
       outcomes: readonly ControllerOperationOutcome[];
+      rollback?: true;
     };
 
 type PreparedReplayEntry = {
@@ -1107,7 +1109,6 @@ export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) 
         outcome = store.mutateGame<AdHocApplyMutationResult>(gameId, (game) => {
           if (game.environmentIdentity !== environmentIdentity || !hasSession(game, sessionId))
             return false;
-          const next = structuredClone(game) as StoredAdHocGame;
           const acknowledged: string[] = [];
           let duplicate = false;
           const parsed =
@@ -1118,11 +1119,13 @@ export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) 
             preparedChunk?.map((entry) => entry.operation) ??
             (parsed as Extract<typeof parsed, { ok: true }>).operations;
           const outcomes: ControllerOperationOutcome[] = [];
+          let conflictingOperationId: string | undefined;
           for (const operation of incoming) {
-            const existing = next.operations[operation.operationId];
+            const existing = game.operations[operation.operationId];
             if (existing !== undefined) {
               if (existing.fingerprint !== operationFingerprint(operation)) {
-                return { conflict: true, operationId: operation.operationId } as const;
+                conflictingOperationId ??= operation.operationId;
+                continue;
               }
               acknowledged.push(operation.operationId);
               duplicate = true;
@@ -1138,44 +1141,25 @@ export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) 
           const reconciledPreparedChunk =
             preparedChunk === undefined
               ? undefined
-              : reconcilePreparedReplayChunk(preparedChunk, next.operations);
-          const acceptedNewOperationCount =
-            preparedChunk === undefined
-              ? (() => {
-                  const retainedStatuses = new Map(
-                    Object.entries(next.operations).map(
-                      ([operationId, operation]) => [operationId, operation.status] as const,
-                    ),
-                  );
-                  const resolution = resolveControllerBatch({
-                    operations: incoming.filter(
-                      (operation) => next.operations[operation.operationId] === undefined,
-                    ),
-                    retainedStatuses,
-                  });
-                  return resolution.ordered.filter(
-                    (operation) => resolution.statuses.get(operation.operationId) === "accepted",
-                  ).length;
-                })()
-              : reconciledPreparedChunk!.filter(
-                  (entry) =>
-                    entry.status === "accepted" &&
-                    next.operations[entry.operation.operationId] === undefined,
-                ).length;
-          if (acceptedNewOperationCount > 0) {
+              : reconcilePreparedReplayChunk(preparedChunk, game.operations);
+          const unseenOperations = incoming.filter(
+            (operation) => game.operations[operation.operationId] === undefined,
+          );
+          const workCost = Math.max(1, unseenOperations.length);
+          {
             const controller = consumeAdHocTokens(
               controllerActionBuckets.get(sessionBucketKey),
               nowMs,
               AD_HOC_CONTROLLER_BURST,
               AD_HOC_CONTROLLER_SUSTAINED_PER_SECOND,
-              acceptedNewOperationCount,
+              workCost,
             );
             const gameBucket = consumeAdHocTokens(
               gameActionBuckets.get(gameId),
               nowMs,
               AD_HOC_GAME_BURST,
               AD_HOC_GAME_SUSTAINED_PER_SECOND,
-              acceptedNewOperationCount,
+              workCost,
             );
             const replay = consumeAdHocTokens(
               replayBuckets.get(sessionBucketKey),
@@ -1184,7 +1168,7 @@ export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) 
                 ? AD_HOC_REPLAY_BURST
                 : AD_HOC_REPLAY_MAX_OPERATIONS_PER_BATCH,
               AD_HOC_REPLAY_SUSTAINED_PER_SECOND,
-              acceptedNewOperationCount,
+              workCost,
             );
             if (!controller.accepted || !gameBucket.accepted || !replay.accepted) {
               const retryAfterMs = Math.max(
@@ -1197,6 +1181,53 @@ export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) 
             nextControllerBucket = controller.bucket;
             nextGameBucket = gameBucket.bucket;
             nextReplayBucket = replay.bucket;
+          }
+          if (conflictingOperationId !== undefined)
+            return { conflict: true, operationId: conflictingOperationId } as const;
+          if (unseenOperations.length === 0) {
+            const acknowledgement = createControllerReplayAcknowledgement({
+              workflow: "ad-hoc",
+              acknowledgedOperationIds: acknowledged,
+              outcomes,
+            });
+            return {
+              acknowledged: [...acknowledgement.acknowledgedOperationIds],
+              duplicate,
+              outcomes: acknowledgement.outcomes,
+              rollback: true,
+            } as const;
+          }
+          const next = structuredClone(game) as StoredAdHocGame;
+          const resolution =
+            preparedChunk === undefined
+              ? resolveControllerBatch({
+                  operations: unseenOperations,
+                  retainedStatuses: new Map(
+                    Object.entries(next.operations).map(
+                      ([operationId, operation]) => [operationId, operation.status] as const,
+                    ),
+                  ),
+                })
+              : undefined;
+          const newRejectedOperationCount =
+            preparedChunk === undefined
+              ? unseenOperations.filter(
+                  (operation) => resolution!.statuses.get(operation.operationId) !== "accepted",
+                ).length
+              : reconciledPreparedChunk!.filter(
+                  (entry) =>
+                    next.operations[entry.operation.operationId] === undefined &&
+                    entry.status !== "accepted" &&
+                    entry.status !== "duplicate",
+                ).length;
+          const retainedRejectedOperationCount = Object.values(next.operations).filter(
+            (operation) => operation.status !== "accepted",
+          ).length;
+          if (
+            retainedRejectedOperationCount + newRejectedOperationCount >
+            AD_HOC_MAX_RETAINED_REJECTED_OPERATIONS_PER_GAME
+          ) {
+            return { rateLimited: true, retryAfterMs: 1_000, rollback: true } as const;
           }
           if (preparedChunk !== undefined) {
             for (const entry of reconciledPreparedChunk!) {
@@ -1224,20 +1255,9 @@ export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) 
               acknowledged.push(operation.operationId);
             }
           } else {
-            const retainedStatuses = new Map(
-              Object.entries(next.operations).map(
-                ([operationId, operation]) => [operationId, operation.status] as const,
-              ),
-            );
-            const resolution = resolveControllerBatch({
-              operations: incoming.filter(
-                (operation) => next.operations[operation.operationId] === undefined,
-              ),
-              retainedStatuses,
-            });
-            for (const operation of resolution.ordered) {
-              const status = resolution.statuses.get(operation.operationId) ?? "rejected";
-              const detail = resolution.details.get(operation.operationId);
+            for (const operation of resolution!.ordered) {
+              const status = resolution!.statuses.get(operation.operationId) ?? "rejected";
+              const detail = resolution!.details.get(operation.operationId);
               next.operations[operation.operationId] =
                 status === "accepted"
                   ? {
@@ -1264,8 +1284,8 @@ export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) 
               )
                 continue;
               if (next.operations[operation.operationId] === undefined) {
-                const status = resolution.statuses.get(operation.operationId) ?? "rejected";
-                const detail = resolution.details.get(operation.operationId) ?? "Causal cycle.";
+                const status = resolution!.statuses.get(operation.operationId) ?? "rejected";
+                const detail = resolution!.details.get(operation.operationId) ?? "Causal cycle.";
                 next.operations[operation.operationId] = rejectedOperation(
                   operation,
                   nowMs,
@@ -1305,6 +1325,10 @@ export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) 
       }
       if (outcome === null || outcome === false)
         return { status: "rejected", reason: "unavailable" };
+      if (nextControllerBucket !== undefined)
+        controllerActionBuckets.set(sessionBucketKey, nextControllerBucket);
+      if (nextGameBucket !== undefined) gameActionBuckets.set(gameId, nextGameBucket);
+      if (nextReplayBucket !== undefined) replayBuckets.set(sessionBucketKey, nextReplayBucket);
       if ("rateLimited" in outcome) {
         metrics.actionRateExhausted += 1;
         metrics.replayPressure += outcome.retryAfterMs > 0 ? 1 : 0;
@@ -1337,10 +1361,6 @@ export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) 
         return { status: "rejected", reason: "unavailable" };
       }
       if (game === null) return { status: "rejected", reason: "unavailable" };
-      if (nextControllerBucket !== undefined)
-        controllerActionBuckets.set(sessionBucketKey, nextControllerBucket);
-      if (nextGameBucket !== undefined) gameActionBuckets.set(gameId, nextGameBucket);
-      if (nextReplayBucket !== undefined) replayBuckets.set(sessionBucketKey, nextReplayBucket);
       return {
         status: outcome.duplicate ? "duplicate" : "accepted",
         ackedOperationIds: outcome.acknowledged,

--- a/src/lib/ad-hoc-resource-budgets.test.ts
+++ b/src/lib/ad-hoc-resource-budgets.test.ts
@@ -6,6 +6,7 @@ import {
   AD_HOC_CONTROLLER_SUSTAINED_PER_SECOND,
   AD_HOC_GAME_BURST,
   AD_HOC_GAME_SUSTAINED_PER_SECOND,
+  AD_HOC_MAX_RETAINED_REJECTED_OPERATIONS_PER_GAME,
   AD_HOC_REPLAY_BURST,
   AD_HOC_REPLAY_SUSTAINED_PER_SECOND,
   adHocCreationDelayMs,
@@ -32,6 +33,10 @@ async function drainScheduled<T>(promise: Promise<T>, queue: (() => void)[]): Pr
 }
 
 describe("Ad Hoc resource budgets", () => {
+  test("bounds only retained rejected Ad Hoc replay evidence", () => {
+    expect(AD_HOC_MAX_RETAINED_REJECTED_OPERATIONS_PER_GAME).toBe(16);
+  });
+
   test("delays only later source attempts and caps the retry guidance", () => {
     expect(adHocCreationDelayMs(AD_HOC_CREATION_IMMEDIATE_ATTEMPTS - 1)).toBe(0);
     expect(adHocCreationDelayMs(AD_HOC_CREATION_IMMEDIATE_ATTEMPTS)).toBe(1_000);
@@ -202,7 +207,108 @@ describe("Ad Hoc resource budgets", () => {
     ).toBe("accepted");
   });
 
-  test("charges accepted operations only and keeps replay acknowledgement explicit", async () => {
+  test("charges fresh causal rejections and retains nothing after budget exhaustion", async () => {
+    const service = createAdHocGamesService({ now: () => 1_000 });
+    const created = await service.create({ homeName: "Home", awayName: "Away" });
+    if (created.status !== "accepted") throw new Error("creation failed");
+    const retained = await service.apply({
+      gameId: created.gameId,
+      sessionId: created.sessionId,
+      operations: Array.from(
+        { length: AD_HOC_MAX_RETAINED_REJECTED_OPERATIONS_PER_GAME },
+        (_, index) => ({
+          id: `retained-rejected-${index}`,
+          clientSentAtMs: 1_000,
+          causalPredecessorIds: [`retained-missing-${index}`],
+          command: { type: "set-running", running: true },
+        }),
+      ) as never[],
+    });
+    expect(retained.status).toBe("accepted");
+    if (retained.status === "accepted")
+      expect(retained.outcomes.every((outcome) => outcome.status === "rejected")).toBe(true);
+    const beforeLimited = service.store.readGame(created.gameId);
+    for (
+      let index = AD_HOC_MAX_RETAINED_REJECTED_OPERATIONS_PER_GAME;
+      index < AD_HOC_CONTROLLER_BURST;
+      index += 1
+    ) {
+      expect(
+        await service.apply({
+          gameId: created.gameId,
+          sessionId: created.sessionId,
+          operations: [
+            {
+              id: `rejected-over-cap-${index}`,
+              clientSentAtMs: 1_000,
+              causalPredecessorIds: [`missing-over-cap-${index}`],
+              command: { type: "set-running", running: true },
+            },
+          ],
+        }),
+      ).toMatchObject({ status: "rejected", reason: "rate-limited", retryAfterMs: 1_000 });
+    }
+    const exhausted = await service.apply({
+      gameId: created.gameId,
+      sessionId: created.sessionId,
+      operations: [
+        {
+          id: "rejected-after-exhaustion",
+          clientSentAtMs: 1_000,
+          causalPredecessorIds: ["still-missing"],
+          command: { type: "set-running", running: true },
+        },
+      ],
+    });
+    expect(exhausted).toMatchObject({
+      status: "rejected",
+      reason: "rate-limited",
+      retryAfterMs: 50,
+    });
+    expect(service.store.readGame(created.gameId)).toEqual(beforeLimited);
+  });
+
+  test("charges duplicate-only requests while preserving no-write idempotency", async () => {
+    const service = createAdHocGamesService({ now: () => 1_000 });
+    const created = await service.create({ homeName: "Home", awayName: "Away" });
+    if (created.status !== "accepted") throw new Error("creation failed");
+    const operation = {
+      id: "duplicate-budget",
+      clientSentAtMs: 1_000,
+      command: { type: "set-running", running: true } as const,
+    };
+    expect(
+      (
+        await service.apply({
+          gameId: created.gameId,
+          sessionId: created.sessionId,
+          operations: [operation],
+        })
+      ).status,
+    ).toBe("accepted");
+    const retained = service.store.readGame(created.gameId);
+    for (let index = 0; index < AD_HOC_CONTROLLER_BURST - 1; index += 1) {
+      expect(
+        (
+          await service.apply({
+            gameId: created.gameId,
+            sessionId: created.sessionId,
+            operations: [operation],
+          })
+        ).status,
+      ).toBe("duplicate");
+    }
+    expect(
+      await service.apply({
+        gameId: created.gameId,
+        sessionId: created.sessionId,
+        operations: [operation],
+      }),
+    ).toMatchObject({ status: "rejected", reason: "rate-limited" });
+    expect(service.store.readGame(created.gameId)).toEqual(retained);
+  });
+
+  test("keeps scheduled replay acknowledgement explicit", async () => {
     let nowMs = 1_000;
     const scheduled: (() => void)[] = [];
     const service = createAdHocGamesService({

--- a/src/lib/ad-hoc-resource-budgets.ts
+++ b/src/lib/ad-hoc-resource-budgets.ts
@@ -17,6 +17,9 @@ export const AD_HOC_REPLAY_SUSTAINED_PER_SECOND = 20;
 // envelope remains 100 so malformed or oversized replay requests fail closed.
 export const AD_HOC_REPLAY_BURST = AD_HOC_REPLAY_SUSTAINED_PER_SECOND;
 export const AD_HOC_REPLAY_MAX_UNACKNOWLEDGED_BATCHES = 1;
+// Bounds only rejected and causally blocked replay evidence retained per Ad Hoc
+// Game. Accepted history remains intact and governed by replay semantics.
+export const AD_HOC_MAX_RETAINED_REJECTED_OPERATIONS_PER_GAME = 16;
 
 // Ad Hoc still applies its own 256-controller workflow cap below. The shared
 // WebSocket envelope leaves room for 500 public spectators and two reserved


### PR DESCRIPTION
## Summary

- charge unseen and duplicate-only Ad Hoc replay work before persistence
- short-circuit duplicate-only replay without rebuilding or rewriting the Game
- cap retained rejected and causally blocked evidence atomically
- preserve accepted-operation replay and idempotent acknowledgements

## Stack

Stacked above #309 to keep the review chain linear; this change has no code dependency on the lower layers.

## Verification

- `bun test --isolate ./src/lib/ad-hoc-resource-budgets.test.ts` (17 passed)
- `bun test --isolate ./src/lib/ad-hoc-games.test.ts` (20 passed)
- complete-stack `bun run check`, `bun run test` (1,080 passed), and `bun run build`
- complete-stack terminal security review found no actionable findings

Fixes #301

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
