### PR TITLE
Batch Ad Hoc broadcast authorization

### DIFF
--- a/src/index-ad-hoc.test.ts
+++ b/src/index-ad-hoc.test.ts
@@ -8,6 +8,7 @@ import {
 import {
   adHocFallbackRoute,
   admitGame,
+  broadcastGameSnapshot,
   calculateAdHocUpgradeCapacity,
   createGame,
   leaveGame,
@@ -15,6 +16,7 @@ import {
   readAuthorizedAdHocGame,
   readGame,
   resolveAdHocWebSocketSubscription,
+  type AdHocBroadcastSocket,
 } from "./index";
 
 function service(): AdHocGamesService {
@@ -45,6 +47,87 @@ async function createViaHttp(games: AdHocGamesService, homeName: string, browser
 }
 
 describe("Ad Hoc HTTP and WebSocket authority boundaries", () => {
+  test("reuses ordinary broadcast serialization while isolating sender acknowledgement and queue failure", async () => {
+    const games = service();
+    const created = await games.create({ homeName: "Home", awayName: "Away" });
+    if (created.status !== "accepted") throw new Error("creation failed");
+    const admitted = await games.admit({
+      gameId: created.gameId,
+      controlQr: created.controlQr,
+    });
+    if (admitted.status !== "accepted") throw new Error("admission failed");
+
+    const socket = (sessionId: string, sendResult: "success" | "failure" = "success") => {
+      const messages: string[] = [];
+      const closes: Array<{ code: number; reason: string }> = [];
+      const candidate: AdHocBroadcastSocket = {
+        data: { subscription: { type: "game", gameId: created.gameId, sessionId } },
+        send(serialized) {
+          messages.push(serialized);
+          return sendResult === "success" ? new TextEncoder().encode(serialized).byteLength : 0;
+        },
+        close(code, reason) {
+          closes.push({ code, reason });
+        },
+      };
+      return { candidate, messages, closes };
+    };
+    const sender = socket(created.sessionId);
+    const ordinary = socket(admitted.game.sessionId);
+    const pressured = socket(admitted.game.sessionId, "failure");
+    const removed = socket("removed-session-abcdefghijklmnopqrstuvwxyz");
+    let serializations = 0;
+    const serialize = (payload: Parameters<typeof JSON.stringify>[0]) => {
+      serializations += 1;
+      return JSON.stringify(payload);
+    };
+
+    const delivered = await broadcastGameSnapshot({
+      gameId: created.gameId,
+      service: games,
+      sender: sender.candidate,
+      candidates: [sender.candidate, ordinary.candidate, pressured.candidate, removed.candidate],
+      senderAckedCommandIds: ["accepted-command"],
+      operationOutcomes: [
+        { operationId: "accepted-command", workflow: "ad-hoc", status: "accepted" },
+      ],
+      serverNowMs: 2_000,
+      serialize,
+    });
+
+    expect(delivered).toBe(true);
+    expect(serializations).toBe(2);
+    expect(ordinary.messages).toEqual(pressured.messages);
+    expect(removed.messages).toEqual([]);
+    expect(sender.messages).toHaveLength(1);
+    expect(JSON.parse(sender.messages[0]!).ackedCommandIds).toEqual(["accepted-command"]);
+    expect(JSON.parse(ordinary.messages[0]!).ackedCommandIds).toEqual([]);
+    expect(pressured.closes).toEqual([{ code: 1013, reason: "Ad Hoc output backpressure." }]);
+    expect(games.getResourceMetrics().queuePressure).toBe(1);
+    expect([...sender.messages, ...ordinary.messages].join("")).not.toContain(created.sessionId);
+
+    await games.leave({ gameId: created.gameId, sessionId: created.sessionId });
+    serializations = 0;
+    sender.messages.length = 0;
+    ordinary.messages.length = 0;
+    expect(
+      await broadcastGameSnapshot({
+        gameId: created.gameId,
+        service: games,
+        sender: sender.candidate,
+        candidates: [sender.candidate, ordinary.candidate],
+        senderAckedCommandIds: ["must-not-be-acknowledged"],
+        operationOutcomes: [],
+        serverNowMs: 3_000,
+        serialize,
+      }),
+    ).toBe(false);
+    expect(sender.messages).toEqual([]);
+    expect(ordinary.messages).toHaveLength(1);
+    expect(JSON.parse(ordinary.messages[0]!).ackedCommandIds).toEqual([]);
+    expect(serializations).toBe(1);
+  });
+
   test("caps pre-upgrade Ad Hoc capacity below the configured Event reserve", () => {
     expect(
       calculateAdHocUpgradeCapacity({

--- a/src/index.ts
+++ b/src/index.ts
@@ -157,6 +157,12 @@ type SessionData = {
   closed: boolean;
 };
 
+export type AdHocBroadcastSocket = {
+  data: { subscription: SessionSubscription };
+  send(serialized: string): number;
+  close(code: number, reason: string): void;
+};
+
 const sockets = new Set<ServerWebSocket<SessionData>>();
 const defaultAdHocService = createAdHocGamesService();
 const pendingSocketReservations = new Map<string, ReturnType<typeof setTimeout>>();
@@ -2997,16 +3003,20 @@ export async function readAuthorizedAdHocGame(
   return result.status === "accepted" ? result.game : null;
 }
 
-async function broadcastGameSnapshot({
+export async function broadcastGameSnapshot({
   gameId,
   service,
   sender,
+  candidates = [...sockets],
   senderAckedCommandIds,
   operationOutcomes,
+  serverNowMs = Date.now(),
+  serialize = (payload) => JSON.stringify(payload),
 }: {
   gameId: string;
   service: AdHocGamesService;
-  sender: ServerWebSocket<SessionData>;
+  sender: AdHocBroadcastSocket;
+  candidates?: readonly AdHocBroadcastSocket[];
   senderAckedCommandIds: string[];
   operationOutcomes: readonly {
     operationId: string;
@@ -3014,32 +3024,63 @@ async function broadcastGameSnapshot({
     status: "accepted" | "duplicate" | "rejected" | "causally-blocked";
     detail?: string;
   }[];
+  serverNowMs?: number;
+  serialize?: (payload: ServerWsMessage) => string;
 }): Promise<boolean> {
-  const delivery = await Promise.all(
-    [...sockets].map(async (ws) => {
-      if (ws.data.subscription.type !== "game" || ws.data.subscription.gameId !== gameId) {
-        return ws === sender ? false : null;
-      }
-      const serverNowMs = Date.now();
-      const game = await readAuthorizedAdHocGame(
-        service,
-        gameId,
-        ws.data.subscription.sessionId,
-        serverNowMs,
-      );
-      if (game === null) return ws === sender ? false : null;
-      const sent = sendMessage(ws, {
+  const matched = candidates.filter(
+    (candidate) =>
+      candidate.data.subscription.type === "game" && candidate.data.subscription.gameId === gameId,
+  );
+  const authorization = await service.authorizeBroadcast({
+    gameId,
+    sessionIds: matched.map((candidate) =>
+      candidate.data.subscription.type === "game" ? candidate.data.subscription.sessionId : null,
+    ),
+    nowMs: serverNowMs,
+  });
+  if (authorization.status !== "accepted") return false;
+
+  let ordinaryEnvelope: string | null = null;
+  let senderEnvelope: string | null = null;
+  let senderDelivered = false;
+  for (let index = 0; index < matched.length; index += 1) {
+    if (authorization.authorized[index] !== true) continue;
+    const candidate = matched[index]!;
+    const isSender = candidate === sender;
+    let envelope: string;
+    if (isSender && senderAckedCommandIds.length > 0) {
+      senderEnvelope ??= serialize({
         type: "game-snapshot",
-        game: stripSession(game),
+        game: authorization.game,
         serverNowMs,
-        ackedCommandIds: ws === sender ? senderAckedCommandIds : [],
+        ackedCommandIds: senderAckedCommandIds,
         operationOutcomes,
       });
-      if (!sent) service.recordResourcePressure("queue-pressure");
-      return ws === sender ? sent : null;
-    }),
-  );
-  return delivery.some((sent) => sent === true);
+      envelope = senderEnvelope;
+    } else {
+      ordinaryEnvelope ??= serialize({
+        type: "game-snapshot",
+        game: authorization.game,
+        serverNowMs,
+        ackedCommandIds: [],
+        operationOutcomes,
+      });
+      envelope = ordinaryEnvelope;
+    }
+    const sent = sendAdHocSerializedEnvelope(candidate, envelope);
+    if (!sent) service.recordResourcePressure("queue-pressure");
+    if (isSender) senderDelivered ||= sent;
+  }
+  return senderDelivered;
+}
+
+function sendAdHocSerializedEnvelope(ws: AdHocBroadcastSocket, serialized: string): boolean {
+  return sendWebSocketText(ws, serialized, {
+    maxBytes: AD_HOC_MAX_QUEUED_OUTPUT_BYTES,
+    overflowCloseReason: "Ad Hoc output limit reached.",
+    shortSendCloseReason: "Ad Hoc output backpressure.",
+    sendErrorCloseReason: "Ad Hoc output unavailable.",
+  });
 }
 
 function sendMessage(ws: ServerWebSocket<SessionData>, payload: ServerWsMessage) {
@@ -3080,7 +3121,7 @@ type WebSocketTextSendPolicy = {
 };
 
 function sendWebSocketText(
-  ws: ServerWebSocket<SessionData>,
+  ws: Pick<ServerWebSocket<SessionData>, "send" | "close">,
   serialized: string,
   policy: WebSocketTextSendPolicy,
 ): boolean {

--- a/src/lib/ad-hoc-games.test.ts
+++ b/src/lib/ad-hoc-games.test.ts
@@ -1,12 +1,16 @@
 import { describe, expect, test } from "bun:test";
 import {
   AD_HOC_DISCONNECTED_GRACE_MS,
+  DEFAULT_AD_HOC_IQA_RULES,
   createAdHocGamesService,
   createInMemoryAdHocStore,
   type AdHocStore,
   type AdHocGamesService,
 } from "@/lib/ad-hoc-games";
-import { AD_HOC_MAX_RETAINED_REJECTED_OPERATIONS_PER_GAME } from "@/lib/ad-hoc-resource-budgets";
+import {
+  AD_HOC_MAX_CONNECTED_CONTROLLERS,
+  AD_HOC_MAX_RETAINED_REJECTED_OPERATIONS_PER_GAME,
+} from "@/lib/ad-hoc-resource-budgets";
 import { applyGameCommand, createInitialGameState } from "@/lib/game-engine";
 import { deriveAdHocOptimisticState } from "@/lib/game-page-support";
 import type { AdHocPendingOperation } from "@/lib/ad-hoc-controller-session";
@@ -255,6 +259,137 @@ describe("Ad Hoc Games service", () => {
     expect(
       (await games.read({ gameId: created.gameId, sessionId: created.sessionId })).status,
     ).toBe("accepted");
+  });
+
+  test("authorizes a bounded positional broadcast from one Game read and one shared projection", async () => {
+    const base = createInMemoryAdHocStore();
+    let reads = 0;
+    let projections = 0;
+    const games = createAdHocGamesService({
+      store: {
+        ...base,
+        readGame(gameId) {
+          reads += 1;
+          return base.readGame(gameId);
+        },
+      },
+      now: () => 1_000,
+      iqaRules: {
+        ...DEFAULT_AD_HOC_IQA_RULES,
+        project(state, nowMs) {
+          projections += 1;
+          return DEFAULT_AD_HOC_IQA_RULES.project(state, nowMs);
+        },
+      },
+    });
+    const created = await games.create({ homeName: "Home", awayName: "Away" });
+    if (created.status !== "accepted") throw new Error("creation failed");
+
+    reads = 0;
+    projections = 0;
+    for (
+      let candidateCount = 0;
+      candidateCount <= AD_HOC_MAX_CONNECTED_CONTROLLERS;
+      candidateCount += 1
+    ) {
+      reads = 0;
+      projections = 0;
+      const result = await games.authorizeBroadcast({
+        gameId: created.gameId,
+        sessionIds: Array.from({ length: candidateCount }, () => created.sessionId),
+        nowMs: 2_000,
+      });
+      expect(result.status).toBe("accepted");
+      if (result.status === "accepted") {
+        expect(result.authorized).toEqual(Array.from({ length: candidateCount }, () => true));
+      }
+      expect(reads).toBe(1);
+      expect(projections).toBe(1);
+    }
+
+    reads = 0;
+    projections = 0;
+    const unauthorized = "unauthorized-session-abcdefghijklmnopqrstuvwxyz";
+    const sessionIds = Array.from({ length: AD_HOC_MAX_CONNECTED_CONTROLLERS }, (_, index) =>
+      index % 2 === 0 ? created.sessionId : unauthorized,
+    );
+    const maximum = await games.authorizeBroadcast({
+      gameId: created.gameId,
+      sessionIds,
+      nowMs: 3_000,
+    });
+    expect(maximum.status).toBe("accepted");
+    if (maximum.status !== "accepted") return;
+    expect(maximum.authorized).toHaveLength(AD_HOC_MAX_CONNECTED_CONTROLLERS);
+    expect(maximum.authorized.slice(0, 4)).toEqual([true, false, true, false]);
+    expect(maximum.game).not.toHaveProperty("sessionId");
+    expect(JSON.stringify(maximum)).not.toContain(created.sessionId);
+    expect(JSON.stringify(maximum)).not.toContain(unauthorized);
+    expect(JSON.stringify(maximum)).not.toContain(
+      base.readGame(created.gameId)!.sessions[0]!.sessionHash,
+    );
+    expect(reads).toBe(1);
+    expect(projections).toBe(1);
+
+    const finished = await games.apply({
+      gameId: created.gameId,
+      sessionId: created.sessionId,
+      operations: [
+        {
+          id: "finish-before-broadcast",
+          clientSentAtMs: 3_100,
+          command: { type: "record-double-forfeit" },
+        },
+      ],
+      nowMs: 3_100,
+    });
+    expect(finished.status).toBe("accepted");
+    reads = 0;
+    projections = 0;
+    const finishedBroadcast = await games.authorizeBroadcast({
+      gameId: created.gameId,
+      sessionIds: [created.sessionId],
+      nowMs: 3_200,
+    });
+    expect(finishedBroadcast).toMatchObject({
+      status: "accepted",
+      authorized: [true],
+      game: { controlQr: null, state: { isFinished: true } },
+    });
+    expect(reads).toBe(1);
+    expect(projections).toBe(1);
+
+    reads = 0;
+    projections = 0;
+    await games.leave({ gameId: created.gameId, sessionId: created.sessionId });
+    const removed = await games.authorizeBroadcast({
+      gameId: created.gameId,
+      sessionIds: [created.sessionId],
+      nowMs: 4_000,
+    });
+    expect(removed).toMatchObject({ status: "accepted", authorized: [false] });
+    expect(reads).toBe(1);
+    expect(projections).toBe(1);
+
+    reads = 0;
+    projections = 0;
+    expect(
+      await games.authorizeBroadcast({
+        gameId: created.gameId,
+        sessionIds: Array.from(
+          { length: AD_HOC_MAX_CONNECTED_CONTROLLERS + 1 },
+          () => unauthorized,
+        ),
+      }),
+    ).toEqual({ status: "unavailable" });
+    expect(
+      await games.authorizeBroadcast({ gameId: created.gameId, sessionIds: ["short"] }),
+    ).toEqual({ status: "unavailable" });
+    expect(await games.authorizeBroadcast({ gameId: "invalid", sessionIds: [] })).toEqual({
+      status: "unavailable",
+    });
+    expect(reads).toBe(0);
+    expect(projections).toBe(0);
   });
 
   test("returns duplicate acknowledgements without rewriting unchanged Game state", async () => {

--- a/src/lib/ad-hoc-games.ts
+++ b/src/lib/ad-hoc-games.ts
@@ -69,6 +69,16 @@ export type AdHocGameView = GameView & {
   controlQr: string | null;
 };
 
+export type AuthorizedAdHocGameProjection = Omit<AdHocGameView, "sessionId">;
+
+export type AdHocBroadcastAuthorizationResult =
+  | {
+      status: "accepted";
+      game: AuthorizedAdHocGameProjection;
+      authorized: readonly boolean[];
+    }
+  | { status: "unavailable" };
+
 export type AdHocCreationInput = {
   homeName: unknown;
   awayName: unknown;
@@ -781,6 +791,44 @@ export function createAdHocGamesService(options: AdHocGamesServiceOptions = {}) 
       return {
         status: "accepted",
         game: projectAuthorizedGame(game, sessionId, null, input.nowMs ?? now(), iqaRules),
+      };
+    },
+
+    async authorizeBroadcast(input: {
+      gameId: unknown;
+      sessionIds: unknown;
+      nowMs?: number;
+    }): Promise<AdHocBroadcastAuthorizationResult> {
+      const gameId = validateGameId(input.gameId);
+      const nowMs = input.nowMs ?? now();
+      if (
+        gameId === null ||
+        !isSafeTimestamp(nowMs) ||
+        !Array.isArray(input.sessionIds) ||
+        input.sessionIds.length > AD_HOC_MAX_CONNECTED_CONTROLLERS
+      ) {
+        return { status: "unavailable" };
+      }
+      const sessionIds = input.sessionIds.map(validateBearer);
+      if (sessionIds.some((sessionId) => sessionId === null)) {
+        return { status: "unavailable" };
+      }
+      let game: StoredAdHocGame | null;
+      try {
+        game = store.readGame(gameId);
+      } catch {
+        return { status: "unavailable" };
+      }
+      if (game === null || game.environmentIdentity !== environmentIdentity) {
+        return { status: "unavailable" };
+      }
+      const authorizedSessionHashes = new Set(game.sessions.map((session) => session.sessionHash));
+      return {
+        status: "accepted",
+        game: projectAuthorizedGameShared(game, nowMs, iqaRules),
+        authorized: sessionIds.map(
+          (sessionId) => sessionId !== null && authorizedSessionHashes.has(digest(sessionId)),
+        ),
       };
     },
 
@@ -2170,12 +2218,24 @@ function projectAuthorizedGame(
   nowMs: number,
   rules: AdHocIqaGameRules = DEFAULT_AD_HOC_IQA_RULES,
 ): AdHocGameView {
+  const shared = projectAuthorizedGameShared(game, nowMs, rules);
+  return {
+    ...shared,
+    sessionId,
+    controlQr: shared.state.isFinished ? null : (controlQr ?? game.controlQr),
+  };
+}
+
+function projectAuthorizedGameShared(
+  game: StoredAdHocGame,
+  nowMs: number,
+  rules: AdHocIqaGameRules = DEFAULT_AD_HOC_IQA_RULES,
+): AuthorizedAdHocGameProjection {
   const view = rules.project(game.state, nowMs);
   return {
     ...view,
     gameId: game.gameId,
-    sessionId,
-    controlQr: view.state.isFinished ? null : (controlQr ?? game.controlQr),
+    controlQr: view.state.isFinished ? null : game.controlQr,
   };
 }
 


### PR DESCRIPTION
## Summary

- authorize all Ad Hoc broadcast recipients from one authoritative persisted Game read
- project shared Game state once and reuse one ordinary serialized envelope
- preserve positional authorization, sender acknowledgements, removed-session suppression, and per-socket queue pressure

## Verification

- Ad Hoc service and WebSocket broadcaster tests through the 256-controller bound
- repository check, full test suite, build, and diff hygiene

Fixes #307

## Stack

1. #312
2. #313
3. #314
4. #315
5. #316

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
