### PR TITLE
Secure Ad Hoc browser cookies

### DIFF
--- a/scripts/test-ad-hoc-browser.ts
+++ b/scripts/test-ad-hoc-browser.ts
@@ -161,6 +161,7 @@ async function run() {
 
         const gameId = new URL(first.url()).pathname.split("/").at(-1);
         if (gameId === undefined) throw new Error("Game route did not contain a Game ID.");
+        assertSecureAdHocCookies(await firstContext.cookies(), [gameId], true);
         const actionSheetContext = await browser!.newContext({ ignoreHTTPSErrors: true });
         const actionSheetPage = await actionSheetContext.newPage();
         actionSheetPage.setDefaultTimeout(15_000);
@@ -170,11 +171,15 @@ async function run() {
         await waitForHealthyControllerHeader(actionSheetPage);
         await assertControllerActionSheet(actionSheetPage, "Ad Hoc initial Controller");
         await actionSheetContext.close();
+        let additionalGameId = "";
         for (let index = 0; index < 4; index += 1) {
           await first.goto(origin);
           await first.getByRole("button", { name: /Start an Ad Hoc Game/ }).click();
           await first.waitForURL(/\/game\/adhoc-/u);
+          if (index === 0) additionalGameId = new URL(first.url()).pathname.split("/").at(-1) ?? "";
         }
+        if (additionalGameId === "") throw new Error("Additional Game route had no Game ID.");
+        assertSecureAdHocCookies(await firstContext.cookies(), [gameId, additionalGameId], true);
         await first.goto(origin);
         await first.getByRole("button", { name: /Start an Ad Hoc Game/ }).click();
         await first
@@ -241,6 +246,7 @@ async function run() {
         const handoffUrl = `${origin}/#adhoc-game=${encodeURIComponent(gameId)}&adhoc-control=${encodeURIComponent(controlQr)}`;
         await second.goto(handoffUrl);
         await waitForGameRoute(second, gameId);
+        assertSecureAdHocCookies(await secondContext.cookies(), [gameId]);
         await assertAccessibleQr(second, "second browser");
 
         const startGame = second.getByRole("button", { name: "Start game" });
@@ -348,6 +354,27 @@ async function run() {
         await waitForGameRoute(second, gameId);
         await first.getByText("Paused", { exact: true }).waitFor();
 
+        const alternateSnapshot = await first.evaluate(async (id) => {
+          const response = await fetch(`/api/games/${id}`);
+          return (await response.json()) as { game?: { controlQr?: string | null } };
+        }, creationRetryGameId);
+        const alternateQr = alternateSnapshot.game?.controlQr;
+        if (typeof alternateQr !== "string")
+          throw new Error("Alternate Ad Hoc handoff QR was unavailable.");
+        const siblingAdmissionStatus = await second.evaluate(
+          async ({ siblingGameId, controlQr }) => {
+            const response = await fetch(`/api/games/${encodeURIComponent(siblingGameId)}/admit`, {
+              method: "POST",
+              headers: { "content-type": "application/json" },
+              body: JSON.stringify({ controlQr }),
+            });
+            return response.status;
+          },
+          { siblingGameId: creationRetryGameId, controlQr: alternateQr },
+        );
+        if (siblingAdmissionStatus !== 200) throw new Error("Sibling Game admission failed.");
+        assertSecureAdHocCookies(await secondContext.cookies(), [gameId, creationRetryGameId]);
+
         // An Ad Hoc returnable session must use the same shared replacement
         // confirmation before an Event admission transport is touched.
         await second.getByRole("button", { name: "Leave Ad Hoc Game Controller" }).click();
@@ -390,6 +417,20 @@ async function run() {
           eventReplacementOrder.slice(0, eventAdmissionIndex).some((entry) => entry !== "finalize")
         )
           throw new Error(`Ad Hoc→Event replacement order was ${eventReplacementOrder.join(",")}.`);
+        if (
+          (await secondContext.cookies()).some(
+            (cookie) => cookie.name === `adhoc_session_${gameId}`,
+          )
+        ) {
+          throw new Error("Confirmed replacement retained the finalized Ad Hoc session cookie.");
+        }
+        assertSecureAdHocCookies(await secondContext.cookies(), [creationRetryGameId]);
+        const siblingReadStatus = await second.evaluate(async (siblingGameId) => {
+          const response = await fetch(`/api/games/${encodeURIComponent(siblingGameId)}`);
+          return response.status;
+        }, creationRetryGameId);
+        if (siblingReadStatus !== 200)
+          throw new Error("Confirmed replacement removed sibling Ad Hoc authority.");
         second.off("request", recordEventOpen);
 
         const creationContext = await browser!.newContext({
@@ -438,13 +479,6 @@ async function run() {
         const admissionStorageState = await creationContext.storageState();
         await creationContext.close();
 
-        const alternateSnapshot = await first.evaluate(async (id) => {
-          const response = await fetch(`/api/games/${id}`);
-          return (await response.json()) as { game?: { controlQr?: string | null } };
-        }, creationRetryGameId);
-        const alternateQr = alternateSnapshot.game?.controlQr;
-        if (typeof alternateQr !== "string")
-          throw new Error("Alternate Ad Hoc handoff QR was unavailable.");
         const admissionContext = await browser!.newContext({
           ignoreHTTPSErrors: true,
           storageState: admissionStorageState,
@@ -770,6 +804,25 @@ async function waitForServer() {
 
 async function waitForGameRoute(page: Page, gameId: string) {
   if (page.url() !== `${origin}/game/${gameId}`) await page.waitForURL(`${origin}/game/${gameId}`);
+}
+
+function assertSecureAdHocCookies(
+  cookies: readonly { name: string; secure: boolean }[],
+  gameIds: readonly string[],
+  requireSource = false,
+) {
+  if (requireSource) {
+    const source = cookies.find((cookie) => cookie.name === "adhoc_source");
+    if (source === undefined || !source.secure) {
+      throw new Error("The Ad Hoc source cookie was absent or not Secure.");
+    }
+  }
+  for (const gameId of gameIds) {
+    const session = cookies.find((cookie) => cookie.name === `adhoc_session_${gameId}`);
+    if (session === undefined || !session.secure) {
+      throw new Error("An expected Ad Hoc session cookie was absent or not Secure.");
+    }
+  }
 }
 
 async function waitForHealthyControllerHeader(page: Page) {

--- a/src/index-ad-hoc.test.ts
+++ b/src/index-ad-hoc.test.ts
@@ -296,6 +296,13 @@ describe("Ad Hoc HTTP and WebSocket authority boundaries", () => {
     const authoritySet = `${first.cookie}; ${second.cookie}`;
     expect(first.setCookie).toContain("Max-Age=31536000");
     expect(second.setCookie).toContain("Max-Age=31536000");
+    expect(first.setCookie).toMatch(/adhoc_source=[^,]+; Secure(?:,|$)/u);
+    expect(first.setCookie).toMatch(
+      new RegExp(`adhoc_session_${first.gameId}=[^,]+; Secure(?:,|$)`, "u"),
+    );
+    expect(second.setCookie).toMatch(
+      new RegExp(`adhoc_session_${second.gameId}=[^,]+; Secure(?:,|$)`, "u"),
+    );
 
     expect(readAdHocSession(authoritySet, first.gameId)).toBeTruthy();
     expect(readAdHocSession(authoritySet, second.gameId)).toBeTruthy();
@@ -350,6 +357,9 @@ describe("Ad Hoc HTTP and WebSocket authority boundaries", () => {
     ).toBe(200);
     expect(left.headers.get("set-cookie")).toContain(`adhoc_session_${first.gameId}=`);
     expect(left.headers.get("set-cookie")).toContain("Max-Age=0");
+    expect(left.headers.get("set-cookie")).toContain(
+      "Path=/; Max-Age=0; HttpOnly; SameSite=Lax; Secure",
+    );
   });
 
   test("lets an admitted Ad Hoc Controller operate with equal authority", async () => {
@@ -397,6 +407,7 @@ describe("Ad Hoc HTTP and WebSocket authority boundaries", () => {
     expect(firstAdmission.status).toBe(200);
     const firstCookie = firstAdmission.headers.get("set-cookie");
     if (firstCookie === null) throw new Error("first admission did not return a session");
+    expect(firstCookie).toContain("HttpOnly; SameSite=Lax; Secure");
 
     const secondAdmission = await admitGame(
       new Request(`http://localhost/api/games/${created.gameId}/admit`, {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3187,7 +3187,7 @@ function readAdHocSource(cookieHeader: string | null): string | null {
 }
 
 function adHocSourceCookie(source: string): string {
-  return `${AD_HOC_SOURCE_COOKIE_NAME}=${encodeURIComponent(source)}; Path=/; Max-Age=31536000; HttpOnly; SameSite=Lax`;
+  return `${AD_HOC_SOURCE_COOKIE_NAME}=${encodeURIComponent(source)}; Path=/; Max-Age=31536000; HttpOnly; SameSite=Lax; Secure`;
 }
 
 function adHocSessionCookieName(gameId: unknown): string | null {
@@ -3196,11 +3196,11 @@ function adHocSessionCookieName(gameId: unknown): string | null {
 }
 
 function adHocSessionCookie(gameId: string, sessionId: string): string {
-  return `${adHocSessionCookieName(gameId)}=${encodeURIComponent(sessionId)}; Path=/; Max-Age=31536000; HttpOnly; SameSite=Lax`;
+  return `${adHocSessionCookieName(gameId)}=${encodeURIComponent(sessionId)}; Path=/; Max-Age=31536000; HttpOnly; SameSite=Lax; Secure`;
 }
 
 function clearAdHocSessionCookie(gameId: string): string {
-  return `${adHocSessionCookieName(gameId)}=; Path=/; Max-Age=0; HttpOnly; SameSite=Lax`;
+  return `${adHocSessionCookieName(gameId)}=; Path=/; Max-Age=0; HttpOnly; SameSite=Lax; Secure`;
 }
 
 export function adHocFallbackRoute(req: Request) {


### PR DESCRIPTION
## Summary

- mark every Ad Hoc source, Game-session, and matching deletion cookie `Secure`
- preserve existing names, paths, lifetimes, `HttpOnly`, `SameSite=Lax`, and Leave Grace Period behavior
- verify creation, admission, finalized deletion, restart continuity, and same-browser multi-Game independence at the HTTP and HTTPS browser seams

## Verification

- `bun test --isolate ./src/index-ad-hoc.test.ts`
- `bun scripts/test-ad-hoc-browser.ts`
- `bun run check`
- `bun run test` (1,098/1,099 passed in the sandbox; the sole ephemeral-listener test was blocked by sandbox `EADDRINUSE`)
- `bun test --isolate ./src/lib/public-health.test.ts` outside the listener restriction (6/6 passed)
- `bun run build`
- `git diff --check`
- final Standards and Spec reviews: no findings

Closes #304
