### PR TITLE
Make Foundation mutation tracking exhaustive

### DIFF
--- a/src/lib/foundation-storage.ts
+++ b/src/lib/foundation-storage.ts
@@ -476,13 +476,7 @@ export type FoundationStorageSnapshot = {
   readGrantAdmissionStateAnchor?(): GrantAdmissionStateAnchor | null;
 };
 
-export type FoundationStorageTransaction = FoundationStorageSnapshot & {
-  findGameplaySlot(gameplaySlotId: string): StoredGameplaySlot | null;
-  listGameplaySlots(gameDayId: string): StoredGameplaySlot[];
-  findPitchSlot(pitchSlotId: string): StoredPitchSlot | null;
-  listPitchSlots(gameDayId: string, pitchId?: string): StoredPitchSlot[];
-  findEventGame(eventGameId: string): StoredEventCatalogGame | null;
-  listEventGames(gameDayId: string): StoredEventCatalogGame[];
+export type FoundationStorageMutations = {
   insertRoot(root: StoredEventGameRecordRoot): void;
   updateRoot(root: StoredEventGameRecordRoot): void;
   insertAction(action: StoredControlAction): void;
@@ -536,66 +530,77 @@ export type FoundationStorageTransaction = FoundationStorageSnapshot & {
   writeGrantAdmissionTelemetry?(value: GrantAdmissionTelemetry): void;
   writeGrantAdmissionGlobalWindow?(value: GrantAdmissionGlobalWindow): void;
   pruneGrantAdmissionTelemetry?(beforeMs: number): void;
-  readGrantAdmissionStateAnchor?(): GrantAdmissionStateAnchor | null;
   writeGrantAdmissionStateAnchor?(): void;
 };
 
+export type FoundationStorageTransaction = FoundationStorageSnapshot &
+  FoundationStorageMutations & {
+    findGameplaySlot(gameplaySlotId: string): StoredGameplaySlot | null;
+    listGameplaySlots(gameDayId: string): StoredGameplaySlot[];
+    findPitchSlot(pitchSlotId: string): StoredPitchSlot | null;
+    listPitchSlots(gameDayId: string, pitchId?: string): StoredPitchSlot[];
+    findEventGame(eventGameId: string): StoredEventCatalogGame | null;
+    listEventGames(gameDayId: string): StoredEventCatalogGame[];
+  };
+
 export type FoundationStorageTransactionWork<T> = (transaction: FoundationStorageTransaction) => T;
 
-const FOUNDATION_STORAGE_MUTATION_METHODS = new Set<PropertyKey>([
-  "insertRoot",
-  "updateRoot",
-  "insertAction",
-  "upsertRecordMetadata",
-  "appendAuditEntry",
-  "insertPresentationChange",
-  "appendPresentationAuditEntry",
-  "appendPresentationAuditRevision",
-  "sealPresentationEvidence",
-  "insertGrant",
-  "updateGrant",
-  "insertGrantSession",
-  "updateGrantSession",
-  "appendGrantAudit",
-  "upsertAcceptanceBudget",
-  "insertReplayReservation",
-  "updateReplayReservation",
-  "insertReplayAttempt",
-  "updateReplayAttempt",
-  "discardReplayAttempts",
-  "discardReplayReservation",
-  "insertReplayReceipt",
-  "updateReplayReceipt",
-  "insertAcceptanceIntegrityAnchor",
-  "insertEvent",
-  "updateEvent",
-  "deleteEvent",
-  "insertGameDay",
-  "updateGameDay",
-  "deleteGameDay",
-  "insertEventTeam",
-  "updateEventTeam",
-  "deleteEventTeam",
-  "insertRosterEntry",
-  "updateRosterEntry",
-  "insertPitch",
-  "updatePitch",
-  "deletePitch",
-  "insertGameplaySlot",
-  "insertPitchSlot",
-  "updateGameplaySlot",
-  "updatePitchSlot",
-  "deleteGameplaySlot",
-  "deletePitchSlot",
-  "insertEventGame",
-  "updateEventGame",
-  "deleteEventGame",
-  "appendEventAudit",
-  "writeGrantAdmissionTelemetry",
-  "writeGrantAdmissionGlobalWindow",
-  "pruneGrantAdmissionTelemetry",
-  "writeGrantAdmissionStateAnchor",
-]);
+const FOUNDATION_STORAGE_MUTATION_METHODS: ReadonlySet<PropertyKey> = new Set(
+  Object.keys({
+    insertRoot: true,
+    updateRoot: true,
+    insertAction: true,
+    upsertRecordMetadata: true,
+    appendAuditEntry: true,
+    insertPresentationChange: true,
+    appendPresentationAuditEntry: true,
+    appendPresentationAuditRevision: true,
+    sealPresentationEvidence: true,
+    insertGrant: true,
+    updateGrant: true,
+    insertGrantSession: true,
+    updateGrantSession: true,
+    appendGrantAudit: true,
+    upsertAcceptanceBudget: true,
+    insertReplayReservation: true,
+    updateReplayReservation: true,
+    insertReplayAttempt: true,
+    updateReplayAttempt: true,
+    discardReplayAttempts: true,
+    discardReplayReservation: true,
+    insertReplayReceipt: true,
+    updateReplayReceipt: true,
+    insertAcceptanceIntegrityAnchor: true,
+    insertEvent: true,
+    updateEvent: true,
+    deleteEvent: true,
+    insertGameDay: true,
+    updateGameDay: true,
+    deleteGameDay: true,
+    insertEventTeam: true,
+    updateEventTeam: true,
+    deleteEventTeam: true,
+    insertRosterEntry: true,
+    updateRosterEntry: true,
+    insertPitch: true,
+    updatePitch: true,
+    deletePitch: true,
+    insertGameplaySlot: true,
+    insertPitchSlot: true,
+    updateGameplaySlot: true,
+    updatePitchSlot: true,
+    deleteGameplaySlot: true,
+    deletePitchSlot: true,
+    insertEventGame: true,
+    updateEventGame: true,
+    deleteEventGame: true,
+    appendEventAudit: true,
+    writeGrantAdmissionTelemetry: true,
+    writeGrantAdmissionGlobalWindow: true,
+    pruneGrantAdmissionTelemetry: true,
+    writeGrantAdmissionStateAnchor: true,
+  } satisfies Record<keyof FoundationStorageMutations, true>),
+);
 
 /** Adapter helper: records callback mutation intent without inspecting physical writes. */
 export function trackFoundationMutationIntent(


### PR DESCRIPTION
## Summary

- centralize Foundation mutation methods in a typed write capability
- make the runtime mutation registry exhaustive over that capability
- turn missing or extra mutation-tracking entries into static-check failures

## Verification

- Foundation memory and SQLite storage contract tests
- terminal Standards and Spec review with zero findings
- repository check, full test suite, build, and diff hygiene

Fixes #306

## Stack

1. #312
2. #313
3. #314
4. #315
5. #316

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
