### PR TITLE
Cache unchanged Event audience inputs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -368,6 +368,16 @@ async function startServer() {
                 ? { status: "unavailable" as const }
                 : await liveEventRuntime.readAudienceProjectionGameInput(eventGameId);
             },
+            async readMany(eventGameIds: readonly string[]) {
+              return liveEventRuntime === null
+                ? new Map(
+                    eventGameIds.map((eventGameId) => [
+                      eventGameId,
+                      { status: "unavailable" as const },
+                    ]),
+                  )
+                : await liveEventRuntime.readAudienceProjectionGameInputs(eventGameIds);
+            },
           };
     const audienceProjection = createAudienceProjection(eventCatalogStorage, {
       ...(liveAudienceGameInput === undefined ? {} : { gameInput: liveAudienceGameInput }),

--- a/src/lib/audience-projection.test.ts
+++ b/src/lib/audience-projection.test.ts
@@ -138,6 +138,57 @@ describe("Audience Publication Projection", () => {
     }
   });
 
+  test("reads unique scheduled Games in one batch and fails closed on a missing outcome", async () => {
+    const games = [
+      createScheduleGame("batch-a", "2026-08-14T10:00:00.000Z", "Pitch 1"),
+      createScheduleGame("batch-b", "2026-08-14T11:00:00.000Z", "Pitch 1"),
+    ];
+    const roots = new Map(
+      games.map((game) => [game.eventGameId, createScheduleRoot(game.eventGameId, "scheduled")]),
+    );
+    const snapshot = createScheduleSnapshot({ pitches: ["Pitch 1"], games, roots });
+    const outcomes = new Map(
+      [...roots].map(([eventGameId, root]) => [
+        eventGameId,
+        readAudienceProjectionGameInput(
+          root,
+          createAudienceControllerProjection({ phase: "scheduled" }),
+        ),
+      ]),
+    );
+    let batchReads = 0;
+    let scalarReads = 0;
+    const requested: string[][] = [];
+    const storage = {
+      snapshot: async () => snapshot,
+    } as unknown as EventCatalogFoundationStorage;
+    const gameInput = {
+      read: async (eventGameId: string) => {
+        scalarReads += 1;
+        return outcomes.get(eventGameId) ?? ({ status: "unavailable" } as const);
+      },
+      readMany: async (eventGameIds: readonly string[]) => {
+        batchReads += 1;
+        requested.push([...eventGameIds]);
+        return outcomes;
+      },
+    };
+
+    expect(
+      (await createAudienceProjection(storage, { gameInput }).read("event-schedule")).status,
+    ).toBe("accepted");
+    expect({ batchReads, scalarReads, requested }).toEqual({
+      batchReads: 1,
+      scalarReads: 0,
+      requested: [["batch-a", "batch-b"]],
+    });
+
+    outcomes.delete("batch-b");
+    expect(
+      (await createAudienceProjection(storage, { gameInput }).read("event-schedule")).status,
+    ).toBe("unavailable");
+  });
+
   test("uses one runtime snapshot for Timeline semantics and scopes the neutral correction notice", async () => {
     const correctedGame = createScheduleGame(
       "runtime-corrected",

--- a/src/lib/audience-projection.ts
+++ b/src/lib/audience-projection.ts
@@ -173,6 +173,9 @@ export type AudienceProjectionGameInputOutcome =
 
 export type AudienceProjectionGameInputReader = {
   read(eventGameId: string): Promise<AudienceProjectionGameInputOutcome>;
+  readMany?(
+    eventGameIds: readonly string[],
+  ): Promise<ReadonlyMap<string, AudienceProjectionGameInputOutcome>>;
 };
 
 export type PublicAudienceScheduleProjection = {
@@ -520,10 +523,16 @@ async function projectSchedule(
     }
   }
 
+  const scheduledGames = projectScheduleGames(snapshot, [...gamesById.values()]);
+  const batch = await gameInput?.readMany?.(scheduledGames.map((game) => game.eventGameId));
+
   const projected = (
     await Promise.all(
-      projectScheduleGames(snapshot, [...gamesById.values()]).map(async (game) => {
-        const current = await gameInput?.read(game.eventGameId);
+      scheduledGames.map(async (game) => {
+        const current =
+          batch === undefined
+            ? await gameInput?.read(game.eventGameId)
+            : (batch.get(game.eventGameId) ?? { status: "unavailable" as const });
         if (current !== undefined && current.status !== "accepted") {
           throw new GameInputReadError(current.status);
         }

--- a/src/lib/event-catalog.test.ts
+++ b/src/lib/event-catalog.test.ts
@@ -4,7 +4,10 @@ import {
   createFoundationEventCatalogStorage,
   createInMemoryEventCatalogStorage,
   createUnavailableEventCatalogStorage,
+  projectScheduleGames,
   projectExpectedStartMs,
+  type EventCatalogStorageSnapshot,
+  type EventGame,
   type InMemoryEventCatalogStorage,
 } from "@/lib/event-catalog";
 import { createInMemoryFoundationStorage } from "@/lib/foundation-storage-memory";
@@ -35,6 +38,108 @@ function createFixture(storage: InMemoryEventCatalogStorage = createInMemoryEven
 }
 
 describe("Event operations catalog", () => {
+  test("precomputes conflict indexes with the strict legacy overlap result", () => {
+    const starts = new Map([
+      ["slot-0", 0],
+      ["slot-10", 10 * 60_000],
+      ["slot-15", 15 * 60_000],
+      ["slot-20", 20 * 60_000],
+      ["slot-30", 30 * 60_000],
+      ["slot-60", 60 * 60_000],
+    ]);
+    const snapshot = {
+      findGameplaySlot(gameplaySlotId: string) {
+        const scheduledStartMs = starts.get(gameplaySlotId);
+        return scheduledStartMs === undefined
+          ? null
+          : { gameplaySlotId, scheduledStartMs, expectedDelayMs: 0 };
+      },
+      findPitchSlot(pitchSlotId: string) {
+        const gameplaySlotId = pitchSlotId.split("@")[1];
+        return gameplaySlotId === undefined
+          ? null
+          : { pitchSlotId, gameplaySlotId, expectedDelayMs: 0 };
+      },
+    } as Pick<EventCatalogStorageSnapshot, "findGameplaySlot" | "findPitchSlot">;
+    const game = (
+      eventGameId: string,
+      slot: string,
+      pitch: string,
+      teams: readonly [string | null, string | null],
+      gameDayId = "day-1",
+    ): EventGame =>
+      ({
+        eventGameId,
+        eventId: "event-1",
+        gameDayId,
+        gameplaySlotId: slot,
+        pitchSlotId: `${pitch}@${slot}`,
+        gameCode: null,
+        gameDesignation: null,
+        sideA: { sideId: `${eventGameId}-a`, eventTeamId: teams[0] },
+        sideB: { sideId: `${eventGameId}-b`, eventTeamId: teams[1] },
+        createdAtMs: 1,
+        updatedAtMs: 1,
+      }) as EventGame;
+    const games = [
+      game("multi-a", "slot-0", "pitch-a", ["team-multi", "team-x"]),
+      game("multi-b", "slot-10", "pitch-b", ["team-multi", "team-y"]),
+      game("multi-c", "slot-20", "pitch-c", ["team-multi", "team-z"]),
+      game("touch-a", "slot-0", "pitch-d", ["team-touch", null]),
+      game("touch-b", "slot-30", "pitch-e", ["team-touch", null]),
+      game("pitch-a", "slot-0", "shared", ["team-p", null]),
+      { ...game("pitch-b", "slot-60", "unused", ["team-q", null]), pitchSlotId: "shared@slot-0" },
+      game("other-day", "slot-10", "pitch-f", ["team-multi", null], "day-2"),
+    ];
+    const oldResult = new Map(
+      games.map((candidate) => {
+        const start = starts.get(candidate.gameplaySlotId) ?? 0;
+        const end = start + 30 * 60_000;
+        const teamIds = [candidate.sideA.eventTeamId, candidate.sideB.eventTeamId].filter(
+          (teamId): teamId is string => teamId !== null,
+        );
+        return [
+          candidate.eventGameId,
+          {
+            scheduleConflict: games.some(
+              (other) =>
+                other.eventGameId !== candidate.eventGameId &&
+                other.pitchSlotId === candidate.pitchSlotId,
+            ),
+            teamScheduleConflict: games.some((other) => {
+              const otherStart = starts.get(other.gameplaySlotId) ?? 0;
+              return (
+                other.eventGameId !== candidate.eventGameId &&
+                other.gameDayId === candidate.gameDayId &&
+                [other.sideA.eventTeamId, other.sideB.eventTeamId].some(
+                  (teamId) => teamId !== null && teamIds.includes(teamId),
+                ) &&
+                otherStart < end &&
+                start < otherStart + 30 * 60_000
+              );
+            }),
+          },
+        ] as const;
+      }),
+    );
+    const indexBuilds: string[] = [];
+    const projected = projectScheduleGames(snapshot, games, {
+      onConflictIndexBuilt: (kind) => indexBuilds.push(kind),
+    });
+    expect(indexBuilds).toEqual(["pitch", "team"]);
+    expect(
+      new Map(
+        projected.map((candidate) => [
+          candidate.eventGameId,
+          {
+            scheduleConflict: candidate.scheduleConflict,
+            teamScheduleConflict: candidate.teamScheduleConflict,
+          },
+        ]),
+      ),
+    ).toEqual(oldResult);
+  });
+
   test("defaults each new Game Day to disabled Heat Stoppage Configuration", async () => {
     const fixture = createFixture();
     const event = await fixture.catalog.createEvent(

--- a/src/lib/event-catalog.ts
+++ b/src/lib/event-catalog.ts
@@ -3186,7 +3186,13 @@ function validateDelay(value: unknown): { ok: true; value: number } | { ok: fals
 export function projectScheduleGames(
   transaction: Pick<EventCatalogStorageSnapshot, "findGameplaySlot" | "findPitchSlot">,
   games: readonly EventGame[],
+  diagnostics?: { onConflictIndexBuilt?(kind: "pitch" | "team"): void },
 ): ProjectedEventGame[] {
+  const pitchSlotCounts = new Map<string, number>();
+  for (const game of games) {
+    pitchSlotCounts.set(game.pitchSlotId, (pitchSlotCounts.get(game.pitchSlotId) ?? 0) + 1);
+  }
+  diagnostics?.onConflictIndexBuilt?.("pitch");
   const projected = games.map((game) => {
     const gameplay = transaction.findGameplaySlot(game.gameplaySlotId);
     const pitch = transaction.findPitchSlot(game.pitchSlotId);
@@ -3201,12 +3207,12 @@ export function projectScheduleGames(
       startMs: expectedStartMs,
       endMs: expectedStartMs + DEFAULT_EVENT_GAME_PLAYING_DURATION_MS,
     };
-    const scheduleConflict = games.some(
-      (other) => other.eventGameId !== game.eventGameId && other.pitchSlotId === game.pitchSlotId,
-    );
-    const teamIds = [game.sideA.eventTeamId, game.sideB.eventTeamId].filter(
-      (id): id is string => id !== null,
-    );
+    const scheduleConflict = (pitchSlotCounts.get(game.pitchSlotId) ?? 0) > 1;
+    const teamIds = [
+      ...new Set(
+        [game.sideA.eventTeamId, game.sideB.eventTeamId].filter((id): id is string => id !== null),
+      ),
+    ];
     return {
       ...structuredClone(game),
       expectedStartMs,
@@ -3215,16 +3221,35 @@ export function projectScheduleGames(
       teamIds,
     };
   });
-  return projected.map(({ teamIds, ...game }) => ({
+  const teamIntervals = new Map<string, typeof projected>();
+  for (const game of projected) {
+    for (const teamId of game.teamIds) {
+      const key = `${game.gameDayId}\u0000${teamId}`;
+      const group = teamIntervals.get(key) ?? [];
+      group.push(game);
+      teamIntervals.set(key, group);
+    }
+  }
+  diagnostics?.onConflictIndexBuilt?.("team");
+  const teamConflictGameIds = new Set<string>();
+  for (const group of teamIntervals.values()) {
+    group.sort(
+      (left, right) =>
+        left.expectedPlayingPeriod.startMs - right.expectedPlayingPeriod.startMs ||
+        left.eventGameId.localeCompare(right.eventGameId),
+    );
+    for (let index = 1; index < group.length; index += 1) {
+      const previous = group[index - 1]!;
+      const current = group[index]!;
+      if (current.expectedPlayingPeriod.startMs < previous.expectedPlayingPeriod.endMs) {
+        teamConflictGameIds.add(previous.eventGameId);
+        teamConflictGameIds.add(current.eventGameId);
+      }
+    }
+  }
+  return projected.map(({ teamIds: _teamIds, ...game }) => ({
     ...game,
-    teamScheduleConflict: projected.some(
-      (other) =>
-        other.eventGameId !== game.eventGameId &&
-        other.gameDayId === game.gameDayId &&
-        other.teamIds.some((otherTeamId) => teamIds.includes(otherTeamId)) &&
-        other.expectedPlayingPeriod.startMs < game.expectedPlayingPeriod.endMs &&
-        game.expectedPlayingPeriod.startMs < other.expectedPlayingPeriod.endMs,
-    ),
+    teamScheduleConflict: teamConflictGameIds.has(game.eventGameId),
   }));
 }
 

--- a/src/lib/event-game-actions.test.ts
+++ b/src/lib/event-game-actions.test.ts
@@ -513,6 +513,7 @@ async function readSnapshot(
   ]);
   return {
     revision: 0,
+    mutationRevision: 0,
     findRootByRecordId: () => root,
     findRootByEventGameId: () => root,
     findRootByPitchSlotId: () => root,

--- a/src/lib/foundation-storage-contract.test.ts
+++ b/src/lib/foundation-storage-contract.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -14,6 +15,7 @@ import { FoundationStorageConstraintError, type FoundationStorage } from "@/lib/
 
 type StorageHarness = {
   storage: FoundationStorage;
+  databasePath?: string;
   cleanup(): Promise<void>;
 };
 
@@ -83,6 +85,7 @@ const sqliteFactory: StorageFactory = async () => {
   await storage.applyMigrations();
   return {
     storage,
+    databasePath,
     cleanup: async () => {
       storage.close();
       await rm(directory, { recursive: true, force: true });
@@ -92,6 +95,91 @@ const sqliteFactory: StorageFactory = async () => {
 
 function runStorageContract(name: string, factory: StorageFactory): void {
   describe(`${name} foundation storage contract`, () => {
+    test("advances only the mutation epoch for committed mutation intent", async () => {
+      const harness = await factory();
+      try {
+        const first = await harness.storage.transaction((snapshot) => ({
+          revision: snapshot.revision,
+          mutationRevision: snapshot.mutationRevision,
+        }));
+        const second = await harness.storage.transaction((snapshot) => ({
+          revision: snapshot.revision,
+          mutationRevision: snapshot.mutationRevision,
+        }));
+        expect(second.revision).toBe(first.revision + 1);
+        expect([first.mutationRevision, second.mutationRevision]).toEqual([0, 0]);
+
+        await harness.storage.transaction((transaction) => {
+          transaction.insertEvent({
+            eventId: "mutation-event",
+            name: "Mutation Event",
+            timeZone: "UTC",
+            publicationStatus: "unpublished",
+            createdAtMs: 1,
+            updatedAtMs: 1,
+          });
+          transaction.updateEvent({
+            eventId: "mutation-event",
+            name: "Mutation Event Updated",
+            timeZone: "UTC",
+            publicationStatus: "unpublished",
+            createdAtMs: 1,
+            updatedAtMs: 2,
+          });
+        });
+        expect(await harness.storage.transaction((snapshot) => snapshot.mutationRevision)).toBe(1);
+      } finally {
+        await harness.cleanup();
+      }
+    });
+
+    test("does not advance the mutation epoch for rolled-back mutation intent", async () => {
+      const harness = await factory();
+      try {
+        let failure: unknown;
+        try {
+          await harness.storage.transaction((transaction) => {
+            transaction.insertEvent({
+              eventId: "rolled-back-event",
+              name: "Rolled Back Event",
+              timeZone: "UTC",
+              publicationStatus: "unpublished",
+              createdAtMs: 1,
+              updatedAtMs: 1,
+            });
+            throw new Error("roll back mutation epoch");
+          });
+        } catch (error) {
+          failure = error;
+        }
+        expect(failure).toMatchObject({ message: "roll back mutation epoch" });
+        expect(await harness.storage.transaction((snapshot) => snapshot.mutationRevision)).toBe(0);
+      } finally {
+        await harness.cleanup();
+      }
+    });
+
+    test("exposes a committed mutation epoch to the next queued snapshot", async () => {
+      const harness = await factory();
+      try {
+        const mutation = harness.storage.transaction((transaction) => {
+          transaction.insertEvent({
+            eventId: "queued-event",
+            name: "Queued Event",
+            timeZone: "UTC",
+            publicationStatus: "unpublished",
+            createdAtMs: 1,
+            updatedAtMs: 1,
+          });
+        });
+        const observed = harness.storage.transaction((snapshot) => snapshot.mutationRevision);
+        await mutation;
+        expect(await observed).toBe(1);
+      } finally {
+        await harness.cleanup();
+      }
+    });
+
     test("registers and reads a semantic Event Game Record root", async () => {
       const harness = await factory();
       try {
@@ -448,3 +536,38 @@ function createScopeResolver(root: EventGameRecordRoot): ExternalScopeResolver {
 
 runStorageContract("in-memory", memoryFactory);
 runStorageContract("SQLite", sqliteFactory);
+
+describe("SQLite Foundation external mutation epoch", () => {
+  test("advances before exposing a snapshot after another connection commits", async () => {
+    const harness = await sqliteFactory();
+    try {
+      const databasePath = harness.databasePath;
+      if (databasePath === undefined) throw new Error("Expected a SQLite database path.");
+      await harness.storage.transaction((transaction) => {
+        transaction.insertEvent({
+          eventId: "external-event",
+          name: "Before External Mutation",
+          timeZone: "UTC",
+          publicationStatus: "unpublished",
+          createdAtMs: 1,
+          updatedAtMs: 1,
+        });
+      });
+      const before = await harness.storage.transaction((snapshot) => snapshot.mutationRevision);
+      const external = new Database(databasePath);
+      try {
+        external
+          .query(
+            "UPDATE foundation_event_catalog_events SET name = ?, updated_at_ms = ? WHERE event_id = ?",
+          )
+          .run("After External Mutation", 2, "external-event");
+      } finally {
+        external.close();
+      }
+      const after = await harness.storage.transaction((snapshot) => snapshot.mutationRevision);
+      expect(after).toBe(before + 1);
+    } finally {
+      await harness.cleanup();
+    }
+  });
+});

--- a/src/lib/foundation-storage-memory.ts
+++ b/src/lib/foundation-storage-memory.ts
@@ -27,6 +27,7 @@ import {
   FoundationStorageClosedError,
   FoundationStorageConstraintError,
   FoundationStorageNotReadyError,
+  trackFoundationMutationIntent,
   type FoundationStorage,
   type FoundationStorageReadiness,
   type FoundationStorageTransaction,
@@ -178,6 +179,7 @@ class InMemoryFoundationStorage implements FoundationStorage {
   private writerTail: Promise<void> = Promise.resolve();
   private closed = false;
   private revision = 0;
+  private mutationRevision = 0;
   private grantValidationContext: GrantStateValidationContext = {};
 
   transaction<T>(work: FoundationStorageTransactionWork<T>): Promise<T> {
@@ -220,9 +222,21 @@ class InMemoryFoundationStorage implements FoundationStorage {
       const previousAnchors = new Map(this.state.grantStateAnchors);
       const previousAdmissionAnchor = this.state.grantAdmissionStateAnchor;
       const previousAdmissionAnchorInstalled = this.state.grantAdmissionAnchorInstalled;
+      let mutationInvoked = false;
       try {
         const result = work(
-          createTransaction(this.state, undo, this.revision, this.grantValidationContext.keyRing),
+          trackFoundationMutationIntent(
+            createTransaction(
+              this.state,
+              undo,
+              this.revision,
+              this.mutationRevision,
+              this.grantValidationContext.keyRing,
+            ),
+            () => {
+              mutationInvoked = true;
+            },
+          ),
         );
         if (isThenable(result)) {
           throw new TypeError("Foundation storage transactions must complete synchronously.");
@@ -255,6 +269,7 @@ class InMemoryFoundationStorage implements FoundationStorage {
         this.rebuildGrantStateAnchors();
         this.rebuildGrantAdmissionStateAnchor();
         this.revision += 1;
+        if (mutationInvoked) this.mutationRevision += 1;
         return result;
       } catch (error) {
         for (const revert of undo.reverse()) revert();
@@ -1099,10 +1114,12 @@ function createTransaction(
   state: MemoryState,
   undo: (() => void)[],
   revision: number,
+  mutationRevision: number,
   keyRing: GrantKeyRing | undefined,
 ): FoundationStorageTransaction {
   return {
     revision,
+    mutationRevision,
     listRoots() {
       return [...state.roots.values()]
         .sort((left, right) => left.root.recordId.localeCompare(right.root.recordId))

--- a/src/lib/foundation-storage-sqlite.ts
+++ b/src/lib/foundation-storage-sqlite.ts
@@ -72,6 +72,7 @@ import {
   FoundationStorageClosedError,
   FoundationStorageConstraintError,
   FoundationStorageNotReadyError,
+  trackFoundationMutationIntent,
   type FoundationStorageEvidence,
   type FoundationStorageFailureCategory,
   type FoundationStorageKeyCategory,
@@ -673,6 +674,7 @@ export class SqliteFoundationStorage implements FoundationStorage {
   private grantStatements: GrantSqliteStatements | undefined;
   private closed = false;
   private revision = 0;
+  private mutationRevision = 0;
   private dataVersion: number;
   private readinessContext: FoundationStorageReadinessContext | undefined;
   private unsafeFailure: FoundationStorageFailureCategory | undefined;
@@ -714,6 +716,7 @@ export class SqliteFoundationStorage implements FoundationStorage {
       const startedAt = Date.now();
       let transactionStarted = false;
       let commitBoundary = false;
+      let mutationInvoked = false;
       try {
         if (this.unsafeFailure === "corruption") {
           throw new FoundationStorageNotReadyError(this.readinessSync());
@@ -730,7 +733,11 @@ export class SqliteFoundationStorage implements FoundationStorage {
         if (!readiness.ok) {
           throw new FoundationStorageNotReadyError(readiness);
         }
-        const result = work(this.createTransaction());
+        const result = work(
+          trackFoundationMutationIntent(this.createTransaction(), () => {
+            mutationInvoked = true;
+          }),
+        );
         if (isThenable(result)) {
           throw new TypeError("Foundation storage transactions must complete synchronously.");
         }
@@ -763,6 +770,7 @@ export class SqliteFoundationStorage implements FoundationStorage {
         this.lastTransactionLatencyMs = boundedMetric(Date.now() - startedAt);
         this.unsafeFailure = undefined;
         this.revision += 1;
+        if (mutationInvoked) this.mutationRevision += 1;
         this.dataVersion = this.readDataVersion();
         return result;
       } catch (error) {
@@ -1216,6 +1224,7 @@ export class SqliteFoundationStorage implements FoundationStorage {
     const statements = this.getStatements();
     return {
       revision: this.revision,
+      mutationRevision: this.mutationRevision,
       listRoots: () =>
         statements.allRoots
           .all()
@@ -2901,6 +2910,7 @@ export class SqliteFoundationStorage implements FoundationStorage {
     const currentDataVersion = this.readDataVersion();
     if (currentDataVersion !== this.dataVersion) {
       this.revision += 1;
+      this.mutationRevision += 1;
       this.dataVersion = currentDataVersion;
     }
   }

--- a/src/lib/foundation-storage.ts
+++ b/src/lib/foundation-storage.ts
@@ -397,6 +397,8 @@ export type FoundationStorageLiveness = { ok: true; process: "available" };
 
 export type FoundationStorageSnapshot = {
   revision: number;
+  /** Process-local epoch of the last committed Foundation mutation. */
+  mutationRevision: number;
   /** Optional inventory used by lifecycle coordinators; older adapters may omit it. */
   listRoots?(): EventGameRecordRoot[];
   findRootByRecordId(recordId: string): EventGameRecordRoot | null;
@@ -539,6 +541,80 @@ export type FoundationStorageTransaction = FoundationStorageSnapshot & {
 };
 
 export type FoundationStorageTransactionWork<T> = (transaction: FoundationStorageTransaction) => T;
+
+const FOUNDATION_STORAGE_MUTATION_METHODS = new Set<PropertyKey>([
+  "insertRoot",
+  "updateRoot",
+  "insertAction",
+  "upsertRecordMetadata",
+  "appendAuditEntry",
+  "insertPresentationChange",
+  "appendPresentationAuditEntry",
+  "appendPresentationAuditRevision",
+  "sealPresentationEvidence",
+  "insertGrant",
+  "updateGrant",
+  "insertGrantSession",
+  "updateGrantSession",
+  "appendGrantAudit",
+  "upsertAcceptanceBudget",
+  "insertReplayReservation",
+  "updateReplayReservation",
+  "insertReplayAttempt",
+  "updateReplayAttempt",
+  "discardReplayAttempts",
+  "discardReplayReservation",
+  "insertReplayReceipt",
+  "updateReplayReceipt",
+  "insertAcceptanceIntegrityAnchor",
+  "insertEvent",
+  "updateEvent",
+  "deleteEvent",
+  "insertGameDay",
+  "updateGameDay",
+  "deleteGameDay",
+  "insertEventTeam",
+  "updateEventTeam",
+  "deleteEventTeam",
+  "insertRosterEntry",
+  "updateRosterEntry",
+  "insertPitch",
+  "updatePitch",
+  "deletePitch",
+  "insertGameplaySlot",
+  "insertPitchSlot",
+  "updateGameplaySlot",
+  "updatePitchSlot",
+  "deleteGameplaySlot",
+  "deletePitchSlot",
+  "insertEventGame",
+  "updateEventGame",
+  "deleteEventGame",
+  "appendEventAudit",
+  "writeGrantAdmissionTelemetry",
+  "writeGrantAdmissionGlobalWindow",
+  "pruneGrantAdmissionTelemetry",
+  "writeGrantAdmissionStateAnchor",
+]);
+
+/** Adapter helper: records callback mutation intent without inspecting physical writes. */
+export function trackFoundationMutationIntent(
+  transaction: FoundationStorageTransaction,
+  markMutation: () => void,
+): FoundationStorageTransaction {
+  return new Proxy(transaction, {
+    get(target, property, receiver) {
+      const value = Reflect.get(target, property, receiver);
+      if (!FOUNDATION_STORAGE_MUTATION_METHODS.has(property) || typeof value !== "function") {
+        return value;
+      }
+      return (...args: unknown[]) => {
+        markMutation();
+        return Reflect.apply(value, target, args);
+      };
+    },
+  });
+}
 
 export type CatalogCapableFoundationStorage = FoundationStorage & {
   eventCatalogStorageCapability(): EventCatalogStorageCapability;

--- a/src/lib/live-event-game-runtime.test.ts
+++ b/src/lib/live-event-game-runtime.test.ts
@@ -258,11 +258,35 @@ describe("Live Event Game SQLite runtime", () => {
       setupStorage.close();
     }
 
+    let audienceEpochReads = 0;
+    let audienceRecordReads = 0;
+    let mutateDuringAudienceRead = false;
     const runtime = await openLiveEventGameRuntime({
       databasePath,
       environmentId,
       keyRing: configured ?? keyRing,
       clock: () => 10_000,
+      audienceInputDiagnostics: {
+        onEpochRead: () => {
+          audienceEpochReads += 1;
+        },
+        onRecordRead: () => {
+          audienceRecordReads += 1;
+          if (mutateDuringAudienceRead) {
+            mutateDuringAudienceRead = false;
+            const external = new Database(databasePath);
+            try {
+              external
+                .query(
+                  "UPDATE foundation_event_catalog_events SET updated_at_ms = updated_at_ms + 1 WHERE event_id = ?",
+                )
+                .run(root.eventId);
+            } finally {
+              external.close();
+            }
+          }
+        },
+      },
     });
     try {
       expect(await runtime.readiness()).toMatchObject({
@@ -307,6 +331,42 @@ describe("Live Event Game SQLite runtime", () => {
           commencement: { status: "commenced", commencedAtMs: 10_000 },
         },
       });
+      expect(
+        await runtime.readAudienceProjectionGameInputs([root.eventGameId, root.eventGameId]),
+      ).toMatchObject(new Map([[root.eventGameId, { status: "accepted" }]]));
+      expect(await runtime.readAudienceProjectionGameInputs([root.eventGameId])).toMatchObject(
+        new Map([[root.eventGameId, { status: "accepted" }]]),
+      );
+      expect({ audienceEpochReads, audienceRecordReads }).toEqual({
+        audienceEpochReads: 4,
+        audienceRecordReads: 1,
+      });
+
+      expect(
+        await runtime.control.submitControllerIntent({
+          sessionBearer: opened.session.sessionBearer,
+          eventGameId: opened.eventGameId,
+          intent: {
+            version: LIVE_EVENT_CONTROL_INTENT_VERSION,
+            type: "clock",
+            operationId: "runtime-clock-running",
+            factId: "runtime-clock-running-fact",
+            running: true,
+            gameTimeMs: 0,
+            occurrence: { clientOriginAtMs: 1_235 },
+          },
+        }),
+      ).toMatchObject({ status: "accepted" });
+      await runtime.readAudienceProjectionGameInputs([root.eventGameId]);
+      await runtime.readAudienceProjectionGameInputs([root.eventGameId]);
+      expect({ audienceEpochReads, audienceRecordReads }).toEqual({
+        audienceEpochReads: 8,
+        audienceRecordReads: 3,
+      });
+      mutateDuringAudienceRead = true;
+      expect(await runtime.readAudienceProjectionGameInputs([root.eventGameId])).toMatchObject(
+        new Map([[root.eventGameId, { status: "unavailable" }]]),
+      );
       const catalogDatabase = new Database(databasePath);
       catalogDatabase
         .query(

--- a/src/lib/live-event-game-runtime.ts
+++ b/src/lib/live-event-game-runtime.ts
@@ -39,6 +39,9 @@ import type { FoundationStorage } from "@/lib/foundation-storage";
 export type LiveEventGameRuntime = {
   control: ReturnType<typeof createLiveEventGameControl>;
   readAudienceProjectionGameInput(eventGameId: string): Promise<AudienceProjectionGameInputOutcome>;
+  readAudienceProjectionGameInputs(
+    eventGameIds: readonly string[],
+  ): Promise<ReadonlyMap<string, AudienceProjectionGameInputOutcome>>;
   readiness(): Promise<FoundationStorageReadiness>;
   close(): void;
 };
@@ -135,6 +138,12 @@ export function readAudienceProjectionGameInput(
   return { status: "accepted", value };
 }
 
+function audienceInputIsTimeDependent(input: AudienceProjectionGameInput): boolean {
+  if (input.operationalStatus === "running" || input.clock?.running === true) return true;
+  if (input.teamTimeout.status === "started") return true;
+  return input.heatStoppage.status === "started" || input.heatStoppage.status === "extended";
+}
+
 export async function openLiveEventGameRuntime(input: {
   databasePath: string;
   environmentId: string;
@@ -142,6 +151,10 @@ export async function openLiveEventGameRuntime(input: {
   clock?: () => number;
   knownDodgeballIdsForEventGame?: (eventGameId: string) => readonly string[] | undefined;
   onControllerCapacityChange?: () => void;
+  audienceInputDiagnostics?: {
+    onEpochRead?(): void;
+    onRecordRead?(eventGameId: string): void;
+  };
 }): Promise<LiveEventGameRuntime> {
   const readiness = await readSqliteFoundationStorageReadiness(input.databasePath, {
     grantKeyRing: input.keyRing,
@@ -360,17 +373,89 @@ export async function openLiveEventGameRuntime(input: {
     refreshEventCapacitySnapshot = () => {
       void control.reconcileActiveControllerSessions();
     };
+    const audienceInputCache = new Map<
+      string,
+      {
+        mutationRevision: number;
+        value: AudienceProjectionGameInput;
+        timeDependent: boolean;
+      }
+    >();
+    let audienceInputCacheGeneration = 0;
+    let closed = false;
+    const readCurrentMutationRevision = () => {
+      input.audienceInputDiagnostics?.onEpochRead?.();
+      return storage.transaction((snapshot) => snapshot.mutationRevision);
+    };
+    const readOneAudienceInput = async (eventGameId: string) => {
+      input.audienceInputDiagnostics?.onRecordRead?.(eventGameId);
+      const root = await storage.transaction((transaction) =>
+        transaction.findRootByEventGameId(eventGameId),
+      );
+      const projection = await control.readControllerProjection(eventGameId);
+      return readAudienceProjectionGameInput(root, projection);
+    };
     return {
       control,
-      async readAudienceProjectionGameInput(eventGameId) {
-        const root = await storage.transaction((transaction) =>
-          transaction.findRootByEventGameId(eventGameId),
+      readAudienceProjectionGameInput: readOneAudienceInput,
+      async readAudienceProjectionGameInputs(eventGameIds) {
+        const requestedIds = [...new Set(eventGameIds)];
+        const outcomes = new Map<string, AudienceProjectionGameInputOutcome>();
+        if (requestedIds.length === 0) return outcomes;
+        if (closed) throw new Error("Live Event Game runtime is closed.");
+        const generation = audienceInputCacheGeneration;
+        const beforeRevision = await readCurrentMutationRevision();
+        const refreshIds: string[] = [];
+        for (const eventGameId of requestedIds) {
+          const cached = audienceInputCache.get(eventGameId);
+          if (
+            cached !== undefined &&
+            cached.mutationRevision === beforeRevision &&
+            !cached.timeDependent
+          ) {
+            outcomes.set(eventGameId, { status: "accepted", value: structuredClone(cached.value) });
+          } else {
+            refreshIds.push(eventGameId);
+          }
+        }
+        const refreshed = await Promise.all(
+          refreshIds.map(
+            async (eventGameId) => [eventGameId, await readOneAudienceInput(eventGameId)] as const,
+          ),
         );
-        const projection = await control.readControllerProjection(eventGameId);
-        return readAudienceProjectionGameInput(root, projection);
+        for (const [eventGameId, outcome] of refreshed) outcomes.set(eventGameId, outcome);
+        const afterRevision = await readCurrentMutationRevision();
+        if (
+          closed ||
+          generation !== audienceInputCacheGeneration ||
+          beforeRevision !== afterRevision
+        ) {
+          return new Map(
+            requestedIds.map((eventGameId) => [eventGameId, { status: "unavailable" as const }]),
+          );
+        }
+        if ([...outcomes.values()].some((outcome) => outcome.status !== "accepted")) {
+          for (const [eventGameId, outcome] of outcomes) {
+            if (outcome.status === "unavailable") audienceInputCache.delete(eventGameId);
+          }
+          return outcomes;
+        }
+        for (const eventGameId of refreshIds) {
+          const outcome = outcomes.get(eventGameId);
+          if (outcome?.status !== "accepted") continue;
+          audienceInputCache.set(eventGameId, {
+            mutationRevision: beforeRevision,
+            value: structuredClone(outcome.value),
+            timeDependent: audienceInputIsTimeDependent(outcome.value),
+          });
+        }
+        return outcomes;
       },
       readiness: () => storage.readiness(),
       close() {
+        closed = true;
+        audienceInputCacheGeneration += 1;
+        audienceInputCache.clear();
         clearInterval(lockTimer);
         control.close();
         storage.close();


### PR DESCRIPTION
## Summary

- add a separate mutation-only Foundation epoch without changing existing revision semantics
- batch and cache allowlisted Event Game audience inputs with fail-closed epoch checks
- precompute Pitch and Team schedule-conflict indexes while preserving strict overlap behavior

## Verification

- Foundation adapter, Audience Projection, runtime-cache, catalog, and stream tests
- repository check, full test suite, build, and diff hygiene

Fixes #306

## Stack

1. #312
2. #313
3. #314
4. #315
5. #316

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
