### PR TITLE
Bound the Ad Hoc creation ledger

### DIFF
--- a/src/lib/ad-hoc-games.focused.ts
+++ b/src/lib/ad-hoc-games.focused.ts
@@ -24,7 +24,11 @@ import {
   createTechnicalAdminAuth,
 } from "@/lib/technical-admin-auth";
 import {
+  AD_HOC_CREATION_GLOBAL_WINDOW_MS,
+  AD_HOC_CREATION_SOURCE_WINDOW_MS,
   AD_HOC_DISCONNECTED_GRACE_MS,
+  AD_HOC_MAX_CREATIONS_PER_HOUR,
+  AD_HOC_MAX_CREATIONS_PER_SOURCE,
   createAdHocGamesService,
   createSqliteAdHocRecoveryAdapter,
   createInMemoryAdHocStore,
@@ -32,6 +36,264 @@ import {
 } from "@/lib/ad-hoc-games";
 
 describe("Ad Hoc SQLite focused integration", () => {
+  test("creates additive indexes for every creation-ledger window query shape", async () => {
+    const root = await mkdtemp(join(tmpdir(), "quadball-timer-adhoc-ledger-indexes-"));
+    const databasePath = join(root, "ad-hoc.sqlite");
+    const store = openSqliteAdHocStore(databasePath, "field-a");
+    try {
+      const database = new Database(databasePath, { strict: true });
+      const indexes = database.query("PRAGMA index_list(adhoc_creation_events)").all() as {
+        name: string;
+      }[];
+      const expectedIndexes = {
+        adhoc_creation_events_source_success_occurred_at_idx: [
+          "source_hash",
+          "successful",
+          "occurred_at_ms",
+        ],
+        adhoc_creation_events_success_occurred_at_idx: ["successful", "occurred_at_ms"],
+      } as const;
+      for (const [indexName, expectedColumns] of Object.entries(expectedIndexes)) {
+        expect(indexes.some((index) => index.name === indexName)).toBe(true);
+        const columns = database
+          .query("SELECT name FROM pragma_index_info(?) ORDER BY seqno")
+          .all(indexName) as { name: string }[];
+        expect(columns.map(({ name }) => name)).toEqual([...expectedColumns]);
+      }
+
+      expect(
+        (
+          database
+            .query(
+              "EXPLAIN QUERY PLAN SELECT COUNT(*) FROM adhoc_creation_events WHERE source_hash = ? AND successful = 1 AND occurred_at_ms > ?",
+            )
+            .all("source", 0) as { detail: string }[]
+        ).some(({ detail }) =>
+          detail.includes("adhoc_creation_events_source_success_occurred_at_idx"),
+        ),
+      ).toBe(true);
+      expect(
+        (
+          database
+            .query(
+              "EXPLAIN QUERY PLAN SELECT MIN(occurred_at_ms) FROM adhoc_creation_events WHERE successful = 1 AND occurred_at_ms > ?",
+            )
+            .all(0) as { detail: string }[]
+        ).some(({ detail }) => detail.includes("adhoc_creation_events_success_occurred_at_idx")),
+      ).toBe(true);
+      expect(
+        (
+          database
+            .query(
+              "EXPLAIN QUERY PLAN DELETE FROM adhoc_creation_events WHERE successful = 0 AND occurred_at_ms <= ?",
+            )
+            .all(0) as { detail: string }[]
+        ).some(({ detail }) => detail.includes("adhoc_creation_events_success_occurred_at_idx")),
+      ).toBe(true);
+      database.close();
+    } finally {
+      store.close();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("bounds global rejection evidence to the active window without changing Games", async () => {
+    const root = await mkdtemp(join(tmpdir(), "quadball-timer-adhoc-global-ledger-"));
+    const databasePath = join(root, "ad-hoc.sqlite");
+    let nowMs = 10_000_000_000;
+    const store = openSqliteAdHocStore(databasePath, "field-a");
+    const games = createAdHocGamesService({
+      store,
+      environmentIdentity: "field-a",
+      now: () => nowMs,
+    });
+    const seedSuccesses = (occurredAtMs: number) => {
+      const database = new Database(databasePath, { strict: true });
+      for (let index = 0; index < AD_HOC_MAX_CREATIONS_PER_HOUR; index += 1) {
+        database.run(
+          "INSERT INTO adhoc_creation_events (source_hash, successful, occurred_at_ms, retry_until_ms) VALUES (?, 1, ?, NULL)",
+          [`seed-${occurredAtMs}-${index}`, occurredAtMs + index],
+        );
+      }
+      database.close();
+    };
+    const readLedger = () => {
+      const database = new Database(databasePath, { strict: true });
+      const rows = database
+        .query(
+          "SELECT source_hash, successful, occurred_at_ms, retry_until_ms FROM adhoc_creation_events ORDER BY occurred_at_ms, source_hash",
+        )
+        .all() as { source_hash: string; successful: number; occurred_at_ms: number }[];
+      database.close();
+      return rows;
+    };
+    try {
+      seedSuccesses(nowMs - 1_000);
+      const seed = new Database(databasePath, { strict: true });
+      seed.run(
+        "INSERT INTO adhoc_creation_events (source_hash, successful, occurred_at_ms, retry_until_ms) VALUES ('expired-success', 1, ?, NULL), ('expired-rejection', 0, ?, ?)",
+        [
+          nowMs - AD_HOC_CREATION_GLOBAL_WINDOW_MS,
+          nowMs - AD_HOC_CREATION_GLOBAL_WINDOW_MS - 1,
+          nowMs - 1,
+        ],
+      );
+      seed.close();
+
+      for (let index = 0; index < 40; index += 1) {
+        expect(
+          await games.create({
+            homeName: "Rejected",
+            awayName: "Globally",
+            sourceKey: `fresh-source-${index}`,
+          }),
+        ).toMatchObject({
+          status: "rejected",
+          reason: "rate-limited",
+          retryAfterMs: AD_HOC_CREATION_GLOBAL_WINDOW_MS - 1_000,
+        });
+      }
+      expect(store.listGames()).toEqual([]);
+      expect(
+        readLedger().every(
+          ({ occurred_at_ms }) => occurred_at_ms > nowMs - AD_HOC_CREATION_GLOBAL_WINDOW_MS,
+        ),
+      ).toBe(true);
+
+      nowMs += AD_HOC_CREATION_GLOBAL_WINDOW_MS + 10_000;
+      seedSuccesses(nowMs - 1_000);
+      expect(
+        await games.create({
+          homeName: "Still",
+          awayName: "Rejected",
+          sourceKey: "fresh-source-after-window",
+        }),
+      ).toMatchObject({
+        status: "rejected",
+        reason: "rate-limited",
+        retryAfterMs: AD_HOC_CREATION_GLOBAL_WINDOW_MS - 1_000,
+      });
+      const retainedRows = readLedger();
+      expect(retainedRows).toHaveLength(AD_HOC_MAX_CREATIONS_PER_HOUR + 1);
+      expect(
+        retainedRows.every(
+          ({ occurred_at_ms }) => occurred_at_ms > nowMs - AD_HOC_CREATION_GLOBAL_WINDOW_MS,
+        ),
+      ).toBe(true);
+      expect(store.listGames()).toEqual([]);
+    } finally {
+      games.close();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("cleans expired evidence on per-source rejection and rolls cleanup back if insertion fails", async () => {
+    const root = await mkdtemp(join(tmpdir(), "quadball-timer-adhoc-source-ledger-"));
+    const databasePath = join(root, "ad-hoc.sqlite");
+    const nowMs = 10_000_000_000;
+    const store = openSqliteAdHocStore(databasePath, "field-a");
+    const games = createAdHocGamesService({
+      store,
+      environmentIdentity: "field-a",
+      now: () => nowMs,
+    });
+    const sourceHash = createHash("sha256").update("limited-source").digest("hex");
+    const repeatedSourceHash = createHash("sha256").update("limited-source-2").digest("hex");
+    const rollbackSourceHash = createHash("sha256").update("limited-source-3").digest("hex");
+    try {
+      const seed = new Database(databasePath, { strict: true });
+      for (let index = 0; index < AD_HOC_MAX_CREATIONS_PER_SOURCE; index += 1) {
+        seed.run(
+          "INSERT INTO adhoc_creation_events (source_hash, successful, occurred_at_ms, retry_until_ms) VALUES (?, 1, ?, NULL)",
+          [sourceHash, nowMs - AD_HOC_CREATION_SOURCE_WINDOW_MS + 1 + index],
+        );
+        seed.run(
+          "INSERT INTO adhoc_creation_events (source_hash, successful, occurred_at_ms, retry_until_ms) VALUES (?, 1, ?, NULL)",
+          [repeatedSourceHash, nowMs - AD_HOC_CREATION_SOURCE_WINDOW_MS + 1 + index],
+        );
+        seed.run(
+          "INSERT INTO adhoc_creation_events (source_hash, successful, occurred_at_ms, retry_until_ms) VALUES (?, 1, ?, NULL)",
+          [rollbackSourceHash, nowMs - AD_HOC_CREATION_SOURCE_WINDOW_MS + 1 + index],
+        );
+      }
+      seed.run(
+        "INSERT INTO adhoc_creation_events (source_hash, successful, occurred_at_ms, retry_until_ms) VALUES ('expired', 0, ?, NULL)",
+        [nowMs - AD_HOC_CREATION_GLOBAL_WINDOW_MS],
+      );
+      seed.close();
+
+      expect(
+        await games.create({
+          homeName: "Source",
+          awayName: "Limited",
+          sourceKey: "limited-source",
+        }),
+      ).toMatchObject({ status: "rejected", reason: "rate-limited", retryAfterMs: 1_000 });
+      const afterCleanup = new Database(databasePath, { strict: true });
+      expect(
+        (
+          afterCleanup
+            .query(
+              "SELECT COUNT(*) AS count FROM adhoc_creation_events WHERE source_hash = 'expired'",
+            )
+            .get() as { count: number }
+        ).count,
+      ).toBe(0);
+      afterCleanup.run(
+        "INSERT INTO adhoc_creation_events (source_hash, successful, occurred_at_ms, retry_until_ms) VALUES ('repeated-expired', 1, ?, NULL)",
+        [nowMs - AD_HOC_CREATION_GLOBAL_WINDOW_MS],
+      );
+      afterCleanup.close();
+
+      expect(
+        await games.create({
+          homeName: "Source",
+          awayName: "Limited",
+          sourceKey: "limited-source-2",
+        }),
+      ).toMatchObject({ status: "rejected", reason: "rate-limited", retryAfterMs: 1_000 });
+      const afterRepeatedCleanup = new Database(databasePath, { strict: true });
+      expect(
+        (
+          afterRepeatedCleanup
+            .query(
+              "SELECT COUNT(*) AS count FROM adhoc_creation_events WHERE source_hash = 'repeated-expired'",
+            )
+            .get() as { count: number }
+        ).count,
+      ).toBe(0);
+      afterRepeatedCleanup.run(
+        "INSERT INTO adhoc_creation_events (source_hash, successful, occurred_at_ms, retry_until_ms) VALUES ('rollback-expired', 0, ?, NULL)",
+        [nowMs - AD_HOC_CREATION_GLOBAL_WINDOW_MS],
+      );
+      afterRepeatedCleanup.run(`CREATE TRIGGER reject_creation_evidence BEFORE INSERT ON adhoc_creation_events
+        WHEN NEW.successful = 0 BEGIN SELECT RAISE(ABORT, 'injected insertion failure'); END`);
+      afterRepeatedCleanup.close();
+
+      expect(
+        await games.create({
+          homeName: "Source",
+          awayName: "Limited",
+          sourceKey: "limited-source-3",
+        }),
+      ).toMatchObject({ status: "rejected", reason: "unavailable" });
+      const verify = new Database(databasePath, { strict: true });
+      expect(
+        (
+          verify
+            .query(
+              "SELECT COUNT(*) AS count FROM adhoc_creation_events WHERE source_hash = 'rollback-expired'",
+            )
+            .get() as { count: number }
+        ).count,
+      ).toBe(1);
+      verify.close();
+    } finally {
+      games.close();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   test("persists a protected SQM fixture game and its public lookup across restart", async () => {
     const root = await mkdtemp(join(tmpdir(), "quadball-timer-adhoc-sqm-restart-"));
     const databasePath = join(root, "ad-hoc.sqlite");

--- a/src/lib/ad-hoc-games.ts
+++ b/src/lib/ad-hoc-games.ts
@@ -1757,6 +1757,12 @@ export function openSqliteAdHocStore(
   if (!creationEventColumns.some((column) => column.name === "retry_until_ms")) {
     db.run("ALTER TABLE adhoc_creation_events ADD COLUMN retry_until_ms INTEGER");
   }
+  db.run(
+    "CREATE INDEX IF NOT EXISTS adhoc_creation_events_source_success_occurred_at_idx ON adhoc_creation_events(source_hash, successful, occurred_at_ms)",
+  );
+  db.run(
+    "CREATE INDEX IF NOT EXISTS adhoc_creation_events_success_occurred_at_idx ON adhoc_creation_events(successful, occurred_at_ms)",
+  );
 
   if (options.reconcileConnectionsAtStartup === true) {
     const startupNowMs = options.startupNowMs ?? Date.now();
@@ -1793,6 +1799,15 @@ export function openSqliteAdHocStore(
     return row === null ? null : parseStoredRow(row);
   };
   const transaction = db.transaction((work: () => unknown) => work());
+  const deleteExpiredCreationEvents = (nowMs: number) => {
+    const expiredAtOrBeforeMs = nowMs - AD_HOC_CREATION_GLOBAL_WINDOW_MS;
+    db.run("DELETE FROM adhoc_creation_events WHERE successful = 0 AND occurred_at_ms <= ?", [
+      expiredAtOrBeforeMs,
+    ]);
+    db.run("DELETE FROM adhoc_creation_events WHERE successful = 1 AND occurred_at_ms <= ?", [
+      expiredAtOrBeforeMs,
+    ]);
+  };
   return {
     close() {
       if (closed) return;
@@ -1832,6 +1847,7 @@ export function openSqliteAdHocStore(
         const expiredPendingDelay = pendingUntilMs > 0 && pendingUntilMs <= nowMs;
         if (sourceCount >= AD_HOC_MAX_CREATIONS_PER_SOURCE && !expiredPendingDelay) {
           const retryAfterMs = adHocCreationDelayMs(sourceCount);
+          deleteExpiredCreationEvents(nowMs);
           db.run(
             "INSERT INTO adhoc_creation_events (source_hash, successful, occurred_at_ms, retry_until_ms) VALUES (?, 0, ?, ?)",
             [sourceHash, nowMs, nowMs + retryAfterMs],
@@ -1863,6 +1879,7 @@ export function openSqliteAdHocStore(
               AD_HOC_CREATION_GLOBAL_WINDOW_MS -
               nowMs,
           );
+          deleteExpiredCreationEvents(nowMs);
           db.run(
             "INSERT INTO adhoc_creation_events (source_hash, successful, occurred_at_ms, retry_until_ms) VALUES (?, 0, ?, ?)",
             [sourceHash, nowMs, nowMs + retryAfterMs],
@@ -1900,9 +1917,7 @@ export function openSqliteAdHocStore(
           ]);
           removedGameId = victim.game_id;
         }
-        db.run("DELETE FROM adhoc_creation_events WHERE occurred_at_ms <= ?", [
-          nowMs - AD_HOC_CREATION_GLOBAL_WINDOW_MS,
-        ]);
+        deleteExpiredCreationEvents(nowMs);
         db.run(
           "INSERT INTO adhoc_games (game_id, environment_identity, created_at_ms, fixture_key, state_json, initial_state_json, replay_baseline_operation_ids_json, control_qr, control_qr_hash, sessions_json, operations_json) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
           [


### PR DESCRIPTION
## Summary

- add indexes for the per-source and global Ad Hoc creation-ledger query shapes
- clean expired evidence transactionally on rejected and successful creation paths
- preserve fully non-mutating retained-capacity rejection behavior

## Verification

- focused Ad Hoc unit and SQLite tests
- repository check, full test suite, build, and diff hygiene

Fixes #302

## Stack

1. #312
2. #313
3. #314
4. #315
5. #316

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
