### PR TITLE
Enforce one WebSocket protocol subscription

### DIFF
--- a/src/index-ad-hoc.test.ts
+++ b/src/index-ad-hoc.test.ts
@@ -10,16 +10,13 @@ import {
   admitGame,
   broadcastGameSnapshot,
   calculateAdHocUpgradeCapacity,
-  canBeginWebSocketSubscription,
   createGame,
   leaveGame,
   readAdHocSession,
   readAuthorizedAdHocGame,
   readGame,
   resolveAdHocWebSocketSubscription,
-  queueWebSocketSubscription,
   type AdHocBroadcastSocket,
-  type WebSocketSubscriptionQueue,
 } from "./index";
 
 function service(): AdHocGamesService {
@@ -50,161 +47,6 @@ async function createViaHttp(games: AdHocGamesService, homeName: string, browser
 }
 
 describe("Ad Hoc HTTP and WebSocket authority boundaries", () => {
-  test("allows a new protocol subscription only from the empty state", () => {
-    expect(canBeginWebSocketSubscription({ type: "none" })).toBe(true);
-    expect(canBeginWebSocketSubscription({ type: "lobby" })).toBe(false);
-    expect(
-      canBeginWebSocketSubscription({
-        type: "game",
-        gameId: "adhoc-existing",
-        sessionId: "existing-session",
-      }),
-    ).toBe(false);
-    expect(canBeginWebSocketSubscription({ type: "public-event", eventId: "event-existing" })).toBe(
-      false,
-    );
-  });
-
-  test("rejects an Ad Hoc Game subscription after a public Audience Projection subscription before side effects", async () => {
-    const queue: WebSocketSubscriptionQueue = {
-      subscription: { type: "public-event" as const, eventId: "event-existing" },
-      subscriptionWork: Promise.resolve(),
-    };
-    const errors: string[] = [];
-    let resolverCalls = 0;
-    let trackingCalls = 0;
-    let connectionCalls = 0;
-    let snapshots = 0;
-
-    const result = await queueWebSocketSubscription(queue, {
-      alreadySubscribed(message) {
-        errors.push(message);
-      },
-      async subscribe() {
-        resolverCalls += 1;
-        trackingCalls += 1;
-        connectionCalls += 1;
-        snapshots += 1;
-        queue.subscription = {
-          type: "game",
-          gameId: "adhoc-attempted",
-          sessionId: "attempted-session",
-        };
-      },
-    });
-
-    expect(result).toBe("already-subscribed");
-    expect(errors).toEqual(["WebSocket is already subscribed."]);
-    expect(queue.subscription).toEqual({ type: "public-event", eventId: "event-existing" });
-    expect({ resolverCalls, trackingCalls, connectionCalls, snapshots }).toEqual({
-      resolverCalls: 0,
-      trackingCalls: 0,
-      connectionCalls: 0,
-      snapshots: 0,
-    });
-  });
-
-  test("rejects a public Audience Projection subscription after an Ad Hoc Game subscription", async () => {
-    const gameQueue: WebSocketSubscriptionQueue = {
-      subscription: {
-        type: "game" as const,
-        gameId: "adhoc-existing",
-        sessionId: "existing-session",
-      },
-      subscriptionWork: Promise.resolve(),
-    };
-    let publicCapacityCalls = 0;
-    expect(
-      await queueWebSocketSubscription(gameQueue, {
-        alreadySubscribed() {},
-        async subscribe() {
-          publicCapacityCalls += 1;
-        },
-      }),
-    ).toBe("already-subscribed");
-    expect(publicCapacityCalls).toBe(0);
-  });
-
-  test("rejects a second subscription to the same protocol without subscription work", async () => {
-    const subscriptions = [
-      { type: "public-event" as const, eventId: "event-existing" },
-      {
-        type: "game" as const,
-        gameId: "adhoc-existing",
-        sessionId: "existing-session",
-      },
-    ];
-
-    for (const subscription of subscriptions) {
-      const queue: WebSocketSubscriptionQueue = {
-        subscription,
-        subscriptionWork: Promise.resolve(),
-      };
-      let sideEffects = 0;
-      expect(
-        await queueWebSocketSubscription(queue, {
-          alreadySubscribed() {},
-          async subscribe() {
-            sideEffects += 1;
-          },
-        }),
-      ).toBe("already-subscribed");
-      expect(sideEffects).toBe(0);
-      expect(queue.subscription).toEqual(subscription);
-    }
-  });
-
-  test("queued handler ordering admits only the first subscription in either protocol order", async () => {
-    const orders = [
-      [
-        { type: "public-event" as const, eventId: "event-first" },
-        {
-          type: "game" as const,
-          gameId: "adhoc-second",
-          sessionId: "second-session",
-        },
-      ],
-      [
-        {
-          type: "game" as const,
-          gameId: "adhoc-first",
-          sessionId: "first-session",
-        },
-        { type: "public-event" as const, eventId: "event-second" },
-      ],
-    ];
-
-    for (const [firstSubscription, secondSubscription] of orders) {
-      if (firstSubscription === undefined || secondSubscription === undefined) {
-        throw new Error("subscription order fixture is incomplete");
-      }
-      const queue: WebSocketSubscriptionQueue = {
-        subscription: { type: "none" },
-        subscriptionWork: Promise.resolve(),
-      };
-      const sideEffects: string[] = [];
-      const first = queueWebSocketSubscription(queue, {
-        alreadySubscribed() {},
-        async subscribe() {
-          await Promise.resolve();
-          sideEffects.push("first-capacity");
-          queue.subscription = firstSubscription;
-        },
-      });
-      const second = queueWebSocketSubscription(queue, {
-        alreadySubscribed() {},
-        async subscribe() {
-          sideEffects.push("second-capacity");
-          queue.subscription = secondSubscription;
-        },
-      });
-
-      expect(await Promise.all([first, second])).toEqual(["started", "already-subscribed"]);
-      expect(sideEffects).toEqual(["first-capacity"]);
-      expect(queue.subscription).toEqual(firstSubscription);
-    }
-  });
-
   test("reuses ordinary broadcast serialization while isolating sender acknowledgement and queue failure", async () => {
     const games = service();
     const created = await games.create({ homeName: "Home", awayName: "Away" });

--- a/src/index-ad-hoc.test.ts
+++ b/src/index-ad-hoc.test.ts
@@ -10,13 +10,16 @@ import {
   admitGame,
   broadcastGameSnapshot,
   calculateAdHocUpgradeCapacity,
+  canBeginWebSocketSubscription,
   createGame,
   leaveGame,
   readAdHocSession,
   readAuthorizedAdHocGame,
   readGame,
   resolveAdHocWebSocketSubscription,
+  queueWebSocketSubscription,
   type AdHocBroadcastSocket,
+  type WebSocketSubscriptionQueue,
 } from "./index";
 
 function service(): AdHocGamesService {
@@ -47,6 +50,161 @@ async function createViaHttp(games: AdHocGamesService, homeName: string, browser
 }
 
 describe("Ad Hoc HTTP and WebSocket authority boundaries", () => {
+  test("allows a new protocol subscription only from the empty state", () => {
+    expect(canBeginWebSocketSubscription({ type: "none" })).toBe(true);
+    expect(canBeginWebSocketSubscription({ type: "lobby" })).toBe(false);
+    expect(
+      canBeginWebSocketSubscription({
+        type: "game",
+        gameId: "adhoc-existing",
+        sessionId: "existing-session",
+      }),
+    ).toBe(false);
+    expect(canBeginWebSocketSubscription({ type: "public-event", eventId: "event-existing" })).toBe(
+      false,
+    );
+  });
+
+  test("rejects an Ad Hoc Game subscription after a public Audience Projection subscription before side effects", async () => {
+    const queue: WebSocketSubscriptionQueue = {
+      subscription: { type: "public-event" as const, eventId: "event-existing" },
+      subscriptionWork: Promise.resolve(),
+    };
+    const errors: string[] = [];
+    let resolverCalls = 0;
+    let trackingCalls = 0;
+    let connectionCalls = 0;
+    let snapshots = 0;
+
+    const result = await queueWebSocketSubscription(queue, {
+      alreadySubscribed(message) {
+        errors.push(message);
+      },
+      async subscribe() {
+        resolverCalls += 1;
+        trackingCalls += 1;
+        connectionCalls += 1;
+        snapshots += 1;
+        queue.subscription = {
+          type: "game",
+          gameId: "adhoc-attempted",
+          sessionId: "attempted-session",
+        };
+      },
+    });
+
+    expect(result).toBe("already-subscribed");
+    expect(errors).toEqual(["WebSocket is already subscribed."]);
+    expect(queue.subscription).toEqual({ type: "public-event", eventId: "event-existing" });
+    expect({ resolverCalls, trackingCalls, connectionCalls, snapshots }).toEqual({
+      resolverCalls: 0,
+      trackingCalls: 0,
+      connectionCalls: 0,
+      snapshots: 0,
+    });
+  });
+
+  test("rejects a public Audience Projection subscription after an Ad Hoc Game subscription", async () => {
+    const gameQueue: WebSocketSubscriptionQueue = {
+      subscription: {
+        type: "game" as const,
+        gameId: "adhoc-existing",
+        sessionId: "existing-session",
+      },
+      subscriptionWork: Promise.resolve(),
+    };
+    let publicCapacityCalls = 0;
+    expect(
+      await queueWebSocketSubscription(gameQueue, {
+        alreadySubscribed() {},
+        async subscribe() {
+          publicCapacityCalls += 1;
+        },
+      }),
+    ).toBe("already-subscribed");
+    expect(publicCapacityCalls).toBe(0);
+  });
+
+  test("rejects a second subscription to the same protocol without subscription work", async () => {
+    const subscriptions = [
+      { type: "public-event" as const, eventId: "event-existing" },
+      {
+        type: "game" as const,
+        gameId: "adhoc-existing",
+        sessionId: "existing-session",
+      },
+    ];
+
+    for (const subscription of subscriptions) {
+      const queue: WebSocketSubscriptionQueue = {
+        subscription,
+        subscriptionWork: Promise.resolve(),
+      };
+      let sideEffects = 0;
+      expect(
+        await queueWebSocketSubscription(queue, {
+          alreadySubscribed() {},
+          async subscribe() {
+            sideEffects += 1;
+          },
+        }),
+      ).toBe("already-subscribed");
+      expect(sideEffects).toBe(0);
+      expect(queue.subscription).toEqual(subscription);
+    }
+  });
+
+  test("queued handler ordering admits only the first subscription in either protocol order", async () => {
+    const orders = [
+      [
+        { type: "public-event" as const, eventId: "event-first" },
+        {
+          type: "game" as const,
+          gameId: "adhoc-second",
+          sessionId: "second-session",
+        },
+      ],
+      [
+        {
+          type: "game" as const,
+          gameId: "adhoc-first",
+          sessionId: "first-session",
+        },
+        { type: "public-event" as const, eventId: "event-second" },
+      ],
+    ];
+
+    for (const [firstSubscription, secondSubscription] of orders) {
+      if (firstSubscription === undefined || secondSubscription === undefined) {
+        throw new Error("subscription order fixture is incomplete");
+      }
+      const queue: WebSocketSubscriptionQueue = {
+        subscription: { type: "none" },
+        subscriptionWork: Promise.resolve(),
+      };
+      const sideEffects: string[] = [];
+      const first = queueWebSocketSubscription(queue, {
+        alreadySubscribed() {},
+        async subscribe() {
+          await Promise.resolve();
+          sideEffects.push("first-capacity");
+          queue.subscription = firstSubscription;
+        },
+      });
+      const second = queueWebSocketSubscription(queue, {
+        alreadySubscribed() {},
+        async subscribe() {
+          sideEffects.push("second-capacity");
+          queue.subscription = secondSubscription;
+        },
+      });
+
+      expect(await Promise.all([first, second])).toEqual(["started", "already-subscribed"]);
+      expect(sideEffects).toEqual(["first-capacity"]);
+      expect(queue.subscription).toEqual(firstSubscription);
+    }
+  });
+
   test("reuses ordinary broadcast serialization while isolating sender acknowledgement and queue failure", async () => {
     const games = service();
     const created = await games.create({ homeName: "Home", awayName: "Away" });

--- a/src/index.ts
+++ b/src/index.ts
@@ -131,7 +131,7 @@ import {
   runTechnicalAdminBootstrapCli,
 } from "@/lib/technical-admin-bootstrap";
 
-type SessionSubscription =
+export type SessionSubscription =
   | {
       type: "none";
     }
@@ -156,6 +156,37 @@ type SessionData = {
   subscriptionWork: Promise<void>;
   closed: boolean;
 };
+
+export type WebSocketSubscriptionQueue = Pick<SessionData, "subscription" | "subscriptionWork">;
+
+export function canBeginWebSocketSubscription(subscription: SessionData["subscription"]): boolean {
+  return subscription.type === "none";
+}
+
+export function queueWebSocketSubscription(
+  queue: WebSocketSubscriptionQueue,
+  operation: {
+    isClosed?: () => boolean;
+    alreadySubscribed: (message: string) => void;
+    subscribe: () => Promise<void>;
+  },
+): Promise<"started" | "already-subscribed" | "closed"> {
+  const handleSubscription = async () => {
+    if (operation.isClosed?.()) return "closed" as const;
+    if (!canBeginWebSocketSubscription(queue.subscription)) {
+      operation.alreadySubscribed("WebSocket is already subscribed.");
+      return "already-subscribed" as const;
+    }
+    await operation.subscribe();
+    return "started" as const;
+  };
+  const queued = queue.subscriptionWork.then(handleSubscription, handleSubscription);
+  queue.subscriptionWork = queued.then(
+    () => undefined,
+    () => undefined,
+  );
+  return queued;
+}
 
 export type AdHocBroadcastSocket = {
   data: { subscription: SessionSubscription };
@@ -2437,119 +2468,125 @@ async function startServer() {
 
             case "subscribe-public-event": {
               const eventId = parsed.message.eventId;
-              const handleSubscription = async () => {
-                if (ws.data.closed) return;
-                if (ws.data.subscription.type !== "none") {
+              const queued = queueWebSocketSubscription(ws.data, {
+                isClosed: () => ws.data.closed,
+                alreadySubscribed(message) {
                   sendMessage(ws, {
                     type: "error",
-                    message: "WebSocket is already subscribed.",
+                    message,
                   });
-                  return;
-                }
-                const subscriber = {
-                  send(serialized: string) {
-                    return sendPublicAudienceSerializedEnvelope(ws, serialized);
-                  },
-                  close(code: number, reason: string) {
-                    if (!ws.data.closed) ws.close(code, reason);
-                  },
-                };
-                const result = await publicEventWebSocketHub.subscribe(
-                  ws.data.id,
-                  eventId,
-                  subscriber,
-                );
-                if (ws.data.closed) return;
-                if (result.status === "rejected") {
-                  sendMessage(ws, { type: "error", message: result.message });
-                  ws.close(1013, result.message);
-                  return;
-                }
-                if (result.status !== "admitted") {
-                  sendPublicEventStreamMessage(ws, {
-                    protocol: "public-event-stream-v1",
-                    type: "event-unavailable",
+                },
+                async subscribe() {
+                  const subscriber = {
+                    send(serialized: string) {
+                      return sendPublicAudienceSerializedEnvelope(ws, serialized);
+                    },
+                    close(code: number, reason: string) {
+                      if (!ws.data.closed) ws.close(code, reason);
+                    },
+                  };
+                  const result = await publicEventWebSocketHub.subscribe(
+                    ws.data.id,
                     eventId,
-                  });
-                  ws.close(1008, "Event unavailable.");
-                  return;
-                }
-                ws.data.subscription = { type: "public-event", eventId };
-              };
-              const queued = ws.data.subscriptionWork.then(handleSubscription, handleSubscription);
-              ws.data.subscriptionWork = queued.catch(() => undefined);
+                    subscriber,
+                  );
+                  if (ws.data.closed) return;
+                  if (result.status === "rejected") {
+                    sendMessage(ws, { type: "error", message: result.message });
+                    ws.close(1013, result.message);
+                    return;
+                  }
+                  if (result.status !== "admitted") {
+                    sendPublicEventStreamMessage(ws, {
+                      protocol: "public-event-stream-v1",
+                      type: "event-unavailable",
+                      eventId,
+                    });
+                    ws.close(1008, "Event unavailable.");
+                    return;
+                  }
+                  ws.data.subscription = { type: "public-event", eventId };
+                },
+              });
               await queued;
               return;
             }
 
             case "subscribe-game": {
               const subscribeGameId = parsed.message.gameId;
-              const handleSubscription = async () => {
-                const result = await resolveAdHocWebSocketSubscription({
-                  service: adHocService,
-                  cookieHeader: ws.data.cookieHeader,
-                  gameId: subscribeGameId,
-                });
-                if (result.status === "capacity") {
-                  if (!ws.data.closed) {
-                    adHocService.recordResourcePressure("connection-shed");
-                    sendMessage(ws, {
-                      type: "error",
-                      message: "Ad Hoc connection busy. Try again later.",
-                      retryAfterMs: result.retryAfterMs,
-                    });
-                    setTimeout(() => ws.close(1013, "Ad Hoc connection busy."), 25);
-                  }
-                  return;
-                }
-                if (result.status !== "accepted") {
-                  if (!ws.data.closed) {
-                    sendMessage(ws, {
-                      type: "error",
-                      message: adHocService.genericUnavailableMessage,
-                    });
-                    ws.close(1008, "Ad Hoc subscription unavailable.");
-                  }
-                  return;
-                }
-                const identity = {
-                  gameId: subscribeGameId,
-                  sessionId: result.sessionId,
-                };
-                const tracking = await liveAdHocSessions.subscribe(ws.data.id, {
-                  ...identity,
-                });
-                if (!tracking.attached) {
-                  if (liveAdHocSessions.count(identity) === 0) {
-                    await adHocService.setConnection({ ...identity, connected: false });
-                  }
-                  if (!ws.data.closed) {
-                    sendMessage(ws, {
-                      type: "error",
-                      message: adHocService.genericUnavailableMessage,
-                    });
-                    ws.close(1008, "Ad Hoc subscription unavailable.");
-                  }
-                  return;
-                }
-                ws.data.sessionId = result.sessionId;
-                ws.data.subscription = {
-                  type: "game",
-                  gameId: subscribeGameId,
-                  sessionId: result.sessionId,
-                };
-                if (!ws.data.closed) {
+              const queued = queueWebSocketSubscription(ws.data, {
+                isClosed: () => ws.data.closed,
+                alreadySubscribed(message) {
                   sendMessage(ws, {
-                    type: "game-snapshot",
-                    game: stripSession(result.game),
-                    serverNowMs: Date.now(),
-                    ackedCommandIds: [],
+                    type: "error",
+                    message,
                   });
-                }
-                if (!tracking.previousDisconnectDurable) void liveAdHocSessions.retryPending();
-              };
-              const queued = ws.data.subscriptionWork.then(handleSubscription, handleSubscription);
-              ws.data.subscriptionWork = queued.catch(() => undefined);
+                },
+                async subscribe() {
+                  const result = await resolveAdHocWebSocketSubscription({
+                    service: adHocService,
+                    cookieHeader: ws.data.cookieHeader,
+                    gameId: subscribeGameId,
+                  });
+                  if (result.status === "capacity") {
+                    if (!ws.data.closed) {
+                      adHocService.recordResourcePressure("connection-shed");
+                      sendMessage(ws, {
+                        type: "error",
+                        message: "Ad Hoc connection busy. Try again later.",
+                        retryAfterMs: result.retryAfterMs,
+                      });
+                      setTimeout(() => ws.close(1013, "Ad Hoc connection busy."), 25);
+                    }
+                    return;
+                  }
+                  if (result.status !== "accepted") {
+                    if (!ws.data.closed) {
+                      sendMessage(ws, {
+                        type: "error",
+                        message: adHocService.genericUnavailableMessage,
+                      });
+                      ws.close(1008, "Ad Hoc subscription unavailable.");
+                    }
+                    return;
+                  }
+                  const identity = {
+                    gameId: subscribeGameId,
+                    sessionId: result.sessionId,
+                  };
+                  const tracking = await liveAdHocSessions.subscribe(ws.data.id, {
+                    ...identity,
+                  });
+                  if (!tracking.attached) {
+                    if (liveAdHocSessions.count(identity) === 0) {
+                      await adHocService.setConnection({ ...identity, connected: false });
+                    }
+                    if (!ws.data.closed) {
+                      sendMessage(ws, {
+                        type: "error",
+                        message: adHocService.genericUnavailableMessage,
+                      });
+                      ws.close(1008, "Ad Hoc subscription unavailable.");
+                    }
+                    return;
+                  }
+                  ws.data.sessionId = result.sessionId;
+                  ws.data.subscription = {
+                    type: "game",
+                    gameId: subscribeGameId,
+                    sessionId: result.sessionId,
+                  };
+                  if (!ws.data.closed) {
+                    sendMessage(ws, {
+                      type: "game-snapshot",
+                      game: stripSession(result.game),
+                      serverNowMs: Date.now(),
+                      ackedCommandIds: [],
+                    });
+                  }
+                  if (!tracking.previousDisconnectDurable) void liveAdHocSessions.retryPending();
+                },
+              });
               await queued;
               return;
             }

--- a/src/index.ts
+++ b/src/index.ts
@@ -130,23 +130,7 @@ import {
   parseTechnicalAdminBootstrapCli,
   runTechnicalAdminBootstrapCli,
 } from "@/lib/technical-admin-bootstrap";
-
-export type SessionSubscription =
-  | {
-      type: "none";
-    }
-  | {
-      type: "lobby";
-    }
-  | {
-      type: "game";
-      gameId: string;
-      sessionId: string;
-    }
-  | {
-      type: "public-event";
-      eventId: string;
-    };
+import { queueWebSocketSubscription, type SessionSubscription } from "@/lib/websocket-subscription";
 
 type SessionData = {
   id: string;
@@ -156,37 +140,6 @@ type SessionData = {
   subscriptionWork: Promise<void>;
   closed: boolean;
 };
-
-export type WebSocketSubscriptionQueue = Pick<SessionData, "subscription" | "subscriptionWork">;
-
-export function canBeginWebSocketSubscription(subscription: SessionData["subscription"]): boolean {
-  return subscription.type === "none";
-}
-
-export function queueWebSocketSubscription(
-  queue: WebSocketSubscriptionQueue,
-  operation: {
-    isClosed?: () => boolean;
-    alreadySubscribed: (message: string) => void;
-    subscribe: () => Promise<void>;
-  },
-): Promise<"started" | "already-subscribed" | "closed"> {
-  const handleSubscription = async () => {
-    if (operation.isClosed?.()) return "closed" as const;
-    if (!canBeginWebSocketSubscription(queue.subscription)) {
-      operation.alreadySubscribed("WebSocket is already subscribed.");
-      return "already-subscribed" as const;
-    }
-    await operation.subscribe();
-    return "started" as const;
-  };
-  const queued = queue.subscriptionWork.then(handleSubscription, handleSubscription);
-  queue.subscriptionWork = queued.then(
-    () => undefined,
-    () => undefined,
-  );
-  return queued;
-}
 
 export type AdHocBroadcastSocket = {
   data: { subscription: SessionSubscription };
@@ -2468,45 +2421,36 @@ async function startServer() {
 
             case "subscribe-public-event": {
               const eventId = parsed.message.eventId;
-              const queued = queueWebSocketSubscription(ws.data, {
-                isClosed: () => ws.data.closed,
-                alreadySubscribed(message) {
-                  sendMessage(ws, {
-                    type: "error",
-                    message,
-                  });
-                },
-                async subscribe() {
-                  const subscriber = {
-                    send(serialized: string) {
-                      return sendPublicAudienceSerializedEnvelope(ws, serialized);
-                    },
-                    close(code: number, reason: string) {
-                      if (!ws.data.closed) ws.close(code, reason);
-                    },
-                  };
-                  const result = await publicEventWebSocketHub.subscribe(
-                    ws.data.id,
+              const queued = queueServerWebSocketSubscription(ws, async () => {
+                const subscriber = {
+                  send(serialized: string) {
+                    return sendPublicAudienceSerializedEnvelope(ws, serialized);
+                  },
+                  close(code: number, reason: string) {
+                    if (!ws.data.closed) ws.close(code, reason);
+                  },
+                };
+                const result = await publicEventWebSocketHub.subscribe(
+                  ws.data.id,
+                  eventId,
+                  subscriber,
+                );
+                if (ws.data.closed) return;
+                if (result.status === "rejected") {
+                  sendMessage(ws, { type: "error", message: result.message });
+                  ws.close(1013, result.message);
+                  return;
+                }
+                if (result.status !== "admitted") {
+                  sendPublicEventStreamMessage(ws, {
+                    protocol: "public-event-stream-v1",
+                    type: "event-unavailable",
                     eventId,
-                    subscriber,
-                  );
-                  if (ws.data.closed) return;
-                  if (result.status === "rejected") {
-                    sendMessage(ws, { type: "error", message: result.message });
-                    ws.close(1013, result.message);
-                    return;
-                  }
-                  if (result.status !== "admitted") {
-                    sendPublicEventStreamMessage(ws, {
-                      protocol: "public-event-stream-v1",
-                      type: "event-unavailable",
-                      eventId,
-                    });
-                    ws.close(1008, "Event unavailable.");
-                    return;
-                  }
-                  ws.data.subscription = { type: "public-event", eventId };
-                },
+                  });
+                  ws.close(1008, "Event unavailable.");
+                  return;
+                }
+                ws.data.subscription = { type: "public-event", eventId };
               });
               await queued;
               return;
@@ -2514,78 +2458,69 @@ async function startServer() {
 
             case "subscribe-game": {
               const subscribeGameId = parsed.message.gameId;
-              const queued = queueWebSocketSubscription(ws.data, {
-                isClosed: () => ws.data.closed,
-                alreadySubscribed(message) {
-                  sendMessage(ws, {
-                    type: "error",
-                    message,
-                  });
-                },
-                async subscribe() {
-                  const result = await resolveAdHocWebSocketSubscription({
-                    service: adHocService,
-                    cookieHeader: ws.data.cookieHeader,
-                    gameId: subscribeGameId,
-                  });
-                  if (result.status === "capacity") {
-                    if (!ws.data.closed) {
-                      adHocService.recordResourcePressure("connection-shed");
-                      sendMessage(ws, {
-                        type: "error",
-                        message: "Ad Hoc connection busy. Try again later.",
-                        retryAfterMs: result.retryAfterMs,
-                      });
-                      setTimeout(() => ws.close(1013, "Ad Hoc connection busy."), 25);
-                    }
-                    return;
+              const queued = queueServerWebSocketSubscription(ws, async () => {
+                const result = await resolveAdHocWebSocketSubscription({
+                  service: adHocService,
+                  cookieHeader: ws.data.cookieHeader,
+                  gameId: subscribeGameId,
+                });
+                if (result.status === "capacity") {
+                  if (!ws.data.closed) {
+                    adHocService.recordResourcePressure("connection-shed");
+                    sendMessage(ws, {
+                      type: "error",
+                      message: "Ad Hoc connection busy. Try again later.",
+                      retryAfterMs: result.retryAfterMs,
+                    });
+                    setTimeout(() => ws.close(1013, "Ad Hoc connection busy."), 25);
                   }
-                  if (result.status !== "accepted") {
-                    if (!ws.data.closed) {
-                      sendMessage(ws, {
-                        type: "error",
-                        message: adHocService.genericUnavailableMessage,
-                      });
-                      ws.close(1008, "Ad Hoc subscription unavailable.");
-                    }
-                    return;
-                  }
-                  const identity = {
-                    gameId: subscribeGameId,
-                    sessionId: result.sessionId,
-                  };
-                  const tracking = await liveAdHocSessions.subscribe(ws.data.id, {
-                    ...identity,
-                  });
-                  if (!tracking.attached) {
-                    if (liveAdHocSessions.count(identity) === 0) {
-                      await adHocService.setConnection({ ...identity, connected: false });
-                    }
-                    if (!ws.data.closed) {
-                      sendMessage(ws, {
-                        type: "error",
-                        message: adHocService.genericUnavailableMessage,
-                      });
-                      ws.close(1008, "Ad Hoc subscription unavailable.");
-                    }
-                    return;
-                  }
-                  ws.data.sessionId = result.sessionId;
-                  ws.data.subscription = {
-                    type: "game",
-                    gameId: subscribeGameId,
-                    sessionId: result.sessionId,
-                  };
+                  return;
+                }
+                if (result.status !== "accepted") {
                   if (!ws.data.closed) {
                     sendMessage(ws, {
-                      type: "game-snapshot",
-                      game: stripSession(result.game),
-                      serverNowMs: Date.now(),
-                      ackedCommandIds: [],
+                      type: "error",
+                      message: adHocService.genericUnavailableMessage,
                     });
+                    ws.close(1008, "Ad Hoc subscription unavailable.");
                   }
-                  if (!tracking.previousDisconnectDurable) void liveAdHocSessions.retryPending();
-                },
+                  return;
+                }
+                const identity = {
+                  gameId: subscribeGameId,
+                  sessionId: result.sessionId,
+                };
+                const tracking = await liveAdHocSessions.subscribe(ws.data.id, {
+                  ...identity,
+                });
+                if (!tracking.attached) {
+                  if (liveAdHocSessions.count(identity) === 0) {
+                    await adHocService.setConnection({ ...identity, connected: false });
+                  }
+                  if (!ws.data.closed) {
+                    sendMessage(ws, {
+                      type: "error",
+                      message: adHocService.genericUnavailableMessage,
+                    });
+                    ws.close(1008, "Ad Hoc subscription unavailable.");
+                  }
+                  return;
+                }
+                ws.data.sessionId = result.sessionId;
+                ws.data.subscription = {
+                  type: "game",
+                  gameId: subscribeGameId,
+                  sessionId: result.sessionId,
+                };
+                if (!ws.data.closed) {
+                  sendMessage(ws, {
+                    type: "game-snapshot",
+                    game: stripSession(result.game),
+                    serverNowMs: Date.now(),
+                    ackedCommandIds: [],
+                  });
+                }
+                if (!tracking.previousDisconnectDurable) void liveAdHocSessions.retryPending();
               });
               await queued;
               return;
@@ -3117,6 +3052,19 @@ function sendAdHocSerializedEnvelope(ws: AdHocBroadcastSocket, serialized: strin
     overflowCloseReason: "Ad Hoc output limit reached.",
     shortSendCloseReason: "Ad Hoc output backpressure.",
     sendErrorCloseReason: "Ad Hoc output unavailable.",
+  });
+}
+
+function queueServerWebSocketSubscription(
+  ws: ServerWebSocket<SessionData>,
+  subscribe: () => Promise<void>,
+) {
+  return queueWebSocketSubscription(ws.data, {
+    isClosed: () => ws.data.closed,
+    alreadySubscribed(message) {
+      sendMessage(ws, { type: "error", message });
+    },
+    subscribe,
   });
 }
 

--- a/src/lib/websocket-subscription.test.ts
+++ b/src/lib/websocket-subscription.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, test } from "bun:test";
+import {
+  canBeginWebSocketSubscription,
+  queueWebSocketSubscription,
+  type SessionSubscription,
+  type WebSocketSubscriptionQueue,
+} from "./websocket-subscription";
+
+describe("WebSocket protocol subscription", () => {
+  test("allows a new protocol subscription only from the empty state", () => {
+    expect(canBeginWebSocketSubscription({ type: "none" })).toBe(true);
+    expect(canBeginWebSocketSubscription({ type: "lobby" })).toBe(false);
+    expect(
+      canBeginWebSocketSubscription({
+        type: "game",
+        gameId: "adhoc-existing",
+        sessionId: "existing-session",
+      }),
+    ).toBe(false);
+    expect(canBeginWebSocketSubscription({ type: "public-event", eventId: "event-existing" })).toBe(
+      false,
+    );
+  });
+
+  test("rejects an Ad Hoc Game subscription after a public Audience Projection subscription before side effects", async () => {
+    const queue: WebSocketSubscriptionQueue = {
+      subscription: { type: "public-event", eventId: "event-existing" },
+      subscriptionWork: Promise.resolve(),
+    };
+    const errors: string[] = [];
+    let resolverCalls = 0;
+    let trackingCalls = 0;
+    let connectionCalls = 0;
+    let snapshots = 0;
+
+    const result = await queueWebSocketSubscription(queue, {
+      alreadySubscribed(message) {
+        errors.push(message);
+      },
+      async subscribe() {
+        resolverCalls += 1;
+        trackingCalls += 1;
+        connectionCalls += 1;
+        snapshots += 1;
+        queue.subscription = {
+          type: "game",
+          gameId: "adhoc-attempted",
+          sessionId: "attempted-session",
+        };
+      },
+    });
+
+    expect(result).toBe("already-subscribed");
+    expect(errors).toEqual(["WebSocket is already subscribed."]);
+    expect(queue.subscription).toEqual({ type: "public-event", eventId: "event-existing" });
+    expect({ resolverCalls, trackingCalls, connectionCalls, snapshots }).toEqual({
+      resolverCalls: 0,
+      trackingCalls: 0,
+      connectionCalls: 0,
+      snapshots: 0,
+    });
+  });
+
+  test("rejects a public Audience Projection subscription after an Ad Hoc Game subscription", async () => {
+    const queue: WebSocketSubscriptionQueue = {
+      subscription: {
+        type: "game",
+        gameId: "adhoc-existing",
+        sessionId: "existing-session",
+      },
+      subscriptionWork: Promise.resolve(),
+    };
+    let publicCapacityCalls = 0;
+
+    expect(
+      await queueWebSocketSubscription(queue, {
+        alreadySubscribed() {},
+        async subscribe() {
+          publicCapacityCalls += 1;
+        },
+      }),
+    ).toBe("already-subscribed");
+    expect(publicCapacityCalls).toBe(0);
+  });
+
+  test("rejects a second subscription to the same protocol without subscription work", async () => {
+    const subscriptions: SessionSubscription[] = [
+      { type: "public-event", eventId: "event-existing" },
+      {
+        type: "game",
+        gameId: "adhoc-existing",
+        sessionId: "existing-session",
+      },
+    ];
+
+    for (const subscription of subscriptions) {
+      const queue: WebSocketSubscriptionQueue = {
+        subscription,
+        subscriptionWork: Promise.resolve(),
+      };
+      let sideEffects = 0;
+      expect(
+        await queueWebSocketSubscription(queue, {
+          alreadySubscribed() {},
+          async subscribe() {
+            sideEffects += 1;
+          },
+        }),
+      ).toBe("already-subscribed");
+      expect(sideEffects).toBe(0);
+      expect(queue.subscription).toEqual(subscription);
+    }
+  });
+
+  test("queued handler ordering admits only the first subscription in either protocol order", async () => {
+    const orders: Array<[SessionSubscription, SessionSubscription]> = [
+      [
+        { type: "public-event", eventId: "event-first" },
+        {
+          type: "game",
+          gameId: "adhoc-second",
+          sessionId: "second-session",
+        },
+      ],
+      [
+        {
+          type: "game",
+          gameId: "adhoc-first",
+          sessionId: "first-session",
+        },
+        { type: "public-event", eventId: "event-second" },
+      ],
+    ];
+
+    for (const [firstSubscription, secondSubscription] of orders) {
+      const queue: WebSocketSubscriptionQueue = {
+        subscription: { type: "none" },
+        subscriptionWork: Promise.resolve(),
+      };
+      const sideEffects: string[] = [];
+      const first = queueWebSocketSubscription(queue, {
+        alreadySubscribed() {},
+        async subscribe() {
+          await Promise.resolve();
+          sideEffects.push("first-capacity");
+          queue.subscription = firstSubscription;
+        },
+      });
+      const second = queueWebSocketSubscription(queue, {
+        alreadySubscribed() {},
+        async subscribe() {
+          sideEffects.push("second-capacity");
+          queue.subscription = secondSubscription;
+        },
+      });
+
+      expect(await Promise.all([first, second])).toEqual(["started", "already-subscribed"]);
+      expect(sideEffects).toEqual(["first-capacity"]);
+      expect(queue.subscription).toEqual(firstSubscription);
+    }
+  });
+});

--- a/src/lib/websocket-subscription.ts
+++ b/src/lib/websocket-subscription.ts
@@ -1,0 +1,39 @@
+export type SessionSubscription =
+  | { type: "none" }
+  | { type: "lobby" }
+  | { type: "game"; gameId: string; sessionId: string }
+  | { type: "public-event"; eventId: string };
+
+export type WebSocketSubscriptionQueue = {
+  subscription: SessionSubscription;
+  subscriptionWork: Promise<void>;
+};
+
+export function canBeginWebSocketSubscription(subscription: SessionSubscription): boolean {
+  return subscription.type === "none";
+}
+
+export function queueWebSocketSubscription(
+  queue: WebSocketSubscriptionQueue,
+  operation: {
+    isClosed?: () => boolean;
+    alreadySubscribed: (message: string) => void;
+    subscribe: () => Promise<void>;
+  },
+): Promise<"started" | "already-subscribed" | "closed"> {
+  const handleSubscription = async () => {
+    if (operation.isClosed?.()) return "closed" as const;
+    if (!canBeginWebSocketSubscription(queue.subscription)) {
+      operation.alreadySubscribed("WebSocket is already subscribed.");
+      return "already-subscribed" as const;
+    }
+    await operation.subscribe();
+    return "started" as const;
+  };
+  const queued = queue.subscriptionWork.then(handleSubscription, handleSubscription);
+  queue.subscriptionWork = queued.then(
+    () => undefined,
+    () => undefined,
+  );
+  return queued;
+}


### PR DESCRIPTION
## Summary

- centralize the serialized WebSocket subscription precondition
- reject cross-protocol and same-protocol resubscription before authorization, capacity, tracking, persistence, or state mutation
- cover both protocol orders and concurrent queued subscription races

## Verification

- `bun test --isolate ./src/index-ad-hoc.test.ts` — 26 passed
- `bun run test` — 1,104 passed
- `bun run check` — passed with no new warnings
- `bun run build` — passed
- `git diff --check` — passed

No qualification test was run.

Closes #303
